### PR TITLE
Fix tunnel OPEN cancellation on listener shutdown

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -47,7 +47,7 @@ use base64::engine::general_purpose::STANDARD as BASE64;
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{Notify, mpsc};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
@@ -705,6 +705,8 @@ mod tests {
 
     struct FakeDeps {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
+        entered: Option<Arc<Notify>>,
+        release: Option<Arc<Notify>>,
     }
 
     #[async_trait]
@@ -712,6 +714,8 @@ mod tests {
         async fn spawn_pty(&self, _spec: SpawnSpec) -> PtyHandle {
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
+            if let Some(entered) = &self.entered { entered.notify_one(); }
+            if let Some(release) = &self.release { release.notified().await; }
             PtyHandle { control: Arc::new(pty.clone()), output: Arc::new(pty), banner: None }
         }
         async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {
@@ -753,7 +757,7 @@ mod tests {
 
     async fn rig_with_limits(max_ptys: usize) -> Rig {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
-        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned) });
+        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned), entered: None, release: None });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
             ("HOME".to_owned(), std::env::temp_dir().to_string_lossy().into_owned()),
@@ -780,6 +784,17 @@ mod tests {
 
     async fn rig() -> Rig {
         rig_with_limits(8).await
+    }
+
+    async fn hanging_rig() -> (Rig, Arc<Notify>) {
+        let entered = Arc::new(Notify::new());
+        let release = Arc::new(Notify::new());
+        let spawned = Arc::new(StdMutex::new(Vec::new()));
+        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned), entered: Some(Arc::clone(&entered)), release: Some(release) });
+        let manager = Arc::new(PtyManager::with_limits(deps, std::env::temp_dir(), HashMap::new(), 8, 32, 1_048_576));
+        let cancel = CancellationToken::new();
+        let port = start_tunnel_terminal_listener(Arc::clone(&manager), cancel.clone(), TUNNEL_TERMINAL_HOST, 0).await.unwrap();
+        (Rig { manager, spawned, port, cancel }, entered)
     }
 
     async fn connect(rig: &Rig) -> TcpStream {
@@ -1009,13 +1024,14 @@ mod tests {
 
     #[tokio::test]
     async fn listener_cancellation_cancels_pending_open_without_attachment() {
-        let rig = rig().await;
+        let (rig, entered) = hanging_rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
             .write_all(&encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })))
             .await
             .unwrap();
+        entered.notified().await;
         rig.cancel.cancel();
         read_eof(&mut read).await;
         assert!(rig.spawned.lock().unwrap().is_empty(), "cancelled open must not reserve a PTY");

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -387,6 +387,7 @@ impl Connection {
 async fn handle_client_frame(
     connection: &Arc<Connection>,
     context: &FrameContext,
+    parent: &CancellationToken,
     frame: TunnelFrame,
 ) {
     if connection.finished.load(Ordering::SeqCst) {
@@ -427,7 +428,24 @@ async fn handle_client_frame(
             if let Some(surface) = surface {
                 open["surface"] = Value::from(surface);
             }
-            connection.manager.handle_frame(&open, context).await;
+            // OPEN may wait on a session or PTY reservation. Keep that exact
+            // task cancellable so listener shutdown cannot strand it.
+            let manager = Arc::clone(&connection.manager);
+            let context = context.clone();
+            let open_task = tokio::spawn(async move { manager.handle_frame(&open, &context).await });
+            tokio::select! {
+                biased;
+                _ = parent.cancelled() => {
+                    open_task.abort();
+                    let _ = open_task.await;
+                    connection.finish();
+                }
+                _ = connection.done.cancelled() => {
+                    open_task.abort();
+                    let _ = open_task.await;
+                }
+                _ = open_task => {}
+            }
         }
         ClientFrame::Resize { cols, rows } => {
             if !connection.open_sent.load(Ordering::SeqCst) {
@@ -548,7 +566,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                 match decoder.push(&buffer[..count]) {
                     Ok(frames) => {
                         for frame in frames {
-                            handle_client_frame(&connection, &context, frame).await;
+                            handle_client_frame(&connection, &context, &parent, frame).await;
                         }
                     }
                     Err(_) => {
@@ -987,6 +1005,20 @@ mod tests {
         assert_eq!(reopened["t"], "opened");
         assert_eq!(reopened["created"], false);
         rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn listener_cancellation_cancels_pending_open_without_attachment() {
+        let rig = rig().await;
+        let stream = connect(&rig).await;
+        let (mut read, mut write) = stream.into_split();
+        write
+            .write_all(&encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })))
+            .await
+            .unwrap();
+        rig.cancel.cancel();
+        read_eof(&mut read).await;
+        assert!(rig.spawned.lock().unwrap().is_empty(), "cancelled open must not reserve a PTY");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1025,6 +1025,7 @@ mod tests {
     #[tokio::test]
     async fn listener_cancellation_cancels_pending_open_without_attachment() {
         let (rig, entered) = hanging_rig().await;
+        let baseline_attachments = rig.manager.attachment_count();
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1034,7 +1035,7 @@ mod tests {
         entered.notified().await;
         rig.cancel.cancel();
         read_eof(&mut read).await;
-        assert!(rig.spawned.lock().unwrap().is_empty(), "cancelled open must not reserve a PTY");
+        assert_eq!(rig.manager.attachment_count(), baseline_attachments, "cancelled open must clean up its attachment");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Cancels and joins the exact in-flight OPEN task when the listener or connection cancellation fires. This prevents stranded reservations and attachments during listener shutdown.

Validation: cargo fmt --check and git diff --check only, per request; no local Rust builds/tests.

Tokio references: https://docs.rs/tokio/latest/tokio/task/struct.JoinHandle.html and https://docs.rs/tokio/latest/tokio/task/fn.spawn.html

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11464"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790865814&installation_model_id=21920&pr_number=11464&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11464&signature=92159efe99ef392ce7c4b1900028ba50657bc9571334494893f141070a6144e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cancels and joins the exact in-flight OPEN task when the listener or connection cancellation fires, so listener shutdown no longer strands session or PTY reservations.

- OPEN now runs in its own spawned task that is aborted and joined on both cancellation paths.
- Adds a test that blocks a PTY spawn and asserts a cancelled OPEN leaves the attachment count unchanged.

<sup>Written for commit c73e038e5d2f4a2e1c315e598f8c3f39211725a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11464?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tunnel shutdown behavior by cancelling pending terminal-opening operations when the listener or connection closes.
  * Prevented terminal resources from being reserved after cancellation.
  * Ensured pending terminal sessions close cleanly during shutdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->