### PR TITLE
ci(tui): add hosted Windows Cargo test lane

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -519,6 +519,66 @@ jobs:
         working-directory: cmux-tui
         run: python3 scripts/smoke-attach.py
 
+  test-windows:
+    name: test (windows)
+    needs: validate-inputs
+    # The full gate already enables the Windows package build. Run the
+    # platform tests in a separate hosted job so package builds stay focused
+    # on release artifacts and this coverage is visible as its own check.
+    if: inputs.mode == 'full'
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        shell: bash
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Resolve Ghostty Zig version
+        id: ghostty-zig-version
+        shell: bash
+        run: |
+          version="$(bash ./scripts/ghostty-zig-version.sh)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: ${{ steps.ghostty-zig-version.outputs.version }}
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Install Rust target
+        shell: bash
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          printf '%s\n' 'C:\\msys64\\mingw64\\bin' >> "$GITHUB_PATH"
+
+      - name: Verify LLVM GNU linker
+        shell: bash
+        run: ld.lld --version
+
+      - name: Run Windows platform Cargo tests
+        working-directory: cmux-tui
+        shell: bash
+        run: |
+          unset CMUX_GHOSTTY_SRC
+          cargo test -p cmux-tui-core --lib --locked \
+            --target x86_64-pc-windows-gnu \
+            platform::tests:: -- --test-threads=1
+
   bindings-e2e:
     needs: validate-inputs
     if: inputs.mode == 'full'
@@ -637,6 +697,7 @@ jobs:
       - web-frontend
       - valgrind-leak-check
       - test
+      - test-windows
       - bindings-e2e
       - build-artifacts
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -648,6 +709,7 @@ jobs:
       WEB_RESULT: ${{ needs.web-frontend.result }}
       VALGRIND_RESULT: ${{ needs.valgrind-leak-check.result }}
       TEST_RESULT: ${{ needs.test.result }}
+      WINDOWS_TEST_RESULT: ${{ needs.test-windows.result }}
       BINDINGS_RESULT: ${{ needs.bindings-e2e.result }}
       ARTIFACT_RESULT: ${{ needs.build-artifacts.result }}
     steps:
@@ -668,6 +730,7 @@ jobs:
           require_success "Rust tests" "$TEST_RESULT"
           require_success "dogfood artifact build" "$ARTIFACT_RESULT"
           if [[ "$MODE" == "full" ]]; then
+            require_success "Windows Rust tests" "$WINDOWS_TEST_RESULT"
             require_success "web frontend" "$WEB_RESULT"
             require_success "Valgrind" "$VALGRIND_RESULT"
             require_success "binding end-to-end tests" "$BINDINGS_RESULT"


### PR DESCRIPTION
## Summary

- Add a separate GitHub-hosted Windows job to full cmux-tui verification.
- Run the cmux-tui-core platform tests against the pinned GNU Windows target.
- Require the Windows test result in the full hosted verification gate without duplicating the release package build.

## Verification

- `actionlint .github/workflows/cmux-tui.yml`
- `git diff --check`
- Local Cargo, Rust, and package builds were not run. The cmux-tui instructions require hosted verification for those checks.

## References

- [Cargo test command](https://doc.rust-lang.org/cargo/commands/cargo-test.html)
- [GitHub-hosted runners](https://docs.github.com/en/actions/how-tos/manage-runners/github-hosted-runners/use-github-hosted-runners)
- [Workflow syntax](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hosted Windows CI job that runs the `cmux-tui-core` platform tests against the pinned GNU target. The full verification gate now requires this job to pass, so Windows test failures block merges without duplicating the existing release package build.

<sup>Written for commit 6e413f0bc8a5cf8de12b2de3ef46820b0e5e0de2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

