### PR TITLE
fix(cmux-tui): resolve relay clippy warnings

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -218,6 +218,7 @@ async fn report_watch_failure(
 }
 
 impl WatchRegistry {
+    #[cfg(test)]
     pub(crate) fn new(outbound: OutboundSink) -> WatchRegistry {
         Self::new_with_teardown_slots(
             outbound,
@@ -225,6 +226,7 @@ impl WatchRegistry {
         )
     }
 
+    #[cfg(test)]
     pub(crate) fn new_with_teardown_slots(
         outbound: OutboundSink,
         teardown_slots: Arc<Semaphore>,
@@ -302,18 +304,20 @@ impl WatchRegistry {
                     // this slot. Tokio guarantees `spawn` does not poll the
                     // future synchronously as part of this call.
                     let task_id = watch_id.clone();
-                    let task_cancellation = opening_cancellation.clone();
+                    let context = OpenContext {
+                        generation,
+                        live: Arc::clone(&opening_live),
+                        cancellation: opening_cancellation,
+                        sessions: Arc::clone(&sessions),
+                        outbound,
+                        setup_slots,
+                        teardown_slots,
+                    };
                     let task = tokio::spawn(coordinate_open(
                         task_id,
                         frame,
                         local_roots_for_task,
-                        generation,
-                        Arc::clone(&opening_live),
-                        task_cancellation,
-                        Arc::clone(&sessions),
-                        outbound,
-                        setup_slots,
-                        teardown_slots,
+                        context,
                     ));
                     slot.opening.as_mut().expect("opening was just reserved").abort =
                         Some(task.abort_handle());
@@ -343,6 +347,19 @@ enum SetupFailure {
     Cancelled,
     Refused { code: wire::WorkspaceErrorCode, message: String },
     Failed(String),
+}
+
+/// State owned by one asynchronous open attempt. Keeping the lifecycle state
+/// together prevents a generation token from being paired with a different
+/// cancellation or liveness token.
+struct OpenContext {
+    generation: u64,
+    live: Arc<AtomicBool>,
+    cancellation: CancellationToken,
+    sessions: Sessions,
+    outbound: OutboundSink,
+    setup_slots: Arc<Semaphore>,
+    teardown_slots: Arc<Semaphore>,
 }
 
 /// Resolve the scoped root, install notify, and discover ignore files on a
@@ -406,57 +423,26 @@ async fn coordinate_open(
     watch_id: String,
     frame: wire::RelayFsWatchOpen,
     local_roots: Option<Vec<String>>,
-    generation: u64,
-    live: Arc<AtomicBool>,
-    cancellation: CancellationToken,
-    sessions: Sessions,
-    outbound: OutboundSink,
-    setup_slots: Arc<Semaphore>,
-    teardown_slots: Arc<Semaphore>,
+    context: OpenContext,
 ) {
-    let setup =
-        setup_watch(frame, local_roots, cancellation.clone(), setup_slots.clone(), teardown_slots)
-            .await;
+    let setup = setup_watch(
+        frame,
+        local_roots,
+        context.cancellation.clone(),
+        context.setup_slots.clone(),
+        context.teardown_slots.clone(),
+    )
+    .await;
     match setup {
         Ok((root, prepared)) => {
-            commit_open(
-                watch_id,
-                root,
-                prepared,
-                generation,
-                live,
-                cancellation,
-                sessions,
-                outbound,
-                setup_slots,
-            );
+            commit_open(watch_id, root, prepared, context);
         }
         Err(SetupFailure::Cancelled) => {}
         Err(SetupFailure::Refused { code, message }) => {
-            finish_open_failure(
-                &watch_id,
-                generation,
-                live,
-                cancellation,
-                sessions,
-                outbound,
-                code,
-                Some(message),
-            )
-            .await;
+            finish_open_failure(&watch_id, code, Some(message), context).await;
         }
         Err(SetupFailure::Failed(_message)) => {
-            finish_open_failure(
-                &watch_id,
-                generation,
-                live,
-                cancellation,
-                sessions,
-                outbound,
-                wire::WorkspaceErrorCode::Failed,
-                None,
-            )
-            .await;
+            finish_open_failure(&watch_id, wire::WorkspaceErrorCode::Failed, None, context).await;
         }
     }
 }
@@ -464,17 +450,16 @@ async fn coordinate_open(
 /// Publish the acknowledgement and active task as one state transition.
 /// `prepared` stays outside the mutex on every rejection path so dropping a
 /// notify watcher cannot run while registry state is locked.
-fn commit_open(
-    watch_id: String,
-    root: PathBuf,
-    prepared: PreparedWatch,
-    generation: u64,
-    live: Arc<AtomicBool>,
-    cancellation: CancellationToken,
-    sessions: Sessions,
-    outbound: OutboundSink,
-    setup_slots: Arc<Semaphore>,
-) {
+fn commit_open(watch_id: String, root: PathBuf, prepared: PreparedWatch, context: OpenContext) {
+    let OpenContext {
+        generation,
+        live,
+        cancellation,
+        sessions,
+        outbound,
+        setup_slots,
+        teardown_slots: _,
+    } = context;
     let opened = serde_json::to_string(&wire::RelayFsWatchOpened {
         version: WORKSPACE_FRAME_VERSION,
         r#type: wire::TagFsWatchOpened::FsWatchOpened,
@@ -496,10 +481,10 @@ fn commit_open(
         {
             let (start_tx, start_rx) = oneshot::channel();
             let run_id = watch_id.clone();
-            let run_root = root.clone();
-            let run_outbound = outbound.clone();
+            let run_root = root;
+            let run_outbound = outbound;
             let run_sessions = Arc::clone(&sessions);
-            let run_setup_slots = Arc::clone(&setup_slots);
+            let run_setup_slots = setup_slots;
             let run_cancellation = cancellation.clone();
             let run_live = Arc::clone(&live);
             let run_prepared = prepared.take().expect("prepared watch present");
@@ -565,14 +550,11 @@ fn commit_open(
 
 async fn finish_open_failure(
     watch_id: &str,
-    generation: u64,
-    live: Arc<AtomicBool>,
-    cancellation: CancellationToken,
-    sessions: Sessions,
-    outbound: OutboundSink,
     code: wire::WorkspaceErrorCode,
     message: Option<String>,
+    context: OpenContext,
 ) {
+    let OpenContext { generation, live, cancellation, sessions, outbound, .. } = context;
     let text = watch_error_frame(watch_id, code, message.as_deref());
     let should_report = sessions.lock().ok().is_some_and(|state| {
         state.get(watch_id).is_some_and(|slot| {
@@ -1322,15 +1304,20 @@ mod tests {
                 }),
             },
         );
-        let task = tokio::spawn(finish_open_failure(
-            "failed",
-            1,
+        let context = OpenContext {
+            generation: 1,
             live,
             cancellation,
-            Arc::clone(&sessions),
-            sink,
+            sessions: Arc::clone(&sessions),
+            outbound: sink,
+            setup_slots: Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            teardown_slots: Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY)),
+        };
+        let task = tokio::spawn(finish_open_failure(
+            "failed",
             wire::WorkspaceErrorCode::Failed,
             None,
+            context,
         ));
         let mut frame = critical.recv().await.expect("failure frame");
         assert!(frame.live.is_some(), "failure keeps its opening liveness token until delivery");
@@ -1362,15 +1349,20 @@ mod tests {
                 }),
             },
         );
-        let task = tokio::spawn(finish_open_failure(
-            "saturated",
-            1,
+        let context = OpenContext {
+            generation: 1,
             live,
             cancellation,
-            Arc::clone(&sessions),
-            sink,
+            sessions: Arc::clone(&sessions),
+            outbound: sink,
+            setup_slots: Arc::new(Semaphore::new(WATCH_SETUP_CONCURRENCY)),
+            teardown_slots: Arc::new(Semaphore::new(WATCH_TEARDOWN_CONCURRENCY)),
+        };
+        let task = tokio::spawn(finish_open_failure(
+            "saturated",
             wire::WorkspaceErrorCode::Failed,
             None,
+            context,
         ));
         tokio::task::yield_now().await;
         assert!(!task.is_finished(), "failure waits instead of dropping under queue pressure");

--- a/cmux-tui/crates/chatmux-relay/src/workspace.rs
+++ b/cmux-tui/crates/chatmux-relay/src/workspace.rs
@@ -1787,6 +1787,7 @@ fn porcelain_v1_xy(xy: &str) -> String {
     xy.chars().map(|column| if column == '.' { ' ' } else { column }).collect()
 }
 
+#[cfg(test)]
 async fn run_git_status(scope: &Scope) -> Result<wire::WorkspaceResultBody, Refusal> {
     let cancellation = CancellationToken::new();
     run_git_status_with_cancel_until(
@@ -1797,6 +1798,7 @@ async fn run_git_status(scope: &Scope) -> Result<wire::WorkspaceResultBody, Refu
     .await
 }
 
+#[cfg(test)]
 async fn run_git_status_with_cancel(
     scope: &Scope,
     cancellation: &CancellationToken,
@@ -1991,6 +1993,7 @@ async fn run_git_status_with_cancel_until(
     }))
 }
 
+#[cfg(test)]
 async fn run_git_diff(
     scope: &Scope,
     op: &wire::GitDiffOp,
@@ -2459,16 +2462,16 @@ impl Connection {
         }
         let outbound = self.outbound.clone();
         let cancellation = self.request_cancel.clone();
-        if let Ok(mut requests) = self.requests.lock() {
-            if !self.request_cancel.is_cancelled() {
-                requests.spawn(async move {
-                    let _ = tokio::select! {
-                        biased;
-                        _ = cancellation.cancelled() => Err(()),
-                        result = outbound.critical_text(text) => result,
-                    };
-                });
-            }
+        if let Ok(mut requests) = self.requests.lock()
+            && !self.request_cancel.is_cancelled()
+        {
+            requests.spawn(async move {
+                let _ = tokio::select! {
+                    biased;
+                    _ = cancellation.cancelled() => Err(()),
+                    result = outbound.critical_text(text) => result,
+                };
+            });
         }
     }
 }
@@ -2534,7 +2537,7 @@ async fn execute(
     let started = std::time::Instant::now();
     let deadline = started + Duration::from_millis(timeout_ms as u64);
     let outcome = run_op(runtime, request, permit, cancellation, deadline).await;
-    if started.elapsed() > std::time::Duration::from_millis(timeout_ms.unsigned_abs()) {
+    if started.elapsed() > Duration::from_millis(timeout_ms.unsigned_abs()) {
         Err(Refusal::new(
             wire::WorkspaceErrorCode::Timeout,
             format!("workspace op exceeded {timeout_ms}ms"),
@@ -3440,7 +3443,7 @@ mod tests {
         let (sink, mut critical, _watch) = OutboundSink::channels();
         let connection = Connection::new(runtime, sink);
         connection.handle_frame(patched);
-        let frame = tokio::time::timeout(std::time::Duration::from_secs(15), critical.recv())
+        let frame = tokio::time::timeout(Duration::from_secs(15), critical.recv())
             .await
             .expect("no answer within 15s")
             .expect("channel open");
@@ -3482,11 +3485,11 @@ mod tests {
         }
 
         let mut ids = [
-            tokio::time::timeout(std::time::Duration::from_secs(15), critical.recv())
+            tokio::time::timeout(Duration::from_secs(15), critical.recv())
                 .await
                 .expect("first request timed out")
                 .expect("channel closed"),
-            tokio::time::timeout(std::time::Duration::from_secs(15), critical.recv())
+            tokio::time::timeout(Duration::from_secs(15), critical.recv())
                 .await
                 .expect("second request timed out")
                 .expect("channel closed"),


### PR DESCRIPTION
Preserve test-only constructors and group each asynchronous watch open attempt in OpenContext to keep generation, cancellation, liveness, sessions, and semaphores aligned. Reduce ownership clones and satisfy relay Clippy style warnings.

Validation: cargo fmt --all -- --check; git diff --check. Hosted focused verification will run via verify-cmux-tui-hosted.sh.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11501"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790887658&installation_model_id=21920&pr_number=11501&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11501&signature=37fd77ecd97aebd6313dc354f19b1ff832061633f87cc86be5b5a320668a28c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes relay Clippy warnings without changing runtime behavior.

- Groups each asynchronous watch-open attempt’s lifecycle state in `OpenContext`.
- Restricts test-only watch and Git helpers to test builds.
- Simplifies request locking and uses the imported `Duration` consistently.

<sup>Written for commit 3441624639d79cecc50d9faeab50948c05442400. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11501?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Improved coordination of watch replacements while preserving generation safety and active watches when acknowledgements fail.
  - Simplified internal request-handling and timing logic without changing behavior.

- **Tests**
  - Updated test setup for watch coordination and workspace operations.
  - Restricted test-only utilities to test builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->