### PR TITLE
Make TextInput rendering side-effect free

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13174,6 +13174,7 @@ impl App {
                 crate::ui::draw(self, frame);
             })
         })??;
+        self.sync_text_input_viewports();
         if self.graphics_host_scene_reset_pending {
             if let Some(writer) = &self.graphics_writer {
                 writer.invalidate_host_scene();
@@ -13202,6 +13203,48 @@ impl App {
             self.host_mouse_capture_applied = Some(desired_mouse_capture);
         }
         Ok(())
+    }
+
+    /// Persist the viewport derived by the immutable text-input renderers
+    /// after a successful frame, so the next input event starts from the
+    /// window the user actually saw.
+    fn sync_text_input_viewports(&mut self) {
+        if let Some(prompt) = self.prompt.as_mut() {
+            let width = prompt.input_rect.width as usize;
+            prompt.input.sync_viewport(width);
+        }
+
+        let omnibar_width = self.omnibar.as_ref().and_then(|state| {
+            self.pane_areas
+                .iter()
+                .find(|area| area.pane == state.pane && area.surface == state.surface)
+                .and_then(|area| area.omnibar)
+                .map(|rect| rect.width as usize)
+        });
+        if let Some(state) = self.omnibar.as_mut() {
+            state.input.sync_viewport(omnibar_width.unwrap_or_default());
+        }
+
+        let menu_search_width = self.menu.as_ref().and_then(|menu| {
+            let search = menu.search.as_ref()?;
+            let level = menu.levels.first()?;
+            let title_width = level.rect.width.saturating_sub(4) as usize;
+            let prefix = format!(" {} · ", search.label);
+            let prefix_width = prefix.width().min(title_width);
+            Some(title_width.saturating_sub(prefix_width).saturating_sub(1))
+        });
+        if let Some(menu) = self.menu.as_mut()
+            && let Some(search) = menu.search.as_mut()
+        {
+            search.input.sync_viewport(menu_search_width.unwrap_or_default());
+        }
+
+        if self.sidebar_files.filter_mode() {
+            let width = self
+                .workspace_sidebar_area(self.outer_size.1)
+                .map_or(0, |area| area.width.saturating_sub(2) as usize);
+            self.sidebar_files.sync_filter_viewport(width);
+        }
     }
 
     /// Full-TUI clients always capture host mouse input. A scoped attach

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13229,8 +13229,14 @@ impl App {
             let search = menu.search.as_ref()?;
             let level = menu.levels.first()?;
             let title_width = level.rect.width.saturating_sub(4) as usize;
-            let prefix = format!(" {} · ", search.label);
-            let prefix_width = prefix.width().min(title_width);
+            // The literal spaces around the label keep the three segments
+            // separate, so their display widths add without constructing a
+            // temporary prefix string on every frame.
+            let prefix_width = " "
+                .width()
+                .saturating_add(search.label.width())
+                .saturating_add(" · ".width())
+                .min(title_width);
             Some(title_width.saturating_sub(prefix_width).saturating_sub(1))
         });
         if let Some(menu) = self.menu.as_mut()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24926,6 +24926,29 @@ mod tests {
     }
 
     #[test]
+    fn prompt_render_persists_text_input_viewport_before_left_movement() {
+        let mux = Mux::new("text-input-viewport-lifecycle-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.prompt = Some(Prompt::new(
+            "Rename",
+            "abcdefghijklmnopqrstuvwxyz0123456789".to_string(),
+            PromptTarget::Workspace(1),
+        ));
+        let mut terminal = Terminal::new(TestBackend::new(24, 12)).unwrap();
+
+        app.draw_terminal(&mut terminal, RenderAction::Draw).unwrap();
+
+        let before = app.prompt.as_ref().unwrap().input.visible_text_and_cursor(18);
+        assert!(before.1 > 0);
+        app.handle_prompt_key(KeyEvent::new(KeyCode::Left, KeyModifiers::NONE)).unwrap();
+        let after = app.prompt.as_ref().unwrap().input.visible_text_and_cursor(18);
+
+        assert_eq!(after.0, before.0);
+        assert_eq!(after.1, before.1 - 1);
+        mux.shutdown();
+    }
+
+    #[test]
     fn enhanced_control_text_uses_prompt_and_omnibar_shortcuts() {
         let mux = Mux::new("enhanced-overlay-shortcut-test", SurfaceOptions::default());
         let mut app = test_app(Session::Local(mux));

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -195,8 +195,14 @@ impl FileBrowser {
         changed
     }
 
-    pub fn visible_filter_text_and_cursor(&mut self, width: usize) -> (String, usize) {
+    pub fn visible_filter_text_and_cursor(&self, width: usize) -> (String, usize) {
         self.query.visible_text_and_cursor(width)
+    }
+
+    pub fn sync_filter_viewport(&mut self, width: usize) {
+        if self.filter_mode {
+            self.query.sync_viewport(width);
+        }
     }
 
     pub fn set_filter_cursor_from_visible_column(&mut self, column: usize, width: usize) {

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -76,7 +76,11 @@ impl TextInput {
                 InputEvent::None
             }
             KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) => {
-                if self.delete_word_left() { InputEvent::Changed } else { InputEvent::None }
+                if self.delete_word_left() {
+                    InputEvent::Changed
+                } else {
+                    InputEvent::None
+                }
             }
             KeyCode::Backspace => {
                 if self.delete_left() {
@@ -115,15 +119,26 @@ impl TextInput {
         if cursor < scroll {
             scroll = cursor;
         }
-        while self.display_width(scroll, cursor) >= width {
-            let next = self.next_boundary(scroll);
-            if next <= scroll || next > cursor {
-                scroll = cursor;
-                break;
-            }
-            scroll = next;
+        // Measure the cursor suffix once, then discard leading graphemes until it fits.
+        // Recomputing widths from `scroll` on every iteration makes long inputs quadratic.
+        let mut suffix_width = 0;
+        for grapheme in self.buffer[scroll..cursor].graphemes(true) {
+            suffix_width += UnicodeWidthStr::width(grapheme);
         }
-        let cursor_col = self.display_width(scroll, cursor);
+        if suffix_width >= width {
+            for (offset, grapheme) in self.buffer[scroll..cursor].grapheme_indices(true) {
+                let next = scroll + offset + grapheme.len();
+                if next > cursor {
+                    break;
+                }
+                suffix_width = suffix_width.saturating_sub(UnicodeWidthStr::width(grapheme));
+                scroll = next;
+                if suffix_width < width {
+                    break;
+                }
+            }
+        }
+        let cursor_col = suffix_width;
         let mut used = 0;
         let mut end = scroll;
         for (offset, grapheme) in self.buffer[scroll..].grapheme_indices(true) {

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -76,11 +76,7 @@ impl TextInput {
                 InputEvent::None
             }
             KeyCode::Backspace if key.modifiers.contains(KeyModifiers::ALT) => {
-                if self.delete_word_left() {
-                    InputEvent::Changed
-                } else {
-                    InputEvent::None
-                }
+                if self.delete_word_left() { InputEvent::Changed } else { InputEvent::None }
             }
             KeyCode::Backspace => {
                 if self.delete_left() {
@@ -112,33 +108,7 @@ impl TextInput {
         if width == 0 {
             return (String::new(), 0);
         }
-        // Rendering must not mutate cursor state. Derive the effective viewport locally;
-        // input events still persist the viewport through `ensure_cursor_visible`.
-        let cursor = self.grapheme_boundary_at_or_after(self.cursor.min(self.buffer.len()));
-        let mut scroll = self.grapheme_boundary_at_or_after(self.scroll.min(cursor));
-        if cursor < scroll {
-            scroll = cursor;
-        }
-        // Measure the cursor suffix once, then discard leading graphemes until it fits.
-        // Recomputing widths from `scroll` on every iteration makes long inputs quadratic.
-        let mut suffix_width = 0;
-        for grapheme in self.buffer[scroll..cursor].graphemes(true) {
-            suffix_width += UnicodeWidthStr::width(grapheme);
-        }
-        if suffix_width >= width {
-            for (offset, grapheme) in self.buffer[scroll..cursor].grapheme_indices(true) {
-                let next = scroll + offset + grapheme.len();
-                if next > cursor {
-                    break;
-                }
-                suffix_width = suffix_width.saturating_sub(UnicodeWidthStr::width(grapheme));
-                scroll = next;
-                if suffix_width < width {
-                    break;
-                }
-            }
-        }
-        let cursor_col = suffix_width;
+        let (scroll, _, cursor_col) = self.viewport_for_width(width);
         let mut used = 0;
         let mut end = scroll;
         for (offset, grapheme) in self.buffer[scroll..].grapheme_indices(true) {
@@ -150,6 +120,16 @@ impl TextInput {
             end = scroll + offset + grapheme.len();
         }
         (self.buffer[scroll..end].to_string(), cursor_col.min(width - 1))
+    }
+
+    /// Reconcile the persistent horizontal viewport at a layout or input boundary.
+    pub(crate) fn sync_viewport(&mut self, width: usize) {
+        if width == 0 {
+            return;
+        }
+        let (scroll, cursor, _) = self.viewport_for_width(width);
+        self.scroll = scroll;
+        self.cursor = cursor;
     }
 
     pub fn set_cursor_from_visible_column(&mut self, column: usize, width: usize) {
@@ -351,19 +331,7 @@ impl TextInput {
         if width == 0 {
             return;
         }
-        self.cursor = self.grapheme_boundary_at_or_after(self.cursor.min(self.buffer.len()));
-        self.scroll = self.grapheme_boundary_at_or_after(self.scroll.min(self.cursor));
-        if self.cursor < self.scroll {
-            self.scroll = self.cursor;
-        }
-        while self.display_width(self.scroll, self.cursor) >= width {
-            let next = self.next_boundary(self.scroll);
-            if next <= self.scroll || next > self.cursor {
-                self.scroll = self.cursor;
-                break;
-            }
-            self.scroll = next;
-        }
+        self.sync_viewport(width);
     }
 
     fn grapheme_boundary_at_or_after(&self, byte: usize) -> usize {
@@ -374,8 +342,35 @@ impl TextInput {
             .unwrap_or(self.buffer.len())
     }
 
-    fn display_width(&self, start: usize, end: usize) -> usize {
-        UnicodeWidthStr::width(&self.buffer[start..end])
+    fn viewport_for_width(&self, width: usize) -> (usize, usize, usize) {
+        debug_assert!(width > 0);
+        let cursor = self.grapheme_boundary_at_or_after(self.cursor.min(self.buffer.len()));
+        let mut scroll = self.grapheme_boundary_at_or_after(self.scroll.min(cursor));
+        if cursor < scroll {
+            scroll = cursor;
+        }
+
+        // Measure the cursor suffix once, then discard leading graphemes until it fits.
+        // Recomputing widths from `scroll` on every iteration makes long inputs quadratic.
+        let mut cursor_col = 0;
+        for grapheme in self.buffer[scroll..cursor].graphemes(true) {
+            cursor_col += UnicodeWidthStr::width(grapheme);
+        }
+        if cursor_col >= width {
+            let viewport_start = scroll;
+            for (offset, grapheme) in self.buffer[viewport_start..cursor].grapheme_indices(true) {
+                let next = viewport_start + offset + grapheme.len();
+                if next > cursor {
+                    break;
+                }
+                cursor_col = cursor_col.saturating_sub(UnicodeWidthStr::width(grapheme));
+                scroll = next;
+                if cursor_col < width {
+                    break;
+                }
+            }
+        }
+        (scroll, cursor, cursor_col)
     }
 
     fn is_word_grapheme(grapheme: &str) -> bool {

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -104,23 +104,37 @@ impl TextInput {
         }
     }
 
-    pub fn visible_text_and_cursor(&mut self, width: usize) -> (String, usize) {
+    pub fn visible_text_and_cursor(&self, width: usize) -> (String, usize) {
         if width == 0 {
             return (String::new(), 0);
         }
-        self.ensure_cursor_visible(width);
-        let cursor_col = self.display_width(self.scroll, self.cursor);
+        // Rendering must not mutate cursor state. Derive the effective viewport locally;
+        // input events still persist the viewport through `ensure_cursor_visible`.
+        let cursor = self.grapheme_boundary_at_or_after(self.cursor.min(self.buffer.len()));
+        let mut scroll = self.grapheme_boundary_at_or_after(self.scroll.min(cursor));
+        if cursor < scroll {
+            scroll = cursor;
+        }
+        while self.display_width(scroll, cursor) >= width {
+            let next = self.next_boundary(scroll);
+            if next <= scroll || next > cursor {
+                scroll = cursor;
+                break;
+            }
+            scroll = next;
+        }
+        let cursor_col = self.display_width(scroll, cursor);
         let mut used = 0;
-        let mut end = self.scroll;
-        for (offset, grapheme) in self.buffer[self.scroll..].grapheme_indices(true) {
+        let mut end = scroll;
+        for (offset, grapheme) in self.buffer[scroll..].grapheme_indices(true) {
             let grapheme_width = UnicodeWidthStr::width(grapheme);
             if used + grapheme_width > width {
                 break;
             }
             used += grapheme_width;
-            end = self.scroll + offset + grapheme.len();
+            end = scroll + offset + grapheme.len();
         }
-        (self.buffer[self.scroll..end].to_string(), cursor_col.min(width - 1))
+        (self.buffer[scroll..end].to_string(), cursor_col.min(width - 1))
     }
 
     pub fn set_cursor_from_visible_column(&mut self, column: usize, width: usize) {

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -559,4 +559,14 @@ mod tests {
         assert_eq!(shown, "abc");
         assert_eq!(cursor, 0);
     }
+
+    #[test]
+    fn viewport_scan_keeps_wide_graphemes_in_order() {
+        let input = text_input("界界界界");
+
+        let (shown, cursor) = input.visible_text_and_cursor(4);
+
+        assert_eq!(shown, "界");
+        assert_eq!(cursor, 2);
+    }
 }


### PR DESCRIPTION
Change visible_text_and_cursor to borrow immutably and derive the effective scroll window locally. This removes render-time mutation while preserving viewport and cursor calculations. No builds/tests run per task instructions; rustfmt and git diff --check passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11465"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790865832&installation_model_id=21920&pr_number=11465&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11465&signature=3f32b993c2cf1939cd7a04dee0e6046253f544f663e23c7886fb0b69f16a4bcc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes `TextInput` rendering side-effect free by deriving the scroll window instead of mutating state. The viewport is synced back after each frame and on input events for the prompt, omnibar, menu search, and sidebar file filter, so the next render starts from the window the user saw.

- Viewport measurement is linear-time instead of quadratic for long inputs.
- Adds tests covering viewport persistence and wide-grapheme ordering.
- Corrects the menu search viewport width to account for the label and separator.

<sup>Written for commit 9ee520bf2d46a8e12f5338d1abd4c83650200f23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11465?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input rendering when the cursor moves or content exceeds the available width.
  * Preserved the visible text position after each screen update, keeping cursor movement within the viewport users just saw.
  * Improved handling of wide characters and graphemes so they remain displayed in the correct order.
  * Reduced unnecessary recalculation when determining the visible portion of entered text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->