### PR TITLE
fix(cmux-tui): select wide graphemes from either cell

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27971,6 +27971,45 @@ mod tests {
     }
 
     #[test]
+    fn double_click_drag_to_a_wide_word_trailing_cell_selects_the_word() {
+        let (mut app, mux, surface, content) = selection_fixture(
+            "double-click-wide-word-drag-selection-test",
+            "alpha 界 omega".as_bytes(),
+        );
+
+        let first_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(first_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..first_click })
+            .unwrap();
+        app.handle_mouse(first_click).unwrap();
+
+        // The wide character starts at column 6 and occupies trailing spacer
+        // column 7. Dragging to that cell must use the grapheme lead.
+        let trailing = MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 7,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(trailing).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..trailing })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (6, 0))),
+            "double-click drag to a wide grapheme's trailing cell must select its word"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_anchors_at_second_press() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-second-press-anchor-test", b"a b c");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27563,6 +27563,35 @@ mod tests {
     }
 
     #[test]
+    fn double_clicking_the_trailing_cell_of_a_wide_word_selects_the_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-wide-word-selection-test", "foo 界 bar".as_bytes());
+
+        // The CJK character occupies columns 4 and 5. A click on the trailing
+        // cell must behave like a click on the grapheme's leading cell.
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 5,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((4, 0), (4, 0))),
+            "double-clicking a wide grapheme's trailing cell must select its word"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_single_cell_press_does_not_store_a_zero_length_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("single-cell-press-selection-state-test", b"alpha beta");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16840,6 +16840,7 @@ impl App {
         let handle = self.session.surface(surface)?;
         let (range, content_generation) =
             handle.with_terminal_and_generation(|terminal, generation| {
+                let point = terminal.normalize_selection_point_screen(point)?;
                 let range = match mode {
                     SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
                     SelectionMode::Line => terminal
@@ -17072,6 +17073,8 @@ impl App {
         }
         let (range, content_generation) = handle
             .with_terminal_and_generation(|terminal, generation| {
+                let anchor_point = terminal.normalize_selection_point_screen(anchor_point)?;
+                let current_point = terminal.normalize_selection_point_screen(current_point)?;
                 let range = match mode {
                     SelectionMode::Word => {
                         // Query both directions: Ghostty's nearest-word lookup is

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16838,8 +16838,8 @@ impl App {
         }
         let point = Self::selection_point(cell)?;
         let handle = self.session.surface(surface)?;
-        let (range, content_generation) =
-            handle.with_terminal_and_generation(|terminal, generation| {
+        let (range, content_generation) = handle
+            .with_terminal_and_generation(|terminal, generation| {
                 let point = terminal.normalize_selection_point_screen(point)?;
                 let range = match mode {
                     SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
@@ -16850,8 +16850,9 @@ impl App {
                         .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
                     SelectionMode::Cell => None,
                 };
-                (range, generation)
-            })?;
+                Some((range, generation))
+            })
+            .flatten()?;
         let range = range?;
         Some((Self::selection_from_range(surface, range), Some(content_generation)))
     }

--- a/cmux-tui/crates/ghostty-vt/src/render.rs
+++ b/cmux-tui/crates/ghostty-vt/src/render.rs
@@ -742,7 +742,7 @@ fn raw_cell_bg_spec(raw: sys::GhosttyCell) -> Option<ColorSpec> {
     }
 }
 
-fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
+pub(crate) fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
     let mut wide = sys::GHOSTTY_CELL_WIDE_NARROW;
     let result = unsafe {
         sys::ghostty_cell_get(raw, sys::GHOSTTY_CELL_DATA_WIDE, &mut wide as *mut _ as *mut c_void)

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -3012,7 +3012,10 @@ impl Terminal {
     /// Move a screen selection point from a wide grapheme's trailing spacer
     /// cell to its leading cell. Mouse reports identify grid cells, so a
     /// click on either half of a wide character must address the same text.
-    pub fn normalize_selection_point_screen(&self, point: SelectionPoint) -> Option<SelectionPoint> {
+    pub fn normalize_selection_point_screen(
+        &self,
+        point: SelectionPoint,
+    ) -> Option<SelectionPoint> {
         let width = self.cell_width_screen(point)?;
         if width != CellWidth::SpacerTail || point.column == 0 {
             return Some(point);
@@ -3022,11 +3025,8 @@ impl Terminal {
     }
 
     fn cell_width_screen(&self, point: SelectionPoint) -> Option<CellWidth> {
-        let grid_ref = self.grid_ref(
-            sys::GHOSTTY_POINT_TAG_SCREEN,
-            point.column,
-            u64::from(point.row),
-        )?;
+        let grid_ref =
+            self.grid_ref(sys::GHOSTTY_POINT_TAG_SCREEN, point.column, u64::from(point.row))?;
         let mut raw = sys::GhosttyCell::default();
         check(unsafe { sys::ghostty_grid_ref_cell(&grid_ref, &mut raw) }).ok()?;
         Some(crate::render::cell_width(raw))

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -3009,6 +3009,29 @@ impl Terminal {
         self.selection_range(&selection).map(Some)
     }
 
+    /// Move a screen selection point from a wide grapheme's trailing spacer
+    /// cell to its leading cell. Mouse reports identify grid cells, so a
+    /// click on either half of a wide character must address the same text.
+    pub fn normalize_selection_point_screen(&self, point: SelectionPoint) -> Option<SelectionPoint> {
+        let width = self.cell_width_screen(point)?;
+        if width != CellWidth::SpacerTail || point.column == 0 {
+            return Some(point);
+        }
+        let leading = SelectionPoint { column: point.column - 1, ..point };
+        (self.cell_width_screen(leading) == Some(CellWidth::Wide)).then_some(leading)
+    }
+
+    fn cell_width_screen(&self, point: SelectionPoint) -> Option<CellWidth> {
+        let grid_ref = self.grid_ref(
+            sys::GHOSTTY_POINT_TAG_SCREEN,
+            point.column,
+            u64::from(point.row),
+        )?;
+        let mut raw = sys::GhosttyCell::default();
+        check(unsafe { sys::ghostty_grid_ref_cell(&grid_ref, &mut raw) }).ok()?;
+        Some(crate::render::cell_width(raw))
+    }
+
     /// Select the nearest word between two absolute screen coordinates.
     /// This is useful while dragging because it skips whitespace and other
     /// empty cells without inventing boundaries in the UI layer.


### PR DESCRIPTION
Stacked on #11511.

Transplants PR #11494 wide-grapheme selection normalization and behavior tests onto the generation-tagged semantic selection anchors in #11511.

Changes:
- normalize trailing spacer cells to the wide grapheme lead before word and line selection
- expose the terminal normalization helper through the Ghostty VT API
- cover wide-word double-click and semantic drag endpoint behavior

Validation:
- rustfmt --edition 2024 --check on changed Rust files
- git diff --check against PR #11511
- Rust/Cargo builds and tests not run, per task constraints

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux-tui` wide-grapheme selection so clicks and semantic drags on a trailing spacer cell now select the same word or line as the leading cell, instead of treating the spacer as a separate selection point.

- Normalizes points before word and line lookup while preserving the content generation for each semantic selection.
- Exposes cell-width lookup through `ghostty-vt` and adds regression tests for wide-word double-clicks and drag endpoints.

<sup>Written for commit 10e01292fd63c4894eb4e1492f6af750a8e8e096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

