### PR TITLE
fix(cmux-tui): exec detached hook child after fork

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -114,6 +114,65 @@ enum Handoff {
     TimedOut,
 }
 
+/// Own a spawned helper until its lifecycle has been handed to the reaper.
+/// `std::process::Child` does not terminate or reap itself when dropped.
+struct DetachedChildGuard(Option<std::process::Child>);
+
+impl DetachedChildGuard {
+    fn new(child: std::process::Child) -> Self {
+        Self(Some(child))
+    }
+
+    fn child_mut(&mut self) -> &mut std::process::Child {
+        self.0.as_mut().expect("detached child guard is occupied")
+    }
+
+    fn take(&mut self) -> std::process::Child {
+        self.0.take().expect("detached child guard is occupied")
+    }
+}
+
+impl Drop for DetachedChildGuard {
+    fn drop(&mut self) {
+        let Some(mut child) = self.0.take() else {
+            return;
+        };
+        let _ = child.kill();
+        let _ = child.wait();
+    }
+}
+
+/// Reap the helper after the provider-facing handoff. The helper normally
+/// exits after its four-second socket deadline. If it does not, terminate it
+/// after that same bounded grace period so repeated hooks cannot accumulate
+/// children or blocked stdout reader threads.
+fn reap_detached_child(mut child: std::process::Child, reader: std::thread::JoinHandle<()>) {
+    let deadline = Instant::now() + SOCKET_TIMEOUT;
+    loop {
+        match child.try_wait() {
+            Ok(Some(_)) => break,
+            Ok(None) if Instant::now() < deadline => {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+            Ok(None) | Err(_) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break;
+            }
+        }
+    }
+    let _ = reader.join();
+}
+
+fn handoff_child_to_reaper(child: std::process::Child, reader: std::thread::JoinHandle<()>) {
+    let guard = DetachedChildGuard::new(child);
+    let _ = std::thread::Builder::new().name("cmux-tui-hook-reaper".to_owned()).spawn(move || {
+        let mut guard = guard;
+        let child = guard.take();
+        reap_detached_child(child, reader);
+    });
+}
+
 fn handoff_wait(source: &str, native_event: &str) -> Duration {
     if source == "codex" && native_event == "SessionEnd" {
         CODEX_SESSION_END_HANDOFF_WAIT
@@ -585,16 +644,19 @@ mod detach {
                 Ok(())
             });
         }
-        let mut child = command.spawn().context("spawn detached hook child")?;
-        let mut stdin = child.stdin.take().context("detached hook child has no stdin")?;
+        let mut child =
+            super::DetachedChildGuard::new(command.spawn().context("spawn detached hook child")?);
+        let mut stdin =
+            child.child_mut().stdin.take().context("detached hook child has no stdin")?;
         stdin.write_all(request_id.as_bytes())?;
         stdin.write_all(b"\n")?;
         stdin.write_all(encoded)?;
         stdin.flush()?;
         drop(stdin);
-        let mut stdout = child.stdout.take().context("detached hook child has no stdout")?;
+        let mut stdout =
+            child.child_mut().stdout.take().context("detached hook child has no stdout")?;
         let (sender, receiver) = mpsc::channel();
-        std::thread::spawn(move || {
+        let reader = std::thread::spawn(move || {
             let mut byte = [0_u8; 1];
             let outcome = match stdout.read(&mut byte) {
                 Ok(1) => Handoff::Sent,
@@ -602,7 +664,9 @@ mod detach {
             };
             let _ = sender.send(outcome);
         });
-        Ok(receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut))
+        let outcome = receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut);
+        super::handoff_child_to_reaper(child.take(), reader);
+        Ok(outcome)
     }
 }
 
@@ -632,17 +696,21 @@ mod detach {
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         let exe = std::env::current_exe().context("locate hook helper")?;
-        let mut child = Command::new(exe)
-            .arg(DETACHED_MODE_ARG)
-            .env("CMUX_TUI_SOCKET", socket)
-            .stdin(Stdio::piped())
-            .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
-            .spawn()
-            .context("spawn detached hook child")?;
-        let mut stdin = child.stdin.take().context("detached hook child has no stdin")?;
-        let mut stdout = child.stdout.take().context("detached hook child has no stdout")?;
+        let mut child = super::DetachedChildGuard::new(
+            Command::new(exe)
+                .arg(DETACHED_MODE_ARG)
+                .env("CMUX_TUI_SOCKET", socket)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::null())
+                .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
+                .spawn()
+                .context("spawn detached hook child")?,
+        );
+        let mut stdin =
+            child.child_mut().stdin.take().context("detached hook child has no stdin")?;
+        let mut stdout =
+            child.child_mut().stdout.take().context("detached hook child has no stdout")?;
         stdin.write_all(request_id.as_bytes())?;
         stdin.write_all(b"\n")?;
         stdin.write_all(encoded)?;
@@ -651,7 +719,7 @@ mod detach {
         // Pipe reads have no timeout on Windows; a reader thread plus a
         // bounded channel wait gives the same absolute deadline as poll(2).
         let (sender, receiver) = mpsc::channel();
-        std::thread::spawn(move || {
+        let reader = std::thread::spawn(move || {
             let mut byte = [0_u8; 1];
             let outcome = match stdout.read(&mut byte) {
                 Ok(1) => Handoff::Sent,
@@ -659,7 +727,9 @@ mod detach {
             };
             let _ = sender.send(outcome);
         });
-        Ok(receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut))
+        let outcome = receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut);
+        super::handoff_child_to_reaper(child.take(), reader);
+        Ok(outcome)
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -579,7 +579,7 @@ mod detach {
         // call unless the closure is limited to async-signal-safe operations.
         unsafe {
             command.pre_exec(|| {
-                if libc::setsid() < 0 {
+                if unsafe { libc::setsid() } < 0 {
                     return Err(std::io::Error::last_os_error());
                 }
                 Ok(())

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -114,8 +114,12 @@ enum Handoff {
     TimedOut,
 }
 
-/// Own a spawned helper until its lifecycle has been handed to the reaper.
-/// `std::process::Child` does not terminate or reap itself when dropped.
+/// Own a spawned helper while setup can still fail.
+/// `std::process::Child` does not terminate or reap itself when dropped, so
+/// this guard synchronously terminates and waits for a child on those error
+/// paths. After a successful handoff, `settle_detached_child` explicitly
+/// releases a still-running child because this one-shot process is about to
+/// return and cannot host a reaper thread.
 struct DetachedChildGuard(Option<std::process::Child>);
 
 impl DetachedChildGuard {
@@ -127,8 +131,12 @@ impl DetachedChildGuard {
         self.0.as_mut().expect("detached child guard is occupied")
     }
 
-    fn take(&mut self) -> std::process::Child {
-        self.0.take().expect("detached child guard is occupied")
+    /// Release the process handle without waiting. The detached child owns
+    /// its remaining bounded receipt attempt; on Unix a parent that exits
+    /// reparents it for eventual collection, and on Windows closing this
+    /// handle releases the parent's ownership of the process object.
+    fn release(mut self) {
+        drop(self.0.take());
     }
 }
 
@@ -142,35 +150,38 @@ impl Drop for DetachedChildGuard {
     }
 }
 
-/// Reap the helper after the provider-facing handoff. The helper normally
-/// exits after its four-second socket deadline. If it does not, terminate it
-/// after that same bounded grace period so repeated hooks cannot accumulate
-/// children or blocked stdout reader threads.
-fn reap_detached_child(mut child: std::process::Child, reader: std::thread::JoinHandle<()>) {
-    let deadline = Instant::now() + SOCKET_TIMEOUT;
-    loop {
-        match child.try_wait() {
-            Ok(Some(_)) => break,
-            Ok(None) if Instant::now() < deadline => {
-                std::thread::sleep(Duration::from_millis(10));
-            }
-            Ok(None) | Err(_) => {
-                let _ = child.kill();
-                let _ = child.wait();
-                break;
+/// Settle the parent-side ownership before the provider-facing process
+/// returns. A child that already exited is reaped and its stdout reader is
+/// joined. A child that is still running must continue waiting for its receipt,
+/// so its process handle and reader are explicitly released instead of being
+/// handed to a thread that would die with this one-shot process. The child has
+/// its own `SOCKET_TIMEOUT` deadline; the OS owns its eventual orphaned
+/// lifetime after this process exits.
+fn settle_detached_child(mut child: DetachedChildGuard, reader: std::thread::JoinHandle<()>) {
+    let status = child.child_mut().try_wait();
+    match status {
+        Ok(Some(_)) => {
+            child.release();
+            // `is_finished` keeps the provider-facing path non-blocking even
+            // if a platform leaves the pipe reader briefly behind the child.
+            if reader.is_finished() {
+                let _ = reader.join();
+            } else {
+                drop(reader);
             }
         }
+        Ok(None) => {
+            drop(reader);
+            child.release();
+        }
+        Err(_) => {
+            // A status-query error cannot justify an unbounded wait on the
+            // provider path. Release both handles; this one-shot parent exits
+            // immediately, while the child keeps its own bounded attempt.
+            drop(reader);
+            child.release();
+        }
     }
-    let _ = reader.join();
-}
-
-fn handoff_child_to_reaper(child: std::process::Child, reader: std::thread::JoinHandle<()>) {
-    let guard = DetachedChildGuard::new(child);
-    let _ = std::thread::Builder::new().name("cmux-tui-hook-reaper".to_owned()).spawn(move || {
-        let mut guard = guard;
-        let child = guard.take();
-        reap_detached_child(child, reader);
-    });
 }
 
 fn handoff_wait(source: &str, native_event: &str) -> Duration {
@@ -665,7 +676,7 @@ mod detach {
             let _ = sender.send(outcome);
         });
         let outcome = receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut);
-        super::handoff_child_to_reaper(child.take(), reader);
+        super::settle_detached_child(child, reader);
         Ok(outcome)
     }
 }
@@ -728,7 +739,7 @@ mod detach {
             let _ = sender.send(outcome);
         });
         let outcome = receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut);
-        super::handoff_child_to_reaper(child.take(), reader);
+        super::settle_detached_child(child, reader);
         Ok(outcome)
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -568,20 +568,24 @@ mod detach {
     ) -> anyhow::Result<Handoff> {
         use std::os::unix::process::CommandExt;
         let exe = std::env::current_exe().context("locate hook helper")?;
-        let mut child = Command::new(exe)
+        let mut command = Command::new(exe);
+        command
             .arg(DETACHED_MODE_ARG)
             .env("CMUX_TUI_SOCKET", socket)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .pre_exec(|| {
-                if unsafe { libc::setsid() } < 0 {
+            .stderr(Stdio::null());
+        // `pre_exec` runs in the child after fork and is therefore unsafe to
+        // call unless the closure is limited to async-signal-safe operations.
+        unsafe {
+            command.pre_exec(|| {
+                if libc::setsid() < 0 {
                     return Err(std::io::Error::last_os_error());
                 }
                 Ok(())
-            })
-            .spawn()
-            .context("spawn detached hook child")?;
+            });
+        }
+        let mut child = command.spawn().context("spawn detached hook child")?;
         let mut stdin = child.stdin.take().context("detached hook child has no stdin")?;
         stdin.write_all(request_id.as_bytes())?;
         stdin.write_all(b"\n")?;

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -429,7 +429,7 @@ fn read_before(
     }
 }
 
-#[cfg(unix)]
+#[cfg(any())]
 mod detach {
     use std::io;
     use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
@@ -545,6 +545,60 @@ mod detach {
             let read = unsafe { libc::read(read_end.as_raw_fd(), byte.as_mut_ptr().cast(), 1) };
             return if read == 1 { Handoff::Sent } else { Handoff::ChildExited };
         }
+    }
+}
+
+#[cfg(unix)]
+mod detach {
+    use super::{DETACHED_MODE_ARG, Handoff};
+    use anyhow::Context;
+    use std::io::{Read, Write};
+    use std::path::Path;
+    use std::process::{Command, Stdio};
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// Spawn performs the platform fork+exec transition. The child does not
+    /// run Rust code before exec, avoiding the POSIX post-fork restrictions.
+    pub(super) fn append_detached(
+        socket: &Path,
+        request_id: &str,
+        encoded: &[u8],
+        handoff_wait: Duration,
+    ) -> anyhow::Result<Handoff> {
+        use std::os::unix::process::CommandExt;
+        let exe = std::env::current_exe().context("locate hook helper")?;
+        let mut child = Command::new(exe)
+            .arg(DETACHED_MODE_ARG)
+            .env("CMUX_TUI_SOCKET", socket)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .pre_exec(|| {
+                if unsafe { libc::setsid() } < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            })
+            .spawn()
+            .context("spawn detached hook child")?;
+        let mut stdin = child.stdin.take().context("detached hook child has no stdin")?;
+        stdin.write_all(request_id.as_bytes())?;
+        stdin.write_all(b"\n")?;
+        stdin.write_all(encoded)?;
+        stdin.flush()?;
+        drop(stdin);
+        let mut stdout = child.stdout.take().context("detached hook child has no stdout")?;
+        let (sender, receiver) = mpsc::channel();
+        std::thread::spawn(move || {
+            let mut byte = [0_u8; 1];
+            let outcome = match stdout.read(&mut byte) {
+                Ok(1) => Handoff::Sent,
+                _ => Handoff::ChildExited,
+            };
+            let _ = sender.send(outcome);
+        });
+        Ok(receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut))
     }
 }
 


### PR DESCRIPTION
POSIX only permits async-signal-safe operations after fork in a multithreaded process. The merged hook helper performed Rust allocation, stdio redirection, socket I/O, and thread creation in the fork child.

Use Command fork+exec on Unix, with setsid as the only pre-exec operation. The detached mode performs all Rust I/O after exec, matching the Windows lifecycle and preserving request handoff confirmation, ordering, timeout, and stdio closure.

Checks: rustfmt --edition 2024; git diff --check. Cargo tests/builds not run per task instructions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes fork safety in the Unix detached hook helper by replacing post-fork Rust work with `Command` fork+exec, so the child only runs `setsid` before exec.

- The child performs all Rust I/O after exec, matching the Windows lifecycle.
- Detached mode still confirms request handoff and preserves ordering, timeout, and stdio closure.
- Settles child ownership before the parent exits: exited children are reaped and their reader threads joined, while still-running children are released to finish their own bounded receipt attempt, so repeated hooks cannot accumulate children or blocked reader threads.

<sup>Written for commit 29b21a47158845aafff0bfe2658d412cba12b97c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11472?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

