### PR TITLE
fix(cmux-tui): nonblocking Hermes reaper fallback

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/unix_process_scope.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/unix_process_scope.rs
@@ -164,7 +164,13 @@ pub struct UnixProcessScope {
 /// PID or process group before its process scope is terminated.
 pub struct UnixChildExitSignal {
     result: mpsc::Receiver<io::Result<()>>,
+    action: Option<mpsc::SyncSender<UnixChildExitAction>>,
     observer: Option<JoinHandle<()>>,
+}
+
+enum UnixChildExitAction {
+    Release,
+    Reap,
 }
 
 impl UnixChildExitSignal {
@@ -174,11 +180,17 @@ impl UnixChildExitSignal {
             io::Error::new(io::ErrorKind::InvalidInput, "child pid is out of range")
         })?;
         let (sender, result) = mpsc::sync_channel(1);
+        let (action_sender, action_receiver) = mpsc::sync_channel(1);
         let observer =
             std::thread::Builder::new().name("cmux-child-exit".into()).spawn(move || {
-                let _ = sender.send(wait_for_child_exit_without_reaping(pid));
+                let result = wait_for_child_exit_without_reaping(pid);
+                let observed = result.is_ok();
+                let _ = sender.send(result);
+                if matches!(action_receiver.recv(), Ok(UnixChildExitAction::Reap)) && observed {
+                    reap_child(pid);
+                }
             })?;
-        Ok(Self { result, observer: Some(observer) })
+        Ok(Self { result, action: Some(action_sender), observer: Some(observer) })
     }
 
     /// Return true when the child is waitable without releasing its PID.
@@ -207,11 +219,36 @@ impl UnixChildExitSignal {
         }
     }
 
+    fn send_action(&mut self, action: UnixChildExitAction) {
+        if let Some(sender) = self.action.take() {
+            let _ = sender.try_send(action);
+        }
+    }
+
     /// Join the observer after the child is waitable or has been killed.
     pub fn finish(mut self) {
+        self.send_action(UnixChildExitAction::Release);
         if let Some(observer) = self.observer.take() {
             let _ = observer.join();
         }
+    }
+
+    /// Transfer Unix wait ownership to the already-running observer and
+    /// return without waiting for the child. The caller must drop its `Child`
+    /// handle after this handoff. The observer performs the blocking `waitpid`
+    /// so a timeout path cannot exceed its caller's deadline when a second
+    /// reaper thread cannot be created.
+    pub fn reap(mut self) {
+        self.send_action(UnixChildExitAction::Reap);
+        // Dropping the join handle intentionally detaches the observer. The
+        // process remains waitable until that observer consumes its status.
+        self.observer.take();
+    }
+}
+
+impl Drop for UnixChildExitSignal {
+    fn drop(&mut self) {
+        self.send_action(UnixChildExitAction::Release);
     }
 }
 
@@ -235,6 +272,25 @@ fn wait_for_child_exit_without_reaping(pid: libc::pid_t) -> io::Result<()> {
         if error.kind() != io::ErrorKind::Interrupted {
             return Err(error);
         }
+    }
+}
+
+fn reap_child(pid: libc::pid_t) {
+    let mut status = 0;
+    loop {
+        // SAFETY: `pid` was validated by `observe`, and this observer is the
+        // sole owner of the wait decision after the WNOWAIT observation.
+        let waited = unsafe { libc::waitpid(pid, &mut status, 0) };
+        if waited == pid {
+            return;
+        }
+        if waited < 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() == io::ErrorKind::Interrupted {
+                continue;
+            }
+        }
+        return;
     }
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/unix_process_scope.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/unix_process_scope.rs
@@ -242,7 +242,7 @@ impl UnixChildExitSignal {
         self.send_action(UnixChildExitAction::Reap);
         // Dropping the join handle intentionally detaches the observer. The
         // process remains waitable until that observer consumes its status.
-        self.observer.take();
+        drop(self.observer.take());
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -1,3 +1,5 @@
+#[cfg(test)]
+use std::cell::Cell;
 use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::OsString;
 use std::fs::{self, OpenOptions};
@@ -51,6 +53,21 @@ const CODEX_SESSION_END_TIMEOUT_SECONDS: u64 = 3;
 const GEMINI_HOOK_TIMEOUT_MILLISECONDS: u64 = 5_000;
 const HERMES_COMMAND_TIMEOUT: Duration = Duration::from_secs(5);
 const HERMES_COMMAND_OUTPUT_BYTES: u64 = 4 * 1024 * 1024;
+
+#[cfg(test)]
+std::thread_local! {
+    static FORCE_HERMES_REAPER_SPAWN_FAILURE: Cell<bool> = const { Cell::new(false) };
+}
+
+#[cfg(test)]
+fn hermes_reaper_spawn_should_fail() -> bool {
+    FORCE_HERMES_REAPER_SPAWN_FAILURE.with(Cell::get)
+}
+
+#[cfg(not(test))]
+fn hermes_reaper_spawn_should_fail() -> bool {
+    false
+}
 
 const CODEX_EVENTS: &[&str] = &[
     "SessionStart",
@@ -709,6 +726,22 @@ fn run_hermes_command(binary: &Path, args: &[&str]) -> anyhow::Result<Output> {
 
 type HermesOutputReader = std::thread::JoinHandle<io::Result<Vec<u8>>>;
 
+fn spawn_hermes_reaper(
+    child: Child,
+    #[cfg(unix)] child_exit: Option<UnixChildExitSignal>,
+) -> io::Result<()> {
+    let reaper = move || {
+        #[cfg(unix)]
+        child_exit.expect("Unix child exit observer").finish();
+        let _ = child.wait();
+    };
+    if hermes_reaper_spawn_should_fail() {
+        drop(reaper);
+        return Err(io::Error::other("forced Hermes reaper spawn failure"));
+    }
+    std::thread::Builder::new().name("hermes-command-reaper".into()).spawn(reaper).map(|_| ())
+}
+
 #[cfg(unix)]
 fn cleanup_hermes_start_failure(
     child: &mut Child,
@@ -865,11 +898,11 @@ fn run_hermes_command_with_timeout(
         // Reaping must not extend the command's absolute deadline. The
         // process scope or Windows job has already issued exact termination;
         // a detached reaper owns the blocking wait.
-        let _ = std::thread::Builder::new().name("hermes-command-reaper".into()).spawn(move || {
+        let _ = spawn_hermes_reaper(
+            child,
             #[cfg(unix)]
-            child_exit.take().expect("Unix child exit observer").finish();
-            let _ = child.wait();
-        });
+            child_exit.take(),
+        );
     }
     let stdout = stdout.join().map_err(|_| anyhow::anyhow!("Hermes stdout reader panicked"))?;
     let stderr = stderr.join().map_err(|_| anyhow::anyhow!("Hermes stderr reader panicked"))?;
@@ -2165,6 +2198,49 @@ mod tests {
         .unwrap_err();
         assert!(error.to_string().contains("timed out"));
         assert!(started.elapsed() < Duration::from_secs(2));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hermes_command_reaps_child_when_reaper_spawn_fails() {
+        struct ReaperFailureGuard;
+
+        impl Drop for ReaperFailureGuard {
+            fn drop(&mut self) {
+                FORCE_HERMES_REAPER_SPAWN_FAILURE.with(|failure| failure.set(false));
+            }
+        }
+
+        let root = tempfile::tempdir().unwrap();
+        let pid_path = root.path().join("hermes.pid");
+        let script = format!(
+            "printf '%s' $$ > {}; sleep 30",
+            shell_quote(pid_path.to_string_lossy().as_ref())
+        );
+        FORCE_HERMES_REAPER_SPAWN_FAILURE.with(|failure| failure.set(true));
+        let _failure_guard = ReaperFailureGuard;
+        let started = Instant::now();
+        let error = run_hermes_command_with_timeout(
+            Path::new("/bin/sh"),
+            &["-c", &script],
+            Duration::from_millis(100),
+        )
+        .unwrap_err();
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(2));
+
+        let pid = fs::read_to_string(pid_path).unwrap().trim().parse::<libc::pid_t>().unwrap();
+        let mut status = 0;
+        let waited = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+        assert_eq!(
+            waited, -1,
+            "Hermes child was not reaped before timeout returned (waitpid={waited})"
+        );
+        assert_eq!(
+            io::Error::last_os_error().raw_os_error(),
+            Some(libc::ECHILD),
+            "waitpid must report ECHILD after the timeout path reaps the child"
+        );
     }
 
     #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -743,15 +743,15 @@ impl HermesReapState {
     }
 
     fn reap(&self) {
-        let child = self.child.lock().expect("Hermes reaper mutex poisoned").take();
-        if let Some(mut child) = child {
-            let _ = child.wait();
-        }
         #[cfg(unix)]
         if let Some(child_exit) =
             self.child_exit.lock().expect("Hermes exit observer mutex poisoned").take()
         {
             child_exit.finish();
+        }
+        let child = self.child.lock().expect("Hermes reaper mutex poisoned").take();
+        if let Some(mut child) = child {
+            let _ = child.wait();
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -754,6 +754,30 @@ impl HermesReapState {
             let _ = child.wait();
         }
     }
+
+    fn handoff_reap(&self) {
+        #[cfg(unix)]
+        let child_exit =
+            self.child_exit.lock().expect("Hermes exit observer mutex poisoned").take();
+        let child = self.child.lock().expect("Hermes reaper mutex poisoned").take();
+
+        #[cfg(unix)]
+        if let Some(child_exit) = child_exit {
+            // The exit observer already owns the child's PID wait path. It
+            // can block in waitpid without extending this timeout caller.
+            child_exit.reap();
+            drop(child);
+            return;
+        }
+
+        // This is only a defensive path. Unix commands install an exit
+        // observer before reaching the timeout branch. On Windows, closing
+        // the process handle after a nonblocking probe leaves termination to
+        // the kernel without making the timeout caller wait.
+        if let Some(mut child) = child {
+            let _ = child.try_wait();
+        }
+    }
 }
 
 fn spawn_hermes_reaper(state: Arc<HermesReapState>) -> io::Result<()> {
@@ -930,9 +954,10 @@ fn run_hermes_command_with_timeout(
         #[cfg(not(unix))]
         let reap_state = Arc::new(HermesReapState::new(child));
         if spawn_hermes_reaper(Arc::clone(&reap_state)).is_err() {
-            // Keep an owner in this scope when the OS cannot create the
-            // detached reaper. Child::drop does not wait on Unix.
-            reap_state.reap();
+            // Keep the already-running Unix observer as the owner when the
+            // OS cannot create the detached reaper. The handoff is
+            // nonblocking, so thread exhaustion cannot extend the deadline.
+            reap_state.handoff_reap();
         }
     }
     let stdout = stdout.join().map_err(|_| anyhow::anyhow!("Hermes stdout reader panicked"))?;
@@ -2261,19 +2286,72 @@ mod tests {
         assert!(started.elapsed() < Duration::from_secs(2));
 
         let pid = fs::read_to_string(pid_path).unwrap().trim().parse::<libc::pid_t>().unwrap();
-        let mut status = 0;
-        // SAFETY: `pid` was written by the direct child started above, and no
-        // other test thread can own or reap that child.
-        let waited = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
-        assert_eq!(
-            waited, -1,
-            "Hermes child was not reaped before timeout returned (waitpid={waited})"
+        let reap_deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            let mut status = 0;
+            // SAFETY: `pid` was written by the direct child started above, and
+            // no other test thread can own or reap that child.
+            let waited = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
+            if waited < 0 {
+                let error = io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::ECHILD) {
+                    break;
+                }
+                panic!("waitpid failed while checking Hermes reaper: {error}");
+            }
+            assert_ne!(waited, pid, "the test thread reaped the Hermes child before the observer");
+            assert!(
+                Instant::now() < reap_deadline,
+                "Hermes child was not reaped after timeout returned"
+            );
+            std::thread::sleep(Duration::from_millis(5));
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hermes_reaper_spawn_failure_does_not_wait_for_a_live_child() {
+        struct ReaperFailureGuard;
+
+        impl Drop for ReaperFailureGuard {
+            fn drop(&mut self) {
+                FORCE_HERMES_REAPER_SPAWN_FAILURE.with(|failure| failure.set(false));
+            }
+        }
+
+        struct ChildGuard(libc::pid_t);
+
+        impl Drop for ChildGuard {
+            fn drop(&mut self) {
+                // SAFETY: this is the direct child created by the test.
+                unsafe {
+                    libc::kill(self.0, libc::SIGKILL);
+                    let mut status = 0;
+                    libc::waitpid(self.0, &mut status, 0);
+                }
+            }
+        }
+
+        let child = std::process::Command::new("/bin/sh").args(["-c", "sleep 30"]).spawn().unwrap();
+        let pid = libc::pid_t::try_from(child.id()).unwrap();
+        let _child_guard = ChildGuard(pid);
+        let child_exit = UnixChildExitSignal::observe(child.id()).unwrap();
+        let state = Arc::new(HermesReapState::new(child, Some(child_exit)));
+        FORCE_HERMES_REAPER_SPAWN_FAILURE.with(|failure| failure.set(true));
+        let _failure_guard = ReaperFailureGuard;
+
+        let started = Instant::now();
+        assert!(spawn_hermes_reaper(Arc::clone(&state)).is_err());
+        state.handoff_reap();
+        assert!(
+            started.elapsed() < Duration::from_millis(200),
+            "reaper fallback waited for a live child"
         );
-        assert_eq!(
-            io::Error::last_os_error().raw_os_error(),
-            Some(libc::ECHILD),
-            "waitpid must report ECHILD after the timeout path reaps the child"
-        );
+
+        // The handoff deliberately leaves the live child to make the
+        // nonblocking property observable. The guard terminates it after the
+        // assertion and consumes any status the detached observer did not yet
+        // consume.
     }
 
     #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -14,6 +14,7 @@ use std::path::{Path, PathBuf};
 #[cfg(not(unix))]
 use std::process::Command;
 use std::process::{Child, Output, Stdio};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::Context as _;
@@ -726,20 +727,45 @@ fn run_hermes_command(binary: &Path, args: &[&str]) -> anyhow::Result<Output> {
 
 type HermesOutputReader = std::thread::JoinHandle<io::Result<Vec<u8>>>;
 
-fn spawn_hermes_reaper(
-    child: Child,
-    #[cfg(unix)] child_exit: Option<UnixChildExitSignal>,
-) -> io::Result<()> {
-    let reaper = move || {
+struct HermesReapState {
+    child: Mutex<Option<Child>>,
+    #[cfg(unix)]
+    child_exit: Mutex<Option<UnixChildExitSignal>>,
+}
+
+impl HermesReapState {
+    fn new(child: Child, #[cfg(unix)] child_exit: Option<UnixChildExitSignal>) -> Self {
+        Self {
+            child: Mutex::new(Some(child)),
+            #[cfg(unix)]
+            child_exit: Mutex::new(child_exit),
+        }
+    }
+
+    fn reap(&self) {
+        let child = self.child.lock().expect("Hermes reaper mutex poisoned").take();
+        if let Some(mut child) = child {
+            let _ = child.wait();
+        }
         #[cfg(unix)]
-        child_exit.expect("Unix child exit observer").finish();
-        let _ = child.wait();
-    };
+        if let Some(child_exit) =
+            self.child_exit.lock().expect("Hermes exit observer mutex poisoned").take()
+        {
+            child_exit.finish();
+        }
+    }
+}
+
+fn spawn_hermes_reaper(state: Arc<HermesReapState>) -> io::Result<()> {
+    let reaper_state = Arc::clone(&state);
     if hermes_reaper_spawn_should_fail() {
-        drop(reaper);
+        drop(reaper_state);
         return Err(io::Error::other("forced Hermes reaper spawn failure"));
     }
-    std::thread::Builder::new().name("hermes-command-reaper".into()).spawn(reaper).map(|_| ())
+    std::thread::Builder::new()
+        .name("hermes-command-reaper".into())
+        .spawn(move || reaper_state.reap())
+        .map(|_| ())
 }
 
 #[cfg(unix)]
@@ -895,14 +921,19 @@ fn run_hermes_command_with_timeout(
     let timed_out = status.is_none();
     if timed_out {
         let _ = child.kill();
-        // Reaping must not extend the command's absolute deadline. The
-        // process scope or Windows job has already issued exact termination;
-        // a detached reaper owns the blocking wait.
-        let _ = spawn_hermes_reaper(
-            child,
-            #[cfg(unix)]
-            child_exit.take(),
-        );
+        // Keep normal reaping detached so it does not extend the command's
+        // absolute deadline. The process scope or Windows job has already
+        // issued exact termination. If the OS cannot create that thread, the
+        // state below keeps ownership for a synchronous fallback.
+        #[cfg(unix)]
+        let reap_state = Arc::new(HermesReapState::new(child, child_exit.take()));
+        #[cfg(not(unix))]
+        let reap_state = Arc::new(HermesReapState::new(child));
+        if spawn_hermes_reaper(Arc::clone(&reap_state)).is_err() {
+            // Keep an owner in this scope when the OS cannot create the
+            // detached reaper. Child::drop does not wait on Unix.
+            reap_state.reap();
+        }
     }
     let stdout = stdout.join().map_err(|_| anyhow::anyhow!("Hermes stdout reader panicked"))?;
     let stderr = stderr.join().map_err(|_| anyhow::anyhow!("Hermes stderr reader panicked"))?;
@@ -2231,6 +2262,8 @@ mod tests {
 
         let pid = fs::read_to_string(pid_path).unwrap().trim().parse::<libc::pid_t>().unwrap();
         let mut status = 0;
+        // SAFETY: `pid` was written by the direct child started above, and no
+        // other test thread can own or reap that child.
         let waited = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
         assert_eq!(
             waited, -1,

--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -948,7 +948,7 @@ fn run_hermes_command_with_timeout(
         // Keep normal reaping detached so it does not extend the command's
         // absolute deadline. The process scope or Windows job has already
         // issued exact termination. If the OS cannot create that thread, the
-        // state below keeps ownership for a synchronous fallback.
+        // state below keeps ownership for a nonblocking fallback handoff.
         #[cfg(unix)]
         let reap_state = Arc::new(HermesReapState::new(child, child_exit.take()));
         #[cfg(not(unix))]

--- a/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
+++ b/cmux-tui/crates/cmux-tui/src/agent_hook_install.rs
@@ -2259,47 +2259,67 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn hermes_command_reaps_child_when_reaper_spawn_fails() {
-        struct ReaperFailureGuard;
-
-        impl Drop for ReaperFailureGuard {
-            fn drop(&mut self) {
-                FORCE_HERMES_REAPER_SPAWN_FAILURE.with(|failure| failure.set(false));
-            }
-        }
-
         let root = tempfile::tempdir().unwrap();
         let pid_path = root.path().join("hermes.pid");
+        let continue_path = root.path().join("hermes.continue");
         let script = format!(
-            "printf '%s' $$ > {}; sleep 30",
-            shell_quote(pid_path.to_string_lossy().as_ref())
+            "printf '%s' $$ > {}; while [ ! -f {} ]; do sleep 0.01; done; sleep 30",
+            shell_quote(pid_path.to_string_lossy().as_ref()),
+            shell_quote(continue_path.to_string_lossy().as_ref())
         );
-        FORCE_HERMES_REAPER_SPAWN_FAILURE.with(|failure| failure.set(true));
-        let _failure_guard = ReaperFailureGuard;
-        let started = Instant::now();
-        let error = run_hermes_command_with_timeout(
-            Path::new("/bin/sh"),
-            &["-c", &script],
-            Duration::from_millis(100),
-        )
-        .unwrap_err();
-        assert!(error.to_string().contains("timed out"));
-        assert!(started.elapsed() < Duration::from_secs(2));
 
-        let pid = fs::read_to_string(pid_path).unwrap().trim().parse::<libc::pid_t>().unwrap();
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(1);
+        let started = Instant::now();
+        let worker = std::thread::spawn(move || {
+            FORCE_HERMES_REAPER_SPAWN_FAILURE.with(|failure| failure.set(true));
+            let result = run_hermes_command_with_timeout(
+                Path::new("/bin/sh"),
+                &["-c", &script],
+                Duration::from_secs(2),
+            );
+            result_sender.send(result).unwrap();
+        });
+
+        let startup_deadline = Instant::now() + Duration::from_secs(1);
+        let pid = loop {
+            if let Ok(contents) = fs::read_to_string(&pid_path) {
+                if let Ok(pid) = contents.trim().parse::<libc::pid_t>() {
+                    break pid;
+                }
+            }
+            assert!(Instant::now() < startup_deadline, "Hermes child did not complete startup");
+            std::thread::sleep(Duration::from_millis(5));
+        };
+        fs::write(&continue_path, b"continue\n").unwrap();
+
+        let error = result_receiver
+            .recv_timeout(Duration::from_secs(4))
+            .expect("Hermes timeout worker did not return")
+            .unwrap_err();
+        worker.join().unwrap();
+        assert!(error.to_string().contains("timed out"));
+        assert!(started.elapsed() < Duration::from_secs(4));
+
         let reap_deadline = Instant::now() + Duration::from_secs(2);
         loop {
-            let mut status = 0;
+            let mut status = std::mem::MaybeUninit::<libc::siginfo_t>::zeroed();
             // SAFETY: `pid` was written by the direct child started above, and
-            // no other test thread can own or reap that child.
-            let waited = unsafe { libc::waitpid(pid, &mut status, libc::WNOHANG) };
-            if waited < 0 {
+            // WNOWAIT keeps this assertion from consuming its exit status.
+            let result = unsafe {
+                libc::waitid(
+                    libc::P_PID,
+                    pid as libc::id_t,
+                    status.as_mut_ptr(),
+                    libc::WEXITED | libc::WNOHANG | libc::WNOWAIT,
+                )
+            };
+            if result < 0 {
                 let error = io::Error::last_os_error();
                 if error.raw_os_error() == Some(libc::ECHILD) {
                     break;
                 }
-                panic!("waitpid failed while checking Hermes reaper: {error}");
+                panic!("waitid failed while checking Hermes reaper: {error}");
             }
-            assert_ne!(waited, pid, "the test thread reaped the Hermes child before the observer");
             assert!(
                 Instant::now() < reap_deadline,
                 "Hermes child was not reaped after timeout returned"


### PR DESCRIPTION
## Summary
- Keep ownership of a timed-out Hermes child and its Unix exit observer in shared state.
- If the per-command reaper thread cannot start, hand wait ownership to the already-running Unix observer. It performs the final waitpid while the timeout caller returns without an unbounded wait.
- On Windows, the fallback performs a nonblocking Child::try_wait probe before releasing the process handle after termination.
- Preserve observer ordering and add behavior coverage for forced reaper-thread failure and a still-live child.

## Testing
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/unix_process_scope.rs cmux-tui/crates/cmux-tui/src/agent_hook_install.rs (pass)
- git diff --check origin/main...HEAD (pass)
- Exact-head stable Codex 0.151.0 review with gpt-5.6-sol/high passed: no actionable findings; overall patch is correct (0.88); merge-conflict and cmux policy gates passed.
- The reaping test now uses a bounded child-start handshake and non-reaping waitid(WNOWAIT) probes, so the assertion does not race the detached observer or consume its exit status.
- Exact-head hosted dispatch was attempted with the available non-admin PAT and --filter hermes_reaper, but GitHub returned HTTP 403 `Must have admin rights to Repository`; no run ID was created.
- Earlier hosted run [33538341698](https://github.com/manaflow-ai/cmux/actions/runs/33538341698) used `--filter hermes_command` at head `a11415877d`, before the final clarification commits. It is not exact-head evidence.
- Cargo, build, and local tests were not run on the Mac, per cmux-tui instructions.

## References
- Rust Child: https://doc.rust-lang.org/std/process/struct.Child.html
- Rust thread::Builder::spawn: https://doc.rust-lang.org/std/thread/struct.Builder.html
- POSIX waitpid: https://pubs.opengroup.org/onlinepubs/9699919799/functions/wait.html

## Exact revision
- Base: 2ead47750ab2f47c13972d0709d99cdcbaa8ad73
- Head: 60f8b3f18dfe7fdc292c4960b9757f4690c22adf

## Commits
- 5c301990b6 adds the failing reaper-spawn behavior test.
- 0c01f93f97 adds shared child ownership.
- bc8e65d695 preserves observer ordering.
- 0ae797a9ab hands reaping to the existing observer without blocking.
- 2f41df1bd9 clarifies the nonblocking fallback contract.
- 60f8b3f18d synchronizes the startup and non-reaping assertions in the reaper test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of timed-out commands so responses return promptly.
  * Ensured timed-out background processes are cleaned up reliably without blocking the interface.
  * Added fallback cleanup behavior when background process cleanup cannot start.
  * Prevented indefinite waits during process cleanup, reducing the risk of lingering processes.
  * Improved reliability when cleaning up still-running child processes after command timeouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
