### PR TITLE
perf(cmux-tui): index machine sidebar metadata

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -95,7 +95,7 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
     for managed in machine_ui.managed_machines() {
         // Keep the previous first-match behavior if malformed input repeats a
         // key, while normal snapshots remain one entry per stable key.
-        managed_machines.entry(managed.key).or_insert(managed);
+        managed_machines.entry(managed.key.clone()).or_insert(managed);
     }
     let rail_selection = machine_ui.rail_selection;
     let palette = rail::RailPalette::for_app(app, app.machine_sidebar_focused());

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -7,6 +7,7 @@ use cmux_tui_core::Rect;
 use ratatui::Frame;
 use ratatui::style::{Color, Modifier, Style};
 use std::borrow::Cow;
+use std::collections::HashMap;
 
 use super::{
     ScrollbarState, ScrollbarStyle, middle_truncate, rail, truncate, viewport_thumb_geometry,
@@ -87,7 +88,15 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
     let active = app.selected_machine();
     let capabilities = machine_ui.snapshot.capabilities;
     let selection = machine_ui.selection;
-    let managed_machines = machine_ui.managed_machines().to_vec();
+    // Machine rows stay in provider order, while lifecycle metadata is keyed
+    // by the same stable key. Building this index once keeps a frame with M
+    // machines linear instead of scanning all managed entries for every row.
+    let mut managed_machines = HashMap::with_capacity(machine_ui.managed_machines().len());
+    for managed in machine_ui.managed_machines() {
+        // Keep the previous first-match behavior if malformed input repeats a
+        // key, while normal snapshots remain one entry per stable key.
+        managed_machines.entry(managed.key).or_insert(managed);
+    }
     let rail_selection = machine_ui.rail_selection;
     let palette = rail::RailPalette::for_app(app, app.machine_sidebar_focused());
     let metrics = rail::RailMetrics::for_app(app);
@@ -155,7 +164,7 @@ pub fn draw_machines(app: &mut App, frame: &mut Frame) {
         let focused = app.machine_sidebar_focused()
             && rail_selection == MachineRailSelection::Machine
             && selection == index;
-        let managed = managed_machines.iter().find(|managed| managed.key == machine.key);
+        let managed = managed_machines.get(&machine.key);
         let recoverable = managed.is_some_and(|managed| {
             managed.status == crate::machine::ManagedMachineStatus::Recoverable
         });


### PR DESCRIPTION
## Summary
- index managed machine metadata once per sidebar frame
- preserve provider row order and first-match behavior for duplicate keys
- reduce machine rail metadata lookup from O(M²) to O(M) per frame

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/ui/sidebar.rs`
- `git diff --check`
- Cargo/Rust compilation and tests not run, per task constraint

The implementation follows the standard library HashMap lookup model: https://doc.rust-lang.org/std/collections/struct.HashMap.html
Ratatui rendering remains in the existing frame path: https://docs.rs/ratatui/latest/ratatui/widgets/trait.Widget.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up the `cmux-tui` machine sidebar by indexing managed machine metadata once per frame, replacing per-row scans with `HashMap` lookups and reducing frame cost from O(M²) to O(M). Machine rows still render in provider order, and duplicate keys keep first-match behavior; the stable key is cloned when building the index.

<sup>Written for commit 9a16961af1c0e2f5255aa1b0a2b96c3dbbee7220. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11480?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved sidebar machine list rendering for faster lookups.
  * Ensured duplicate machine entries are handled consistently, displaying only the first occurrence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->