### PR TITLE
ci: allow the reviewed CLA runner variable

### DIFF
--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -1160,6 +1160,30 @@ def run_environment_regression_matrix!
   puts "PASS: CLA environment regression matrix (#{checks} cases)"
 end
 
+def run_runner_regression_matrix!
+  expected_runner = "${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"
+  cla_jobs = %w[
+    CLACommentGate
+    CLAAssistant
+    CLALedgerWriter
+    CLACompatibility
+    RerunFailedCLA
+    LockMergedPullRequest
+  ]
+  cla_jobs.each do |job_name|
+    assert_cla_runner(expected_runner, "#{job_name}.runs-on")
+  end
+
+  {
+    "bare GitHub runner" => "ubuntu-24.04",
+    "alternate repository variable" => "${{ vars.OTHER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+    "event-controlled runner" => "${{ github.event.repository.default_branch }}"
+  }.each do |name, runner|
+    expect_policy_error(name) { assert_cla_runner(runner, "CLACommentGate.runs-on") }
+  end
+  puts "PASS: CLA runner contract regression matrix (#{cla_jobs.length + 3} cases)"
+end
+
 def run_trusted_review_regression_matrix!
   head = "a" * 40
   review = lambda do |id, state, at, commit = head, user = 54008264, dismissed = nil|
@@ -1652,6 +1676,7 @@ begin
   run_guard_contract_regression_matrix!
   run_trusted_cla_regression_matrix!
   run_environment_regression_matrix!
+  run_runner_regression_matrix!
   run_trusted_review_regression_matrix!
   repository = required_env("GH_REPO", REPOSITORY)
   pr_number = required_env("PR_NUMBER", /\A[1-9][0-9]*\z/)

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -21,7 +21,9 @@ REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
 MAX_YAML_NODES = 10_000
 MAX_YAML_DEPTH = 64
-CLA_ACTION = "manaflow-ai/cla-github-action@482864f7296623ba4e8ddb7d6bc1836635306eb1"
+CLA_ACTION = "manaflow-ai/cla-github-action@537cbad33cd5e55bd3ef9bcf33d26a965da4fe4a"
+CLA_RUNNER = "${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}".freeze
+CLA_RUNNER_PATH = /\Ajobs\.(?:CLACommentGate|CLAAssistant|CLALedgerWriter|CLACompatibility|RerunFailedCLA|LockMergedPullRequest)\.runs-on\z/
 # The privileged workflow is an explicit reviewed policy, not an extensible
 # script. Its candidate structure is checked as data, and every policy change
 # requires trusted review without a fragile follow-up hash bump.
@@ -29,7 +31,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "0b11a4abcf4b91b0ed3d862475dae345dcfa46569c2d75caedaa49f3ac8f7ccb"
+EXPECTED_GUARD_SCRIPT_DIGEST = "1a928da913f61d6a203fdd38f6795b424c188df3f30c3a75be7417ba69b2eea8"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -111,6 +113,7 @@ GITHUB_TOKEN_EXPRESSION_PATTERN = /\bgithub\b.*\btoken\b|\btoJSON\s*\(\s*github\
 ALLOWED_EXPRESSION_PATHS = [
   /\Aenv\.[^.]+\z/,
   /\Ajobs\.[^.]+\.if\z/,
+  CLA_RUNNER_PATH,
   /\Ajobs\.[^.]+\.concurrency\.group\z/,
   /\Ajobs\.[^.]+\.outputs\.[^.]+\z/,
   /\Ajobs\.[^.]+\.steps\.\d+\.env\.[^.]+\z/,
@@ -710,6 +713,10 @@ def assert_string(value, name)
   value
 end
 
+def assert_cla_runner(value, name)
+  fail!("#{name} must use the reviewed CLA runner") unless value == CLA_RUNNER
+end
+
 def assert_action_reference(reference, name)
   fail!("#{name} must be a pinned action reference") unless reference.is_a?(String)
   fail!("#{name} uses an unapproved action") unless ALLOWED_ACTIONS.include?(reference)
@@ -770,6 +777,9 @@ def assert_safe_expression_fields(document, name, allowed_secret_paths: ALLOWED_
     joined_path = path.map(&:to_s).join(".")
     fail!("#{name} has an expression in an unreviewed field") unless
       ALLOWED_EXPRESSION_PATHS.any? { |pattern| joined_path.match?(pattern) }
+    if joined_path.match?(CLA_RUNNER_PATH) && value != CLA_RUNNER
+      fail!("#{name} has an unapproved CLA runner expression")
+    end
     if value.match?(GITHUB_CONTEXT_EXPRESSION) && value.match?(GITHUB_TOKEN_EXPRESSION_PATTERN)
       fail!("#{name} may not reference the GitHub token or serialized context")
     end
@@ -1305,7 +1315,7 @@ def validate_workflow(raw)
     fail!("#{names[index]} has no runner") unless value.key?("runs-on")
     assert_exact_keys(value, job_keys.fetch(names[index]), names[index])
     assert_safe_job_common(value, names[index])
-    fail!("#{names[index]} must use the reviewed ephemeral runner") unless value["runs-on"] == "ubuntu-24.04"
+    assert_cla_runner(value["runs-on"], names[index])
   end
 
   fail!("CLACommentGate must use read-only permissions") unless
@@ -1621,6 +1631,7 @@ def validate_guard_script(raw)
     "mapping keys must be strings",
     "run_yaml_regression_matrix!",
     "run_environment_regression_matrix!",
+    "run_runner_regression_matrix!",
     "run_trusted_review_regression_matrix!",
     "collect_latest_trusted_review!",
     "def workflow_digest",
@@ -1632,6 +1643,9 @@ def validate_guard_script(raw)
     "assert_exact_typed_inputs",
     "assert_exact_secret_paths",
     "assert_safe_expression_fields",
+    "assert_cla_runner",
+    "CLA_RUNNER",
+    "CLA_RUNNER_PATH",
     "assert_safe_run_text",
     "assert_exact_normalized_run",
     "run_guard_contract_regression_matrix!",

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -21,7 +21,7 @@ REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
 MAX_YAML_NODES = 10_000
 MAX_YAML_DEPTH = 64
-CLA_ACTION = "manaflow-ai/cla-github-action@537cbad33cd5e55bd3ef9bcf33d26a965da4fe4a"
+CLA_ACTION = "manaflow-ai/cla-github-action@5749bd2e5867b7545e66b55ac44acf616595bde3"
 CLA_RUNNER = "${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}".freeze
 CLA_RUNNER_PATH = /\Ajobs\.(?:CLACommentGate|CLAAssistant|CLALedgerWriter|CLACompatibility|RerunFailedCLA|LockMergedPullRequest)\.runs-on\z/
 # The privileged workflow is an explicit reviewed policy, not an extensible
@@ -31,7 +31,7 @@ EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f
 # The guard workflow remains pinned to its reviewed immutable bytes. The CLA
 # policy itself is validated structurally, then authorized by an exact-head
 # trusted review.
-EXPECTED_GUARD_SCRIPT_DIGEST = "1a928da913f61d6a203fdd38f6795b424c188df3f30c3a75be7417ba69b2eea8"
+EXPECTED_GUARD_SCRIPT_DIGEST = "8af51413cbb503fc1cc4aa306f85932dd6ba37b1b58ecd4bfddb06d19e2735a9"
 # Migration marker for the base v2 guard validator. That validator requires
 # the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
 # validator does not use this inert marker for policy authorization.
@@ -185,7 +185,7 @@ GUARD_VALIDATE_RUN_HASH = "759f3978ae0a2e0620eb2630cd4c1ec2cbff8f9bcc9a37f76b330
 CLA_SIGN_PHRASE = "I have read the CLA Document v2.2 and I hereby sign the CLA"
 CLA_RECHECK_PHRASE = "recheck"
 CLA_DOCUMENT_INPUT = "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
-CLA_LIFECYCLE_ACTIONS = %w[opened edited reopened synchronize].freeze
+CLA_LIFECYCLE_ACTIONS = %w[opened edited reopened synchronize ready_for_review].freeze
 CLA_TRUSTED_ASSOCIATIONS = %w[OWNER MEMBER COLLABORATOR].freeze
 POSITIVE_ID = /\A[1-9][0-9]*\z/
 CLA_WRITER_CONDITION = <<~'EXPRESSION'.gsub(/\s+/, " ").strip.freeze
@@ -198,7 +198,8 @@ CLA_WRITER_CONDITION = <<~'EXPRESSION'.gsub(/\s+/, " ").strip.freeze
         github.event.action == 'opened' ||
         github.event.action == 'edited' ||
         github.event.action == 'reopened' ||
-        github.event.action == 'synchronize'
+        github.event.action == 'synchronize' ||
+        github.event.action == 'ready_for_review'
       )
     ) ||
     (
@@ -1281,7 +1282,7 @@ def validate_workflow(raw)
   target = triggers["pull_request_target"]
   fail!("pull_request_target is malformed") unless target.is_a?(Hash)
   fail!("pull_request_target must target main only") unless target["branches"] == ["main"]
-  expected_types = %w[opened closed edited reopened synchronize]
+  expected_types = %w[opened closed edited reopened synchronize ready_for_review]
   fail!("pull_request_target event set is unsafe") unless target["types"] == expected_types
   fail!("top-level permissions must be empty") unless document["permissions"] == {}
 
@@ -1633,6 +1634,8 @@ def validate_guard_script(raw)
     "run_environment_regression_matrix!",
     "run_runner_regression_matrix!",
     "run_trusted_review_regression_matrix!",
+    "CLA_LIFECYCLE_ACTIONS",
+    "ready_for_review",
     "collect_latest_trusted_review!",
     "def workflow_digest",
     "Digest::SHA256.hexdigest(raw)",


### PR DESCRIPTION
## Summary

- allow only the exact `vars.LINUX_RUNNER` expression for all six CLA policy jobs
- keep `cla-policy-guard.yml` on fixed `ubuntu-24.04`
- pin the validator contract to merged cla-github-action PR #6
- add a fail-closed runner regression matrix and refresh the validator self-digest

## Verification

- test-only commit `81dc349877` fails before the runner contract exists
- implementation commit `9ffa936b28` passes the runner matrix
- `ruby -c scripts/ci/validate-cla-policy.rb`
- `actionlint .github/workflows/cla-policy-guard.yml .github/workflows/cla.yml`
- `./tests/test_ci_self_hosted_guard.sh`
- `git diff --check`

Do not merge from this branch. This guard PR must land before the CLA v3 policy PR uses the configurable runner and action PR #6 pin.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the CLA policy validator to allow the `vars.LINUX_RUNNER` runner expression for all six CLA jobs and to track the `ready_for_review` lifecycle event.

- Allows the exact `vars.LINUX_RUNNER` expression instead of the hardcoded `ubuntu-24.04` for all six CLA jobs.
- Adds a fail-closed regression matrix covering the allowed runner expression and three rejected alternatives.
- Accepts `ready_for_review` in the CLA trigger types, lifecycle actions, and writer condition.
- Pins the validator contract to the merged `cla-github-action` commit and refreshes the self-digest.
- Updates the guard workflow digest to match the revised validator script.

This guard PR must merge before the CLA v3 policy PR that uses the configurable runner.

<sup>Written for commit acca3ef5aacb26068d3bf7bd6677169d7a25ee75. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11488?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the contribution agreement workflow to use a reviewed, pinned action version.
  * Restricted workflow execution to approved runner configurations for improved security and consistency.

* **Tests**
  * Added validation and regression coverage for contribution agreement jobs.
  * Integrated runner checks into workflow verification and self-checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->