### PR TITLE
test: keep remote mirror close fixture headless

### DIFF
--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -252,28 +252,37 @@ import Testing
             restoreEnvironment(sshLogKey, previousValue: previousLog)
         }
 
-        let harness = try Harness()
-        defer { harness.tearDown() }
-        let host = RemoteTmuxHost(destination: "tab-close-\(UUID().uuidString)@example.test")
-        let connection = RemoteTmuxControlConnection(host: host, sessionName: "dev")
-        let controller = harness.controller
-        defer {
-            if controller.sessionMirror(host: host, sessionName: "dev") != nil {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            // This route is model-only: mounting the workspaces in a real window
+            // realizes Ghostty renderers that are unrelated to the close contract
+            // and can still be drawing while the fixture frees their surfaces.
+            let previousAppDelegate = AppDelegate.shared
+            let appDelegate = AppDelegate()
+            AppDelegate.shared = appDelegate
+            defer { AppDelegate.shared = previousAppDelegate }
+            let manager = TabManager()
+            let localWorkspace = try #require(manager.selectedWorkspace)
+            let host = RemoteTmuxHost(destination: "tab-close-\(UUID().uuidString)@example.test")
+            let connection = RemoteTmuxControlConnection(host: host, sessionName: "dev")
+            let controller = appDelegate.remoteTmuxController
+            defer {
+                // Always remove the cached connection, including when setup fails
+                // before the mirror workspace is registered.
                 controller.detach(host: host, sessionName: "dev")
             }
+            controller.cacheConnection(connection)
+            #expect(try controller.mirrorSession(host: host, sessionName: "dev", into: manager))
+            let mirrorWorkspace = try #require(manager.tabs.first(where: { $0.isRemoteTmuxMirror }))
+            #expect(manager.tabs.count == 2)
+
+            manager.closeWorkspace(mirrorWorkspace, recordHistory: false)
+
+            let log = try await waitForSSHArgument("exit", at: logURL)
+            #expect(!log.contains("kill-session"), Comment(rawValue: log))
+            #expect(manager.tabs.map(\.id) == [localWorkspace.id])
+            #expect(controller.sessionMirror(host: host, sessionName: "dev") == nil)
+            #expect(connection.exited)
         }
-        controller.cacheConnection(connection)
-        #expect(try controller.mirrorSession(host: host, sessionName: "dev", into: harness.manager))
-        let mirrorWorkspace = try #require(harness.manager.tabs.first(where: { $0.isRemoteTmuxMirror }))
-        #expect(harness.manager.tabs.count == 2)
-
-        harness.manager.closeWorkspace(mirrorWorkspace, recordHistory: false)
-
-        let log = try await waitForSSHArgument("exit", at: logURL)
-        #expect(!log.contains("kill-session"), Comment(rawValue: log))
-        #expect(harness.manager.tabs.map(\.id) == [harness.workspace.id])
-        #expect(controller.sessionMirror(host: host, sessionName: "dev") == nil)
-        #expect(connection.exited)
     }
 
     @Test func windowCreationFailureUsesLocalErrorMessage() {


### PR DESCRIPTION
## Summary

Keep ordinary remote-tmux mirror close coverage model-only. The old fixture created a real app window and Ghostty renderer, then freed it during close. Main CI shard 6 crashed with SIGSEGV in that path. The close contract does not need renderer ownership, so the test now uses a standalone TabManager.

## Testing

- `git diff --check`
- Tagged cloud compile reload is running
- Main CI crash: https://github.com/manaflow-ai/cmux/actions/runs/33514013015/job/99878373149

No production behavior changes. Focused fleet tests were blocked before test execution by host setup and SwiftPM permission errors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworks the remote-tmux mirror close test to run headless so it no longer crashes CI with a SIGSEGV. The old fixture created a real app window and Ghostty renderer, then freed it during close; the new fixture uses a standalone `TabManager` since the close contract doesn't require renderer ownership.

<sup>Written for commit 3916f191c8b9068291d4d33f0b9ad718ca24b587. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11462?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

