### PR TITLE
fix(relay): stop when process file setup fails

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -932,6 +932,7 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
         return command.to_owned();
     }
     let mut setup: Vec<String> = vec!["set -e".to_owned()];
+    let mut initializers: Vec<String> = Vec::new();
     let mut cleanup: Vec<String> = Vec::new();
     for (index, file) in files.iter().enumerate() {
         let sanitized: String = file
@@ -944,6 +945,7 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
             .collect();
         let hint = if sanitized.is_empty() { "secret".to_owned() } else { sanitized };
         let shell_path = format!("__chatmux_file_{index}");
+        initializers.push(format!("{shell_path}="));
         cleanup
             .push(format!("if [ -n \"${{{shell_path}-}}\" ]; then rm -f -- \"${shell_path}\"; fi"));
         setup.push(format!("{shell_path}=$(mktemp \"${{TMPDIR:-/tmp}}/chatmux-{hint}.XXXXXX\")"));
@@ -956,13 +958,18 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
         setup.push(format!("export {}=\"${shell_path}\"", file.path_environment_variable,));
     }
     let cleanup_body = cleanup.join("; ");
-    setup.insert(
-        1,
+    let mut supervisor = vec![
+        "set -e".to_owned(),
         format!("__chatmux_cleanup() {{ trap '' HUP INT TERM; set +e; {cleanup_body}; }}"),
-    );
-    setup.insert(2, "trap __chatmux_cleanup 0".to_owned());
-    setup.insert(3, "trap 'exit 143' HUP INT TERM".to_owned());
-    setup.insert(4, "umask 077".to_owned());
+    ];
+    supervisor.extend(initializers);
+    supervisor.extend([
+        "trap __chatmux_cleanup 0".to_owned(),
+        "trap 'exit 143' HUP INT TERM".to_owned(),
+        "umask 077".to_owned(),
+    ]);
+    supervisor.extend(setup.into_iter().skip(1));
+    let mut setup = supervisor;
     setup.push(format!("if ( /bin/sh -c {} ); then", shell_quote(command)));
     setup.push("  __chatmux_status=$?".to_owned());
     setup.push("else".to_owned());

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2514,6 +2514,49 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn process_file_setup_failure_does_not_run_command_or_leak_secret() {
+        let root = scratch("process-file-setup-failure");
+        let tmpdir_file = root.join("not-a-directory");
+        std::fs::write(&tmpdir_file, "").unwrap();
+        let marker = root.join("command-ran");
+        let roots = vec![root.display().to_string()];
+        let mut context = ctx("supervised", Some(roots.clone()), root.clone());
+        context.env = scrubbed_env(&HashMap::from([
+            ("PATH".to_owned(), "/usr/bin:/bin".to_owned()),
+            ("TMPDIR".to_owned(), tmpdir_file.display().to_string()),
+        ]));
+        let secret = "process-file-secret";
+        let exec = perform_action(
+            &json!({
+                "verb": "exec",
+                "actionId": "process-file-setup-failure",
+                "allowedRoots": roots,
+                "args": {
+                    "command": format!("printf '%s' \"$MY_SECRET\" > '{}'", marker.display()),
+                },
+                "runtime": {
+                    "environment": { "MY_SECRET": secret },
+                    "files": [{
+                        "contentEnvironmentVariable": "MY_SECRET",
+                        "pathEnvironmentVariable": "MY_SECRET_PATH",
+                        "pathHint": "credentials",
+                    }],
+                },
+                "timeoutMs": 10000,
+            }),
+            &context,
+        )
+        .await;
+
+        assert_eq!(exec["ok"], true, "{exec}");
+        assert_ne!(exec["result"]["exitCode"], 0, "setup unexpectedly succeeded: {exec}");
+        assert!(!marker.exists(), "target command ran after setup failure: {exec}");
+        assert!(!exec.to_string().contains(secret), "secret leaked in action result: {exec}");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn observe_trust_refuses_mutating_verbs_allows_reads() {
         let root = scratch("observe");
         std::fs::write(root.join("f.txt"), "data").unwrap();

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -955,7 +955,10 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
         setup.push(format!("export {}=\"${shell_path}\"", file.path_environment_variable,));
     }
     let cleanup_body = cleanup.join("; ");
-    setup.insert(1, format!("__chatmux_cleanup() {{ set +e; {cleanup_body}; }}"));
+    setup.insert(
+        1,
+        format!("__chatmux_cleanup() {{ trap '' HUP INT TERM; set +e; {cleanup_body}; }}"),
+    );
     setup.insert(2, "trap __chatmux_cleanup 0".to_owned());
     setup.insert(3, "trap 'exit 143' HUP INT TERM".to_owned());
     setup.insert(4, "umask 077".to_owned());
@@ -964,9 +967,9 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
     setup.push("else".to_owned());
     setup.push("  __chatmux_status=$?".to_owned());
     setup.push("fi".to_owned());
+    setup.push("trap '' HUP INT TERM".to_owned());
     setup.push("trap - 0".to_owned());
     setup.push("__chatmux_cleanup".to_owned());
-    setup.push("trap - HUP INT TERM".to_owned());
     setup.push("exit $__chatmux_status".to_owned());
     setup.join("\n")
 }

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -944,7 +944,8 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
             .collect();
         let hint = if sanitized.is_empty() { "secret".to_owned() } else { sanitized };
         let shell_path = format!("__chatmux_file_{index}");
-        cleanup.push(format!("if [ -n \"${shell_path-}\" ]; then rm -f -- \"${shell_path}\"; fi"));
+        cleanup
+            .push(format!("if [ -n \"${{{shell_path}-}}\" ]; then rm -f -- \"${shell_path}\"; fi"));
         setup.push(format!("{shell_path}=$(mktemp \"${{TMPDIR:-/tmp}}/chatmux-{hint}.XXXXXX\")"));
         setup.push(format!("chmod 600 \"${shell_path}\""));
         setup.push(format!(

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -931,7 +931,7 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
     if files.is_empty() {
         return command.to_owned();
     }
-    let mut setup: Vec<String> = vec!["set +e".to_owned(), "umask 077".to_owned()];
+    let mut setup: Vec<String> = vec!["set -e".to_owned()];
     let mut cleanup: Vec<String> = Vec::new();
     for (index, file) in files.iter().enumerate() {
         let sanitized: String = file
@@ -944,6 +944,7 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
             .collect();
         let hint = if sanitized.is_empty() { "secret".to_owned() } else { sanitized };
         let shell_path = format!("__chatmux_file_{index}");
+        cleanup.push(format!("if [ -n \"${shell_path-}\" ]; then rm -f -- \"${shell_path}\"; fi"));
         setup.push(format!("{shell_path}=$(mktemp \"${{TMPDIR:-/tmp}}/chatmux-{hint}.XXXXXX\")"));
         setup.push(format!("chmod 600 \"${shell_path}\""));
         setup.push(format!(
@@ -952,16 +953,20 @@ pub fn command_with_process_files(command: &str, files: &[RuntimeFile]) -> Strin
         ));
         setup.push(format!("unset {}", file.content_environment_variable));
         setup.push(format!("export {}=\"${shell_path}\"", file.path_environment_variable,));
-        cleanup.push(format!("rm -f -- \"${shell_path}\""));
     }
     let cleanup_body = cleanup.join("; ");
-    setup.push(format!("__chatmux_cleanup() {{ {cleanup_body}; }}"));
-    setup.push("trap __chatmux_cleanup EXIT".to_owned());
-    setup.push("trap 'exit 143' HUP INT TERM".to_owned());
-    setup.push(format!("( /bin/sh -c {} )", shell_quote(command)));
-    setup.push("__chatmux_status=$?".to_owned());
+    setup.insert(1, format!("__chatmux_cleanup() {{ set +e; {cleanup_body}; }}"));
+    setup.insert(2, "trap __chatmux_cleanup 0".to_owned());
+    setup.insert(3, "trap 'exit 143' HUP INT TERM".to_owned());
+    setup.insert(4, "umask 077".to_owned());
+    setup.push(format!("if ( /bin/sh -c {} ); then", shell_quote(command)));
+    setup.push("  __chatmux_status=$?".to_owned());
+    setup.push("else".to_owned());
+    setup.push("  __chatmux_status=$?".to_owned());
+    setup.push("fi".to_owned());
+    setup.push("trap - 0".to_owned());
     setup.push("__chatmux_cleanup".to_owned());
-    setup.push("trap - EXIT HUP INT TERM".to_owned());
+    setup.push("trap - HUP INT TERM".to_owned());
     setup.push("exit $__chatmux_status".to_owned());
     setup.join("\n")
 }


### PR DESCRIPTION
Summary:
- add deterministic regression coverage for failed process-file setup
- fail closed before launching the command and clean up partial files

The first commit adds the failing behavior test; the second commit fixes the supervisor.

Verification:
- CMUX_ALLOW_LOW_SPACE_BUILD=1 cargo fmt --check --manifest-path cmux-tui/crates/chatmux-relay/Cargo.toml
- Local Cargo/Rust tests not run by request

References:
- https://doc.rust-lang.org/std/process/struct.Command.html
- https://pubs.opengroup.org/onlinepubs/9699919799/utilities/V3_chap02.html

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790884754&installation_model_id=21920&pr_number=11491&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11491&signature=54fe2740e3db16f2d2c1e97ce4f1e398bd7c3bb0844fb469c3e449ff577714b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Previously, a process-file setup failure could still launch the target command and expose secrets in the action result. The relay now fails closed, cleans up safely across exits and signals, and preserves command statuses and interruption behavior.

- Initializes cleanup paths before setup so partial files are removed.
- Rejects environment, content, and path variable names matching reserved `__chatmux_file_<number>` names.
- Adds regression coverage for setup failure, command suppression, secret leakage, and reserved names.

<sup>Written for commit 7344245326758bfe8765bee630572ddd1b3cc4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11491?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved command execution reliability when temporary-file setup fails.
  * Prevented commands from running or exposing sensitive data after setup errors.
  * Ensured temporary resources are cleaned up safely, including when commands are interrupted.
  * Preserved command exit statuses and restored normal interruption handling after execution.
  * Added safeguards to prevent incomplete setup from producing unexpected command behavior.
  * Rejected reserved temporary-file names in environment and file-related inputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->