### PR TITLE
cmux-tui: reuse surface lookup in tree construction

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -323,44 +323,34 @@ pub fn tree_from_state_with_notifications(
             tabs: pane
                 .tabs
                 .iter()
-                .map(|sid| TabView {
-                    surface: *sid,
-                    public_id: state
-                        .surfaces
-                        .get(sid)
-                        .and_then(|surface| surface.resource_identity())
-                        .map(|identity| identity.tab_id.clone()),
-                    content_id: state
-                        .surfaces
-                        .get(sid)
-                        .and_then(|surface| surface.resource_identity())
-                        .map(|identity| identity.content_id.clone()),
-                    terminal_id: state
-                        .surfaces
-                        .get(sid)
-                        .and_then(|surface| surface.resource_identity())
-                        .and_then(|identity| match &identity.content_id {
+                .map(|sid| {
+                    let surface = state.surfaces.get(sid);
+                    let identity = surface.and_then(|surface| surface.resource_identity());
+                    TabView {
+                        surface: *sid,
+                        public_id: identity.map(|identity| identity.tab_id.clone()),
+                        content_id: identity.map(|identity| identity.content_id.clone()),
+                        terminal_id: identity.and_then(|identity| match &identity.content_id {
                             ContentPublicId::Terminal(id) => Some(id.clone()),
                             ContentPublicId::Browser(_) => None,
                         }),
-                    short_id: short_ids.get(sid).cloned().unwrap_or_default(),
-                    name: state.surfaces.get(sid).and_then(|s| s.name()),
-                    title: state.surfaces.get(sid).map(|s| s.title()).unwrap_or_default(),
-                    kind: state.surfaces.get(sid).map(|s| s.kind()).unwrap_or(SurfaceKind::Pty),
-                    browser_source: state.surfaces.get(sid).and_then(|s| s.browser_source()),
-                    browser_frames_stalled: state
-                        .surfaces
-                        .get(sid)
-                        .and_then(|s| s.browser_frames_stalled())
-                        .unwrap_or(false),
-                    supports_clear_history_key_fallback: state
-                        .surfaces
-                        .get(sid)
-                        .is_some_and(|surface| surface.supports_clear_history_key_fallback()),
-                    notification: notifications.get(sid).map(|notification| TabNotificationView {
-                        unread: notification.unread,
-                        level: notification.level.as_str(),
-                    }),
+                        short_id: short_ids.get(sid).cloned().unwrap_or_default(),
+                        name: surface.and_then(|surface| surface.name()),
+                        title: surface.map(|surface| surface.title()).unwrap_or_default(),
+                        kind: surface.map(|surface| surface.kind()).unwrap_or(SurfaceKind::Pty),
+                        browser_source: surface.and_then(|surface| surface.browser_source()),
+                        browser_frames_stalled: surface
+                            .and_then(|surface| surface.browser_frames_stalled())
+                            .unwrap_or(false),
+                        supports_clear_history_key_fallback: surface
+                            .is_some_and(|surface| surface.supports_clear_history_key_fallback()),
+                        notification: notifications.get(sid).map(|notification| {
+                            TabNotificationView {
+                                unread: notification.unread,
+                                level: notification.level.as_str(),
+                            }
+                        }),
+                    }
                 })
                 .collect(),
         })


### PR DESCRIPTION
Cache each tab surface reference and resource identity while building the tree. This removes repeated map probes and enum dispatch from the per-tab path while preserving ordering and notifications.

Verification: hosted Rust checks, rustfmt and diff check. No local Cargo build was used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches each tab’s surface and resource identity lookup while building session trees, avoiding repeated `state.surfaces` map probes and enum dispatch. Tab ordering and notification behavior remain unchanged.

<sup>Written for commit 72d91235a203f4e59756783930712226ab4b0dc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11460?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session tree processing to ensure tab information and notifications remain consistent.
  * Reduced redundant surface lookups, improving reliability when displaying session tabs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->