### PR TITLE
fix(tui): narrow workspace registry APIs

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -574,7 +574,7 @@ impl WorkspaceRegistry {
         Ok(())
     }
 
-    pub fn enqueue_agent_hook_pending(
+    pub(crate) fn enqueue_agent_hook_pending(
         &mut self,
         producer_id: &str,
         origin: &str,
@@ -825,7 +825,7 @@ impl WorkspaceRegistry {
         Ok((pending, next_cursor))
     }
 
-    pub fn commit_agent_projection_with_hook_state(
+    pub(crate) fn commit_agent_projection_with_hook_state(
         &mut self,
         mutation: &WorkspaceMutation,
         fingerprint: &Value,
@@ -847,7 +847,7 @@ impl WorkspaceRegistry {
         )
     }
 
-    pub fn commit_agent_projection_with_hook_state_and_sequence(
+    pub(crate) fn commit_agent_projection_with_hook_state_and_sequence(
         &mut self,
         mutation: &WorkspaceMutation,
         fingerprint: &Value,
@@ -883,7 +883,7 @@ impl WorkspaceRegistry {
         resource_patch_replay(&self.connection, mutation, operation, &fingerprint)
     }
 
-    pub fn commit_agent_projection(
+    pub(crate) fn commit_agent_projection(
         &mut self,
         mutation: &WorkspaceMutation,
         fingerprint: &Value,


### PR DESCRIPTION
Narrow WorkspaceRegistry methods to pub(crate) because their parameter types are crate-private. This resolves Clippy private_interfaces warnings without behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Narrows four `WorkspaceRegistry` methods to `pub(crate)` so their crate-private parameter types no longer trigger Clippy `private_interfaces` warnings. No behavior changes.

<sup>Written for commit dcbb71f80f48bd1ad3bc32806820b28b4d5685b6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11498?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

