### PR TITLE
test: align cloud help contract with prompt command

### DIFF
--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -589,8 +589,8 @@ the expected text without connecting to a cmux socket.
 - `cmux capabilities --help` -> `Usage: cmux capabilities`
 - `cmux events --help` -> `Usage: cmux events [options]`
 - `cmux auth --help` -> `Usage: cmux auth <status|login|logout>`
-- `cmux vm --help` -> `Usage: cmux vm <base|new|ls|tree|status|stats|rename|snapshot|fork|restore|rm|run|route|agent|exec|push|pull|wait|shell|tui|desktop|open|ports|tools|handoff|promote-template|attach|ssh|ssh-info> [args...]`
-- `cmux cloud --help` -> `Usage: cmux cloud <base|new|ls|tree|status|stats|rename|snapshot|fork|restore|rm|run|route|agent|exec|push|pull|wait|shell|tui|desktop|open|ports|tools|handoff|promote-template|attach|ssh|ssh-info> [args...]`
+- `cmux vm --help` -> `Usage: cmux vm <base|new|ls|tree|status|stats|rename|snapshot|fork|restore|rm|run|route|agent|prompt|exec|push|pull|wait|shell|tui|desktop|open|ports|tools|handoff|promote-template|attach|ssh|ssh-info> [args...]`
+- `cmux cloud --help` -> `Usage: cmux cloud <base|new|ls|tree|status|stats|rename|snapshot|fork|restore|rm|run|route|agent|prompt|exec|push|pull|wait|shell|tui|desktop|open|ports|tools|handoff|promote-template|attach|ssh|ssh-info> [args...]`
 - `cmux remotes --help` -> `Usage: cmux remotes <list|add|remove> [options]`
 - `cmux remote --help` -> `Usage: cmux remotes <list|add|remove> [options]`
 - `cmux rpc --help` -> `Usage: cmux rpc <method> [json-params]`


### PR DESCRIPTION
## Summary

- Align the executable `cmux vm --help` and `cmux cloud --help` contracts with the shipped `prompt` subcommand.
- Fix the no-socket CLI contract failure in main CI.

The failure was observed in [main CI shard 6](https://github.com/manaflow-ai/cmux/actions/runs/33521123132/job/99902959345). The CLI already printed `prompt`; the documentation probes omitted it. This change updates only the contract documentation.

## Verification

- `git diff --check`
- Documentation parity assertion for both probes
- Exact-head local autoreview: clean, confidence 0.98


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLI contract documentation to include the `prompt` subcommand, resolving the no-socket contract failure in CI.

The `cmux vm --help` and `cmux cloud --help` contracts now list `prompt`, matching the actual CLI output. Only the contract docs change; no runtime behavior is affected.

<sup>Written for commit 39e93bccc7ea45ca442805bd011bf702ed2d4263. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11473?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

