### PR TITLE
Make the New Workspace button clickable across its full frame

### DIFF
--- a/Sources/Update/TitlebarNewWorkspaceSplitButton.swift
+++ b/Sources/Update/TitlebarNewWorkspaceSplitButton.swift
@@ -42,11 +42,17 @@ struct TitlebarNewWorkspaceSplitButton: View {
         titlebarControlBorderOpacity(config: config, isHovering: isHovering, isPressed: false, isEnabled: true)
     }
 
+    /// Makes each segment's full frame interactive, including transparent label space.
     var body: some View {
         HStack(spacing: 0) {
             Button(action: onNewTab) {
-                CmuxSystemSymbolImage(systemName: "plus", pointSize: config.iconSize, weight: .medium)
-                    .frame(width: primaryWidth, height: config.buttonSize)
+                ZStack {
+                    Rectangle()
+                        .fill(Color.clear)
+                    CmuxSystemSymbolImage(systemName: "plus", pointSize: config.iconSize, weight: .medium)
+                }
+                .frame(width: primaryWidth, height: config.buttonSize)
+                .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             .frame(width: primaryWidth, height: config.buttonSize)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1813,6 +1813,7 @@
 		EBEEFD57F5B44FD3D569C2A7 /* NewMachineModelUncappedPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70D01FA1A02DF947CEAEA499 /* NewMachineModelUncappedPlanTests.swift */; };
 		DD3322FE8D4021EB0FAFE7F6 /* NewMachineSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3770734999CDCF396F04F32 /* NewMachineSheet.swift */; };
 		548D90758DB3CF890BFDC603 /* NewMachineSheetPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EC4096C4A05D3A58980308A /* NewMachineSheetPresenter.swift */; };
+		A1122301A1B2C3D4E5F60718 /* NewWorkspaceButtonHitAreaUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1122302A1B2C3D4E5F60718 /* NewWorkspaceButtonHitAreaUITests.swift */; };
 		C0DE77060000000000000003 /* NewWorkspaceMenuModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE77060000000000000004 /* NewWorkspaceMenuModel.swift */; };
 		A5FB1400 /* NewWorkspaceMenuModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB1401 /* NewWorkspaceMenuModelTests.swift */; };
 		734F49D37E543DD01C2F4FEF /* NotificationAndMenuBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */; };
@@ -5076,6 +5077,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		70D01FA1A02DF947CEAEA499 /* NewMachineModelUncappedPlanTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewMachineModelUncappedPlanTests.swift; sourceTree = "<group>"; };
 		D3770734999CDCF396F04F32 /* NewMachineSheet.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewMachineSheet.swift; sourceTree = "<group>"; };
 		7EC4096C4A05D3A58980308A /* NewMachineSheetPresenter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewMachineSheetPresenter.swift; sourceTree = "<group>"; };
+		A1122302A1B2C3D4E5F60718 /* NewWorkspaceButtonHitAreaUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceButtonHitAreaUITests.swift; sourceTree = "<group>"; };
 		C0DE77060000000000000004 /* NewWorkspaceMenuModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceMenuModel.swift; sourceTree = "<group>"; };
 		A5FB1401 /* NewWorkspaceMenuModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewWorkspaceMenuModelTests.swift; sourceTree = "<group>"; };
 		D2C075029771815DD5DA1332 /* NotificationAndMenuBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationAndMenuBarTests.swift; sourceTree = "<group>"; };
@@ -6755,6 +6757,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DE32470000000000000006 /* CommandPaletteIdentifierClipboardUITests.swift */,
 				B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */,
 				F0F0A002A1B2C3D4E5F60718 /* WorkspaceSidebarScrollUITests.swift */,
+				A1122302A1B2C3D4E5F60718 /* NewWorkspaceButtonHitAreaUITests.swift */,
 				C2577001A1B2C3D4E5F60718 /* TerminalCmdClickUITests.swift */,
 				B82090010000000000000002 /* TCCUsageDescriptionUITests.swift */,
 				B9000131A1B2C3D4E5F60719 /* SidebarPullRequestInteractivityUITests.swift */,
@@ -12848,6 +12851,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B9000015A1B2C3D4E5F60719 /* MultiWindowNotificationsUITests.swift in Sources */,
 				D77690000000000000000005 /* MultiWindowNotificationsWorkspaceHeadlineUITests.swift in Sources */,
 				8B1B2AB6EC6ACDB2CD39A9BB /* NewBrowserWorkspaceShortcutUITests.swift in Sources */,
+				A1122301A1B2C3D4E5F60718 /* NewWorkspaceButtonHitAreaUITests.swift in Sources */,
 				0857775ACBD4B3C507EBB232 /* RemoteTmuxSizingUITests+Content.swift in Sources */,
 				703CAAF15AF4CA4399BDD26B /* RemoteTmuxSizingUITests+Lab.swift in Sources */,
 				08577759CBD4B3C507EBB231 /* RemoteTmuxSizingUITests+Oracle.swift in Sources */,

--- a/cmuxTests/TitlebarInteractiveControlTests.swift
+++ b/cmuxTests/TitlebarInteractiveControlTests.swift
@@ -21,6 +21,7 @@ struct TitlebarInteractiveControlTests {
         }
     }
 
+    /// Creates a deterministic left-button event for titlebar hit-testing fixtures.
     private static func makeLeftMouseDownEvent(location: NSPoint, window: NSWindow, clickCount: Int = 1) -> NSEvent {
         guard let event = NSEvent.mouseEvent(
             with: .leftMouseDown,
@@ -244,5 +245,68 @@ struct TitlebarInteractiveControlTests {
             !hitView.mouseDownCanMoveWindow,
             "Registered SwiftUI titlebar controls must not degrade into hosting-view drag hits."
         )
+    }
+
+    /// A click in the transparent portion of the primary segment must invoke
+    /// the same action as a click on the painted plus glyph.
+    @Test(arguments: TitlebarControlsStyle.allCases)
+    func primarySegmentUsesWholeFrameAsHitTarget(style: TitlebarControlsStyle) {
+        _ = NSApplication.shared
+
+        let config = style.config
+        let primaryWidth = TitlebarNewWorkspaceSplitButtonMetrics.primaryWidth(config: config)
+        let totalWidth = TitlebarNewWorkspaceSplitButtonMetrics.totalWidth(config: config)
+        var actionCount = 0
+        let root = TitlebarNewWorkspaceSplitButton(
+            config: config,
+            foregroundColor: .primary,
+            onNewTab: { actionCount += 1 }
+        )
+        let hostingView = NSHostingView(rootView: root)
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: totalWidth, height: config.buttonSize),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
+        window.contentView = hostingView
+        window.makeKeyAndOrderFront(nil)
+        hostingView.frame = NSRect(x: 0, y: 0, width: totalWidth, height: config.buttonSize)
+        hostingView.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+
+        // Cover the transparent corners and edges as well as the painted center.
+        for x in [1, primaryWidth / 2, primaryWidth - 1] {
+            for y in [1, config.buttonSize / 2, config.buttonSize - 1] {
+                let point = NSPoint(x: x, y: y)
+                let locationInWindow = hostingView.convert(point, to: nil)
+                let previousActionCount = actionCount
+                let down = Self.makeLeftMouseDownEvent(location: locationInWindow, window: window)
+                guard let up = NSEvent.mouseEvent(
+                    with: .leftMouseUp,
+                    location: locationInWindow,
+                    modifierFlags: [],
+                    timestamp: down.timestamp,
+                    windowNumber: window.windowNumber,
+                    context: nil,
+                    eventNumber: 2,
+                    clickCount: 1,
+                    pressure: 0
+                ) else {
+                    Issue.record("Expected to create a primary-segment mouse-up event")
+                    return
+                }
+                window.sendEvent(down)
+                window.sendEvent(up)
+                #expect(
+                    actionCount == previousActionCount + 1,
+                    "A click at \(point) in the primary frame must create exactly one workspace."
+                )
+            }
+        }
     }
 }

--- a/cmuxUITests/NewWorkspaceButtonHitAreaUITests.swift
+++ b/cmuxUITests/NewWorkspaceButtonHitAreaUITests.swift
@@ -1,0 +1,67 @@
+import XCTest
+
+/// Verifies workspace creation through mouse clicks across the actual titlebar button.
+final class NewWorkspaceButtonHitAreaUITests: XCTestCase {
+    /// Transparent corners and edges must create exactly one workspace, just like the glyph.
+    @MainActor
+    func testPrimaryButtonAcceptsClicksAcrossItsFullFrame() {
+        continueAfterFailure = false
+        let app = XCUIApplication.cmuxTestApplication()
+        app.launchEnvironment["CMUX_UI_TEST_MODE"] = "1"
+        app.launchArguments += [
+            "-workspacePresentationMode", "standard",
+            "-newWorkspacePlacement", "end",
+            "-AppleLanguages", "(en)",
+            "-AppleLocale", "en_US",
+        ]
+        app.launch()
+        defer { app.terminate() }
+
+        XCTAssertTrue(app.windows.firstMatch.waitForExistence(timeout: 10))
+        XCTAssertTrue(workspaceRow(in: app, count: 1).waitForExistence(timeout: 10))
+
+        let button = app.descendants(matching: .any)
+            .matching(identifier: "titlebarControl.newTab").firstMatch
+        XCTAssertTrue(button.waitForExistence(timeout: 5))
+        XCTAssertTrue(button.isHittable)
+        let frame = button.frame
+        XCTAssertGreaterThan(frame.width, 10)
+        XCTAssertGreaterThan(frame.height, 10)
+        attachScreenshot(of: app, name: "Before full-frame clicks: one workspace")
+
+        var expectedCount = 1
+        for x in [CGFloat(1), frame.width / 2, frame.width - 1] {
+            for y in [CGFloat(1), frame.height / 2, frame.height - 1] {
+                XCTContext.runActivity(named: "Click primary frame at (\(x), \(y))") { _ in
+                    // Coordinate clicks exercise hit testing; an accessibility press would bypass it.
+                    button.coordinate(withNormalizedOffset: .zero)
+                        .withOffset(CGVector(dx: x, dy: y)).click()
+                    expectedCount += 1
+                    XCTAssertTrue(
+                        workspaceRow(in: app, count: expectedCount).waitForExistence(timeout: 5),
+                        "A click at (\(x), \(y)) must create exactly one workspace (total \(expectedCount))."
+                    )
+                    XCTAssertEqual(app.windows.count, 1, "The action must stay in the current window.")
+                }
+            }
+        }
+        attachScreenshot(of: app, name: "After nine full-frame clicks: ten workspaces")
+    }
+
+    /// Uses the sidebar's accessible position/count so virtualization cannot hide the result.
+    @MainActor
+    private func workspaceRow(in app: XCUIApplication, count: Int) -> XCUIElement {
+        app.descendants(matching: .other)
+            .matching(NSPredicate(format: "label ENDSWITH %@", "workspace \(count) of \(count)"))
+            .firstMatch
+    }
+
+    /// Keeps before/after app evidence with the hosted UI test result.
+    @MainActor
+    private func attachScreenshot(of app: XCUIApplication, name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/11223

## Summary

- Make the shared New Workspace split button's primary label own its full rectangular hit target, matching the existing caret segment. Transparent padding invokes the same workspace action as the plus glyph.
- Carry the fix into `TitlebarNewWorkspaceSplitButton.swift` after upstream replaced the old cloud-specific component.
- Add an AppKit/Swift Testing regression that mounts the production component and sends mouse events to a 3×3 grid across all five styles (45 locations).
- Add an independent XCUITest that clicks the actual app's primary button at its corners, edge midpoints, and center and verifies exactly one additional workspace after every click. Keep before/after screenshots in the hosted result.

## Architecture and trade-offs

- The split-button label owns its layout and interaction shape. A clear rectangle and framed `contentShape(Rectangle())` mirror the caret implementation without visible pixels, size changes, timers, new state, or another action path. This is the result of the requested architectural rethink; unavailable `$swift-guidance` was replaced with the available SwiftUI and repository guidance.
- Other sidebar chrome already applies a framed rectangular content shape in its shared button style. Minimal-mode AppKit proxies and the drag registry already own full rectangular lanes. A window-wide hit-test override would duplicate geometry and affect unrelated controls, so those working paths stay unchanged.
- The in-process test exercises real actions, not source text or a non-nil hit result. Upstream removed DEBUG `@AppStorage` geometry; it now passes immutable style configs and does not change persisted settings.
- The broader unit target currently fails to compile on main. Supplemental UI coverage uses the separate `cmux`/`cmuxUITests` scheme, without deleting, excluding, or modifying unrelated failing tests. It is slower than the in-process test but validates actual workspace creation. It fixes the app locale to English to read the sidebar's accessible position/count, and standard presentation mode to exercise the affected SwiftUI control; the unit test retains all five style configurations. Coordinate clicks intentionally avoid accessibility activation, which would bypass hit testing.
- Two-commit regression-first history is preserved: `8d0d0926afac153cc50a2c4c8059d4613ec06039` adds the regressions and test wiring only; `cc70d336f90d68e88678026749099910e71f2ba1` adds the production fix. The supplemental UI test was folded into the first commit, and both commits were pushed together with an exact force-with-lease check.
- No user-facing strings, shortcuts, settings, or localization catalogs changed. Changed UI/test literals were audited; English text added here is only test diagnostics and locale-bound assertions.
- This checkout lacks `scripts/swift_file_length_budget.py` and the file-length TSV. The exact requested command was attempted again and reports the missing file. Changed Swift files have 201, 312, and 67 lines; no new file approaches 500 lines. No budget TSV was modified or regenerated.
- The pre-existing clean-internally Ghostty checkout differs from the committed gitlink. Cloud snapshots temporarily use the committed gitlink and restore the original checkout afterward; no gitlink change is committed. Backend services are disabled for this local-workspace verification, so cloud/network behavior is outside the evidence.
- All compilation and executable test runs are remote. The tagged build uses the machine-wide queue and disables local fallback. GUI verification stays off the shared local Mac. A temporary cloud Mac was attempted while logged-in fleet hosts were leased; that adds a short-lived remote session instead of disturbing another agent's desktop. Its unreachable session was cancelled.

## Verification — in progress on current HEAD

Current HEAD: `cc70d336f90d68e88678026749099910e71f2ba1`, based on `2bde0876f2a1b0416e52b7b50b4ddafdf7b495cf`.

- Static checks passed: `git diff --check`, normalized pbxproj, and test wiring. No product source or resource differs from the previously built `b80093dd59`; the new changes add UI coverage only.
- New hosted UI test-only run: https://github.com/manaflow-ai/cmux/actions/runs/34182686850. Fixed run: https://github.com/manaflow-ai/cmux/actions/runs/34182697354. Both record video; results are pending and are not yet claimed as red/green proof.
- A new exact-HEAD tagged cloud build is queued. The prior `b80093dd59` build succeeded on macOS 26.5.1 (`issue-11223-new-workspace-button-hit-area-703ce50eb889`); it is not relabeled as a build of the new HEAD.
- In-process macOS 26 runs stopped on duplicate Sentry outputs under Xcode 27 beta: https://github.com/manaflow-ai/cmux/actions/runs/34177430579 and https://github.com/manaflow-ai/cmux/actions/runs/34177300568.
- In-process macOS 15 runs stopped compiling unchanged `SurfaceCatalogTests.swift` calls to removed APIs: https://github.com/manaflow-ai/cmux/actions/runs/34177639657 and https://github.com/manaflow-ai/cmux/actions/runs/34177642005. Unmodified main independently fails on missing local-tmux symbols: https://github.com/manaflow-ai/cmux/actions/runs/34177884784. These are not behavioral red/green results.
- Neither of the original changed Swift files emitted diagnostics in that fixed compile log. Both incomplete unit builds exceed the repository warning budget in unchanged files; those totals are not a complete comparable warning inventory. The overall warning gate is not claimed green and no budget was raised.
- Older red/green runs https://github.com/manaflow-ai/cmux/actions/runs/33581285548 and https://github.com/manaflow-ai/cmux/actions/runs/33594873871 cover the old component/base only, not this HEAD. Earlier abbreviated-SHA checkout and Homebrew download failures are not regression evidence either.

## Evidence and review closeout

Reporter recording: https://github.com/user-attachments/assets/79c80060-5e03-41ea-b821-8b7903522066

Old live screenshots remain in `cmuxterm-hq/artifacts/verify-remote/manual-11223-live/` and are not represented as current-HEAD evidence. Fresh live clicks and captures are in progress. The temporary cloud Mac run https://github.com/manaflow-ai/cmux-loader/actions/runs/34181914196 did not become visible on the local tailnet before timeout and was cancelled; no permissions, tailnet policy, or another agent's lease was changed.

The single audit comment `5505104364` will be updated in place after the new results and review inventory are re-checked. The sole geometry review finding already has direct replies; no thread was resolved silently. No autoreview/iterate-pr script or separate review agent is used.

**Not merged:** the new tests/build, final live click evidence, and refreshed CI/review closeout are still pending.

Tagged launch command:

```sh
CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-11223-new-workspace-button-hit-area --launch
```
