### PR TITLE
perf(cmux-tui): avoid cloning projection specs per frame

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -42770,6 +42770,31 @@ mod tests {
     }
 
     #[test]
+    fn empty_projection_uses_its_leaf_resource_label() {
+        let mux = Mux::new("projection-empty-leaf-label-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "workspace-tabs".into(),
+            levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Tabs],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.sync_layout((100, 12));
+
+        let mut terminal = Terminal::new(TestBackend::new(100, 12)).unwrap();
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+        let rendered = buffer_text(terminal.backend().buffer());
+
+        assert!(rendered.contains("no tabs"), "{rendered}");
+        assert!(!rendered.contains("no workspaces"), "{rendered}");
+    }
+
+    #[test]
     fn workspace_keyboard_enter_returns_focus_to_pane() {
         let mux = Mux::new("workspace-keyboard-enter-focus-test", SurfaceOptions::default());
         let first = mux.new_workspace(Some("Alpha".into()), Some((80, 24))).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -321,7 +321,15 @@ pub fn draw_tabs(app: &mut App, frame: &mut Frame) {
 /// Render one configurable resource path as a dense native tree column.
 pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
     let Some(area) = app.projection_sidebar_area(view_index) else { return };
-    let Some(spec) = app.config.sidebar.views.get(view_index).cloned() else { return };
+    let Some(empty_resource) = app
+        .config
+        .sidebar
+        .views
+        .get(view_index)
+        .map(|spec| spec.levels.last().copied().unwrap_or(SidebarResourceKind::Workspaces))
+    else {
+        return;
+    };
     let rows = app.projection_rows(view_index);
     let actions = app.sidebar_action_rows(view_index);
     let focused = app.projection_sidebar_focused(view_index);
@@ -363,8 +371,7 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
     if rows.is_empty()
         && let Some(y) = viewport.body_y(rail::RowSpan::new(0, 1))
     {
-        let resource = spec.levels.last().copied().unwrap_or(SidebarResourceKind::Workspaces);
-        rail::button(frame, area, y, projection_empty_label(resource), false, palette);
+        rail::button(frame, area, y, projection_empty_label(empty_resource), false, palette);
     }
     for (row_index, row) in rows.iter().enumerate() {
         let Some(y) = viewport.body_y(rail::RowSpan::new(row_index, 1)) else { continue };


### PR DESCRIPTION
## Summary
- extract the `SidebarResourceKind` leaf value before mutable projection rendering
- preserve the empty projection label and missing-view return behavior
- add a render behavior test for the configured leaf label

`SidebarViewSpec::clone` copied the view id, levels, actions, and optional labels on every visible projection render. The scalar extraction removes those per-frame heap copies without changing row ordering, selection, hit targets, or labels. The behavior test guards the rendered semantics. Allocation behavior was reviewed statically because this change has no observable UI difference and local Rust/Cargo execution is prohibited by the worktree instructions.

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/ui/sidebar.rs cmux-tui/crates/cmux-tui/src/app.rs`
- `git diff --check`
- hosted focused test pending

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11485"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790880715&installation_model_id=21920&pr_number=11485&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11485&signature=b9a5e3db1533e485f833aba51bccdbe9170444c7f17a3037bb0fcb16d83110f3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Draws the sidebar projection without cloning the whole view spec each frame, removing per-frame heap copies while keeping row ordering, selection, hit targets, and labels unchanged.

- Extracts only the leaf resource kind before mutable rendering.
- Adds a render test covering the empty projection's leaf label.

<sup>Written for commit b357092fbf909f2ad1862b3ca2b628c0c4ba2fe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11485?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the empty sidebar state to display the appropriate “no tabs” label instead of “no workspaces.”
  * Improved consistency when showing empty workspace and tab projections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->