### PR TITLE
cmux-tui: remove stale provider client lint suppressions

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -1,12 +1,11 @@
 //! Synchronous client for the versioned machine-provider protocol.
 //!
-//! This module intentionally has no `App` or CLI integration yet. It owns the
-//! security and framing boundary between a provider daemon and cmux's existing
-//! `RemoteTransport` abstraction, so later runtime wiring does not need to know
-//! how provider requests, events, authentication, or one-use stream tickets are
-//! represented on the wire.
-
-#![allow(dead_code)]
+//! `machine_provider_runtime` uses this client to back the machine controller,
+//! while startup's provider CLI and configuration paths select the transport
+//! connector. This module owns the security and framing boundary between a
+//! provider daemon and cmux's existing `RemoteTransport` abstraction, keeping
+//! provider requests, events, authentication, and one-use stream tickets out
+//! of the runtime and UI layers.
 
 #[cfg(unix)]
 use std::collections::{BTreeMap, HashMap, VecDeque};
@@ -62,7 +61,6 @@ use crate::session::{
 #[path = "machine_provider_transport.rs"]
 mod machine_provider_transport;
 #[cfg(unix)]
-#[allow(unused_imports)] // Consumed by the upcoming runtime/CLI migration.
 pub(crate) use machine_provider_transport::{
     CommandProviderConnector, MachineProviderConnector, SshProviderConnector, UnixProviderConnector,
 };

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -13,12 +13,14 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 #[cfg(unix)]
 use std::io::{self, BufRead, BufReader, Write};
-#[cfg(unix)]
+#[cfg(all(unix, test))]
 use std::path::Path;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+#[cfg(all(unix, test))]
+use std::sync::mpsc::Receiver;
 #[cfg(unix)]
-use std::sync::mpsc::{self, Receiver, RecvTimeoutError, SyncSender, TrySendError};
+use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 #[cfg(unix)]
 use std::sync::{Arc, Condvar, Mutex, Weak};
 #[cfg(unix)]
@@ -605,6 +607,9 @@ pub(crate) struct ProviderClient {
 
 #[cfg(unix)]
 impl ProviderClient {
+    /// Test-only unauthenticated connection. Runtime callers go through
+    /// `connect_authenticated_with` so every generation performs `hello`.
+    #[cfg(test)]
     pub(crate) fn connect(socket_path: impl AsRef<Path>) -> ProviderResult<Self> {
         let (control, streams) =
             UnixProviderConnector::open_unauthenticated(socket_path.as_ref().to_path_buf())?;
@@ -638,6 +643,8 @@ impl ProviderClient {
         Ok(Self { inner })
     }
 
+    /// Test-only Unix-socket convenience over `connect_authenticated_with`.
+    #[cfg(test)]
     pub(crate) fn connect_authenticated(
         socket_path: impl AsRef<Path>,
         token: BearerToken,
@@ -924,6 +931,8 @@ impl ProviderClient {
     }
 
     /// Subscribe to revision invalidations. Receivers are removed after drop.
+    /// The runtime fetches snapshots on demand and does not subscribe yet.
+    #[cfg(test)]
     pub(crate) fn subscribe_snapshot_changes(&self) -> ProviderResult<Receiver<u64>> {
         self.ensure_live()?;
         let (sender, receiver) = mpsc::sync_channel(1);
@@ -1020,7 +1029,7 @@ impl ProviderClient {
 
         drop(deadline);
         Ok(RemoteTransport::new(
-            Box::new(BoundedRemoteReader { inner: reader, guard: guard.clone() }),
+            Box::new(BoundedRemoteReader { inner: reader, _guard: guard.clone() }),
             Box::new(BoundedRemoteWriter { inner: writer, guard: guard.clone() }),
             Arc::new(ProviderRemoteAbort { guard }),
         ))
@@ -1427,7 +1436,8 @@ fn write_json_frame<W: Write, T: Serialize>(
 #[cfg(unix)]
 struct BoundedRemoteReader {
     inner: BufReader<Box<dyn io::Read + Send>>,
-    guard: ProviderIoGuard,
+    /// Keeps the endpoint cleanup alive for as long as the reader exists.
+    _guard: ProviderIoGuard,
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
@@ -13,12 +13,8 @@ use std::collections::{BTreeMap, HashMap, VecDeque};
 use std::fmt;
 #[cfg(unix)]
 use std::io::{self, BufRead, BufReader, Write};
-#[cfg(all(unix, test))]
-use std::path::Path;
 #[cfg(unix)]
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-#[cfg(all(unix, test))]
-use std::sync::mpsc::Receiver;
 #[cfg(unix)]
 use std::sync::mpsc::{self, RecvTimeoutError, SyncSender, TrySendError};
 #[cfg(unix)]
@@ -610,7 +606,7 @@ impl ProviderClient {
     /// Test-only unauthenticated connection. Runtime callers go through
     /// `connect_authenticated_with` so every generation performs `hello`.
     #[cfg(test)]
-    pub(crate) fn connect(socket_path: impl AsRef<Path>) -> ProviderResult<Self> {
+    pub(crate) fn connect(socket_path: impl AsRef<std::path::Path>) -> ProviderResult<Self> {
         let (control, streams) =
             UnixProviderConnector::open_unauthenticated(socket_path.as_ref().to_path_buf())?;
         Self::from_transport(control, streams)
@@ -646,7 +642,7 @@ impl ProviderClient {
     /// Test-only Unix-socket convenience over `connect_authenticated_with`.
     #[cfg(test)]
     pub(crate) fn connect_authenticated(
-        socket_path: impl AsRef<Path>,
+        socket_path: impl AsRef<std::path::Path>,
         token: BearerToken,
         client: ClientDescriptor,
     ) -> ProviderResult<(Self, HelloResult)> {
@@ -933,7 +929,7 @@ impl ProviderClient {
     /// Subscribe to revision invalidations. Receivers are removed after drop.
     /// The runtime fetches snapshots on demand and does not subscribe yet.
     #[cfg(test)]
-    pub(crate) fn subscribe_snapshot_changes(&self) -> ProviderResult<Receiver<u64>> {
+    pub(crate) fn subscribe_snapshot_changes(&self) -> ProviderResult<mpsc::Receiver<u64>> {
         self.ensure_live()?;
         let (sender, receiver) = mpsc::sync_channel(1);
         self.inner

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_transport.rs
@@ -179,7 +179,8 @@ impl UnixProviderConnector {
         Self { socket_path: socket_path.into(), token: None }
     }
 
-    /// Compatibility seam for callers that still perform `hello` separately.
+    /// Test-only seam for exercising the control socket before `hello`.
+    #[cfg(test)]
     pub(crate) fn open_unauthenticated(
         socket_path: impl Into<PathBuf>,
     ) -> io::Result<(ProviderIo, Arc<dyn MachineStreamConnector>)> {
@@ -296,6 +297,8 @@ pub(crate) struct SshProviderConnector {
 }
 
 impl SshProviderConnector {
+    /// Test-only raw-destination constructor. Runtime callers use `cloud`.
+    #[cfg(test)]
     pub(crate) fn new(destination: impl Into<OsString>) -> io::Result<Self> {
         Self::with_program("ssh", destination)
     }
@@ -334,6 +337,7 @@ impl SshProviderConnector {
         Ok(Self { ssh_program, destination: OsString::from(destination), port, identity_file })
     }
 
+    #[cfg(test)]
     fn with_program(
         ssh_program: impl Into<OsString>,
         destination: impl Into<OsString>,
@@ -697,6 +701,7 @@ fn random_hex(byte_count: usize) -> io::Result<String> {
     Ok(encoded)
 }
 
+#[cfg(test)]
 fn validate_ssh_destination(destination: &OsStr) -> io::Result<()> {
     let Some(destination) = destination.to_str() else {
         return Err(io::Error::new(


### PR DESCRIPTION
Summary:
- document the existing machine-provider runtime and startup CLI integration
- remove module-wide dead-code and unused-import suppressions now that the client is wired

Verification:
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/machine_provider_client.rs
- git diff --check
- hosted cmux-tui compile/package proof pending

No runtime behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11490"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790884520&installation_model_id=21920&pr_number=11490&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11490&signature=749eeed19b032848eaf439bfbe6ae50a68063fa1dcf0847541fca592afe0a58a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale dead-code and unused-import lint suppressions in `cmux-tui`'s machine provider client now that the runtime and startup CLI wire it in, and updates the module docs to describe that integration. Test-only provider helpers are now `#[cfg(test)]`, with `Path` and `Receiver` fully qualified at call sites so the import list needs no `cfg(test)` variants. `BoundedRemoteReader`'s guard is renamed `_guard` to make clear it only keeps endpoint cleanup alive. No runtime behavior changes.

<sup>Written for commit 47d2245f3feeaf3c567d6d8d47eb92d9581bbc06. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11490?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified documentation covering runtime behavior, startup, command-line usage, configuration, and transport responsibilities.
  * Updated guidance to distinguish test-only connection and transport helpers from runtime functionality.
* **Refactor**
  * Restricted several connection and validation helpers to test use and cleaned up related internal code.
  * Removed a temporary compiler-suppression directive without changing runtime behavior or public functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->