### PR TITLE
fix(cmux-tui): select wide graphemes from either cell

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16827,14 +16827,17 @@ impl App {
         let point = Self::selection_point(cell)?;
         let handle = self.session.surface(surface)?;
         let range = handle
-            .with_terminal(|terminal| match mode {
-                SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
-                SelectionMode::Line => terminal
-                    .select_line_screen(point)
-                    .ok()
-                    .flatten()
-                    .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
-                SelectionMode::Cell => None,
+            .with_terminal(|terminal| {
+                let point = terminal.normalize_selection_point_screen(point)?;
+                match mode {
+                    SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
+                    SelectionMode::Line => terminal
+                        .select_line_screen(point)
+                        .ok()
+                        .flatten()
+                        .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
+                    SelectionMode::Cell => None,
+                }
             })
             .flatten()?;
         Some(Self::selection_from_range(surface, range))
@@ -17036,40 +17039,43 @@ impl App {
             return;
         }
         let range = handle
-            .with_terminal(|terminal| match mode {
-                SelectionMode::Word => {
-                    let first = terminal
-                        .select_word_between_screen(anchor_point, current_point)
-                        .ok()
-                        .flatten()?;
-                    let second = terminal
-                        .select_word_between_screen(current_point, anchor_point)
-                        .ok()
-                        .flatten()?;
-                    let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
-                    Some(if current_before_anchor {
-                        SelectionRange { start: second.start, end: first.end }
-                    } else {
-                        SelectionRange { start: first.start, end: second.end }
-                    })
-                }
-                SelectionMode::Line => {
-                    let select_line =
-                        |point| {
+            .with_terminal(|terminal| {
+                let anchor_point = terminal.normalize_selection_point_screen(anchor_point)?;
+                let current_point = terminal.normalize_selection_point_screen(current_point)?;
+                match mode {
+                    SelectionMode::Word => {
+                        let first = terminal
+                            .select_word_between_screen(anchor_point, current_point)
+                            .ok()
+                            .flatten()?;
+                        let second = terminal
+                            .select_word_between_screen(current_point, anchor_point)
+                            .ok()
+                            .flatten()?;
+                        let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
+                        Some(if current_before_anchor {
+                            SelectionRange { start: second.start, end: first.end }
+                        } else {
+                            SelectionRange { start: first.start, end: second.end }
+                        })
+                    }
+                    SelectionMode::Line => {
+                        let select_line = |point| {
                             terminal.select_line_screen(point).ok().flatten().or_else(|| {
                                 terminal.select_line_screen_untrimmed(point).ok().flatten()
                             })
                         };
-                    let first = select_line(anchor_point)?;
-                    let second = select_line(current_point)?;
-                    let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
-                    Some(if current_before_anchor {
-                        SelectionRange { start: second.start, end: first.end }
-                    } else {
-                        SelectionRange { start: first.start, end: second.end }
-                    })
+                        let first = select_line(anchor_point)?;
+                        let second = select_line(current_point)?;
+                        let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
+                        Some(if current_before_anchor {
+                            SelectionRange { start: second.start, end: first.end }
+                        } else {
+                            SelectionRange { start: first.start, end: second.end }
+                        })
+                    }
+                    SelectionMode::Cell => None,
                 }
-                SelectionMode::Cell => None,
             })
             .flatten();
         if let Some(generation) = content_generation {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27414,6 +27414,35 @@ mod tests {
     }
 
     #[test]
+    fn double_clicking_the_trailing_cell_of_a_wide_word_selects_the_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-wide-word-selection-test", "foo 界 bar".as_bytes());
+
+        // The CJK character occupies columns 4 and 5. A click on the trailing
+        // cell must behave like a click on the grapheme's leading cell.
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 5,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((4, 0), (4, 0))),
+            "double-clicking a wide grapheme's trailing cell must select its word"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_single_cell_press_does_not_store_a_zero_length_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("single-cell-press-selection-state-test", b"alpha beta");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27578,6 +27578,45 @@ mod tests {
     }
 
     #[test]
+    fn double_click_drag_to_a_wide_word_trailing_cell_selects_the_word() {
+        let (mut app, mux, surface, content) = selection_fixture(
+            "double-click-wide-word-drag-selection-test",
+            "alpha 界 omega".as_bytes(),
+        );
+
+        let first_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(first_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..first_click })
+            .unwrap();
+        app.handle_mouse(first_click).unwrap();
+
+        // The wide character starts at column 6 and occupies trailing spacer
+        // column 7. Dragging to that cell must use the grapheme lead.
+        let trailing = MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 7,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(trailing).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..trailing })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (6, 0))),
+            "double-click drag to a wide grapheme's trailing cell must select its word"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_anchors_at_second_press() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-second-press-anchor-test", b"a b c");

--- a/cmux-tui/crates/ghostty-vt/src/render.rs
+++ b/cmux-tui/crates/ghostty-vt/src/render.rs
@@ -742,7 +742,7 @@ fn raw_cell_bg_spec(raw: sys::GhosttyCell) -> Option<ColorSpec> {
     }
 }
 
-fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
+pub(crate) fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
     let mut wide = sys::GHOSTTY_CELL_WIDE_NARROW;
     let result = unsafe {
         sys::ghostty_cell_get(raw, sys::GHOSTTY_CELL_DATA_WIDE, &mut wide as *mut _ as *mut c_void)

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -3012,7 +3012,10 @@ impl Terminal {
     /// Move a screen selection point from a wide grapheme's trailing spacer
     /// cell to its leading cell. Mouse reports identify grid cells, so a
     /// click on either half of a wide character must address the same text.
-    pub fn normalize_selection_point_screen(&self, point: SelectionPoint) -> Option<SelectionPoint> {
+    pub fn normalize_selection_point_screen(
+        &self,
+        point: SelectionPoint,
+    ) -> Option<SelectionPoint> {
         let width = self.cell_width_screen(point)?;
         if width != CellWidth::SpacerTail || point.column == 0 {
             return Some(point);
@@ -3022,11 +3025,8 @@ impl Terminal {
     }
 
     fn cell_width_screen(&self, point: SelectionPoint) -> Option<CellWidth> {
-        let grid_ref = self.grid_ref(
-            sys::GHOSTTY_POINT_TAG_SCREEN,
-            point.column,
-            u64::from(point.row),
-        )?;
+        let grid_ref =
+            self.grid_ref(sys::GHOSTTY_POINT_TAG_SCREEN, point.column, u64::from(point.row))?;
         let mut raw = sys::GhosttyCell::default();
         check(unsafe { sys::ghostty_grid_ref_cell(&grid_ref, &mut raw) }).ok()?;
         Some(crate::render::cell_width(raw))

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -3009,6 +3009,29 @@ impl Terminal {
         self.selection_range(&selection).map(Some)
     }
 
+    /// Move a screen selection point from a wide grapheme's trailing spacer
+    /// cell to its leading cell. Mouse reports identify grid cells, so a
+    /// click on either half of a wide character must address the same text.
+    pub fn normalize_selection_point_screen(&self, point: SelectionPoint) -> Option<SelectionPoint> {
+        let width = self.cell_width_screen(point)?;
+        if width != CellWidth::SpacerTail || point.column == 0 {
+            return Some(point);
+        }
+        let leading = SelectionPoint { column: point.column - 1, ..point };
+        (self.cell_width_screen(leading) == Some(CellWidth::Wide)).then_some(leading)
+    }
+
+    fn cell_width_screen(&self, point: SelectionPoint) -> Option<CellWidth> {
+        let grid_ref = self.grid_ref(
+            sys::GHOSTTY_POINT_TAG_SCREEN,
+            point.column,
+            u64::from(point.row),
+        )?;
+        let mut raw = sys::GhosttyCell::default();
+        check(unsafe { sys::ghostty_grid_ref_cell(&grid_ref, &mut raw) }).ok()?;
+        Some(crate::render::cell_width(raw))
+    }
+
     /// Select the nearest word between two absolute screen coordinates.
     /// This is useful while dragging because it skips whitespace and other
     /// empty cells without inventing boundaries in the UI layer.


### PR DESCRIPTION
## Summary

Double-clicking the trailing cell of a wide Unicode grapheme did not select the word because Ghostty treats that cell as a spacer. Normalize semantic selection points to the grapheme lead before word and drag lookup.

## Testing

- `git diff --check`
- Hosted focused cmux-tui verification pending
- No local Cargo or Rust tests run

Regression and fix are separate commits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11494"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790884981&installation_model_id=21920&pr_number=11494&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11494&signature=03c0c749f36b63951405ca8bce7f469e4589a91eb45e48cd222d431749b47be3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Word and Line selection for wide Unicode graphemes so clicking or dragging from either cell of a wide character now selects the correct text; previously only the leading cell worked because Ghostty reported the trailing cell as a spacer.

<sup>Written for commit 6c2630974117ae852ecf2a898a036bf5a2b8586c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11494?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text selection for wide characters, including CJK graphemes.
  * Double-clicking either half of a wide character now selects the correct text consistently.
  * Mouse-based selection is more reliable when targeting trailing cells of wide characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->