### PR TITLE
fix(cmux-tui-core): use iterator cloned adapter

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/browser.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/browser.rs
@@ -1614,7 +1614,8 @@ fn release_abandoned_pointer_presses(
                 }
             }
         })
-        .map(|(button, _)| button.clone())
+        .map(|(button, _)| button)
+        .cloned()
         .collect::<Vec<_>>();
     for button in expired {
         let Some(press) = failures.active_pointer_presses.remove(&button) else {


### PR DESCRIPTION
Fix the Clippy map_clone warning in browser pointer cleanup by using the iterator cloned adapter. Behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11500"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790887617&installation_model_id=21920&pr_number=11500&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11500&signature=88c7e7e2a58c0d9c99b407d3ad3448c6e247de9cdf3b37bffed9b2845ed34653"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Clippy `map_clone` warning in `cmux-tui-core` by using the iterator `cloned()` adapter when cleaning up abandoned browser pointer presses. Behavior is unchanged.

<sup>Written for commit 9821fc34bcca9537be060331c8f3a578d2c9b6bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11500?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Simplified internal handling of expired pointer-press records without changing user-visible behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->