### PR TITLE
Release Markdown and diff find focus when switching panes

### DIFF
--- a/Sources/Panels/MarkdownPanel+Focus.swift
+++ b/Sources/Panels/MarkdownPanel+Focus.swift
@@ -1,0 +1,163 @@
+import AppKit
+import CmuxBrowser
+import Foundation
+
+extension MarkdownPanel {
+    // MARK: - Find in preview focus
+
+    /// Shows (or refocuses) the preview find bar. Preview-only: text mode uses
+    /// the NSTextView's native find panel via the responder chain.
+    func startFind() {
+        guard displayMode == .preview else { return }
+        let created = searchState == nil
+        let recoveredNeedle = created ? lastSearchNeedle : ""
+        if created { searchState = BrowserSearchState(needle: recoveredNeedle) }
+        let shouldSelectAll = created && !recoveredNeedle.isEmpty
+        searchFocusRequestGeneration &+= 1
+        let generation = searchFocusRequestGeneration
+        activeSearchFocusRequestGeneration = generation
+        postSearchFocusNotification(generation: generation, selectAll: shouldSelectAll)
+        // Re-post once because the overlay mounts on the same runloop turn and
+        // can miss the first notification.
+        DispatchQueue.main.async { [weak self] in
+            self?.postSearchFocusNotification(generation: generation, selectAll: shouldSelectAll)
+        }
+    }
+
+    /// Hides the preview find bar without changing focus owned by its document.
+    func hideFind() {
+        guard let searchState else { return }
+        let window = windowOwningPreviewFocus()
+        let findResponder = window?.firstResponder.flatMap { cmuxFindTextFieldOwner(for: $0) }
+        let shouldRestorePreviewFocus = findResponder?.window === window &&
+            findResponder?.cmuxSelectionOwner === searchState
+        if shouldRestorePreviewFocus {
+            _ = window?.makeFirstResponder(nil)
+        }
+        self.searchState = nil
+        if shouldRestorePreviewFocus {
+            pendingPreviewFocus = false
+            if displayMode == .preview,
+               let webView = rendererSession.webView,
+               webView.window === window {
+                _ = window?.makeFirstResponder(webView)
+            }
+        }
+    }
+
+    /// Whether an async find-field focus request for `generation` may still
+    /// be applied. Guards against focus theft after hide or a newer request.
+    func canApplySearchFocusRequest(_ generation: UInt64) -> Bool {
+        searchState != nil &&
+            generation == searchFocusRequestGeneration &&
+            activeSearchFocusRequestGeneration == generation
+    }
+
+    /// Invalidates deferred notifications that could otherwise reclaim focus.
+    fileprivate func invalidateSearchFocusRequests() {
+        searchFocusRequestGeneration &+= 1
+        activeSearchFocusRequestGeneration = nil
+    }
+
+    /// Posts a focus request only while its generation is still current.
+    private func postSearchFocusNotification(generation: UInt64, selectAll: Bool) {
+        guard canApplySearchFocusRequest(generation) else { return }
+        NotificationCenter.default.post(
+            name: .browserSearchFocus,
+            object: id,
+            userInfo: [FindFocusNotificationKey.selectAll: selectAll]
+        )
+    }
+
+    /// Releases Markdown-owned AppKit responders when this pane is left.
+    func unfocus() {
+        pendingPreviewFocus = false
+        invalidateSearchFocusRequests()
+
+        guard let window = windowOwningPreviewFocus() else { return }
+        _ = yieldFocusIntent(.panel, in: window)
+    }
+
+    /// Identifies a responder currently owned by this Markdown panel.
+    func ownedFocusIntent(for responder: NSResponder, in window: NSWindow) -> PanelFocusIntent? {
+        ownsKeyboardResponder(responder, in: window) ? .panel : nil
+    }
+
+    @discardableResult
+    /// Yields a previously identified Markdown responder to another panel.
+    func yieldFocusIntent(_ intent: PanelFocusIntent, in window: NSWindow) -> Bool {
+        guard intent == .panel,
+              let firstResponder = window.firstResponder,
+              ownsKeyboardResponder(firstResponder, in: window) else {
+            return false
+        }
+
+        pendingPreviewFocus = false
+        invalidateSearchFocusRequests()
+        return window.makeFirstResponder(nil)
+    }
+
+    /// Finds the AppKit window containing the panel's current first responder.
+    private func windowOwningPreviewFocus() -> NSWindow? {
+        var candidates: [NSWindow] = []
+        if let window = rendererSession.webView?.window {
+            candidates.append(window)
+        }
+        if let keyWindow = NSApp.keyWindow {
+            candidates.append(keyWindow)
+        }
+        if let mainWindow = NSApp.mainWindow {
+            candidates.append(mainWindow)
+        }
+        candidates.append(contentsOf: NSApp.windows)
+
+        var visited = Set<ObjectIdentifier>()
+        for window in candidates {
+            guard visited.insert(ObjectIdentifier(window)).inserted,
+                  let firstResponder = window.firstResponder else {
+                continue
+            }
+            if ownsKeyboardResponder(firstResponder, in: window) {
+                return window
+            }
+        }
+
+        return rendererSession.webView?.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+    }
+
+    /// Returns whether a responder belongs to this panel's input surfaces.
+    private func ownsKeyboardResponder(_ responder: NSResponder, in window: NSWindow) -> Bool {
+        if let searchState,
+           let owner = cmuxFindTextFieldOwner(for: responder),
+           owner.window === window,
+           owner.cmuxSelectionOwner === searchState {
+            return true
+        }
+
+        if let textView,
+           textView.window === window,
+           Self.responderChainContains(responder, target: textView) {
+            return true
+        }
+
+        if let webView = rendererSession.webView,
+           webView.window === window,
+           Self.responderChainContains(responder, target: webView) {
+            return true
+        }
+
+        return false
+    }
+
+    /// Checks a bounded AppKit responder chain for a target view.
+    private static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
+        var current = start
+        var hops = 0
+        while let responder = current, hops < 64 {
+            if responder === target { return true }
+            current = responder.nextResponder
+            hops += 1
+        }
+        return false
+    }
+}

--- a/Sources/Panels/MarkdownPanel+Focus.swift
+++ b/Sources/Panels/MarkdownPanel+Focus.swift
@@ -54,7 +54,7 @@ extension MarkdownPanel {
     }
 
     /// Invalidates deferred notifications that could otherwise reclaim focus.
-    fileprivate func invalidateSearchFocusRequests() {
+    func invalidateSearchFocusRequests() {
         searchFocusRequestGeneration &+= 1
         activeSearchFocusRequestGeneration = nil
     }

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -222,14 +222,20 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         }
     }
 
-    /// Hides the preview find bar after yielding its AppKit responder.
+    /// Hides the preview find bar without changing focus owned by its document.
     func hideFind() {
-        // Release the field editor while searchState still identifies the
-        // overlay as this panel's responder. Clearing the state first would
-        // make the hidden find field indistinguishable from another pane's
-        // responder during the teardown transaction.
-        unfocus()
-        searchState = nil
+        guard let searchState else { return }
+        let window = windowOwningPreviewFocus()
+        let findResponder = window?.firstResponder.flatMap { cmuxFindTextFieldOwner(for: $0) }
+        let shouldRestorePreviewFocus = findResponder?.window === window &&
+            findResponder?.cmuxSelectionOwner === searchState
+        if shouldRestorePreviewFocus {
+            _ = window?.makeFirstResponder(nil)
+        }
+        self.searchState = nil
+        if shouldRestorePreviewFocus {
+            focus()
+        }
     }
 
     /// Whether an async find-field focus request for `generation` may still
@@ -468,7 +474,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         invalidateSearchFocusRequests()
 
         guard let window = windowOwningPreviewFocus() else { return }
-        _ = yieldOwnedKeyboardResponder(in: window)
+        _ = yieldFocusIntent(.panel, in: window)
     }
 
     /// Identifies a responder currently owned by this Markdown panel.
@@ -540,15 +546,6 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         }
 
         return false
-    }
-
-    /// Resigns the panel-owned first responder in the supplied window.
-    private func yieldOwnedKeyboardResponder(in window: NSWindow) -> Bool {
-        guard let firstResponder = window.firstResponder,
-              ownsKeyboardResponder(firstResponder, in: window) else {
-            return false
-        }
-        return window.makeFirstResponder(nil)
     }
 
     /// Checks a bounded AppKit responder chain for a target view.

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -234,7 +234,12 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         }
         self.searchState = nil
         if shouldRestorePreviewFocus {
-            focus()
+            pendingPreviewFocus = false
+            if displayMode == .preview,
+               let webView = rendererSession.webView,
+               webView.window === window {
+                _ = window?.makeFirstResponder(webView)
+            }
         }
     }
 

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -88,16 +88,16 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     /// Incremented whenever find focus ownership changes, so stale async
     /// focus requests posted before a hide/re-show can never steal focus.
-    @Published fileprivate(set) var searchFocusRequestGeneration: UInt64 = 0
+    @Published internal(set) var searchFocusRequestGeneration: UInt64 = 0
 
     /// The generation currently allowed to claim the find field. Leaving the
     /// pane clears this lease even though the monotonic counter continues, so
     /// a newly mounted overlay cannot mistake an invalidated request for a
     /// fresh one.
-    fileprivate var activeSearchFocusRequestGeneration: UInt64?
+    var activeSearchFocusRequestGeneration: UInt64?
 
     private var searchNeedleCancellable: AnyCancellable?
-    fileprivate var lastSearchNeedle = ""
+    var lastSearchNeedle = ""
     private lazy var findService = BrowserFindService(
         evaluator: MarkdownFindWebViewEvaluator(panel: self)
     )
@@ -119,8 +119,8 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     private var pendingSearchNeedle: String?
     /// Set when activation asks a preview panel to focus before SwiftUI has
     /// mounted its WKWebView. The renderer fulfills this at window attach.
-    fileprivate var pendingPreviewFocus = false
-    fileprivate weak var textView: NSTextView?
+    var pendingPreviewFocus = false
+    weak var textView: NSTextView?
     private let selectionReader = NativeTextSurfaceSelectionReader()
     var isClosed: Bool = false
     // NotificationCenter token; removal is thread-safe so deinit can drop it.

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -88,16 +88,16 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     /// Incremented whenever find focus ownership changes, so stale async
     /// focus requests posted before a hide/re-show can never steal focus.
-    @Published private(set) var searchFocusRequestGeneration: UInt64 = 0
+    @Published fileprivate(set) var searchFocusRequestGeneration: UInt64 = 0
 
     /// The generation currently allowed to claim the find field. Leaving the
     /// pane clears this lease even though the monotonic counter continues, so
     /// a newly mounted overlay cannot mistake an invalidated request for a
     /// fresh one.
-    private var activeSearchFocusRequestGeneration: UInt64?
+    fileprivate var activeSearchFocusRequestGeneration: UInt64?
 
     private var searchNeedleCancellable: AnyCancellable?
-    private var lastSearchNeedle = ""
+    fileprivate var lastSearchNeedle = ""
     private lazy var findService = BrowserFindService(
         evaluator: MarkdownFindWebViewEvaluator(panel: self)
     )
@@ -119,8 +119,8 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     private var pendingSearchNeedle: String?
     /// Set when activation asks a preview panel to focus before SwiftUI has
     /// mounted its WKWebView. The renderer fulfills this at window attach.
-    private var pendingPreviewFocus = false
-    private weak var textView: NSTextView?
+    fileprivate var pendingPreviewFocus = false
+    fileprivate weak var textView: NSTextView?
     private let selectionReader = NativeTextSurfaceSelectionReader()
     var isClosed: Bool = false
     // NotificationCenter token; removal is thread-safe so deinit can drop it.
@@ -187,27 +187,6 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         }
     }
 
-    // MARK: - Find in preview (methods)
-
-    /// Shows (or refocuses) the preview find bar. Preview-only: text mode uses
-    /// the NSTextView's native find panel via the responder chain.
-    func startFind() {
-        guard displayMode == .preview else { return }
-        let created = searchState == nil
-        let recoveredNeedle = created ? lastSearchNeedle : ""
-        if created { searchState = BrowserSearchState(needle: recoveredNeedle) }
-        let shouldSelectAll = created && !recoveredNeedle.isEmpty
-        searchFocusRequestGeneration &+= 1
-        let generation = searchFocusRequestGeneration
-        activeSearchFocusRequestGeneration = generation
-        postSearchFocusNotification(generation: generation, selectAll: shouldSelectAll)
-        // Re-post once because the overlay mounts on the same runloop turn and
-        // can miss the first notification.
-        DispatchQueue.main.async { [weak self] in
-            self?.postSearchFocusNotification(generation: generation, selectAll: shouldSelectAll)
-        }
-    }
-
     func findNext() {
         Task { @MainActor [weak self] in
             guard let self else { return }
@@ -220,51 +199,6 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
             guard let self else { return }
             self.applyFindMatchCount(await self.findService.previous())
         }
-    }
-
-    /// Hides the preview find bar without changing focus owned by its document.
-    func hideFind() {
-        guard let searchState else { return }
-        let window = windowOwningPreviewFocus()
-        let findResponder = window?.firstResponder.flatMap { cmuxFindTextFieldOwner(for: $0) }
-        let shouldRestorePreviewFocus = findResponder?.window === window &&
-            findResponder?.cmuxSelectionOwner === searchState
-        if shouldRestorePreviewFocus {
-            _ = window?.makeFirstResponder(nil)
-        }
-        self.searchState = nil
-        if shouldRestorePreviewFocus {
-            pendingPreviewFocus = false
-            if displayMode == .preview,
-               let webView = rendererSession.webView,
-               webView.window === window {
-                _ = window?.makeFirstResponder(webView)
-            }
-        }
-    }
-
-    /// Whether an async find-field focus request for `generation` may still
-    /// be applied. Guards against focus theft after hide or a newer request.
-    func canApplySearchFocusRequest(_ generation: UInt64) -> Bool {
-        searchState != nil &&
-            generation == searchFocusRequestGeneration &&
-            activeSearchFocusRequestGeneration == generation
-    }
-
-    /// Invalidates deferred notifications that could otherwise reclaim focus.
-    private func invalidateSearchFocusRequests() {
-        searchFocusRequestGeneration &+= 1
-        activeSearchFocusRequestGeneration = nil
-    }
-
-    /// Posts a focus request only while its generation is still current.
-    private func postSearchFocusNotification(generation: UInt64, selectAll: Bool) {
-        guard canApplySearchFocusRequest(generation) else { return }
-        NotificationCenter.default.post(
-            name: .browserSearchFocus,
-            object: id,
-            userInfo: [FindFocusNotificationKey.selectAll: selectAll]
-        )
     }
 
     private func handleSearchStateChange(oldValue: BrowserSearchState?) {
@@ -471,98 +405,6 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     func replayPendingPreviewFocusAfterWindowAttach() {
         guard pendingPreviewFocus, displayMode == .preview else { return }
         focus()
-    }
-
-    /// Releases Markdown-owned AppKit responders when this pane is left.
-    func unfocus() {
-        pendingPreviewFocus = false
-        invalidateSearchFocusRequests()
-
-        guard let window = windowOwningPreviewFocus() else { return }
-        _ = yieldFocusIntent(.panel, in: window)
-    }
-
-    /// Identifies a responder currently owned by this Markdown panel.
-    func ownedFocusIntent(for responder: NSResponder, in window: NSWindow) -> PanelFocusIntent? {
-        ownsKeyboardResponder(responder, in: window) ? .panel : nil
-    }
-
-    @discardableResult
-    /// Yields a previously identified Markdown responder to another panel.
-    func yieldFocusIntent(_ intent: PanelFocusIntent, in window: NSWindow) -> Bool {
-        guard intent == .panel,
-              let firstResponder = window.firstResponder,
-              ownsKeyboardResponder(firstResponder, in: window) else {
-            return false
-        }
-
-        pendingPreviewFocus = false
-        invalidateSearchFocusRequests()
-        return window.makeFirstResponder(nil)
-    }
-
-    /// Finds the AppKit window containing the panel's current first responder.
-    private func windowOwningPreviewFocus() -> NSWindow? {
-        var candidates: [NSWindow] = []
-        if let window = rendererSession.webView?.window {
-            candidates.append(window)
-        }
-        if let keyWindow = NSApp.keyWindow {
-            candidates.append(keyWindow)
-        }
-        if let mainWindow = NSApp.mainWindow {
-            candidates.append(mainWindow)
-        }
-        candidates.append(contentsOf: NSApp.windows)
-
-        var visited = Set<ObjectIdentifier>()
-        for window in candidates {
-            guard visited.insert(ObjectIdentifier(window)).inserted,
-                  let firstResponder = window.firstResponder else {
-                continue
-            }
-            if ownsKeyboardResponder(firstResponder, in: window) {
-                return window
-            }
-        }
-
-        return rendererSession.webView?.window ?? NSApp.keyWindow ?? NSApp.mainWindow
-    }
-
-    /// Returns whether a responder belongs to this panel's input surfaces.
-    private func ownsKeyboardResponder(_ responder: NSResponder, in window: NSWindow) -> Bool {
-        if let searchState,
-           let owner = cmuxFindTextFieldOwner(for: responder),
-           owner.window === window,
-           owner.cmuxSelectionOwner === searchState {
-            return true
-        }
-
-        if let textView,
-           textView.window === window,
-           Self.responderChainContains(responder, target: textView) {
-            return true
-        }
-
-        if let webView = rendererSession.webView,
-           webView.window === window,
-           Self.responderChainContains(responder, target: webView) {
-            return true
-        }
-
-        return false
-    }
-
-    /// Checks a bounded AppKit responder chain for a target view.
-    private static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
-        var current = start
-        var hops = 0
-        while let responder = current, hops < 64 {
-            if responder === target { return true }
-            current = responder.nextResponder
-            hops += 1
-        }
-        return false
     }
 
     /// Closes the panel and tears down its renderer and file watcher.

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -90,6 +90,12 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
     /// focus requests posted before a hide/re-show can never steal focus.
     @Published private(set) var searchFocusRequestGeneration: UInt64 = 0
 
+    /// The generation currently allowed to claim the find field. Leaving the
+    /// pane clears this lease even though the monotonic counter continues, so
+    /// a newly mounted overlay cannot mistake an invalidated request for a
+    /// fresh one.
+    private var activeSearchFocusRequestGeneration: UInt64?
+
     private var searchNeedleCancellable: AnyCancellable?
     private var lastSearchNeedle = ""
     private lazy var findService = BrowserFindService(
@@ -193,6 +199,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         let shouldSelectAll = created && !recoveredNeedle.isEmpty
         searchFocusRequestGeneration &+= 1
         let generation = searchFocusRequestGeneration
+        activeSearchFocusRequestGeneration = generation
         postSearchFocusNotification(generation: generation, selectAll: shouldSelectAll)
         // Re-post once because the overlay mounts on the same runloop turn and
         // can miss the first notification.
@@ -215,16 +222,31 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         }
     }
 
+    /// Hides the preview find bar after yielding its AppKit responder.
     func hideFind() {
+        // Release the field editor while searchState still identifies the
+        // overlay as this panel's responder. Clearing the state first would
+        // make the hidden find field indistinguishable from another pane's
+        // responder during the teardown transaction.
+        unfocus()
         searchState = nil
     }
 
     /// Whether an async find-field focus request for `generation` may still
     /// be applied. Guards against focus theft after hide or a newer request.
     func canApplySearchFocusRequest(_ generation: UInt64) -> Bool {
-        searchState != nil && generation == searchFocusRequestGeneration
+        searchState != nil &&
+            generation == searchFocusRequestGeneration &&
+            activeSearchFocusRequestGeneration == generation
     }
 
+    /// Invalidates deferred notifications that could otherwise reclaim focus.
+    private func invalidateSearchFocusRequests() {
+        searchFocusRequestGeneration &+= 1
+        activeSearchFocusRequestGeneration = nil
+    }
+
+    /// Posts a focus request only while its generation is still current.
     private func postSearchFocusNotification(generation: UInt64, selectAll: Bool) {
         guard canApplySearchFocusRequest(generation) else { return }
         NotificationCenter.default.post(
@@ -256,7 +278,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         } else if let oldValue {
             lastSearchNeedle = oldValue.needle
             searchNeedleCancellable = nil
-            searchFocusRequestGeneration &+= 1
+            invalidateSearchFocusRequests()
             executeFindClear()
         }
     }
@@ -440,11 +462,110 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
         focus()
     }
 
+    /// Releases Markdown-owned AppKit responders when this pane is left.
     func unfocus() {
         pendingPreviewFocus = false
+        invalidateSearchFocusRequests()
+
+        guard let window = windowOwningPreviewFocus() else { return }
+        _ = yieldOwnedKeyboardResponder(in: window)
     }
 
+    /// Identifies a responder currently owned by this Markdown panel.
+    func ownedFocusIntent(for responder: NSResponder, in window: NSWindow) -> PanelFocusIntent? {
+        ownsKeyboardResponder(responder, in: window) ? .panel : nil
+    }
+
+    @discardableResult
+    /// Yields a previously identified Markdown responder to another panel.
+    func yieldFocusIntent(_ intent: PanelFocusIntent, in window: NSWindow) -> Bool {
+        guard intent == .panel,
+              let firstResponder = window.firstResponder,
+              ownsKeyboardResponder(firstResponder, in: window) else {
+            return false
+        }
+
+        pendingPreviewFocus = false
+        invalidateSearchFocusRequests()
+        return window.makeFirstResponder(nil)
+    }
+
+    /// Finds the AppKit window containing the panel's current first responder.
+    private func windowOwningPreviewFocus() -> NSWindow? {
+        var candidates: [NSWindow] = []
+        if let window = rendererSession.webView?.window {
+            candidates.append(window)
+        }
+        if let keyWindow = NSApp.keyWindow {
+            candidates.append(keyWindow)
+        }
+        if let mainWindow = NSApp.mainWindow {
+            candidates.append(mainWindow)
+        }
+        candidates.append(contentsOf: NSApp.windows)
+
+        var visited = Set<ObjectIdentifier>()
+        for window in candidates {
+            guard visited.insert(ObjectIdentifier(window)).inserted,
+                  let firstResponder = window.firstResponder else {
+                continue
+            }
+            if ownsKeyboardResponder(firstResponder, in: window) {
+                return window
+            }
+        }
+
+        return rendererSession.webView?.window ?? NSApp.keyWindow ?? NSApp.mainWindow
+    }
+
+    /// Returns whether a responder belongs to this panel's input surfaces.
+    private func ownsKeyboardResponder(_ responder: NSResponder, in window: NSWindow) -> Bool {
+        if let searchState,
+           let owner = cmuxFindTextFieldOwner(for: responder),
+           owner.window === window,
+           owner.cmuxSelectionOwner === searchState {
+            return true
+        }
+
+        if let textView,
+           textView.window === window,
+           Self.responderChainContains(responder, target: textView) {
+            return true
+        }
+
+        if let webView = rendererSession.webView,
+           webView.window === window,
+           Self.responderChainContains(responder, target: webView) {
+            return true
+        }
+
+        return false
+    }
+
+    /// Resigns the panel-owned first responder in the supplied window.
+    private func yieldOwnedKeyboardResponder(in window: NSWindow) -> Bool {
+        guard let firstResponder = window.firstResponder,
+              ownsKeyboardResponder(firstResponder, in: window) else {
+            return false
+        }
+        return window.makeFirstResponder(nil)
+    }
+
+    /// Checks a bounded AppKit responder chain for a target view.
+    private static func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
+        var current = start
+        var hops = 0
+        while let responder = current, hops < 64 {
+            if responder === target { return true }
+            current = responder.nextResponder
+            hops += 1
+        }
+        return false
+    }
+
+    /// Closes the panel and tears down its renderer and file watcher.
     func close() {
+        unfocus()
         isClosed = true
         pendingPreviewFocus = false
         searchState = nil

--- a/Sources/Panels/MarkdownPanel.swift
+++ b/Sources/Panels/MarkdownPanel.swift
@@ -88,7 +88,7 @@ final class MarkdownPanel: Panel, ObservableObject, FilePreviewTextEditingPanel 
 
     /// Incremented whenever find focus ownership changes, so stale async
     /// focus requests posted before a hide/re-show can never steal focus.
-    @Published internal(set) var searchFocusRequestGeneration: UInt64 = 0
+    @Published var searchFocusRequestGeneration: UInt64 = 0
 
     /// The generation currently allowed to claim the find field. Leaving the
     /// pane clears this lease even though the monotonic counter continues, so

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1732,7 +1732,6 @@
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F0 /* MarkdownPanelFileLinkResolver.swift */; };
 		D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3664001D3664001D3664001 /* MarkdownPanelTests.swift */; };
-		D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
 		F5168A020000000000000001 /* MarkdownTypographyControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A020000000000000002 /* MarkdownTypographyControl.swift */; };
 		F5168A060000000000000001 /* MarkdownTypographyDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A060000000000000002 /* MarkdownTypographyDefaults.swift */; };
@@ -1964,6 +1963,7 @@
 		D0B752900000000000000002 /* PaneDropRoutingRegistration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B752900000000000000001 /* PaneDropRoutingRegistration.swift */; };
 		D0B752900000000000000004 /* PaneDropRoutingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B752900000000000000003 /* PaneDropRoutingSession.swift */; };
 		D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */; };
+		D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		986900050000000000000001 /* PanelHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986900050000000000000002 /* PanelHost.swift */; };
@@ -5092,7 +5092,6 @@
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
 		D3664001D3664001D3664001 /* MarkdownPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTests.swift; sourceTree = "<group>"; };
-		D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneFocusFindResponderTests.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
 		F5168A020000000000000002 /* MarkdownTypographyControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTypographyControl.swift; sourceTree = "<group>"; };
 		F5168A060000000000000002 /* MarkdownTypographyDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTypographyDefaults.swift; sourceTree = "<group>"; };
@@ -5323,6 +5322,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		D0B752900000000000000001 /* PaneDropRoutingRegistration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingRegistration.swift; sourceTree = "<group>"; };
 		D0B752900000000000000003 /* PaneDropRoutingSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSession.swift; sourceTree = "<group>"; };
 		D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSupport.swift; sourceTree = "<group>"; };
+		D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneFocusFindResponderTests.swift; sourceTree = "<group>"; };
 		A5001410 /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/Panel.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		986900050000000000000002 /* PanelHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelHost.swift; sourceTree = "<group>"; };
@@ -13685,7 +13685,6 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7470002D7470002D7470002 /* MarkdownLinkBoundaryRegressionTests.swift in Sources */,
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
-				D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */,
 					7490A0017490A0017490A001 /* MemoryPressureMonitorTests.swift in Sources */,
 				606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */,
 					C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */,
@@ -13730,6 +13729,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				9637C6D3170F4BE1A7EF6243 /* OmnibarSubmitDecisionTests.swift in Sources */,
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
+				D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */,
 					C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
 					6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
 				B88350000000000000000003 /* PasteboardThreadSignalingDataProvider.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1729,6 +1729,7 @@
 		D7470002D7470002D7470002 /* MarkdownLinkBoundaryRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */; };
 		F5168A050000000000000001 /* MarkdownMaxWidthSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A050000000000000002 /* MarkdownMaxWidthSettings.swift */; };
 		D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */; };
+		C0DE11362000000000000001 /* MarkdownPanel+Focus.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE11362000000000000002 /* MarkdownPanel+Focus.swift */; };
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F0 /* MarkdownPanelFileLinkResolver.swift */; };
 		D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3664001D3664001D3664001 /* MarkdownPanelTests.swift */; };
@@ -5090,6 +5091,7 @@
 		D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownLinkBoundaryRegressionTests.swift; sourceTree = "<group>"; };
 		F5168A050000000000000002 /* MarkdownMaxWidthSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownMaxWidthSettings.swift; sourceTree = "<group>"; };
 		D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMermaidZoomTests.swift; sourceTree = "<group>"; };
+		C0DE11362000000000000002 /* MarkdownPanel+Focus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel+Focus.swift; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
 		D3664001D3664001D3664001 /* MarkdownPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTests.swift; sourceTree = "<group>"; };
@@ -8684,6 +8686,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5010000000000000000001D /* BrowserWebAuthnTransport.swift */,
 				A5010000000000000000001F /* BrowserWebAuthnTransportSummary.swift */,
 				A50100000000000000000021 /* BrowserWebAuthnUserDescriptor.swift */,
+				C0DE11362000000000000002 /* MarkdownPanel+Focus.swift */,
 				A5001418 /* MarkdownPanel.swift */,
 				10200F1E0000000000000002 /* FileContentChangeCoordinator.swift */,
 				10200F1E0000000000000008 /* FileContentChangeCoordinator+Entry.swift */,
@@ -11798,6 +11801,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F5168A070000000000000001 /* MarkdownFontFamilyCache.swift in Sources */,
 				F5168A030000000000000001 /* MarkdownFontSizeSettings.swift in Sources */,
 				F5168A050000000000000001 /* MarkdownMaxWidthSettings.swift in Sources */,
+				C0DE11362000000000000001 /* MarkdownPanel+Focus.swift in Sources */,
 				A5001420 /* MarkdownPanel.swift in Sources */,
 				A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */,
 				A5001421 /* MarkdownPanelView.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1732,6 +1732,7 @@
 		A5001420 /* MarkdownPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001418 /* MarkdownPanel.swift */; };
 		A50014F2 /* MarkdownPanelFileLinkResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50014F0 /* MarkdownPanelFileLinkResolver.swift */; };
 		D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3664001D3664001D3664001 /* MarkdownPanelTests.swift */; };
+		D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */; };
 		A5001421 /* MarkdownPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001419 /* MarkdownPanelView.swift */; };
 		F5168A020000000000000001 /* MarkdownTypographyControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A020000000000000002 /* MarkdownTypographyControl.swift */; };
 		F5168A060000000000000001 /* MarkdownTypographyDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5168A060000000000000002 /* MarkdownTypographyDefaults.swift */; };
@@ -5091,6 +5092,7 @@
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
 		D3664001D3664001D3664001 /* MarkdownPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTests.swift; sourceTree = "<group>"; };
+		D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneFocusFindResponderTests.swift; sourceTree = "<group>"; };
 		A5001419 /* MarkdownPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelView.swift; sourceTree = "<group>"; };
 		F5168A020000000000000002 /* MarkdownTypographyControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTypographyControl.swift; sourceTree = "<group>"; };
 		F5168A060000000000000002 /* MarkdownTypographyDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownTypographyDefaults.swift; sourceTree = "<group>"; };
@@ -9796,6 +9798,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D8072A03D8072A03D8072A03 /* BrowserViewportRuntimeTests.swift */,
 				D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
+				D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */,
 				A3340001A3340001A3340001 /* ViewerNavigationTests.swift */,
 				9648DEAE0000000000000001 /* DiffViewerPickerCommandRunnerTests.swift */,
 				9648DEAD0000000000000001 /* DiffViewerURLSchemeHandlerLifecycleTests.swift */,
@@ -13682,6 +13685,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7470002D7470002D7470002 /* MarkdownLinkBoundaryRegressionTests.swift in Sources */,
 				D6069002D6069002D6069002 /* MarkdownMermaidZoomTests.swift in Sources */,
 				D3664002D3664002D3664002 /* MarkdownPanelTests.swift in Sources */,
+				D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */,
 					7490A0017490A0017490A001 /* MemoryPressureMonitorTests.swift in Sources */,
 				606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */,
 					C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -195,6 +195,7 @@
 		REE0CA0000000000000000E2 /* AIAccountsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = REE0CA0000000000000000E1 /* AIAccountsClient.swift */; };
 		A115C0DE0000000000000002 /* AllShortcutsPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A115C0DE0000000000000001 /* AllShortcutsPopover.swift */; };
 		9758A0000000000000000002 /* AmpVaultRegistrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9758A0000000000000000001 /* AmpVaultRegistrationTests.swift */; };
+		A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */; };
 		F4350A110000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */; };
 		F4350A120000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */; };
 		A5C01700000000000000000D /* AppDelegate+AccountSignInWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5C01700000000000000000E /* AppDelegate+AccountSignInWorkspace.swift */; };
@@ -1252,6 +1253,7 @@
 		C0DE31410000000000000103 /* DebugEventLogSerializedAppendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31410000000000000104 /* DebugEventLogSerializedAppendTests.swift */; };
 		A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */; };
 		917300000000000000000001 /* DeferredActionReplacementStackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917300000000000000000002 /* DeferredActionReplacementStackTests.swift */; };
+		A54730000000000000000006 /* DeferredAgentResumeIndexFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */; };
 		D10786DB0000000000000001 /* DeferredBrowserPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10786DB0000000000000002 /* DeferredBrowserPanel.swift */; };
 		D10786DB0000000000000003 /* DeferredBrowserPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10786DB0000000000000004 /* DeferredBrowserPanelView.swift */; };
 		F87910140000000000000001 /* DeferredWorkspaceTerminalFontSizeCoordinatorJoin.swift in Sources */ = {isa = PBXBuildFile; fileRef = F87910140000000000000002 /* DeferredWorkspaceTerminalFontSizeCoordinatorJoin.swift */; };
@@ -2015,9 +2017,6 @@
 		8672F0018672F0018672F001 /* PiFeedOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8672F0028672F0028672F002 /* PiFeedOwnershipTests.swift */; };
 		8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
-		A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */; };
-		A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000003 /* RestoredStartupInputResendTests.swift */; };
-		A54730000000000000000006 /* DeferredAgentResumeIndexFallbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */; };
 		5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */; };
 		B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */; };
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
@@ -2251,6 +2250,7 @@
 		F54100B0A1B2C3D4E5F60718 /* RestorableCodexForkTagTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F54100B1A1B2C3D4E5F60718 /* RestorableCodexForkTagTests.swift */; };
 		C7C5FAF3145342F395DB4C40 /* RestoredAgentCompletedGeneration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9864510B84F2428BB83568CF /* RestoredAgentCompletedGeneration.swift */; };
 		C7C5FAF2145342F395DB4C40 /* RestoredAgentLifecycleCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9864510A84F2428BB83568CF /* RestoredAgentLifecycleCoordinator.swift */; };
+		A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A54730000000000000000003 /* RestoredStartupInputResendTests.swift */; };
 		9200B0019200B0019200B001 /* ResumeLauncherCwdConsistencyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9200B0019200B0019200B002 /* ResumeLauncherCwdConsistencyTests.swift */; };
 		B7F9A600B7F9A600B7F9A600 /* RightSidebarChromeGeometryReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F9A601B7F9A601B7F9A601 /* RightSidebarChromeGeometryReporting.swift */; };
 		AA1B2C3D4E5F60720 /* RightSidebarChromeHeightUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F60721 /* RightSidebarChromeHeightUITests.swift */; };
@@ -3664,6 +3664,7 @@
 		REE0CA0000000000000000E1 /* AIAccountsClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AIAccountsClient.swift; sourceTree = "<group>"; };
 		A115C0DE0000000000000001 /* AllShortcutsPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllShortcutsPopover.swift; sourceTree = "<group>"; };
 		9758A0000000000000000001 /* AmpVaultRegistrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AmpVaultRegistrationTests.swift; sourceTree = "<group>"; };
+		A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntigravityHookSessionSnapshotRestoreTests.swift; sourceTree = "<group>"; };
 		F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AppBundleIconPersistencePolicy.swift; sourceTree = "<group>"; };
 		A5C01700000000000000000E /* AppDelegate+AccountSignInWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+AccountSignInWorkspace.swift"; sourceTree = "<group>"; };
 		80410000000000000000000A /* AppDelegate+AdjacentNavigationShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+AdjacentNavigationShortcut.swift"; sourceTree = "<group>"; };
@@ -4622,6 +4623,7 @@
 		C0DE31410000000000000104 /* DebugEventLogSerializedAppendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugEventLogSerializedAppendTests.swift; sourceTree = "<group>"; };
 		A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DebugLogging.swift; sourceTree = "<group>"; };
 		917300000000000000000002 /* DeferredActionReplacementStackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredActionReplacementStackTests.swift; sourceTree = "<group>"; };
+		A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredAgentResumeIndexFallbackTests.swift; sourceTree = "<group>"; };
 		D10786DB0000000000000002 /* DeferredBrowserPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DeferredBrowserPanel.swift; sourceTree = "<group>"; };
 		D10786DB0000000000000004 /* DeferredBrowserPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DeferredBrowserPanelView.swift; sourceTree = "<group>"; };
 		F87910140000000000000002 /* DeferredWorkspaceTerminalFontSizeCoordinatorJoin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredWorkspaceTerminalFontSizeCoordinatorJoin.swift; sourceTree = "<group>"; };
@@ -5376,9 +5378,6 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		8672F0028672F0028672F002 /* PiFeedOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiFeedOwnershipTests.swift; sourceTree = "<group>"; };
 		8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiFeedV2CallResultBox.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
-		A54730000000000000000001 /* AntigravityHookSessionSnapshotRestoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AntigravityHookSessionSnapshotRestoreTests.swift; sourceTree = "<group>"; };
-		A54730000000000000000003 /* RestoredStartupInputResendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoredStartupInputResendTests.swift; sourceTree = "<group>"; };
-		A54730000000000000000005 /* DeferredAgentResumeIndexFallbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeferredAgentResumeIndexFallbackTests.swift; sourceTree = "<group>"; };
 		5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerCursorOcclusionTests.swift; sourceTree = "<group>"; };
 		4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalHitTestingPerformanceTests.swift; sourceTree = "<group>"; };
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
@@ -5608,6 +5607,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		F54100B1A1B2C3D4E5F60718 /* RestorableCodexForkTagTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestorableCodexForkTagTests.swift; sourceTree = "<group>"; };
 		9864510B84F2428BB83568CF /* RestoredAgentCompletedGeneration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoredAgentCompletedGeneration.swift; sourceTree = "<group>"; };
 		9864510A84F2428BB83568CF /* RestoredAgentLifecycleCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoredAgentLifecycleCoordinator.swift; sourceTree = "<group>"; };
+		A54730000000000000000003 /* RestoredStartupInputResendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RestoredStartupInputResendTests.swift; sourceTree = "<group>"; };
 		9200B0019200B0019200B002 /* ResumeLauncherCwdConsistencyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResumeLauncherCwdConsistencyTests.swift; sourceTree = "<group>"; };
 		B7F9A601B7F9A601B7F9A601 /* RightSidebarChromeGeometryReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarChromeGeometryReporting.swift; sourceTree = "<group>"; };
 		AA1B2C3D4E5F60721 /* RightSidebarChromeHeightUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RightSidebarChromeHeightUITests.swift; sourceTree = "<group>"; };
@@ -13302,6 +13302,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A9E030000000000000000002 /* AgentSessionSocketSurfaceTests.swift in Sources */,
 				A9E050000000000000000002 /* AgentSessionWebRendererTests.swift in Sources */,
 				9758A0000000000000000002 /* AmpVaultRegistrationTests.swift in Sources */,
+				A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */,
 				725746692D9647948561044D /* AppDelegateBareSpaceShortcutRoutingTests.swift in Sources */,
 				A1B2C3D4E5F600000000CF01 /* AppDelegateDisplayConfigRestoreTests.swift in Sources */,
 				E3309A09 /* AppDelegateEqualizeSplitsShortcutTests.swift in Sources */,
@@ -13553,6 +13554,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				DEBDADADADADADADAD000003 /* DebugDogfoodCredentialResolverTests.swift in Sources */,
 				C0DE31410000000000000103 /* DebugEventLogSerializedAppendTests.swift in Sources */,
 				917300000000000000000001 /* DeferredActionReplacementStackTests.swift in Sources */,
+				A54730000000000000000006 /* DeferredAgentResumeIndexFallbackTests.swift in Sources */,
 				C0DE75890000000000000003 /* DeflatedAssetTestSupport.swift in Sources */,
 				B0555303B0555303B0555303 /* DetachedFolderPathLookupCacheTests.swift in Sources */,
 				DE71CE000000000000000002 /* DeviceRegistryClientTests.swift in Sources */,
@@ -13751,9 +13753,6 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8672F0018672F0018672F001 /* PiFeedOwnershipTests.swift in Sources */,
 				8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */,
 				B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
-				A54730000000000000000002 /* AntigravityHookSessionSnapshotRestoreTests.swift in Sources */,
-				A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */,
-				A54730000000000000000006 /* DeferredAgentResumeIndexFallbackTests.swift in Sources */,
 				5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */,
 					B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,
@@ -13836,6 +13835,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					F5410006A1B2C3D4E5F60718 /* RestorableAgentSessionIndexTests.swift in Sources */,
 					F54100A0A1B2C3D4E5F60718 /* RestorableAgentSessionStalePIDTests.swift in Sources */,
 					F54100B0A1B2C3D4E5F60718 /* RestorableCodexForkTagTests.swift in Sources */,
+				A54730000000000000000004 /* RestoredStartupInputResendTests.swift in Sources */,
 				9200B0019200B0019200B001 /* ResumeLauncherCwdConsistencyTests.swift in Sources */,
 				C3408A000000000000000003 /* RightSidebarCommandPaletteTests.swift in Sources */,
 				C57570010000000000000002 /* RightSidebarPanelViewTestSupport.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -5091,7 +5091,7 @@
 		D7470001D7470001D7470001 /* MarkdownLinkBoundaryRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownLinkBoundaryRegressionTests.swift; sourceTree = "<group>"; };
 		F5168A050000000000000002 /* MarkdownMaxWidthSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownMaxWidthSettings.swift; sourceTree = "<group>"; };
 		D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownMermaidZoomTests.swift; sourceTree = "<group>"; };
-		C0DE11362000000000000002 /* MarkdownPanel+Focus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel+Focus.swift; sourceTree = "<group>"; };
+		C0DE11362000000000000002 /* MarkdownPanel+Focus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/MarkdownPanel+Focus.swift"; sourceTree = "<group>"; };
 		A5001418 /* MarkdownPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanel.swift; sourceTree = "<group>"; };
 		A50014F0 /* MarkdownPanelFileLinkResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/MarkdownPanelFileLinkResolver.swift; sourceTree = "<group>"; };
 		D3664001D3664001D3664001 /* MarkdownPanelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownPanelTests.swift; sourceTree = "<group>"; };

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1964,6 +1964,7 @@
 		D0B752900000000000000004 /* PaneDropRoutingSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B752900000000000000003 /* PaneDropRoutingSession.swift */; };
 		D0B1001CA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */; };
 		D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */; };
+		D1136204D1136204D1136204 /* PaneFocusTestWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1136203D1136203D1136203 /* PaneFocusTestWindow.swift */; };
 		A5001400 /* Panel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001410 /* Panel.swift */; };
 		A5001405 /* PanelContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001415 /* PanelContentView.swift */; };
 		986900050000000000000001 /* PanelHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986900050000000000000002 /* PanelHost.swift */; };
@@ -5323,6 +5324,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		D0B752900000000000000003 /* PaneDropRoutingSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSession.swift; sourceTree = "<group>"; };
 		D0B1001DA1B2C3D4E5F60001 /* PaneDropRoutingSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneDropRoutingSupport.swift; sourceTree = "<group>"; };
 		D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneFocusFindResponderTests.swift; sourceTree = "<group>"; };
+		D1136203D1136203D1136203 /* PaneFocusTestWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneFocusTestWindow.swift; sourceTree = "<group>"; };
 		A5001410 /* Panel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/Panel.swift; sourceTree = "<group>"; };
 		A5001415 /* PanelContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PanelContentView.swift; sourceTree = "<group>"; };
 		986900050000000000000002 /* PanelHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PanelHost.swift; sourceTree = "<group>"; };
@@ -9799,6 +9801,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D6069001D6069001D6069001 /* MarkdownMermaidZoomTests.swift */,
 				D3664001D3664001D3664001 /* MarkdownPanelTests.swift */,
 				D1136201D1136201D1136201 /* PaneFocusFindResponderTests.swift */,
+				D1136203D1136203D1136203 /* PaneFocusTestWindow.swift */,
 				A3340001A3340001A3340001 /* ViewerNavigationTests.swift */,
 				9648DEAE0000000000000001 /* DiffViewerPickerCommandRunnerTests.swift */,
 				9648DEAD0000000000000001 /* DiffViewerURLSchemeHandlerLifecycleTests.swift */,
@@ -13730,6 +13733,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				0A0F00550000000000000001 /* OmpSupportTests.swift in Sources */,
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
 				D1136202D1136202D1136202 /* PaneFocusFindResponderTests.swift in Sources */,
+				D1136204D1136204D1136204 /* PaneFocusTestWindow.swift in Sources */,
 					C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
 					6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
 				B88350000000000000000003 /* PasteboardThreadSignalingDataProvider.swift in Sources */,

--- a/cmuxTests/PaneFocusFindResponderTests.swift
+++ b/cmuxTests/PaneFocusFindResponderTests.swift
@@ -1,6 +1,6 @@
 import AppKit
+import Testing
 import WebKit
-import XCTest
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -11,7 +11,10 @@ import XCTest
 /// Regression coverage for find controls that must yield AppKit focus when a
 /// pane-selection transaction moves keyboard input to another pane.
 @MainActor
-final class PaneFocusFindResponderTests: XCTestCase {
+@Suite("Pane focus find responder", .serialized)
+struct PaneFocusFindResponderTests {
+    /// Verifies that pane leave releases a Markdown find field responder.
+    @Test
     func testMarkdownFindFieldIsReleasedWhenPaneFocusMoves() throws {
         let fileManager = FileManager.default
         let directoryURL = fileManager.temporaryDirectory
@@ -38,7 +41,7 @@ final class PaneFocusFindResponderTests: XCTestCase {
         }
 
         panel.startFind()
-        let searchState = try XCTUnwrap(panel.searchState)
+        let searchState = try #require(panel.searchState)
         let container = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 240))
         let rendererCoordinator = panel.rendererSession.coordinator(
             panelId: panel.id,
@@ -66,17 +69,13 @@ final class PaneFocusFindResponderTests: XCTestCase {
         window.initialFirstResponder = findField
         window.makeKeyAndOrderFront(nil)
 
-        XCTAssertTrue(
+        #expect(
             window.makeFirstResponder(findField),
             "The Markdown find field must own first responder before the pane move"
         )
-        guard let firstResponder = window.firstResponder else {
-            XCTFail("Expected a Markdown find responder")
-            return
-        }
-        XCTAssertEqual(
-            panel.ownedFocusIntent(for: firstResponder, in: window),
-            .panel,
+        let firstResponder = try #require(window.firstResponder)
+        #expect(
+            panel.ownedFocusIntent(for: firstResponder, in: window) == .panel,
             "The pane boundary must identify the Markdown find field as owned focus"
         )
         let generationBeforeLeave = panel.searchFocusRequestGeneration
@@ -85,20 +84,82 @@ final class PaneFocusFindResponderTests: XCTestCase {
         // split, and close selection paths.
         panel.unfocus()
 
-        XCTAssertFalse(
-            panel.ownedFocusIntent(for: window.firstResponder ?? window, in: window) == .panel,
+        #expect(
+            panel.ownedFocusIntent(for: window.firstResponder ?? window, in: window) != .panel,
             "A Markdown find field must no longer own focus after leaving its pane"
         )
-        XCTAssertFalse(
-            window.firstResponder === findField,
+        #expect(
+            window.firstResponder !== findField,
             "Leaving a Markdown pane must resign its find field first responder"
         )
-        XCTAssertFalse(
-            panel.canApplySearchFocusRequest(generationBeforeLeave),
+        #expect(
+            !panel.canApplySearchFocusRequest(generationBeforeLeave),
             "Pending Cmd+F focus requests must be invalidated when the pane is left"
+        )
+        #expect(
+            !panel.canApplySearchFocusRequest(panel.searchFocusRequestGeneration),
+            "A newly mounted find overlay must not reclaim focus after the pane is left"
         )
     }
 
+    /// Verifies that hiding the find bar releases its field editor first.
+    @Test
+    func testMarkdownHideFindReleasesItsFieldEditorBeforeTeardown() throws {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-hide-find-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        let fileURL = directoryURL.appendingPathComponent("README.md")
+        try "# Hide find\n".write(to: fileURL, atomically: true, encoding: .utf8)
+        let panel = MarkdownPanel(workspaceId: UUID(), filePath: fileURL.path)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 180),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+
+        panel.startFind()
+        let searchState = try #require(panel.searchState)
+        let findField = FindSelectionTrackingTextField(
+            frame: NSRect(x: 20, y: 120, width: 180, height: 24)
+        )
+        findField.isEditable = true
+        findField.isSelectable = true
+        findField.isEnabled = true
+        findField.cmuxSelectionOwner = searchState
+        window.contentView = findField
+        window.makeKeyAndOrderFront(nil)
+
+        #expect(window.makeFirstResponder(findField))
+        #expect(
+            panel.ownedFocusIntent(for: window.firstResponder ?? window, in: window) == .panel
+        )
+        let capturedResponder = try #require(window.firstResponder)
+
+        panel.hideFind()
+
+        #expect(panel.searchState == nil)
+        #expect(
+            window.firstResponder !== capturedResponder,
+            "Hiding the find bar must resign the field editor responder itself"
+        )
+        #expect(
+            window.firstResponder !== findField,
+            "Hiding the find bar must resign its field editor before removing ownership state"
+        )
+    }
+
+    /// Verifies that a diff viewer WebView yields focus on pane leave.
+    @Test
     func testDiffViewerFindWebViewIsReleasedWhenPaneFocusMoves() throws {
         let panel = BrowserPanel(
             workspaceId: UUID(),
@@ -116,13 +177,13 @@ final class PaneFocusFindResponderTests: XCTestCase {
             panel.close()
         }
 
-        let webView = try XCTUnwrap(panel.webView as? CmuxWebView)
+        let webView = try #require(panel.webView as? CmuxWebView)
         webView.diffViewerFocusStateDidChange(
             viewer: true,
             editable: true,
             rendererReady: true
         )
-        XCTAssertTrue(
+        #expect(
             panel.isDiffViewerFindOwner,
             "The fixture must model a ready diff viewer that owns Cmd+F"
         )
@@ -131,23 +192,23 @@ final class PaneFocusFindResponderTests: XCTestCase {
         container.addSubview(webView)
         window.contentView = container
         window.makeKeyAndOrderFront(nil)
-        XCTAssertTrue(
+        #expect(
             window.makeFirstResponder(webView),
             "The diff viewer WebView must own first responder before the pane move"
         )
-        XCTAssertEqual(
-            panel.ownedFocusIntent(for: window.firstResponder ?? window, in: window),
-            .browser(.webView)
+        #expect(
+            panel.ownedFocusIntent(for: window.firstResponder ?? window, in: window) == .browser(.webView)
         )
 
         panel.unfocus()
 
-        XCTAssertFalse(
-            responderChainContains(window.firstResponder, target: webView),
+        #expect(
+            !responderChainContains(window.firstResponder, target: webView),
             "Leaving a diff viewer pane must resign the WebView responder"
         )
     }
 
+    /// Returns whether a responder chain contains the supplied target.
     private func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
         var current = start
         var hops = 0

--- a/cmuxTests/PaneFocusFindResponderTests.swift
+++ b/cmuxTests/PaneFocusFindResponderTests.swift
@@ -1,0 +1,161 @@
+import AppKit
+import WebKit
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for find controls that must yield AppKit focus when a
+/// pane-selection transaction moves keyboard input to another pane.
+@MainActor
+final class PaneFocusFindResponderTests: XCTestCase {
+    func testMarkdownFindFieldIsReleasedWhenPaneFocusMoves() throws {
+        let fileManager = FileManager.default
+        let directoryURL = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-pane-focus-find-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(
+            at: directoryURL,
+            withIntermediateDirectories: true
+        )
+        let fileURL = directoryURL.appendingPathComponent("README.md")
+        try "# Find focus\n".write(to: fileURL, atomically: true, encoding: .utf8)
+
+        let panel = MarkdownPanel(workspaceId: UUID(), filePath: fileURL.path)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+            try? fileManager.removeItem(at: directoryURL)
+        }
+
+        panel.startFind()
+        let searchState = try XCTUnwrap(panel.searchState)
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 240))
+        let rendererCoordinator = panel.rendererSession.coordinator(
+            panelId: panel.id,
+            workspaceId: panel.workspaceId,
+            filePath: panel.filePath
+        )
+        let webView = MarkdownWebView(
+            frame: NSRect(x: 0, y: 0, width: 420, height: 160),
+            configuration: WKWebViewConfiguration()
+        )
+        rendererCoordinator.webView = webView
+        container.addSubview(webView)
+        let findField = FindSelectionTrackingTextField(
+            frame: NSRect(x: 20, y: 180, width: 180, height: 24)
+        )
+        findField.isEditable = true
+        findField.isSelectable = true
+        findField.isEnabled = true
+        findField.stringValue = "needle"
+        // BrowserSearchOverlay uses this exact owner link. It lets the panel
+        // distinguish its field editor from another pane's find control.
+        findField.cmuxSelectionOwner = searchState
+        container.addSubview(findField)
+        window.contentView = container
+        window.initialFirstResponder = findField
+        window.makeKeyAndOrderFront(nil)
+
+        XCTAssertTrue(
+            window.makeFirstResponder(findField),
+            "The Markdown find field must own first responder before the pane move"
+        )
+        guard let firstResponder = window.firstResponder else {
+            XCTFail("Expected a Markdown find responder")
+            return
+        }
+        XCTAssertEqual(
+            panel.ownedFocusIntent(for: firstResponder, in: window),
+            .panel,
+            "The pane boundary must identify the Markdown find field as owned focus"
+        )
+        let generationBeforeLeave = panel.searchFocusRequestGeneration
+
+        // This is the same panel-leave hook used by keyboard, pointer, CLI,
+        // split, and close selection paths.
+        panel.unfocus()
+
+        XCTAssertFalse(
+            panel.ownedFocusIntent(for: window.firstResponder ?? window, in: window) == .panel,
+            "A Markdown find field must no longer own focus after leaving its pane"
+        )
+        XCTAssertFalse(
+            window.firstResponder === findField,
+            "Leaving a Markdown pane must resign its find field first responder"
+        )
+        XCTAssertFalse(
+            panel.canApplySearchFocusRequest(generationBeforeLeave),
+            "Pending Cmd+F focus requests must be invalidated when the pane is left"
+        )
+    }
+
+    func testDiffViewerFindWebViewIsReleasedWhenPaneFocusMoves() throws {
+        let panel = BrowserPanel(
+            workspaceId: UUID(),
+            renderInitialNavigation: false
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 300),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+        }
+
+        let webView = try XCTUnwrap(panel.webView as? CmuxWebView)
+        webView.diffViewerFocusStateDidChange(
+            viewer: true,
+            editable: true,
+            rendererReady: true
+        )
+        XCTAssertTrue(
+            panel.isDiffViewerFindOwner,
+            "The fixture must model a ready diff viewer that owns Cmd+F"
+        )
+
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 520, height: 300))
+        container.addSubview(webView)
+        window.contentView = container
+        window.makeKeyAndOrderFront(nil)
+        XCTAssertTrue(
+            window.makeFirstResponder(webView),
+            "The diff viewer WebView must own first responder before the pane move"
+        )
+        XCTAssertEqual(
+            panel.ownedFocusIntent(for: window.firstResponder ?? window, in: window),
+            .browser(.webView)
+        )
+
+        panel.unfocus()
+
+        XCTAssertFalse(
+            responderChainContains(window.firstResponder, target: webView),
+            "Leaving a diff viewer pane must resign the WebView responder"
+        )
+    }
+
+    private func responderChainContains(_ start: NSResponder?, target: NSResponder) -> Bool {
+        var current = start
+        var hops = 0
+        while let responder = current, hops < 64 {
+            if responder === target { return true }
+            current = responder.nextResponder
+            hops += 1
+        }
+        return false
+    }
+}

--- a/cmuxTests/PaneFocusFindResponderTests.swift
+++ b/cmuxTests/PaneFocusFindResponderTests.swift
@@ -304,6 +304,7 @@ struct PaneFocusFindResponderTests {
         // explicit destination, AppKit may choose the preview WebView as the
         // next key view before the direct focus attempt below.
         window.resignationDestination = foreignEditor
+        window.resetRejectedFocusAttempts()
 
         panel.hideFind()
         #expect(window.rejectedFocusAttempts == 1)

--- a/cmuxTests/PaneFocusFindResponderTests.swift
+++ b/cmuxTests/PaneFocusFindResponderTests.swift
@@ -300,6 +300,10 @@ struct PaneFocusFindResponderTests {
         window.contentView?.addSubview(foreignEditor)
         window.makeKeyAndOrderFront(nil)
         #expect(window.makeFirstResponder(findField))
+        // Keep the field-editor resignation deterministic. Without an
+        // explicit destination, AppKit may choose the preview WebView as the
+        // next key view before the direct focus attempt below.
+        window.resignationDestination = foreignEditor
 
         panel.hideFind()
         #expect(window.rejectedFocusAttempts == 1)

--- a/cmuxTests/PaneFocusFindResponderTests.swift
+++ b/cmuxTests/PaneFocusFindResponderTests.swift
@@ -269,6 +269,47 @@ struct PaneFocusFindResponderTests {
         #expect(window.firstResponder === editor)
     }
 
+    /// Find dismissal must not arm a deferred preview-focus lease after a
+    /// failed direct focus attempt.
+    @Test
+    func testMarkdownHideFindDoesNotReclaimFocusAfterRejectedPreviewFocus() throws {
+        let directoryURL = try makeMarkdownFixture()
+        let panel = MarkdownPanel(
+            workspaceId: UUID(), filePath: directoryURL.appendingPathComponent("README.md").path
+        )
+        let window = PaneFocusTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 240),
+            styleMask: [.titled, .closable], backing: .buffered, defer: false
+        )
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        let webView = attachPreview(to: panel, in: window)
+        window.rejectedFirstResponder = webView
+        panel.startFind()
+        let searchState = try #require(panel.searchState)
+        let findField = FindSelectionTrackingTextField(
+            frame: NSRect(x: 20, y: 120, width: 180, height: 24)
+        )
+        findField.cmuxSelectionOwner = searchState
+        window.contentView?.addSubview(findField)
+        let foreignEditor = NSTextView(frame: NSRect(x: 0, y: 0, width: 180, height: 80))
+        window.contentView?.addSubview(foreignEditor)
+        window.makeKeyAndOrderFront(nil)
+        #expect(window.makeFirstResponder(findField))
+
+        panel.hideFind()
+        #expect(window.rejectedFocusAttempts == 1)
+        window.rejectedFirstResponder = nil
+        #expect(window.makeFirstResponder(foreignEditor))
+        panel.replayPendingPreviewFocusAfterWindowAttach()
+
+        #expect(window.firstResponder === foreignEditor)
+    }
+
     private func makeMarkdownFixture() throws -> URL {
         let directoryURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-find-dismiss-\(UUID().uuidString)", isDirectory: true)

--- a/cmuxTests/PaneFocusFindResponderTests.swift
+++ b/cmuxTests/PaneFocusFindResponderTests.swift
@@ -136,7 +136,8 @@ struct PaneFocusFindResponderTests {
         findField.isSelectable = true
         findField.isEnabled = true
         findField.cmuxSelectionOwner = searchState
-        window.contentView = findField
+        let webView = attachPreview(to: panel, in: window)
+        window.contentView?.addSubview(findField)
         window.makeKeyAndOrderFront(nil)
 
         #expect(window.makeFirstResponder(findField))
@@ -156,6 +157,146 @@ struct PaneFocusFindResponderTests {
             window.firstResponder !== findField,
             "Hiding the find bar must resign its field editor before removing ownership state"
         )
+        #expect(
+            responderChainContains(window.firstResponder, target: webView),
+            "Dismissing an active find field must return keyboard focus to its document"
+        )
+    }
+
+    /// Hiding find must not behave like leaving an otherwise focused preview.
+    @Test(arguments: [false, true])
+    func testMarkdownHideFindPreservesPreviewFocus(findVisible: Bool) throws {
+        let directoryURL = try makeMarkdownFixture()
+        let panel = MarkdownPanel(
+            workspaceId: UUID(), filePath: directoryURL.appendingPathComponent("README.md").path
+        )
+        let window = makeWindow()
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        let webView = attachPreview(to: panel, in: window)
+        if findVisible { panel.startFind() }
+        window.makeKeyAndOrderFront(nil)
+        #expect(window.makeFirstResponder(webView))
+        let capturedResponder = try #require(window.firstResponder)
+
+        panel.hideFind()
+
+        #expect(panel.searchState == nil)
+        #expect(window.firstResponder === capturedResponder)
+    }
+
+    /// Hide-find is a no-op for the raw-text editor's keyboard ownership.
+    @Test
+    func testMarkdownHideFindPreservesTextEditorFocus() throws {
+        let directoryURL = try makeMarkdownFixture()
+        let panel = MarkdownPanel(
+            workspaceId: UUID(), filePath: directoryURL.appendingPathComponent("README.md").path
+        )
+        let window = makeWindow()
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        let editor = NSTextView(frame: NSRect(x: 0, y: 0, width: 420, height: 240))
+        window.contentView = editor
+        panel.attachTextView(editor)
+        panel.setDisplayMode(.text)
+        window.makeKeyAndOrderFront(nil)
+        #expect(window.makeFirstResponder(editor))
+
+        panel.hideFind()
+
+        #expect(window.firstResponder === editor)
+    }
+
+    /// A no-op dismissal must not cancel an activation waiting for view mount.
+    @Test
+    func testMarkdownHideFindPreservesPendingPreviewActivation() throws {
+        let directoryURL = try makeMarkdownFixture()
+        let panel = MarkdownPanel(
+            workspaceId: UUID(), filePath: directoryURL.appendingPathComponent("README.md").path
+        )
+        let window = makeWindow()
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        panel.focus()
+        panel.hideFind()
+        let webView = attachPreview(to: panel, in: window)
+        window.makeKeyAndOrderFront(nil)
+        #expect(window.makeFirstResponder(nil))
+
+        panel.replayPendingPreviewFocusAfterWindowAttach()
+
+        #expect(responderChainContains(window.firstResponder, target: webView))
+    }
+
+    /// Dismissing an inactive pane's find bar must not steal another pane's input.
+    @Test
+    func testMarkdownHideFindPreservesForeignResponder() throws {
+        let directoryURL = try makeMarkdownFixture()
+        let panel = MarkdownPanel(
+            workspaceId: UUID(), filePath: directoryURL.appendingPathComponent("README.md").path
+        )
+        let window = makeWindow()
+        defer {
+            window.orderOut(nil)
+            window.close()
+            panel.close()
+            try? FileManager.default.removeItem(at: directoryURL)
+        }
+        _ = attachPreview(to: panel, in: window)
+        panel.startFind()
+        panel.unfocus()
+        let editor = NSTextView(frame: NSRect(x: 0, y: 0, width: 200, height: 200))
+        window.contentView?.addSubview(editor)
+        window.makeKeyAndOrderFront(nil)
+        #expect(window.makeFirstResponder(editor))
+
+        panel.hideFind()
+        panel.replayPendingPreviewFocusAfterWindowAttach()
+
+        #expect(panel.searchState == nil)
+        #expect(window.firstResponder === editor)
+    }
+
+    private func makeMarkdownFixture() throws -> URL {
+        let directoryURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-find-dismiss-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        try "# Find dismissal\n".write(
+            to: directoryURL.appendingPathComponent("README.md"), atomically: true, encoding: .utf8
+        )
+        return directoryURL
+    }
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 240),
+            styleMask: [.titled, .closable], backing: .buffered, defer: false
+        )
+    }
+
+    private func attachPreview(to panel: MarkdownPanel, in window: NSWindow) -> MarkdownWebView {
+        let webView = MarkdownWebView(
+            frame: NSRect(x: 0, y: 0, width: 420, height: 240), configuration: WKWebViewConfiguration()
+        )
+        panel.rendererSession.coordinator(
+            panelId: panel.id, workspaceId: panel.workspaceId, filePath: panel.filePath
+        ).webView = webView
+        let container = NSView(frame: webView.frame)
+        container.addSubview(webView)
+        window.contentView = container
+        return webView
     }
 
     /// Verifies that a diff viewer WebView yields focus on pane leave.

--- a/cmuxTests/PaneFocusTestWindow.swift
+++ b/cmuxTests/PaneFocusTestWindow.swift
@@ -5,9 +5,16 @@ import AppKit
 @MainActor
 final class PaneFocusTestWindow: NSWindow {
     weak var rejectedFirstResponder: NSResponder?
+    /// Deterministic destination for tests that resign a field editor. AppKit
+    /// otherwise chooses the window's next key view when passed `nil`, which
+    /// can be the very responder the test is intentionally rejecting.
+    weak var resignationDestination: NSResponder?
     private(set) var rejectedFocusAttempts = 0
 
     override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
+        if responder == nil, let resignationDestination {
+            return super.makeFirstResponder(resignationDestination)
+        }
         if let rejectedFirstResponder, responder === rejectedFirstResponder {
             rejectedFocusAttempts += 1
             return false

--- a/cmuxTests/PaneFocusTestWindow.swift
+++ b/cmuxTests/PaneFocusTestWindow.swift
@@ -1,0 +1,17 @@
+import AppKit
+
+/// Models a responder that temporarily cannot take focus, without replacing
+/// the panel's real AppKit views or exposing production-only test hooks.
+@MainActor
+final class PaneFocusTestWindow: NSWindow {
+    weak var rejectedFirstResponder: NSResponder?
+    private(set) var rejectedFocusAttempts = 0
+
+    override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
+        if let rejectedFirstResponder, responder === rejectedFirstResponder {
+            rejectedFocusAttempts += 1
+            return false
+        }
+        return super.makeFirstResponder(responder)
+    }
+}

--- a/cmuxTests/PaneFocusTestWindow.swift
+++ b/cmuxTests/PaneFocusTestWindow.swift
@@ -11,6 +11,10 @@ final class PaneFocusTestWindow: NSWindow {
     weak var resignationDestination: NSResponder?
     private(set) var rejectedFocusAttempts = 0
 
+    func resetRejectedFocusAttempts() {
+        rejectedFocusAttempts = 0
+    }
+
     override func makeFirstResponder(_ responder: NSResponder?) -> Bool {
         if responder == nil, let resignationDestination {
             return super.makeFirstResponder(resignationDestination)


### PR DESCRIPTION
## Summary

- Release Markdown-owned find field/editor, raw text editor, and preview WebView responders when the panel leaves the focused pane.
- Invalidate deferred Markdown find-focus requests at the shared panel lifecycle boundary so an old overlay cannot reclaim keyboard input after a pane move or close.
- Keep find dismissal narrower than pane-leave: preserve document/foreign focus and avoid arming stale preview activation.
- Cover Markdown and the diff viewer's existing `BrowserPanel` responder-yield path with behavior-level AppKit/WebKit tests.

## Shared boundary

`MarkdownPanel.unfocus()` enforces the responder ownership invariant at the existing `Panel` lifecycle boundary used by pane transitions. `close()` also calls it. Directional/index shortcuts, pointer selection, CLI focus operations, split/move/replacement, and close do not need separate shortcut-specific patches. `BrowserPanel.unfocus()` already provides the diff/browser equivalent. Real CUA verification on the tagged `aa12a478dd` build passed for Markdown keyboard, mouse, CLI, split, and close handoffs, and diff keyboard/mouse handoffs. A repeat build of the latest main-only merge is queued; the earlier build is not mislabeled as the latest SHA.

## Validation and current status

- Initial test-only commit `fc115c35f0`; fix `86662156e0`. Subsequent review fixes retain separate test-first/fix pairs (`f4b86742cf` / `479e1a0ac1`, `6e95a040e7` / `7061124c0b`).
- The focused responder suite [34266826894](https://github.com/manaflow-ai/cmux/actions/runs/34266826894) passed before the main-only merges. Its `TEST_REF` checks out this branch; the workflow metadata SHA is main by design. Exact-HEAD responder validation [34293064859](https://github.com/manaflow-ai/cmux/actions/runs/34293064859) is running against `ebd333c11a6b8c68dc19e9d494b13dd7081b2ed6`.
- Required PR checks passed on `aa12a478dd`; fresh checks are running on current HEAD `ebd333c11a6b8c68dc19e9d494b13dd7081b2ed6`, which contains `origin/main` `91718ec98adb529489b77fe1598e3d4dcb94136d`.
- Full CI [34279166491](https://github.com/manaflow-ai/cmux/actions/runs/34279166491) on `aa12a478dd` passed three app-host shards, Swift package tests, runtime/typing-lag checks, and the universal Release build. Shards 1/2/4 exceeded the 75-minute job limit and are being retried (attempt 2). No timeout is counted as a pass. Earlier main-obsolete full runs were canceled; broad failures from those runs were not treated as proven environmental or as clean validation.
- `./scripts/check-pbxproj.sh`, `./scripts/lint-pbxproj-test-wiring.sh` (826 test files), `python3 scripts/check-package-resolved-policy.py`, `python3 scripts/swift_file_length_budget.py`, and `git diff --check` passed after merging main. Neither budget TSV was modified.
- No user-facing strings or new shortcuts were added. The localization/shortcut audit found no catalog or shortcut-registry changes required.
- Tagged cloud build `issue-11362-markdown-find-focus-regression-272e81533d35` succeeded on `aa12a478dd` with parent-pinned Ghostty `abd40f6e472d57f2d4bb182004bb5f3fac8df961`. The original local Ghostty checkout was restored. A new cloud build for `ebd333c11a6b8c68dc19e9d494b13dd7081b2ed6` is queued behind the global lock. No local compilation was performed.

## Real-app evidence

On macOS 26.4 (25E246), Cua Driver physical key events reproduced the exact sequence on the tagged app: Cmd+F, type `needle`, Cmd+Option+Left, then type. Markdown left `mdhandoff` in the terminal; diff left `diffhandoff` in the terminal; both find values remained `needle`. Mouse-click handoffs also passed for both. Markdown CLI focus, Cmd+D split, and close handoffs produced `cliok`, `splitok`, and `closeok` in the destination terminals.

Genuine before/after interaction screenshots and AX state are preserved at `cmuxterm-hq/artifacts/issue-11362-markdown-find-focus-regression/cua-ssh/` (`md-before.png`, `md-after.png`, `diff-before.png`, `diff-after.png`, and `verification.md`). These are before/after the handoff on the fixed build, not a fabricated before-fix baseline. Browser attachment is unavailable in this session (`No browser is available`, then `Sky Computer Use native pipe startup failed`), so no public image URL is claimed. The exact tagged runtime, temporary verification directories/sockets, and local 669 MB tag install were cleaned; the cloud archive and evidence remain.

## Trade-offs

- Keep one existing `@MainActor` pane lifecycle boundary instead of duplicating fixes across entrypoints. The cost is a bounded AppKit responder-chain/window lookup during focus transitions.
- Deterministic hosted AppKit/WebKit tests assert responder ownership and deferred-focus invalidation; real-app CUA verification separately proves shortcut routing and physical typed input. Verification was run on macOS 26.4; the hosted focused suite covers the macOS 15 lane.
- Merge the latest main (`91718ec98adb529489b77fe1598e3d4dcb94136d`) into the reviewed branch to retain feature commit SHAs. The upstream iOS changes are not part of this PR's five-file diff. Repeat exact-HEAD validation is kept separate from the earlier successful real-app build.
- Wait for the mandated serial build lock despite available fleet slots; do not bypass the queue or silently verify with the divergent local Ghostty dependency.

## Review / closeout

All four inline threads are replied to and resolved. The single [audit comment 5505131905](https://github.com/manaflow-ai/cmux/pull/11512#issuecomment-5505131905) records every review disposition and will be refreshed against the final validation. Remaining gates: current-HEAD focused tests/build, required checks, public evidence attachment when the browser surface is available, and the final main/review/approval check. No merge is authorized solely by this metadata; repo policy requires Austin's explicit post-dogfood approval for runtime/UI changes.

Closes https://github.com/manaflow-ai/cmux/issues/11362

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes AppKit first-responder and async find-focus leasing on a shared pane lifecycle path; regressions would show up as stuck find fields or focus theft across panes, but behavior is heavily covered by new tests.
> 
> **Overview**
> **Markdown preview find and keyboard focus** now go through a dedicated `MarkdownPanel+Focus` extension instead of inline methods in `MarkdownPanel`.
> 
> **Pane leave (`unfocus`)** resigns AppKit first responder for this panel’s find field, raw text editor, and preview `WKWebView`, and invalidates deferred Cmd+F focus via `activeSearchFocusRequestGeneration` so a late-mounted overlay cannot steal input after a switch or close. **`close()`** calls `unfocus()` at teardown.
> 
> **`hideFind()`** is no longer a bare `searchState = nil`: it resigns only when this pane’s find field owns focus, optionally returns focus to the preview web view, and avoids disturbing foreign or pending activation focus.
> 
> **Tests** add `PaneFocusFindResponderTests` and `PaneFocusTestWindow` for Markdown hide/leave behavior and diff viewer `BrowserPanel.unfocus()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bedd64f4161e74a53723ad6726b3ec7527427507. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

