### PR TITLE
fix(tui): retain semantic selection anchors on current main

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8344,19 +8344,14 @@ mod tests {
     #[test]
     fn kitty_limit_generation_stays_paired_with_terminal_mutation() {
         let mux = Mux::new_for_test("kitty-limit-generation", SurfaceOptions::default());
-        let surface = Surface::spawn_for_test(
-            1,
-            SurfaceOptions::default(),
-            Arc::downgrade(&mux),
-        )
-        .unwrap();
+        let surface =
+            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
         let (probe_tx, probe_rx) = std::sync::mpsc::channel();
         let weak_surface = Arc::downgrade(&surface);
         surface.as_pty().unwrap().kitty_limits_test_hook.lock().unwrap().replace(Arc::new(
             move || {
-                let probe = weak_surface
-                    .upgrade()
-                    .and_then(|surface| surface.try_pointer_snapshot());
+                let probe =
+                    weak_surface.upgrade().and_then(|surface| surface.try_pointer_snapshot());
                 probe_tx.send(probe).unwrap();
             },
         ));

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8380,6 +8380,36 @@ mod tests {
     }
 
     #[test]
+    fn terminal_generation_snapshot_stays_paired_with_terminal_lock() {
+        let mux = Mux::new_for_test("terminal-generation-snapshot", SurfaceOptions::default());
+        let surface =
+            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+        let callback_surface = surface.clone();
+
+        let captured_generation = surface
+            .with_terminal_and_generation(|_terminal, generation| {
+                probe_tx.send(callback_surface.try_pointer_snapshot()).unwrap();
+                generation
+            })
+            .expect("test fixture surface must be a PTY");
+
+        assert_eq!(
+            probe_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            Some(PointerSnapshotProbe::Contended),
+            "terminal generation callbacks must hold the terminal lock"
+        );
+        let observed_generation = match surface.try_pointer_snapshot() {
+            Some(PointerSnapshotProbe::Ready(snapshot)) => snapshot.content_generation,
+            other => panic!("expected a stable post-callback snapshot, got {other:?}"),
+        };
+        assert_eq!(
+            captured_generation, observed_generation,
+            "the generation callback must match the locked terminal snapshot"
+        );
+    }
+
+    #[test]
     fn geometry_updates_skip_vt_replay_without_byte_attach_subscribers() {
         let mux = Mux::new_for_test("resize-without-byte-attach", SurfaceOptions::default());
         let surface =

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4414,14 +4414,14 @@ impl Surface {
                 render.latest = None;
                 render.initial_graphics = None;
             }
-            graphics_changed
+            let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
+            #[cfg(test)]
+            pty.run_kitty_limits_test_hook();
+            (graphics_changed, generation)
         };
         if !graphics_changed {
             return Ok(());
         }
-        #[cfg(test)]
-        pty.run_kitty_limits_test_hook();
-        let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
         pty.request_frame(generation);
         Ok(())
     }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4343,6 +4343,21 @@ impl Surface {
         Some(result)
     }
 
+    /// Run `f` with exclusive access to the terminal and its content generation.
+    /// The generation is captured while the terminal lock is held, so the
+    /// callback cannot pair a semantic result with a different terminal state.
+    pub fn with_terminal_and_generation<R>(
+        &self,
+        f: impl FnOnce(&mut Terminal, u64) -> R,
+    ) -> Option<R> {
+        let pty = self.as_pty()?;
+        let mut term = pty.term.lock().unwrap();
+        let generation = pty.render_generation.load(Ordering::Acquire);
+        let result = f(&mut term, generation);
+        pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+        Some(result)
+    }
+
     fn configure_terminal_kitty_graphics_limits(
         terminal: &mut Terminal,
         limits: KittyGraphicsLimits,

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1218,6 +1218,9 @@ type PtyGeometryTestHook = Arc<dyn Fn(PtyGeometryTestStep) + Send + Sync>;
 #[cfg(test)]
 type DeferredCellPixelAckTestHook = Arc<dyn Fn() + Send + Sync>;
 
+#[cfg(test)]
+type KittyLimitsTestHook = Arc<dyn Fn() + Send + Sync>;
+
 pub struct PtySurface {
     pub(crate) meta: SurfaceMeta,
     terminal: Arc<PtyTerminalRuntime>,
@@ -1445,6 +1448,8 @@ pub struct PtyTerminalRuntime {
     geometry_test_hook: Mutex<Option<PtyGeometryTestHook>>,
     #[cfg(test)]
     deferred_cell_pixel_ack_test_hook: Mutex<Option<DeferredCellPixelAckTestHook>>,
+    #[cfg(test)]
+    kitty_limits_test_hook: Mutex<Option<KittyLimitsTestHook>>,
     #[cfg(test)]
     test_master_control: Option<Arc<TestMasterPtyControl>>,
     #[cfg(test)]
@@ -2345,6 +2350,8 @@ impl Surface {
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        #[cfg(test)]
+        let kitty_limits_test_hook = Mutex::new(None);
         let surface = Arc::new(Surface::Pty(PtySurface {
             meta: SurfaceMeta {
                 id,
@@ -2399,6 +2406,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
                 #[cfg(test)]
@@ -2820,6 +2828,8 @@ impl Surface {
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        #[cfg(test)]
+        let kitty_limits_test_hook = Mutex::new(None);
         let surface = Arc::new(Surface::Pty(PtySurface {
             meta: SurfaceMeta {
                 id,
@@ -2874,6 +2884,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
                 #[cfg(test)]
@@ -3858,6 +3869,8 @@ impl Surface {
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        #[cfg(test)]
+        let kitty_limits_test_hook = Mutex::new(None);
         let command = opts
             .command
             .clone()
@@ -3915,6 +3928,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
                 #[cfg(test)]
@@ -4087,6 +4101,7 @@ impl Surface {
         let (frame_requests, _frame_rx) = sync_channel(1);
         let test_master_control = Arc::new(TestMasterPtyControl::default());
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        let kitty_limits_test_hook = Mutex::new(None);
 
         let surface = Arc::new(Surface::Pty(PtySurface {
             meta: SurfaceMeta {
@@ -4142,6 +4157,7 @@ impl Surface {
                 kitty_graphics_limits: Box::new(Mutex::new(initial_kitty_limits)),
                 geometry_test_hook: Mutex::new(None),
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 test_master_control: Some(test_master_control),
                 vt_replay_builds: AtomicUsize::new(0),
                 mux,
@@ -4403,6 +4419,8 @@ impl Surface {
         if !graphics_changed {
             return Ok(());
         }
+        #[cfg(test)]
+        pty.run_kitty_limits_test_hook();
         let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
         pty.request_frame(generation);
         Ok(())
@@ -6224,6 +6242,14 @@ impl PtySurface {
         let hook = self.geometry_test_hook.lock().unwrap().clone();
         if let Some(hook) = hook {
             hook(step);
+        }
+    }
+
+    #[cfg(test)]
+    fn run_kitty_limits_test_hook(&self) {
+        let hook = self.kitty_limits_test_hook.lock().unwrap().clone();
+        if let Some(hook) = hook {
+            hook();
         }
     }
 
@@ -8312,6 +8338,35 @@ mod tests {
                 Ok(AttachFrame::Resized { .. } | AttachFrame::ResizedWithColors { .. })
             ),
             "a byte-stream mirror was left on the pre-eviction Kitty scene"
+        );
+    }
+
+    #[test]
+    fn kitty_limit_generation_stays_paired_with_terminal_mutation() {
+        let mux = Mux::new_for_test("kitty-limit-generation", SurfaceOptions::default());
+        let surface = Surface::spawn_for_test(
+            1,
+            SurfaceOptions::default(),
+            Arc::downgrade(&mux),
+        )
+        .unwrap();
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+        let weak_surface = Arc::downgrade(&surface);
+        surface.as_pty().unwrap().kitty_limits_test_hook.lock().unwrap().replace(Arc::new(
+            move || {
+                let probe = weak_surface
+                    .upgrade()
+                    .and_then(|surface| surface.try_pointer_snapshot());
+                probe_tx.send(probe).unwrap();
+            },
+        ));
+
+        surface.set_kitty_graphics_limits(0, 0, 0, 0).unwrap();
+
+        assert_eq!(
+            probe_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            Some(PointerSnapshotProbe::Contended),
+            "terminal mutation and its render generation must share the terminal lock"
         );
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8363,6 +8363,20 @@ mod tests {
             Some(PointerSnapshotProbe::Contended),
             "terminal mutation and its render generation must share the terminal lock"
         );
+
+        let changed_generation = match surface.try_pointer_snapshot() {
+            Some(PointerSnapshotProbe::Ready(snapshot)) => snapshot.content_generation,
+            other => panic!("expected a stable post-mutation snapshot, got {other:?}"),
+        };
+        surface.set_kitty_graphics_limits(0, 0, 0, 0).unwrap();
+        let no_op_generation = match surface.try_pointer_snapshot() {
+            Some(PointerSnapshotProbe::Ready(snapshot)) => snapshot.content_generation,
+            other => panic!("expected a stable no-op snapshot, got {other:?}"),
+        };
+        assert_eq!(
+            no_op_generation, changed_generation,
+            "unchanged Kitty limits must not invalidate terminal content"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4414,14 +4414,14 @@ impl Surface {
                 render.latest = None;
                 render.initial_graphics = None;
             }
+            if !graphics_changed {
+                return Ok(());
+            }
             let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
             #[cfg(test)]
             pty.run_kitty_limits_test_hook();
-            (graphics_changed, generation)
+            generation
         };
-        if !graphics_changed {
-            return Ok(());
-        }
         pty.request_frame(generation);
         Ok(())
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16892,6 +16892,9 @@ impl App {
         let repeated = previous.as_ref().is_some_and(|previous| {
             Self::selection_repeat_allowed(previous, surface, screen, position, modifiers, now)
         });
+        if !repeated {
+            self.replace_selection(None);
+        }
         let (mut count, mut tracked_anchor) = if repeated {
             let previous = previous.expect("repeated selection click has prior state");
             (previous.count.saturating_add(1).min(3), previous.tracked_anchor)
@@ -27610,6 +27613,17 @@ mod tests {
             Some(((6, 0), (15, 0))),
             "double-click drag must start at the selected word and end at the whole target word"
         );
+
+        let plain_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 2,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(plain_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..plain_click })
+            .unwrap();
+        assert!(app.selection.is_none(), "a plain click after a selection drag must clear it");
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5350,6 +5350,7 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
+    semantic_range: Option<SelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
     /// press.
@@ -16937,6 +16938,7 @@ impl App {
             anchor: cell,
             dragged: false,
             tracked_anchor,
+            semantic_range: None,
             repeatable: true,
         });
         mode
@@ -17070,13 +17072,27 @@ impl App {
             .flatten();
         let range = range.map(|range| {
             if mode == SelectionMode::Word {
-                self.selection
-                    .filter(|selection| selection.surface == surface)
-                    .map(|selection| {
-                        let initial = selection.range();
+                self.selection_click_sequence
+                    .as_ref()
+                    .and_then(|sequence| sequence.semantic_range)
+                    .map(|initial| {
+                        let start = if (initial.start.row, initial.start.column)
+                            <= (range.start.row, range.start.column)
+                        {
+                            initial.start
+                        } else {
+                            range.start
+                        };
+                        let end = if (initial.end.row, initial.end.column)
+                            >= (range.end.row, range.end.column)
+                        {
+                            initial.end
+                        } else {
+                            range.end
+                        };
                         SelectionRange {
-                            start: initial.0.min(range.start),
-                            end: initial.1.max(range.end),
+                            start,
+                            end,
                         }
                     })
                     .unwrap_or(range)
@@ -22329,6 +22345,20 @@ impl App {
                         self.selection_mode_surface = Some(area.surface);
                         if let Some(selection) = self.selection_for_click(area.surface, cell, mode)
                         {
+                            if let Some(sequence) = self.selection_click_sequence.as_mut()
+                                && mode != SelectionMode::Cell
+                            {
+                                sequence.semantic_range = Some(SelectionRange {
+                                    start: SelectionPoint {
+                                        column: selection.range().0.0,
+                                        row: selection.range().0.1 as u32,
+                                    },
+                                    end: SelectionPoint {
+                                        column: selection.range().1.0,
+                                        row: selection.range().1.1 as u32,
+                                    },
+                                });
+                            }
                             self.replace_selection(Some(selection));
                         } else {
                             // A semantic lookup can legitimately return no

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27522,6 +27522,30 @@ mod tests {
     }
 
     #[test]
+    fn plain_click_clears_an_existing_selection() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("plain-click-clears-selection-test", b"alpha beta gamma");
+        app.replace_selection(Some(Selection {
+            surface: surface.id,
+            anchor: (0, 0),
+            head: (4, 0),
+        }));
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert!(app.selection.is_none(), "a plain click must clear an existing selection");
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_selects_a_complete_whitespace_run() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-whitespace-selection-test", b"alpha   beta");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -20849,14 +20849,17 @@ impl App {
                     terminal_admission,
                 )
             }
-            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => self
-                .handle_horizontal_scroll_with_admission(
+            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
+                // Scrolling is a distinct gesture and ends click-repeat state.
+                self.reset_selection_click_sequence();
+                self.handle_horizontal_scroll_with_admission(
                     mouse.column,
                     mouse.row,
                     matches!(mouse.kind, MouseEventKind::ScrollRight),
                     mouse.modifiers,
                     terminal_admission,
-                ),
+                )
+            }
         }
     }
 
@@ -23862,10 +23865,6 @@ impl App {
         modifiers: KeyModifiers,
         terminal_admission: Option<TerminalPointerAdmission>,
     ) -> anyhow::Result<RenderAction> {
-        // Scrolling is a distinct gesture and ends click-repeat state. Plain
-        // pointer motion is routed to handle_hover_with_admission and keeps
-        // the sequence alive until the next press.
-        self.reset_selection_click_sequence();
         if self.menu.is_some() || self.prompt.is_some() {
             return Ok(RenderAction::None);
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5350,6 +5350,10 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
+    /// Generation of the semantic selection currently installed on `App`.
+    /// `None` means the range cannot be safely copied because no stable
+    /// terminal snapshot was available.
+    semantic_content_generation: Option<u64>,
     semantic_range: Option<GenerationTaggedSelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
@@ -16798,6 +16802,8 @@ impl App {
             && sequence.surface == surface
         {
             sequence.mode = SelectionMode::Cell;
+            sequence.semantic_content_generation = None;
+            sequence.semantic_range = None;
         }
     }
 
@@ -16952,6 +16958,7 @@ impl App {
             anchor: cell,
             dragged: false,
             tracked_anchor,
+            semantic_content_generation: None,
             semantic_range: None,
             repeatable: true,
         });
@@ -16999,7 +17006,20 @@ impl App {
             && sequence.surface == surface
         {
             sequence.mode = mode;
+            sequence.semantic_content_generation = None;
         }
+    }
+
+    fn current_semantic_selection_generation(&self, surface: SurfaceId) -> Option<u64> {
+        let Some(sequence) =
+            self.selection_click_sequence.as_ref().filter(|sequence| sequence.surface == surface)
+        else {
+            return None;
+        };
+        let Some(expected) = sequence.semantic_content_generation else {
+            return None;
+        };
+        (self.terminal_content_generation(surface) == Some(expected)).then_some(expected)
     }
 
     fn update_semantic_selection(
@@ -17127,6 +17147,19 @@ impl App {
             });
         } else {
             self.semantic_selection_cache = None;
+        }
+        if let Some(sequence) =
+            self.selection_click_sequence.as_mut().filter(|sequence| sequence.surface == surface)
+        {
+            if let (Some(content_generation), Some(range)) = (content_generation, range) {
+                sequence.semantic_content_generation = Some(content_generation);
+                if mode == SelectionMode::Word {
+                    sequence.semantic_range =
+                        Some(GenerationTaggedSelectionRange { content_generation, range });
+                }
+            } else {
+                sequence.semantic_content_generation = None;
+            }
         }
         match range {
             Some(range) => self.replace_selection(Some(Self::selection_from_range(surface, range))),
@@ -22385,6 +22418,10 @@ impl App {
                                                 },
                                             },
                                         });
+                                    sequence.semantic_content_generation = Some(content_generation);
+                                } else {
+                                    sequence.semantic_content_generation = None;
+                                    sequence.semantic_range = None;
                                 }
                             }
                             self.replace_selection(Some(selection));
@@ -22699,6 +22736,13 @@ impl App {
         let semantic_select = was_select
             && self.selection_mode_surface.is_some()
             && self.selection_mode != SelectionMode::Cell;
+        let semantic_content_generation = if semantic_select {
+            self.selection_mode_surface
+                .and_then(|surface| self.current_semantic_selection_generation(surface))
+        } else {
+            None
+        };
+        let stale_semantic_selection = semantic_select && semantic_content_generation.is_none();
         let selection_dragged = was_select
             && self.selection_click_sequence.as_ref().is_some_and(|sequence| sequence.dragged);
         let was_drag = self.drag.is_some();
@@ -22707,6 +22751,13 @@ impl App {
             // Keep the sequence through the gesture so word and line drags use
             // their semantic mode, then make the next press a plain click.
             self.reset_selection_click_sequence();
+        }
+        if stale_semantic_selection {
+            // The selected endpoints are screen coordinates. If terminal
+            // content changed while the button was held, copying them could
+            // return unrelated text from the new generation.
+            self.replace_selection(None);
+            return Ok(RenderAction::Draw);
         }
         if !was_select {
             return Ok(if was_drag { RenderAction::Draw } else { RenderAction::None });
@@ -22719,7 +22770,7 @@ impl App {
         }
         match self.selection {
             Some(sel) if sel.anchor != sel.head || semantic_select => {
-                self.copy_selection(sel);
+                self.copy_selection(sel, semantic_content_generation);
                 Ok(RenderAction::Draw)
             }
             _ => {
@@ -22732,13 +22783,25 @@ impl App {
 
     /// Copy the selected text to the host clipboard via OSC 52 (the host
     /// terminal owns the clipboard; this works over SSH too).
-    fn copy_selection(&mut self, sel: Selection) {
+    fn copy_selection(&mut self, sel: Selection, expected_content_generation: Option<u64>) {
+        if let Some(expected) = expected_content_generation
+            && self.terminal_content_generation(sel.surface) != Some(expected)
+        {
+            self.replace_selection(None);
+            return;
+        }
         let Some(surface) = self.session.surface(sel.surface) else { return };
         let (start, end) = sel.range();
         let Some(text) = surface.with_terminal(|t| t.selection_text_absolute(start, end)).flatten()
         else {
             return;
         };
+        if let Some(expected) = expected_content_generation
+            && self.terminal_content_generation(sel.surface) != Some(expected)
+        {
+            self.replace_selection(None);
+            return;
+        }
         if text.is_empty() {
             return;
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27500,6 +27500,36 @@ mod tests {
     }
 
     #[test]
+    fn whitespace_double_click_drag_preserves_whitespace_anchor() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-whitespace-drag-selection-test", b"alpha   beta");
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 6,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 9,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((5, 0), (11, 0))),
+            "dragging from whitespace must retain its initial whitespace range"
+        );
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_extends_selection_by_complete_words() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-word-drag-selection-test", b"alpha beta gamma");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16859,12 +16859,15 @@ impl App {
         modifiers: KeyModifiers,
         now: Instant,
     ) -> bool {
+        let host_selection_modifier = |modifiers| {
+            modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT
+        };
         if !previous.repeatable
             || screen.is_none()
             || previous.surface != surface
             || previous.screen != screen
-            || previous.modifiers != KeyModifiers::NONE
-            || modifiers != KeyModifiers::NONE
+            || previous.modifiers != modifiers
+            || !host_selection_modifier(modifiers)
         {
             return false;
         }
@@ -21995,9 +21998,9 @@ impl App {
         self.finish_active_drag();
 
         // A repeat is valid only for presses that land directly in a PTY
-        // content cell. Any chrome, overlay, browser, or modified click ends
-        // the pending terminal click sequence.
-        let repeat_target = modifiers == KeyModifiers::NONE
+        // content cell. Shift is the host-selection override when an inner
+        // PTY application owns mouse input, so preserve it for repeats.
+        let repeat_target = (modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT)
             && self.hit_at(x, y).is_none()
             && self.pane_area_at(x, y).is_some_and(|area| {
                 self.surface_kind(area.surface) == Some(SurfaceKind::Pty)

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27613,6 +27613,44 @@ mod tests {
         );
         app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
             .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn failed_semantic_repeat_resets_the_click_sequence() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("failed-semantic-repeat-reset-test", b"alpha\n");
+        let first_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(first_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..first_click })
+            .unwrap();
+
+        let blank_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            row: content.y + 1,
+            ..first_click
+        };
+        app.handle_mouse(blank_click).unwrap();
+        assert_eq!(app.selection_mode, SelectionMode::Word);
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..blank_click })
+            .unwrap();
+        assert!(app.selection.is_none(), "an unsupported semantic cell must not retain selection");
+
+        app.handle_mouse(blank_click).unwrap();
+        assert_eq!(
+            app.selection_mode,
+            SelectionMode::Cell,
+            "a failed semantic repeat must reset the next click to cell mode"
+        );
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..blank_click })
+            .unwrap();
+
         mux.close_surface(surface.id).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27655,6 +27655,30 @@ mod tests {
     }
 
     #[test]
+    fn forwarded_pty_click_resets_host_repeat_sequence() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("forwarded-pty-click-repeat-reset-test", b"alpha beta");
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        assert!(app.selection_click_sequence.is_some());
+
+        surface.with_terminal(|terminal| terminal.vt_write(b"\x1b[?1002h\x1b[?1006h"));
+        app.handle_mouse(click).unwrap();
+        assert!(app.selection_click_sequence.is_none());
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn plain_click_clears_an_existing_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("plain-click-clears-selection-test", b"alpha beta gamma");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17068,6 +17068,22 @@ impl App {
                 SelectionMode::Cell => None,
             })
             .flatten();
+        let range = range.map(|range| {
+            if mode == SelectionMode::Word {
+                self.selection
+                    .filter(|selection| selection.surface == surface)
+                    .map(|selection| {
+                        let initial = selection.range();
+                        SelectionRange {
+                            start: initial.0.min(range.start),
+                            end: initial.1.max(range.end),
+                        }
+                    })
+                    .unwrap_or(range)
+            } else {
+                range
+            }
+        });
         if let Some(generation) = content_generation {
             self.semantic_selection_cache = Some(SemanticSelectionCache {
                 surface,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27892,6 +27892,45 @@ mod tests {
     }
 
     #[test]
+    fn double_click_drag_back_shrinks_to_the_press_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-word-drag-back-test", b"alpha beta gamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 7,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 15,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 7,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((6, 0), (10, 0))),
+            "dragging back must shrink to the word selected at the press"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_anchors_at_second_press() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-second-press-anchor-test", b"a b c");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -22686,6 +22686,12 @@ impl App {
         if !was_select {
             return Ok(if was_drag { RenderAction::Draw } else { RenderAction::None });
         }
+        if !semantic_select && !selection_dragged {
+            // A click without motion is not a selection. Clear the provisional
+            // cell anchor created on press, including any prior selection.
+            self.replace_selection(None);
+            return Ok(RenderAction::Draw);
+        }
         match self.selection {
             Some(sel) if sel.anchor != sel.head || semantic_select => {
                 self.copy_selection(sel);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27491,6 +27491,90 @@ mod tests {
     }
 
     #[test]
+    fn shift_double_click_selects_a_complete_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-double-click-word-selection-test", b"alpha beta gamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (4, 0))),
+            "Shift double click must select the complete word when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn shift_triple_click_selects_a_complete_line() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-triple-click-line-selection-test", b"alpha beta\ngamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        for _ in 0..3 {
+            app.handle_mouse(click).unwrap();
+            app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+                .unwrap();
+        }
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (10, 0))),
+            "Shift triple click must select the complete line when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn changing_shift_modifier_prevents_a_repeat_selection() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-repeat-modifier-mismatch-test", b"alpha beta gamma");
+
+        let shift_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        app.handle_mouse(shift_click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            ..shift_click
+        })
+        .unwrap();
+        let plain_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            ..shift_click
+        };
+        app.handle_mouse(plain_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..plain_click })
+            .unwrap();
+
+        assert!(app.selection.is_none(), "a modifier change must reset the click sequence");
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_failed_word_lookup_downgrades_to_a_cell_gesture() {
         let (mut app, mux, surface, content) =
             selection_fixture("failed-word-lookup-selection-state-test", b"alpha");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -22756,6 +22756,7 @@ impl App {
             // The selected endpoints are screen coordinates. If terminal
             // content changed while the button was held, copying them could
             // return unrelated text from the new generation.
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return Ok(RenderAction::Draw);
         }
@@ -22787,6 +22788,7 @@ impl App {
         if let Some(expected) = expected_content_generation
             && self.terminal_content_generation(sel.surface) != Some(expected)
         {
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return;
         }
@@ -22799,6 +22801,7 @@ impl App {
         if let Some(expected) = expected_content_generation
             && self.terminal_content_generation(sel.surface) != Some(expected)
         {
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return;
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17039,6 +17039,9 @@ impl App {
         let range = handle
             .with_terminal(|terminal| match mode {
                 SelectionMode::Word => {
+                    // Query both directions: Ghostty's nearest-word lookup is
+                    // directional, and the paired bounds preserve reverse
+                    // drags through whitespace or punctuation.
                     let first = terminal
                         .select_word_between_screen(anchor_point, current_point)
                         .ok()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17054,8 +17054,8 @@ impl App {
             self.semantic_selection_cache = None;
             return;
         };
-        let content_generation = self.terminal_content_generation(surface);
-        if let Some(generation) = content_generation
+        let cache_generation = self.terminal_content_generation(surface);
+        if let Some(generation) = cache_generation
             && let Some(cache) = self.semantic_selection_cache
             && cache.surface == surface
             && cache.mode == mode
@@ -17070,46 +17070,49 @@ impl App {
             }
             return;
         }
-        let range = handle
-            .with_terminal(|terminal| match mode {
-                SelectionMode::Word => {
-                    // Query both directions: Ghostty's nearest-word lookup is
-                    // directional, and the paired bounds preserve reverse
-                    // drags through whitespace or punctuation.
-                    let first = terminal
-                        .select_word_between_screen(anchor_point, current_point)
-                        .ok()
-                        .flatten()?;
-                    let second = terminal
-                        .select_word_between_screen(current_point, anchor_point)
-                        .ok()
-                        .flatten()?;
-                    let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
-                    Some(if current_before_anchor {
-                        SelectionRange { start: second.start, end: first.end }
-                    } else {
-                        SelectionRange { start: first.start, end: second.end }
-                    })
-                }
-                SelectionMode::Line => {
-                    let select_line =
-                        |point| {
+        let (range, content_generation) = handle
+            .with_terminal_and_generation(|terminal, generation| {
+                let range = match mode {
+                    SelectionMode::Word => {
+                        // Query both directions: Ghostty's nearest-word lookup is
+                        // directional, and the paired bounds preserve reverse
+                        // drags through whitespace or punctuation.
+                        let first = terminal
+                            .select_word_between_screen(anchor_point, current_point)
+                            .ok()
+                            .flatten()?;
+                        let second = terminal
+                            .select_word_between_screen(current_point, anchor_point)
+                            .ok()
+                            .flatten()?;
+                        let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
+                        Some(if current_before_anchor {
+                            SelectionRange { start: second.start, end: first.end }
+                        } else {
+                            SelectionRange { start: first.start, end: second.end }
+                        })
+                    }
+                    SelectionMode::Line => {
+                        let select_line = |point| {
                             terminal.select_line_screen(point).ok().flatten().or_else(|| {
                                 terminal.select_line_screen_untrimmed(point).ok().flatten()
                             })
                         };
-                    let first = select_line(anchor_point)?;
-                    let second = select_line(current_point)?;
-                    let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
-                    Some(if current_before_anchor {
-                        SelectionRange { start: second.start, end: first.end }
-                    } else {
-                        SelectionRange { start: first.start, end: second.end }
-                    })
-                }
-                SelectionMode::Cell => None,
+                        let first = select_line(anchor_point)?;
+                        let second = select_line(current_point)?;
+                        let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
+                        Some(if current_before_anchor {
+                            SelectionRange { start: second.start, end: first.end }
+                        } else {
+                            SelectionRange { start: first.start, end: second.end }
+                        })
+                    }
+                    SelectionMode::Cell => None,
+                };
+                Some((range, generation))
             })
-            .flatten();
+            .flatten()
+            .map_or((None, None), |(range, generation)| (range.flatten(), Some(generation)));
         let range = range.map(|range| {
             if mode == SelectionMode::Word {
                 self.selection_click_sequence

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16832,24 +16832,27 @@ impl App {
         surface: SurfaceId,
         cell: (u16, u64),
         mode: SelectionMode,
-    ) -> Option<Selection> {
+    ) -> Option<(Selection, Option<u64>)> {
         if mode == SelectionMode::Cell {
-            return Some(Selection { surface, anchor: cell, head: cell });
+            return Some((Selection { surface, anchor: cell, head: cell }, None));
         }
         let point = Self::selection_point(cell)?;
         let handle = self.session.surface(surface)?;
-        let range = handle
-            .with_terminal(|terminal| match mode {
-                SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
-                SelectionMode::Line => terminal
-                    .select_line_screen(point)
-                    .ok()
-                    .flatten()
-                    .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
-                SelectionMode::Cell => None,
-            })
-            .flatten()?;
-        Some(Self::selection_from_range(surface, range))
+        let (range, content_generation) =
+            handle.with_terminal_and_generation(|terminal, generation| {
+                let range = match mode {
+                    SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
+                    SelectionMode::Line => terminal
+                        .select_line_screen(point)
+                        .ok()
+                        .flatten()
+                        .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
+                    SelectionMode::Cell => None,
+                };
+                (range, generation)
+            })?;
+        let range = range?;
+        Some((Self::selection_from_range(surface, range), Some(content_generation)))
     }
 
     fn terminal_active_screen(&self, surface: SurfaceId) -> Option<Screen> {
@@ -17154,8 +17157,12 @@ impl App {
             if let (Some(content_generation), Some(range)) = (content_generation, range) {
                 sequence.semantic_content_generation = Some(content_generation);
                 if mode == SelectionMode::Word {
-                    sequence.semantic_range =
-                        Some(GenerationTaggedSelectionRange { content_generation, range });
+                    let anchor_generation =
+                        sequence.semantic_range.map(|anchor| anchor.content_generation);
+                    if anchor_generation != Some(content_generation) {
+                        sequence.semantic_range =
+                            Some(GenerationTaggedSelectionRange { content_generation, range });
+                    }
                 }
             } else {
                 sequence.semantic_content_generation = None;
@@ -22388,9 +22395,6 @@ impl App {
                         (x.saturating_sub(content.x), y.saturating_sub(content.y)),
                         modifiers,
                     );
-                    let content_generation = (mode != SelectionMode::Cell)
-                        .then(|| self.terminal_content_generation(area.surface))
-                        .flatten();
                     if mode == SelectionMode::Cell && modifiers == KeyModifiers::NONE {
                         // Ghostty's cell behavior returns no range on press.
                         // Keep only the tracked anchor until a drag moves it.
@@ -22398,7 +22402,8 @@ impl App {
                     } else {
                         self.selection_mode = mode;
                         self.selection_mode_surface = Some(area.surface);
-                        if let Some(selection) = self.selection_for_click(area.surface, cell, mode)
+                        if let Some((selection, content_generation)) =
+                            self.selection_for_click(area.surface, cell, mode)
                         {
                             if let Some(sequence) = self.selection_click_sequence.as_mut()
                                 && mode != SelectionMode::Cell

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16859,9 +16859,8 @@ impl App {
         modifiers: KeyModifiers,
         now: Instant,
     ) -> bool {
-        let host_selection_modifier = |modifiers| {
-            modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT
-        };
+        let host_selection_modifier =
+            |modifiers| modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT;
         if !previous.repeatable
             || screen.is_none()
             || previous.surface != surface
@@ -27561,11 +27560,8 @@ mod tests {
             modifiers: KeyModifiers::SHIFT,
         };
         app.handle_mouse(shift_click).unwrap();
-        app.handle_mouse(MouseEvent {
-            kind: MouseEventKind::Up(MouseButton::Left),
-            ..shift_click
-        })
-        .unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..shift_click })
+            .unwrap();
         let plain_click = MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
             modifiers: KeyModifiers::NONE,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5350,11 +5350,20 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
-    semantic_range: Option<SelectionRange>,
+    semantic_range: Option<GenerationTaggedSelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
     /// press.
     repeatable: bool,
+}
+
+/// A semantic range is valid only for the terminal content generation that
+/// produced it. Screen coordinates can move when output, reflow, or scrollback
+/// changes the terminal, so never union a range from an older generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GenerationTaggedSelectionRange {
+    content_generation: u64,
+    range: SelectionRange,
 }
 
 /// The most recent semantic drag result. Pointer reports often repeat the
@@ -17083,7 +17092,9 @@ impl App {
                 self.selection_click_sequence
                     .as_ref()
                     .and_then(|sequence| sequence.semantic_range)
+                    .filter(|initial| content_generation == Some(initial.content_generation))
                     .map(|initial| {
+                        let initial = initial.range;
                         let start = if (initial.start.row, initial.start.column)
                             <= (range.start.row, range.start.column)
                         {
@@ -22344,6 +22355,9 @@ impl App {
                         (x.saturating_sub(content.x), y.saturating_sub(content.y)),
                         modifiers,
                     );
+                    let content_generation = (mode != SelectionMode::Cell)
+                        .then(|| self.terminal_content_generation(area.surface))
+                        .flatten();
                     if mode == SelectionMode::Cell && modifiers == KeyModifiers::NONE {
                         // Ghostty's cell behavior returns no range on press.
                         // Keep only the tracked anchor until a drag moves it.
@@ -22356,16 +22370,22 @@ impl App {
                             if let Some(sequence) = self.selection_click_sequence.as_mut()
                                 && mode != SelectionMode::Cell
                             {
-                                sequence.semantic_range = Some(SelectionRange {
-                                    start: SelectionPoint {
-                                        column: selection.range().0.0,
-                                        row: selection.range().0.1 as u32,
-                                    },
-                                    end: SelectionPoint {
-                                        column: selection.range().1.0,
-                                        row: selection.range().1.1 as u32,
-                                    },
-                                });
+                                if let Some(content_generation) = content_generation {
+                                    sequence.semantic_range =
+                                        Some(GenerationTaggedSelectionRange {
+                                            content_generation,
+                                            range: SelectionRange {
+                                                start: SelectionPoint {
+                                                    column: selection.range().0.0,
+                                                    row: selection.range().0.1 as u32,
+                                                },
+                                                end: SelectionPoint {
+                                                    column: selection.range().1.0,
+                                                    row: selection.range().1.1 as u32,
+                                                },
+                                            },
+                                        });
+                                }
                             }
                             self.replace_selection(Some(selection));
                         } else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17098,10 +17098,7 @@ impl App {
                         } else {
                             range.end
                         };
-                        SelectionRange {
-                            start,
-                            end,
-                        }
+                        SelectionRange { start, end }
                     })
                     .unwrap_or(range)
             } else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -23863,6 +23863,9 @@ impl App {
         modifiers: KeyModifiers,
         terminal_admission: Option<TerminalPointerAdmission>,
     ) -> anyhow::Result<RenderAction> {
+        // Scrolling is a distinct gesture and ends click-repeat state. Plain
+        // pointer motion is routed to handle_hover_with_admission and keeps
+        // the sequence alive until the next press.
         self.reset_selection_click_sequence();
         if self.menu.is_some() || self.prompt.is_some() {
             return Ok(RenderAction::None);

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -2246,6 +2246,23 @@ impl SurfaceHandle {
         }
     }
 
+    pub fn with_terminal_and_generation<R>(
+        &self,
+        f: impl FnOnce(&mut Terminal, u64) -> R,
+    ) -> Option<R> {
+        match self {
+            SurfaceHandle::Local(surface, _) => surface.with_terminal_and_generation(f),
+            SurfaceHandle::Remote(surface, _) if surface.kind == SurfaceKind::Pty => {
+                let mut terminal = surface.term.lock().unwrap();
+                let generation = surface.content_generation.load(Ordering::Acquire);
+                let result = f(&mut terminal, generation);
+                surface.sync_mouse_encoders(&terminal);
+                Some(result)
+            }
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowserUnsupported => None,
+        }
+    }
+
     pub fn encode_mouse(
         &self,
         input: MouseInput,


### PR DESCRIPTION
Rebased selection-only replay of #11411 onto live main 544c0e0ff4.

Changes are limited to cmux-tui/crates/cmux-tui/src/app.rs. Preserves whitespace/word and line anchors during semantic drags, clears stale selections on plain clicks, handles Shift repeats, and invalidates ranges after content changes.

Overlap and supersession:
- Coordinates with #11445, which modifies the same click-repeat state machine for host Shift selection. Apply its focused follow-up after this branch or consolidate before merge.
- Coordinates with #11494, which modifies semantic endpoints and ghostty-vt wide-grapheme normalization. Resolve its endpoint changes on top; do not cherry-pick blindly.
- #11254 is a Ghostty fork pointer change and is not included.

Verification: direct rustfmt check and git diff --check pass. No Cargo tests run per review instructions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux-tui` semantic mouse selection so word and line ranges retain their original anchors during whitespace, reverse, and overshooting drags instead of shifting. Also rejects stale copies on release after terminal content changes and keeps selection repeat state and render generations consistent.

- Plain clicks clear existing selections; Shift supports double- and triple-click repeats when the PTY does not own mouse input.
- Modifier changes, scrolling, forwarded PTY clicks, and failed semantic lookups reset repeat state; hover keeps it alive.
- Semantic ranges use a single terminal snapshot and content generation; Kitty limit generation bumps now hold the terminal lock, and unchanged limits do not create a new generation.
- Adds regression coverage for anchors, repeat boundaries, stale copies, and Kitty generation locking.

**Coordination**

- #11445 overlaps the click-repeat state machine; apply its follow-up or consolidate the changes before merging.
- #11494 overlaps semantic endpoints and `ghostty-vt` wide-grapheme normalization; resolve those endpoint changes on top.
- #11254 is a Ghostty fork pointer change and is not included.

<sup>Written for commit c25b4f53686b2b0ad69ae7319e5e9d629cf9feb1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11511?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved repeated selections and word dragging, including reverse selections and punctuation or whitespace.
  - Prevented stale selections from being copied after terminal content changes.
  - Improved clipboard reliability by validating content before and after copying.
  - Shift-click actions can now be repeated consistently.
  - Selection state now resets appropriately after modifier changes, scrolling, mode changes, and terminal-forwarded clicks.
  - Added safer fallback behavior when semantic selection cannot be repeated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->