### PR TITLE
fix(cmux-tui): close stale listeners after identity-fenced cleanup

### DIFF
--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -96,7 +96,7 @@ png = "0.17"
 libc = "0.2"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake"] }
 uds_windows = "1.2"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
 regex = "1"
 # reqwest and time are already in the dependency graph via iroh; declaring
 # them here adds no new transitive code. chatmux-relay uses reqwest for the

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -96,7 +96,7 @@ png = "0.17"
 libc = "0.2"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake"] }
 uds_windows = "1.2"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Networking_WinSock", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_SystemServices", "Win32_System_Threading"] }
 regex = "1"
 # reqwest and time are already in the dependency graph via iroh; declaring
 # them here adds no new transitive code. chatmux-relay uses reqwest for the

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -76,7 +76,7 @@ pub mod transport {
         use std::os::unix::net::{UnixListener, UnixStream};
         use std::path::Path;
         use std::sync::{Arc, Mutex};
-        use std::time::Duration;
+        use std::time::{Duration, Instant};
 
         use super::Stream;
 
@@ -169,8 +169,10 @@ pub mod transport {
             }
 
             pub(super) fn wait(&self, timeout: Duration) -> io::Result<bool> {
-                let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+                let deadline = Instant::now() + timeout;
                 loop {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
                     let mut descriptor = libc::pollfd {
                         fd: self.inner.reader.as_raw_fd(),
                         events: libc::POLLIN,
@@ -216,7 +218,7 @@ pub mod transport {
         use std::os::windows::io::AsRawSocket;
         use std::path::Path;
         use std::sync::{Arc, Mutex};
-        use std::time::Duration;
+        use std::time::{Duration, Instant};
 
         use super::Stream;
         use uds_windows::{UnixListener, UnixStream};
@@ -309,8 +311,10 @@ pub mod transport {
             }
 
             pub(super) fn wait(&self, timeout: Duration) -> io::Result<bool> {
-                let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+                let deadline = Instant::now() + timeout;
                 loop {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    let timeout_ms = remaining.as_millis().min(i32::MAX as u128) as i32;
                     let mut descriptor = WSAPOLLFD {
                         fd: self.inner.reader.as_raw_socket(),
                         events: POLLIN,

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -60,6 +60,13 @@ pub mod transport {
         pub fn wake(&self) -> io::Result<()> {
             self.inner.wake()
         }
+
+        /// Wait for a shutdown wakeup, returning `false` when the timeout
+        /// expires. The wait is path-independent and does not consume the
+        /// listener's readiness state.
+        pub fn wait(&self, timeout: Duration) -> io::Result<bool> {
+            self.inner.wait(timeout)
+        }
     }
 
     #[cfg(unix)]
@@ -158,6 +165,28 @@ pub mod transport {
                         Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
                         Err(error) => return Err(error),
                     }
+                }
+            }
+
+            pub(super) fn wait(&self, timeout: Duration) -> io::Result<bool> {
+                let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+                loop {
+                    let mut descriptor = libc::pollfd {
+                        fd: self.inner.reader.as_raw_fd(),
+                        events: libc::POLLIN,
+                        revents: 0,
+                    };
+                    // SAFETY: the reader remains owned by this wake handle for
+                    // the duration of the poll call.
+                    let result = unsafe { libc::poll(&mut descriptor, 1, timeout_ms) };
+                    if result < 0 {
+                        let error = io::Error::last_os_error();
+                        if error.kind() == io::ErrorKind::Interrupted {
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                    return Ok(result > 0 && descriptor.revents != 0);
                 }
             }
         }
@@ -276,6 +305,28 @@ pub mod transport {
                         Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
                         Err(error) => return Err(error),
                     }
+                }
+            }
+
+            pub(super) fn wait(&self, timeout: Duration) -> io::Result<bool> {
+                let timeout_ms = timeout.as_millis().min(i32::MAX as u128) as i32;
+                loop {
+                    let mut descriptor = WSAPOLLFD {
+                        fd: self.inner.reader.as_raw_socket(),
+                        events: POLLIN,
+                        revents: 0,
+                    };
+                    // SAFETY: the reader remains owned by this wake handle for
+                    // the duration of the poll call.
+                    let result = unsafe { WSAPoll(&mut descriptor, 1, timeout_ms) };
+                    if result < 0 {
+                        let error = io::Error::from_raw_os_error(unsafe { WSAGetLastError() });
+                        if error.kind() == io::ErrorKind::Interrupted {
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                    return Ok(result > 0 && descriptor.revents != 0);
                 }
             }
         }

--- a/cmux-tui/crates/cmux-tui-core/src/platform.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/platform.rs
@@ -24,6 +24,12 @@ pub mod transport {
         inner: imp::Listener,
     }
 
+    /// A path-independent wakeup for one local listener accept loop.
+    #[derive(Clone)]
+    pub struct ListenerWake {
+        inner: imp::ListenerWake,
+    }
+
     pub fn listen(path: &Path) -> io::Result<Listener> {
         imp::listen(path).map(|inner| Listener { inner })
     }
@@ -36,19 +42,49 @@ pub mod transport {
         pub fn accept(&self) -> io::Result<Box<dyn Stream>> {
             self.inner.accept()
         }
+
+        pub fn wake_handle(&self) -> io::Result<ListenerWake> {
+            self.inner.wake_handle().map(|inner| ListenerWake { inner })
+        }
+
+        /// Wait for a client or the retained listener-local wakeup.
+        ///
+        /// `None` means the wakeup fired and the caller should close this
+        /// listener instead of accepting another client.
+        pub fn accept_with_wake(&self, wake: &ListenerWake) -> io::Result<Option<Box<dyn Stream>>> {
+            self.inner.accept_with_wake(&wake.inner)
+        }
+    }
+
+    impl ListenerWake {
+        pub fn wake(&self) -> io::Result<()> {
+            self.inner.wake()
+        }
     }
 
     #[cfg(unix)]
     mod imp {
-        use std::io;
+        use std::io::{self, Write};
+        use std::os::fd::AsRawFd;
         use std::os::unix::net::{UnixListener, UnixStream};
         use std::path::Path;
+        use std::sync::{Arc, Mutex};
         use std::time::Duration;
 
         use super::Stream;
 
         pub(super) struct Listener {
             inner: UnixListener,
+        }
+
+        #[derive(Clone)]
+        pub(super) struct ListenerWake {
+            inner: Arc<ListenerWakeState>,
+        }
+
+        struct ListenerWakeState {
+            reader: UnixStream,
+            writer: Mutex<UnixStream>,
         }
 
         pub(super) fn listen(path: &Path) -> io::Result<Listener> {
@@ -63,6 +99,66 @@ pub mod transport {
             pub(super) fn accept(&self) -> io::Result<Box<dyn Stream>> {
                 let (stream, _) = self.inner.accept()?;
                 Ok(Box::new(stream))
+            }
+
+            pub(super) fn wake_handle(&self) -> io::Result<ListenerWake> {
+                let (reader, writer) = UnixStream::pair()?;
+                writer.set_nonblocking(true)?;
+                Ok(ListenerWake {
+                    inner: Arc::new(ListenerWakeState { reader, writer: Mutex::new(writer) }),
+                })
+            }
+
+            pub(super) fn accept_with_wake(
+                &self,
+                wake: &ListenerWake,
+            ) -> io::Result<Option<Box<dyn Stream>>> {
+                loop {
+                    let mut descriptors = [
+                        libc::pollfd {
+                            fd: self.inner.as_raw_fd(),
+                            events: libc::POLLIN,
+                            revents: 0,
+                        },
+                        libc::pollfd {
+                            fd: wake.inner.reader.as_raw_fd(),
+                            events: libc::POLLIN,
+                            revents: 0,
+                        },
+                    ];
+                    // SAFETY: both descriptors point at live sockets owned by
+                    // this listener and wake handle for the duration of poll.
+                    let result =
+                        unsafe { libc::poll(descriptors.as_mut_ptr(), descriptors.len() as _, -1) };
+                    if result < 0 {
+                        let error = io::Error::last_os_error();
+                        if error.kind() == io::ErrorKind::Interrupted {
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                    if descriptors[1].revents != 0 {
+                        return Ok(None);
+                    }
+                    if descriptors[0].revents != 0 {
+                        return self.accept().map(Some);
+                    }
+                }
+            }
+        }
+
+        impl ListenerWake {
+            pub(super) fn wake(&self) -> io::Result<()> {
+                let mut writer =
+                    self.inner.writer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                loop {
+                    match writer.write(&[1]) {
+                        Ok(_) => return Ok(()),
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                        Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                        Err(error) => return Err(error),
+                    }
+                }
             }
         }
 
@@ -87,15 +183,30 @@ pub mod transport {
 
     #[cfg(windows)]
     mod imp {
-        use std::io;
+        use std::io::{self, Write};
+        use std::os::windows::io::AsRawSocket;
         use std::path::Path;
+        use std::sync::{Arc, Mutex};
         use std::time::Duration;
 
         use super::Stream;
         use uds_windows::{UnixListener, UnixStream};
+        use windows_sys::Win32::Networking::WinSock::{
+            POLLERR, POLLHUP, POLLIN, POLLNVAL, WSAGetLastError, WSAPOLLFD, WSAPoll,
+        };
 
         pub(super) struct Listener {
             inner: UnixListener,
+        }
+
+        #[derive(Clone)]
+        pub(super) struct ListenerWake {
+            inner: Arc<ListenerWakeState>,
+        }
+
+        struct ListenerWakeState {
+            reader: UnixStream,
+            writer: Mutex<UnixStream>,
         }
 
         pub(super) fn listen(path: &Path) -> io::Result<Listener> {
@@ -110,6 +221,62 @@ pub mod transport {
             pub(super) fn accept(&self) -> io::Result<Box<dyn Stream>> {
                 let (stream, _) = self.inner.accept()?;
                 Ok(Box::new(stream))
+            }
+
+            pub(super) fn wake_handle(&self) -> io::Result<ListenerWake> {
+                let (reader, writer) = UnixStream::pair()?;
+                writer.set_nonblocking(true)?;
+                Ok(ListenerWake {
+                    inner: Arc::new(ListenerWakeState { reader, writer: Mutex::new(writer) }),
+                })
+            }
+
+            pub(super) fn accept_with_wake(
+                &self,
+                wake: &ListenerWake,
+            ) -> io::Result<Option<Box<dyn Stream>>> {
+                loop {
+                    let mut descriptors = [
+                        WSAPOLLFD { fd: self.inner.as_raw_socket(), events: POLLIN, revents: 0 },
+                        WSAPOLLFD {
+                            fd: wake.inner.reader.as_raw_socket(),
+                            events: POLLIN,
+                            revents: 0,
+                        },
+                    ];
+                    // SAFETY: both descriptors point at live sockets owned by
+                    // this listener and wake handle for the duration of poll.
+                    let result =
+                        unsafe { WSAPoll(descriptors.as_mut_ptr(), descriptors.len() as u32, -1) };
+                    if result < 0 {
+                        let error = io::Error::from_raw_os_error(unsafe { WSAGetLastError() });
+                        if error.kind() == io::ErrorKind::Interrupted {
+                            continue;
+                        }
+                        return Err(error);
+                    }
+                    if descriptors[1].revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL) != 0 {
+                        return Ok(None);
+                    }
+                    if descriptors[0].revents != 0 {
+                        return self.accept().map(Some);
+                    }
+                }
+            }
+        }
+
+        impl ListenerWake {
+            pub(super) fn wake(&self) -> io::Result<()> {
+                let mut writer =
+                    self.inner.writer.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                loop {
+                    match writer.write(&[1]) {
+                        Ok(_) => return Ok(()),
+                        Err(error) if error.kind() == io::ErrorKind::WouldBlock => return Ok(()),
+                        Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                        Err(error) => return Err(error),
+                    }
+                }
             }
         }
 

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4851,7 +4851,9 @@ fn windows_socket_identity(path: &Path) -> std::io::Result<(u32, u64)> {
         .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
         .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
         .open(path)?;
-    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    // `windows-sys` exposes this FFI struct without a `Default` impl.
+    // Zero-initialization is the documented Windows API input pattern.
+    let mut information: BY_HANDLE_FILE_INFORMATION = unsafe { std::mem::zeroed() };
     // SAFETY: `file` owns a valid Windows handle and `information` points to
     // writable storage for the fixed-size API result.
     if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) } == 0 {
@@ -4930,6 +4932,11 @@ impl ServedSocketLease {
             return Ok(());
         }
 
+        // A lease performs at most one bounded cleanup attempt. Mark it as
+        // handled before waiting so Drop cannot repeat the deadline after an
+        // acquisition or identity error.
+        self.linked = false;
+
         let _start_lock =
             match SocketStartLock::acquire(&self.path, Instant::now() + SOCKET_CLEANUP_DEADLINE) {
                 Ok(lock) => lock,
@@ -4950,7 +4957,6 @@ impl ServedSocketLease {
                 Err(error) => return Err(error),
             }
         }
-        self.linked = false;
         Ok(())
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13497,6 +13497,11 @@ mod tests {
         assert!(json_line_payload_len(&oversized_line) > MAX_JSON_LINE_BYTES);
     }
 
+    #[test]
+    fn listener_accept_retries_a_connection_reset() {
+        assert!(retry_accept_error(std::io::ErrorKind::ConnectionReset));
+    }
+
     struct TestSocketDir(PathBuf);
 
     impl TestSocketDir {

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -31,9 +31,12 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 fn retry_accept_error(kind: std::io::ErrorKind) -> bool {
+    // A queued client can terminate before accept completes. Keep serving
+    // after the resulting connection reset instead of abandoning the listener.
     matches!(
         kind,
         std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::ConnectionReset
             | std::io::ErrorKind::Interrupted
             | std::io::ErrorKind::WouldBlock
             | std::io::ErrorKind::ResourceBusy

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13847,6 +13847,34 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn failed_socket_claim_cleans_an_unreachable_bound_listener_path() {
+        let dir = TestSocketDir::create("failed-socket-claim");
+        let path = dir.path().join("mux.sock");
+        let listener = transport::listen(&path).unwrap();
+
+        cleanup_unclaimed_listener(listener, &path);
+
+        assert!(!path.exists(), "failed socket claim left a dead publication behind");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn failed_socket_claim_preserves_a_live_replacement_listener() {
+        let dir = TestSocketDir::create("failed-socket-claim-replacement");
+        let path = dir.path().join("mux.sock");
+        let listener = transport::listen(&path).unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+        let replacement = transport::listen(&path).unwrap();
+        cleanup_unclaimed_listener(listener, &path);
+
+        assert!(transport::connect(&path).is_ok(), "failed claim removed a live replacement");
+        drop(replacement);
+        std::fs::remove_file(&path).unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unix_socket_path_reserves_trailing_nul() {
         const SUN_PATH_CAPACITY: usize =
             size_of::<libc::sockaddr_un>() - offset_of!(libc::sockaddr_un, sun_path);

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13519,6 +13519,82 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn dropping_a_stale_pending_server_preserves_a_replacement_socket() {
+        let dir = TestSocketDir::create("pending-server-replacement");
+        let path = dir.path().join("mux.sock");
+        let first_mux = test_mux();
+        let first = serve_paused(first_mux.clone(), Some(path.clone())).unwrap();
+
+        std::fs::remove_file(&path).unwrap();
+        let second = serve_paused(test_mux(), Some(path.clone())).unwrap();
+        drop(first);
+
+        assert_eq!(
+            Arc::strong_count(&first_mux),
+            1,
+            "stale pending server did not exit its old listener thread"
+        );
+        assert!(path.exists(), "stale pending-server cleanup removed the replacement socket");
+        assert!(transport::connect(&path).is_ok());
+        drop(second);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn pending_server_cleanup_waits_for_the_start_lock() {
+        let dir = TestSocketDir::create("pending-server-cleanup-lock");
+        let path = dir.path().join("mux.sock");
+        let mux = test_mux();
+        let pending = serve_paused(mux.clone(), Some(path.clone())).unwrap();
+        let listener_refs = Arc::strong_count(&mux);
+        let start_lock = SocketStartLock::acquire(&path, Instant::now()).unwrap();
+        let (observed_tx, observed_rx) = std::sync::mpsc::channel();
+        let cleanup = std::thread::spawn(move || {
+            drop(pending);
+            observed_tx.send(()).unwrap();
+        });
+
+        assert!(
+            observed_rx.recv_timeout(Duration::from_millis(100)).is_err(),
+            "pending-server cleanup bypassed the concurrent start lock"
+        );
+        assert_eq!(
+            Arc::strong_count(&mux),
+            listener_refs,
+            "pending-server cleanup stopped its listener before acquiring the start lock"
+        );
+        drop(start_lock);
+        observed_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("pending-server cleanup did not resume after the start lock was released");
+        cleanup.join().unwrap();
+        assert!(!path.exists());
+    }
+
+    #[cfg(all(not(unix), not(windows)))]
+    #[test]
+    fn socket_cleanup_without_identity_fails_closed() {
+        assert!(
+            !SocketPathIdentity::Unavailable.matches_path(Path::new("replacement.sock")).unwrap()
+        );
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn socket_cleanup_matches_the_bound_windows_socket_identity() {
+        let dir = TestSocketDir::create("windows-socket-identity");
+        let path = dir.path().join("mux.sock");
+        let listener = transport::listen(&path).unwrap();
+        let lease = ServedSocketLease::claim(path.clone()).unwrap();
+
+        assert!(lease.identity.matches_path(&path).unwrap());
+        drop(listener);
+        lease.cleanup();
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn unix_socket_path_reserves_trailing_nul() {
         const SUN_PATH_CAPACITY: usize =
             size_of::<libc::sockaddr_un>() - offset_of!(libc::sockaddr_un, sun_path);

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13505,6 +13505,22 @@ mod tests {
         assert!(retry_accept_error(std::io::ErrorKind::ConnectionReset));
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn listener_accept_retries_descriptor_exhaustion() {
+        let error = std::io::Error::from_raw_os_error(libc::EMFILE);
+        assert!(retry_accept_error(error.kind()));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn listener_accept_retries_windows_descriptor_exhaustion() {
+        use windows_sys::Win32::Networking::WinSock::WSAEMFILE;
+
+        let error = std::io::Error::from_raw_os_error(WSAEMFILE);
+        assert!(retry_accept_error(error.kind()));
+    }
+
     struct TestSocketDir(PathBuf);
 
     impl TestSocketDir {

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -30,6 +30,10 @@ use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
+fn retry_accept_error(kind: std::io::ErrorKind) -> bool {
+    matches!(kind, std::io::ErrorKind::ConnectionAborted | std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock | std::io::ErrorKind::ResourceBusy)
+}
+
 use anyhow::Context;
 use base64::Engine;
 use ghostty_vt::{
@@ -5230,7 +5234,11 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
                 Ok(Some(stream)) => stream,
                 Ok(None) => break,
                 Err(_) if server_shutdown.load(Ordering::Acquire) => break,
-                Err(_) => continue,
+                Err(error) if retry_accept_error(error.kind()) => continue,
+                Err(error) => {
+                    eprintln!("cmux-tui: listener accept failed: {error}");
+                    break;
+                }
             };
             if server_shutdown.load(Ordering::Acquire) {
                 break;

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -38,9 +38,32 @@ fn retry_accept_error(kind: std::io::ErrorKind) -> bool {
         std::io::ErrorKind::ConnectionAborted
             | std::io::ErrorKind::ConnectionReset
             | std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::NetworkDown
             | std::io::ErrorKind::WouldBlock
             | std::io::ErrorKind::ResourceBusy
     )
+}
+
+fn retry_accept_os_error(error: &std::io::Error) -> bool {
+    if retry_accept_error(error.kind()) {
+        return true;
+    }
+
+    match error.raw_os_error() {
+        #[cfg(unix)]
+        Some(code) => matches!(code, libc::EMFILE | libc::ENFILE | libc::ENOBUFS | libc::ENOMEM),
+        #[cfg(windows)]
+        Some(code) => {
+            use windows_sys::Win32::Networking::WinSock::{
+                WSA_NOT_ENOUGH_MEMORY, WSAEMFILE, WSAENOBUFS,
+            };
+
+            matches!(code, WSAEMFILE | WSAENOBUFS | WSA_NOT_ENOUGH_MEMORY)
+        }
+        #[cfg(all(not(unix), not(windows)))]
+        Some(_) => false,
+        None => false,
+    }
 }
 
 use anyhow::Context;
@@ -5188,6 +5211,8 @@ impl SocketStartLock {
 const START_LOCK_DEADLINE: Duration = Duration::from_secs(10);
 /// Bound cleanup waits so a shutdown path cannot hang on a wedged starter.
 const SOCKET_CLEANUP_DEADLINE: Duration = Duration::from_secs(2);
+/// Bound retries after a transient listener error without spinning the thread.
+const ACCEPT_RETRY_BACKOFF: Duration = Duration::from_millis(100);
 
 /// Bind the socket and accept protocol clients before lifecycle readiness.
 pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PendingServer> {
@@ -5243,7 +5268,16 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
                 Ok(Some(stream)) => stream,
                 Ok(None) => break,
                 Err(_) if server_shutdown.load(Ordering::Acquire) => break,
-                Err(error) if retry_accept_error(error.kind()) => continue,
+                Err(error) if retry_accept_os_error(&error) => {
+                    match server_wake.wait(ACCEPT_RETRY_BACKOFF) {
+                        Ok(true) => break,
+                        Ok(false) => continue,
+                        Err(wait_error) => {
+                            eprintln!("cmux-tui: listener wake wait failed: {wait_error}");
+                            break;
+                        }
+                    }
+                }
                 Err(error) => {
                     eprintln!("cmux-tui: listener accept failed: {error}");
                     break;
@@ -13509,7 +13543,7 @@ mod tests {
     #[test]
     fn listener_accept_retries_descriptor_exhaustion() {
         let error = std::io::Error::from_raw_os_error(libc::EMFILE);
-        assert!(retry_accept_error(error.kind()));
+        assert!(retry_accept_os_error(&error));
     }
 
     #[cfg(windows)]
@@ -13518,7 +13552,7 @@ mod tests {
         use windows_sys::Win32::Networking::WinSock::WSAEMFILE;
 
         let error = std::io::Error::from_raw_os_error(WSAEMFILE);
-        assert!(retry_accept_error(error.kind()));
+        assert!(retry_accept_os_error(&error));
     }
 
     struct TestSocketDir(PathBuf);

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -31,7 +31,13 @@ use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
 
 fn retry_accept_error(kind: std::io::ErrorKind) -> bool {
-    matches!(kind, std::io::ErrorKind::ConnectionAborted | std::io::ErrorKind::Interrupted | std::io::ErrorKind::WouldBlock | std::io::ErrorKind::ResourceBusy)
+    matches!(
+        kind,
+        std::io::ErrorKind::ConnectionAborted
+            | std::io::ErrorKind::Interrupted
+            | std::io::ErrorKind::WouldBlock
+            | std::io::ErrorKind::ResourceBusy
+    )
 }
 
 use anyhow::Context;

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4826,6 +4826,21 @@ fn windows_socket_identity(path: &Path) -> std::io::Result<(u32, u64)> {
     Ok((information.dwVolumeSerialNumber, file_index))
 }
 
+/// Close a listener whose lease could not capture an identity, then remove its
+/// unreachable publication when the path still names a socket. The caller
+/// holds the per-path start lock, so cooperative replacements cannot race the
+/// probe. The second identity check avoids removing a replacement that appears
+/// after the initial probe.
+fn cleanup_unclaimed_listener(listener: transport::Listener, path: &Path) {
+    drop(listener);
+
+    let Ok(identity) = SocketPathIdentity::capture(path) else { return };
+    if transport::connect(path).is_ok() || !identity.matches_path(path).unwrap_or(false) {
+        return;
+    }
+    let _ = std::fs::remove_file(path);
+}
+
 struct ListenerControl {
     shutdown: Arc<AtomicBool>,
     wake: transport::ListenerWake,
@@ -5183,7 +5198,13 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
         }
     }
     let listener = transport::listen(&path)?;
-    let lease = ServedSocketLease::claim(path.clone())?;
+    let lease = match ServedSocketLease::claim(path.clone()) {
+        Ok(lease) => lease,
+        Err(error) => {
+            cleanup_unclaimed_listener(listener, &path);
+            return Err(error.into());
+        }
+    };
     drop(start_lock);
     let listener_wake = match listener.wake_handle() {
         Ok(wake) => wake,

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4718,32 +4718,260 @@ fn validate_resource_client_label(
     Ok(Some(value))
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SocketPathIdentity {
+    #[cfg(unix)]
+    Unix { device: u64, inode: u64 },
+    #[cfg(windows)]
+    Windows { volume_serial: u32, file_index: u64 },
+    #[cfg(all(not(unix), not(windows)))]
+    Unavailable,
+}
+
+impl SocketPathIdentity {
+    fn capture(path: &Path) -> std::io::Result<Self> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+            let metadata = std::fs::symlink_metadata(path)?;
+            if !metadata.file_type().is_socket() {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    "session socket path is not a Unix socket",
+                ));
+            }
+            Ok(Self::Unix { device: metadata.dev(), inode: metadata.ino() })
+        }
+        #[cfg(windows)]
+        {
+            let (volume_serial, file_index) = windows_socket_identity(path)?;
+            Ok(Self::Windows { volume_serial, file_index })
+        }
+        #[cfg(all(not(unix), not(windows)))]
+        {
+            let _ = path;
+            Ok(Self::Unavailable)
+        }
+    }
+
+    fn matches_path(self, path: &Path) -> std::io::Result<bool> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::{FileTypeExt, MetadataExt};
+
+            let metadata = match std::fs::symlink_metadata(path) {
+                Ok(metadata) => metadata,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+                Err(error) => return Err(error),
+            };
+            Ok(metadata.file_type().is_socket()
+                && matches!(
+                    self,
+                    Self::Unix { device, inode }
+                        if metadata.dev() == device && metadata.ino() == inode
+                ))
+        }
+        #[cfg(windows)]
+        {
+            let current = match windows_socket_identity(path) {
+                Ok(identity) => identity,
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+                Err(error) => return Err(error),
+            };
+            Ok(matches!(
+                self,
+                Self::Windows { volume_serial, file_index }
+                    if file_index != 0
+                        && current.0 != 0
+                        && current.1 != 0
+                        && current == (volume_serial, file_index)
+            ))
+        }
+        #[cfg(all(not(unix), not(windows)))]
+        {
+            let _ = (self, path);
+            // This platform has no stable path identity in the supported
+            // standard-library API. Never remove an unverified successor.
+            Ok(false)
+        }
+    }
+}
+
+#[cfg(windows)]
+fn windows_socket_identity(path: &Path) -> std::io::Result<(u32, u64)> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::Storage::FileSystem::{
+        BY_HANDLE_FILE_INFORMATION, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, GetFileInformationByHandle,
+    };
+
+    // AF_UNIX pathname sockets are NTFS reparse points. Open the reparse
+    // point itself, not a target selected by normal reparse traversal, then
+    // read the volume serial and file index that identify this publication.
+    let file = std::fs::OpenOptions::new()
+        .access_mode(FILE_READ_ATTRIBUTES)
+        .share_mode(FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE)
+        .custom_flags(FILE_FLAG_OPEN_REPARSE_POINT)
+        .open(path)?;
+    let mut information = BY_HANDLE_FILE_INFORMATION::default();
+    // SAFETY: `file` owns a valid Windows handle and `information` points to
+    // writable storage for the fixed-size API result.
+    if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) } == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    let file_index =
+        (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
+    Ok((information.dwVolumeSerialNumber, file_index))
+}
+
+struct ListenerControl {
+    shutdown: Arc<AtomicBool>,
+    wake: transport::ListenerWake,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl ListenerControl {
+    fn stop(mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        let _ = self.wake.wake();
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Identity-fenced ownership of one bound local server socket.
+///
+/// Cleanup removes the path only when it still names the socket identity
+/// captured after this server bound it. The start lock serializes that check
+/// and removal with other cmux server starts.
+pub struct ServedSocketLease {
+    path: PathBuf,
+    identity: SocketPathIdentity,
+    linked: bool,
+    listener: Option<ListenerControl>,
+}
+
+impl ServedSocketLease {
+    /// Capture the identity of a successfully bound socket path.
+    pub fn claim(path: PathBuf) -> std::io::Result<Self> {
+        let identity = SocketPathIdentity::capture(&path)?;
+        Ok(Self { path, identity, linked: true, listener: None })
+    }
+
+    /// Return the public path owned by this lease.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    fn stop_listener(&mut self) {
+        if let Some(listener) = self.listener.take() {
+            listener.stop();
+        }
+    }
+
+    /// Remove this publication only while it still belongs to this lease.
+    pub fn unlink(&mut self) -> std::io::Result<()> {
+        if !self.linked {
+            self.stop_listener();
+            return Ok(());
+        }
+
+        let _start_lock =
+            match SocketStartLock::acquire(&self.path, Instant::now() + SOCKET_CLEANUP_DEADLINE) {
+                Ok(lock) => lock,
+                Err(error) => {
+                    // A failed lock acquisition cannot safely remove the path, but
+                    // the listener must still be stopped before the lease drops.
+                    self.stop_listener();
+                    return Err(error);
+                }
+            };
+        // Keep the start lock while closing this listener. A successor cannot
+        // bind and reuse its identity between shutdown and the fenced check.
+        self.stop_listener();
+        if self.identity.matches_path(&self.path)? {
+            match std::fs::remove_file(&self.path) {
+                Ok(()) => {}
+                Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+                Err(error) => return Err(error),
+            }
+        }
+        self.linked = false;
+        Ok(())
+    }
+
+    /// Remove this lease and ignore cleanup errors, as required by `Drop`.
+    pub fn cleanup(mut self) {
+        let _ = self.unlink();
+        // `unlink` stops the listener even when lock or identity checks fail.
+        // Do not make Drop wait for a second cleanup attempt after the caller
+        // has already consumed this lease's explicit cleanup result.
+        self.linked = false;
+    }
+
+    fn into_unfenced_path(mut self) -> PathBuf {
+        self.linked = false;
+        // The legacy path-only API keeps the process-lifetime listener
+        // detached, matching its behavior before listener ownership existed.
+        self.listener.take();
+        self.path.clone()
+    }
+
+    fn with_listener(mut self, listener: ListenerControl) -> Self {
+        self.listener = Some(listener);
+        self
+    }
+}
+
+impl Drop for ServedSocketLease {
+    fn drop(&mut self) {
+        let _ = self.unlink();
+    }
+}
+
 /// A bound local server whose lifecycle endpoint is not ready yet.
 pub struct PendingServer {
-    path: Option<PathBuf>,
+    lease: Option<ServedSocketLease>,
     mux: Arc<Mux>,
-    shutdown: Arc<AtomicBool>,
 }
 
 impl PendingServer {
     /// Publish lifecycle readiness and transfer socket cleanup to the caller.
     pub fn mark_ready(mut self) -> anyhow::Result<PathBuf> {
         self.mux.mark_server_lifecycle_ready();
-        Ok(self.path.take().expect("pending server path is available"))
+        Ok(self
+            .lease
+            .take()
+            .expect("pending server socket lease is available")
+            .into_unfenced_path())
     }
 
-    /// Transfer socket cleanup while another startup owner publishes readiness.
+    /// Publish lifecycle readiness and retain identity-fenced socket ownership.
+    pub fn mark_ready_owned(mut self) -> anyhow::Result<ServedSocketLease> {
+        self.mux.mark_server_lifecycle_ready();
+        Ok(self.lease.take().expect("pending server socket lease is available"))
+    }
+
+    /// Transfer identity-fenced socket cleanup while another startup owner
+    /// publishes readiness.
+    pub fn into_bound_socket(mut self) -> ServedSocketLease {
+        self.lease.take().expect("pending server socket lease is available")
+    }
+
+    /// Transfer legacy path cleanup while another startup owner publishes
+    /// readiness. New owners should use [`Self::into_bound_socket`].
     pub fn into_bound_path(mut self) -> PathBuf {
-        self.path.take().expect("pending server path is available")
+        self.lease.take().expect("pending server socket lease is available").into_unfenced_path()
     }
 }
 
 impl Drop for PendingServer {
     fn drop(&mut self) {
-        if let Some(path) = self.path.take() {
-            self.shutdown.store(true, Ordering::Release);
-            let _ = transport::connect(&path);
-            cleanup(&path);
+        if let Some(lease) = self.lease.take() {
+            lease.cleanup();
         }
     }
 }
@@ -4848,15 +5076,16 @@ pub fn prepare_socket_parent(path: &Path, is_derived: bool) -> anyhow::Result<()
     Ok(())
 }
 
-/// Exclusive lock serializing every local server start for one socket path:
-/// foreground `server start`, in-process TUI hosting, and detached-owner
-/// spawns. The stale-socket recovery below (probe, unlink, bind) is not
-/// atomic, so two unserialized starts can both classify a socket as stale,
-/// and the second unlink disconnects the first starter's freshly bound
-/// socket while its process keeps running unreachably. The lock file lives
-/// next to the socket and is left in place: unlinking it would reopen the
-/// very race it exists to close. The OS releases the lock when the holder
-/// exits, so a crashed starter never wedges the session.
+/// Exclusive lock serializing every local server start and identity-fenced
+/// cleanup for one socket path: foreground `server start`, in-process TUI
+/// hosting, and detached-owner spawns. The stale-socket recovery below
+/// (probe, unlink, bind) is not atomic, so two unserialized starts can both
+/// classify a socket as stale, and the second unlink disconnects the first
+/// starter's freshly bound socket while its process keeps running
+/// unreachably. The lock file lives next to the socket and is left in place:
+/// unlinking it would reopen the very race it exists to close. The OS releases
+/// the lock when the holder exits, so a crashed starter never wedges the
+/// session.
 pub struct SocketStartLock {
     _file: std::fs::File,
 }
@@ -4929,6 +5158,8 @@ impl SocketStartLock {
 /// healthy contender clears in milliseconds; the bound exists to surface a
 /// wedged holder as an error instead of a hang.
 const START_LOCK_DEADLINE: Duration = Duration::from_secs(10);
+/// Bound cleanup waits so a shutdown path cannot hang on a wedged starter.
+const SOCKET_CLEANUP_DEADLINE: Duration = Duration::from_secs(2);
 
 /// Bind the socket and accept protocol clients before lifecycle readiness.
 pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PendingServer> {
@@ -4952,9 +5183,17 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
         }
     }
     let listener = transport::listen(&path)?;
+    let lease = ServedSocketLease::claim(path.clone())?;
     drop(start_lock);
+    let listener_wake = match listener.wake_handle() {
+        Ok(wake) => wake,
+        Err(error) => {
+            lease.cleanup();
+            return Err(error.into());
+        }
+    };
     if let Err(error) = platform::restrict_file(&path) {
-        cleanup(&path);
+        lease.cleanup();
         return Err(error.into());
     }
     let active_connections = Arc::new(AtomicU64::new(0));
@@ -4962,10 +5201,16 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
     let shutdown = Arc::new(AtomicBool::new(false));
     let server_shutdown = shutdown.clone();
     let server_mux = mux.clone();
+    let server_wake = listener_wake.clone();
 
-    let server = std::thread::Builder::new().name("mux-server".into()).spawn(move || {
+    let server = match std::thread::Builder::new().name("mux-server".into()).spawn(move || {
         loop {
-            let Ok(stream) = listener.accept() else { continue };
+            let stream = match listener.accept_with_wake(&server_wake) {
+                Ok(Some(stream)) => stream,
+                Ok(None) => break,
+                Err(_) if server_shutdown.load(Ordering::Acquire) => break,
+                Err(_) => continue,
+            };
             if server_shutdown.load(Ordering::Acquire) {
                 break;
             }
@@ -4976,12 +5221,19 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
                 handle_connection_with_permit(mux, stream, render_service, Some(permit));
             });
         }
+    }) {
+        Ok(server) => server,
+        Err(error) => {
+            lease.cleanup();
+            return Err(error.into());
+        }
+    };
+    let lease = lease.with_listener(ListenerControl {
+        shutdown,
+        wake: listener_wake,
+        thread: Some(server),
     });
-    if let Err(error) = server {
-        cleanup(&path);
-        return Err(error.into());
-    }
-    Ok(PendingServer { path: Some(path), mux, shutdown })
+    Ok(PendingServer { lease: Some(lease), mux })
 }
 
 /// Bind the socket and serve connections on background threads.

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4839,9 +4839,12 @@ fn windows_socket_identity(path: &Path) -> std::io::Result<(u32, u64)> {
     use std::os::windows::fs::OpenOptionsExt;
     use std::os::windows::io::AsRawHandle;
     use windows_sys::Win32::Storage::FileSystem::{
-        BY_HANDLE_FILE_INFORMATION, FILE_FLAG_OPEN_REPARSE_POINT, FILE_READ_ATTRIBUTES,
-        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, GetFileInformationByHandle,
+        BY_HANDLE_FILE_INFORMATION, FILE_ATTRIBUTE_REPARSE_POINT, FILE_ATTRIBUTE_TAG_INFO,
+        FILE_FLAG_OPEN_REPARSE_POINT, FILE_INFO_BY_HANDLE_CLASS, FILE_READ_ATTRIBUTES,
+        FILE_SHARE_DELETE, FILE_SHARE_READ, FILE_SHARE_WRITE, FileAttributeTagInfo,
+        GetFileInformationByHandle, GetFileInformationByHandleEx,
     };
+    use windows_sys::Win32::System::SystemServices::IO_REPARSE_TAG_AF_UNIX;
 
     // AF_UNIX pathname sockets are NTFS reparse points. Open the reparse
     // point itself, not a target selected by normal reparse traversal, then
@@ -4858,6 +4861,28 @@ fn windows_socket_identity(path: &Path) -> std::io::Result<(u32, u64)> {
     // writable storage for the fixed-size API result.
     if unsafe { GetFileInformationByHandle(file.as_raw_handle(), &mut information) } == 0 {
         return Err(std::io::Error::last_os_error());
+    }
+    let mut tag_info = FILE_ATTRIBUTE_TAG_INFO::default();
+    // SAFETY: `file` owns a valid handle and `tag_info` points to writable
+    // storage of the exact size required by `FileAttributeTagInfo`.
+    let tag_info_result = unsafe {
+        GetFileInformationByHandleEx(
+            file.as_raw_handle(),
+            FileAttributeTagInfo as FILE_INFO_BY_HANDLE_CLASS,
+            (&mut tag_info as *mut FILE_ATTRIBUTE_TAG_INFO).cast(),
+            std::mem::size_of::<FILE_ATTRIBUTE_TAG_INFO>() as u32,
+        )
+    };
+    if tag_info_result == 0 {
+        return Err(std::io::Error::last_os_error());
+    }
+    if tag_info.FileAttributes & FILE_ATTRIBUTE_REPARSE_POINT == 0
+        || tag_info.ReparseTag != IO_REPARSE_TAG_AF_UNIX
+    {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "session socket path is not an AF_UNIX socket",
+        ));
     }
     let file_index =
         (u64::from(information.nFileIndexHigh) << 32) | u64::from(information.nFileIndexLow);
@@ -5219,6 +5244,12 @@ const START_LOCK_DEADLINE: Duration = Duration::from_secs(10);
 const SOCKET_CLEANUP_DEADLINE: Duration = Duration::from_secs(2);
 /// Bound retries after a transient listener error without spinning the thread.
 const ACCEPT_RETRY_BACKOFF: Duration = Duration::from_millis(100);
+/// Stop retrying persistent resource errors after a bounded recovery window.
+const ACCEPT_RETRY_LIMIT: u32 = 50;
+
+fn accept_retry_allowed(retries: u32) -> bool {
+    retries < ACCEPT_RETRY_LIMIT
+}
 
 /// Bind the socket and accept protocol clients before lifecycle readiness.
 pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PendingServer> {
@@ -5269,12 +5300,23 @@ pub fn serve_paused(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<Pend
     let server_wake = listener_wake.clone();
 
     let server = match std::thread::Builder::new().name("mux-server".into()).spawn(move || {
+        let mut transient_accept_failures = 0;
         loop {
             let stream = match listener.accept_with_wake(&server_wake) {
-                Ok(Some(stream)) => stream,
+                Ok(Some(stream)) => {
+                    transient_accept_failures = 0;
+                    stream
+                }
                 Ok(None) => break,
                 Err(_) if server_shutdown.load(Ordering::Acquire) => break,
                 Err(error) if retry_accept_os_error(&error) => {
+                    if !accept_retry_allowed(transient_accept_failures) {
+                        eprintln!(
+                            "cmux-tui: listener accept retry limit exceeded after {transient_accept_failures} failures: {error}"
+                        );
+                        break;
+                    }
+                    transient_accept_failures = transient_accept_failures.saturating_add(1);
                     match server_wake.wait(ACCEPT_RETRY_BACKOFF) {
                         Ok(true) => break,
                         Ok(false) => continue,

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13545,6 +13545,13 @@ mod tests {
         assert!(retry_accept_error(std::io::ErrorKind::ConnectionReset));
     }
 
+    #[test]
+    fn listener_accept_retry_budget_stops_persistent_resource_errors() {
+        assert!(accept_retry_allowed(0));
+        assert!(accept_retry_allowed(ACCEPT_RETRY_LIMIT - 1));
+        assert!(!accept_retry_allowed(ACCEPT_RETRY_LIMIT));
+    }
+
     #[cfg(unix)]
     #[test]
     fn listener_accept_retries_descriptor_exhaustion() {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1827,25 +1827,32 @@ fn socket_option(fd: std::os::fd::RawFd, option: libc::c_int) -> io::Result<libc
 
 struct ServedMuxCleanup {
     mux: Option<Arc<Mux>>,
-    socket_path: PathBuf,
+    socket: Option<cmux_tui_core::server::ServedSocketLease>,
 }
 
 impl ServedMuxCleanup {
-    fn new(mux: Arc<Mux>, socket_path: PathBuf) -> Self {
-        Self { mux: Some(mux), socket_path }
+    fn new(mux: Arc<Mux>, socket: cmux_tui_core::server::ServedSocketLease) -> Self {
+        Self { mux: Some(mux), socket: Some(socket) }
     }
 
     fn disarm(&mut self) {
         self.mux = None;
+        self.socket = None;
+    }
+
+    fn cleanup(&mut self) {
+        if let Some(mux) = self.mux.take() {
+            mux.shutdown();
+        }
+        if let Some(socket) = self.socket.take() {
+            socket.cleanup();
+        }
     }
 }
 
 impl Drop for ServedMuxCleanup {
     fn drop(&mut self) {
-        if let Some(mux) = self.mux.take() {
-            mux.shutdown();
-            cmux_tui_core::server::cleanup(&self.socket_path);
-        }
+        self.cleanup();
     }
 }
 
@@ -2134,7 +2141,7 @@ fn run_server(
             server.local_addr()
         );
     }
-    let served_socket = pending_server.into_bound_path();
+    let served_socket = pending_server.into_bound_socket();
     let mut served_mux_cleanup = ServedMuxCleanup::new(mux.clone(), served_socket);
 
     let machine_runtime = (config.machine_sidebar.enabled
@@ -2184,8 +2191,7 @@ fn run_server(
     {
         let shutdown_result = finish_server_shutdown(
             websocket_server,
-            &mux,
-            &socket_path,
+            &mut served_mux_cleanup,
             remote_shutdown,
             result.and(owner_event_result),
         );
@@ -2196,8 +2202,7 @@ fn run_server(
     #[cfg(not(unix))]
     {
         drop(websocket_server);
-        mux.shutdown();
-        cmux_tui_core::server::cleanup(&socket_path);
+        served_mux_cleanup.cleanup();
         served_mux_cleanup.disarm();
         drop(served_mux_cleanup);
         result.and(owner_event_result)
@@ -2254,14 +2259,12 @@ fn start_local_owner_event_loop_with_completion(
 #[cfg(unix)]
 fn finish_server_shutdown<W, R>(
     websocket_server: Option<W>,
-    mux: &Arc<Mux>,
-    socket_path: &Path,
+    served_mux_cleanup: &mut ServedMuxCleanup,
     remote_shutdown: anyhow::Result<Option<R>>,
     result: anyhow::Result<()>,
 ) -> anyhow::Result<()> {
     drop(websocket_server);
-    mux.shutdown();
-    cmux_tui_core::server::cleanup(socket_path);
+    served_mux_cleanup.cleanup();
     remote_shutdown.map(|_| ())?;
     result
 }
@@ -3100,18 +3103,23 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn remote_shutdown_failure_still_stops_the_mux_and_removes_the_socket() {
-        let socket_path = std::env::temp_dir().join(format!(
-            "cmux-remote-shutdown-{}-{}.sock",
+        let directory = std::env::temp_dir().join(format!(
+            "cmux-remote-shutdown-{}-{}",
             std::process::id(),
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
         ));
-        std::fs::write(&socket_path, b"test socket marker").unwrap();
+        std::fs::create_dir(&directory).unwrap();
+        let socket_path = directory.join("server.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
         let mux = Mux::new("remote-shutdown-failure", SurfaceOptions::default());
+        let mut cleanup = ServedMuxCleanup::new(
+            mux.clone(),
+            cmux_tui_core::server::ServedSocketLease::claim(socket_path.clone()).unwrap(),
+        );
 
         let error = finish_server_shutdown(
             Some(()),
-            &mux,
-            &socket_path,
+            &mut cleanup,
             Err::<Option<()>, _>(anyhow::anyhow!("injected remote shutdown failure")),
             Ok(()),
         )
@@ -3121,24 +3129,32 @@ mod tests {
         assert!(error.contains("injected remote shutdown failure"), "{error}");
         assert!(mux.daemon_shutdown_requested());
         assert!(!socket_path.exists());
+        cleanup.disarm();
+        drop(listener);
+        let _ = std::fs::remove_file(directory.join("server.sock.spawn-lock"));
+        std::fs::remove_dir(directory).unwrap();
     }
 
     #[cfg(unix)]
     #[test]
     fn normal_server_cleanup_disarms_the_fallback_guard() {
-        let socket_path = std::env::temp_dir().join(format!(
-            "cmux-normal-shutdown-{}-{}.sock",
+        let directory = std::env::temp_dir().join(format!(
+            "cmux-normal-shutdown-{}-{}",
             std::process::id(),
             std::time::SystemTime::now().duration_since(std::time::UNIX_EPOCH).unwrap().as_nanos()
         ));
-        std::fs::write(&socket_path, b"test socket marker").unwrap();
+        std::fs::create_dir(&directory).unwrap();
+        let socket_path = directory.join("server.sock");
+        let listener = std::os::unix::net::UnixListener::bind(&socket_path).unwrap();
         let mux = Mux::new("normal-shutdown", SurfaceOptions::default());
-        let mut cleanup = ServedMuxCleanup::new(mux.clone(), socket_path.clone());
+        let mut cleanup = ServedMuxCleanup::new(
+            mux.clone(),
+            cmux_tui_core::server::ServedSocketLease::claim(socket_path.clone()).unwrap(),
+        );
 
         finish_server_shutdown(
             Some(()),
-            &mux,
-            &socket_path,
+            &mut cleanup,
             Ok::<Option<()>, anyhow::Error>(None),
             Ok(()),
         )
@@ -3148,6 +3164,9 @@ mod tests {
         assert!(cleanup.mux.is_none());
         assert!(mux.daemon_shutdown_requested());
         assert!(!socket_path.exists());
+        drop(listener);
+        let _ = std::fs::remove_file(directory.join("server.sock.spawn-lock"));
+        std::fs::remove_dir(directory).unwrap();
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary
- preserve the bound socket identity during cleanup and never unlink a successor publication
- retain a listener-local wake handle and join the accept thread during lease cleanup, including when the pathname now names a successor
- add deterministic coverage that the old listener exits after replacement

This replaces closed PR https://github.com/manaflow-ai/cmux/pull/11475, which could not be reopened after its deleted parent branch was merged. The stack is now based directly on `main` at `eaa899cb20bd411019744fbd2bdedeb397f3070b`.

Commits remain test-first:
1. `test(tui): preserve replacement listener during stale cleanup`
2. `fix(tui): fence listener cleanup by socket identity`

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/platform.rs cmux-tui/crates/cmux-tui-core/src/server.rs cmux-tui/crates/cmux-tui/src/main.rs`
- `git diff --check origin/main...HEAD`
- local Cargo/Rust tests were not run by instruction
- focused hosted verification: `./scripts/verify-cmux-tui-hosted.sh --filter dropping_a_stale_pending_server_preserves_a_replacement_socket`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11482"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790876850&installation_model_id=21920&pr_number=11482&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11482&signature=fad5acfe21c9c402f1c32d2600f1dcf215174ca0ea3129ba0c2af388d9646220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux-tui` stale socket cleanup so it no longer unlinks a replacement socket or leaves the original listener running. Cleanup now verifies socket identity before removal and wakes and stops the old listener; the accept loop also survives transient errors instead of exiting on them.

**Bug Fixes**
- Identifies sockets via Unix device/inode and Windows volume/file index, failing closed where stable identity is unavailable.
- Wakes and joins listener threads during cleanup, even after the pathname names a successor.
- Cleans up a failed socket claim only when the path still names the original unreachable socket.
- Serializes cleanup with the per-path start lock and limits lock acquisition to two seconds.
- Retries connection resets, descriptor exhaustion, and other transient accept errors with 100 ms backoff, stopping after 50 failures or on fatal errors.

<sup>Written for commit 3b61ee85ff6f52696c88dd6d353e10fee7106dfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11482?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added more responsive listener wake-up behavior during server lifecycle changes.
  * Improved server listener control for smoother shutdown and restart handling.
* **Bug Fixes**
  * Prevented cleanup from removing replacement sockets at the same location.
  * Improved cleanup when server startup or ownership claims fail.
  * Improved recovery from temporary listener errors.
* **Reliability**
  * Strengthened socket ownership verification and cleanup timing across supported platforms.
  * Added Windows networking support for improved platform compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->