### PR TITLE
docs: sync resource operation catalog counts

### DIFF
--- a/cmux-tui/bindings/ERGONOMICS.md
+++ b/cmux-tui/bindings/ERGONOMICS.md
@@ -1,7 +1,7 @@
 # SDK ergonomics findings
 
 The seven public SDKs expose handwritten resource handles over the reviewed
-124-operation `cmux.protocol/2` catalog. The raw protocol inventory is a
+125-operation `cmux.protocol/2` catalog. The raw protocol inventory is a
 separate compatibility surface with 101 commands and 46 events. Deterministic
 generation is limited to those private protocol-12 models under each package's
 explicit `raw` namespace. Consumers do not run a generator or install a
@@ -64,7 +64,7 @@ implemented public behavior. None remains protocol work.
 
 ## Conformance evidence
 
-The 124 public operations are the API inventory. The public fake-server
+The 125 public operations are the API inventory. The public fake-server
 matrix is test inventory: 20 cases in each language, 140 cases total. It checks
 exact envelopes, decimal preservation, mutation replay, indeterminate effects,
 revision conflicts, duplicate-name ambiguity, bounded stream overflow,

--- a/cmux-tui/spec/README.md
+++ b/cmux-tui/spec/README.md
@@ -23,7 +23,7 @@ high-level SDKs:
 | --- | --- |
 | [`resource-api-v2.md`](resource-api-v2.md) | IDs, selectors, envelopes, mutations, streams, limits, and lifecycle rules |
 | [`resource-api-v2.json`](resource-api-v2.json) | JSON Schema for request, response, and stream envelopes |
-| [`resource-operations-v2.json`](resource-operations-v2.json) | Normative catalog of 124 transported and six local operations |
+| [`resource-operations-v2.json`](resource-operations-v2.json) | Normative catalog of 125 transported and six local operations |
 | [`resource-operations-v2.schema.json`](resource-operations-v2.schema.json) | JSON Schema for the operation catalog |
 | [`resource-operations-v2.md`](resource-operations-v2.md) | Human-readable operation inventory |
 | [`cli.md`](cli.md) | Noun-first public CLI |

--- a/cmux-tui/spec/bindings.md
+++ b/cmux-tui/spec/bindings.md
@@ -12,7 +12,7 @@ The split is deliberate:
   handwritten in each language.
 - Mechanical protocol-v12 models are generated deterministically and exposed
   only through `raw`.
-- A catalog descriptor in every package proves that all 124 transported
+- A catalog descriptor in every package proves that all 125 transported
   operations have the same class and wire name.
 - The six sidebar plugin operations are local CLI/filesystem APIs. Transported
   SDK roots expose sidebar views, not plugin resource handles.

--- a/cmux-tui/spec/resource-operations-v2.md
+++ b/cmux-tui/spec/resource-operations-v2.md
@@ -6,13 +6,13 @@ selectors, fields, results, errors, constraints, or stream types.
 
 ## Transported operations
 
-`cmux.protocol/2` transports 124 operations for exactly one local mux
+`cmux.protocol/2` transports 125 operations for exactly one local mux
 session. Cross-machine aggregation and provider lifecycle require a later
 broker protocol.
 
 | Class | Count | Semantics |
 | --- | ---: | --- |
-| `read` | 40 | Reads state and forbids an idempotency key |
+| `read` | 41 | Reads state and forbids an idempotency key |
 | `mutation` | 67 | Requires an idempotency key and returns a mutation result |
 | `stream_open` | 5 | Opens a connection-owned typed stream |
 | `connection_control` | 12 | Changes only connection-local state |
@@ -42,7 +42,7 @@ correlation, and idempotency metadata.
 | `sidebar_view` | 6 | `sidebar_view.attach`, `sidebar_view.ensure`, `sidebar_view.get`, `sidebar_view.input`, `sidebar_view.reload`, `sidebar_view.resize` |
 | `stream` | 1 | `stream.cancel` |
 | `tab` | 8 | `tab.close`, `tab.create_browser`, `tab.create_terminal`, `tab.focus`, `tab.get`, `tab.list`, `tab.move`, `tab.rename` |
-| `terminal` | 22 | `terminal.attach`, `terminal.close`, `terminal.copy`, `terminal.get`, `terminal.history.clear`, `terminal.history.read`, `terminal.input.focus`, `terminal.input.keys`, `terminal.input.mouse`, `terminal.input.write`, `terminal.list`, `terminal.move`, `terminal.process.get`, `terminal.project`, `terminal.renderer_grant.create`, `terminal.screen.read`, `terminal.state.read`, `terminal.viewer.release`, `terminal.viewer.resize`, `terminal.viewport.scroll`, `terminal.wait`, `terminal.wait_exit` |
+| `terminal` | 23 | `terminal.attach`, `terminal.close`, `terminal.copy`, `terminal.get`, `terminal.history.clear`, `terminal.history.read`, `terminal.input.focus`, `terminal.input.keys`, `terminal.input.mouse`, `terminal.input.write`, `terminal.list`, `terminal.move`, `terminal.output_read`, `terminal.process.get`, `terminal.project`, `terminal.renderer_grant.create`, `terminal.screen.read`, `terminal.state.read`, `terminal.viewer.release`, `terminal.viewer.resize`, `terminal.viewport.scroll`, `terminal.wait`, `terminal.wait_exit` |
 | `workspace` | 9 | `workspace.close`, `workspace.create`, `workspace.focus`, `workspace.get`, `workspace.layout.apply`, `workspace.list`, `workspace.move`, `workspace.rename`, `workspace.run` |
 
 ## Local operations


### PR DESCRIPTION
The resource API catalog now contains 125 transported operations, including terminal.output_read. Update the README, bindings contract, and human inventory counts to match the normative JSON catalog.

Checks: python3 cmux-tui/scripts/test_check_spec_inventory.py; python3 cmux-tui/scripts/check-spec-inventory.py; python3 cmux-tui/scripts/test_check_resource_api_boundary.py; python3 cmux-tui/scripts/check-resource-api-boundary.py; git diff --check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11502"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790888700&installation_model_id=21920&pr_number=11502&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11502&signature=38624aa62e3dc0d7250f067a7026cd217c165dea8e197e2dd7f785a59c25f3d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Syncs the spec docs and SDK ergonomics operation counts to match the normative JSON catalog, which now lists 125 transported operations after adding `terminal.output_read`.

- Updates the spec README, bindings contract, and human-readable inventory to 125 transported operations.
- Updates the SDK ergonomics findings from 124 to 125 public operations.

<sup>Written for commit a809b0ebdd61c886d6d329bc6a8f13f452e4c009. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11502?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the resource operation catalog to include 125 transported operations.
  * Updated SDK binding requirements to reflect the expanded operation count.
  * Added `terminal.output_read` to the terminal operations list.
  * Updated operation totals for the `read` class and `terminal` target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->