### PR TITLE
fix: cancel raw attach control requests

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -294,6 +294,11 @@ mod unix {
             receiver
         }
 
+        #[cfg(test)]
+        pub(crate) fn pending_len(&self) -> usize {
+            self.shared.pending.lock().expect("control pending lock").len()
+        }
+
         fn encode_line(id: u64, cmd: &str, params: Value) -> Vec<u8> {
             let mut frame = match params {
                 Value::Object(map) => map,
@@ -486,6 +491,58 @@ mod tests {
             .await
             .expect("second waiter wakes")
             .expect("second waiter joins");
+    }
+
+    #[tokio::test]
+    async fn dropped_request_retires_pending_entry() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-cancel-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control cancel test socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (request_seen_tx, request_seen_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept control cancel test socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            let (read_half, write_half) = stream.into_split();
+            let mut reader = tokio::io::BufReader::new(read_half);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.expect("read in-flight control request");
+            let request: Value =
+                serde_json::from_str(line.trim_end()).expect("decode in-flight control request");
+            assert_eq!(request.get("cmd").and_then(Value::as_str), Some("attach-surface"));
+            request_seen_tx.send(()).expect("tell client request is in flight");
+            release_rx.await.expect("release control cancel test socket");
+            drop(write_half);
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect control cancel test socket");
+        accepted_rx.await.expect("wait for control cancel test server");
+        let request_control = Arc::clone(&control);
+        let request = tokio::spawn(async move {
+            request_control.request("attach-surface", json!({ "surface": 7 })).await
+        });
+        request_seen_rx.await.expect("wait for in-flight control request");
+        assert_eq!(control.pending_len(), 1, "request must register before it is canceled");
+
+        request.abort();
+        let join = tokio::time::timeout(Duration::from_secs(1), request)
+            .await
+            .expect("canceled request task must finish promptly")
+            .expect_err("aborting the request task must report cancellation");
+        assert!(join.is_cancelled());
+        assert_eq!(control.pending_len(), 0, "dropping the request must retire its map entry");
+
+        release_tx.send(()).expect("release control cancel test socket");
+        control.end();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("join control cancel test server")
+            .expect("control cancel test server must not panic");
+        let _ = std::fs::remove_file(socket_path);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -95,6 +95,20 @@ mod unix {
         }
     }
 
+    // `ControlHandle::request` futures can be dropped by `tokio::select!`
+    // while they wait for a write acknowledgement or response. Retire the
+    // registration from `Drop`, rather than relying on a timeout or `end()`.
+    struct PendingRequestGuard {
+        shared: Arc<Shared>,
+        id: u64,
+    }
+
+    impl Drop for PendingRequestGuard {
+        fn drop(&mut self) {
+            self.shared.pending.lock().expect("control pending lock").remove(&self.id);
+        }
+    }
+
     pub struct UnixControl {
         shared: Arc<Shared>,
         writer_tx: Sender<OutboundLine>,
@@ -344,22 +358,20 @@ mod unix {
                     }
                     pending.insert(id, sender);
                 }
+                let _pending_guard = PendingRequestGuard { shared: Arc::clone(&self.shared), id };
                 let deadline = tokio::time::Instant::now() + Duration::from_millis(self.timeout_ms);
                 let (written, write_result) = oneshot::channel();
                 if !self.enqueue_line(id, &cmd, params, Some(written)) {
-                    self.shared.pending.lock().expect("control pending lock").remove(&id);
                     return None;
                 }
                 let write_ok =
                     matches!(tokio::time::timeout_at(deadline, write_result).await, Ok(Ok(true)));
                 if !write_ok {
-                    self.shared.pending.lock().expect("control pending lock").remove(&id);
                     return None;
                 }
                 if let Ok(Ok(value)) = tokio::time::timeout_at(deadline, receiver).await {
                     Some(value)
                 } else {
-                    self.shared.pending.lock().expect("control pending lock").remove(&id);
                     None
                 }
             })

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2038,7 +2038,6 @@ mod tests {
 
     struct NeverResolvingControl {
         requests: AtomicUsize,
-        started: Notify,
     }
 
     impl ControlHandle for NeverResolvingControl {
@@ -2048,7 +2047,6 @@ mod tests {
             _params: Value,
         ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
             self.requests.fetch_add(1, AtomicOrdering::SeqCst);
-            self.started.notify_one();
             Box::pin(std::future::pending())
         }
         fn send(&self, _cmd: &str, _params: Value) {}
@@ -2061,35 +2059,22 @@ mod tests {
 
     #[tokio::test]
     async fn raw_attach_request_observes_cancellation() {
-        let control = TestArc::new(NeverResolvingControl {
-            requests: AtomicUsize::new(0),
-            started: Notify::new(),
-        });
+        let control = TestArc::new(NeverResolvingControl { requests: AtomicUsize::new(0) });
         let cancellation = CancellationToken::new();
-        let request_control = TestArc::clone(&control);
-        let request_cancellation = cancellation.clone();
-        let task = tokio::spawn(async move {
-            control_request_until_cancelled(
-                request_control.as_ref(),
-                "attach-surface",
-                json!({ "surface": 7 }),
-                &request_cancellation,
-            )
-            .await
-        });
-        control.started.notified().await;
         cancellation.cancel();
-        let result = tokio::time::timeout(std::time::Duration::from_secs(1), task)
-            .await
-            .expect("cancellation must resolve promptly")
-            .expect("request task must not panic");
+        let result = control_request_until_cancelled(
+            control.as_ref(),
+            "attach-surface",
+            json!({ "surface": 7 }),
+            &cancellation,
+        )
+        .await;
         assert!(matches!(result, ControlRequestOutcome::Cancelled));
-        assert_eq!(control.requests.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(control.requests.load(AtomicOrdering::SeqCst), 0);
     }
 
     struct ConcurrentAttachControl {
         attach_requests: AtomicUsize,
-        attach_started: Notify,
         detach_requests: AtomicUsize,
         ends: AtomicUsize,
     }
@@ -2108,13 +2093,8 @@ mod tests {
                     }))
                 }),
                 "attach-surface" => {
-                    let request = self.attach_requests.fetch_add(1, AtomicOrdering::SeqCst);
-                    self.attach_started.notify_waiters();
-                    if request == 0 {
-                        Box::pin(std::future::pending())
-                    } else {
-                        Box::pin(async { Some(json!({ "ok": true })) })
-                    }
+                    self.attach_requests.fetch_add(1, AtomicOrdering::SeqCst);
+                    Box::pin(async { Some(json!({ "ok": true })) })
                 }
                 _ => Box::pin(async { Some(json!({ "ok": true })) }),
             }
@@ -2138,7 +2118,6 @@ mod tests {
     async fn canceled_attachment_does_not_end_control_for_concurrent_attachment() {
         let control = TestArc::new(ConcurrentAttachControl {
             attach_requests: AtomicUsize::new(0),
-            attach_started: Notify::new(),
             detach_requests: AtomicUsize::new(0),
             ends: AtomicUsize::new(0),
         });
@@ -2161,14 +2140,11 @@ mod tests {
             "allowedRoots": Value::Null,
         });
         let first_context = h.context("supervised", h.owner.clone());
-        let first_cancellation = first_context.cancellation.clone();
-        let first_started = control.attach_started.notified();
+        first_context.cancellation.cancel();
         let first_task = tokio::spawn({
             let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
             async move { manager.handle_frame(&first_frame, &first_context).await }
         });
-        first_started.await;
-        first_cancellation.cancel();
 
         let second_frame = serde_json::json!({
             "version": 4,
@@ -2191,7 +2167,8 @@ mod tests {
         second_task.await.expect("concurrent attach task must not panic");
 
         assert_eq!(control.ends.load(AtomicOrdering::SeqCst), 0);
-        assert_eq!(control.detach_requests.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(control.attach_requests.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(control.detach_requests.load(AtomicOrdering::SeqCst), 0);
         let sent = h.sent();
         assert!(sent.iter().any(|frame| frame["ptyId"] == "p1" && frame["type"] == "pty_error"));
         assert!(sent.iter().any(|frame| frame["ptyId"] == "p2" && frame["type"] == "pty_opened"));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1516,13 +1516,16 @@ impl PtyControl for ControlTerminalControl {
     }
     fn kill(&self) {
         if self.detach_supported {
-            if let Some(lease) = self.lease.as_deref() {
-                self.control.send(
-                    "detach-attached-view",
-                    json!({ "surface": self.surface_id, "lease": lease }),
-                );
+            let Some(lease) = self.lease.as_deref() else {
+                // A missing lease cannot be safely replaced with a broad
+                // connection close because another attachment may share it.
                 return;
-            }
+            };
+            self.control.send(
+                "detach-attached-view",
+                json!({ "surface": self.surface_id, "lease": lease }),
+            );
+            return;
         }
         self.control.end(); // detach only; the daemon keeps the terminal
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -38,6 +38,18 @@ use crate::relay_wire::RelayPtyErrorCode;
 
 pub const PTY_PROTOCOL_VERSION: u64 = 4;
 
+async fn control_request_until_cancelled(
+    control: &dyn ControlHandle,
+    cmd: &str,
+    params: Value,
+    cancellation: &CancellationToken,
+) -> Option<Value> {
+    tokio::select! {
+        response = control.request(cmd, params) => response,
+        _ = cancellation.cancelled() => None,
+    }
+}
+
 pub type DataSink = Arc<dyn Fn(Bytes) + Send + Sync>;
 pub type ExitSink = Arc<dyn Fn(i64) + Send + Sync>;
 /// Max concurrent attachments per relay process.
@@ -1788,7 +1800,13 @@ impl Inner {
         } else {
             json!({ "surface": surface_id })
         };
-        let attached = control.request("attach-surface", attach_params).await;
+        let attached = control_request_until_cancelled(
+            control.as_ref(),
+            "attach-surface",
+            attach_params,
+            &context.cancellation,
+        )
+        .await;
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
             control.end();
             let reason = attached
@@ -2000,6 +2018,38 @@ mod tests {
     use std::thread;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
+
+    struct NeverResolvingControl;
+
+    impl ControlHandle for NeverResolvingControl {
+        fn request(
+            &self,
+            _cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            Box::pin(std::future::pending())
+        }
+        fn send(&self, _cmd: &str, _params: Value) {}
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {}
+    }
+
+    #[tokio::test]
+    async fn raw_attach_request_observes_cancellation() {
+        let cancellation = CancellationToken::new();
+        let request = control_request_until_cancelled(
+            &NeverResolvingControl,
+            "attach-surface",
+            json!({ "surface": 7 }),
+            &cancellation,
+        );
+        tokio::pin!(request);
+        cancellation.cancel();
+        assert!(request.await.is_none());
+    }
 
     /// A unique, real directory for tests that exercise cwd canonicalization.
     /// Do not reuse a process-id-only path: tests run in parallel and a stale

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2049,13 +2049,17 @@ mod tests {
             started: Notify::new(),
         });
         let cancellation = CancellationToken::new();
-        let request = control_request_until_cancelled(
-            control.as_ref(),
-            "attach-surface",
-            json!({ "surface": 7 }),
-            &cancellation,
-        );
-        let task = tokio::spawn(request);
+        let request_control = TestArc::clone(&control);
+        let request_cancellation = cancellation.clone();
+        let task = tokio::spawn(async move {
+            control_request_until_cancelled(
+                request_control.as_ref(),
+                "attach-surface",
+                json!({ "surface": 7 }),
+                &request_cancellation,
+            )
+            .await
+        });
         control.started.notified().await;
         cancellation.cancel();
         let result = tokio::time::timeout(std::time::Duration::from_secs(1), task)

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1860,26 +1860,25 @@ impl Inner {
             .and_then(Value::as_str)
             .map(str::to_owned);
         if context.cancellation.is_cancelled() {
-            if detach_supported {
-                if let Some(lease) = lease.as_deref() {
-                    let _ = control
-                        .request(
-                            "detach-attached-view",
-                            json!({ "surface": surface_id, "lease": lease }),
-                        )
-                        .await;
-                } else {
-                    // A peer that advertises bilateral leases but omits the
-                    // returned token cannot honor scoped cleanup safely.
-                    control.end();
+            if detach_supported && let Some(lease) = lease.as_deref() {
+                let detached = control
+                    .request(
+                        "detach-attached-view",
+                        json!({ "surface": surface_id, "lease": lease }),
+                    )
+                    .await;
+                if detached
+                    .as_ref()
+                    .and_then(|response| response.get("ok"))
+                    .and_then(Value::as_bool)
+                    == Some(true)
+                {
+                    return Err((RelayPtyErrorCode::Failed, "attach-surface cancelled".to_owned()));
                 }
-            } else {
-                // Older peers have no lease-addressed detach. This control
-                // socket is owned by this opening, so closing it is the only
-                // stream cleanup fence available to that peer.
-                control.end();
+                // Keep the attachment owned by the relay when targeted
+                // cleanup is not confirmed. The caller can retry cleanup via
+                // the live attachment instead of abandoning a remote stream.
             }
-            return Err((RelayPtyErrorCode::Failed, "attach-surface cancelled".to_owned()));
         }
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
             control.end();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -44,10 +44,13 @@ async fn control_request_until_cancelled(
     params: Value,
     cancellation: &CancellationToken,
 ) -> ControlRequestOutcome {
-    tokio::select! {
-        response = control.request(cmd, params) => ControlRequestOutcome::Response(response),
-        _ = cancellation.cancelled() => ControlRequestOutcome::Cancelled,
+    if cancellation.is_cancelled() {
+        return ControlRequestOutcome::Cancelled;
     }
+    // Once a request is handed to the control writer, let it finish. Dropping
+    // the future cannot retract a queued attach and would leave an unscoped
+    // server-side stream on peers without lease-addressed detach support.
+    ControlRequestOutcome::Response(control.request(cmd, params).await)
 }
 
 enum ControlRequestOutcome {
@@ -1814,13 +1817,9 @@ impl Inner {
         .await
         {
             ControlRequestOutcome::Response(response) => response,
-            // The attachment cancellation belongs to this open request. Do
-            // not end the shared control connection while another attachment
-            // may still be using it. Ask the server to retire this stream;
-            // older peers treat the request as a no-op and still keep the
-            // connection available for other attachments.
+            // Cancellation was observed before the request reached the
+            // control writer, so no remote attach exists to clean up.
             ControlRequestOutcome::Cancelled => {
-                control.send("detach-attached-view", json!({ "surface": surface_id }));
                 return Err((RelayPtyErrorCode::Failed, "attach-surface cancelled".to_owned()));
             }
         };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2019,7 +2019,10 @@ mod tests {
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 
-    struct NeverResolvingControl;
+    struct NeverResolvingControl {
+        requests: AtomicUsize,
+        started: Notify,
+    }
 
     impl ControlHandle for NeverResolvingControl {
         fn request(
@@ -2027,6 +2030,8 @@ mod tests {
             _cmd: &str,
             _params: Value,
         ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            self.requests.fetch_add(1, AtomicOrdering::SeqCst);
+            self.started.notify_one();
             Box::pin(std::future::pending())
         }
         fn send(&self, _cmd: &str, _params: Value) {}
@@ -2039,16 +2044,26 @@ mod tests {
 
     #[tokio::test]
     async fn raw_attach_request_observes_cancellation() {
+        let control = TestArc::new(NeverResolvingControl {
+            requests: AtomicUsize::new(0),
+            started: Notify::new(),
+        });
         let cancellation = CancellationToken::new();
         let request = control_request_until_cancelled(
-            &NeverResolvingControl,
+            control.as_ref(),
             "attach-surface",
             json!({ "surface": 7 }),
             &cancellation,
         );
-        tokio::pin!(request);
+        let task = tokio::spawn(request);
+        control.started.notified().await;
         cancellation.cancel();
-        assert!(request.await.is_none());
+        let result = tokio::time::timeout(std::time::Duration::from_secs(1), task)
+            .await
+            .expect("cancellation must resolve promptly")
+            .expect("request task must not panic");
+        assert!(result.is_none());
+        assert_eq!(control.requests.load(AtomicOrdering::SeqCst), 1);
     }
 
     /// A unique, real directory for tests that exercise cwd canonicalization.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -68,6 +68,8 @@ pub const SCROLLBACK_LIMIT: usize = 256 * 1024;
 pub const OUTPUT_BUFFER_CAP: u64 = 1024 * 1024;
 /// cmux-tui control protocol floor for attach-surface/send.
 const CONTROL_MIN_PROTOCOL: i64 = 5;
+const VIEW_ATTACHMENT_LEASE_CAPABILITY: &str = "view-attachment-lease-v1";
+const VIEW_ATTACHMENT_DETACH_CAPABILITY: &str = "view-attachment-detach-v1";
 /// Inner terminals listed per session (surface_list stays bounded).
 const MAX_ENUM_TERMINALS: usize = 8;
 const MAX_ALLOWED_ROOTS: usize = 32;
@@ -1491,6 +1493,8 @@ impl TerminalStream {
 struct ControlTerminalControl {
     control: Arc<dyn ControlHandle>,
     surface_id: i64,
+    lease: Option<String>,
+    detach_supported: bool,
 }
 
 impl PtyControl for ControlTerminalControl {
@@ -1511,6 +1515,15 @@ impl PtyControl for ControlTerminalControl {
         self.control.resume();
     }
     fn kill(&self) {
+        if self.detach_supported {
+            if let Some(lease) = self.lease.as_deref() {
+                self.control.send(
+                    "detach-attached-view",
+                    json!({ "surface": self.surface_id, "lease": lease }),
+                );
+                return;
+            }
+        }
         self.control.end(); // detach only; the daemon keeps the terminal
     }
 }
@@ -1710,6 +1723,23 @@ impl Inner {
             .into_iter()
             .filter_map(|v| v.as_str().map(str::to_owned))
             .collect();
+        let scoped_detach_advertised =
+            capabilities.iter().any(|c| c == VIEW_ATTACHMENT_LEASE_CAPABILITY)
+                && capabilities.iter().any(|c| c == VIEW_ATTACHMENT_DETACH_CAPABILITY);
+        let detach_supported = scoped_detach_advertised
+            && control
+                .request(
+                    "set-client-info",
+                    json!({
+                        "kind": "relay",
+                        "capabilities": [
+                            VIEW_ATTACHMENT_LEASE_CAPABILITY,
+                            VIEW_ATTACHMENT_DETACH_CAPABILITY,
+                        ],
+                    }),
+                )
+                .await
+                .is_some_and(|response| response.get("ok").and_then(Value::as_bool) == Some(true));
 
         // Resolve the ref: numeric surface id directly, else via the tree.
         let mut surface_id: Option<i64> = if surface_ref.bytes().all(|b| b.is_ascii_digit()) {
@@ -1823,6 +1853,34 @@ impl Inner {
                 return Err((RelayPtyErrorCode::Failed, "attach-surface cancelled".to_owned()));
             }
         };
+        let lease = attached
+            .as_ref()
+            .and_then(|response| response.get("data"))
+            .and_then(|data| data.get("lease"))
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+        if context.cancellation.is_cancelled() {
+            if detach_supported {
+                if let Some(lease) = lease.as_deref() {
+                    let _ = control
+                        .request(
+                            "detach-attached-view",
+                            json!({ "surface": surface_id, "lease": lease }),
+                        )
+                        .await;
+                } else {
+                    // A peer that advertises bilateral leases but omits the
+                    // returned token cannot honor scoped cleanup safely.
+                    control.end();
+                }
+            } else {
+                // Older peers have no lease-addressed detach. This control
+                // socket is owned by this opening, so closing it is the only
+                // stream cleanup fence available to that peer.
+                control.end();
+            }
+            return Err((RelayPtyErrorCode::Failed, "attach-surface cancelled".to_owned()));
+        }
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
             control.end();
             let reason = attached
@@ -1836,7 +1894,8 @@ impl Inner {
             ));
         }
 
-        let proxy = Arc::new(ControlTerminalControl { control, surface_id });
+        let proxy =
+            Arc::new(ControlTerminalControl { control, surface_id, lease, detach_supported });
         let (on_data, _) = self.sinks(pty_id, context);
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2070,6 +2070,109 @@ mod tests {
         assert_eq!(control.requests.load(AtomicOrdering::SeqCst), 1);
     }
 
+    struct ConcurrentAttachControl {
+        attach_requests: AtomicUsize,
+        attach_started: Notify,
+        ends: AtomicUsize,
+    }
+
+    impl ControlHandle for ConcurrentAttachControl {
+        fn request(
+            &self,
+            cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            match cmd {
+                "identify" => Box::pin(async {
+                    Some(json!({
+                        "ok": true,
+                        "data": { "protocol": CONTROL_MIN_PROTOCOL, "capabilities": [] },
+                    }))
+                }),
+                "attach-surface" => {
+                    let request = self.attach_requests.fetch_add(1, AtomicOrdering::SeqCst);
+                    self.attach_started.notify_waiters();
+                    if request == 0 {
+                        Box::pin(std::future::pending())
+                    } else {
+                        Box::pin(async { Some(json!({ "ok": true })) })
+                    }
+                }
+                _ => Box::pin(async { Some(json!({ "ok": true })) }),
+            }
+        }
+
+        fn send(&self, _cmd: &str, _params: Value) {}
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {
+            self.ends.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn canceled_attachment_does_not_end_control_for_concurrent_attachment() {
+        let control = TestArc::new(ConcurrentAttachControl {
+            attach_requests: AtomicUsize::new(0),
+            attach_started: Notify::new(),
+            ends: AtomicUsize::new(0),
+        });
+        let h = harness_with_control(
+            Some(CmuxTui { file: "/bin/cmux-tui".to_owned(), prefix: Vec::new() }),
+            None,
+            None,
+            Some(control.clone()),
+        );
+        let first_frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "surface": "7",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+            "trust": "supervised",
+            "allowedRoots": Value::Null,
+        });
+        let first_context = h.context("supervised", h.owner.clone());
+        let first_cancellation = first_context.cancellation.clone();
+        let first_started = control.attach_started.notified();
+        let first_task = tokio::spawn({
+            let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+            async move { manager.handle_frame(&first_frame, &first_context).await }
+        });
+        first_started.await;
+        first_cancellation.cancel();
+
+        let second_frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p2",
+            "session": "main",
+            "surface": "8",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+            "trust": "supervised",
+            "allowedRoots": Value::Null,
+        });
+        let second_context = h.context("supervised", h.owner.clone());
+        let second_task = tokio::spawn({
+            let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+            async move { manager.handle_frame(&second_frame, &second_context).await }
+        });
+        first_task.await.expect("canceled attach task must not panic");
+        second_task.await.expect("concurrent attach task must not panic");
+
+        assert_eq!(control.ends.load(AtomicOrdering::SeqCst), 0);
+        let sent = h.sent();
+        assert!(sent.iter().any(|frame| frame["ptyId"] == "p1" && frame["type"] == "pty_error"));
+        assert!(sent.iter().any(|frame| frame["ptyId"] == "p2" && frame["type"] == "pty_opened"));
+    }
+
     /// A unique, real directory for tests that exercise cwd canonicalization.
     /// Do not reuse a process-id-only path: tests run in parallel and a stale
     /// path from an interrupted run must never be removed or reused.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -43,11 +43,16 @@ async fn control_request_until_cancelled(
     cmd: &str,
     params: Value,
     cancellation: &CancellationToken,
-) -> Option<Value> {
+) -> ControlRequestOutcome {
     tokio::select! {
-        response = control.request(cmd, params) => response,
-        _ = cancellation.cancelled() => None,
+        response = control.request(cmd, params) => ControlRequestOutcome::Response(response),
+        _ = cancellation.cancelled() => ControlRequestOutcome::Cancelled,
     }
+}
+
+enum ControlRequestOutcome {
+    Response(Option<Value>),
+    Cancelled,
 }
 
 pub type DataSink = Arc<dyn Fn(Bytes) + Send + Sync>;
@@ -1800,13 +1805,22 @@ impl Inner {
         } else {
             json!({ "surface": surface_id })
         };
-        let attached = control_request_until_cancelled(
+        let attached = match control_request_until_cancelled(
             control.as_ref(),
             "attach-surface",
             attach_params,
             &context.cancellation,
         )
-        .await;
+        .await
+        {
+            ControlRequestOutcome::Response(response) => response,
+            // The attachment cancellation belongs to this open request. Do
+            // not end the shared control connection while another attachment
+            // may still be using it.
+            ControlRequestOutcome::Cancelled => {
+                return Err((RelayPtyErrorCode::Failed, "attach-surface cancelled".to_owned()));
+            }
+        };
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
             control.end();
             let reason = attached
@@ -2066,7 +2080,7 @@ mod tests {
             .await
             .expect("cancellation must resolve promptly")
             .expect("request task must not panic");
-        assert!(result.is_none());
+        assert!(matches!(result, ControlRequestOutcome::Cancelled));
         assert_eq!(control.requests.load(AtomicOrdering::SeqCst), 1);
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1816,8 +1816,11 @@ impl Inner {
             ControlRequestOutcome::Response(response) => response,
             // The attachment cancellation belongs to this open request. Do
             // not end the shared control connection while another attachment
-            // may still be using it.
+            // may still be using it. Ask the server to retire this stream;
+            // older peers treat the request as a no-op and still keep the
+            // connection available for other attachments.
             ControlRequestOutcome::Cancelled => {
+                control.send("detach-attached-view", json!({ "surface": surface_id }));
                 return Err((RelayPtyErrorCode::Failed, "attach-surface cancelled".to_owned()));
             }
         };
@@ -2087,6 +2090,7 @@ mod tests {
     struct ConcurrentAttachControl {
         attach_requests: AtomicUsize,
         attach_started: Notify,
+        detach_requests: AtomicUsize,
         ends: AtomicUsize,
     }
 
@@ -2116,7 +2120,11 @@ mod tests {
             }
         }
 
-        fn send(&self, _cmd: &str, _params: Value) {}
+        fn send(&self, cmd: &str, _params: Value) {
+            if cmd == "detach-attached-view" {
+                self.detach_requests.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+        }
         fn on_event(&self, _handler: EventHandler) {}
         fn on_close(&self, _handler: CloseHandler) {}
         fn pause(&self) {}
@@ -2131,6 +2139,7 @@ mod tests {
         let control = TestArc::new(ConcurrentAttachControl {
             attach_requests: AtomicUsize::new(0),
             attach_started: Notify::new(),
+            detach_requests: AtomicUsize::new(0),
             ends: AtomicUsize::new(0),
         });
         let h = harness_with_control(
@@ -2182,6 +2191,7 @@ mod tests {
         second_task.await.expect("concurrent attach task must not panic");
 
         assert_eq!(control.ends.load(AtomicOrdering::SeqCst), 0);
+        assert_eq!(control.detach_requests.load(AtomicOrdering::SeqCst), 1);
         let sent = h.sent();
         assert!(sent.iter().any(|frame| frame["ptyId"] == "p1" && frame["type"] == "pty_error"));
         assert!(sent.iter().any(|frame| frame["ptyId"] == "p2" && frame["type"] == "pty_opened"));


### PR DESCRIPTION
Raw attach-surface requests now use the shared cancellation-aware helper. Added a behavior test with a never-resolving control to prove transport cancellation returns promptly.\n\nValidation: rustfmt --edition 2024 and git diff --check. Rust builds/tests not run per task.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11466"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790865882&installation_model_id=21920&pr_number=11466&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11466&signature=021497e2f54e8123323caa5b7e5863cb491c7237daa287be3f9924c1014012ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Canceled raw attach-surface requests now return promptly without closing the shared control connection or leaving pending requests behind.

- Rejects cancellation before sending the attach request so no unscoped remote stream is created.
- Cleans up a late-canceled attach with a lease-scoped detach when the peer supports it.
- Keeps the attachment instead of ending the control socket when detach is unconfirmed or the lease is missing, and falls back to closing the control socket for peers without detach support.
- Removes pending control request entries when their futures are dropped.
- Adds coverage for prompt cancellation, pending-request cleanup, and concurrent attachments surviving cancellation.

<sup>Written for commit 69ba000727a95703a22feefced4a3c4ea49a2207. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11466?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Canceled terminal attachment requests now stop promptly instead of waiting indefinitely for a daemon response.
  * Canceled control requests are properly retired, preventing stale pending requests from accumulating.
  * Improved reliability when transport operations are interrupted during writing or response handling.
  * Terminal views now detach more reliably after cancellation or closure, reducing the risk of lingering attachments.
  * Multiple terminal attachments can share a control connection more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->