### PR TITLE
cmux-tui: remove unused socket2 dependency

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -681,7 +681,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "snow",
- "socket2 0.5.10",
  "subtle",
  "tempfile",
  "tokio",
@@ -2065,7 +2064,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2313,7 +2312,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.5",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -3040,7 +3039,7 @@ dependencies = [
  "objc2-system-configuration",
  "pin-project-lite",
  "serde",
- "socket2 0.6.5",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -3100,7 +3099,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -3143,7 +3142,7 @@ checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3794,7 +3793,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "smallvec",
- "socket2 0.6.5",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -4749,16 +4748,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -5161,7 +5150,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -136,7 +136,6 @@ wait-timeout = "0.2"
 # declaring that MSRV. Keep the workspace's advertised Rust 1.91 support.
 rusqlite = { version = "=0.39.0", default-features = false, features = ["bundled", "hooks"] }
 sha2 = "0.10"
-socket2 = { version = "0.5", features = ["all"] }
 snow = "0.10"
 tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "handshake", "rustls-tls-native-roots"] }

--- a/cmux-tui/crates/cmux-remote/Cargo.toml
+++ b/cmux-tui/crates/cmux-remote/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [features]
 default = ["iroh-transport"]
-iroh-transport = ["dep:iroh", "dep:socket2"]
+iroh-transport = ["dep:iroh"]
 
 [dependencies]
 anyhow.workspace = true
@@ -37,7 +37,6 @@ libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-socket2 = { workspace = true, optional = true }
 snow.workspace = true
 subtle.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
Remove the unused optional socket2 dependency, feature wiring, and orphaned lockfile entry from cmux-remote. This reduces dependency resolution and package surface without changing runtime code.

Verification: hosted Rust checks, rustfmt and diff check. No local Cargo build was used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused optional `socket2` dependency from `cmux-remote`, along with its feature wiring and lockfile entry. Dependency resolution and package surface shrink without changing runtime behavior.

<sup>Written for commit d70d69924683ed024fca40088f92926067dfa45e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11459?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

