### PR TITLE
fix(cmux-tui): fence listener cleanup by socket identity

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4718,9 +4718,146 @@ fn validate_resource_client_label(
     Ok(Some(value))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketPathIdentity {
+    #[cfg(unix)]
+    Unix { device: u64, inode: u64 },
+    #[cfg(not(unix))]
+    Unavailable,
+}
+
+impl SocketPathIdentity {
+    fn capture(path: &Path) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+            let metadata = std::fs::symlink_metadata(path)?;
+            if !metadata.file_type().is_socket() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "session socket path is not a Unix socket",
+                ));
+            }
+            Ok(Self::Unix { device: metadata.dev(), inode: metadata.ino() })
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = path;
+            Ok(Self::Unavailable)
+        }
+    }
+
+    fn matches_path(self, path: &Path) -> std::io::Result<bool> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+            let metadata = match std::fs::symlink_metadata(path) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+                Err(error) => return Err(error),
+            };
+            Ok(metadata.file_type().is_socket()
+                && matches!(
+                    self,
+                    Self::Unix { device, inode }
+                        if metadata.dev() == device && metadata.ino() == inode
+                ))
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = (self, path);
+            Ok(true)
+        }
+    }
+}
+
+/// Identity-fenced ownership of one bound local server socket.
+///
+/// Unix cleanup removes the path only when it still names the socket inode
+/// captured after this server bound it. The start lock serializes that check
+/// and removal with other cmux server starts.
+pub struct ServedSocketLease {
+    path: PathBuf,
+    identity: SocketPathIdentity,
+    linked: bool,
+}
+
+impl ServedSocketLease {
+    /// Capture the identity of a successfully bound socket path.
+    pub fn claim(path: PathBuf) -> std::io::Result<Self> {
+        let identity = SocketPathIdentity::capture(&path)?;
+        Ok(Self { path, identity, linked: true })
+    }
+
+    /// Return the public path owned by this lease.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Remove this publication only while it still belongs to this lease.
+    pub fn unlink(&mut self) -> std::io::Result<()> {
+        if !self.linked {
+            return Ok(());
+        }
+
+        let _start_lock =
+            SocketStartLock::acquire(&self.path, Instant::now() + SOCKET_CLEANUP_DEADLINE)?;
+        if self.identity.matches_path(&self.path)? {
+            match std::fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        self.linked = false;
+        Ok(())
+    }
+
+    /// Remove this lease and ignore cleanup errors, as required by `Drop`.
+    pub fn cleanup(mut self) {
+        let _ = self.unlink();
+    }
+
+    fn into_unfenced_path(mut self) -> PathBuf {
+        self.linked = false;
+        self.path.clone()
+    }
+
+    fn unlink_with_wake(mut self) {
+        let result = (|| {
+            if !self.linked {
+                return Ok(());
+            }
+            let _start_lock =
+                SocketStartLock::acquire(&self.path, Instant::now() + SOCKET_CLEANUP_DEADLINE)?;
+            if self.identity.matches_path(&self.path)? {
+                // Wake only this listener. If the path now names a successor,
+                // connecting would deliver an unsolicited client to it.
+                let _ = transport::connect(&self.path);
+                match std::fs::remove_file(&self.path) {
+                    Ok(()) => {}
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                    Err(error) => return Err(error),
+                }
+            }
+            self.linked = false;
+            Ok(())
+        })();
+        let _ = result;
+    }
+}
+
+impl Drop for ServedSocketLease {
+    fn drop(&mut self) {
+        let _ = self.unlink();
+    }
+}
+
 /// A bound local server whose lifecycle endpoint is not ready yet.
 pub struct PendingServer {
-    path: Option<PathBuf>,
+    lease: Option<ServedSocketLease>,
     mux: Arc<Mux>,
     shutdown: Arc<AtomicBool>,
 }
@@ -4729,21 +4866,37 @@ impl PendingServer {
     /// Publish lifecycle readiness and transfer socket cleanup to the caller.
     pub fn mark_ready(mut self) -> anyhow::Result<PathBuf> {
         self.mux.mark_server_lifecycle_ready();
-        Ok(self.path.take().expect("pending server path is available"))
+        Ok(self
+            .lease
+            .take()
+            .expect("pending server socket lease is available")
+            .into_unfenced_path())
     }
 
-    /// Transfer socket cleanup while another startup owner publishes readiness.
+    /// Publish lifecycle readiness and retain identity-fenced socket ownership.
+    pub fn mark_ready_owned(mut self) -> anyhow::Result<ServedSocketLease> {
+        self.mux.mark_server_lifecycle_ready();
+        Ok(self.lease.take().expect("pending server socket lease is available"))
+    }
+
+    /// Transfer identity-fenced socket cleanup while another startup owner
+    /// publishes readiness.
+    pub fn into_bound_socket(mut self) -> ServedSocketLease {
+        self.lease.take().expect("pending server socket lease is available")
+    }
+
+    /// Transfer legacy path cleanup while another startup owner publishes
+    /// readiness. New owners should use [`Self::into_bound_socket`].
     pub fn into_bound_path(mut self) -> PathBuf {
-        self.path.take().expect("pending server path is available")
+        self.lease.take().expect("pending server socket lease is available").into_unfenced_path()
     }
 }
 
 impl Drop for PendingServer {
     fn drop(&mut self) {
-        if let Some(path) = self.path.take() {
+        if let Some(lease) = self.lease.take() {
             self.shutdown.store(true, Ordering::Release);
-            let _ = transport::connect(&path);
-            cleanup(&path);
+            lease.unlink_with_wake();
         }
     }
 }
@@ -4848,15 +5001,16 @@ pub fn prepare_socket_parent(path: &Path, is_derived: bool) -> anyhow::Result<()
     Ok(())
 }
 
-/// Exclusive lock serializing every local server start for one socket path:
-/// foreground `server start`, in-process TUI hosting, and detached-owner
-/// spawns. The stale-socket recovery below (probe, unlink, bind) is not
-/// atomic, so two unserialized starts can both classify a socket as stale,
-/// and the second unlink disconnects the first starter's freshly bound
-/// socket while its process keeps running unreachably. The lock file lives
-/// next to the socket and is left in place: unlinking it would reopen the
-/// very race it exists to close. The OS releases the lock when the holder
-/// exits, so a crashed starter never wedges the session.
+/// Exclusive lock serializing every local server start and identity-fenced
+/// cleanup for one socket path: foreground `server start`, in-process TUI
+/// hosting, and detached-owner spawns. The stale-socket recovery below
+/// (probe, unlink, bind) is not atomic, so two unserialized starts can both
+/// classify a socket as stale, and the second unlink disconnects the first
+/// starter's freshly bound socket while its process keeps running
+/// unreachably. The lock file lives next to the socket and is left in place:
+/// unlinking it would reopen the very race it exists to close. The OS releases
+/// the lock when the holder exits, so a crashed starter never wedges the
+/// session.
 pub struct SocketStartLock {
     _file: std::fs::File,
 }
@@ -4929,6 +5083,8 @@ impl SocketStartLock {
 /// healthy contender clears in milliseconds; the bound exists to surface a
 /// wedged holder as an error instead of a hang.
 const START_LOCK_DEADLINE: Duration = Duration::from_secs(10);
+/// Bound cleanup waits so a shutdown path cannot hang on a wedged starter.
+const SOCKET_CLEANUP_DEADLINE: Duration = Duration::from_secs(2);
 
 /// Bind the socket and accept protocol clients before lifecycle readiness.
 pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PendingServer> {
@@ -4952,9 +5108,10 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
         }
     }
     let listener = transport::listen(&path)?;
+    let lease = ServedSocketLease::claim(path.clone())?;
     drop(start_lock);
     if let Err(error) = platform::restrict_file(&path) {
-        cleanup(&path);
+        lease.cleanup();
         return Err(error.into());
     }
     let active_connections = Arc::new(AtomicU64::new(0));
@@ -4978,10 +5135,10 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
         }
     });
     if let Err(error) = server {
-        cleanup(&path);
+        lease.cleanup();
         return Err(error.into());
     }
-    Ok(PendingServer { path: Some(path), mux, shutdown })
+    Ok(PendingServer { lease: Some(lease), mux, shutdown })
 }
 
 /// Bind the socket and serve connections on background threads.

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13519,6 +13519,47 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn dropping_a_stale_pending_server_preserves_a_replacement_socket() {
+        let dir = TestSocketDir::create("pending-server-replacement");
+        let path = dir.path().join("mux.sock");
+        let first = serve_paused(test_mux(), Some(path.clone())).unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+        let second = serve_paused(test_mux(), Some(path.clone())).unwrap();
+        drop(first);
+
+        assert!(path.exists(), "stale pending-server cleanup removed the replacement socket");
+        assert!(transport::connect(&path).is_ok());
+        drop(second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_server_cleanup_waits_for_the_start_lock() {
+        let dir = TestSocketDir::create("pending-server-cleanup-lock");
+        let path = dir.path().join("mux.sock");
+        let pending = serve_paused(test_mux(), Some(path.clone())).unwrap();
+        let start_lock = SocketStartLock::acquire(&path, Instant::now()).unwrap();
+        let (observed_tx, observed_rx) = std::sync::mpsc::channel();
+        let cleanup = std::thread::spawn(move || {
+            drop(pending);
+            observed_tx.send(()).unwrap();
+        });
+
+        assert!(
+            observed_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "pending-server cleanup bypassed the concurrent start lock"
+        );
+        drop(start_lock);
+        observed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("pending-server cleanup did not resume after the start lock was released");
+        cleanup.join().unwrap();
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unix_socket_path_reserves_trailing_nul() {
         const SUN_PATH_CAPACITY: usize =
             size_of::<libc::sockaddr_un>() - offset_of!(libc::sockaddr_un, sun_path);

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1827,25 +1827,32 @@ fn socket_option(fd: std::os::fd::RawFd, option: libc::c_int) -> io::Result<libc
 
 struct ServedMuxCleanup {
     mux: Option<Arc<Mux>>,
-    socket_path: PathBuf,
+    socket: Option<cmux_tui_core::server::ServedSocketLease>,
 }
 
 impl ServedMuxCleanup {
-    fn new(mux: Arc<Mux>, socket_path: PathBuf) -> Self {
-        Self { mux: Some(mux), socket_path }
+    fn new(mux: Arc<Mux>, socket: cmux_tui_core::server::ServedSocketLease) -> Self {
+        Self { mux: Some(mux), socket: Some(socket) }
     }
 
     fn disarm(&mut self) {
         self.mux = None;
+        self.socket = None;
+    }
+
+    fn cleanup(&mut self) {
+        if let Some(mux) = self.mux.take() {
+            mux.shutdown();
+        }
+        if let Some(socket) = self.socket.take() {
+            socket.cleanup();
+        }
     }
 }
 
 impl Drop for ServedMuxCleanup {
     fn drop(&mut self) {
-        if let Some(mux) = self.mux.take() {
-            mux.shutdown();
-            cmux_tui_core::server::cleanup(&self.socket_path);
-        }
+        self.cleanup();
     }
 }
 
@@ -2134,7 +2141,7 @@ fn run_server(
             server.local_addr()
         );
     }
-    let served_socket = pending_server.into_bound_path();
+    let served_socket = pending_server.into_bound_socket();
     let mut served_mux_cleanup = ServedMuxCleanup::new(mux.clone(), served_socket);
 
     let machine_runtime = (config.machine_sidebar.enabled
@@ -2184,8 +2191,7 @@ fn run_server(
     {
         let shutdown_result = finish_server_shutdown(
             websocket_server,
-            &mux,
-            &socket_path,
+            &mut served_mux_cleanup,
             remote_shutdown,
             result.and(owner_event_result),
         );
@@ -2196,8 +2202,7 @@ fn run_server(
     #[cfg(not(unix))]
     {
         drop(websocket_server);
-        mux.shutdown();
-        cmux_tui_core::server::cleanup(&socket_path);
+        served_mux_cleanup.cleanup();
         served_mux_cleanup.disarm();
         drop(served_mux_cleanup);
         result.and(owner_event_result)
@@ -2254,14 +2259,12 @@ fn start_local_owner_event_loop_with_completion(
 #[cfg(unix)]
 fn finish_server_shutdown<W, R>(
     websocket_server: Option<W>,
-    mux: &Arc<Mux>,
-    socket_path: &Path,
+    served_mux_cleanup: &mut ServedMuxCleanup,
     remote_shutdown: anyhow::Result<Option<R>>,
     result: anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     drop(websocket_server);
-    mux.shutdown();
-    cmux_tui_core::server::cleanup(socket_path);
+    served_mux_cleanup.cleanup();
     remote_shutdown.map(|_| ())?;
     result
 }
@@ -3100,18 +3103,23 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn remote_shutdown_failure_still_stops_the_mux_and_removes_the_socket() {
-        let socket_path = std::env::temp_dir().join(format!(
-            "cmux-remote-shutdown-{}-{}.sock",
+        let directory = std::env::temp_dir().join(format!(
+            "cmux-remote-shutdown-{}-{}",
             std::process::id(),
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
         ));
-        std::fs::write(&socket_path, b"test socket marker").unwrap();
+        std::fs::create_dir(&directory).unwrap();
+        let socket_path = directory.join("server.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
         let mux = Mux::new("remote-shutdown-failure", SurfaceOptions::default());
+        let mut cleanup = ServedMuxCleanup::new(
+            mux.clone(),
+            cmux_tui_core::server::ServedSocketLease::claim(socket_path.clone()).unwrap(),
+        );
 
         let error = finish_server_shutdown(
             Some(()),
-            &mux,
-            &socket_path,
+            &mut cleanup,
             Err::<Option<()>, _>(anyhow::anyhow!("injected remote shutdown failure")),
             Ok(()),
         )
@@ -3121,24 +3129,32 @@ mod tests {
         assert!(error.contains("injected remote shutdown failure"), "{error}");
         assert!(mux.daemon_shutdown_requested());
         assert!(!socket_path.exists());
+        cleanup.disarm();
+        drop(listener);
+        let _ = std::fs::remove_file(directory.join("server.sock.spawn-lock"));
+        std::fs::remove_dir(directory).unwrap();
     }
 
     #[cfg(unix)]
     #[test]
     fn normal_server_cleanup_disarms_the_fallback_guard() {
-        let socket_path = std::env::temp_dir().join(format!(
-            "cmux-normal-shutdown-{}-{}.sock",
+        let directory = std::env::temp_dir().join(format!(
+            "cmux-normal-shutdown-{}-{}",
             std::process::id(),
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
         ));
-        std::fs::write(&socket_path, b"test socket marker").unwrap();
+        std::fs::create_dir(&directory).unwrap();
+        let socket_path = directory.join("server.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
         let mux = Mux::new("normal-shutdown", SurfaceOptions::default());
-        let mut cleanup = ServedMuxCleanup::new(mux.clone(), socket_path.clone());
+        let mut cleanup = ServedMuxCleanup::new(
+            mux.clone(),
+            cmux_tui_core::server::ServedSocketLease::claim(socket_path.clone()).unwrap(),
+        );
 
         finish_server_shutdown(
             Some(()),
-            &mux,
-            &socket_path,
+            &mut cleanup,
             Ok::<Option<()>, anyhow::Error>(None),
             Ok(()),
         )
@@ -3148,6 +3164,9 @@ mod tests {
         assert!(cleanup.mux.is_none());
         assert!(mux.daemon_shutdown_requested());
         assert!(!socket_path.exists());
+        drop(listener);
+        let _ = std::fs::remove_file(directory.join("server.sock.spawn-lock"));
+        std::fs::remove_dir(directory).unwrap();
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- retain the bound Unix socket's device/inode identity in a `ServedSocketLease`
- serialize lease cleanup with the hardened `SocketStartLock` before checking and unlinking
- route `PendingServer` and the main shutdown guard through the identity-fenced lease

This PR depends on https://github.com/manaflow-ai/cmux/pull/11396 at head `825658868468bf730eb90de5c3a5dfc1fc1b1d17`. Merge #11396 first, then this PR.

The regression test reproduces a stale listener dropping after a successor rebinds the same pathname. The old cleanup connected to and unlinked the successor. The fix checks device/inode while holding the same per-path start lock, and skips the successor when identity differs.

## Verification
- `git diff --check`
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/server.rs cmux-tui/crates/cmux-tui/src/main.rs`
- hosted focused cmux-tui workflow: `./scripts/verify-cmux-tui-hosted.sh --filter dropping_a_stale_pending_server_preserves_a_replacement_socket`
- local Cargo/Rust tests were not run by instruction

## References
- Rust filesystem TOCTOU guidance: https://doc.rust-lang.org/std/fs/index.html
- Rust `OpenOptions`: https://doc.rust-lang.org/std/fs/struct.OpenOptions.html
- POSIX `unlink`: https://pubs.opengroup.org/onlinepubs/9799919799/functions/unlink.html
- POSIX `rename`: https://pubs.opengroup.org/onlinepubs/9799919799/functions/rename.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale listener cleanup in the TUI server so dropping a pending server no longer removes a successor socket that rebinds the same path.

- Captures the bound socket's device/inode in a `ServedSocketLease` and checks identity while holding the `SocketStartLock` before unlinking.
- Routes `PendingServer` and the shutdown guard through the lease; cleanup skips the path when it no longer names the original socket.
- Adds regression tests covering a stale pending server replacement and cleanup waiting for the start lock.

**Notes**
- Depends on `manaflow-ai/cmux#11396`; merge that PR first.

<sup>Written for commit 2c43f78e587839dd0379fbe14c4fc86ed60dc505. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11475?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

