### PR TITLE
Prevent staging origins in production iOS builds

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxBrokerService.swift
@@ -7,6 +7,7 @@ public enum IrxBrokerServiceError: Error, Sendable {
     case invalidIdentity
     case noCredentialsIssued
     case unknownRelayURL(String)
+    case deactivated
 }
 
 /// Persisted registration receipt: the full binding tuple, so the host can
@@ -145,6 +146,11 @@ public actor IrxBrokerService {
     private var lastHintRegistered: (url: String?, at: Date)?
     private var lastDiscovery: CmxIrohDiscoveryResponse?
     private var lastDiscoveryAt: Date?
+    /// Monotonic lifecycle fence. URLSession work can outlive task
+    /// cancellation, so every async operation captures this value and proves
+    /// it is still current before publishing a cache result.
+    private var lifecycleEpoch: UInt64 = 0
+    private var deactivated = false
 
     public init(
         configuration: Configuration,
@@ -220,6 +226,7 @@ public actor IrxBrokerService {
     // MARK: - Registration
 
     public func cachedBinding() -> IrxBindingSnapshot? {
+        guard !deactivated else { return nil }
         guard let snapshot = bindingCache.load(),
             snapshot.endpointIDHex == identity.endpointIDHex
         else { return nil }
@@ -251,6 +258,7 @@ public actor IrxBrokerService {
         relayURLHint: String?,
         directPorts: CmxIrohDirectPorts? = nil
     ) async throws -> IrxBindingSnapshot {
+        let epoch = try beginOperation()
         if let registrationInFlight {
             return try await registrationInFlight.value
         }
@@ -258,7 +266,8 @@ public actor IrxBrokerService {
             try await self.registerOnce(
                 pairingEnabled: pairingEnabled,
                 relayURLHint: relayURLHint,
-                directPorts: directPorts
+                directPorts: directPorts,
+                epoch: epoch
             )
         }
         registrationInFlight = task
@@ -269,8 +278,10 @@ public actor IrxBrokerService {
     private func registerOnce(
         pairingEnabled: Bool,
         relayURLHint: String?,
-        directPorts: CmxIrohDirectPorts?
+        directPorts: CmxIrohDirectPorts?,
+        epoch: UInt64
     ) async throws -> IrxBindingSnapshot {
+        try requireCurrent(epoch)
         let startedAt = DispatchTime.now()
         var hints: [CmxIrohPathHint] = []
         let now = Date()
@@ -309,6 +320,7 @@ public actor IrxBrokerService {
         )
         let prepared = try signer.prepare(payload: payload)
         let response = try await client.register(prepared: prepared, signer: signer)
+        try requireCurrent(epoch)
         let snapshot = IrxBindingSnapshot(
             bindingID: response.binding.bindingID,
             deviceID: response.binding.deviceID,
@@ -317,6 +329,7 @@ public actor IrxBrokerService {
             identityGeneration: response.binding.identityGeneration,
             registeredAt: Date()
         )
+        try requireCurrent(epoch)
         bindingCache.save(snapshot)
         lastHintRegistered = (relayURLHint, Date())
         let elapsedMs =
@@ -336,7 +349,8 @@ public actor IrxBrokerService {
     // MARK: - Discovery / trust material
 
     public func cachedTrust() -> IrxTrustSnapshot? {
-        trustCache.load()
+        guard !deactivated else { return nil }
+        return trustCache.load()
     }
 
     /// Synchronous trust read for the admission path (no actor hop). Reads
@@ -349,6 +363,7 @@ public actor IrxBrokerService {
     /// Fresh-enough discovery, from memory or the wire. Never called on the
     /// admission path; admission uses `cachedTrust()`.
     public func discover(maximumAge: TimeInterval = 30) async throws -> CmxIrohDiscoveryResponse {
+        let epoch = try beginOperation()
         if let lastDiscovery, let lastDiscoveryAt,
             Date().timeIntervalSince(lastDiscoveryAt) < maximumAge
         {
@@ -356,6 +371,7 @@ public actor IrxBrokerService {
         }
         let startedAt = DispatchTime.now()
         let response = try await client.discover()
+        try requireCurrent(epoch)
         lastDiscovery = response
         lastDiscoveryAt = Date()
         trustCache.save(
@@ -381,19 +397,23 @@ public actor IrxBrokerService {
     /// Drops the in-memory discovery snapshot after a presence push proves it
     /// stale, so the next discovery-consuming call refetches.
     public func invalidateDiscoverySnapshot() {
+        guard !deactivated else { return }
         lastDiscovery = nil
         lastDiscoveryAt = nil
     }
 
     /// Revokes one account-owned binding (the "forget computer" server leg).
     public func revoke(bindingID: String) async throws {
+        let epoch = try beginOperation()
         try await client.revoke(bindingID: bindingID)
+        try requireCurrent(epoch)
         journal.record("broker", "binding-revoked", ["binding": bindingID])
     }
 
     // MARK: - Relay credentials
 
     public func cachedRelayCredentials() -> [IrxRelayCredential] {
+        guard !deactivated else { return [] }
         guard let snapshot = credentialCache.load(),
             snapshot.endpointIDHex == identity.endpointIDHex
         else { return [] }
@@ -421,6 +441,7 @@ public actor IrxBrokerService {
     /// in the authenticated discovery fleet are accepted, so a corrupted
     /// credential response can never point the endpoint at a foreign relay.
     public func mintRelayCredentials() async throws -> [IrxRelayCredential] {
+        let epoch = try beginOperation()
         let startedAt = DispatchTime.now()
         let endpointID = try CmxIrohPeerIdentity(endpointID: identity.endpointIDHex)
         // Union of both mint hardenings: the stale-pooled-connection retry
@@ -432,6 +453,7 @@ public actor IrxBrokerService {
             bootstrap = try await issueRelayBootstrapRetryingStaleConnection(
                 endpointID: endpointID
             )
+            try requireCurrent(epoch)
         } catch {
             invalidateBindingOnProofRejection(error)
             throw error
@@ -469,6 +491,7 @@ public actor IrxBrokerService {
         guard !minted.isEmpty else {
             throw IrxBrokerServiceError.noCredentialsIssued
         }
+        try requireCurrent(epoch)
         credentialCache.save(
             IrxRelayCredentialSnapshot(
                 credentials: minted,
@@ -497,6 +520,7 @@ public actor IrxBrokerService {
     public func acceptPushedRelayCredentials(
         _ pushed: [IrxRelayCredential]
     ) -> [IrxRelayCredential]? {
+        guard !deactivated else { return nil }
         guard !pushed.isEmpty else { return nil }
         let allowedFleet = Set(trustCache.load()?.relayFleet ?? [])
         guard allowedFleet.isEmpty == false,
@@ -588,6 +612,7 @@ public actor IrxBrokerService {
         acceptorEndpointIDHex: String,
         now: Date = Date()
     ) -> IrxGrantSnapshot? {
+        guard !deactivated else { return nil }
         guard let grants = grantCache.load(),
             let snapshot = grants[acceptorEndpointIDHex],
             snapshot.isFresh(at: now)
@@ -598,6 +623,7 @@ public actor IrxBrokerService {
     /// Drops a grant the host just refused, so the next dial re-mints
     /// instead of re-presenting stale cache.
     public func dropGrant(acceptorEndpointIDHex: String) {
+        guard !deactivated else { return }
         var grants = grantCache.load() ?? [:]
         guard grants.removeValue(forKey: acceptorEndpointIDHex) != nil else { return }
         grantCache.save(grants)
@@ -609,6 +635,7 @@ public actor IrxBrokerService {
         acceptorBindingID: String,
         acceptorEndpointIDHex: String
     ) async throws -> IrxGrantSnapshot {
+        let epoch = try beginOperation()
         guard let binding = cachedBinding() else {
             throw IrxBrokerServiceError.notRegistered
         }
@@ -618,6 +645,7 @@ public actor IrxBrokerService {
                 initiatorBindingID: binding.bindingID,
                 acceptorBindingID: acceptorBindingID
             )
+            try requireCurrent(epoch)
         } catch {
             invalidateBindingOnProofRejection(error)
             throw error
@@ -636,6 +664,7 @@ public actor IrxBrokerService {
         )
         var grants = grantCache.load() ?? [:]
         grants[acceptorEndpointIDHex] = snapshot
+        try requireCurrent(epoch)
         grantCache.save(grants)
         journal.record(
             "broker", "grant-issued",
@@ -645,5 +674,35 @@ public actor IrxBrokerService {
             ]
         )
         return snapshot
+    }
+
+    /// Invalidates this broker instance and erases every endpoint-bearing
+    /// cache. The instance is discarded after sign-out. The epoch fence is
+    /// required because cancelling URLSession does not guarantee that a late
+    /// response cannot resume and attempt a cache write.
+    public func deactivate() {
+        lifecycleEpoch &+= 1
+        deactivated = true
+        registrationInFlight?.cancel()
+        registrationInFlight = nil
+        lastHintRegistered = nil
+        lastDiscovery = nil
+        lastDiscoveryAt = nil
+        bindingCache.clear()
+        trustCache.clear()
+        credentialCache.clear()
+        grantCache.clear()
+        journal.record("broker", "deactivated")
+    }
+
+    private func beginOperation() throws -> UInt64 {
+        guard !deactivated else { throw IrxBrokerServiceError.deactivated }
+        return lifecycleEpoch
+    }
+
+    private func requireCurrent(_ epoch: UInt64) throws {
+        guard !deactivated, lifecycleEpoch == epoch else {
+            throw IrxBrokerServiceError.deactivated
+        }
     }
 }

--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxEndpoint.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxEndpoint.swift
@@ -61,6 +61,11 @@ public actor IrxEndpointSupervisor {
     private var closeWatcher: Task<Void, Never>?
     private var installedRelayURLs: Set<String> = []
     private var bindInFlight: Task<Endpoint, any Error>?
+    /// Sign-out invalidates this supervisor permanently. A cancelled bind can
+    /// still resume after URLSession/iroh returns, so the epoch is checked
+    /// before that stale endpoint is published or advertised.
+    private var lifecycleEpoch: UInt64 = 0
+    private var deactivated = false
 
     public init(configuration: IrxEndpointConfiguration, journal: IrxJournal) {
         self.configuration = configuration
@@ -74,14 +79,16 @@ public actor IrxEndpointSupervisor {
     /// Returns a bound, relay-online endpoint, binding one if needed.
     /// Single-flight: concurrent callers join the in-progress bind.
     public func readyEndpoint(credentials: [IrxRelayCredential]) async throws -> Endpoint {
+        guard !deactivated else { throw IrxEndpointError.endpointClosed }
         if let driver, driver.isClosed() == false, onlineReached {
             return driver
         }
         if let bindInFlight {
             return try await bindInFlight.value
         }
+        let epoch = lifecycleEpoch
         let task = Task<Endpoint, any Error> {
-            try await bindGeneration(credentials: credentials)
+            try await bindGeneration(credentials: credentials, epoch: epoch)
         }
         bindInFlight = task
         defer { bindInFlight = nil }
@@ -140,6 +147,7 @@ public actor IrxEndpointSupervisor {
     /// swapping routes, so live sessions continue. Never removeRelay for a
     /// URL being rotated - remove tears the active relay down instantly.
     public func rotateCredentials(_ credentials: [IrxRelayCredential]) async {
+        guard !deactivated else { return }
         guard let driver, !driver.isClosed() else { return }
         for credential in credentials {
             do {
@@ -186,7 +194,25 @@ public actor IrxEndpointSupervisor {
         journal.record("endpoint", "closed", ["generation": String(generation)])
     }
 
-    private func bindGeneration(credentials: [IrxRelayCredential]) async throws -> Endpoint {
+    /// Permanently invalidates this endpoint generation during sign-out.
+    /// ``close()`` remains a reusable shutdown for callers that only need to
+    /// rebind; this method additionally fences all stale bind completions.
+    public func deactivate() async {
+        lifecycleEpoch &+= 1
+        deactivated = true
+        bindInFlight?.cancel()
+        bindInFlight = nil
+        await close()
+        journal.record("endpoint", "deactivated")
+    }
+
+    private func bindGeneration(
+        credentials: [IrxRelayCredential],
+        epoch: UInt64
+    ) async throws -> Endpoint {
+        guard !deactivated, epoch == lifecycleEpoch else {
+            throw IrxEndpointError.endpointClosed
+        }
         if let old = driver {
             try? await old.close()
             driver = nil
@@ -232,6 +258,10 @@ public actor IrxEndpointSupervisor {
             options.bindAddr = nil
             bound = try await Endpoint.bind(options: options)
         }
+        guard !deactivated, epoch == lifecycleEpoch else {
+            try? await bound.close()
+            throw IrxEndpointError.endpointClosed
+        }
         driver = bound
         installedRelayURLs = Set(usable.map(\.relayURL))
         journal.record(
@@ -250,6 +280,11 @@ public actor IrxEndpointSupervisor {
         let cameOnline = try await withIrxDeadline(.seconds(20)) {
             await bound.online()
             return true
+        }
+        guard !deactivated, epoch == lifecycleEpoch else {
+            try? await bound.close()
+            driver = nil
+            throw IrxEndpointError.endpointClosed
         }
         guard cameOnline == true else {
             journal.record(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceServiceConfiguration.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceServiceConfiguration.swift
@@ -62,6 +62,12 @@ extension PresenceClient {
         isDebugBuild: Bool = PresenceClient.isDebugBuild,
         isDevelopmentAuthChannel: Bool? = nil
     ) -> String? {
+        // Release and production-auth builds must use the production worker
+        // before consulting any stale environment, defaults, or baked value.
+        // This protects already-installed artifacts from staging injection.
+        if !isDebugBuild || isDevelopmentAuthChannel == false {
+            return productionServiceURL
+        }
         let override = environment[serviceURLEnvKey]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             ?? defaults.string(forKey: serviceURLDefaultsKey)?

--- a/Sources/Auth/AuthEnvironment.swift
+++ b/Sources/Auth/AuthEnvironment.swift
@@ -2,6 +2,14 @@ import CMUXAuthCore
 import Foundation
 
 enum AuthEnvironment {
+    private static var isDebugBuild: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+
     private static let developmentStackProjectID = "454ecd03-1db2-4050-845e-4ce5b0cd9895"
     private static let developmentStackPublishableClientKey = "pck_xb63160bwe9699vtxfzfj6emmxpafg5mkjrtp6ehzxv5g"
     private static let productionStackProjectID = "9790718f-14cd-4f7e-824d-eaf527a82b82"
@@ -84,10 +92,7 @@ enum AuthEnvironment {
     }
 
     static var websiteOrigin: URL {
-        resolvedURL(
-            environmentKey: "CMUX_WWW_ORIGIN",
-            fallback: "https://cmux.com"
-        )
+        appWebOrigin(environment: ProcessInfo.processInfo.environment)
     }
 
     /// Pricing page used by every "Upgrade to cmux Pro" entrypoint
@@ -194,19 +199,37 @@ enum AuthEnvironment {
     }
 
     static var signInWebsiteOrigin: URL {
-        canonicalizedLoopbackURL(
-            resolvedURL(
-                environmentKey: "CMUX_AUTH_WWW_ORIGIN",
-                fallback: defaultWebOrigin
-            )
-        )
+        resolvedAuthWebOrigin(environment: ProcessInfo.processInfo.environment)
     }
 
     static var apiBaseURL: URL {
-        canonicalizedLoopbackURL(
+        resolvedAPIBaseURL(
+            environment: ProcessInfo.processInfo.environment,
+            isDebugBuild: isDebugBuild
+        )
+    }
+
+    /// Resolve the authenticated web API origin. Release and production-auth
+    /// processes are pinned to cmux.com before reading ambient launch values,
+    /// so a stale staging variable cannot redirect credential-bearing traffic.
+    static func resolvedAPIBaseURL(
+        environment: [String: String],
+        isDebugBuild: Bool
+    ) -> URL {
+        if !isDebugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: isDebugBuild
+            ) == .production {
+            return URL(string: "https://cmux.com")!
+        }
+        return canonicalizedLoopbackURL(
             resolvedURL(
                 environmentKey: "CMUX_API_BASE_URL",
-                fallback: defaultAPIBaseURL
+                fallback: isDebugBuild
+                    ? "http://localhost:\(resolvedCmuxPort(environment: environment))"
+                    : "https://cmux.com",
+                environment: environment
             )
         )
     }
@@ -219,7 +242,20 @@ enum AuthEnvironment {
     ///      the app was launched (click-through, Dock, `open`, etc.). Only honored in DEBUG.
     ///   3. VM backend dev origin (`http://localhost:$CMUX_PORT` in Debug, cmux.com in Release).
     static var vmAPIBaseURL: URL {
-        if let overridden = ProcessInfo.processInfo.environment["CMUX_VM_API_BASE_URL"]?
+        let environment = ProcessInfo.processInfo.environment
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return URL(string: "https://cmux.com")!
+        }
+        if let overridden = environment["CMUX_VM_API_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !overridden.isEmpty,
            let url = URL(string: overridden) {
@@ -245,6 +281,18 @@ enum AuthEnvironment {
     /// keeps the production VM-API origin.
     static var pushAPIBaseURL: URL {
         let environment = ProcessInfo.processInfo.environment
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return URL(string: "https://cmux.com")!
+        }
         if let overridden = environment["CMUX_PUSH_API_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !overridden.isEmpty,
@@ -275,6 +323,18 @@ enum AuthEnvironment {
     /// `pushAPIBaseURL`; Release keeps the production VM-API origin.
     static var deviceRegistryAPIBaseURL: URL {
         let environment = ProcessInfo.processInfo.environment
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return URL(string: "https://cmux.com")!
+        }
         if let overridden = environment["CMUX_DEVICE_REGISTRY_API_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !overridden.isEmpty,
@@ -306,6 +366,18 @@ enum AuthEnvironment {
     /// account-scoped registry. Release keeps the production cmux origin.
     static var irohBrokerBaseURL: URL? {
         let environment = ProcessInfo.processInfo.environment
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return validatedIrohBrokerURL("https://cmux.com")
+        }
         if let overridden = environment["CMUX_IROH_BROKER_BASE_URL"]?
            .trimmingCharacters(in: .whitespacesAndNewlines),
            !overridden.isEmpty {
@@ -325,6 +397,17 @@ enum AuthEnvironment {
         environment: [String: String],
         isDebugBuild: Bool
     ) -> URL? {
+        // A production-auth or Release process must never be redirected to a
+        // staging broker by ambient launch environment. Release/TestFlight
+        // artifacts get their origins from build settings, and this runtime
+        // guard is the final defense for an already-installed app.
+        if !isDebugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: isDebugBuild
+            ) == .production {
+            return validatedIrohBrokerURL("https://cmux.com")
+        }
         if let explicit = environment["CMUX_IROH_BROKER_BASE_URL"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !explicit.isEmpty {
@@ -384,13 +467,56 @@ enum AuthEnvironment {
     }
 
     private static func billingWebsiteOrigin(environment: [String: String]) -> URL {
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return URL(string: "https://cmux.com")!
+        }
         if let overridden = environmentURL("CMUX_BILLING_WWW_ORIGIN", environment: environment) {
             return overridden
         }
         return appWebOrigin(environment: environment)
     }
 
+    private static func resolvedAuthWebOrigin(environment: [String: String]) -> URL {
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return URL(string: "https://cmux.com")!
+        }
+        if let authWebsite = environmentURL("CMUX_AUTH_WWW_ORIGIN", environment: environment) {
+            return canonicalizedLoopbackURL(authWebsite)
+        }
+        return appWebOrigin(environment: environment)
+    }
+
     private static func appWebOrigin(environment: [String: String]) -> URL {
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return URL(string: "https://cmux.com")!
+        }
         if let explicitWebsite = environmentURL("CMUX_WWW_ORIGIN", environment: environment) {
             return canonicalizedLoopbackURL(explicitWebsite)
         }
@@ -454,6 +580,18 @@ enum AuthEnvironment {
     }
 
     private static func resolvedDefaultWebOrigin(environment: [String: String]) -> String {
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return "https://cmux.com"
+        }
         if let origin = environment["CMUX_WWW_ORIGIN"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !origin.isEmpty {
@@ -516,6 +654,7 @@ enum AuthEnvironment {
         environment: [String: String],
         isDebugBuild: Bool
     ) -> CMUXAuthEnvironment {
+        guard isDebugBuild else { return .production }
         switch environment["CMUX_AUTH_ENVIRONMENT"]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased() {
@@ -532,6 +671,12 @@ enum AuthEnvironment {
         environment: [String: String],
         isDebugBuild: Bool
     ) -> String {
+        if resolvedStackAuthEnvironment(
+            environment: environment,
+            isDebugBuild: isDebugBuild
+        ) == .production {
+            return productionStackProjectID
+        }
         if let projectID = environment["CMUX_STACK_PROJECT_ID"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !projectID.isEmpty {
@@ -566,6 +711,12 @@ enum AuthEnvironment {
         environment: [String: String],
         isDebugBuild: Bool
     ) -> String {
+        if resolvedStackAuthEnvironment(
+            environment: environment,
+            isDebugBuild: isDebugBuild
+        ) == .production {
+            return productionStackPublishableClientKey
+        }
         if let clientKey = environment["CMUX_STACK_PUBLISHABLE_CLIENT_KEY"]?
             .trimmingCharacters(in: .whitespacesAndNewlines),
            !clientKey.isEmpty {
@@ -588,11 +739,7 @@ enum AuthEnvironment {
     }
 
     static func resolvedAfterSignInOrigin(environment: [String: String]) -> URL {
-        resolvedURL(
-            environmentKey: "CMUX_AUTH_WWW_ORIGIN",
-            fallback: resolvedDefaultWebOrigin(environment: environment),
-            environment: environment
-        )
+        resolvedAuthWebOrigin(environment: environment)
     }
 
     static func signInURL(callbackState: String? = nil) -> URL {

--- a/Sources/Cloud/PresenceHeartbeatClient.swift
+++ b/Sources/Cloud/PresenceHeartbeatClient.swift
@@ -111,6 +111,18 @@ final class PresenceHeartbeatClient {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard
     ) -> URL? {
+        #if DEBUG
+        let debugBuild = true
+        #else
+        let debugBuild = false
+        #endif
+        if !debugBuild
+            || AuthEnvironment.resolvedStackAuthEnvironment(
+                environment: environment,
+                isDebugBuild: debugBuild
+            ) == .production {
+            return URL(string: PresenceSettings.productionServiceURL)
+        }
         var raw = environment[PresenceSettings.serviceURLEnvKey]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             ?? defaults.string(forKey: PresenceSettings.serviceURLKey)?

--- a/cmuxTests/AuthEnvironmentTests.swift
+++ b/cmuxTests/AuthEnvironmentTests.swift
@@ -41,7 +41,7 @@ struct AuthEnvironmentTests {
     @Test("explicit Stack values override the selected auth channel")
     func explicitStackValuesOverrideSelectedAuthChannel() {
         let environment = [
-            "CMUX_AUTH_ENVIRONMENT": "production",
+            "CMUX_AUTH_ENVIRONMENT": "development",
             "CMUX_STACK_PROJECT_ID": "test-project",
             "CMUX_STACK_PUBLISHABLE_CLIENT_KEY": "test-key",
         ]
@@ -82,6 +82,61 @@ struct AuthEnvironmentTests {
             environment: ["CMUX_IROH_BROKER_BASE_URL": ":// malformed"],
             isDebugBuild: true
         ) == nil)
+    }
+
+    @Test("production auth cannot be redirected to a staging Iroh broker")
+    func productionAuthCannotBeRedirectedToStagingIrohBroker() {
+        let staging = AuthEnvironment.resolvedIrohBrokerBaseURL(
+            environment: [
+                "CMUX_AUTH_ENVIRONMENT": "production",
+                "CMUX_IROH_BROKER_BASE_URL": "https://cmux-staging.vercel.app",
+            ],
+            isDebugBuild: true
+        )
+        #expect(staging?.absoluteString == "https://cmux.com")
+
+        let release = AuthEnvironment.resolvedIrohBrokerBaseURL(
+            environment: [
+                "CMUX_IROH_BROKER_BASE_URL": "https://cmux-staging.vercel.app",
+            ],
+            isDebugBuild: false
+        )
+        #expect(release?.absoluteString == "https://cmux.com")
+    }
+
+    @Test("production auth pins the authenticated API origin")
+    func productionAuthPinsAuthenticatedAPIOrigin() {
+        let debugProduction = AuthEnvironment.resolvedAPIBaseURL(
+            environment: [
+                "CMUX_AUTH_ENVIRONMENT": "production",
+                "CMUX_API_BASE_URL": "https://cmux-staging.vercel.app",
+            ],
+            isDebugBuild: true
+        )
+        #expect(debugProduction.absoluteString == "https://cmux.com")
+
+        let release = AuthEnvironment.resolvedAPIBaseURL(
+            environment: ["CMUX_API_BASE_URL": "https://cmux-staging.vercel.app"],
+            isDebugBuild: false
+        )
+        #expect(release.absoluteString == "https://cmux.com")
+    }
+
+    @Test("production auth pins Stack project and client key")
+    func productionAuthPinsStackCredentials() {
+        let environment = [
+            "CMUX_AUTH_ENVIRONMENT": "production",
+            "CMUX_STACK_PROJECT_ID": "staging-project",
+            "CMUX_STACK_PUBLISHABLE_CLIENT_KEY": "staging-key",
+        ]
+        #expect(AuthEnvironment.resolvedStackProjectID(
+            environment: environment,
+            isDebugBuild: true
+        ) == "9790718f-14cd-4f7e-824d-eaf527a82b82")
+        #expect(AuthEnvironment.resolvedStackPublishableClientKey(
+            environment: environment,
+            isDebugBuild: true
+        ) == "pck_kzj80gx4mh2jrzn1cx6y5e8jk0kwa01vkevh2p9zd4twr")
     }
 
     @Test("device registry publishes to shared staging in debug so dev phones read fresh routes")

--- a/cmuxTests/PresenceHeartbeatClientTests.swift
+++ b/cmuxTests/PresenceHeartbeatClientTests.swift
@@ -128,4 +128,14 @@ import Testing
         )
         #expect(JSONSerialization.isValidJSONObject(body))
     }
+    @Test func productionPresenceIgnoresStagingEnvironment() {
+        let defaults = UserDefaults(suiteName: "presence-prod-origin-\(UUID().uuidString)")!
+        #expect(PresenceHeartbeatClient.resolvedServiceURL(
+            environment: [
+                "CMUX_AUTH_ENVIRONMENT": "production",
+                PresenceSettings.serviceURLEnvKey: "https://cmux-presence-dev.example",
+            ],
+            defaults: defaults
+        )?.absoluteString == PresenceSettings.productionServiceURL)
+    }
 }

--- a/ios/Config/Release.xcconfig
+++ b/ios/Config/Release.xcconfig
@@ -7,6 +7,16 @@
 PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.app.beta
 DEVELOPMENT_TEAM = 7WLXT3NR37
 
+// Release/TestFlight/App Store artifacts always use production authorities.
+// Keep these defaults in the configuration as a second line of defense behind
+// the archive scripts, so a new Release workflow cannot inherit staging from a
+// runner environment or a tagged development build.
+CMUX_IOS_AUTH_ENV = production
+CMUX_API_BASE_URL = https://cmux.com
+CMUX_IROH_BROKER_BASE_URL = https://cmux.com
+CMUX_PRESENCE_BASE_URL = https://presence.cmux.dev
+CMUX_DEV_TAG =
+
 // Distinguish the TestFlight beta on-device from a future App Store "cmux"
 // (overrides PRODUCT_DISPLAY_NAME = cmux from Shared.xcconfig). Debug stays "cmux".
 PRODUCT_DISPLAY_NAME = cmux BETA

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -83091,6 +83091,74 @@
         }
       }
     },
+    "computers.listauth.unverified.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Not verified on the new connection system yet"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい接続システムでまだ確認されていません"
+          }
+        }
+      }
+    },
+    "computers.listauth.unverified.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "It may be running an older cmux version. Update the Mac, or if it's already updated, open cmux on it once to verify."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "古いバージョンの cmux が動作している可能性があります。Mac をアップデートするか、すでに最新の場合は、その Mac で cmux を一度開いて確認してください。"
+          }
+        }
+      }
+    },
+    "computers.version.outdated.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac update required"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac のアップデートが必要です"
+          }
+        }
+      }
+    },
+    "computers.version.outdated.detail": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Mac is running %@. Update it to %@ or later."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac は %@ を実行しています。%@ 以降にアップデートしてください。"
+          }
+        }
+      }
+    },
     "mobile.connectionsUpdate.macUpdate.detail.official": {
       "extractionState": "manual",
       "localizations": {
@@ -83339,7 +83407,7 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "「Macをスリープさせない」を操作するには、このMacに接続してください。"
+          "value": "「Macをスリープさせない」を操作するには、このMacに接続してください。"
           }
         },
         "de": {

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -77,7 +77,7 @@ public struct MobileAuthComposition {
         self.appNamespace = appNamespace
         self.keychainAccessGroup = keychainAccessGroup
 
-        let overrides = Self.authOverrides(
+        let sourcedOverrides = Self.authOverrides(
             localConfig: Self.localConfigStringOverrides(in: bundle),
             bakedAuthEnvironment: bundle.object(
                 forInfoDictionaryKey: Self.authEnvironmentInfoPlistKey
@@ -88,7 +88,11 @@ public struct MobileAuthComposition {
         )
         let resolvedEnvironment = Self.resolvedAuthEnvironment(
             isDevelopmentBuild: Self.isDevelopmentBuild,
-            overrides: overrides
+            overrides: sourcedOverrides
+        )
+        let overrides = Self.productionSafeOverrides(
+            sourcedOverrides,
+            authEnvironment: resolvedEnvironment
         )
         self.authEnvironment = resolvedEnvironment
         let resolvedConfig = AuthConfig(
@@ -260,6 +264,7 @@ public struct MobileAuthComposition {
         isDevelopmentBuild: Bool,
         overrides: [String: String]
     ) -> CMUXAuthEnvironment {
+        guard isDevelopmentBuild else { return .production }
         switch overrides[authEnvironmentOverrideKey]?
             .trimmingCharacters(in: .whitespacesAndNewlines)
             .lowercased() {
@@ -270,6 +275,20 @@ public struct MobileAuthComposition {
         default:
             return isDevelopmentBuild ? .development : .production
         }
+    }
+
+    /// Release and production-auth builds cannot be redirected by a stale
+    /// LocalConfig.plist or launch override. Keep the auth channel and its
+    /// credential-bearing API origin aligned before constructing AuthConfig.
+    nonisolated static func productionSafeOverrides(
+        _ overrides: [String: String],
+        authEnvironment: CMUXAuthEnvironment
+    ) -> [String: String] {
+        guard authEnvironment == .production else { return overrides }
+        var safe = overrides
+        safe[authEnvironmentOverrideKey] = "production"
+        safe["ApiBaseURL"] = "https://cmux.com"
+        return safe
     }
 
     /// Whether launch enables the `42` debug sign-in shortcut. It signs in

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -2407,17 +2407,25 @@ public final class MobileIrohRuntimeComposition:
         bundleIdentifier: String? = nil,
         allowsLoopback: Bool = true
     ) -> URL? {
+        // Official/TestFlight bundles are always production artifacts. Their
+        // Info.plist must not be able to route Iroh to staging, even when a
+        // stale CMUXIrohBrokerBaseURL or CMUXDevTag was accidentally carried
+        // into the archive. Keep this defense in the runtime as well as the
+        // release-build gate, because an already-installed artifact cannot be
+        // repaired by changing the launch environment.
+        let authEnvironment = (infoDictionary?["CMUXAuthEnvironment"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if authEnvironment == "production"
+            || isOfficialReleaseBundle(bundleIdentifier) {
+            return URL(string: "https://cmux.com")
+        }
+
         if let baked = infoDictionary?["CMUXIrohBrokerBaseURL"] as? String {
             let trimmed = baked.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty {
                 return validatedBrokerBaseURL(trimmed, allowsLoopback: allowsLoopback)
             }
-        }
-        let authEnvironment = (infoDictionary?["CMUXAuthEnvironment"] as? String)?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
-        if authEnvironment == "production" {
-            return URL(string: "https://cmux.com")
         }
         if MobileIOSBuildScope.current(
             infoDictionary: infoDictionary,
@@ -2426,6 +2434,13 @@ public final class MobileIrohRuntimeComposition:
             return URL(string: "https://cmux-staging.vercel.app")
         }
         return validatedBrokerBaseURL(apiBaseURL, allowsLoopback: allowsLoopback)
+    }
+
+    private static func isOfficialReleaseBundle(_ bundleIdentifier: String?) -> Bool {
+        guard let bundleIdentifier else { return false }
+        return bundleIdentifier == "com.cmux.app"
+            || bundleIdentifier == "com.cmuxterm.app.nightly"
+            || bundleIdentifier.hasPrefix("dev.cmux.app.")
     }
 
     private static func validatedBrokerBaseURL(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -102,6 +102,12 @@ public actor MobileIrxRuntimeComposition {
     private var deviceListStore: IrxDeviceListStore?
     private var provisioningTask: Task<Void, Never>?
     private var provisionInFlight: Task<IrxBrokerService, any Error>?
+    /// Auth observation stays alive for the lifetime of the composition. A
+    /// successful first provision must not terminate it, otherwise an
+    /// implicit token clear or account switch leaves the endpoint running.
+    private var authObservationTask: Task<Void, Never>?
+    private var activeAccountID: String?
+    private var lifecycleEpoch: UInt64 = 0
     /// One reconnect owner per Mac endpoint (contract: the single dialer).
     private var enginesByPeer: [String: IrxPeerEngine] = [:]
     /// Route material per peer, refreshed on every transport request.
@@ -150,23 +156,6 @@ public actor MobileIrxRuntimeComposition {
         IrxStateLocation.removeLegacySharedDirectory(base: appSupport)
     }
 
-    /// irx mints its own durable device UUID (persisted beside the identity),
-    /// giving the irx binding its own broker slot: it can never reincarnate
-    /// the legacy runtime's binding out from under another build.
-    private func irxDeviceID() -> String {
-        let url = stateDirectory.appendingPathComponent("device-id")
-        if let existing = try? String(contentsOf: url, encoding: .utf8),
-            !existing.isEmpty
-        {
-            return existing.trimmingCharacters(in: .whitespacesAndNewlines)
-        }
-        let minted = UUID().uuidString.lowercased()
-        try? FileManager.default.createDirectory(
-            at: stateDirectory, withIntermediateDirectories: true)
-        try? minted.write(to: url, atomically: true, encoding: .utf8)
-        return minted
-    }
-
     // MARK: - Lifecycle
 
     public func configure(
@@ -186,58 +175,94 @@ public actor MobileIrxRuntimeComposition {
                 "broker": brokerBaseURL?.host() ?? "-",
             ]
         )
-        // Proactive provisioning so the user-visible connect is warm:
-        // identity, binding, discovery, relay credentials all resolve in the
-        // background at launch, never on the dial path.
-        //
-        // EVENT-DRIVEN on auth: setup never starts before sign-in is
-        // affirmatively complete. The identity stream's first element is the
-        // current state, so an already-signed-in launch provisions
-        // immediately, and a launch that races sign-in provisions the
-        // instant the session publishes instead of discovering it on a
-        // timer. Pre-auth attempts are not just wasted: a failed provision
-        // can burn broker registrations, and every registration write bumps
-        // the account route revision fleet-wide.
+        authObservationTask?.cancel()
         provisioningTask?.cancel()
-        provisioningTask = Task { [weak self] in
-            // Restored sessions first: bootstrap completion is the point
-            // where signed-in state is definitively known, and a session
-            // restored from the keychain may have published before this
-            // subscription existed. Checking directly here means a
-            // signed-in launch provisions immediately without depending on
-            // catching that publish.
+        provisioningTask = nil
+        lifecycleEpoch &+= 1
+        // Proactive provisioning is event-driven on auth. The observation task
+        // never exits after a successful provision, so implicit sign-out and
+        // account switches receive the same teardown as explicit sign-out.
+        authObservationTask = Task { [weak self, weak auth] in
+            guard let auth else { return }
             await auth.awaitBootstrapped()
             guard !Task.isCancelled else { return }
             Self.journal.record("client-runtime", "auth-gate-bootstrapped")
-            if await self?.provisionSignedInWithRetry() == true { return }
-            // Fresh sign-ins and account transitions: provision the instant
-            // the session publishes. Still zero pre-auth attempts.
             for await identity in await auth.authenticatedSessionIdentities() {
                 guard !Task.isCancelled else { return }
-                Self.journal.record(
-                    "client-runtime", "auth-gate-identity",
-                    ["signed_in": String(identity != nil)]
-                )
-                guard identity != nil else { continue }
-                if await self?.provisionSignedInWithRetry() == true { return }
+                await self?.applyAuthIdentity(identity)
             }
+        }
+    }
+
+    private func applyAuthIdentity(
+        _ sessionIdentity: AuthenticatedSessionIdentity?
+    ) async {
+        guard let sessionIdentity else {
+            await handleSignOut()
+            return
+        }
+        guard activeAccountID != sessionIdentity.accountID || broker == nil else {
+            // A same-account refresh does not replace a healthy runtime. If a
+            // prior task was cancelled before publication, restart it.
+            if provisioningTask == nil {
+                startProvisioning(for: sessionIdentity)
+            }
+            return
+        }
+        if activeAccountID != nil || broker != nil {
+            await handleSignOut()
+        }
+        activeAccountID = sessionIdentity.accountID
+        startProvisioning(for: sessionIdentity)
+    }
+
+    private func isCurrent(_ epoch: UInt64) -> Bool {
+        epoch == lifecycleEpoch && activeAccountID != nil
+    }
+
+    private func requireCurrent(_ epoch: UInt64) throws {
+        guard isCurrent(epoch) else { throw CancellationError() }
+    }
+
+    private func requireLifecycle(_ epoch: UInt64) throws {
+        guard epoch == lifecycleEpoch else { throw CancellationError() }
+    }
+
+    private func startProvisioning(for sessionIdentity: AuthenticatedSessionIdentity) {
+        provisioningTask?.cancel()
+        let epoch = lifecycleEpoch
+        provisioningTask = Task { [weak self] in
+            guard let self else { return }
+            _ = await self.provisionSignedInWithRetry(
+                sessionIdentity: sessionIdentity,
+                epoch: epoch
+            )
         }
     }
 
     /// Provisions with capped backoff. Returns true on success; returns
     /// false immediately when not signed in (the caller's auth signal owns
     /// the next attempt, so no pre-auth retries ever run).
-    private func provisionSignedInWithRetry() async -> Bool {
+    private func provisionSignedInWithRetry(
+        sessionIdentity: AuthenticatedSessionIdentity,
+        epoch: UInt64
+    ) async -> Bool {
         guard let auth else { return false }
         Self.journal.record("client-runtime", "auth-gate-snapshot-check")
-        guard (try? await auth.authenticatedSessionSnapshot()) != nil else {
+        guard await auth.isAuthenticatedSessionIdentityCurrent(sessionIdentity) else {
             Self.journal.record("client-runtime", "auth-gate-not-signed-in")
             return false
         }
         Self.journal.record("client-runtime", "auth-gate-signed-in")
         var delay: Duration = .seconds(1)
         while !Task.isCancelled {
-            if await provisionIfPossible() { return true }
+            guard lifecycleEpoch == epoch,
+                  await auth.isAuthenticatedSessionIdentityCurrent(sessionIdentity)
+            else { return false }
+            if await provisionIfPossible(
+                sessionIdentity: sessionIdentity,
+                epoch: epoch
+            ) { return true }
             try? await Task.sleep(for: delay)
             delay = min(delay * 2, .seconds(30))
         }
@@ -259,6 +284,7 @@ public actor MobileIrxRuntimeComposition {
 
     private func startControlPlane(identity: IrxIdentity) {
         guard controlPlane == nil, let controlPlaneBaseURL, let auth else { return }
+        let epoch = lifecycleEpoch
         let client = IrxControlPlaneClient(
             configuration: .init(
                 socketURL: controlPlaneBaseURL
@@ -288,19 +314,23 @@ public actor MobileIrxRuntimeComposition {
             },
             handlers: .init(
                 onRelayPasses: { [weak self] credentials in
-                    await self?.ingestPushedPasses(credentials) ?? false
+                    guard let self, await self.isCurrent(epoch) else { return false }
+                    return await self.ingestPushedPasses(credentials)
                 },
                 onHintUpdate: { [weak self] endpointIDHex, relayURL in
-                    await self?.ingestHintUpdate(
-                        endpointIDHex: endpointIDHex, relayURL: relayURL) ?? false
+                    guard let self, await self.isCurrent(epoch) else { return false }
+                    return await self.ingestHintUpdate(
+                        endpointIDHex: endpointIDHex, relayURL: relayURL)
                 },
                 onDirectory: { _ in true },
                 onSnapshotComplete: { _ in },
                 onDirectoryFact: { [weak self] fact in
-                    await self?.applyDeviceListFact(fact) ?? false
+                    guard let self, await self.isCurrent(epoch) else { return false }
+                    return await self.applyDeviceListFact(fact)
                 },
                 onFreshness: { [weak self] rev, issuedAt in
-                    await self?.applyDeviceListFreshness(rev: rev, issuedAt: issuedAt)
+                    guard let self, await self.isCurrent(epoch) else { return }
+                    await self.applyDeviceListFreshness(rev: rev, issuedAt: issuedAt)
                 }
             ),
             journal: Self.journal
@@ -398,6 +428,47 @@ public actor MobileIrxRuntimeComposition {
     /// Sign-out: drop the lease everywhere (memory, durable store, UI), so
     /// the next account starts from its own directory.
     public func handleSignOut() async {
+        lifecycleEpoch &+= 1
+        activeAccountID = nil
+        provisioningTask?.cancel()
+        provisioningTask = nil
+        provisionInFlight?.cancel()
+        provisionInFlight = nil
+
+        // Stop every live authority before erasing its persisted state. The
+        // broker and endpoint both carry endpoint identity in memory, while
+        // their epoch fences prevent late network completions from restoring
+        // a cache entry after this method returns.
+        let controlPlane = self.controlPlane
+        self.controlPlane = nil
+        await controlPlane?.stop()
+        let autopilot = self.autopilot
+        self.autopilot = nil
+        await autopilot?.stop()
+        let supervisor = self.endpointSupervisor
+        self.endpointSupervisor = nil
+        await supervisor?.deactivate()
+        let engines = Array(enginesByPeer.values)
+        enginesByPeer.removeAll()
+        for engine in engines {
+            await engine.stop(code: .userRequested)
+        }
+        // irx adopts the legacy identity repository, so the donor must run its
+        // sign-out preparation even when legacy transport is dormant. This is
+        // what removes the Ed25519 endpoint key and queues any binding revoke
+        // for an implicit token clear or account switch.
+        if let legacyComposition {
+            let preparation = await legacyComposition.beginSignOutPreparation()
+            _ = await preparation.value
+        }
+        let broker = self.broker
+        self.broker = nil
+        await broker?.deactivate()
+        identity = nil
+        routesByPeer.removeAll()
+        claimedControlSessions.removeAll()
+        claimedEventSessions.removeAll()
+
         deviceListBox.clear()
         if let deviceListStore {
             await deviceListStore.clear()
@@ -476,14 +547,20 @@ public actor MobileIrxRuntimeComposition {
         return true
     }
 
-    private func provisionIfPossible() async -> Bool {
+    private func provisionIfPossible(
+        sessionIdentity: AuthenticatedSessionIdentity,
+        epoch: UInt64
+    ) async -> Bool {
         guard let auth else { return false }
-        guard let session = try? await auth.authenticatedSessionSnapshot() else {
+        guard lifecycleEpoch == epoch,
+              await auth.isAuthenticatedSessionIdentityCurrent(sessionIdentity),
+              let session = try? await auth.authenticatedSessionSnapshot(),
+              session.accountID == sessionIdentity.accountID else {
             return false
         }
         _ = session
         do {
-            _ = try await provisionedBroker()
+            _ = try await provisionedBroker(epoch: epoch)
             Self.journal.record("client-runtime", "provisioned")
             return true
         } catch {
@@ -501,24 +578,33 @@ public actor MobileIrxRuntimeComposition {
     /// half-initialized broker behind: an unregistered client 403s every
     /// later call, which is exactly the poisoned state this single-flight
     /// all-or-nothing shape forbids.
-    private func provisionedBroker() async throws -> IrxBrokerService {
+    private func provisionedBroker(epoch: UInt64? = nil) async throws -> IrxBrokerService {
+        if let epoch {
+            try requireCurrent(epoch)
+        }
         if let broker { return broker }
         if let provisionInFlight {
             return try await provisionInFlight.value
         }
+        let operationEpoch = epoch ?? lifecycleEpoch
         let task = Task<IrxBrokerService, any Error> {
-            try await self.provisionOnce()
+            try await self.provisionOnce(epoch: operationEpoch)
         }
         provisionInFlight = task
         defer { provisionInFlight = nil }
         return try await task.value
     }
 
-    private func provisionOnce() async throws -> IrxBrokerService {
+    private func provisionOnce(epoch: UInt64) async throws -> IrxBrokerService {
+        try requireLifecycle(epoch)
         guard let auth, let brokerBaseURL else {
             throw CompositionError.notSignedIn
         }
         let session = try await auth.authenticatedSessionSnapshot()
+        try requireLifecycle(epoch)
+        guard activeAccountID == nil || activeAccountID == session.accountID else {
+            throw CancellationError()
+        }
         // IDENTITY ADOPTION: same identity/device/app-instance as the legacy
         // stack, so the binding refreshes in place and stored routes + pair
         // grants stay valid across the transport switch.
@@ -528,6 +614,7 @@ public actor MobileIrxRuntimeComposition {
         else {
             throw CompositionError.notSignedIn
         }
+        try requireLifecycle(epoch)
         let identity = IrxIdentity(
             privateKeyData: adopted.material.secretKey.bytes,
             deviceID: adopted.deviceID,
@@ -578,6 +665,7 @@ public actor MobileIrxRuntimeComposition {
         let cachedBinding = await broker.cachedBinding()
         let cachedTrust = await broker.cachedTrust()
         let cachedCredentials = await broker.cachedRelayCredentials()
+        try requireLifecycle(epoch)
         if cachedBinding == nil || cachedTrust == nil {
             // First run for this identity: the full serial path, correctness
             // over speed (registration must precede mint/discovery).
@@ -603,10 +691,17 @@ public actor MobileIrxRuntimeComposition {
             }
         }
         let credentials = try await pilot.usableCredentials()
+        try requireLifecycle(epoch)
         // Fire-and-forget relay-link warm-up: bind + come online now, in
         // parallel with whatever the UI is doing.
         Task { _ = try? await supervisor.readyEndpoint(credentials: credentials) }
         await pilot.start()
+        guard isCurrent(epoch) else {
+            await pilot.stop()
+            await supervisor.deactivate()
+            await broker.deactivate()
+            throw CancellationError()
+        }
         self.identity = identity
         self.broker = broker
         endpointSupervisor = supervisor

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthEnvironmentOverrideTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthEnvironmentOverrideTests.swift
@@ -102,7 +102,7 @@ private struct OfflineReachabilityStub: ReachabilityProviding {
         #expect(MobileAuthComposition.resolvedAuthEnvironment(
             isDevelopmentBuild: false,
             overrides: ["AuthEnvironment": "development"]
-        ) == .development)
+        ) == .production)
     }
 
     @Test func overrideIsCaseInsensitiveAndTrimmed() {
@@ -184,6 +184,27 @@ private struct OfflineReachabilityStub: ReachabilityProviding {
         )
 
         #expect(overrides["ApiBaseURL"] == "http://localhost:8123")
+    }
+
+    @Test func productionBuildCannotKeepDevelopmentAuthOrAPIOverrides() {
+        let resolved = MobileAuthComposition.resolvedAuthEnvironment(
+            isDevelopmentBuild: false,
+            overrides: [
+                "AuthEnvironment": "development",
+                "ApiBaseURL": "https://cmux-staging.vercel.app",
+            ]
+        )
+        #expect(resolved == .production)
+
+        let safe = MobileAuthComposition.productionSafeOverrides(
+            [
+                "AuthEnvironment": "development",
+                "ApiBaseURL": "https://cmux-staging.vercel.app",
+            ],
+            authEnvironment: resolved
+        )
+        #expect(safe["AuthEnvironment"] == "production")
+        #expect(safe["ApiBaseURL"] == "https://cmux.com")
     }
 
     // MARK: - Dev sign-in shortcut gating
@@ -395,5 +416,23 @@ private struct OfflineReachabilityStub: ReachabilityProviding {
             isDebugBuild: true,
             isDevelopmentAuthChannel: false
         ) == "https://cmux-presence-dev-alice.acct.workers.dev")
+    }
+
+    @Test func productionPresenceCannotUseAStaleStagingOverride() throws {
+        #expect(PresenceClient.resolvedServiceBaseURL(
+            environment: [PresenceClient.serviceURLEnvKey: "https://cmux-presence-dev-alice.acct.workers.dev"],
+            defaults: try freshDefaults(),
+            infoPlistValue: "https://cmux-presence-dev-bob.acct.workers.dev",
+            isDebugBuild: false,
+            isDevelopmentAuthChannel: nil
+        ) == PresenceClient.productionServiceURL)
+
+        #expect(PresenceClient.resolvedServiceBaseURL(
+            environment: [PresenceClient.serviceURLEnvKey: "https://cmux-presence-dev-alice.acct.workers.dev"],
+            defaults: try freshDefaults(),
+            infoPlistValue: nil,
+            isDebugBuild: true,
+            isDevelopmentAuthChannel: false
+        ) == PresenceClient.productionServiceURL)
     }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -90,6 +90,29 @@ struct MobileIrohRuntimeCompositionTests {
     }
 
     @Test
+    func productionAuthIgnoresAStagingBrokerBake() {
+        #expect(MobileIrohRuntimeComposition.resolvedBrokerBaseURL(
+            apiBaseURL: "https://cmux.com",
+            infoDictionary: [
+                "CMUXAuthEnvironment": "production",
+                "CMUXIrohBrokerBaseURL": "https://cmux-staging.vercel.app",
+                "CMUXDevTag": "internal",
+            ]
+        )?.absoluteString == "https://cmux.com")
+    }
+
+    @Test
+    func officialReleaseBundleIgnoresAStagingBrokerBakeWithoutAuthMarker() {
+        #expect(MobileIrohRuntimeComposition.resolvedBrokerBaseURL(
+            apiBaseURL: "https://cmux.com",
+            infoDictionary: [
+                "CMUXIrohBrokerBaseURL": "https://cmux-staging.vercel.app",
+            ],
+            bundleIdentifier: "dev.cmux.app.internal"
+        )?.absoluteString == "https://cmux.com")
+    }
+
+    @Test
     func initialAuthenticationAndFirstConnectionDoNotReplayTheSameAuthState() async throws {
         let fixture = try await MobileIrohSignOutFixture.make()
 

--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -45,6 +45,20 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 REPO_ROOT="$(cd "$IOS_DIR/.." && pwd)"
 
+# Distribution archives, including the INTERNAL TestFlight lane, are always
+# production-level artifacts. These values are exported for the cloud archive
+# serializer and repeated as xcodebuild settings in the local fallback.
+export CMUX_IOS_AUTH_ENV=production
+export CMUX_API_BASE_URL=https://cmux.com
+export CMUX_IROH_BROKER_BASE_URL=https://cmux.com
+export CMUX_PRESENCE_BASE_URL=https://presence.cmux.dev
+PRODUCTION_RUNTIME_BUILD_ARGS=(
+  CMUX_IOS_AUTH_ENV=production
+  CMUX_API_BASE_URL=https://cmux.com
+  CMUX_IROH_BROKER_BASE_URL=https://cmux.com
+  CMUX_PRESENCE_BASE_URL=https://presence.cmux.dev
+)
+
 LANE="beta"
 TAG="beta"
 # TestFlight orders by marketing version FIRST: uploading below the testers'
@@ -253,6 +267,7 @@ build_archive_local() {
       ${LANE_DISPLAY_NAME:+PRODUCT_DISPLAY_NAME="$LANE_DISPLAY_NAME"} \
       CURRENT_PROJECT_VERSION="$build_number" \
       ${MARKETING_VERSION_OVERRIDE:+MARKETING_VERSION="$MARKETING_VERSION_OVERRIDE"} \
+      "${PRODUCTION_RUNTIME_BUILD_ARGS[@]}" \
       CODE_SIGNING_ALLOWED=NO \
       CODE_SIGNING_REQUIRED=NO \
       CODE_SIGN_IDENTITY="" \

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -267,15 +267,30 @@ fi
 # server. A physical device cannot: localhost is the phone itself, so Debug
 # device builds use staging unless the caller supplies a reachable override.
 # Production-auth builds retain production origins. Explicit overrides always
-# win, including the shared CMUX_DEV_API_BASE_URL used by tagged Mac builds.
+# win for Debug builds, including the shared CMUX_DEV_API_BASE_URL used by
+# tagged Mac builds. --prod-auth is fail-closed: it cannot be combined with a
+# staging/loopback origin.
+cmux_ios_require_production_origin() {
+  local label="$1"
+  local value="$2"
+  if [[ -n "$value" && "$value" != "https://cmux.com" ]]; then
+    echo "error: --prod-auth cannot use $label '$value'; production builds must use https://cmux.com" >&2
+    return 1
+  fi
+}
+
 cmux_ios_resolve_api_base_url() {
   local target="$1"
   local explicit_base_url="${CMUX_IOS_API_BASE_URL:-${CMUX_DEV_API_BASE_URL:-}}"
 
+  if [[ "$PROD_AUTH" -eq 1 ]]; then
+    cmux_ios_require_production_origin "the API origin" "$explicit_base_url" || return 1
+    printf '%s' "https://cmux.com"
+    return 0
+  fi
+
   if [[ -n "$explicit_base_url" ]]; then
     printf '%s' "$explicit_base_url"
-  elif [[ "$PROD_AUTH" -eq 1 ]]; then
-    printf '%s' "https://cmux.com"
   elif [[ -n "${CMUX_VM_API_BASE_URL:-}" ]]; then
     printf '%s' "$CMUX_VM_API_BASE_URL"
   elif [[ "$target" == "physical_device" ]]; then
@@ -293,14 +308,24 @@ cmux_ios_resolve_api_base_url() {
 cmux_ios_resolve_iroh_broker_base_url() {
   local explicit_base_url="${CMUX_IOS_IROH_BROKER_BASE_URL:-${CMUX_IROH_BROKER_BASE_URL:-}}"
 
+  if [[ "$PROD_AUTH" -eq 1 ]]; then
+    cmux_ios_require_production_origin "the Iroh broker origin" "$explicit_base_url" || return 1
+    printf '%s' "https://cmux.com"
+    return 0
+  fi
+
   if [[ -n "$explicit_base_url" ]]; then
     printf '%s' "$explicit_base_url"
-  elif [[ "$PROD_AUTH" -eq 1 ]]; then
-    printf '%s' "https://cmux.com"
   else
     printf '%s' "https://cmux-staging.vercel.app"
   fi
 }
+
+if [[ "$PROD_AUTH" -eq 1 ]]; then
+  cmux_ios_require_production_origin "the presence origin" "${CMUX_PRESENCE_BASE_URL:-}" || exit 1
+  CMUX_PRESENCE_BASE_URL="https://presence.cmux.dev"
+  export CMUX_PRESENCE_BASE_URL
+fi
 
 CMUX_IOS_SIMULATOR_API_BASE_URL_VALUE="$(cmux_ios_resolve_api_base_url simulator)"
 CMUX_IOS_DEVICE_API_BASE_URL_VALUE="$(cmux_ios_resolve_api_base_url physical_device)"

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -88,6 +88,12 @@ verify_ipa_bundle_identity() {
     return 1
   fi
 
+  if ! "$REPO_ROOT/scripts/lib/verify-ios-release-origins.sh" --app "$app"; then
+    echo "error: exported IPA runtime origins are not production-only: $ipa" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+
   plist_bundle_id="$("$PLISTBUDDY" -c 'Print :CFBundleIdentifier' "$app/Info.plist" 2>/dev/null || true)"
   if [[ "$plist_bundle_id" != "$expected_bundle_id" ]]; then
     echo "error: signed IPA CFBundleIdentifier is '${plist_bundle_id:-<absent>}', expected '$expected_bundle_id': $ipa" >&2
@@ -611,6 +617,7 @@ esac
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+REPO_ROOT="$(cd "$IOS_DIR/.." && pwd)"
 WORKSPACE="$IOS_DIR/cmux.xcworkspace"
 SCHEME="cmux-ios"
 DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM:-7WLXT3NR37}"
@@ -627,6 +634,18 @@ case "$LANE" in
     ;;
 esac
 require_marketing_version "$LANE" "$LANE_MARKETING_VERSION"
+
+# All distribution lanes are production-level artifacts, including the
+# INTERNAL TestFlight app. Keep the four runtime authorities together and pass
+# them explicitly to every archive invocation. This prevents a runner's
+# staging environment, a stale shell export, or a reused archive from silently
+# producing a production-auth app that talks to staging Iroh infrastructure.
+PRODUCTION_RUNTIME_BUILD_ARGS=(
+  CMUX_IOS_AUTH_ENV=production
+  CMUX_API_BASE_URL=https://cmux.com
+  CMUX_IROH_BROKER_BASE_URL=https://cmux.com
+  CMUX_PRESENCE_BASE_URL=https://presence.cmux.dev
+)
 
 # Notes audience is driven by the testing lane (External block for --external).
 NOTES_AUDIENCE="internal"
@@ -890,6 +909,7 @@ if [[ -z "$ARCHIVE_PATH" ]]; then
       CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
       CMUX_CRASH_REPORTING_ENABLED="$CRASH_REPORTING_ENABLED" \
       ${MARKETING_VERSION_ARGS[@]+"${MARKETING_VERSION_ARGS[@]}"} \
+      "${PRODUCTION_RUNTIME_BUILD_ARGS[@]}" \
       CODE_SIGN_STYLE=Automatic \
       CODE_SIGNING_ALLOWED=YES \
       CODE_SIGNING_REQUIRED=YES \
@@ -912,6 +932,7 @@ if [[ -z "$ARCHIVE_PATH" ]]; then
       CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
       CMUX_CRASH_REPORTING_ENABLED="$CRASH_REPORTING_ENABLED" \
       ${MARKETING_VERSION_ARGS[@]+"${MARKETING_VERSION_ARGS[@]}"} \
+      "${PRODUCTION_RUNTIME_BUILD_ARGS[@]}" \
       CODE_SIGNING_ALLOWED=NO \
       CODE_SIGNING_REQUIRED=NO \
       CODE_SIGN_IDENTITY="" \
@@ -930,6 +951,10 @@ if [[ -n "$ARCHIVE_BUNDLE_IDENTIFIER" && "$ARCHIVE_BUNDLE_IDENTIFIER" != "$PRODU
   exit 1
 fi
 ARCHIVE_APP="$(find "$ARCHIVE_PATH/Products/Applications" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -n 1 || true)"
+if [[ -z "$ARCHIVE_APP" || ! -d "$ARCHIVE_APP" ]]; then
+  echo "error: archive has no Products/Applications/*.app to verify runtime origins: $ARCHIVE_PATH" >&2
+  exit 1
+fi
 if [[ -n "$ARCHIVE_APP" && -d "$ARCHIVE_APP" ]]; then
   ARCHIVE_APP_BUNDLE_IDENTIFIER="$("$PLISTBUDDY" -c 'Print :CFBundleIdentifier' "$ARCHIVE_APP/Info.plist" 2>/dev/null || true)"
   if [[ -n "$ARCHIVE_APP_BUNDLE_IDENTIFIER" && "$ARCHIVE_APP_BUNDLE_IDENTIFIER" != "$PRODUCT_BUNDLE_IDENTIFIER" ]]; then
@@ -943,6 +968,11 @@ if [[ -n "$ARCHIVE_APP" && -d "$ARCHIVE_APP" ]]; then
       exit 1
     fi
   fi
+fi
+
+if ! "$REPO_ROOT/scripts/lib/verify-ios-release-origins.sh" --app "$ARCHIVE_APP"; then
+  echo "error: archive runtime origins are not production-only; refusing to export or upload" >&2
+  exit 1
 fi
 
 ARCHIVE_MARKETING_VERSION="$("$PLISTBUDDY" -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"

--- a/scripts/lib/iroh-production-gate.test.mjs
+++ b/scripts/lib/iroh-production-gate.test.mjs
@@ -221,6 +221,36 @@ test("release gate iOS build is isolated from the configured default iPhone", ()
   ].join("\n"));
 });
 
+test("iOS release artifact gate rejects staged runtime origins", (t) => {
+  const directory = fixtureDirectory();
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const app = path.join(directory, "cmux.app");
+  const args = ["scripts/lib/verify-ios-release-origins.sh", "--app", app];
+
+  writeGateAppPlist(app, {
+    CFBundleIdentifier: "dev.cmux.app.internal",
+    CMUXAuthEnvironment: "production",
+    CMUXApiBaseURL: "https://cmux.com",
+    CMUXIrohBrokerBaseURL: "https://cmux.com",
+    CMUXPresenceBaseURL: "https://presence.cmux.dev",
+    CMUXDevTag: "",
+  });
+  const valid = run("bash", args);
+  assert.equal(valid.status, 0, valid.stderr);
+
+  writeGateAppPlist(app, {
+    CFBundleIdentifier: "dev.cmux.app.internal",
+    CMUXAuthEnvironment: "production",
+    CMUXApiBaseURL: "https://cmux.com",
+    CMUXIrohBrokerBaseURL: "https://cmux-staging.vercel.app",
+    CMUXPresenceBaseURL: "https://presence.cmux.dev",
+    CMUXDevTag: "internal",
+  });
+  const invalid = run("bash", args);
+  assert.notEqual(invalid.status, 0);
+  assert.match(invalid.stderr, /CMUXIrohBrokerBaseURL/u);
+});
+
 test("production release gate gives its account helper a normalized protected state directory", (t) => {
   const directory = fixtureDirectory();
   t.after(() => rmSync(directory, { recursive: true, force: true }));

--- a/scripts/lib/mobile-attach.test.mjs
+++ b/scripts/lib/mobile-attach.test.mjs
@@ -169,10 +169,11 @@ function extractShellFunction(source, name) {
 
 function resolveIOSAPIBaseURL(target, extraEnv = {}) {
   const source = fs.readFileSync(path.join(repoRoot, "ios/scripts/reload.sh"), "utf8");
+  const productionGuard = extractShellFunction(source, "cmux_ios_require_production_origin");
   const resolver = extractShellFunction(source, "cmux_ios_resolve_api_base_url");
   return run(
     "bash",
-    ["-c", `${resolver}; cmux_ios_resolve_api_base_url "$1"`, "ios-origin-test", target],
+    ["-c", `${productionGuard}; ${resolver}; cmux_ios_resolve_api_base_url "$1"`, "ios-origin-test", target],
     {
       CMUX_IOS_API_BASE_URL: "",
       CMUX_DEV_API_BASE_URL: "",
@@ -186,10 +187,11 @@ function resolveIOSAPIBaseURL(target, extraEnv = {}) {
 
 function resolveIOSIrohBrokerBaseURL(extraEnv = {}) {
   const source = fs.readFileSync(path.join(repoRoot, "ios/scripts/reload.sh"), "utf8");
+  const productionGuard = extractShellFunction(source, "cmux_ios_require_production_origin");
   const resolver = extractShellFunction(source, "cmux_ios_resolve_iroh_broker_base_url");
   return run(
     "bash",
-    ["-c", `${resolver}; cmux_ios_resolve_iroh_broker_base_url`, "ios-origin-test"],
+    ["-c", `${productionGuard}; ${resolver}; cmux_ios_resolve_iroh_broker_base_url`, "ios-origin-test"],
     {
       CMUX_IOS_IROH_BROKER_BASE_URL: "",
       CMUX_IROH_BROKER_BASE_URL: "",
@@ -633,6 +635,22 @@ test("iOS production-auth builds keep production service origins", () => {
   const broker = resolveIOSIrohBrokerBaseURL({ PROD_AUTH: "1" });
   assert.equal(broker.status, 0, broker.stderr);
   assert.equal(broker.stdout, "https://cmux.com");
+});
+
+test("iOS production-auth rejects staging origin overrides", () => {
+  const api = resolveIOSAPIBaseURL("physical_device", {
+    PROD_AUTH: "1",
+    CMUX_DEV_API_BASE_URL: "https://cmux-staging.vercel.app",
+  });
+  assert.notEqual(api.status, 0);
+  assert.match(api.stderr, /--prod-auth cannot use the API origin/u);
+
+  const broker = resolveIOSIrohBrokerBaseURL({
+    PROD_AUTH: "1",
+    CMUX_IROH_BROKER_BASE_URL: "https://cmux-staging.vercel.app",
+  });
+  assert.notEqual(broker.status, 0);
+  assert.match(broker.stderr, /--prod-auth cannot use the Iroh broker origin/u);
 });
 
 test("tagged reloads share a dedicated Iroh broker", () => {

--- a/scripts/lib/verify-ios-release-origins.sh
+++ b/scripts/lib/verify-ios-release-origins.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Fail-closed artifact gate for every signed/unsigned iOS Release archive.
+# TestFlight and App Store builds use the production Stack project and must
+# carry only production API, Iroh broker, and presence origins. This checks the
+# built Info.plist, rather than the source settings, so an accidental CI
+# environment override cannot reach an upload.
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/lib/verify-ios-release-origins.sh --app <path>
+EOF
+}
+
+APP=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --app) APP="${2:-}"; shift 2 ;;
+    -h|--help) usage; exit 0 ;;
+    *) echo "error: unknown argument '$1'" >&2; usage >&2; exit 2 ;;
+  esac
+done
+
+[[ -n "$APP" ]] || { echo "error: --app is required" >&2; exit 2; }
+[[ -d "$APP" ]] || { echo "error: iOS app does not exist: $APP" >&2; exit 1; }
+PLIST="$APP/Info.plist"
+[[ -f "$PLIST" ]] || { echo "error: iOS app Info.plist is missing: $PLIST" >&2; exit 1; }
+
+read_plist() {
+  local key="$1"
+  /usr/libexec/PlistBuddy -c "Print :$key" "$PLIST" 2>/dev/null || true
+}
+
+require_exact() {
+  local label="$1"
+  local actual="$2"
+  local expected="$3"
+  if [[ "$actual" != "$expected" ]]; then
+    echo "error: production iOS artifact $label is '${actual:-<absent>}', expected '$expected'; refusing to ship staging content" >&2
+    return 1
+  fi
+}
+
+require_empty() {
+  local label="$1"
+  local actual="$2"
+  if [[ -n "$actual" ]]; then
+    echo "error: production iOS artifact $label is '$actual'; release artifacts cannot carry a development tag" >&2
+    return 1
+  fi
+}
+
+bundle_id="$(read_plist CFBundleIdentifier)"
+case "$bundle_id" in
+  com.cmux.app|com.cmuxterm.app.nightly|dev.cmux.app.beta|dev.cmux.app.internal|dev.cmux.app.demo) ;;
+  *)
+    echo "error: production iOS artifact has unexpected release bundle identifier '${bundle_id:-<absent>}'" >&2
+    exit 1
+    ;;
+esac
+require_exact "CMUXAuthEnvironment" "$(read_plist CMUXAuthEnvironment)" "production"
+require_exact "CMUXApiBaseURL" "$(read_plist CMUXApiBaseURL)" "https://cmux.com"
+require_exact "CMUXIrohBrokerBaseURL" "$(read_plist CMUXIrohBrokerBaseURL)" "https://cmux.com"
+require_exact "CMUXPresenceBaseURL" "$(read_plist CMUXPresenceBaseURL)" "https://presence.cmux.dev"
+require_empty "CMUXDevTag" "$(read_plist CMUXDevTag)"
+
+echo "==> production iOS runtime origins verified for ${bundle_id:-unknown bundle}"

--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -1232,8 +1232,16 @@ CMUX_IROH_BROKER_BASE_URL_VALUE="${CMUX_IROH_BROKER_BASE_URL:-https://cmux-stagi
 CMUX_AUTH_WWW_ORIGIN_VALUE="$CMUX_DEV_ORIGIN"
 CMUX_WWW_ORIGIN_VALUE="$CMUX_DEV_ORIGIN"
 if [[ "$PROD_AUTH" -eq 1 ]]; then
-  CMUX_DEV_API_BASE_URL_VALUE="${CMUX_DEV_API_BASE_URL:-https://cmux.com}"
-  CMUX_IROH_BROKER_BASE_URL_VALUE="${CMUX_IROH_BROKER_BASE_URL:-https://cmux.com}"
+  if [[ -n "${CMUX_DEV_API_BASE_URL:-}" && "$CMUX_DEV_API_BASE_URL" != "https://cmux.com" ]]; then
+    echo "error: --prod-auth cannot use API origin '$CMUX_DEV_API_BASE_URL'; production builds must use https://cmux.com" >&2
+    exit 1
+  fi
+  if [[ -n "${CMUX_IROH_BROKER_BASE_URL:-}" && "$CMUX_IROH_BROKER_BASE_URL" != "https://cmux.com" ]]; then
+    echo "error: --prod-auth cannot use Iroh broker origin '$CMUX_IROH_BROKER_BASE_URL'; production builds must use https://cmux.com" >&2
+    exit 1
+  fi
+  CMUX_DEV_API_BASE_URL_VALUE="https://cmux.com"
+  CMUX_IROH_BROKER_BASE_URL_VALUE="https://cmux.com"
   CMUX_AUTH_WWW_ORIGIN_VALUE="https://cmux.com"
   CMUX_WWW_ORIGIN_VALUE="https://cmux.com"
 fi


### PR DESCRIPTION
## Summary
- force production API, Iroh broker, auth, and presence origins in iOS Release/TestFlight archives
- reject staging overrides in production-auth reloads and ignore staging broker bakes at runtime
- add archive and exported IPA artifact gates so production bundles cannot ship staging content

## Verification
- `bash -n ios/scripts/upload-testflight.sh ios/scripts/cloud-testflight.sh ios/scripts/reload.sh scripts/reload.sh scripts/lib/verify-ios-release-origins.sh`
- `swiftc -parse ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift Sources/Auth/AuthEnvironment.swift`
- `bun test scripts/lib/mobile-attach.test.mjs --test-name-pattern 'iOS production-auth'`
- `bun test scripts/lib/iroh-production-gate.test.mjs --test-name-pattern 'iOS release artifact gate'`
- cloud macOS reload attempted; remote build hit unrelated pre-existing `BrowserAppLinkOpenRequest` compile errors in `Sources/Panels/BrowserPopupWindowController.swift`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves iOS list-auth admission onto the irx control plane and hardens production distribution. Phones now admit Macs from the persisted account device directory rather than a grant alone, while production builds fail closed instead of inheriting staging settings.

**Control Plane and Runtime**
- Adds generated v1 control-plane types, socket delivery for relay and directory updates, and revocation handling that closes admitted sessions.
- Shows warnings for Macs that have not verified list-auth or need a version update.
- Keeps auth observation active across provisioning so implicit sign-out and account changes tear down the full irx runtime.
- Fences late network completions, scopes broker caches per bundle and broker, and protects Release credentials with the Keychain.
- Fixes stale-connection bootstrap retries, pairing timeout suppression, QR peer intent, and shared staging routes for debug Macs.

**Production Safeguards**
- Pins Release/TestFlight Stack credentials, API, Iroh broker, presence, and web origins to production at runtime and in `Release.xcconfig`.
- Makes `--prod-auth` reject staging or loopback API, broker, and presence overrides.
- Verifies archived apps and exported IPAs from their built `Info.plist` before export or upload, rejecting staging origins and development tags.
- Keeps Settings Networking aligned with the active irx runtime and makes unsupported mutations fail loudly.

<sup>Written for commit 3090b8320d30132591e508a069575d7be8007a96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added safer sign-out handling that stops active connections and prevents stale network responses from affecting a signed-out session.
  * Added production safeguards for authentication, API, broker, and presence service connections.
  * Added release checks that block uploads when non-production service settings are detected.
  * Added English and Japanese messages for computer authentication and outdated versions.

* **Bug Fixes**
  * Prevented development or staging overrides from redirecting production and release builds.
  * Improved session reconfiguration when authentication identity changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->