### PR TITLE
ci: migrate CLA workflow to guarded v3 writer

### DIFF
--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -34,6 +34,11 @@ if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign 
   fail "The signing comment did not result in a persisted signature"
 fi
 [[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{7,40}$ ]] || fail "Invalid CLA generation marker"
+[[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
+checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
+[[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"
+[[ "${WORKFLOW_PATH}" == ".github/workflows/cla.yml" ]] || fail "Unexpected CLA workflow path"
+[[ -f .github/scripts/rerun-failed-cla.sh ]] || fail "The trusted CLA rerun helper is missing"
 
 # These values are part of the trusted workflow contract. They are deliberately
 # constants, not event or comment input, so a contributor cannot redirect this
@@ -109,6 +114,27 @@ issue_state="$(jq -r '.state // empty' <<<"${issue_json}")"
 issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
 [[ "${issue_state}" == "open" ]] || fail "The issue is not an open pull request"
 [[ "${issue_pr_url}" == "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" ]] || fail "The issue is not the exact repository pull request"
+
+# Re-fetch the triggering comment immediately before using its ledger entry.
+# A comment can be edited or deleted after the writer records a signature; a
+# stale event payload must never authorize a rerun of the failed check.
+comment_json="$(gh api "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" 2>/dev/null)" || fail "Could not query the triggering comment"
+jq -e \
+  --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+  --arg body "${COMMENT_BODY}" \
+  --arg author_id "${COMMENT_AUTHOR_ID}" \
+  --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
+  --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+  --arg created_at "${COMMENT_CREATED_AT}" \
+  '.issue_url == $issue_url and
+   .body == $body and
+   (.user | type == "object") and
+   (.user.id | type == "number") and
+   (.user.id | tostring) == $author_id and
+   .user.login == $author_login and
+   .user.type == $author_type and
+   .created_at == $created_at and
+   .updated_at == $created_at' <<<"${comment_json}" >/dev/null || fail "The triggering CLA comment was edited, deleted, or moved"
 
 pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
 jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,31 +1,25 @@
-name: "CLA Assistant v2"
+name: "CLA Assistant v3"
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     branches: [main]
-    # Re-run full CLA validation for every non-closed edit. Do not narrow
-    # edited events to a base-change payload, because title/body edits also
-    # need to refresh required check contexts.
     types: [opened,closed,edited,reopened,synchronize]
 
-# Jobs declare only the permissions they need.
 permissions: {}
 
-# Bump this value when the CLA workflow policy or maintained action pin
-# changes. Do not derive the rerun marker from `github.workflow_sha`: that SHA
-# changes for every unrelated commit on main and would strand valid failed
-# checks on open pull requests.
+# This marker changes only when the policy or maintained action changes. It
+# gives the rerun worker a stable generation that is independent of unrelated
+# commits on main.
 env:
-  CLA_GENERATION: 'v2.2-action-fc608ba7106e7029d981d487d7bad28a64325956'
+  CLA_GENERATION: "v2.2-action-0502e16018c7c71dc7647e0d41d056a11903941a"
 
 jobs:
+  # This job has read-only permissions. It performs the exact event check and
+  # authenticates a new signing comment before any write-capable job starts.
   CLACommentGate:
     name: "Validate CLA trigger"
-    # This job is intentionally unprivileged. The job-level expression is a
-    # coarse admission filter, and the shell step below is the exact,
-    # case-sensitive check. GitHub expressions compare strings without case,
-    # so the shell remains the authority for the declaration itself.
     if: >-
       (
         github.event_name == 'pull_request_target' &&
@@ -43,156 +37,97 @@ jobs:
         github.event.issue.pull_request &&
         github.event.comment.user.type == 'User' &&
         (
-          (
-            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-            github.event.comment.user.id == github.event.issue.user.id
-          ) ||
-          (
-            github.event.comment.body == 'recheck' &&
-            (
-              github.event.comment.user.id == github.event.issue.user.id ||
-              github.event.comment.author_association == 'OWNER' ||
-              github.event.comment.author_association == 'MEMBER' ||
-              github.event.comment.author_association == 'COLLABORATOR'
-            )
-          )
+          github.event.comment.body == 'recheck' ||
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
         )
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 5
-    # Bound issue-comment fanout to one running and one pending admission per
-    # pull request. GitHub expression equality is case-insensitive, so a
-    # rejected case variant can replace a valid pending comment in this queue;
-    # the shell remains the exact-byte authority and the signer queue runs only
-    # after this gate succeeds. This is an availability tradeoff, not an
-    # authorization bypass.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
     concurrency:
       group: cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
-    permissions: {}
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     outputs:
       admitted: ${{ steps.admission.outputs.admitted }}
+      signer_authorized: ${{ steps.signer_preflight.outputs.signer_authorized }}
+      head_sha: ${{ steps.signer_preflight.outputs.head_sha }}
     steps:
       - name: "Validate exact CLA trigger"
         id: admission
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id }}
-          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
-          PR_AUTHOR_ID: ${{ github.event.issue.user.id }}
-          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
-          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id || '' }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login || '' }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || '' }}
+          PR_AUTHOR_ID: ${{ github.event.issue.user.id || '' }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || '' }}
         run: |
           set -euo pipefail
-
           fail() {
             echo "::error::$1"
             exit 1
           }
-
-          # Actions supplies GITHUB_OUTPUT. A missing output file is a runner
-          # protocol failure, so do not let a dependent privileged job run
-          # without an explicit admission result.
-          [[ -n "${GITHUB_OUTPUT+x}" && -n "${GITHUB_OUTPUT}" ]] || fail "GITHUB_OUTPUT is unavailable"
-          [[ -n "${EVENT_NAME+x}" && -n "${EVENT_ACTION+x}" ]] || fail "The event metadata is incomplete"
-
+          emit() {
+            [[ -n "${GITHUB_OUTPUT:-}" ]] || fail "GITHUB_OUTPUT is unavailable"
+            printf 'admitted=%s\n' "$1" >>"${GITHUB_OUTPUT}"
+          }
+          [[ -n "${EVENT_NAME:-}" && -n "${EVENT_ACTION:-}" ]] || fail "Event metadata is incomplete"
           if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
-            [[ "${EVENT_ACTION}" == "created" ]] || fail "The issue-comment event action is not supported"
-            [[ -n "${COMMENT_BODY+x}" &&
-               -n "${COMMENT_AUTHOR_TYPE+x}" &&
-               -n "${COMMENT_AUTHOR_ID+x}" &&
-               -n "${COMMENT_AUTHOR_LOGIN+x}" &&
-               -n "${PR_AUTHOR_ID+x}" &&
-               -n "${COMMENT_AUTHOR_ASSOCIATION+x}" ]] || fail "The issue-comment metadata is incomplete"
-            [[ "${COMMENT_AUTHOR_TYPE}" == "User" && -n "${COMMENT_AUTHOR_LOGIN}" ]] ||
-              fail "Bot and malformed comments cannot trigger the CLA action"
-            case "${COMMENT_AUTHOR_LOGIN,,}" in
-              *"[bot]")
-                fail "Bot comments cannot trigger the CLA action"
-                ;;
-            esac
-            [[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The issue-comment author ID is malformed"
-            [[ "${PR_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request author ID is malformed"
-            [[ -n "${COMMENT_AUTHOR_ASSOCIATION}" &&
-               "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\n'* &&
-               "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\r'* ]] ||
-              fail "The issue-comment author association is malformed"
-
+            [[ "${EVENT_ACTION}" == "created" ]] || fail "Issue-comment event action is unsupported"
+            [[ "${COMMENT_AUTHOR_TYPE}" == "User" && -n "${COMMENT_AUTHOR_LOGIN}" ]] || fail "Comment author is not a human user"
+            [[ "${COMMENT_AUTHOR_LOGIN,,}" != *"[bot]" ]] || fail "Bot comments cannot trigger the CLA action"
+            [[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ && "${PR_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment identity is malformed"
+            [[ -n "${COMMENT_AUTHOR_ASSOCIATION}" && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\n'* && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\r'* ]] || fail "Comment association is malformed"
             if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
-              if [[ "${COMMENT_AUTHOR_ID}" != "${PR_AUTHOR_ID}" ]]; then
-                printf 'admitted=false\n' >>"${GITHUB_OUTPUT}"
-                exit 0
-              fi
               printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-              exit 0
+            elif [[ "${COMMENT_BODY}" == "recheck" ]]; then
+              printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
+            else
+              emit false
             fi
-            if [[ "${COMMENT_BODY}" == "recheck" ]]; then
-              if [[ "${COMMENT_AUTHOR_ID}" == "${PR_AUTHOR_ID}" ]]; then
-                printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-                exit 0
-              fi
-              if [[ "${COMMENT_AUTHOR_ID}" != "${PR_AUTHOR_ID}" ]]; then
-                case "${COMMENT_AUTHOR_ASSOCIATION}" in
-                  OWNER|MEMBER|COLLABORATOR)
-                    printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-                    exit 0
-                    ;;
-                  *)
-                    # A well-formed but unauthorized recheck is ordinary
-                    # discussion and must not reach the privileged signer.
-                    printf 'admitted=false\n' >>"${GITHUB_OUTPUT}"
-                    exit 0
-                    ;;
-                esac
-              fi
-            fi
-            # All other well-formed human comments are ordinary discussion.
-            printf 'admitted=false\n' >>"${GITHUB_OUTPUT}"
-            exit 0
           elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
             case "${EVENT_ACTION}" in
-              opened|edited|reopened|synchronize)
-                printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-                exit 0
-                ;;
-              *)
-                fail "The pull request event is not an accepted CLA trigger"
-                ;;
+              opened|edited|reopened|synchronize) emit true ;;
+              *) fail "Pull-request event action is unsupported" ;;
             esac
           else
-            fail "The event is not an accepted CLA trigger"
+            fail "Event is not an accepted CLA trigger"
           fi
 
-  CLAAssistant:
-    # This versioned context is deliberate. The old "CLA Assistant" check
-    # could remain successful on an unchanged PR after this workflow changed.
-    # Update the main ruleset to require this context only after the migration
-    # smoke test and open-PR sweep complete.
-    name: "CLA Assistant v2"
+      - name: "Authenticate exact CLA signer"
+        id: signer_preflight
+        if: >-
+          success() &&
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+        uses: manaflow-ai/cla-github-action@0502e16018c7c71dc7647e0d41d056a11903941a
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "signer-preflight"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          require-opener-as-author: "true"
+          allowlist-ids: "38676809,67667005"
+
+  # This is the only job with ledger and comment write permissions. It has no
+  # shell step, so policy text cannot execute with its token. The action repeats
+  # live PR/comment validation and binds a signing write to the exact head SHA
+  # observed by the read-only gate.
+  CLALedgerWriter:
+    name: "CLA ledger writer"
     needs: CLACommentGate
-    outputs:
-      # The rerun worker may use this only as proof that this exact action run
-      # persisted a new signature. A comment by itself is not authorization
-      # for a job with actions:write.
-      signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 15
-    # Filter before concurrency admission. Untrusted recheck comments cannot
-    # consume the signature queue or invoke the write-capable action. Keep
-    # `always()` here so a gate failure produces a visible failed signer check
-    # instead of a skipped result; the first shell step enforces the gate
-    # result before any privileged step can run.
     if: >-
-      always() &&
-      (
-        needs.CLACommentGate.result == 'failure' ||
-        (
-          needs.CLACommentGate.result == 'success' &&
-          needs.CLACommentGate.outputs.admitted == 'true'
-        )
-      ) &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
       (
         (
           github.event_name == 'pull_request_target' &&
@@ -210,10 +145,6 @@ jobs:
           github.event.comment.user.type == 'User' &&
           (
             (
-              github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-              github.event.comment.user.id == github.event.issue.user.id
-            ) ||
-            (
               github.event.comment.body == 'recheck' &&
               (
                 github.event.comment.user.id == github.event.issue.user.id ||
@@ -221,176 +152,106 @@ jobs:
                 github.event.comment.author_association == 'MEMBER' ||
                 github.event.comment.author_association == 'COLLABORATOR'
               )
+            ) ||
+            (
+              github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+              needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+              needs.CLACommentGate.outputs.head_sha != ''
             )
           )
         )
       )
-    # Serialize every signer event for one PR, but let independent PRs proceed.
-    # A signing comment and a lifecycle event must not compute competing
-    # ledger/status plans from different snapshots.
-    # The maintained action at fc608ba7106e7029d981d487d7bad28a64325956 uses
-    # Contents-API SHA compare-and-swap writes. On HTTP 409 it rereads and
-    # merges the current ledger, with three bounded attempts; its persistence
-    # unit test covers a concurrent update. This is the ledger writer lock.
-    # A global Actions lock would retain only one pending run and could drop
-    # valid signatures from unrelated PRs, so it is not safe for this intake.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
     concurrency:
       group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
     permissions:
       contents: write
       issues: write
-      # The maintained action does not call the commit-status API. GitHub
-      # creates the job check run itself and keys it to the pull request head
-      # for pull_request_target runs, so statuses:write would add an unused
-      # write capability without changing the displayed CLA result. The
-      # production check-run API confirms this head binding; do not replace it
-      # with a manually posted status.
-      # GitHub's pull_request_target token denied issue comments for fork PRs
-      # with this set to read, despite the endpoint documentation allowing
-      # issues:write. Keep write until that live behavior changes.
       pull-requests: write
+    outputs:
+      signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
     steps:
-      - name: "Require CLA admission"
-        if: always()
-        env:
-          GATE_RESULT: ${{ needs.CLACommentGate.result }}
-          ADMITTED: ${{ needs.CLACommentGate.outputs.admitted }}
-        run: |
-          set -euo pipefail
-          if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
-            echo "::error::CLA trigger admission did not pass (gate: ${GATE_RESULT}, admitted: ${ADMITTED})"
-            exit 1
-          fi
-
-      # Stable generation marker. It changes only when the policy or action
-      # pin changes, unlike github.workflow_sha, which follows every main
-      # commit.
-      - name: "CLA generation ${{ env.CLA_GENERATION }}"
-        if: success()
-        run: echo "CLA generation ${{ env.CLA_GENERATION }}"
-
-      - name: "Validate CLA comment declaration"
-        if: success() && github.event_name == 'issue_comment'
-        env:
-          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          set -euo pipefail
-          # GitHub Actions string equality is case-insensitive, and the
-          # archived action also accepts broad regular-expression matches.
-          # Check the complete body in a shell before the action can record a
-          # signature. `recheck` is the only other accepted trigger.
-          if [[ "${EVENT_COMMENT_BODY}" != "recheck" &&
-                "${EVENT_COMMENT_BODY}" != "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
-            echo "::error::The comment is not an exact CLA declaration or recheck command"
-            exit 1
-          fi
-
-      - name: "Validate CLA pull request"
-        id: cla-preflight
-        if: success()
-        # The maintained action bounds its commit-identity pagination at 1,000
-        # commits. Keep the same fail-closed limit here so the preflight and
-        # action operate on the same contribution envelope.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-        run: |
-          set -euo pipefail
-          if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Invalid pull request number"
-            exit 1
-          fi
-          if ! pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-            echo "::error::Could not query the pull request"
-            exit 1
-          fi
-          if ! jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" '
-            .number == $number and
-            .state == "open" and
-            .base.ref == "main" and
-            .base.repo.full_name == $repo and
-            (.head.sha | type == "string") and
-            (.head.sha | test("^[0-9a-f]{40}$")) and
-            (.commits | type == "number")
-          ' <<<"${pr_json}" >/dev/null; then
-            echo "::error::The pull request is not an open pull request targeting main"
-            exit 1
-          fi
-          live_head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
-          if [[ "${EVENT_NAME}" == "pull_request_target" ]] && {
-            [[ "${EVENT_HEAD_SHA}" != "${live_head_sha}" ]] ||
-            [[ "${EVENT_BASE_REF}" != "main" ]] ||
-            [[ "${EVENT_BASE_REPO}" != "${GH_REPO}" ]]
-          }; then
-            echo "::error::The pull request changed while the CLA workflow was starting"
-            exit 1
-          fi
-          commit_count="$(jq -r '.commits' <<<"${pr_json}")"
-          if ! [[ "${commit_count}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Could not determine the pull request commit count"
-            exit 1
-          fi
-          if (( commit_count > 1000 )); then
-            echo "::error title=Pull request commit limit::This pull request has ${commit_count} commits. Split it into 1,000 or fewer commits before requesting a CLA check."
-            exit 1
-          fi
-
-      - name: "CLA Assistant v2"
+      - name: "Write CLA result"
         id: cla_action
-        if: success()
-        # Use the reviewed in-organization action fork. Pin the runtime commit
-        # so a branch move cannot change the code executed by this workflow.
-        # The fork's default branch must be protected before this check is made
-        # required in repository rulesets.
-        uses: manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a64325956 # v0.0.1
+        uses: manaflow-ai/cla-github-action@0502e16018c7c71dc7647e0d41d056a11903941a
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # Version 2 has a separate ledger. Existing version-1 signatures were
-          # collected under earlier CLA terms and must not silently accept this
-          # revised document.
-          path-to-signatures: 'signatures/version2/cla.json'
-          path-to-document: 'https://github.com/manaflow-ai/cmux/blob/${{ github.workflow_sha }}/CLA.md'
-          # Merged pull requests use the explicit lock step below, which
-          # supplies a valid lock reason and fails on API errors.
-          lock-pullrequest-aftermerge: 'false'
-          # signatures live on the unprotected cla-signatures branch so required checks on main don't block the bot's signature commits
-          branch: 'cla-signatures'
-          # Pin the policy branch explicitly.
-          required-base-ref: 'main'
-          # Require the exact phrase below. Raw-name allowlists are disabled;
-          # commit metadata is not authenticated identity evidence.
-          custom-pr-sign-comment: 'I have read the CLA Document v2.2 and I hereby sign the CLA'
-          # These reviewed numeric IDs exempt only authenticated pull-request
-          # openers: @austinywang (Austin Wang, 38676809) and
-          # @azooz2003-bit (Abdulaziz Albahar, 67667005). Names, commit
-          # authors, commenters, and later collaborators do not receive an
-          # exemption. Other bot-opened PRs remain fail-closed.
-          allowlist-ids: '38676809,67667005'
-          require-opener-as-author: 'true'
-          # Pre-merge administrator action: before making "CLA Assistant v2" a
-          # required check, verify that the `cla-signatures` branch contains
-          # `signatures/version2/cla.json` with a read-only Contents API query.
-          # If it is absent, run the maintained action's reviewed bootstrap once
-          # under administrator control. Never create or edit this data branch
-          # from a pull-request workflow.
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          path-to-signatures: "signatures/version2/cla.json"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "false"
+          expected-head-sha: "${{ needs.CLACommentGate.outputs.head_sha }}"
 
-  # Compatibility check for the current ruleset. It mirrors the v2 action
-  # result under the old context while administrators migrate the required
-  # check to "CLA Assistant v2". It runs for every non-closed pull-request
-  # lifecycle event, including edited events, because issue_comment checks
-  # attach to the default branch SHA, not the pull request head, and cannot
-  # safely refresh the old required context by themselves. On a signing
-  # comment, RerunFailedCLA validates both failed contexts in the exact prior
-  # target run and uses the failed-jobs endpoint to refresh them together.
-  # `always()` is required so a failed v2 action cannot turn this old required
-  # context into a skipped-success check.
+  # This no-permission job owns the required v3 check context. A gate or writer
+  # failure is visible as a failed check instead of being hidden as a skipped
+  # privileged job.
+  CLAAssistant:
+    name: "CLA Assistant v3"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+    if: >-
+      always() &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.action == 'created' &&
+          github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
+          (
+            github.event.comment.body == 'recheck' ||
+            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+          )
+        )
+      )
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: "Publish CLA Assistant v3 result"
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          GATE_RESULT: ${{ needs.CLACommentGate.result }}
+          ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
+          SIGNER_AUTHORIZED: ${{ needs.CLACommentGate.outputs.signer_authorized || '' }}
+          WRITER_RESULT: ${{ needs.CLALedgerWriter.result }}
+        run: |
+          set -euo pipefail
+          if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
+            echo "::error::CLA trigger admission failed"
+            exit 1
+          fi
+          if [[ "${EVENT_NAME}" == "issue_comment" &&
+                "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" &&
+                "${SIGNER_AUTHORIZED}" != "true" ]]; then
+            echo "::error::CLA signer preflight failed"
+            exit 1
+          fi
+          if [[ "${WRITER_RESULT}" != "success" ]]; then
+            echo "::error::CLA ledger writer failed"
+            exit 1
+          fi
+
+  # Keep the old context during migration. It has no token and is not the
+  # required context after the v3 ruleset migration.
   CLACompatibility:
     name: "CLA Assistant"
     needs:
@@ -405,89 +266,74 @@ jobs:
         github.event.action == 'reopened' ||
         github.event.action == 'synchronize'
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 5
     permissions: {}
     steps:
-      - name: "Require CLA Assistant v2 success"
+      - name: "Mirror CLA Assistant compatibility result"
         env:
-          GATE_RESULT: ${{ needs.CLACommentGate.result }}
-          V2_RESULT: ${{ needs.CLAAssistant.result }}
+          RESULT: ${{ needs.CLAAssistant.result }}
         run: |
           set -euo pipefail
-          if [[ "${GATE_RESULT}" != "success" || "${V2_RESULT}" != "success" ]]; then
-            echo "::error::CLA Assistant v2 did not pass (gate: ${GATE_RESULT}, action: ${V2_RESULT})"
+          [[ "${RESULT}" == "success" ]] || {
+            echo "::error::CLA Assistant v3 did not pass"
             exit 1
-          fi
+          }
 
+  # This job can refresh a failed check only through the immutable helper from
+  # the base workflow revision. It receives actions:write, never contents or
+  # comment write access, and its shell command and environment are fixed by
+  # the base-controlled policy validator.
   RerunFailedCLA:
     name: "Rerun failed CLA check"
-    needs: CLAAssistant
-    # Keep the workflow-rerun token out of the signature-writing job. This
-    # isolated fixed shell is the only job that can rerun a failed check, and
-    # it runs only after the exact accepted issue-comment path reaches the
-    # assistant. A signing declaration may authorize a rerun only when the
-    # action output proves that this run persisted a new signature. `recheck`
-    # remains available to the PR author or a trusted repository participant
-    # for a normal failed-check refresh.
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+      - CLAAssistant
     if: >-
       always() &&
-      (
-        needs.CLAAssistant.result == 'success' ||
-        needs.CLAAssistant.result == 'failure'
-      ) &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      needs.CLAAssistant.result != 'skipped' &&
       github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
       github.event.issue.state == 'open' &&
       github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
       (
         (
           github.event.comment.body == 'recheck' &&
-          github.event.comment.user.type == 'User' &&
           (
             github.event.comment.user.id == github.event.issue.user.id ||
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||
             github.event.comment.author_association == 'COLLABORATOR'
-          )
+          ) &&
+          needs.CLALedgerWriter.result == 'success'
         ) ||
         (
           github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-          github.event.comment.user.type == 'User' &&
-          github.event.comment.user.id == github.event.issue.user.id &&
-          needs.CLAAssistant.outputs.signature_recorded == 'true'
+          needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.signature_recorded == 'true'
         )
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
-    # A contributor can submit more than one valid comment while the signing
-    # job is running. Serialize reruns per PR so two comments cannot race the
-    # same workflow run. The default Actions policy keeps one pending rerun
-    # and replaces older pending requests. The script rechecks the run state
-    # before POSTing.
-    concurrency:
-      group: cla-rerun-${{ github.event.issue.number }}
-      cancel-in-progress: false
     permissions:
-      # The job checks out only the fixed script at the immutable workflow
-      # revision below. actions:write is required by the rerun endpoint;
-      # contents:read is limited to that trusted sparse checkout.
       actions: write
       contents: read
       issues: read
       pull-requests: read
     steps:
-      # Check out only the immutable workflow revision. Never use the PR head
-      # ref, and never execute files supplied by the pull request.
-      - name: "Checkout trusted CLA guard"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "Checkout trusted CLA rerun helper"
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.workflow_sha }}
-          fetch-depth: 1
           persist-credentials: false
           sparse-checkout: .github/scripts/rerun-failed-cla.sh
           sparse-checkout-cone-mode: false
-
       - name: "Rerun exact failed pull_request_target run"
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -502,45 +348,22 @@ jobs:
           COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
           COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
-          WORKFLOW_PATH: '.github/workflows/cla.yml'
+          WORKFLOW_PATH: ".github/workflows/cla.yml"
           WORKFLOW_SHA: ${{ github.workflow_sha }}
           CLA_GENERATION: ${{ env.CLA_GENERATION }}
-          TARGET_EVENT: 'pull_request_target'
-          TARGET_BASE_REF: 'main'
-          SIGNATURE_RECORDED: ${{ needs.CLAAssistant.outputs.signature_recorded }}
-        run: |
-          set -euo pipefail
-          [[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::The trusted workflow revision is invalid"
-            exit 1
-          }
-          checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || {
-            echo "::error::Could not verify the trusted workflow checkout"
-            exit 1
-          }
-          [[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || {
-            echo "::error::The checkout is not the immutable workflow revision"
-            exit 1
-          }
-          [[ -f .github/scripts/rerun-failed-cla.sh ]] || {
-            echo "::error::The trusted CLA guard script is missing"
-            exit 1
-          }
-          bash .github/scripts/rerun-failed-cla.sh
+          TARGET_EVENT: "pull_request_target"
+          TARGET_BASE_REF: "main"
+          SIGNATURE_RECORDED: ${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}
+        run: bash .github/scripts/rerun-failed-cla.sh
+
   LockMergedPullRequest:
     name: "Lock merged pull request"
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
-    # Keep merge locks in a stable per-PR queue that is separate from the
-    # signer's signature queue. A later sign/comment event must not replace a
-    # pending lock event, and a close event must not replace a pending ledger
-    # write. The default Actions policy keeps one pending event in each queue;
-    # the live merged-PR check below prevents stale events from locking a
-    # reopened or retargeted pull request.
     concurrency:
       group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
@@ -549,171 +372,16 @@ jobs:
       pull-requests: read
     steps:
       - name: "Lock merged pull request"
+        uses: manaflow-ai/cla-github-action@0502e16018c7c71dc7647e0d41d056a11903941a
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-          EVENT_BASE_REPO_ID: ${{ github.event.pull_request.base.repo.id }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          # GitHub can redact a deleted fork from a merged pull-request
-          # payload. Validate the event shape, but do not treat source-head
-          # fields as immutable. GitHub permits a source branch to advance or
-          # be deleted after merge while the issue still needs locking.
-          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
-          EVENT_HEAD_REPO_ID: ${{ github.event.pull_request.head.repo.id || '' }}
-          EVENT_OPENER_ID: ${{ github.event.pull_request.user.id }}
-          EVENT_OPENER_LOGIN: ${{ github.event.pull_request.user.login }}
-        run: |
-          set -euo pipefail
-
-          fail() {
-            echo "::error::$1"
-            exit 1
-          }
-
-          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]] || fail "Invalid pull request number"
-          [[ "${EVENT_BASE_REF}" == "main" ]] || fail "The merge event targets an unexpected base branch"
-          [[ "${EVENT_BASE_REPO}" == "${GH_REPO}" ]] || fail "The merge event targets an unexpected base repository"
-          [[ "${EVENT_BASE_REPO_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The merge event has no valid base repository ID"
-          [[ "${EVENT_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "The merge event has no valid head SHA"
-          [[ -n "${EVENT_HEAD_REF}" && "${EVENT_HEAD_REF}" != *$'\n'* && "${EVENT_HEAD_REF}" != *$'\r'* ]] || fail "The merge event has no valid head ref"
-          if [[ -z "${EVENT_HEAD_REPO}" || -z "${EVENT_HEAD_REPO_ID}" ]]; then
-            [[ -z "${EVENT_HEAD_REPO}" && -z "${EVENT_HEAD_REPO_ID}" ]] || fail "The merge event has incomplete head repository metadata"
-          else
-            [[ "${EVENT_HEAD_REPO}" == */* && "${EVENT_HEAD_REPO}" != */*/* ]] || fail "The merge event has no valid head repository"
-            [[ "${EVENT_HEAD_REPO_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The merge event has no valid head repository ID"
-          fi
-          [[ "${EVENT_OPENER_ID}" =~ ^[1-9][0-9]*$ && -n "${EVENT_OPENER_LOGIN}" ]] || fail "The merge event has no valid pull request opener"
-
-          validate_live_merged_pr() {
-            local live_pr_json="$1"
-            jq -e \
-              --arg repo "${GH_REPO}" \
-              --argjson number "${PR_NUMBER}" \
-              --arg base_ref "${EVENT_BASE_REF}" \
-              --arg base_repo "${EVENT_BASE_REPO}" \
-              --argjson base_repo_id "${EVENT_BASE_REPO_ID}" \
-              --argjson opener_id "${EVENT_OPENER_ID}" \
-              --arg opener_login "${EVENT_OPENER_LOGIN}" '
-                .number == $number and
-                .state == "closed" and
-                .merged == true and
-                .base.ref == $base_ref and
-                .base.repo.full_name == $base_repo and
-                .base.repo.full_name == $repo and
-                .base.repo.id == $base_repo_id and
-                (.head.sha | type == "string") and
-                (.head.ref | type == "string") and
-                (
-                  if .head.repo == null then
-                    true
-                  else
-                    (.head.repo.full_name | type == "string") and
-                    (.head.repo.id | type == "number") and
-                    .head.repo.id > 0
-                  end
-                ) and
-                .user.id == $opener_id and
-                (.user.login | type == "string") and
-                (.user.login | length > 0)
-              ' <<<"${live_pr_json}" >/dev/null || return 1
-          }
-
-          live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the merged pull request"
-          validate_live_merged_pr "${live_pr_json}" || fail "The live pull request no longer matches the merged event"
-
-          issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
-          lock_endpoint="${issue_endpoint}/lock"
-
-          unlock_after_state_change() {
-            if ! gh api --method DELETE \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "${lock_endpoint}" \
-              >/dev/null 2>&1; then
-              echo "::error::The pull request changed after locking and the stale lock could not be removed"
-              exit 1
-            fi
-            if ! unlocked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-              echo "::error::The stale pull request lock was removed, but its state could not be verified"
-              exit 1
-            fi
-            [[ "${unlocked}" == "false" ]] || {
-              echo "::error::The stale pull request lock could not be removed"
-              exit 1
-            }
-          }
-
-          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-            echo "::error::Could not query the pull request lock state"
-            exit 1
-          fi
-          if [[ "${locked}" == "true" ]]; then
-            # An existing lock may have been left behind by an earlier close
-            # event. Recheck the live state before treating it as valid, and
-            # remove it if the pull request was reopened or retargeted.
-            if ! live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-              fail "Could not verify the already-locked pull request"
-            fi
-            if ! validate_live_merged_pr "${live_pr_json}"; then
-              unlock_after_state_change
-              fail "The already-locked pull request changed; the stale lock was removed"
-            fi
-            # A lock may change state immediately after the first validation.
-            # Re-read before returning success so a concurrent reopen or
-            # retarget does not leave a stale lock with no later close event
-            # available to clean it up. Only a successful read that proves a
-            # stale state permits unlocking; an API error preserves the lock.
-            if ! final_live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-              fail "Could not verify the already-locked pull request before success"
-            fi
-            if ! validate_live_merged_pr "${final_live_pr_json}"; then
-              unlock_after_state_change
-              fail "The already-locked pull request changed; the stale lock was removed"
-            fi
-            echo "Pull request ${PR_NUMBER} is already locked"
-            exit 0
-          fi
-
-          # Re-fetch immediately before the state-changing call. A queued lock
-          # job must not lock a pull request that was reopened or retargeted
-          # after the closed event was delivered.
-          live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the merged pull request before locking"
-          validate_live_merged_pr "${live_pr_json}" || fail "The pull request changed before locking"
-
-          if ! gh api --method PUT \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "${lock_endpoint}" \
-            --field lock_reason=resolved >/dev/null 2>&1; then
-            echo "::error::Could not lock the merged pull request"
-            exit 1
-          fi
-
-          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-            echo "::error::Could not verify the pull request lock state"
-            unlock_after_state_change
-            exit 1
-          fi
-          if [[ "${locked}" != "true" ]]; then
-            echo "::error::The merged pull request is not locked"
-            unlock_after_state_change
-            exit 1
-          fi
-
-          # There is no conditional lock endpoint. Re-read the live pull
-          # request after the PUT and remove the lock if an administrator
-          # reopened or retargeted it during the request. The final read is
-          # the recovery boundary for the API's unavoidable TOCTOU window.
-          if ! live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-            unlock_after_state_change
-            fail "Could not verify the merged pull request after locking"
-          fi
-          if ! validate_live_merged_pr "${live_pr_json}"; then
-            unlock_after_state_change
-            fail "The pull request changed after locking; the stale lock was removed"
-          fi
-          echo "Pull request ${PR_NUMBER} is locked"
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "sign"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "true"


### PR DESCRIPTION
## Summary
- replace the legacy CLA workflow with a closed v3 gate, read-only preflight, exact-head writer, visible result, compatibility result, rerun guard, and merge lock
- pin the maintained Manaflow CLA action at `0502e16018c7c71dc7647e0d41d056a11903941a`
- bind every write to the read-only signer preflight head and revalidate rerun comments by immutable ID and timestamps

## Verification
- local YAML parse and actionlint pass
- policy schema passes against the base-controlled validator
- shell syntax and diff checks pass

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11469"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790866071&installation_model_id=21920&pr_number=11469&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11469&signature=cf64a1591b18eed8b6e378524d9d06de4afdbd579b9b72bd6d9e6126b2dc4288"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the legacy CLA Assistant v2 workflow with a guarded v3 architecture: a read-only gate handles admission and signer preflight, and a separate write-capable ledger writer persists signatures bound to the preflight head.

**Refactors**
- The signer preflight authenticates the contributor before the writer runs; the writer binds its write to the exact head SHA the gate observed.
- The rerun guard re-fetches the triggering comment and refuses to act if it was edited, deleted, or moved since the event payload.
- The rerun script now also validates the workflow path and checkout SHA against the immutable workflow revision.
- Pins the maintained Manaflow CLA action to a reviewed revision and moves merge locking into that action instead of the hand-written script.

**Migration**
- The required check context changes from `CLA Assistant v2` to `CLA Assistant v3`; a compatibility job keeps the old `CLA Assistant` context green until the ruleset is updated.

<sup>Written for commit 6cbfea28aa403ada4fe9e59184136cd4d8187ad1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11469?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

