### PR TITLE
cmux-tui: keep debug mirror dumps private

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3760,7 +3760,7 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         {
             continue;
         }
-        let Some(name) = name.to_str() else { continue };
+        let Ok(name) = name.to_str() else { continue };
         let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
         let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
             continue;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3624,12 +3624,14 @@ impl Drop for RemoteSession {
 
 fn private_dump_file(path: &Path) -> io::Result<fs::File> {
     let mut options = fs::OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    options.write(true).create(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
+    #[cfg(not(unix))]
+    options.truncate(true);
     let file = options.open(path)?;
     #[cfg(unix)]
     {
@@ -3646,6 +3648,9 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
                 format!("dump target is not a private regular file: {}", path.display()),
             ));
         }
+        // Truncate only after validating the opened descriptor, so a hard
+        // link cannot cause data loss in another file.
+        file.set_len(0)?;
         // `mode` only applies when the file is new. Set permissions through
         // the opened descriptor so existing files are also private without a
         // path-based symlink race.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3693,6 +3693,8 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
     use std::ptr;
 
+    // Any extended ACL can carry non-owner grants or inheritance. Reject the
+    // directory instead of trying to interpret ACE ordering and masks.
     let descriptor = directory.as_raw_fd();
     let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
     if size < 0 {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3689,7 +3689,43 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private: {}", path.display()),
         ));
     }
+    prune_stale_dump_temps(&directory, path)?;
     Ok(directory)
+}
+
+#[cfg(unix)]
+fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+
+    let uid = unsafe { libc::geteuid() };
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_bytes = name.as_os_str().as_bytes();
+        let is_dump_temp = (name_bytes.starts_with(b".mirror-")
+            || name_bytes.starts_with(b".frames-"))
+            && name_bytes.windows(b".tmp-".len()).any(|part| part == b".tmp-");
+        if !is_dump_temp {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
+            continue;
+        }
+        let name = CString::new(name_bytes)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+        let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(error);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3635,87 +3635,132 @@ impl Drop for RemoteSession {
 #[cfg(unix)]
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-
-    // Validate existing ancestors before create_dir_all follows them, then
-    // validate again after creation to catch newly created components. A
-    // writable non-sticky ancestor permits another user to replace the dump
-    // directory between path operations and redirect secret-bearing output.
-    validate_dump_ancestors(path)?;
-
-    let existed = match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.is_dir() => true,
-        Ok(_) => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("dump path is not a directory: {}", path.display()),
-            ));
-        }
-        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
-        Err(error) => return Err(error),
-    };
-    if !existed {
-        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
-            fs::create_dir_all(parent)?;
-        }
-        let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
-            io::Error::new(io::ErrorKind::InvalidInput, "invalid dump directory path")
-        })?;
-        let status = unsafe { libc::mkdir(path.as_ptr(), 0o700) };
-        if status != 0 {
+    let start = if path.is_absolute() { "/" } else { "." };
+    let start = CString::new(start).unwrap();
+    let fd =
+        unsafe { libc::open(start.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut directory = unsafe { fs::File::from_raw_fd(fd) };
+    for component in path.components() {
+        use std::path::Component;
+        let Component::Normal(component) = component else {
+            if matches!(component, Component::ParentDir) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "dump path must not contain '..'",
+                ));
+            }
+            continue;
+        };
+        validate_dump_directory(&directory, false)?;
+        let component =
+            CString::new(component.as_bytes()).map_err(|_| io::ErrorKind::InvalidInput)?;
+        let next = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                component.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        let next = if next >= 0 {
+            next
+        } else {
             let error = io::Error::last_os_error();
-            if error.kind() != io::ErrorKind::AlreadyExists {
+            if error.kind() != io::ErrorKind::NotFound {
                 return Err(error);
             }
-        }
+            if unsafe { libc::mkdirat(directory.as_raw_fd(), component.as_ptr(), 0o700) } != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let next = unsafe {
+                libc::openat(
+                    directory.as_raw_fd(),
+                    component.as_ptr(),
+                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )
+            };
+            if next < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            next
+        };
+        directory = unsafe { fs::File::from_raw_fd(next) };
     }
-    validate_dump_ancestors(path)?;
-    let directory = fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(path)?;
-    let metadata = directory.metadata()?;
-    if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!("dump directory is not private and user-owned: {}", path.display()),
-        ));
-    }
-    reject_extended_acl(&directory)?;
-    if metadata.mode() & 0o077 != 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!("dump directory is not private: {}", path.display()),
-        ));
-    }
-    prune_stale_dump_temps(&directory, path)?;
+    validate_dump_directory(&directory, true)?;
+    prune_stale_dump_temps(&directory)?;
     Ok(directory)
 }
 
 #[cfg(unix)]
-fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
+fn validate_dump_directory(directory: &fs::File, private: bool) -> io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = directory.metadata()?;
+    let trusted_owner = metadata.uid() == unsafe { libc::geteuid() } || metadata.uid() == 0;
+    let sticky = metadata.mode() & 0o1000 != 0;
+    if !trusted_owner
+        || (!private && metadata.mode() & 0o022 != 0 && !sticky)
+        || (private && metadata.mode() & 0o077 != 0)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump directory component is not private or trusted",
+        ));
+    }
+    reject_extended_acl(directory)
+}
+
+#[cfg(unix)]
+fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
-    use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::MetadataExt;
 
     let uid = unsafe { libc::geteuid() };
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_bytes = name.as_os_str().as_bytes();
+    let duplicate = unsafe { libc::dup(directory.as_raw_fd()) };
+    if duplicate < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let stream = unsafe { libc::fdopendir(duplicate) };
+    if stream.is_null() {
+        unsafe { libc::close(duplicate) };
+        return Err(io::Error::last_os_error());
+    }
+    loop {
+        let entry = unsafe { libc::readdir(stream) };
+        if entry.is_null() {
+            break;
+        }
+        let name = unsafe { std::ffi::CStr::from_ptr((*entry).d_name.as_ptr()) };
+        let name_bytes = name.to_bytes();
         let is_dump_temp = (name_bytes.starts_with(b".mirror-")
             || name_bytes.starts_with(b".frames-"))
             && name_bytes.windows(b".tmp-".len()).any(|part| part == b".tmp-");
         if !is_dump_temp {
             continue;
         }
-        let metadata = fs::symlink_metadata(entry.path())?;
-        if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
+        let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+        if unsafe {
+            libc::fstatat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                metadata.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } != 0
+        {
             continue;
         }
-        let Some(name) = name.to_str() else { continue };
+        let metadata = unsafe { metadata.assume_init() };
+        if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
+            || metadata.st_uid != uid
+            || metadata.st_nlink != 1
+        {
+            continue;
+        }
+        let Some(name) = name.to_str().ok() else { continue };
         let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
         let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
             continue;
@@ -3725,8 +3770,7 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         if process_alive {
             continue;
         }
-        let name = CString::new(name_bytes)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+        let name = CString::new(name_bytes).map_err(|_| io::ErrorKind::InvalidInput)?;
         let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
         if status != 0 {
             let error = io::Error::last_os_error();
@@ -3735,77 +3779,8 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
             }
         }
     }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn validate_dump_ancestors(path: &Path) -> io::Result<()> {
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-
-    let mut ancestor = path.parent();
-    while let Some(candidate) = ancestor {
-        if candidate.as_os_str().is_empty() {
-            break;
-        }
-        match fs::symlink_metadata(candidate) {
-            Ok(metadata) => {
-                let resolved = if metadata.file_type().is_symlink() {
-                    if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
-                        return Err(io::Error::new(
-                            io::ErrorKind::PermissionDenied,
-                            format!(
-                                "dump directory ancestor is not trusted: {}",
-                                candidate.display()
-                            ),
-                        ));
-                    }
-                    let resolved = fs::canonicalize(candidate)?;
-                    validate_dump_ancestors(&resolved)?;
-                    resolved
-                } else {
-                    candidate.to_path_buf()
-                };
-                let metadata = fs::symlink_metadata(&resolved)?;
-                if !metadata.is_dir() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "dump directory ancestor is not a directory: {}",
-                            candidate.display()
-                        ),
-                    ));
-                }
-                if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        format!("dump directory ancestor is not trusted: {}", candidate.display()),
-                    ));
-                }
-                let mode = metadata.mode();
-                let sticky = mode & 0o1000 != 0;
-                if mode & 0o022 != 0 && !sticky {
-                    return Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        format!(
-                            "dump directory ancestor is writable without private protection: {}",
-                            candidate.display()
-                        ),
-                    ));
-                }
-                let directory = fs::OpenOptions::new()
-                    .read(true)
-                    .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-                    .open(&resolved)?;
-                reject_extended_acl(&directory)?;
-            }
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
-        }
-        let next = candidate.parent();
-        if next == Some(candidate) {
-            break;
-        }
-        ancestor = next;
+    unsafe {
+        libc::closedir(stream);
     }
     Ok(())
 }
@@ -4860,6 +4835,37 @@ mod tests {
         let _directory = private_dump_directory(&dump_path).unwrap();
 
         assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_directory_rejects_symlink_components() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        fs::create_dir(&target).unwrap();
+        let link = root.path().join("link");
+        symlink(&target, &link).unwrap();
+
+        assert!(private_dump_directory(&link.join("dumps")).is_err());
+        assert!(!target.join("dumps").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_dump_directory_is_stable_across_path_replacement() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let original = root.path().join("original");
+        fs::rename(&dump_path, &original).unwrap();
+        fs::create_dir(&dump_path).unwrap();
+
+        write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"secret")).unwrap();
+
+        assert_eq!(fs::read(original.join("mirror.txt")).unwrap(), b"secret");
+        assert!(!dump_path.join("mirror.txt").exists());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4686,6 +4686,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_rejects_writable_ancestor_without_sticky_bit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        fs::set_permissions(root.path(), fs::Permissions::from_mode(0o777)).unwrap();
+        let path = root.path().join("dumps");
+
+        let error = private_dump_directory(&path).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
         let directory = private_dump_directory(root.path()).unwrap();
@@ -4720,6 +4735,44 @@ mod tests {
 
         assert_eq!(fs::read(&final_path).unwrap(), b"replacement");
         assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_file_rejects_existing_hard_link_without_truncation() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        let linked_path = root.path().join("mirror-backup.txt");
+        fs::write(&final_path, b"previous").unwrap();
+        fs::hard_link(&final_path, &linked_path).unwrap();
+
+        let error = private_dump_file(&directory, "mirror.txt").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&final_path).unwrap(), b"previous");
+        assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_rename_failure_preserves_previous_directory_and_cleans_temp() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        fs::create_dir(&final_path).unwrap();
+
+        let error = write_private_dump(&directory, "mirror.txt", |file| {
+            file.write_all(b"replacement")
+        })
+        .unwrap_err();
+
+        assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
+        assert!(final_path.is_dir());
+        assert!(fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| entry.file_name() == "mirror.txt"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -19,7 +19,7 @@ use cmux_tui_core::{
     MuxEventReceiver, NotificationEvent, NotificationLevel, PairingChallenge, PointerSemanticProbe,
     PointerSnapshotProbe, REMOTE_SESSION_MESSAGE_MAX_BYTES, Rgb, SurfaceId, SurfaceKind,
     TerminalPointerSnapshot,
-    platform::{restrict_directory, transport},
+    platform::transport,
     server::{
         CLEAR_HISTORY_CAPABILITY, CLEAR_HISTORY_KEY_CAPABILITY, CREATION_RECEIPTS_CAPABILITY,
         CREATION_SELECTOR_FALLBACKS_CAPABILITY, GUARDED_BROWSER_POINTER_CAPABILITY,
@@ -3598,69 +3598,101 @@ impl Drop for RemoteSession {
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;
         };
-        let _ = fs::create_dir_all(dir);
-        // Frame mirrors contain terminal output and may include secrets. Keep
-        // the opt-in dump directory and files private even when the process
-        // runs with a permissive umask.
-        let _ = restrict_directory(dir);
-        let logs = self.frame_logs.lock().unwrap();
-        let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
-        for entry in &logs.entries {
-            entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
+        #[cfg(not(unix))]
+        {
+            // Secure descriptor-relative file creation is not available in
+            // this implementation. Do not emit secret-bearing dumps through
+            // path-based APIs on unsupported targets.
+            let _ = dir;
+            return;
         }
-        for surface in self.surfaces.lock().unwrap().values() {
-            let path = dir.join(format!("mirror-{}.txt", surface.id));
-            let _ = write_private_dump(&path, &dump_mirror(surface));
-            let frames = dir.join(format!("frames-{}.log", surface.id));
-            if let Ok(file) = private_dump_file(&frames) {
-                let mut writer = io::BufWriter::new(file);
-                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                    let _ = writeln!(writer, "{line}");
+        #[cfg(unix)]
+        {
+            let Ok(directory) = private_dump_directory(dir) else { return };
+            let logs = self.frame_logs.lock().unwrap();
+            let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
+            for entry in &logs.entries {
+                entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
+            }
+            for surface in self.surfaces.lock().unwrap().values() {
+                let mirror_name = format!("mirror-{}.txt", surface.id);
+                let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
+                let frames_name = format!("frames-{}.log", surface.id);
+                if let Ok(file) = private_dump_file(&directory, &frames_name) {
+                    let mut writer = io::BufWriter::new(file);
+                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                        let _ = writeln!(writer, "{line}");
+                    }
                 }
             }
         }
     }
 }
 
-fn private_dump_file(path: &Path) -> io::Result<fs::File> {
-    let mut options = fs::OpenOptions::new();
-    options.write(true).create(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+#[cfg(unix)]
+fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+
+    fs::create_dir_all(path)?;
+    let directory = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)?;
+    let metadata = directory.metadata()?;
+    if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("dump directory is not private and user-owned: {}", path.display()),
+        ));
     }
-    #[cfg(not(unix))]
-    options.truncate(true);
-    let file = options.open(path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        let metadata = file.metadata()?;
-        // O_NOFOLLOW protects only the final path component. Verify the
-        // opened descriptor as well, so a stale or malicious dump entry
-        // cannot block on a FIFO or redirect output to a device. A link count
-        // above one indicates a hard link, which could otherwise truncate a
-        // different file when the dump is refreshed.
-        if !metadata.is_file() || metadata.nlink() != 1 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("dump target is not a private regular file: {}", path.display()),
-            ));
-        }
-        // Truncate only after validating the opened descriptor, so a hard
-        // link cannot cause data loss in another file.
-        file.set_len(0)?;
-        // `mode` only applies when the file is new. Set permissions through
-        // the opened descriptor so existing files are also private without a
-        // path-based symlink race.
-        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    Ok(directory)
+}
+
+#[cfg(unix)]
+fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let name = CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_WRONLY
+                | libc::O_CREAT
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if descriptor < 0 {
+        return Err(io::Error::last_os_error());
     }
+    let file = unsafe { fs::File::from_raw_fd(descriptor) };
+    let metadata = file.metadata()?;
+    if !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.nlink() != 1
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump target is not a private user-owned regular file",
+        ));
+    }
+    // Truncate only after validating the opened descriptor, so a hard link
+    // cannot cause data loss in another file.
+    file.set_len(0)?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
 
-fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {
-    let mut file = private_dump_file(path)?;
+#[cfg(unix)]
+fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
+    let mut file = private_dump_file(directory, name)?;
     file.write_all(contents.as_bytes())?;
     Ok(())
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3708,8 +3708,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
         ));
     }
     // Exclusive creation means an existing hard link or symlink is never
-    // opened, and no previously existing file is truncated. The temporary
-    // file is atomically renamed into the deterministic final name below.
+    // opened, and no previously existing file is truncated.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
@@ -3722,47 +3721,26 @@ where
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
 
-    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    let (mut file, temp) = 'allocate: loop {
-        for _ in 0..16 {
-            let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
-            let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
-            let file = match private_dump_file(directory, &temp) {
-                Ok(file) => break 'allocate (file, temp),
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-                Err(error) => return Err(error),
+    let mut file = match private_dump_file(directory, name) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            // Replace only through the validated directory descriptor. This
+            // avoids truncating a hard link and leaves no crash-prone temp
+            // files behind.
+            let status = unsafe {
+                libc::unlinkat(directory.as_raw_fd(), final_name.as_ptr(), 0)
             };
+            if status != 0 {
+                return Err(error);
+            }
+            private_dump_file(directory, name)?
         }
-        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"));
+        Err(error) => return Err(error),
     };
-    let result = (|| {
-        write_contents(&mut file)?;
-        file.sync_all()?;
-        drop(file);
-        let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-        let status = unsafe {
-            libc::renameat(
-                directory.as_raw_fd(),
-                temp_name.as_ptr(),
-                directory.as_raw_fd(),
-                final_name.as_ptr(),
-            )
-        };
-        if status != 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(())
-    })();
-    if result.is_ok() {
-        return Ok(());
-    }
-    let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-    unsafe {
-        libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
-    }
-    result
+    write_contents(&mut file)?;
+    file.sync_all()
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4849,6 +4849,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_preserves_unowned_matching_files() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let unrelated_path = dump_path.join(".mirror-notes.tmp-99999999-backup");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        drop(directory);
+        fs::write(&unrelated_path, b"user data").unwrap();
+
+        let _directory = private_dump_directory(&dump_path).unwrap();
+
+        assert_eq!(fs::read(&unrelated_path).unwrap(), b"user data");
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_directory_rejects_symlink_components() {
         use std::os::unix::fs::symlink;
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3773,7 +3773,7 @@ impl Drop for DirectoryStream {
 #[cfg(unix)]
 fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
     use std::ffi::CString;
-    use std::os::fd::AsRawFd;
+    use std::os::fd::{AsRawFd, FromRawFd};
 
     let uid = unsafe { libc::geteuid() };
     let duplicate = unsafe { libc::dup(directory.as_raw_fd()) };
@@ -3818,15 +3818,23 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         {
             continue;
         }
-        let Ok(name) = name.to_str() else { continue };
-        let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
-        let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
-            continue;
+        let descriptor = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+            )
         };
-        let process_alive = unsafe { libc::kill(pid, 0) == 0 }
-            || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
-        if process_alive {
+        if descriptor < 0 {
             continue;
+        }
+        let candidate = unsafe { fs::File::from_raw_fd(descriptor) };
+        if unsafe { libc::flock(candidate.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::EWOULDBLOCK) {
+                continue;
+            }
+            return Err(error);
         }
         let name = CString::new(name_bytes).map_err(|_| io::ErrorKind::InvalidInput)?;
         let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
@@ -3952,6 +3960,9 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     // Exclusive creation means an existing hard link or symlink is never
     // opened, and no previously existing file is truncated.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
     Ok(file)
 }
 
@@ -4891,6 +4902,25 @@ mod tests {
         let _directory = private_dump_directory(&dump_path).unwrap();
 
         assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_directory_preserves_locked_temporary_dumps() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let name = ".mirror-1.txt.tmp-99999999-1";
+        let active = private_dump_file(&directory.temporary, name).unwrap();
+        let temp_path = dump_path.join(".cmux-dump-tmp").join(name);
+
+        let next_directory = private_dump_directory(&dump_path).unwrap();
+        assert!(temp_path.exists());
+        drop(active);
+        drop(next_directory);
+
+        let _directory = private_dump_directory(&dump_path).unwrap();
+        assert!(!temp_path.exists());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3628,12 +3628,24 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
     let file = options.open(path)?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let metadata = file.metadata()?;
+        // O_NOFOLLOW protects only the final path component. Verify the
+        // opened descriptor as well, so a stale or malicious dump entry
+        // cannot block on a FIFO or redirect output to a device. A link count
+        // above one indicates a hard link, which could otherwise truncate a
+        // different file when the dump is refreshed.
+        if !metadata.is_file() || metadata.nlink() != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("dump target is not a private regular file: {}", path.display()),
+            ));
+        }
         // `mode` only applies when the file is new. Set permissions through
         // the opened descriptor so existing files are also private without a
         // path-based symlink race.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3633,7 +3633,13 @@ impl Drop for RemoteSession {
 }
 
 #[cfg(unix)]
-fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+struct PrivateDumpDirectory {
+    output: fs::File,
+    temporary: fs::File,
+}
+
+#[cfg(unix)]
+fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::ffi::OsStrExt;
@@ -3691,7 +3697,45 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         directory = unsafe { fs::File::from_raw_fd(next) };
     }
     validate_dump_directory(&directory, true)?;
-    prune_stale_dump_temps(&directory)?;
+    let temporary = open_private_child_directory(&directory, ".cmux-dump-tmp")?;
+    prune_stale_dump_temps(&temporary)?;
+    Ok(PrivateDumpDirectory { output: directory, temporary })
+}
+
+#[cfg(unix)]
+fn open_private_child_directory(parent: &fs::File, name: &str) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name = CString::new(name).map_err(|_| io::ErrorKind::InvalidInput)?;
+    let mut descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::NotFound {
+            return Err(error);
+        }
+        if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        descriptor = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if descriptor < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    let directory = unsafe { fs::File::from_raw_fd(descriptor) };
+    validate_dump_directory(&directory, true)?;
     Ok(directory)
 }
 
@@ -3911,7 +3955,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
 }
 
 #[cfg(unix)]
-fn write_private_dump<F>(directory: &fs::File, name: &str, write_contents: F) -> io::Result<()>
+fn write_private_dump<F>(directory: &PrivateDumpDirectory, name: &str, write_contents: F) -> io::Result<()>
 where
     F: FnOnce(&mut fs::File) -> io::Result<()>,
 {
@@ -3926,7 +3970,7 @@ where
     for _ in 0..16 {
         let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
         let candidate = format!(".{name}.tmp-{}-{id}", unsafe { libc::getpid() });
-        match private_dump_file(directory, &candidate) {
+        match private_dump_file(&directory.temporary, &candidate) {
             Ok(candidate_file) => {
                 temp_name = Some(CString::new(candidate).expect("generated temp name is valid"));
                 file = Some(candidate_file);
@@ -3947,22 +3991,22 @@ where
     drop(file);
     if let Err(error) = result {
         unsafe {
-            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+            libc::unlinkat(directory.temporary.as_raw_fd(), temp_name.as_ptr(), 0);
         }
         return Err(error);
     }
     let status = unsafe {
         libc::renameat(
-            directory.as_raw_fd(),
+            directory.temporary.as_raw_fd(),
             temp_name.as_ptr(),
-            directory.as_raw_fd(),
+            directory.output.as_raw_fd(),
             final_name.as_ptr(),
         )
     };
     if status != 0 {
         let error = io::Error::last_os_error();
         unsafe {
-            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+            libc::unlinkat(directory.temporary.as_raw_fd(), temp_name.as_ptr(), 0);
         }
         return Err(error);
     }
@@ -4814,7 +4858,8 @@ mod tests {
         let path = root.path().join("dumps");
         let directory = private_dump_directory(&path).unwrap();
 
-        assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+        assert_eq!(directory.output.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+        assert_eq!(directory.temporary.metadata().unwrap().permissions().mode() & 0o777, 0o700);
     }
 
     #[cfg(unix)]
@@ -4837,9 +4882,9 @@ mod tests {
     fn private_dump_directory_prunes_stale_temporary_dumps() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
-        let stale_path = dump_path.join(".mirror-1.txt.tmp-99999999-1");
         let directory = private_dump_directory(&dump_path).unwrap();
         drop(directory);
+        let stale_path = dump_path.join(".cmux-dump-tmp/.mirror-1.txt.tmp-99999999-1");
         fs::write(&stale_path, b"partial secret").unwrap();
 
         let _directory = private_dump_directory(&dump_path).unwrap();
@@ -4913,7 +4958,9 @@ mod tests {
             fs::read_dir(&dump_path)
                 .unwrap()
                 .filter_map(Result::ok)
-                .all(|entry| entry.file_name() == "mirror.txt")
+                .all(|entry| {
+                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+                })
         );
     }
 
@@ -4946,7 +4993,7 @@ mod tests {
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
-        let error = private_dump_file(&directory, "mirror.txt").unwrap_err();
+        let error = private_dump_file(&directory.output, "mirror.txt").unwrap_err();
 
         assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
@@ -4972,7 +5019,9 @@ mod tests {
             fs::read_dir(&dump_path)
                 .unwrap()
                 .filter_map(Result::ok)
-                .all(|entry| entry.file_name() == "mirror.txt")
+                .all(|entry| {
+                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+                })
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3633,6 +3633,7 @@ impl Drop for RemoteSession {
 }
 
 #[cfg(unix)]
+#[derive(Debug)]
 struct PrivateDumpDirectory {
     output: fs::File,
     temporary: fs::File,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3636,7 +3636,13 @@ impl Drop for RemoteSession {
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    // Validate existing ancestors before create_dir_all follows them, then
+    // validate again after creation to catch newly created components. A
+    // writable non-sticky ancestor permits another user to replace the dump
+    // directory between path operations and redirect secret-bearing output.
+    validate_dump_ancestors(path)?;
 
     let existed = match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_dir() => true,
@@ -3650,10 +3656,7 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         Err(error) => return Err(error),
     };
     if !existed {
-        if let Some(parent) = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-        {
+        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
             fs::create_dir_all(parent)?;
         }
         let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
@@ -3667,6 +3670,7 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             }
         }
     }
+    validate_dump_ancestors(path)?;
     let directory = fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
@@ -3678,57 +3682,121 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
+    reject_extended_acl(&directory)?;
     if metadata.mode() & 0o077 != 0 {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             format!("dump directory is not private: {}", path.display()),
         ));
     }
-    reject_extended_acl(&directory)?;
     Ok(directory)
+}
+
+#[cfg(unix)]
+fn validate_dump_ancestors(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let mut ancestor = path.parent();
+    while let Some(candidate) = ancestor {
+        if candidate.as_os_str().is_empty() {
+            break;
+        }
+        match fs::symlink_metadata(candidate) {
+            Ok(metadata) => {
+                let resolved = if metadata.file_type().is_symlink() {
+                    if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            format!(
+                                "dump directory ancestor is not trusted: {}",
+                                candidate.display()
+                            ),
+                        ));
+                    }
+                    let resolved = fs::canonicalize(candidate)?;
+                    validate_dump_ancestors(&resolved)?;
+                    resolved
+                } else {
+                    candidate.to_path_buf()
+                };
+                let metadata = fs::symlink_metadata(&resolved)?;
+                if !metadata.is_dir() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "dump directory ancestor is not a directory: {}",
+                            candidate.display()
+                        ),
+                    ));
+                }
+                if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("dump directory ancestor is not trusted: {}", candidate.display()),
+                    ));
+                }
+                let mode = metadata.mode();
+                let sticky = mode & 0o1000 != 0;
+                if mode & 0o022 != 0 && !sticky {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!(
+                            "dump directory ancestor is writable without private protection: {}",
+                            candidate.display()
+                        ),
+                    ));
+                }
+                let directory = fs::OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+                    .open(&resolved)?;
+                reject_extended_acl(&directory)?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        let next = candidate.parent();
+        if next == Some(candidate) {
+            break;
+        }
+        ancestor = next;
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
 fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
-    use std::ptr;
 
-    // Any extended ACL can carry non-owner grants or inheritance. Reject the
-    // directory instead of trying to interpret ACE ordering and masks.
-    let descriptor = directory.as_raw_fd();
-    let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
-    if size < 0 {
+    // `acl_get_fd_np` reads the effective macOS ACL from the opened
+    // descriptor, including inherited ACEs that are not exposed by the mode
+    // bits. Reject any extended ACL instead of attempting to interpret ACE
+    // ordering, principals, and inheritance flags here.
+    unsafe extern "C" {
+        fn acl_get_fd_np(fd: libc::c_int, acl_type: libc::c_int) -> *mut libc::c_void;
+        fn acl_free(object: *mut libc::c_void) -> libc::c_int;
+    }
+
+    const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+    let acl = unsafe { acl_get_fd_np(directory.as_raw_fd(), ACL_TYPE_EXTENDED) };
+    if acl.is_null() {
         let error = io::Error::last_os_error();
-        if matches!(error.raw_os_error(), Some(libc::ENOTSUP) | Some(libc::ENOSYS)) {
+        if matches!(
+            error.raw_os_error(),
+            Some(libc::ENOENT)
+                | Some(libc::ENOATTR)
+                | Some(libc::ENOTSUP)
+                | Some(libc::EOPNOTSUPP)
+                | Some(libc::ENOSYS)
+        ) {
             return Ok(());
         }
         return Err(error);
     }
-    if size == 0 {
-        return Ok(());
+    unsafe {
+        acl_free(acl);
     }
-    let mut names = vec![0_u8; size as usize];
-    let size = unsafe {
-        libc::flistxattr(
-            descriptor,
-            names.as_mut_ptr().cast(),
-            names.len(),
-            0,
-        )
-    };
-    if size < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    if names[..size as usize]
-        .split(|byte| *byte == 0)
-        .any(|name| name == b"com.apple.acl.text")
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "dump directory has an extended ACL",
-        ));
-    }
-    Ok(())
+    Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -3762,9 +3830,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     }
     let file = unsafe { fs::File::from_raw_fd(descriptor) };
     let metadata = file.metadata()?;
-    if !metadata.is_file()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.nlink() != 1
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } || metadata.nlink() != 1
     {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
@@ -4703,8 +4769,9 @@ mod tests {
     #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
         fs::write(&final_path, b"previous").unwrap();
 
         let error = write_private_dump(&directory, "mirror.txt", |_file| {
@@ -4714,19 +4781,22 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
-        assert!(fs::read_dir(root.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .all(|entry| entry.file_name() == "mirror.txt"));
+        assert!(
+            fs::read_dir(&dump_path)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| entry.file_name() == "mirror.txt")
+        );
     }
 
     #[cfg(unix)]
     #[test]
     fn private_dump_replacement_does_not_modify_hard_linked_previous_dump() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
-        let linked_path = root.path().join("mirror-backup.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
+        let linked_path = dump_path.join("mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -4741,9 +4811,10 @@ mod tests {
     #[test]
     fn private_dump_file_rejects_existing_hard_link_without_truncation() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
-        let linked_path = root.path().join("mirror-backup.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
+        let linked_path = dump_path.join("mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -4758,21 +4829,23 @@ mod tests {
     #[test]
     fn private_dump_rename_failure_preserves_previous_directory_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
         fs::create_dir(&final_path).unwrap();
 
-        let error = write_private_dump(&directory, "mirror.txt", |file| {
-            file.write_all(b"replacement")
-        })
-        .unwrap_err();
+        let error =
+            write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"replacement"))
+                .unwrap_err();
 
         assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
         assert!(final_path.is_dir());
-        assert!(fs::read_dir(root.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .all(|entry| entry.file_name() == "mirror.txt"));
+        assert!(
+            fs::read_dir(&dump_path)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| entry.file_name() == "mirror.txt")
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4606,6 +4606,44 @@ mod tests {
         assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        fs::write(&final_path, b"previous").unwrap();
+
+        let error = write_private_dump(&directory, "mirror.txt", |_file| {
+            Err(io::Error::other("simulated dump failure"))
+        })
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(fs::read(&final_path).unwrap(), b"previous");
+        assert!(fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| entry.file_name() == "mirror.txt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_replacement_does_not_modify_hard_linked_previous_dump() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        let linked_path = root.path().join("mirror-backup.txt");
+        fs::write(&final_path, b"previous").unwrap();
+        fs::hard_link(&final_path, &linked_path).unwrap();
+
+        write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"replacement"))
+            .unwrap();
+
+        assert_eq!(fs::read(&final_path).unwrap(), b"replacement");
+        assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
     #[test]
     fn disabled_frame_logging_does_not_format_hot_path_messages() {
         struct FormattingProbe(Arc<AtomicBool>);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3603,12 +3603,30 @@ impl Drop for RemoteSession {
             // Secure descriptor-relative file creation is not available in
             // this implementation. Do not emit secret-bearing dumps through
             // path-based APIs on unsupported targets.
-            let _ = dir;
+            crate::client_log::error(
+                "mux-dump",
+                &format!(
+                    "CMUX_MUX_DEBUG_MIRROR_DUMP={} is unsupported on this platform; no dump was written",
+                    dir.display()
+                ),
+            );
             return;
         }
         #[cfg(unix)]
         {
-            let Ok(directory) = private_dump_directory(dir) else { return };
+            let directory = match private_dump_directory(dir) {
+                Ok(directory) => directory,
+                Err(error) => {
+                    crate::client_log::error(
+                        "mux-dump",
+                        &format!(
+                            "cannot use CMUX_MUX_DEBUG_MIRROR_DUMP={}: {error}; choose a directory owned by the current user with mode 0700",
+                            dir.display()
+                        ),
+                    );
+                    return;
+                }
+            };
             let logs = self.frame_logs.lock().unwrap();
             let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
             for entry in &logs.entries {
@@ -3617,16 +3635,26 @@ impl Drop for RemoteSession {
             for surface in self.surfaces.lock().unwrap().values() {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
                 let mirror = dump_mirror(surface);
-                let _ = write_private_dump(&directory, &mirror_name, |file| {
+                if let Err(error) = write_private_dump(&directory, &mirror_name, |file| {
                     file.write_all(mirror.as_bytes())
-                });
+                }) {
+                    crate::client_log::error(
+                        "mux-dump",
+                        &format!("cannot write private dump {mirror_name}: {error}"),
+                    );
+                }
                 let frames_name = format!("frames-{}.log", surface.id);
-                let _ = write_private_dump(&directory, &frames_name, |file| {
+                if let Err(error) = write_private_dump(&directory, &frames_name, |file| {
                     for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
                         writeln!(file, "{line}")?;
                     }
                     Ok(())
-                });
+                }) {
+                    crate::client_log::error(
+                        "mux-dump",
+                        &format!("cannot write private dump {frames_name}: {error}"),
+                    );
+                }
             }
         }
     }
@@ -3644,6 +3672,7 @@ fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::ffi::OsStrExt;
+    let path = normalize_dump_path(path)?;
     let start = if path.is_absolute() { "/" } else { "." };
     let start = CString::new(start).unwrap();
     let fd =
@@ -3701,6 +3730,42 @@ fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
     let temporary = open_private_child_directory(&directory, ".cmux-dump-tmp")?;
     prune_stale_dump_temps(&temporary)?;
     Ok(PrivateDumpDirectory { output: directory, temporary })
+}
+
+#[cfg(unix)]
+fn normalize_dump_path(path: &Path) -> io::Result<PathBuf> {
+    use std::path::Component;
+
+    if path.components().any(|component| matches!(component, Component::ParentDir)) {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "dump path must not contain '..'"));
+    }
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match fs::symlink_metadata(&existing) {
+            Ok(_) => break,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        let Some(name) = existing.file_name().map(ToOwned::to_owned) else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "dump path has no existing ancestor",
+            ));
+        };
+        missing.push(name);
+        if !existing.pop() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "dump path has no existing ancestor",
+            ));
+        }
+    }
+    let mut normalized = fs::canonicalize(existing)?;
+    for component in missing.into_iter().rev() {
+        normalized.push(component);
+    }
+    Ok(normalized)
 }
 
 #[cfg(unix)]
@@ -3852,13 +3917,22 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
 fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
 
-    // `acl_get_fd_np` reads the effective macOS ACL from the opened
-    // descriptor, including inherited ACEs that are not exposed by the mode
-    // bits. Reject any extended ACL instead of attempting to interpret ACE
-    // ordering, principals, and inheritance flags here.
     unsafe extern "C" {
         fn acl_get_fd_np(fd: libc::c_int, acl_type: libc::c_int) -> *mut libc::c_void;
+        fn acl_get_entry(
+            acl: *mut libc::c_void,
+            entry_id: libc::c_int,
+            entry: *mut *mut libc::c_void,
+        ) -> libc::c_int;
+        fn acl_get_tag_type(entry: *mut libc::c_void, tag: *mut libc::c_int) -> libc::c_int;
         fn acl_free(object: *mut libc::c_void) -> libc::c_int;
+    }
+
+    struct Acl(*mut libc::c_void);
+    impl Drop for Acl {
+        fn drop(&mut self) {
+            unsafe { acl_free(self.0) };
+        }
     }
 
     const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
@@ -3877,10 +3951,35 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
         }
         return Err(error);
     }
-    unsafe {
-        acl_free(acl);
+    let acl = Acl(acl);
+    let mut entry = std::ptr::null_mut();
+    let mut entry_id = 0;
+    loop {
+        let status = unsafe { acl_get_entry(acl.0, entry_id, &mut entry) };
+        if status == 0 {
+            return Ok(());
+        }
+        if status < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut tag = 0;
+        if unsafe { acl_get_tag_type(entry, &mut tag) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if !macos_dump_acl_tag_is_safe(tag) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "dump directory ACL grants access; remove allow entries or choose another directory",
+            ));
+        }
+        entry_id = 1;
     }
-    Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_dump_acl_tag_is_safe(tag: libc::c_int) -> bool {
+    const ACL_EXTENDED_DENY: libc::c_int = 2;
+    tag == ACL_EXTENDED_DENY
 }
 
 #[cfg(target_os = "linux")]
@@ -3967,7 +4066,11 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
 }
 
 #[cfg(unix)]
-fn write_private_dump<F>(directory: &PrivateDumpDirectory, name: &str, write_contents: F) -> io::Result<()>
+fn write_private_dump<F>(
+    directory: &PrivateDumpDirectory,
+    name: &str,
+    write_contents: F,
+) -> io::Result<()>
 where
     F: FnOnce(&mut fs::File) -> io::Result<()>,
 {
@@ -4996,14 +5099,9 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
-        assert!(
-            fs::read_dir(&dump_path)
-                .unwrap()
-                .filter_map(Result::ok)
-                .all(|entry| {
-                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
-                })
-        );
+        assert!(fs::read_dir(&dump_path).unwrap().filter_map(Result::ok).all(|entry| {
+            entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+        }));
     }
 
     #[cfg(unix)]
@@ -5057,14 +5155,9 @@ mod tests {
 
         assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
         assert!(final_path.is_dir());
-        assert!(
-            fs::read_dir(&dump_path)
-                .unwrap()
-                .filter_map(Result::ok)
-                .all(|entry| {
-                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
-                })
-        );
+        assert!(fs::read_dir(&dump_path).unwrap().filter_map(Result::ok).all(|entry| {
+            entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+        }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3616,13 +3616,17 @@ impl Drop for RemoteSession {
             }
             for surface in self.surfaces.lock().unwrap().values() {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
-                let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
+                let mirror = dump_mirror(surface);
+                let _ = write_private_dump(&directory, &mirror_name, |file| {
+                    file.write_all(mirror.as_bytes())
+                });
                 let frames_name = format!("frames-{}.log", surface.id);
-                let mut frames = String::new();
-                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                    let _ = writeln!(frames, "{line}");
-                }
-                let _ = write_private_dump(&directory, &frames_name, &frames);
+                let _ = write_private_dump(&directory, &frames_name, |file| {
+                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                        writeln!(file, "{line}")?;
+                    }
+                    Ok(())
+                });
             }
         }
     }
@@ -3632,6 +3636,17 @@ impl Drop for RemoteSession {
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
+    let existed = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => true,
+        Ok(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("dump path is not a directory: {}", path.display()),
+            ));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
     fs::create_dir_all(path)?;
     let directory = fs::OpenOptions::new()
         .read(true)
@@ -3644,7 +3659,16 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
-    directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    if existed {
+        if metadata.mode() & 0o077 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("dump directory is not private: {}", path.display()),
+            ));
+        }
+    } else {
+        directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    }
     Ok(directory)
 }
 
@@ -3684,56 +3708,61 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
         ));
     }
     // Exclusive creation means an existing hard link or symlink is never
-    // opened, and no previously existing file is truncated. A repeated dump
-    // is skipped when its deterministic name already exists.
+    // opened, and no previously existing file is truncated. The temporary
+    // file is atomically renamed into the deterministic final name below.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
 
 #[cfg(unix)]
-fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
+fn write_private_dump<F>(directory: &fs::File, name: &str, write_contents: F) -> io::Result<()>
+where
+    F: FnOnce(&mut fs::File) -> io::Result<()>,
+{
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    for _ in 0..16 {
-        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
-        let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
-        let mut file = match private_dump_file(directory, &temp) {
-            Ok(file) => file,
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error),
-        };
-        let result = (|| {
-            file.write_all(contents.as_bytes())?;
-            file.sync_all()?;
-            drop(file);
-            let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-            let status = unsafe {
-                libc::renameat(
-                    directory.as_raw_fd(),
-                    temp_name.as_ptr(),
-                    directory.as_raw_fd(),
-                    final_name.as_ptr(),
-                )
+    let (mut file, temp) = 'allocate: loop {
+        for _ in 0..16 {
+            let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+            let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
+            let file = match private_dump_file(directory, &temp) {
+                Ok(file) => break 'allocate (file, temp),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
             };
-            if status != 0 {
-                return Err(io::Error::last_os_error());
-            }
-            Ok(())
-        })();
-        if result.is_ok() {
-            return Ok(());
         }
+        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"));
+    };
+    let result = (|| {
+        write_contents(&mut file)?;
+        file.sync_all()?;
+        drop(file);
         let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-        unsafe {
-            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        let status = unsafe {
+            libc::renameat(
+                directory.as_raw_fd(),
+                temp_name.as_ptr(),
+                directory.as_raw_fd(),
+                final_name.as_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(io::Error::last_os_error());
         }
-        return result;
+        Ok(())
+    })();
+    if result.is_ok() {
+        return Ok(());
     }
-    Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"))
+    let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+    unsafe {
+        libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+    }
+    result
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3715,6 +3715,16 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
             continue;
         }
+        let Some(name) = name.to_str() else { continue };
+        let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
+        let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
+            continue;
+        };
+        let process_alive = unsafe { libc::kill(pid, 0) == 0 }
+            || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+        if process_alive {
+            continue;
+        }
         let name = CString::new(name_bytes)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
         let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
@@ -3835,7 +3845,43 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let size = unsafe { libc::flistxattr(directory.as_raw_fd(), std::ptr::null_mut(), 0) };
+    if size < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if size == 0 {
+        return Ok(());
+    }
+    let mut names = vec![0u8; size as usize];
+    let read =
+        unsafe { libc::flistxattr(directory.as_raw_fd(), names.as_mut_ptr().cast(), names.len()) };
+    if read < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    for name in names[..read as usize].split(|byte| *byte == 0) {
+        if name == b"system.posix_acl_access" || name == b"system.posix_acl_default" {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "dump directory has a POSIX ACL",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "linux")))]
+fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "cannot validate dump directory ACLs on this Unix target",
+    ))
+}
+
+#[cfg(not(unix))]
 fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
     Ok(())
 }
@@ -4806,7 +4852,7 @@ mod tests {
     fn private_dump_directory_prunes_stale_temporary_dumps() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
-        let stale_path = dump_path.join(".mirror-1.txt.tmp-123-1");
+        let stale_path = dump_path.join(".mirror-1.txt.tmp-99999999-1");
         let directory = private_dump_directory(&dump_path).unwrap();
         drop(directory);
         fs::write(&stale_path, b"partial secret").unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3760,7 +3760,7 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         {
             continue;
         }
-        let Some(name) = name.to_str().ok() else { continue };
+        let Some(name) = name.to_str() else { continue };
         let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
         let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
             continue;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4579,6 +4579,18 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_directory_is_private_when_created() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("dumps");
+        let directory = private_dump_directory(&path).unwrap();
+
+        assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+    }
+
     #[test]
     fn disabled_frame_logging_does_not_format_hot_path_messages() {
         struct FormattingProbe(Arc<AtomicBool>);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3684,7 +3684,54 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private: {}", path.display()),
         ));
     }
+    reject_extended_acl(&directory)?;
     Ok(directory)
+}
+
+#[cfg(target_os = "macos")]
+fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::ptr;
+
+    let descriptor = directory.as_raw_fd();
+    let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
+    if size < 0 {
+        let error = io::Error::last_os_error();
+        if matches!(error.raw_os_error(), Some(libc::ENOTSUP) | Some(libc::ENOSYS)) {
+            return Ok(());
+        }
+        return Err(error);
+    }
+    if size == 0 {
+        return Ok(());
+    }
+    let mut names = vec![0_u8; size as usize];
+    let size = unsafe {
+        libc::flistxattr(
+            descriptor,
+            names.as_mut_ptr().cast(),
+            names.len(),
+            0,
+        )
+    };
+    if size < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if names[..size as usize]
+        .split(|byte| *byte == 0)
+        .any(|name| name == b"com.apple.acl.text")
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump directory has an extended ACL",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -3738,24 +3785,53 @@ where
 
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    let mut file = match private_dump_file(directory, name) {
-        Ok(file) => file,
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            // Replace only through the validated directory descriptor. This
-            // avoids truncating a hard link and leaves no crash-prone temp
-            // files behind.
-            let status = unsafe {
-                libc::unlinkat(directory.as_raw_fd(), final_name.as_ptr(), 0)
-            };
-            if status != 0 {
-                return Err(error);
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(1);
+    let mut temp_name = None;
+    let mut file = None;
+    for _ in 0..16 {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let candidate = format!(".{name}.tmp-{}-{id}", unsafe { libc::getpid() });
+        match private_dump_file(directory, &candidate) {
+            Ok(candidate_file) => {
+                temp_name = Some(CString::new(candidate).expect("generated temp name is valid"));
+                file = Some(candidate_file);
+                break;
             }
-            private_dump_file(directory, name)?
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
         }
-        Err(error) => return Err(error),
+    }
+    let temp_name = temp_name.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a private dump temporary file",
+        )
+    })?;
+    let mut file = file.expect("temporary file is present when its name is present");
+    let result = write_contents(&mut file).and_then(|()| file.sync_all());
+    drop(file);
+    if let Err(error) = result {
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return Err(error);
+    }
+    let status = unsafe {
+        libc::renameat(
+            directory.as_raw_fd(),
+            temp_name.as_ptr(),
+            directory.as_raw_fd(),
+            final_name.as_ptr(),
+        )
     };
-    write_contents(&mut file)?;
-    file.sync_all()
+    if status != 0 {
+        let error = io::Error::last_os_error();
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return Err(error);
+    }
+    Ok(())
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4767,6 +4767,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_prunes_stale_temporary_dumps() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let stale_path = dump_path.join(".mirror-1.txt.tmp-123-1");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        drop(directory);
+        fs::write(&stale_path, b"partial secret").unwrap();
+
+        let _directory = private_dump_directory(&dump_path).unwrap();
+
+        assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3714,6 +3714,18 @@ fn validate_dump_directory(directory: &fs::File, private: bool) -> io::Result<()
 }
 
 #[cfg(unix)]
+struct DirectoryStream(*mut libc::DIR);
+
+#[cfg(unix)]
+impl Drop for DirectoryStream {
+    fn drop(&mut self) {
+        unsafe {
+            libc::closedir(self.0);
+        }
+    }
+}
+
+#[cfg(unix)]
 fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
@@ -3728,8 +3740,9 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         unsafe { libc::close(duplicate) };
         return Err(io::Error::last_os_error());
     }
+    let stream = DirectoryStream(stream);
     loop {
-        let entry = unsafe { libc::readdir(stream) };
+        let entry = unsafe { libc::readdir(stream.0) };
         if entry.is_null() {
             break;
         }
@@ -3778,9 +3791,6 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
                 return Err(error);
             }
         }
-    }
-    unsafe {
-        libc::closedir(stream);
     }
     Ok(())
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3663,6 +3663,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
             name.as_ptr(),
             libc::O_WRONLY
                 | libc::O_CREAT
+                | libc::O_EXCL
                 | libc::O_NOFOLLOW
                 | libc::O_NONBLOCK
                 | libc::O_CLOEXEC,
@@ -3683,9 +3684,9 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
             "dump target is not a private user-owned regular file",
         ));
     }
-    // Truncate only after validating the opened descriptor, so a hard link
-    // cannot cause data loss in another file.
-    file.set_len(0)?;
+    // Exclusive creation means an existing hard link or symlink is never
+    // opened, and no previously existing file is truncated. A repeated dump
+    // is skipped when its deterministic name already exists.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -19,7 +19,7 @@ use cmux_tui_core::{
     MuxEventReceiver, NotificationEvent, NotificationLevel, PairingChallenge, PointerSemanticProbe,
     PointerSnapshotProbe, REMOTE_SESSION_MESSAGE_MAX_BYTES, Rgb, SurfaceId, SurfaceKind,
     TerminalPointerSnapshot,
-    platform::transport,
+    platform::{restrict_directory, transport},
     server::{
         CLEAR_HISTORY_CAPABILITY, CLEAR_HISTORY_KEY_CAPABILITY, CREATION_RECEIPTS_CAPABILITY,
         CREATION_SELECTOR_FALLBACKS_CAPABILITY, GUARDED_BROWSER_POINTER_CAPABILITY,
@@ -3599,6 +3599,10 @@ impl Drop for RemoteSession {
             return;
         };
         let _ = fs::create_dir_all(dir);
+        // Frame mirrors contain terminal output and may include secrets. Keep
+        // the opt-in dump directory and files private even when the process
+        // runs with a permissive umask.
+        let _ = restrict_directory(dir);
         let logs = self.frame_logs.lock().unwrap();
         let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
         for entry in &logs.entries {
@@ -3606,9 +3610,9 @@ impl Drop for RemoteSession {
         }
         for surface in self.surfaces.lock().unwrap().values() {
             let path = dir.join(format!("mirror-{}.txt", surface.id));
-            let _ = fs::write(path, dump_mirror(surface));
+            let _ = write_private_dump(&path, &dump_mirror(surface));
             let frames = dir.join(format!("frames-{}.log", surface.id));
-            if let Ok(file) = fs::File::create(frames) {
+            if let Ok(file) = private_dump_file(&frames) {
                 let mut writer = io::BufWriter::new(file);
                 for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
                     let _ = writeln!(writer, "{line}");
@@ -3616,6 +3620,23 @@ impl Drop for RemoteSession {
             }
         }
     }
+}
+
+fn private_dump_file(path: &Path) -> io::Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(path)
+}
+
+fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {
+    let mut file = private_dump_file(path)?;
+    file.write_all(contents.as_bytes())?;
+    Ok(())
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3630,7 +3630,16 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
     }
-    options.open(path)
+    let file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // `mode` only applies when the file is new. Set permissions through
+        // the opened descriptor so existing files are also private without a
+        // path-based symlink race.
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(file)
 }
 
 fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4940,7 +4940,8 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn private_dump_directory_rejects_symlink_components() {
+    fn private_dump_directory_normalizes_symlink_components() {
+        use std::os::unix::fs::PermissionsExt;
         use std::os::unix::fs::symlink;
 
         let root = tempfile::tempdir().unwrap();
@@ -4949,8 +4950,18 @@ mod tests {
         let link = root.path().join("link");
         symlink(&target, &link).unwrap();
 
-        assert!(private_dump_directory(&link.join("dumps")).is_err());
-        assert!(!target.join("dumps").exists());
+        let directory = private_dump_directory(&link.join("dumps")).unwrap();
+
+        assert_eq!(directory.output.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+        assert!(target.join("dumps").is_dir());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_dump_acl_accepts_deny_and_rejects_allow_entries() {
+        assert!(macos_dump_acl_tag_is_safe(2));
+        assert!(!macos_dump_acl_tag_is_safe(1));
+        assert!(!macos_dump_acl_tag_is_safe(99));
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3618,12 +3618,11 @@ impl Drop for RemoteSession {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
                 let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
                 let frames_name = format!("frames-{}.log", surface.id);
-                if let Ok(file) = private_dump_file(&directory, &frames_name) {
-                    let mut writer = io::BufWriter::new(file);
-                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                        let _ = writeln!(writer, "{line}");
-                    }
+                let mut frames = String::new();
+                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                    let _ = writeln!(frames, "{line}");
                 }
+                let _ = write_private_dump(&directory, &frames_name, &frames);
             }
         }
     }
@@ -3693,9 +3692,48 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
 
 #[cfg(unix)]
 fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
-    let mut file = private_dump_file(directory, name)?;
-    file.write_all(contents.as_bytes())?;
-    Ok(())
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+    let final_name = CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+    for _ in 0..16 {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
+        let mut file = match private_dump_file(directory, &temp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        };
+        let result = (|| {
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()?;
+            drop(file);
+            let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+            let status = unsafe {
+                libc::renameat(
+                    directory.as_raw_fd(),
+                    temp_name.as_ptr(),
+                    directory.as_raw_fd(),
+                    final_name.as_ptr(),
+                )
+            };
+            if status != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        })();
+        if result.is_ok() {
+            return Ok(());
+        }
+        let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return result;
+    }
+    Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"))
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3634,6 +3634,8 @@ impl Drop for RemoteSession {
 
 #[cfg(unix)]
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
     let existed = match fs::symlink_metadata(path) {
@@ -3647,7 +3649,24 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         Err(error) if error.kind() == io::ErrorKind::NotFound => false,
         Err(error) => return Err(error),
     };
-    fs::create_dir_all(path)?;
+    if !existed {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent)?;
+        }
+        let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "invalid dump directory path")
+        })?;
+        let status = unsafe { libc::mkdir(path.as_ptr(), 0o700) };
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::AlreadyExists {
+                return Err(error);
+            }
+        }
+    }
     let directory = fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
@@ -3659,15 +3678,11 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
-    if existed {
-        if metadata.mode() & 0o077 != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("dump directory is not private: {}", path.display()),
-            ));
-        }
-    } else {
-        directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    if metadata.mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("dump directory is not private: {}", path.display()),
+        ));
     }
     Ok(directory)
 }


### PR DESCRIPTION
Create debug mirror directories with mode 0700 and files with mode 0600, using O_NOFOLLOW for the final file. This prevents umask-dependent disclosure and symlink redirection in the opt-in mirror path.

Verification: rustfmt check and git diff check. Cargo/Rust tests are deferred to hosted CI per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens opt-in `cmux-tui` debug mirror dumps. Previously, path-based, umask-dependent writes could expose or redirect dump contents; they now use private descriptor-relative files and atomic replacement. Existing targets are never followed or truncated, failed writes preserve the previous dump, and non-Unix builds skip dump emission.

- Creates and validates output and `.cmux-dump-tmp` directories with `0700`, trusted ownership, safe ancestors, and detectable macOS/Linux ACL checks.
- Writes `0600` user-owned regular temporary files, syncs them before replacement, and prunes only single-linked, unlocked stale temporaries.

<sup>Written for commit d899838bfc287d44b6e017f7a784882758bcb92f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11458?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Privacy & Security**
  * Improved protection for optional session diagnostic dumps.
  * Restricted dump directories and secured generated files against unauthorized access.
  * Added safeguards against symlink-based, hard-link, and other unsafe file-access scenarios.
  * Diagnostic dump files are now written atomically, with improved handling of temporary and failed writes.
  * Diagnostic dump generation is limited to Unix platforms; unsafe or invalid dump locations are rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->