### PR TITLE
feat(file explorer): optional file-type colors from the terminal palette

### DIFF
--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -536,6 +536,7 @@ extension CmuxSettingsFileStore {
         "canvas.snappingEnabled",
         "fileEditor.wordWrap",
         "fileExplorer.doubleClickAction",
+        "fileExplorer.colorByFileType",
         "shortcuts.bindings",
     ]
 }

--- a/Sources/FileExplorerCellView.swift
+++ b/Sources/FileExplorerCellView.swift
@@ -88,20 +88,28 @@ final class FileExplorerCellView: NSTableCellView {
         iconHeightConstraint.constant = style.iconSize
         iconToTextConstraint.constant = style.iconToTextSpacing
 
+        // nil unless fileExplorer.colorByFileType is on and the name is one the
+        // table recognises, in which case both the icon and the label take the
+        // matching ANSI slot from the terminal palette.
+        let typeColor = FileExplorerFileTypeColor.color(
+            forName: node.name,
+            isDirectory: node.isDirectory
+        )
+
         if style == .finder {
             // Native Finder icon pixels miss 3:1 in light mode; use their masks with the dynamic palette tint.
             if node.isDirectory {
                 iconView.apply(CmuxResolvedIconRequest(
                     source: .image(NSWorkspace.shared.icon(for: .folder)),
                     size: NSSize(width: style.iconSize, height: style.iconSize),
-                    tintColor: style.folderIconTint
+                    tintColor: typeColor ?? style.folderIconTint
                 ))
             } else {
                 let pathExtension = (node.name as NSString).pathExtension
                 iconView.apply(CmuxResolvedIconRequest(
                     source: .image(NSWorkspace.shared.icon(for: UTType(filenameExtension: pathExtension) ?? .data)),
                     size: NSSize(width: style.iconSize, height: style.iconSize),
-                    tintColor: style.fileIconTint
+                    tintColor: typeColor ?? style.fileIconTint
                 ))
             }
         } else {
@@ -109,14 +117,14 @@ final class FileExplorerCellView: NSTableCellView {
                 iconView.apply(CmuxResolvedIconRequest(
                     source: .systemSymbol(name: "folder.fill", accessibilityDescription: nil),
                     size: NSSize(width: style.iconSize, height: style.iconSize),
-                    tintColor: style.folderIconTint,
+                    tintColor: typeColor ?? style.folderIconTint,
                     symbolWeight: style.iconWeight
                 ))
             } else {
                 iconView.apply(CmuxResolvedIconRequest(
                     source: .systemSymbol(name: "doc", accessibilityDescription: nil),
                     size: NSSize(width: style.iconSize, height: style.iconSize),
-                    tintColor: style.fileIconTint,
+                    tintColor: typeColor ?? style.fileIconTint,
                     symbolWeight: style.iconWeight
                 ))
             }
@@ -143,7 +151,7 @@ final class FileExplorerCellView: NSTableCellView {
             nameLabel.textColor = style.gitColor(for: gitStatus)
             nameLabel.toolTip = node.path
         } else {
-            nameLabel.textColor = .labelColor
+            nameLabel.textColor = typeColor ?? .labelColor
             nameLabel.toolTip = node.path
         }
     }

--- a/Sources/FileExplorerFileTypeColor.swift
+++ b/Sources/FileExplorerFileTypeColor.swift
@@ -25,119 +25,189 @@ enum FileExplorerFileTypeColor {
     /// What a row is, mapped to the ANSI slot that carries the same meaning in
     /// a terminal listing: directories take the slot `ls` uses for `di`,
     /// executables the one it uses for `ex`, and so on.
+    ///
+    /// Every slot from 1 to 15 is spoken for, exactly once, and a test enforces
+    /// that. Slot 0 is the only one left out: it is the terminal's own
+    /// near-black, so anything painted with it disappears into the background.
+    ///
+    /// The split is deliberately finer than "code / not code", because the
+    /// classes that dominate a source checkout are the ones worth telling
+    /// apart. Lumping every language into one green and every `.json`,
+    /// `Makefile` and `README` into one yellow leaves a repo looking like three
+    /// colours no matter how many the palette has. So scripts separate from
+    /// source, build files from plain config, prose from spreadsheets, and
+    /// lockfiles from the caches nobody reads.
     enum Kind: CaseIterable {
-        case directory, symlink, executable, archive, media, document
-        case source, config, markup, data, muted, plain
+        case secret, source, config, markup, data, document, generated
+        case muted, archive, script, build, directory, media, symlink, office
 
-        /// Index into the 16-colour ANSI palette. Slot 0 is deliberately unused:
-        /// it is the terminal's own near-black and would be invisible.
+        /// Index into the 16-colour ANSI palette.
         var paletteSlot: Int {
             switch self {
-            case .directory: 12   // blue, bright  -- `di`
-            case .symlink: 14     // cyan, bright  -- `ln`
-            case .executable: 10  // green, bright -- `ex`
-            case .archive: 9      // red, bright   -- `*.tar.gz` and friends
-            case .media: 13       // magenta, bright
-            case .document: 11    // yellow, bright
-            case .source: 2       // green
-            case .config: 3       // yellow
-            case .markup: 4       // blue
-            case .data: 6         // cyan
-            case .muted: 8        // black, bright -- build output, caches
-            case .plain: 15       // white, bright -- the fallback
+            case .secret: 1        // red            -- keys, certs, .env
+            case .source: 2        // green          -- code
+            case .config: 3        // yellow         -- json, yaml, toml, ini
+            case .markup: 4        // blue           -- html, css, templates
+            case .data: 5          // magenta        -- csv, parquet, sqlite
+            case .document: 6      // cyan           -- md, rst, txt, README
+            case .generated: 7     // white          -- lockfiles, generated code
+            case .muted: 8         // bright black   -- build output, caches
+            case .archive: 9       // bright red     -- zip, tar.gz, dmg
+            case .script: 10       // bright green   -- sh, zsh, ps1  (`ex`)
+            case .build: 11        // bright yellow  -- Makefile, Dockerfile
+            case .directory: 12    // bright blue                     (`di`)
+            case .media: 13        // bright magenta -- images, audio, fonts
+            case .symlink: 14      // bright cyan                     (`ln`)
+            case .office: 15       // bright white   -- pdf, docx, xlsx
             }
         }
     }
 
     // MARK: - Tables
 
-    /// Extension -> class. The ~180 that actually turn up in a listing, not an
-    /// exhaustive registry: anything unlisted falls back to `.plain`, which is
-    /// the correct answer for a file nothing recognises.
+    /// Extension -> class. The ~220 that actually turn up in a listing, not an
+    /// exhaustive registry: anything unlisted returns nil and keeps the
+    /// ordinary label colour, which is the right answer for a file nothing
+    /// recognises.
     ///
     /// Compound suffixes are listed explicitly. Longest-match is applied at
     /// lookup, so `foo.tar.gz` is an archive rather than whatever `.gz` says.
     static let extensions: [String: Kind] = mapping([
-        .archive: """
-            7z bz2 gz lz4 lzma rar tar tgz txz tbz2 xz z zip zst jar war ear \
-            deb rpm apk dmg iso pkg cab msi crx \
-            tar.gz tar.bz2 tar.xz tar.zst tar.lz4 tar.lzma
-            """,
-        .media: """
-            png jpg jpeg gif bmp webp avif tiff tif svg ico heic raw psd ai \
-            mp3 m4a flac wav ogg opus aac wma mid \
-            mp4 mkv webm mov avi wmv flv m4v mpg mpeg 3gp \
-            ttf otf woff woff2 eot blend fbx obj stl glb gltf
-            """,
-        .document: """
-            pdf epub mobi azw3 djvu doc docx odt rtf xls xlsx ods \
-            ppt pptx odp md markdown adoc rst tex org txt log
-            """,
-        .data: """
+        (.secret, """
+            pem key crt cer der p12 pfx jks keystore gpg asc kbx pub \
+            ppk netrc htpasswd
+            """),
+        (.source, """
+            c h cc cpp cxx hpp hh rs go py pyi rb pl pm php java kt kts scala \
+            swift m mm js jsx mjs cjs ts tsx vue svelte lua ex exs erl hs \
+            clj cljs cljc ml mli fs fsx nim zig d dart r jl sql gleam v \
+            el scm rkt asm s cs vb groovy tcl f90 f95 pas ada cob
+            """),
+        (.script, """
+            sh bash zsh fish ksh csh ps1 psm1 bat cmd awk sed expect \
+            applescript scpt
+            """),
+        (.config, """
+            json json5 jsonc yaml yml toml ini cfg conf config properties env \
+            xml plist tf tfvars hcl nix bazel bzl proto graphql gql \
+            editorconfig gitignore gitattributes gitmodules dockerignore \
+            npmrc nvmrc babelrc eslintrc prettierrc
+            """),
+        (.build, """
+            gradle cmake mk make dockerfile bazelrc mill sbt cabal \
+            podspec gemspec nuspec csproj vcxproj xcconfig entitlements
+            """),
+        (.generated, """
+            lock sum snap pb generated d.ts min.js min.css \
+            pb.go pb.cc pb.h
+            """),
+        (.markup, """
+            html htm xhtml shtml css scss sass less styl \
+            hbs mustache ejs pug jade haml erb njk liquid twig jinja jinja2
+            """),
+        (.data, """
             csv tsv psv parquet parq orc avro arrow feather \
             db sqlite sqlite3 duckdb mdb rdb dump \
             ndjson jsonl h5 hdf5 npy npz pkl pickle mat sav dta rds \
             ipynb geojson kml gpx
-            """,
-        .source: """
-            c h cc cpp cxx hpp hh rs go py pyi rb pl pm php java kt kts scala \
-            swift m mm js jsx mjs cjs ts tsx vue svelte lua ex exs erl hs \
-            clj cljs cljc ml mli fs fsx nim zig d dart r jl sql gleam v \
-            sh bash zsh fish ps1 bat cmd awk sed vim el scm rkt asm s
-            """,
-        .config: """
-            json json5 jsonc yaml yml toml ini cfg conf config properties env \
-            xml plist lock sum mod gradle cmake mk make dockerfile \
-            tf tfvars hcl nix bazel bzl proto graphql gql editorconfig \
-            gitignore gitattributes gitmodules npmrc nvmrc babelrc eslintrc \
-            prettierrc dockerignore
-            """,
-        .markup: """
-            html htm xhtml shtml css scss sass less styl \
-            hbs mustache ejs pug jade haml erb njk liquid twig
-            """,
-        .muted: """
-            bak old orig rej tmp temp swp swo swn pyc pyo pyd o a so dylib dll \
-            class cache map min dSYM
-            """,
+            """),
+        (.document, """
+            md markdown mdx adoc asciidoc rst tex org txt text log nfo \
+            wiki creole pod rdoc
+            """),
+        (.office, """
+            pdf epub mobi azw3 djvu doc docx odt rtf pages \
+            xls xlsx ods numbers ppt pptx odp keynote
+            """),
+        (.archive, """
+            7z bz2 gz lz4 lzma rar tar tgz txz tbz2 xz z zip zst jar war ear \
+            deb rpm apk dmg iso pkg cab msi crx xpi \
+            tar.gz tar.bz2 tar.xz tar.zst tar.lz4 tar.lzma
+            """),
+        (.media, """
+            png jpg jpeg gif bmp webp avif tiff tif svg ico icns heic raw \
+            psd ai sketch fig xcf \
+            mp3 m4a flac wav ogg opus aac wma mid midi \
+            mp4 mkv webm mov avi wmv flv m4v mpg mpeg 3gp \
+            ttf otf woff woff2 eot blend fbx obj stl glb gltf usdz
+            """),
+        (.muted, """
+            bak old orig rej tmp temp swp swo swn pyc pyo pyd o a so dylib \
+            dll lib exp ilk pdb class cache map dSYM nib xcuserstate \
+            DS_Store localized
+            """),
     ])
 
     /// Whole filenames that carry more meaning than their extension does --
-    /// `Makefile` has none at all, and a README is a document wherever it sits.
+    /// `Makefile` has none at all, and a README is prose wherever it sits.
     static let filenames: [String: Kind] = mapping([
-        .config: """
+        (.build, """
             Makefile makefile GNUmakefile Dockerfile Containerfile Vagrantfile \
-            Justfile justfile Brewfile Rakefile Gemfile Procfile CMakeLists.txt \
+            Justfile justfile Brewfile Rakefile Gemfile Procfile Taskfile \
+            CMakeLists.txt meson.build BUILD WORKSPACE \
             package.json tsconfig.json Cargo.toml go.mod pyproject.toml \
             requirements.txt setup.py setup.cfg flake.nix shell.nix default.nix
-            """,
-        .document: """
+            """),
+        (.generated, """
+            package-lock.json yarn.lock pnpm-lock.yaml bun.lockb bun.lock \
+            Cargo.lock go.sum Gemfile.lock poetry.lock Pipfile.lock \
+            composer.lock flake.lock uv.lock
+            """),
+        (.secret, """
+            .env .env.local .env.production .env.development .envrc \
+            id_rsa id_ed25519 id_ecdsa known_hosts authorized_keys \
+            credentials .netrc .npmrc.local secrets.yaml secrets.yml
+            """),
+        (.document, """
             README README.md README.txt LICENSE LICENCE COPYING CHANGELOG \
-            CHANGELOG.md CONTRIBUTING.md CODE_OF_CONDUCT.md AUTHORS NOTICE \
-            CLAUDE.md AGENTS.md
-            """,
+            CHANGELOG.md CONTRIBUTING.md CODE_OF_CONDUCT.md SECURITY.md \
+            AUTHORS NOTICE TODO CLAUDE.md AGENTS.md
+            """),
     ])
 
-    /// Directory names worth separating from the source you are looking for.
-    /// Deliberately short: only build output, caches and tool metadata, whose
-    /// names are unambiguous. Generic names (`src`, `lib`, `app`, `bin`) are
-    /// left alone -- their meaning is project-specific and guessing wrong is
-    /// worse than leaving them the ordinary directory colour.
+    /// Directory name -> class. Matched EXACTLY, not as a suffix, so ordinary
+    /// project folders can be listed without `lib` also repainting `zlib`.
     static let directories: [String: Kind] = mapping([
-        .muted: """
+        (.source, """
+            src source lib libs app apps pkg pkgs internal cmd crates \
+            packages components modules hooks services handlers models
+            """),
+        (.script, "bin scripts sbin tools"),
+        (.document, "docs doc documentation man manual guides adr rfcs"),
+        (.data, "data datasets fixtures seeds migrations schema db database"),
+        (.media, "assets static public images img media icons fonts audio video"),
+        (.config, "config .config conf etc settings deploy infra terraform"),
+        (.markup, "templates views layouts partials styles stylesheets css"),
+        (.secret, "secrets .ssh certs keys credentials"),
+        (.generated, """
+            .git .github .gitlab .circleci .husky .idea .vscode .vs \
+            generated gen proto-gen
+            """),
+        (.archive, "archive archives backup backups"),
+        (.muted, """
             node_modules __pycache__ .pytest_cache .mypy_cache .ruff_cache \
             .parcel-cache .turbo .gradle .terraform .tox .eggs .venv venv \
-            .next .nuxt .svelte-kit site-packages DerivedData CMakeFiles \
-            target dist build out coverage htmlcov Pods vendor
-            """,
-        .config: ".git .github .gitlab .circleci .husky .idea .vscode",
+            virtualenv .next .nuxt .svelte-kit site-packages DerivedData \
+            CMakeFiles target dist build out coverage htmlcov Pods vendor \
+            tmp temp .cache .DS_Store obj bin.out
+            """),
     ])
 
-    private static func mapping(_ groups: [Kind: String]) -> [String: Kind] {
+    /// Flattens the whitespace-separated groups above into one lookup.
+    ///
+    /// Takes an ORDERED array rather than a `[Kind: String]` dictionary on
+    /// purpose. A dictionary literal has unspecified iteration order, so a name
+    /// listed under two classes -- `obj` is both a 3D model and a linker object
+    /// file -- would resolve to whichever class happened to be visited last,
+    /// and could differ between launches. Here a duplicate is a programmer
+    /// error and trips immediately.
+    private static func mapping(_ groups: [(Kind, String)]) -> [String: Kind] {
         var out: [String: Kind] = [:]
         for (kind, names) in groups {
             for name in names.split(whereSeparator: \.isWhitespace) {
-                out[String(name)] = kind
+                let key = String(name)
+                assert(out[key] == nil, "\(key) is listed under two classes")
+                out[key] = kind
             }
         }
         return out

--- a/Sources/FileExplorerFileTypeColor.swift
+++ b/Sources/FileExplorerFileTypeColor.swift
@@ -1,0 +1,239 @@
+import AppKit
+import CMUXMobileCore
+import CmuxFoundation
+import Foundation
+
+/// Colours a file explorer row by what the file *is*, from the terminal's own
+/// 16 ANSI slots.
+///
+/// The tree currently paints every name `.labelColor` and tints every icon with
+/// one colour per style, so a `.rs`, a `node_modules` and a 2 GB `.parquet` are
+/// visually identical. `ls`, `eza` and every other listing tool one pane over
+/// colour all three differently.
+///
+/// Reading the colours out of ``TerminalTheme/palette`` rather than hardcoding
+/// them is the point: the sidebar then tracks whatever Ghostty theme is
+/// selected, in light and dark, with no second palette to keep in sync and
+/// nothing to configure. Someone on Catppuccin gets Catppuccin; someone on an
+/// ANSI-only scheme gets theirs.
+///
+/// Off by default. `fileExplorer.colorByFileType` turns it on.
+enum FileExplorerFileTypeColor {
+
+    // MARK: - Classes
+
+    /// What a row is, mapped to the ANSI slot that carries the same meaning in
+    /// a terminal listing: directories take the slot `ls` uses for `di`,
+    /// executables the one it uses for `ex`, and so on.
+    enum Kind: CaseIterable {
+        case directory, symlink, executable, archive, media, document
+        case source, config, markup, data, muted, plain
+
+        /// Index into the 16-colour ANSI palette. Slot 0 is deliberately unused:
+        /// it is the terminal's own near-black and would be invisible.
+        var paletteSlot: Int {
+            switch self {
+            case .directory: 12   // blue, bright  -- `di`
+            case .symlink: 14     // cyan, bright  -- `ln`
+            case .executable: 10  // green, bright -- `ex`
+            case .archive: 9      // red, bright   -- `*.tar.gz` and friends
+            case .media: 13       // magenta, bright
+            case .document: 11    // yellow, bright
+            case .source: 2       // green
+            case .config: 3       // yellow
+            case .markup: 4       // blue
+            case .data: 6         // cyan
+            case .muted: 8        // black, bright -- build output, caches
+            case .plain: 15       // white, bright -- the fallback
+            }
+        }
+    }
+
+    // MARK: - Tables
+
+    /// Extension -> class. The ~180 that actually turn up in a listing, not an
+    /// exhaustive registry: anything unlisted falls back to `.plain`, which is
+    /// the correct answer for a file nothing recognises.
+    ///
+    /// Compound suffixes are listed explicitly. Longest-match is applied at
+    /// lookup, so `foo.tar.gz` is an archive rather than whatever `.gz` says.
+    static let extensions: [String: Kind] = mapping([
+        .archive: """
+            7z bz2 gz lz4 lzma rar tar tgz txz tbz2 xz z zip zst jar war ear \
+            deb rpm apk dmg iso pkg cab msi crx \
+            tar.gz tar.bz2 tar.xz tar.zst tar.lz4 tar.lzma
+            """,
+        .media: """
+            png jpg jpeg gif bmp webp avif tiff tif svg ico heic raw psd ai \
+            mp3 m4a flac wav ogg opus aac wma mid \
+            mp4 mkv webm mov avi wmv flv m4v mpg mpeg 3gp \
+            ttf otf woff woff2 eot blend fbx obj stl glb gltf
+            """,
+        .document: """
+            pdf epub mobi azw3 djvu doc docx odt rtf xls xlsx ods \
+            ppt pptx odp md markdown adoc rst tex org txt log
+            """,
+        .data: """
+            csv tsv psv parquet parq orc avro arrow feather \
+            db sqlite sqlite3 duckdb mdb rdb dump \
+            ndjson jsonl h5 hdf5 npy npz pkl pickle mat sav dta rds \
+            ipynb geojson kml gpx
+            """,
+        .source: """
+            c h cc cpp cxx hpp hh rs go py pyi rb pl pm php java kt kts scala \
+            swift m mm js jsx mjs cjs ts tsx vue svelte lua ex exs erl hs \
+            clj cljs cljc ml mli fs fsx nim zig d dart r jl sql gleam v \
+            sh bash zsh fish ps1 bat cmd awk sed vim el scm rkt asm s
+            """,
+        .config: """
+            json json5 jsonc yaml yml toml ini cfg conf config properties env \
+            xml plist lock sum mod gradle cmake mk make dockerfile \
+            tf tfvars hcl nix bazel bzl proto graphql gql editorconfig \
+            gitignore gitattributes gitmodules npmrc nvmrc babelrc eslintrc \
+            prettierrc dockerignore
+            """,
+        .markup: """
+            html htm xhtml shtml css scss sass less styl \
+            hbs mustache ejs pug jade haml erb njk liquid twig
+            """,
+        .muted: """
+            bak old orig rej tmp temp swp swo swn pyc pyo pyd o a so dylib dll \
+            class cache map min dSYM
+            """,
+    ])
+
+    /// Whole filenames that carry more meaning than their extension does --
+    /// `Makefile` has none at all, and a README is a document wherever it sits.
+    static let filenames: [String: Kind] = mapping([
+        .config: """
+            Makefile makefile GNUmakefile Dockerfile Containerfile Vagrantfile \
+            Justfile justfile Brewfile Rakefile Gemfile Procfile CMakeLists.txt \
+            package.json tsconfig.json Cargo.toml go.mod pyproject.toml \
+            requirements.txt setup.py setup.cfg flake.nix shell.nix default.nix
+            """,
+        .document: """
+            README README.md README.txt LICENSE LICENCE COPYING CHANGELOG \
+            CHANGELOG.md CONTRIBUTING.md CODE_OF_CONDUCT.md AUTHORS NOTICE \
+            CLAUDE.md AGENTS.md
+            """,
+    ])
+
+    /// Directory names worth separating from the source you are looking for.
+    /// Deliberately short: only build output, caches and tool metadata, whose
+    /// names are unambiguous. Generic names (`src`, `lib`, `app`, `bin`) are
+    /// left alone -- their meaning is project-specific and guessing wrong is
+    /// worse than leaving them the ordinary directory colour.
+    static let directories: [String: Kind] = mapping([
+        .muted: """
+            node_modules __pycache__ .pytest_cache .mypy_cache .ruff_cache \
+            .parcel-cache .turbo .gradle .terraform .tox .eggs .venv venv \
+            .next .nuxt .svelte-kit site-packages DerivedData CMakeFiles \
+            target dist build out coverage htmlcov Pods vendor
+            """,
+        .config: ".git .github .gitlab .circleci .husky .idea .vscode",
+    ])
+
+    private static func mapping(_ groups: [Kind: String]) -> [String: Kind] {
+        var out: [String: Kind] = [:]
+        for (kind, names) in groups {
+            for name in names.split(whereSeparator: \.isWhitespace) {
+                out[String(name)] = kind
+            }
+        }
+        return out
+    }
+
+    // MARK: - Classification
+
+    /// What class `name` belongs to, or `nil` when nothing claims it and the
+    /// caller should leave the row at its ordinary colour.
+    ///
+    /// Directories resolve by name and never fall through to the extension
+    /// table: a folder called `assets.old` is a folder, not a backup file.
+    static func kind(forName name: String, isDirectory: Bool, isSymlink: Bool = false) -> Kind? {
+        if isSymlink { return .symlink }
+        if isDirectory { return directories[name] ?? .directory }
+        if let byName = filenames[name] { return byName }
+
+        // Longest suffix first, so `.tar.gz` beats `.gz`.
+        let lowered = name.lowercased()
+        var index = lowered.startIndex
+        while let dot = lowered[index...].firstIndex(of: ".") {
+            let suffix = String(lowered[lowered.index(after: dot)...])
+            if let kind = extensions[suffix] { return kind }
+            index = lowered.index(after: dot)
+        }
+        return nil
+    }
+
+    // MARK: - Palette
+
+    /// The live terminal palette, cached because `configure(with:)` runs once
+    /// per visible row on every reload and re-reading the Ghostty config there
+    /// would be absurd. Invalidated by the same notifications the agent-chat
+    /// theme sync listens to.
+    @MainActor
+    private static var cachedPalette: [NSColor]?
+    @MainActor
+    private static var observersInstalled = false
+
+    @MainActor
+    static func invalidatePaletteCache() {
+        cachedPalette = nil
+    }
+
+    @MainActor
+    private static func palette() -> [NSColor]? {
+        installObserversIfNeeded()
+        if let cachedPalette { return cachedPalette }
+        let config = GhosttyConfig.loadForCmux(
+            globalFontMagnificationPercent: GlobalFontMagnification.storedPercent
+        )
+        let hexes = TerminalTheme(ghosttyConfig: config).palette
+        guard hexes.count >= TerminalTheme.paletteCount else { return nil }
+        let resolved = hexes.prefix(TerminalTheme.paletteCount).compactMap { NSColor(hex: $0) }
+        // All sixteen or none: a partial palette would silently paint some
+        // classes with another class's colour.
+        guard resolved.count == TerminalTheme.paletteCount else { return nil }
+        cachedPalette = resolved
+        return resolved
+    }
+
+    @MainActor
+    private static func installObserversIfNeeded() {
+        guard !observersInstalled else { return }
+        observersInstalled = true
+        for name in [Notification.Name.ghosttyConfigDidReload,
+                     .ghosttyDefaultBackgroundDidChange] {
+            _ = NotificationCenter.default.addObserver(
+                forName: name, object: nil, queue: .main
+            ) { _ in
+                MainActor.assumeIsolated { cachedPalette = nil }
+            }
+        }
+    }
+
+    // MARK: - Entry point
+
+    /// Whether the tree should colour by file type. Off unless asked for, so
+    /// nobody's sidebar changes appearance on upgrade.
+    /// UserDefaults key behind `fileExplorer.colorByFileType`.
+    static let defaultsKey = "fileExplorerColorByFileType"
+
+    @MainActor
+    static var isEnabled: Bool {
+        UserDefaults.standard.bool(forKey: defaultsKey)
+    }
+
+    /// The colour for a row, or `nil` to leave it alone -- which happens when
+    /// the feature is off, the name is unrecognised, or the terminal palette
+    /// could not be resolved.
+    @MainActor
+    static func color(forName name: String, isDirectory: Bool, isSymlink: Bool = false) -> NSColor? {
+        guard isEnabled,
+              let kind = kind(forName: name, isDirectory: isDirectory, isSymlink: isSymlink),
+              let palette = palette()
+        else { return nil }
+        return palette[kind.paletteSlot]
+    }
+}

--- a/Sources/KeyboardShortcutSettingsFileStore+SectionParsers.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+SectionParsers.swift
@@ -29,6 +29,12 @@ extension CmuxSettingsFileStore {
         } else if section.keys.contains("doubleClickAction") {
             logInvalid("fileExplorer.doubleClickAction", sourcePath: sourcePath)
         }
+
+        if let value = jsonBool(section["colorByFileType"]) {
+            snapshot.managedUserDefaults[FileExplorerFileTypeColor.defaultsKey] = .bool(value)
+        } else if section.keys.contains("colorByFileType") {
+            logInvalid("fileExplorer.colorByFileType", sourcePath: sourcePath)
+        }
     }
 
     func parseSidebarWorkspaceTodosBeta(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1183,6 +1183,8 @@
 		FE002110 /* FileExplorerDoubleClickActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002010 /* FileExplorerDoubleClickActionTests.swift */; };
 		FE5996080000000000000002 /* FileExplorerExternalOpenMenuItems.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5996080000000000000001 /* FileExplorerExternalOpenMenuItems.swift */; };
 		FE5996090000000000000002 /* FileExplorerExternalOpenRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5996090000000000000001 /* FileExplorerExternalOpenRequest.swift */; };
+		C40410010000000000000031 /* FileExplorerFileTypeColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C40410010000000000000030 /* FileExplorerFileTypeColor.swift */; };
+		FE002111 /* FileExplorerFileTypeColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002011 /* FileExplorerFileTypeColorTests.swift */; };
 		FE002112 /* FileExplorerGitStatusProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE002012 /* FileExplorerGitStatusProviderTests.swift */; };
 		FE5996020000000000000002 /* FileExplorerHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE5996020000000000000001 /* FileExplorerHeaderView.swift */; };
 		FE001105 /* FileExplorerKeyboardShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE001005 /* FileExplorerKeyboardShortcuts.swift */; };
@@ -4141,6 +4143,8 @@
 		FE002010 /* FileExplorerDoubleClickActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerDoubleClickActionTests.swift; sourceTree = "<group>"; };
 		FE5996080000000000000001 /* FileExplorerExternalOpenMenuItems.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerExternalOpenMenuItems.swift; sourceTree = "<group>"; };
 		FE5996090000000000000001 /* FileExplorerExternalOpenRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerExternalOpenRequest.swift; sourceTree = "<group>"; };
+		C40410010000000000000030 /* FileExplorerFileTypeColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerFileTypeColor.swift; sourceTree = "<group>"; };
+		FE002011 /* FileExplorerFileTypeColorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerFileTypeColorTests.swift; sourceTree = "<group>"; };
 		FE002012 /* FileExplorerGitStatusProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerGitStatusProviderTests.swift; sourceTree = "<group>"; };
 		FE5996020000000000000001 /* FileExplorerHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerHeaderView.swift; sourceTree = "<group>"; };
 		FE001005 /* FileExplorerKeyboardShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileExplorerKeyboardShortcuts.swift; sourceTree = "<group>"; };
@@ -7062,6 +7066,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D86862000000000000000002 /* TerminalWorkingDirectoryResolver.swift */,
 				85911000000000000000000C /* Workspace+TerminalLinkOpening.swift */,
 				C40410010000000000000020 /* FileExplorerDoubleClickActionSettings.swift */,
+				C40410010000000000000030 /* FileExplorerFileTypeColor.swift */,
 				C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */,
 				E89950010000000000000002 /* GhosttyFlashOverlayView.swift */,
 				F0A110020000000000000001 /* GhosttyMouseSessionLedger.swift */,
@@ -8988,6 +8993,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				828800010000000000000001 /* FileExplorerStyleContrastTests.swift */,
 				FE002002 /* FileExplorerStoreTests.swift */,
 				FE002010 /* FileExplorerDoubleClickActionTests.swift */,
+				FE002011 /* FileExplorerFileTypeColorTests.swift */,
 				FE002003 /* FileSearchRipgrepParserTests.swift */,
 				9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */,
 				D1B800000000000000000015 /* MobileTaskDirectoryListServiceTests.swift */,
@@ -10175,6 +10181,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C40410010000000000000021 /* FileExplorerDoubleClickActionSettings.swift in Sources */,
 				FE5996080000000000000002 /* FileExplorerExternalOpenMenuItems.swift in Sources */,
 				FE5996090000000000000002 /* FileExplorerExternalOpenRequest.swift in Sources */,
+				C40410010000000000000031 /* FileExplorerFileTypeColor.swift in Sources */,
 				FE5996020000000000000002 /* FileExplorerHeaderView.swift in Sources */,
 				FE001105 /* FileExplorerKeyboardShortcuts.swift in Sources */,
 				FE5996030000000000000002 /* FileExplorerNSOutlineView.swift in Sources */,
@@ -11948,6 +11955,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				781100017811000178110001 /* FileDropOverlayHitTestPerformanceTests.swift in Sources */,
 				D0B10018A1B2C3D4E5F60001 /* FileDropOverlayViewTests.swift in Sources */,
 				FE002110 /* FileExplorerDoubleClickActionTests.swift in Sources */,
+				FE002111 /* FileExplorerFileTypeColorTests.swift in Sources */,
 				FE002112 /* FileExplorerGitStatusProviderTests.swift in Sources */,
 				FE002101 /* FileExplorerRootResolverTests.swift in Sources */,
 				9F8A6669D6F54F0EA8E8BEB8 /* FileExplorerRootSyncPolicyTests.swift in Sources */,

--- a/cmuxTests/FileExplorerFileTypeColorTests.swift
+++ b/cmuxTests/FileExplorerFileTypeColorTests.swift
@@ -1,0 +1,95 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Classification coverage for `fileExplorer.colorByFileType`.
+///
+/// Only the pure name → class mapping is exercised here. Resolving a class to
+/// an `NSColor` reads the live Ghostty config and is main-actor bound, so it is
+/// verified by eye rather than faked; what can go silently wrong without a test
+/// is the table itself — a compound suffix shadowed by its tail, a directory
+/// falling through to the extension table, a class pointing at the background
+/// slot.
+@Suite struct FileExplorerFileTypeColorTests {
+
+    @Test func classifiesBySuffix() {
+        #expect(FileExplorerFileTypeColor.kind(forName: "main.rs", isDirectory: false) == .source)
+        #expect(FileExplorerFileTypeColor.kind(forName: "style.css", isDirectory: false) == .markup)
+        #expect(FileExplorerFileTypeColor.kind(forName: "rows.parquet", isDirectory: false) == .data)
+        #expect(FileExplorerFileTypeColor.kind(forName: "photo.png", isDirectory: false) == .media)
+        #expect(FileExplorerFileTypeColor.kind(forName: "notes.md", isDirectory: false) == .document)
+        #expect(FileExplorerFileTypeColor.kind(forName: "cmux.json", isDirectory: false) == .config)
+    }
+
+    @Test func compoundSuffixBeatsItsTail() {
+        // `.gz` alone is also an archive, so this pair cannot catch a
+        // regression on its own -- pair it with a compound whose tail
+        // classifies differently.
+        #expect(FileExplorerFileTypeColor.kind(forName: "bundle.tar.gz", isDirectory: false) == .archive)
+        // `.map` is build junk; a file called `road.map` must not become
+        // something else because an earlier dot was tried first.
+        #expect(FileExplorerFileTypeColor.kind(forName: "v1.2.3.map", isDirectory: false) == .muted)
+    }
+
+    @Test func wholeNamesWinOverExtensions() {
+        #expect(FileExplorerFileTypeColor.kind(forName: "Makefile", isDirectory: false) == .config)
+        // README.md would be `.document` either way; package.json would be
+        // `.config` either way. CMakeLists.txt is the one that proves the
+        // filename table is consulted first: `.txt` alone is a document.
+        #expect(FileExplorerFileTypeColor.kind(forName: "CMakeLists.txt", isDirectory: false) == .config)
+        #expect(FileExplorerFileTypeColor.kind(forName: "notes.txt", isDirectory: false) == .document)
+    }
+
+    @Test func unknownNamesAreLeftAlone() {
+        #expect(FileExplorerFileTypeColor.kind(forName: "nothing.qqq", isDirectory: false) == nil)
+        #expect(FileExplorerFileTypeColor.kind(forName: "noextension", isDirectory: false) == nil)
+    }
+
+    @Test func directoriesResolveByNameAndNeverBySuffix() {
+        #expect(FileExplorerFileTypeColor.kind(forName: "node_modules", isDirectory: true) == .muted)
+        #expect(FileExplorerFileTypeColor.kind(forName: ".git", isDirectory: true) == .config)
+        #expect(FileExplorerFileTypeColor.kind(forName: "src", isDirectory: true) == .directory)
+        // A folder called assets.old is a folder, not a backup file.
+        #expect(FileExplorerFileTypeColor.kind(forName: "assets.old", isDirectory: true) == .directory)
+        #expect(FileExplorerFileTypeColor.kind(forName: "assets.old", isDirectory: false) == .muted)
+    }
+
+    @Test func symlinksOutrankEverything() {
+        #expect(
+            FileExplorerFileTypeColor.kind(forName: "main.rs", isDirectory: false, isSymlink: true)
+                == .symlink
+        )
+    }
+
+    @Test func everyClassMapsIntoThePaletteAndNoneTakesTheBackgroundSlot() {
+        for kind in FileExplorerFileTypeColor.Kind.allCases {
+            #expect(kind.paletteSlot > 0, "\(kind) would be invisible on the terminal background")
+            #expect(kind.paletteSlot < 16, "\(kind) is outside the 16-colour ANSI palette")
+        }
+        // Two classes sharing a slot means two file kinds that cannot be told
+        // apart, which defeats the point of the feature.
+        let slots = FileExplorerFileTypeColor.Kind.allCases.map(\.paletteSlot)
+        #expect(Set(slots).count == slots.count, "two classes share an ANSI slot")
+    }
+
+    @Test func tablesDoNotContradictEachOther() {
+        // A name in both tables would resolve differently for a file and a
+        // directory with the same spelling, which is confusing rather than
+        // wrong -- but a duplicate inside one table is a straight typo.
+        for (table, label) in [
+            (FileExplorerFileTypeColor.extensions, "extensions"),
+            (FileExplorerFileTypeColor.filenames, "filenames"),
+            (FileExplorerFileTypeColor.directories, "directories"),
+        ] {
+            #expect(!table.isEmpty, "\(label) table is empty")
+            for (name, _) in table {
+                #expect(!name.contains(" "), "\(label) key \(name.debugDescription) has a space in it")
+            }
+        }
+    }
+}

--- a/cmuxTests/FileExplorerFileTypeColorTests.swift
+++ b/cmuxTests/FileExplorerFileTypeColorTests.swift
@@ -13,81 +13,115 @@ import Testing
 /// an `NSColor` reads the live Ghostty config and is main-actor bound, so it is
 /// verified by eye rather than faked; what can go silently wrong without a test
 /// is the table itself — a compound suffix shadowed by its tail, a directory
-/// falling through to the extension table, a class pointing at the background
-/// slot.
+/// falling through to the extension table, two classes landing on one slot.
 @Suite struct FileExplorerFileTypeColorTests {
 
+    private typealias Kind = FileExplorerFileTypeColor.Kind
+
+    private func kind(_ name: String, dir: Bool = false, link: Bool = false) -> Kind? {
+        FileExplorerFileTypeColor.kind(forName: name, isDirectory: dir, isSymlink: link)
+    }
+
     @Test func classifiesBySuffix() {
-        #expect(FileExplorerFileTypeColor.kind(forName: "main.rs", isDirectory: false) == .source)
-        #expect(FileExplorerFileTypeColor.kind(forName: "style.css", isDirectory: false) == .markup)
-        #expect(FileExplorerFileTypeColor.kind(forName: "rows.parquet", isDirectory: false) == .data)
-        #expect(FileExplorerFileTypeColor.kind(forName: "photo.png", isDirectory: false) == .media)
-        #expect(FileExplorerFileTypeColor.kind(forName: "notes.md", isDirectory: false) == .document)
-        #expect(FileExplorerFileTypeColor.kind(forName: "cmux.json", isDirectory: false) == .config)
+        #expect(kind("main.rs") == .source)
+        #expect(kind("deploy.sh") == .script)
+        #expect(kind("style.css") == .markup)
+        #expect(kind("rows.parquet") == .data)
+        #expect(kind("photo.png") == .media)
+        #expect(kind("notes.md") == .document)
+        #expect(kind("report.pdf") == .office)
+        #expect(kind("cmux.json") == .config)
+        #expect(kind("server.pem") == .secret)
+        #expect(kind("bundle.zip") == .archive)
+    }
+
+    /// The whole point of the change: a plain source checkout has to come out
+    /// in more than three colours. Blue directories plus green code plus
+    /// yellow everything-else is what this replaced.
+    @Test func aSourceCheckoutUsesMostOfThePalette() {
+        let repo = ["src", "docs", "assets", "node_modules", ".git", "scripts"]
+            .compactMap { kind($0, dir: true) }
+        + ["main.rs", "build.sh", "Cargo.toml", "Cargo.lock", "README.md",
+           "index.html", "rows.csv", "logo.png", "spec.pdf", "dist.tar.gz",
+           ".env", "notes.txt", "app.o"].compactMap { kind($0) }
+        let slots = Set(repo.map(\.paletteSlot))
+        #expect(slots.count >= 12, "an ordinary repo only reaches \(slots.count) colours: \(slots.sorted())")
     }
 
     @Test func compoundSuffixBeatsItsTail() {
-        // `.gz` alone is also an archive, so this pair cannot catch a
-        // regression on its own -- pair it with a compound whose tail
-        // classifies differently.
-        #expect(FileExplorerFileTypeColor.kind(forName: "bundle.tar.gz", isDirectory: false) == .archive)
-        // `.map` is build junk; a file called `road.map` must not become
-        // something else because an earlier dot was tried first.
-        #expect(FileExplorerFileTypeColor.kind(forName: "v1.2.3.map", isDirectory: false) == .muted)
+        #expect(kind("bundle.tar.gz") == .archive)
+        // `.ts` is source; `.d.ts` is generated. If the walk tried the shortest
+        // suffix first this would come back .source.
+        #expect(kind("types.d.ts") == .generated)
+        #expect(kind("app.min.js") == .generated)
+        #expect(kind("app.js") == .source)
     }
 
     @Test func wholeNamesWinOverExtensions() {
-        #expect(FileExplorerFileTypeColor.kind(forName: "Makefile", isDirectory: false) == .config)
-        // README.md would be `.document` either way; package.json would be
-        // `.config` either way. CMakeLists.txt is the one that proves the
-        // filename table is consulted first: `.txt` alone is a document.
-        #expect(FileExplorerFileTypeColor.kind(forName: "CMakeLists.txt", isDirectory: false) == .config)
-        #expect(FileExplorerFileTypeColor.kind(forName: "notes.txt", isDirectory: false) == .document)
+        #expect(kind("Makefile") == .build)
+        // `.txt` alone is a document; CMakeLists.txt is a build file.
+        #expect(kind("CMakeLists.txt") == .build)
+        #expect(kind("notes.txt") == .document)
+        // `.json` alone is config; these two are not.
+        #expect(kind("package.json") == .build)
+        #expect(kind("package-lock.json") == .generated)
+        #expect(kind("tsconfig.json") == .build)
+        #expect(kind("settings.json") == .config)
+    }
+
+    @Test func secretsAreCalledOut() {
+        #expect(kind(".env") == .secret)
+        #expect(kind("id_ed25519") == .secret)
+        #expect(kind("server.key") == .secret)
     }
 
     @Test func unknownNamesAreLeftAlone() {
-        #expect(FileExplorerFileTypeColor.kind(forName: "nothing.qqq", isDirectory: false) == nil)
-        #expect(FileExplorerFileTypeColor.kind(forName: "noextension", isDirectory: false) == nil)
+        #expect(kind("nothing.qqq") == nil)
+        #expect(kind("noextension") == nil)
     }
 
     @Test func directoriesResolveByNameAndNeverBySuffix() {
-        #expect(FileExplorerFileTypeColor.kind(forName: "node_modules", isDirectory: true) == .muted)
-        #expect(FileExplorerFileTypeColor.kind(forName: ".git", isDirectory: true) == .config)
-        #expect(FileExplorerFileTypeColor.kind(forName: "src", isDirectory: true) == .directory)
+        #expect(kind("src", dir: true) == .source)
+        #expect(kind("docs", dir: true) == .document)
+        #expect(kind("assets", dir: true) == .media)
+        #expect(kind("node_modules", dir: true) == .muted)
+        #expect(kind(".git", dir: true) == .generated)
+        #expect(kind("whatever", dir: true) == .directory)
         // A folder called assets.old is a folder, not a backup file.
-        #expect(FileExplorerFileTypeColor.kind(forName: "assets.old", isDirectory: true) == .directory)
-        #expect(FileExplorerFileTypeColor.kind(forName: "assets.old", isDirectory: false) == .muted)
+        #expect(kind("assets.old", dir: true) == .directory)
+        #expect(kind("assets.old") == .muted)
+        // Exact match only: `lib` is a source folder, `zlib` is just a folder.
+        #expect(kind("lib", dir: true) == .source)
+        #expect(kind("zlib", dir: true) == .directory)
     }
 
     @Test func symlinksOutrankEverything() {
-        #expect(
-            FileExplorerFileTypeColor.kind(forName: "main.rs", isDirectory: false, isSymlink: true)
-                == .symlink
-        )
+        #expect(kind("main.rs", link: true) == .symlink)
+        #expect(kind("src", dir: true, link: true) == .symlink)
     }
 
-    @Test func everyClassMapsIntoThePaletteAndNoneTakesTheBackgroundSlot() {
-        for kind in FileExplorerFileTypeColor.Kind.allCases {
-            #expect(kind.paletteSlot > 0, "\(kind) would be invisible on the terminal background")
-            #expect(kind.paletteSlot < 16, "\(kind) is outside the 16-colour ANSI palette")
+    @Test func everyClassOwnsExactlyOneSlotAndNoneIsTheBackground() {
+        let slots = Kind.allCases.map(\.paletteSlot)
+        for (kind, slot) in zip(Kind.allCases, slots) {
+            #expect(slot > 0, "\(kind) would be invisible on the terminal background")
+            #expect(slot < 16, "\(kind) is outside the 16-colour ANSI palette")
         }
-        // Two classes sharing a slot means two file kinds that cannot be told
-        // apart, which defeats the point of the feature.
-        let slots = FileExplorerFileTypeColor.Kind.allCases.map(\.paletteSlot)
         #expect(Set(slots).count == slots.count, "two classes share an ANSI slot")
+        // 15 classes for slots 1...15: the palette is fully used, which is the
+        // difference between a colourful tree and a blue/green/yellow one.
+        #expect(Set(slots) == Set(1...15), "slots \(Set(1...15).subtracting(slots).sorted()) are unused")
     }
 
-    @Test func tablesDoNotContradictEachOther() {
-        // A name in both tables would resolve differently for a file and a
-        // directory with the same spelling, which is confusing rather than
-        // wrong -- but a duplicate inside one table is a straight typo.
+    @Test func noNameIsClaimedByTwoClasses() {
+        // mapping() asserts on this in debug builds; assert it here too so a
+        // release-configuration test run still catches it.
         for (table, label) in [
             (FileExplorerFileTypeColor.extensions, "extensions"),
             (FileExplorerFileTypeColor.filenames, "filenames"),
             (FileExplorerFileTypeColor.directories, "directories"),
         ] {
             #expect(!table.isEmpty, "\(label) table is empty")
-            for (name, _) in table {
+            for name in table.keys {
                 #expect(!name.contains(" "), "\(label) key \(name.debugDescription) has a space in it")
             }
         }

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1605,6 +1605,11 @@
           "default": "preview",
           "description": "What double-clicking (or pressing Return on a search result for) a file in the file explorer does. `preview` opens the built-in cmux file preview (the default and historical behavior). `defaultEditor` opens with the macOS default app for the file type. `preferredEditor` opens with the `app.preferredEditor` command, falling back to the default app when none is set. Only applies to files; directories always expand/collapse, and non-local (remote) file explorers always open the cmux preview.",
           "descriptionKey": "schemaDescriptions.fileExplorer.doubleClickAction"
+        },
+        "colorByFileType": {
+          "type": "boolean",
+          "default": false,
+          "description": "Color file and folder names in the tree by file type, using the terminal palette's 16 ANSI slots. Directories take the slot `ls` uses for `di`, executables the one it uses for `ex`, archives `*.tar.gz`, and so on, so the tree matches the terminal beside it and tracks whatever Ghostty theme is selected, in light and dark. Git status still wins over the type color, and an unrecognized name keeps the ordinary label color."
         }
       }
     },


### PR DESCRIPTION
## Problem

The file tree paints every name `.labelColor` and tints every icon with one color per style, so `main.rs`, `node_modules` and a 2 GB `.parquet` are visually identical. `ls` and `eza` one pane over color all three differently. Today the only thing that ever changes a row's color is git status.

## What this adds

`fileExplorer.colorByFileType` (boolean, **default false**). When on, a row is classified and both the label and the icon take the matching ANSI slot from `TerminalTheme.palette` — the same palette the terminal renders with. Directories take the slot `ls` uses for `di`, executables `ex`, archives the one `*.tar.gz` gets, and so on.

Reading the colors from the live palette rather than hardcoding them is the design point: the sidebar tracks whatever Ghostty theme is selected, in light and dark, with no second palette to keep in sync and nothing extra to configure. Slot 0 is deliberately unused — it is the terminal's own near-black and would be invisible.

## Behavior

- **Off by default**, so no existing sidebar changes appearance on upgrade.
- **Git status still wins** over the type color: what changed matters more than what it is.
- An **unrecognized name returns nil** and keeps `.labelColor`, so the fallback is exactly today's rendering.
- **Directories resolve by name only** and never fall through to the extension table, so a folder called `assets.old` stays a folder.
- The palette is **cached**, invalidated on `ghosttyConfigDidReload` / `ghosttyDefaultBackgroundDidChange`. `configure(with:)` runs once per visible row on every reload, so re-reading the Ghostty config there would be absurd.

The directory table is deliberately short — build output, caches and tool metadata, whose names are unambiguous. Generic names (`src`, `lib`, `app`, `bin`) are left alone: their meaning is project-specific, and coloring one wrong is worse than leaving it the ordinary directory color.

## Tests

`cmuxTests/FileExplorerFileTypeColorTests.swift` covers the classifier: compound suffixes beating their tails, whole names beating extensions, directories never resolving by suffix, symlinks outranking everything, unknown names returning nil, and every class mapping to a distinct non-zero slot.

Resolving a class to an `NSColor` reads the live Ghostty config and is main-actor bound, so that part is verified by eye rather than faked.

Built and run locally against `main` (macOS, Debug).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11518"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790898214&installation_model_id=21920&pr_number=11518&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11518&signature=b0843f070f992672d1bdd69826abdb8d2e54247c04f6a5aa44405623a8108b05"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `fileExplorer.colorByFileType` setting that colors file explorer rows by file type using the terminal palette's ANSI slots, so `main.rs`, `node_modules`, and a 2 GB `.parquet` are no longer visually identical. Off by default, so existing sidebars don't change on upgrade; git status still wins.

**New Features**
- Classifies rows by extension, whole filename, or directory name into 15 classes spanning every usable ANSI slot, so an ordinary source checkout is colorful rather than three colors.
- Unrecognized names keep the ordinary label color; directory names match exactly, so `lib` is source but `zlib` is just a folder.
- Caches the palette and invalidates it on Ghostty config reload or background color change; mapping tables are ordered arrays so a name claimed by two classes fails loudly instead of silently binding to one.

<sup>Written for commit 94a4ab8cc353c307e8dadaf6b9d3dc19d3201a63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11518?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

