### PR TITLE
fix(cmux-tui): preserve projection key during validation

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux/public_projections.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux/public_projections.rs
@@ -9,7 +9,7 @@ pub(super) struct RestoredPublicProjections {
     pub(super) has_terminal_defaults: bool,
     pub(super) next_notification_id: u64,
     pub(super) agent_records: HashMap<TerminalPublicId, TerminalAgentRecord>,
-    pub(super) agent_hook_fences: HashMap<TerminalPublicId, super::HookFence>,
+    pub(super) agent_hook_fences: HashMap<TerminalPublicId, HookFence>,
     pub(super) terminal_notifications: HashMap<TerminalPublicId, SurfaceNotification>,
     pub(super) notification_ledger: VecDeque<ResourceNotification>,
 }
@@ -64,7 +64,7 @@ pub(super) fn restore_public_projections(
     for hook_state in projections.agent_hook_states {
         agent_hook_fences.insert(
             hook_state.terminal_id,
-            super::HookFence {
+            HookFence {
                 session_id: hook_state.agent_session_id,
                 sequence: hook_state.applied_sequence,
                 ended: hook_state.ended,
@@ -84,8 +84,8 @@ pub(super) fn restore_public_projections(
                 // marker sequence as their legacy generation token so a
                 // session-less event continues the same lifecycle after a
                 // restart without reusing a terminal-wide identity.
-                agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(super::HookFence {
-                    session_id: super::legacy_hook_session_id(&agent.terminal_id, value),
+                agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(HookFence {
+                    session_id: legacy_hook_session_id(&agent.terminal_id, value),
                     sequence: value,
                     ended: ended.is_some(),
                 });
@@ -97,8 +97,8 @@ pub(super) fn restore_public_projections(
             // cannot resurrect the completed session. Sequence zero is the
             // one-release compatibility generation for records without a
             // marker.
-            agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(super::HookFence {
-                session_id: super::legacy_hook_session_id(&agent.terminal_id, 0),
+            agent_hook_fences.entry(agent.terminal_id.clone()).or_insert(HookFence {
+                session_id: legacy_hook_session_id(&agent.terminal_id, 0),
                 sequence: 0,
                 ended: true,
             });

--- a/cmux-tui/crates/cmux-tui-core/src/resource.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/resource.rs
@@ -4,6 +4,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::sync::OnceLock;
 
+use crate::{PaneId, ScreenId, SplitId, SurfaceId, WorkspaceId};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 
@@ -1561,23 +1562,23 @@ impl ResourceJournal {
 
 #[derive(Debug, Default, Clone)]
 pub struct PublicSlotIndexes {
-    pub workspaces: HashMap<WorkspacePublicId, crate::WorkspaceId>,
-    pub screens: HashMap<ScreenPublicId, crate::ScreenId>,
-    pub panes: HashMap<PanePublicId, crate::PaneId>,
-    pub tabs: HashMap<TabPublicId, crate::SurfaceId>,
+    pub workspaces: HashMap<WorkspacePublicId, WorkspaceId>,
+    pub screens: HashMap<ScreenPublicId, ScreenId>,
+    pub panes: HashMap<PanePublicId, PaneId>,
+    pub tabs: HashMap<TabPublicId, SurfaceId>,
     /// Every view placement of a content resource. Terminal content may have
     /// any number of placements; browser content currently has one.
-    pub content_placements: HashMap<ContentPublicId, Vec<crate::SurfaceId>>,
-    pub workspace_ids: HashMap<crate::WorkspaceId, WorkspacePublicId>,
-    pub screen_ids: HashMap<crate::ScreenId, ScreenPublicId>,
-    pub pane_ids: HashMap<crate::PaneId, PanePublicId>,
-    pub tab_ids: HashMap<crate::SurfaceId, TabPublicId>,
-    pub content_ids: HashMap<crate::SurfaceId, ContentPublicId>,
-    pub splits: HashMap<SplitPublicId, crate::SplitId>,
-    pub split_ids: HashMap<crate::SplitId, SplitPublicId>,
-    pub screen_workspace: HashMap<crate::ScreenId, crate::WorkspaceId>,
-    pub pane_screen: HashMap<crate::PaneId, crate::ScreenId>,
-    pub tab_pane: HashMap<crate::SurfaceId, crate::PaneId>,
+    pub content_placements: HashMap<ContentPublicId, Vec<SurfaceId>>,
+    pub workspace_ids: HashMap<WorkspaceId, WorkspacePublicId>,
+    pub screen_ids: HashMap<ScreenId, ScreenPublicId>,
+    pub pane_ids: HashMap<PaneId, PanePublicId>,
+    pub tab_ids: HashMap<SurfaceId, TabPublicId>,
+    pub content_ids: HashMap<SurfaceId, ContentPublicId>,
+    pub splits: HashMap<SplitPublicId, SplitId>,
+    pub split_ids: HashMap<SplitId, SplitPublicId>,
+    pub screen_workspace: HashMap<ScreenId, WorkspaceId>,
+    pub pane_screen: HashMap<PaneId, ScreenId>,
+    pub tab_pane: HashMap<SurfaceId, PaneId>,
 }
 
 #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/public_projection_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/public_projection_store.rs
@@ -473,7 +473,7 @@ impl WorkspaceRegistry {
                 ) = row?;
                 validate_identifier("frontend", &frontend)?;
                 validate_identifier("projection scope", &scope)?;
-                FrontendProjectionPublicId::parse(subject_key.clone())?;
+                FrontendProjectionPublicId::parse(subject_key)?;
                 anyhow::ensure!(
                     schema_version
                         == i64::from(RESOURCE_API_FRONTEND_PROJECTION_SCHEMA_VERSION),

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/public_projection_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/public_projection_store.rs
@@ -473,7 +473,7 @@ impl WorkspaceRegistry {
                 ) = row?;
                 validate_identifier("frontend", &frontend)?;
                 validate_identifier("projection scope", &scope)?;
-                FrontendProjectionPublicId::parse(subject_key)?;
+                FrontendProjectionPublicId::parse(subject_key.as_str())?;
                 anyhow::ensure!(
                     schema_version
                         == i64::from(RESOURCE_API_FRONTEND_PROJECTION_SCHEMA_VERSION),

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/resource_store.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::JournalIngress;
+use crate::resource::TerminalPublicId;
 
 /// Completed pure mutations keep a finite exactly-once replay window. Pruning
 /// runs in batches, so a live registry may temporarily retain the interval as
@@ -551,7 +553,7 @@ impl WorkspaceRegistry {
         origin: &str,
         idempotency_key: &str,
         sequence: u64,
-        ingress: &crate::JournalIngress,
+        ingress: &JournalIngress,
     ) -> anyhow::Result<()> {
         let ingress_json = serde_json::to_string(ingress)?;
         let terminal_id = ingress
@@ -578,7 +580,7 @@ impl WorkspaceRegistry {
         origin: &str,
         idempotency_key: &str,
         sequence: u64,
-        ingress: &crate::JournalIngress,
+        ingress: &JournalIngress,
         error: &str,
         retry_class: AgentHookRetryClass,
     ) -> anyhow::Result<()> {
@@ -645,7 +647,7 @@ impl WorkspaceRegistry {
 
     pub(crate) fn purge_agent_hook_pending_for_terminal(
         &mut self,
-        terminal_id: &crate::resource::TerminalPublicId,
+        terminal_id: &TerminalPublicId,
     ) -> anyhow::Result<()> {
         self.connection.execute(
             "DELETE FROM resource_agent_hook_pending WHERE terminal_id = ?1",
@@ -692,7 +694,7 @@ impl WorkspaceRegistry {
 
     pub fn pending_agent_hook_projections(
         &self,
-    ) -> anyhow::Result<Vec<(String, String, String, u64, crate::JournalIngress)>> {
+    ) -> anyhow::Result<Vec<(String, String, String, u64, JournalIngress)>> {
         let mut statement = self.connection.prepare(
             "SELECT producer_id, origin, idempotency_key, event_sequence, ingress_json
              FROM resource_agent_hook_pending ORDER BY event_sequence ASC, idempotency_key ASC",
@@ -722,8 +724,8 @@ impl WorkspaceRegistry {
 
     pub fn pending_agent_hook_projections_for_terminal(
         &self,
-        terminal_id: &crate::resource::TerminalPublicId,
-    ) -> anyhow::Result<Vec<(String, String, String, u64, crate::JournalIngress)>> {
+        terminal_id: &TerminalPublicId,
+    ) -> anyhow::Result<Vec<(String, String, String, u64, JournalIngress)>> {
         let mut statement = self.connection.prepare(
             "SELECT producer_id, origin, idempotency_key, event_sequence, ingress_json
              FROM resource_agent_hook_pending
@@ -770,7 +772,7 @@ impl WorkspaceRegistry {
         &self,
         after: Option<(u64, String, i64)>,
     ) -> anyhow::Result<(
-        Vec<(String, String, String, u64, crate::JournalIngress)>,
+        Vec<(String, String, String, u64, JournalIngress)>,
         Option<(u64, String, i64)>,
     )> {
         let (after_sequence, after_key, after_rowid) = after.unwrap_or((0, String::new(), 0));
@@ -1592,7 +1594,7 @@ impl WorkspaceRegistry {
     #[cfg(test)]
     pub(crate) fn delete_agent_hook_state_for_test(
         &mut self,
-        terminal_id: &crate::resource::TerminalPublicId,
+        terminal_id: &TerminalPublicId,
     ) -> anyhow::Result<()> {
         self.connection.execute(
             "DELETE FROM resource_agent_hook_state WHERE terminal_id = ?1",


### PR DESCRIPTION
## Summary

- Stacked on [parent PR #11499](https://github.com/manaflow-ai/cmux/pull/11499).
- Preserve `subject_key` after validating its public ID by passing a string slice to `FrontendProjectionPublicId::parse`.
- This fixes the exact-head compile failure in [seven-language conformance run 33556355459](https://github.com/manaflow-ai/cmux/actions/runs/33556355459).

## Evidence

The `Build exact headless cmux-tui` job ran `cargo build -p cmux-tui --bin cmux-tui --locked` and failed with `error[E0382]` at `cmux-tui/crates/cmux-tui-core/src/workspace_registry/public_projection_store.rs:490`: `subject_key` moved at line 476 and was borrowed again in the invalid-JSON context. The compiler exited with code 101.

## Verification

- `git diff --check`
- Hosted SDK conformance should rerun on this repair branch.
- Local Cargo/Rust commands were not run, per cmux-tui instructions.

## References

- [Cargo build](https://doc.rust-lang.org/cargo/commands/cargo-build.html)
- [cmux public SDK conformance contract](https://github.com/manaflow-ai/cmux/blob/main/cmux-tui/bindings/conformance/README.md)
- [Rust String conversion](https://doc.rust-lang.org/std/string/struct.String.html)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in `cmux-tui` where `subject_key` was moved during validation, preventing its use later. Now passes a string slice to `FrontendProjectionPublicId::parse` so the key is preserved.

<sup>Written for commit 6db553e1956c6b1c355a3c530a117c5a4748dfef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11508?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

