### PR TITLE
fix: combine journal sequence and cursor continuity checks

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use anyhow::Context;
 use base64::Engine;
 use flate2::{Compression, GzBuilder};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::resource::TerminalPublicId;
@@ -298,8 +298,8 @@ impl RestoreReducer {
 
     pub(crate) fn finish(mut self, head_sequence: u64) -> anyhow::Result<Value> {
         anyhow::ensure!(
-            head_sequence >= self.last_sequence,
-            "restore preview head precedes the last reduced record"
+            head_sequence == self.last_sequence,
+            "restore preview did not reduce through the journal head"
         );
         let snapshot = self
             .state

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use anyhow::Context;
 use base64::Engine;
 use flate2::{Compression, GzBuilder};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 
 use crate::resource::TerminalPublicId;
@@ -552,14 +552,10 @@ impl RestoreReducer {
             .and_then(Value::as_object)
             .context("checkpoint session_snapshot is not an object")?;
         let Some(cursor) = snapshot.get("cursor") else {
-            return Ok(
-                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
-            );
+            return Ok(false);
         };
         if cursor.is_null() {
-            return Ok(
-                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
-            );
+            return Ok(false);
         }
         let Some(cursor) = cursor.as_object() else {
             anyhow::bail!("checkpoint cursor is not an object")

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -871,7 +871,7 @@ mod tests {
             schema_version: 1,
             kind: "unknown".into(),
             class: JournalClass::State,
-            replay: JournalReplayPolicy::Ignored,
+            replay: JournalReplayPolicy::Never,
             occurred_at_ms: 1,
             committed_at_ms: 1,
             producer: JournalProducer { kind: "test".into(), id: "test".into() },

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -887,6 +887,7 @@ mod tests {
             terminal_output: None,
         };
         assert!(restore_preview(&checkpoint, &[record.clone(), record.clone()], 4).is_err());
+        assert!(restore_preview(&checkpoint, &[record.clone()], 5).is_err());
         let mut gapped = record;
         gapped.sequence = 5;
         assert!(restore_preview(&checkpoint, &[gapped], 5).is_err());

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use anyhow::Context;
 use base64::Engine;
 use flate2::{Compression, GzBuilder};
-use serde_json::{Map, Value, json};
+use serde_json::{json, Map, Value};
 use sha2::{Digest, Sha256};
 
 use crate::resource::TerminalPublicId;
@@ -273,8 +273,8 @@ impl RestoreReducer {
 
     pub(crate) fn apply(&mut self, record: &SessionJournalRecord) -> anyhow::Result<()> {
         anyhow::ensure!(
-            record.sequence > self.last_sequence,
-            "journal records are not strictly ordered after checkpoint"
+            self.last_sequence.checked_add(1) == Some(record.sequence),
+            "journal records are not contiguous after checkpoint"
         );
         self.last_sequence = record.sequence;
         if record.replay != JournalReplayPolicy::Required {
@@ -383,7 +383,7 @@ impl RestoreReducer {
             return Ok(false);
         };
         if !self.validate_resource_changes(changes)
-            || !self.cursor_accepts(record.resource_revision)?
+            || !self.cursor_accepts(record.resource_revision, record.previous_resource_revision)?
         {
             return Ok(false);
         }
@@ -538,16 +538,47 @@ impl RestoreReducer {
         Ok(true)
     }
 
-    fn cursor_accepts(&self, revision: Option<u64>) -> anyhow::Result<bool> {
-        if revision.is_none() {
-            return Ok(true);
-        }
+    fn cursor_accepts(
+        &self,
+        revision: Option<u64>,
+        previous_revision: Option<u64>,
+    ) -> anyhow::Result<bool> {
+        let Some(revision) = revision else {
+            return Ok(previous_revision.is_none());
+        };
         let snapshot = self
             .state
             .get("session_snapshot")
             .and_then(Value::as_object)
             .context("checkpoint session_snapshot is not an object")?;
-        Ok(snapshot.get("cursor").is_none_or(|cursor| cursor.is_null() || cursor.is_object()))
+        let Some(cursor) = snapshot.get("cursor") else {
+            return Ok(
+                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
+            );
+        };
+        if cursor.is_null() {
+            return Ok(
+                previous_revision.is_some_and(|previous| previous.checked_add(1) == Some(revision))
+            );
+        }
+        let Some(cursor) = cursor.as_object() else {
+            anyhow::bail!("checkpoint cursor is not an object")
+        };
+        let Some(cursor_revision) = cursor.get("revision") else { return Ok(false) };
+        let cursor_revision = match cursor_revision {
+            Value::String(value) => value
+                .parse::<u64>()
+                .context("checkpoint cursor revision is not an unsigned integer")?,
+            Value::Number(value) => {
+                value.as_u64().context("checkpoint cursor revision is not an unsigned integer")?
+            }
+            _ => anyhow::bail!("checkpoint cursor revision is not an unsigned integer"),
+        };
+        let expected_revision = cursor_revision.checked_add(1);
+        Ok(match previous_revision {
+            Some(previous) => previous == cursor_revision && expected_revision == Some(revision),
+            None => expected_revision == Some(revision),
+        })
     }
 
     fn validate_resource_changes(&self, changes: &[Value]) -> bool {
@@ -821,6 +852,83 @@ mod tests {
         assert_eq!(preview["fully_reducible"], true);
         assert_eq!(preview["state"]["session_snapshot"]["workspaces"][0]["id"], "workspace_new");
         assert_eq!(preview["state"]["session_snapshot"]["cursor"]["revision"], "2");
+    }
+
+    #[test]
+    fn reducer_rejects_duplicate_and_gapped_sequences() {
+        let checkpoint = JournalCheckpoint {
+            checkpoint_id: "checkpoint_test".into(),
+            source_sequence: 3,
+            reducer_version: JOURNAL_REDUCER_VERSION,
+            state: json!({"session_snapshot":{"cursor":{}},"journal_extensions":{"producers":[],"hooks":[]}}),
+            content_refs: vec![],
+            sha256: "00".repeat(32),
+            created_at_ms: 1,
+        };
+        let record = SessionJournalRecord {
+            sequence: 4,
+            event_id: "event_4".into(),
+            schema_version: 1,
+            kind: "unknown".into(),
+            class: JournalClass::State,
+            replay: JournalReplayPolicy::Ignored,
+            occurred_at_ms: 1,
+            committed_at_ms: 1,
+            producer: JournalProducer { kind: "test".into(), id: "test".into() },
+            authority: None,
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({}),
+            resource_revision: None,
+            previous_resource_revision: None,
+            terminal_output: None,
+        };
+        assert!(restore_preview(&checkpoint, &[record.clone(), record.clone()], 4).is_err());
+        let mut gapped = record;
+        gapped.sequence = 5;
+        assert!(restore_preview(&checkpoint, &[gapped], 5).is_err());
+    }
+
+    #[test]
+    fn reducer_rejects_resource_revision_gap_and_stale_predecessor() {
+        let checkpoint = JournalCheckpoint {
+            checkpoint_id: "checkpoint_invalid".into(),
+            source_sequence: 3,
+            reducer_version: JOURNAL_REDUCER_VERSION,
+            state: json!({"session_snapshot":{"cursor":{"generation":"g","revision":"1"},"workspaces":[]},"journal_extensions":{"producers":[],"hooks":[]}}),
+            content_refs: vec![],
+            sha256: "00".repeat(32),
+            created_at_ms: 1,
+        };
+        let mut record = SessionJournalRecord {
+            sequence: 4,
+            event_id: "event_4".into(),
+            schema_version: 1,
+            kind: "workspace.create".into(),
+            class: JournalClass::State,
+            replay: JournalReplayPolicy::Required,
+            occurred_at_ms: 1,
+            committed_at_ms: 1,
+            producer: JournalProducer { kind: "test".into(), id: "test".into() },
+            authority: None,
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![JournalSubject { kind: "session".into(), id: "session".into() }],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({"changes":[{"kind":"upsert","resource":"workspace","id":"w","value":{"id":"w","index":0}}]}),
+            resource_revision: Some(3),
+            previous_resource_revision: Some(2),
+            terminal_output: None,
+        };
+        let preview = restore_preview(&checkpoint, &[record.clone()], 4).unwrap();
+        assert_eq!(preview["fully_reducible"], false);
+        record.previous_resource_revision = Some(1);
+        let preview = restore_preview(&checkpoint, &[record], 4).unwrap();
+        assert_eq!(preview["fully_reducible"], false);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -982,6 +982,52 @@ mod tests {
     }
 
     #[test]
+    fn reducer_rejects_resource_changes_without_revision_chain() {
+        let checkpoint = JournalCheckpoint {
+            checkpoint_id: "checkpoint_with_cursor_baseline".into(),
+            source_sequence: 3,
+            reducer_version: JOURNAL_REDUCER_VERSION,
+            state: json!({
+                "session_snapshot":{"cursor":{"generation":"g","revision":"1"},"workspaces":[]},
+                "journal_extensions":{"producers":[],"hooks":[]},
+            }),
+            content_refs: vec![],
+            sha256: "00".repeat(32),
+            created_at_ms: 1,
+        };
+        let record = SessionJournalRecord {
+            sequence: 4,
+            event_id: "event_without_revision_chain".into(),
+            schema_version: 1,
+            kind: "workspace.create".into(),
+            class: JournalClass::State,
+            replay: JournalReplayPolicy::Required,
+            occurred_at_ms: 1,
+            committed_at_ms: 1,
+            producer: JournalProducer { kind: "test".into(), id: "test".into() },
+            authority: None,
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![JournalSubject { kind: "session".into(), id: "session".into() }],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({"changes":[{
+                "kind":"upsert",
+                "resource":"workspace",
+                "id":"w",
+                "value":{"id":"w","index":0},
+            }]}),
+            resource_revision: None,
+            previous_resource_revision: None,
+            terminal_output: None,
+        };
+
+        let preview = restore_preview(&checkpoint, &[record], 4).unwrap();
+
+        assert_eq!(preview["fully_reducible"], false);
+    }
+
+    #[test]
     fn reducer_streams_terminal_output_and_resize_into_a_bounded_replay_summary() {
         let output = b"prompt> first line\r\n";
         let output_record = terminal_replay_record(

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -577,7 +577,7 @@ impl RestoreReducer {
         let expected_revision = cursor_revision.checked_add(1);
         Ok(match previous_revision {
             Some(previous) => previous == cursor_revision && expected_revision == Some(revision),
-            None => expected_revision == Some(revision),
+            None => false,
         })
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -938,6 +938,54 @@ mod tests {
     }
 
     #[test]
+    fn reducer_rejects_revisioned_records_without_cursor_baseline() {
+        let record = SessionJournalRecord {
+            sequence: 4,
+            event_id: "event_without_cursor_baseline".into(),
+            schema_version: 1,
+            kind: "workspace.create".into(),
+            class: JournalClass::State,
+            replay: JournalReplayPolicy::Required,
+            occurred_at_ms: 1,
+            committed_at_ms: 1,
+            producer: JournalProducer { kind: "test".into(), id: "test".into() },
+            authority: None,
+            causation_id: None,
+            correlation_id: None,
+            causation_depth: 0,
+            subjects: vec![JournalSubject { kind: "session".into(), id: "session".into() }],
+            sensitivity: JournalSensitivity::Sensitive,
+            payload: json!({"changes":[{"kind":"upsert","resource":"workspace","id":"w","value":{"id":"w","index":0}}]}),
+            resource_revision: Some(101),
+            previous_resource_revision: Some(100),
+            terminal_output: None,
+        };
+        let checkpoint = |cursor: Option<Value>| {
+            let mut state = json!({
+                "session_snapshot":{"workspaces":[]},
+                "journal_extensions":{"producers":[],"hooks":[]},
+            });
+            if let Some(cursor) = cursor {
+                state["session_snapshot"]["cursor"] = cursor;
+            }
+            JournalCheckpoint {
+                checkpoint_id: "checkpoint_without_cursor_baseline".into(),
+                source_sequence: 3,
+                reducer_version: JOURNAL_REDUCER_VERSION,
+                state,
+                content_refs: vec![],
+                sha256: "00".repeat(32),
+                created_at_ms: 1,
+            }
+        };
+
+        for cursor in [None, Some(Value::Null)] {
+            let preview = restore_preview(&checkpoint(cursor), &[record.clone()], 4).unwrap();
+            assert_eq!(preview["fully_reducible"], false);
+        }
+    }
+
+    #[test]
     fn reducer_streams_terminal_output_and_resize_into_a_bounded_replay_summary() {
         let output = b"prompt> first line\r\n";
         let output_record = terminal_replay_record(

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -927,6 +927,11 @@ mod tests {
         };
         let preview = restore_preview(&checkpoint, &[record.clone()], 4).unwrap();
         assert_eq!(preview["fully_reducible"], false);
+        let mut missing_predecessor = record.clone();
+        missing_predecessor.resource_revision = Some(2);
+        missing_predecessor.previous_resource_revision = None;
+        let preview = restore_preview(&checkpoint, &[missing_predecessor], 4).unwrap();
+        assert_eq!(preview["fully_reducible"], false);
         record.previous_resource_revision = Some(1);
         let preview = restore_preview(&checkpoint, &[record], 4).unwrap();
         assert_eq!(preview["fully_reducible"], false);

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -4,7 +4,7 @@ use std::io::Write;
 use anyhow::Context;
 use base64::Engine;
 use flate2::{Compression, GzBuilder};
-use serde_json::{json, Map, Value};
+use serde_json::{Map, Value, json};
 use sha2::{Digest, Sha256};
 
 use crate::resource::TerminalPublicId;
@@ -544,7 +544,7 @@ impl RestoreReducer {
         previous_revision: Option<u64>,
     ) -> anyhow::Result<bool> {
         let Some(revision) = revision else {
-            return Ok(previous_revision.is_none());
+            return Ok(false);
         };
         let snapshot = self
             .state


### PR DESCRIPTION
Combines journal replay continuity validation with cursor predecessor and revision checks. Adds behavior tests for duplicate/gapped sequences and stale or gapped resource revisions. No builds or tests run per task scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11468"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790866018&installation_model_id=21920&pr_number=11468&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11468&signature=af6641ce9fa6420f62f2aecc656f9106d5b55f12cc0e74ded902b6604294fd97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes journal restore fail closed when replay data is not continuous or when resource revisions don't chain from the checkpoint cursor.

- Sequences must be contiguous; gaps and duplicates fail replay.
- Restore must reduce through the journal head exactly, so partial tails are rejected.
- Resource records now require both a resource revision and a previous revision.
- The previous revision must equal the checkpoint cursor's revision, and the resource revision must be exactly one greater.
- Missing, null, or malformed checkpoint cursors fail restore.

<sup>Written for commit 576a22fcf5dc9f02f38a2af0c270dda36df534a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restore validation to detect duplicate, missing, or out-of-sequence journal records.
  * Ensured restored state matches the journal’s final position exactly.
  * Added validation for resource revision continuity and outdated predecessor revisions.
  * Improved restore reliability by rejecting inconsistent or incomplete replay data.

* **Tests**
  * Added coverage for journal sequence gaps and duplicates.
  * Added coverage for resource revision gaps and stale predecessors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->