### PR TITLE
cmux-tui: cancel completion sends and reap machine worker

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8641,7 +8641,8 @@ impl MachineActionWorker {
         self.sender.take();
         // The stop flag is cooperative: an in-flight provider action returns
         // at its transport deadline, then the worker observes stop and closes
-        // the controller. Join so provider cleanup cannot outlive the owner.
+        // the controller. Transfer the worker handle to the reaper so owner
+        // teardown does not wait for that provider deadline.
         if let Some(worker) = self.worker.take() {
             // Provider calls are synchronous and may remain blocked until
             // their transport deadline. Reap the owned handle asynchronously
@@ -8677,8 +8678,16 @@ impl MachineActionWorker {
 impl Drop for MachineActionWorker {
     fn drop(&mut self) {
         self.shutdown();
+        // The reaper owns the worker handle. Join only when it has already
+        // finished; dropping an unfinished reaper handle intentionally lets
+        // that cleanup thread continue without blocking owner teardown. The
+        // reaper still joins the worker and calls controller.close() after the
+        // provider's bounded transport call returns, so no worker handle is
+        // detached or leaked.
         if let Some(reaper) = self.reaper.take() {
-            let _ = reaper.join();
+            if reaper.is_finished() {
+                let _ = reaper.join();
+            }
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8386,6 +8386,9 @@ impl MachineActionWorker {
                     if let Some(receive_hook) = receive_hook.as_ref() {
                         receive_hook();
                     }
+                    if worker_stop.load(Ordering::Acquire) {
+                        break;
+                    }
                     let completion = match command {
                         MachineControllerCommand::Perform { request, preparation } => {
                             if pending_replacement.is_some() {
@@ -43793,7 +43796,7 @@ mod tests {
         let (resume_tx, resume_rx) = crossbeam_channel::bounded(1);
         let receive_count = Arc::new(AtomicU64::new(0));
         let hook_count = receive_count.clone();
-        let receive_hook: MachineActionReceiveHook = Arc::new(move || {
+        let receive_hook: super::MachineActionReceiveHook = Arc::new(move || {
             if hook_count.fetch_add(1, Ordering::SeqCst) == 1 {
                 received_tx.send(()).unwrap();
                 resume_rx.recv().unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43711,6 +43711,32 @@ mod tests {
     }
 
     #[test]
+    fn machine_action_worker_drop_waits_for_reaper_cleanup() {
+        let (events, _event_receiver) = crossbeam_channel::bounded(4);
+        let (started, starts) = std::sync::mpsc::channel();
+        let (release, releases) = std::sync::mpsc::channel();
+        let worker = MachineActionWorker::spawn(
+            Box::new(OrderedBlockingMachineController { started, release: releases, closed: None }),
+            events,
+        )
+        .unwrap();
+        worker
+            .perform(MachineRequest::Switch(MachineKey(1)), unused_machine_preparation())
+            .unwrap();
+        assert_eq!(starts.recv_timeout(Duration::from_secs(1)).unwrap(), MachineKey(1));
+
+        let (dropped, dropped_rx) = std::sync::mpsc::channel();
+        let drop_thread = std::thread::spawn(move || {
+            drop(worker);
+            dropped.send(()).unwrap();
+        });
+        assert!(dropped_rx.recv_timeout(Duration::from_millis(20)).is_err());
+        release.send(()).unwrap();
+        dropped_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        drop_thread.join().unwrap();
+    }
+
+    #[test]
     fn in_place_machine_switch_preserves_rail_view_focus_and_widths() {
         let first = Mux::new("machine-switch-first", SurfaceOptions::default());
         first.new_workspace(None, None).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8338,6 +8338,8 @@ struct MachineActionWorker {
     reaper: Option<JoinHandle<()>>,
 }
 
+type MachineActionReceiveHook = Arc<dyn Fn() + Send + Sync>;
+
 #[derive(Debug)]
 enum MachineSubmitError {
     Busy(MachineRequest),
@@ -8346,8 +8348,25 @@ enum MachineSubmitError {
 
 impl MachineActionWorker {
     fn spawn(
+        controller: Box<dyn MachineController>,
+        app_events: SyncSender<AppEvent>,
+    ) -> anyhow::Result<Self> {
+        Self::spawn_inner(controller, app_events, None)
+    }
+
+    #[cfg(test)]
+    fn spawn_with_receive_hook(
+        controller: Box<dyn MachineController>,
+        app_events: SyncSender<AppEvent>,
+        receive_hook: MachineActionReceiveHook,
+    ) -> anyhow::Result<Self> {
+        Self::spawn_inner(controller, app_events, Some(receive_hook))
+    }
+
+    fn spawn_inner(
         mut controller: Box<dyn MachineController>,
         app_events: SyncSender<AppEvent>,
+        receive_hook: Option<MachineActionReceiveHook>,
     ) -> anyhow::Result<Self> {
         let (sender, receiver) = std::sync::mpsc::sync_channel(1);
         let stop = Arc::new(AtomicBool::new(false));
@@ -8364,6 +8383,9 @@ impl MachineActionWorker {
                         Err(RecvTimeoutError::Timeout) => continue,
                         Err(RecvTimeoutError::Disconnected) => break,
                     };
+                    if let Some(receive_hook) = receive_hook.as_ref() {
+                        receive_hook();
+                    }
                     let completion = match command {
                         MachineControllerCommand::Perform { request, preparation } => {
                             if pending_replacement.is_some() {
@@ -43616,6 +43638,31 @@ mod tests {
         }
     }
 
+    struct FirstActionBlockingMachineController {
+        started: std::sync::mpsc::Sender<MachineKey>,
+        release_first: StdReceiver<()>,
+        closed: Option<std::sync::mpsc::Sender<()>>,
+    }
+
+    impl MachineController for FirstActionBlockingMachineController {
+        fn perform(&mut self, request: MachineRequest) -> anyhow::Result<MachineActionResult> {
+            let MachineRequest::Switch(machine) = request else {
+                panic!("first-action fake received a non-switch request");
+            };
+            self.started.send(machine).unwrap();
+            if machine == MachineKey(1) {
+                self.release_first.recv().expect("release first machine action");
+            }
+            Ok(MachineActionResult::ui(provider_machine_ui()))
+        }
+
+        fn close(&mut self) {
+            if let Some(closed) = self.closed.take() {
+                let _ = closed.send(());
+            }
+        }
+    }
+
     #[test]
     fn blocked_machine_action_does_not_block_the_app_event_loop() {
         let mux = Mux::new("machine-action-responsive", SurfaceOptions::default());
@@ -43734,6 +43781,54 @@ mod tests {
         release.send(()).unwrap();
         dropped_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         drop_thread.join().unwrap();
+    }
+
+    #[test]
+    fn machine_action_worker_shutdown_discards_command_dequeued_after_stop() {
+        let (events, _event_receiver) = crossbeam_channel::bounded(4);
+        let (started, starts) = std::sync::mpsc::channel();
+        let (release_first, releases_first) = std::sync::mpsc::channel();
+        let (closed, closes) = std::sync::mpsc::channel();
+        let (received_tx, received_rx) = crossbeam_channel::bounded(1);
+        let (resume_tx, resume_rx) = crossbeam_channel::bounded(1);
+        let receive_count = Arc::new(AtomicU64::new(0));
+        let hook_count = receive_count.clone();
+        let receive_hook: MachineActionReceiveHook = Arc::new(move || {
+            if hook_count.fetch_add(1, Ordering::SeqCst) == 1 {
+                received_tx.send(()).unwrap();
+                resume_rx.recv().unwrap();
+            }
+        });
+        let mut worker = MachineActionWorker::spawn_with_receive_hook(
+            Box::new(FirstActionBlockingMachineController {
+                started,
+                release_first: releases_first,
+                closed: Some(closed),
+            }),
+            events,
+            receive_hook,
+        )
+        .unwrap();
+
+        worker
+            .perform(MachineRequest::Switch(MachineKey(1)), unused_machine_preparation())
+            .unwrap();
+        assert_eq!(starts.recv_timeout(Duration::from_secs(1)).unwrap(), MachineKey(1));
+        worker
+            .perform(MachineRequest::Switch(MachineKey(2)), unused_machine_preparation())
+            .unwrap();
+        release_first.send(()).unwrap();
+
+        received_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker did not dequeue the queued command");
+        let started_shutdown = Instant::now();
+        worker.shutdown();
+        assert!(started_shutdown.elapsed() < Duration::from_millis(50));
+        resume_tx.send(()).unwrap();
+        closes.recv_timeout(Duration::from_secs(1)).expect("worker did not close");
+        assert!(starts.try_recv().is_err(), "queued action ran after shutdown");
+        worker.shutdown();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -586,6 +586,7 @@ impl FrontendJournalQueue {
 struct FrontendJournalWorker {
     queue: Option<Arc<FrontendJournalQueue>>,
     worker: Option<JoinHandle<()>>,
+    reaper: Option<JoinHandle<()>>,
 }
 
 impl FrontendJournalWorker {
@@ -8521,7 +8522,7 @@ impl MachineActionWorker {
                 }
                 controller.close();
             })?;
-        Ok(Self { sender: Some(sender), stop, cancellation, worker: Some(worker) })
+        Ok(Self { sender: Some(sender), stop, cancellation, worker: Some(worker), reaper: None })
     }
 
     fn perform(
@@ -8620,11 +8621,17 @@ impl MachineActionWorker {
             // Provider calls are synchronous and may remain blocked until
             // their transport deadline. Reap the owned handle asynchronously
             // so shutdown stays responsive without detaching the worker.
-            let _ = std::thread::Builder::new()
+            self.reaper = std::thread::Builder::new()
                 .name("machine-actions-reaper".into())
                 .spawn(move || {
                     let _ = worker.join();
-                });
+                })
+                .ok();
+        }
+        if self.reaper.as_ref().is_some_and(JoinHandle::is_finished)
+            && let Some(reaper) = self.reaper.take()
+        {
+            let _ = reaper.join();
         }
     }
 }
@@ -43685,6 +43692,7 @@ mod tests {
         assert!(started_shutdown.elapsed() < Duration::from_millis(50));
         release.send(()).unwrap();
         closes.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker.shutdown();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44840,6 +44840,35 @@ mod tests {
     }
 
     #[test]
+    fn canceling_machine_controller_completion_send_unblocks_when_queue_is_full() {
+        let (events, receiver) = crossbeam_channel::bounded(1);
+        events.send(AppEvent::Mux(MuxEvent::Empty)).unwrap();
+        let cancellation = EventCancellation::new();
+        let worker_cancellation = cancellation.clone();
+        let (started_tx, started_rx) = std::sync::mpsc::sync_channel(1);
+        let (completed_tx, completed_rx) = std::sync::mpsc::sync_channel(1);
+        let worker = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            let completed = send_machine_controller_completion(
+                &events,
+                MachineControllerCompletion::Updates(Err("cancelled".into())),
+                &worker_cancellation,
+            );
+            completed_tx.send(completed).unwrap();
+        });
+
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(matches!(
+            completed_rx.recv_timeout(Duration::from_millis(50)),
+            Err(std::sync::mpsc::RecvTimeoutError::Timeout)
+        ));
+        cancellation.cancel();
+        assert!(!completed_rx.recv_timeout(Duration::from_secs(1)).unwrap());
+        worker.join().unwrap();
+        drop(receiver);
+    }
+
+    #[test]
     fn prepared_machine_session_events_stay_paused_until_commit_activation() {
         let mux = Mux::new("prepared-machine-session-events", SurfaceOptions::default());
         let pty_input = PtyInputDispatcher::spawn(|_| {}).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8621,12 +8621,26 @@ impl MachineActionWorker {
             // Provider calls are synchronous and may remain blocked until
             // their transport deadline. Reap the owned handle asynchronously
             // so shutdown stays responsive without detaching the worker.
-            self.reaper = std::thread::Builder::new()
+            let worker = Arc::new(std::sync::Mutex::new(Some(worker)));
+            let worker_for_reaper = worker.clone();
+            match std::thread::Builder::new()
                 .name("machine-actions-reaper".into())
                 .spawn(move || {
-                    let _ = worker.join();
+                    if let Some(worker) = worker_for_reaper.lock().unwrap().take() {
+                        let _ = worker.join();
+                    }
                 })
-                .ok();
+            {
+                Ok(reaper) => self.reaper = Some(reaper),
+                Err(_) => {
+                    // Restore ownership when the reaper cannot start. This
+                    // is exceptional, so synchronously finish cleanup rather
+                    // than dropping the worker handle.
+                    if let Some(worker) = worker.lock().unwrap().take() {
+                        let _ = worker.join();
+                    }
+                }
+            }
         }
         if self.reaper.as_ref().is_some_and(JoinHandle::is_finished)
             && let Some(reaper) = self.reaper.take()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8333,6 +8333,7 @@ pub(crate) enum MachineControllerCompletion {
 struct MachineActionWorker {
     sender: Option<std::sync::mpsc::SyncSender<MachineControllerCommand>>,
     stop: Arc<AtomicBool>,
+    cancellation: EventCancellation,
     worker: Option<JoinHandle<()>>,
 }
 
@@ -8350,6 +8351,8 @@ impl MachineActionWorker {
         let (sender, receiver) = std::sync::mpsc::sync_channel(1);
         let stop = Arc::new(AtomicBool::new(false));
         let worker_stop = stop.clone();
+        let cancellation = EventCancellation::new();
+        let worker_cancellation = cancellation.clone();
         let worker =
             std::thread::Builder::new().name("machine-actions".into()).spawn(move || {
                 let mut next_action_id = 1_u64;
@@ -8505,7 +8508,11 @@ impl MachineActionWorker {
                             }
                         }
                     };
-                    if !send_machine_controller_completion(&app_events, completion, &worker_stop) {
+                    if !send_machine_controller_completion(
+                        &app_events,
+                        completion,
+                        &worker_cancellation,
+                    ) {
                         break;
                     }
                 }
@@ -8514,7 +8521,7 @@ impl MachineActionWorker {
                 }
                 controller.close();
             })?;
-        Ok(Self { sender: Some(sender), stop, worker: Some(worker) })
+        Ok(Self { sender: Some(sender), stop, cancellation, worker: Some(worker) })
     }
 
     fn perform(
@@ -8604,6 +8611,7 @@ impl MachineActionWorker {
 
     fn shutdown(&mut self) {
         self.stop.store(true, Ordering::Release);
+        self.cancellation.cancel();
         self.sender.take();
         if self.worker.as_ref().is_some_and(JoinHandle::is_finished)
             && let Some(worker) = self.worker.take()
@@ -8662,25 +8670,15 @@ fn prepare_machine_session(
 
 fn send_machine_controller_completion(
     app_events: &SyncSender<AppEvent>,
-    mut completion: MachineControllerCompletion,
-    stop: &AtomicBool,
+    completion: MachineControllerCompletion,
+    cancellation: &EventCancellation,
 ) -> bool {
-    loop {
-        match app_events.try_send(AppEvent::MachineControllerCompleted(Box::new(completion))) {
-            Ok(()) => return true,
-            Err(TrySendError::Full(AppEvent::MachineControllerCompleted(returned))) => {
-                completion = *returned;
-                if stop.load(Ordering::Acquire) {
-                    return false;
-                }
-                std::thread::park_timeout(Duration::from_millis(1));
-            }
-            Err(TrySendError::Full(_)) => {
-                unreachable!("machine completion sender returned a different event")
-            }
-            Err(TrySendError::Disconnected(_)) => return false,
-        }
-    }
+    send_bounded_cancelable(
+        app_events,
+        AppEvent::MachineControllerCompleted(Box::new(completion)),
+        cancellation,
+    )
+    .is_ok()
 }
 
 impl MachineUpdatePump {
@@ -24377,7 +24375,8 @@ mod tests {
         DeferredReplayDisposition, Drag, EventCancellation, FocusTarget, ForwardMuxOutcome,
         FrontendJournalQueue, FrontendJournalWorker, GraphicIdentity, GraphicPlacement,
         GraphicSourceRect, GraphicsSceneCache, GuardedMouseEncode, HostInputIngress,
-        HostInputMessage, HostInputRuntime, MachineActionWorker, MachineConnectRoute, MenuAction,
+        HostInputMessage, HostInputRuntime, MachineActionWorker, MachineConnectRoute,
+        MachineControllerCompletion, MenuAction,
         MenuItem, MutationImpact, MuxTitleIngress, OmnibarHit, OmnibarState, OrderedSession,
         OuterCursorSpec, PaneArea, PaneAreaProjection, PaneContentGeneration, PaneEdge,
         PaneFocusHistory, PaneResizeDragTarget, PaneViewportClip, PendingSessionMutation,
@@ -24404,9 +24403,9 @@ mod tests {
         pane_parts_for_rect, prepare_ordered_session, preserve_client_view, rail_drag_width,
         rebuild_pane_areas, record_surface_resize_dispatch_result, report_after_unwind,
         reset_pane_area_projection_work, run_status_command, send_bounded_cancelable,
-        should_claim_clear_history_shortcut, sidebar_layout_for, sidebar_layout_for_state,
-        sidebar_plugin_status_settles_passive_claim, start_ordered_session,
-        swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
+        send_machine_controller_completion, should_claim_clear_history_shortcut,
+        sidebar_layout_for, sidebar_layout_for_state, sidebar_plugin_status_settles_passive_claim,
+        start_ordered_session, swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
         workspace_creation_selection,
     };
     use cmux_tui_core::{FrontendFocusTarget, FrontendJournalEvent};

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8617,7 +8617,14 @@ impl MachineActionWorker {
         // at its transport deadline, then the worker observes stop and closes
         // the controller. Join so provider cleanup cannot outlive the owner.
         if let Some(worker) = self.worker.take() {
-            let _ = worker.join();
+            // Provider calls are synchronous and may remain blocked until
+            // their transport deadline. Reap the owned handle asynchronously
+            // so shutdown stays responsive without detaching the worker.
+            let _ = std::thread::Builder::new()
+                .name("machine-actions-reaper".into())
+                .spawn(move || {
+                    let _ = worker.join();
+                });
         }
     }
 }
@@ -43673,8 +43680,10 @@ mod tests {
             .unwrap();
         assert_eq!(starts.recv_timeout(Duration::from_secs(1)).unwrap(), MachineKey(1));
 
-        release.send(()).unwrap();
+        let started_shutdown = Instant::now();
         worker.shutdown();
+        assert!(started_shutdown.elapsed() < Duration::from_millis(50));
+        release.send(()).unwrap();
         closes.recv_timeout(Duration::from_secs(1)).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8623,14 +8623,13 @@ impl MachineActionWorker {
             // so shutdown stays responsive without detaching the worker.
             let worker = Arc::new(std::sync::Mutex::new(Some(worker)));
             let worker_for_reaper = worker.clone();
-            match std::thread::Builder::new()
-                .name("machine-actions-reaper".into())
-                .spawn(move || {
+            match std::thread::Builder::new().name("machine-actions-reaper".into()).spawn(
+                move || {
                     if let Some(worker) = worker_for_reaper.lock().unwrap().take() {
                         let _ = worker.join();
                     }
-                })
-            {
+                },
+            ) {
                 Ok(reaper) => self.reaper = Some(reaper),
                 Err(_) => {
                     // Restore ownership when the reaper cannot start. This
@@ -8653,6 +8652,9 @@ impl MachineActionWorker {
 impl Drop for MachineActionWorker {
     fn drop(&mut self) {
         self.shutdown();
+        if let Some(reaper) = self.reaper.take() {
+            let _ = reaper.join();
+        }
     }
 }
 
@@ -24401,26 +24403,25 @@ mod tests {
         FrontendJournalQueue, FrontendJournalWorker, GraphicIdentity, GraphicPlacement,
         GraphicSourceRect, GraphicsSceneCache, GuardedMouseEncode, HostInputIngress,
         HostInputMessage, HostInputRuntime, MachineActionWorker, MachineConnectRoute,
-        MachineControllerCompletion, MenuAction,
-        MenuItem, MutationImpact, MuxTitleIngress, OmnibarHit, OmnibarState, OrderedSession,
-        OuterCursorSpec, PaneArea, PaneAreaProjection, PaneContentGeneration, PaneEdge,
-        PaneFocusHistory, PaneResizeDragTarget, PaneViewportClip, PendingSessionMutation,
-        PendingSessionMutationState, PointerHitIdentity, PointerRouteIdentity, PointerRoutePhase,
-        Prompt, PromptTarget, PtyFailureIngress, PtyMousePressResult, RailKind, RenderAction,
-        RenderedMenuLevel, RenderedPaneRoute, RenderedPointerFrame, Selection, SelectionMode,
-        SessionCompletion, SessionCompletionAction, SessionEventSender, ShortcutHelp,
-        SidebarActionTarget, SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState,
-        SidebarWidthOverrides, StatusTemplateValues, StatusWorkerStop, StdoutLock,
-        SurfaceAttachClaimState, SurfaceResizeDecision, SurfaceResizeOwnership,
-        TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer, TerminalPointerAdmission,
-        TerminalPointerAdmissionResult, TerminalPointerEncoding, TextInput, Toast,
-        VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
-        WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
-        browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
-        canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
-        client_menu_item, clip_horizontal_rect, content_size_for_rect,
-        disable_host_keyboard_protocol, enable_host_keyboard_protocol, expand_status_tokens,
-        forward_host_input, forward_mux_event, forward_mux_events,
+        MachineControllerCompletion, MenuAction, MenuItem, MutationImpact, MuxTitleIngress,
+        OmnibarHit, OmnibarState, OrderedSession, OuterCursorSpec, PaneArea, PaneAreaProjection,
+        PaneContentGeneration, PaneEdge, PaneFocusHistory, PaneResizeDragTarget, PaneViewportClip,
+        PendingSessionMutation, PendingSessionMutationState, PointerHitIdentity,
+        PointerRouteIdentity, PointerRoutePhase, Prompt, PromptTarget, PtyFailureIngress,
+        PtyMousePressResult, RailKind, RenderAction, RenderedMenuLevel, RenderedPaneRoute,
+        RenderedPointerFrame, Selection, SelectionMode, SessionCompletion, SessionCompletionAction,
+        SessionEventSender, ShortcutHelp, SidebarActionTarget, SidebarLayout,
+        SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarWidthOverrides,
+        StatusTemplateValues, StatusWorkerStop, StdoutLock, SurfaceAttachClaimState,
+        SurfaceResizeDecision, SurfaceResizeOwnership, TERMINAL_PAINT_CADENCE, TerminalInput,
+        TerminalPaintPacer, TerminalPointerAdmission, TerminalPointerAdmissionResult,
+        TerminalPointerEncoding, TextInput, Toast, VIEWPORT_ANIMATION_DURATION, ViewportMotion,
+        ViewportPaneAreaProjection, WorkspaceRailSelection, action_available_in_mode,
+        browser_content_size_for_rect, browser_frame_source_crop, browser_hover_forward_allowed,
+        browser_source_crop, canonical_terminal_content, catch_renderer_panic,
+        clamp_split_ratio_for_tab_bars, client_menu_item, clip_horizontal_rect,
+        content_size_for_rect, disable_host_keyboard_protocol, enable_host_keyboard_protocol,
+        expand_status_tokens, forward_host_input, forward_mux_event, forward_mux_events,
         host_mouse_capture_escape_if_changed, host_startup_input_modes,
         initial_applied_outer_cursor, initial_host_mouse_capture, keyboard_protocol_accepts,
         layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8613,15 +8613,12 @@ impl MachineActionWorker {
         self.stop.store(true, Ordering::Release);
         self.cancellation.cancel();
         self.sender.take();
-        if self.worker.as_ref().is_some_and(JoinHandle::is_finished)
-            && let Some(worker) = self.worker.take()
-        {
+        // The stop flag is cooperative: an in-flight provider action returns
+        // at its transport deadline, then the worker observes stop and closes
+        // the controller. Join so provider cleanup cannot outlive the owner.
+        if let Some(worker) = self.worker.take() {
             let _ = worker.join();
         }
-        // A provider action has a bounded transport deadline but may still be
-        // in progress. Dropping the handle detaches that bounded cleanup so
-        // quitting the TUI never waits for the provider deadline.
-        self.worker.take();
     }
 }
 
@@ -43657,7 +43654,7 @@ mod tests {
     }
 
     #[test]
-    fn machine_action_worker_shutdown_never_joins_a_blocked_action() {
+    fn machine_action_worker_shutdown_joins_after_cooperative_cancellation() {
         let (events, _event_receiver) = crossbeam_channel::bounded(4);
         let (started, starts) = std::sync::mpsc::channel();
         let (release, releases) = std::sync::mpsc::channel();
@@ -43676,11 +43673,8 @@ mod tests {
             .unwrap();
         assert_eq!(starts.recv_timeout(Duration::from_secs(1)).unwrap(), MachineKey(1));
 
-        let started_shutdown = Instant::now();
-        worker.shutdown();
-
-        assert!(started_shutdown.elapsed() < Duration::from_millis(50));
         release.send(()).unwrap();
+        worker.shutdown();
         closes.recv_timeout(Duration::from_secs(1)).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -586,7 +586,6 @@ impl FrontendJournalQueue {
 struct FrontendJournalWorker {
     queue: Option<Arc<FrontendJournalQueue>>,
     worker: Option<JoinHandle<()>>,
-    reaper: Option<JoinHandle<()>>,
 }
 
 impl FrontendJournalWorker {
@@ -8336,6 +8335,7 @@ struct MachineActionWorker {
     stop: Arc<AtomicBool>,
     cancellation: EventCancellation,
     worker: Option<JoinHandle<()>>,
+    reaper: Option<JoinHandle<()>>,
 }
 
 #[derive(Debug)]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43761,12 +43761,17 @@ mod tests {
     }
 
     #[test]
-    fn machine_action_worker_drop_waits_for_reaper_cleanup() {
+    fn machine_action_worker_drop_does_not_wait_for_reaper_cleanup() {
         let (events, _event_receiver) = crossbeam_channel::bounded(4);
         let (started, starts) = std::sync::mpsc::channel();
         let (release, releases) = std::sync::mpsc::channel();
+        let (closed, closes) = std::sync::mpsc::channel();
         let worker = MachineActionWorker::spawn(
-            Box::new(OrderedBlockingMachineController { started, release: releases, closed: None }),
+            Box::new(OrderedBlockingMachineController {
+                started,
+                release: releases,
+                closed: Some(closed),
+            }),
             events,
         )
         .unwrap();
@@ -43780,10 +43785,15 @@ mod tests {
             drop(worker);
             dropped.send(()).unwrap();
         });
-        assert!(dropped_rx.recv_timeout(Duration::from_millis(20)).is_err());
+        let drop_completed_before_release =
+            dropped_rx.recv_timeout(Duration::from_millis(200)).is_ok();
         release.send(()).unwrap();
-        dropped_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        closes.recv_timeout(Duration::from_secs(1)).expect("reaper did not close controller");
         drop_thread.join().unwrap();
+        assert!(
+            drop_completed_before_release,
+            "dropping a blocked machine worker waited for provider completion"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace the machine completion sender's 1ms retry loop with the existing cancellation-aware bounded send.
- Cancel that send during worker shutdown so a full app-event queue cannot retain a blocked worker.
- Keep the worker JoinHandle owned through an asynchronous reaper, join the reaper on owner drop, and synchronously join if reaper creation fails.

## Testing

- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/app.rs`
- `git diff --check`
- Local Cargo and Rust tests were not run per cmux-tui worktree policy.
- Hosted filters: `canceling_machine_controller_completion_send_unblocks_when_queue_is_full`; `machine_action_worker_shutdown_joins_after_cooperative_cancellation`.

## Related

- https://github.com/manaflow-ai/cmux/pull/11416
- https://github.com/manaflow-ai/cmux/pull/11424

Base is current `origin/main` at `6b425641ae4d474e77854da535442af2a0d0a475`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes machine action worker shutdown so a full app-event queue no longer keeps the completion send blocked, and dropping the worker no longer waits for an in-flight provider call.

- Replaces the completion sender's 1ms retry loop with a cancellation-aware send, canceled during shutdown so the worker unblocks.
- Discards a queued command that is dequeued after shutdown, so a queued action no longer runs after stop.
- Spawns an asynchronous reaper to join the worker; joins synchronously when the reaper thread can't spawn, and joins a finished reaper on later shutdown calls.
- Dropping the worker detaches an unfinished reaper, so drop returns immediately and the provider call finishes in the background.
- Adds regression tests for cancellation unblocking, cooperative shutdown join, queued-command shutdown, and responsive drop.

<sup>Written for commit 7888a600338bd1790a736783ea46770789851ae8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11479?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shutdown behavior for background operations, allowing them to stop cooperatively without blocking the interface.
  * Prevented hangs when completion queues are full or an operation is waiting for a provider response.
  * Ensured queued work is discarded after shutdown begins and cleanup completes safely when components are released.
  * Made shutdown safe to invoke repeatedly.

* **Tests**
  * Added coverage for cancellation, queue unblocking, repeated shutdown, discarded work, and non-blocking cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->