### PR TITLE
Fix RouteGate waits on Tokio workers

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -93,6 +93,11 @@ mod unix {
             // broadcast wakeup so either task can observe closure without
             // consuming the other's permit.
             self.closed_notify.notify_waiters();
+            // Serialize marker enqueue with on_close registration. The event
+            // worker may receive the marker immediately, so the handler must
+            // be either installed before enqueue or installed by on_close
+            // while the worker waits on this same mutex.
+            let _close_handler = self.close_handler.lock().expect("control close lock");
             let _ = self.dispatch_tx.try_send(Dispatch::Closed);
         }
     }
@@ -147,23 +152,40 @@ mod unix {
         std::thread::Builder::new()
             .name("chatmux-relay-control-events".to_owned())
             .spawn(move || {
-                while let Ok(dispatch) = dispatch_rx.recv() {
-                    let Some(shared) = weak_shared.upgrade() else { break };
-                    if shared.closed.load(Ordering::SeqCst) {
-                        if !shared.deliberate.load(Ordering::SeqCst) {
-                            let handler =
-                                shared.close_handler.lock().expect("control close lock").take();
-                            if let Some(handler) = handler {
-                                handler();
+                loop {
+                    let dispatch = match dispatch_rx.recv_timeout(Duration::from_millis(50)) {
+                        Ok(dispatch) => dispatch,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                            let Some(shared) = weak_shared.upgrade() else { break };
+                            if shared.closed.load(Ordering::SeqCst) {
+                                Dispatch::Closed
+                            } else {
+                                continue;
                             }
                         }
-                        break;
-                    }
-                    if let Dispatch::Event(event) = dispatch {
-                        let handler =
-                            shared.event_handler.lock().expect("control event lock").clone();
-                        if let Some(handler) = handler {
-                            handler(&event);
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    };
+                    let Some(shared) = weak_shared.upgrade() else { break };
+                    match dispatch {
+                        Dispatch::Event(event) => {
+                            // Closure is settled before the marker is queued,
+                            // but events already in the FIFO still belong to
+                            // the stream and must be delivered first.
+                            let handler =
+                                shared.event_handler.lock().expect("control event lock").clone();
+                            if let Some(handler) = handler {
+                                handler(&event);
+                            }
+                        }
+                        Dispatch::Closed => {
+                            if !shared.deliberate.load(Ordering::SeqCst) {
+                                let handler =
+                                    shared.close_handler.lock().expect("control close lock").take();
+                                if let Some(handler) = handler {
+                                    handler();
+                                }
+                            }
+                            break;
                         }
                     }
                 }
@@ -404,11 +426,16 @@ mod unix {
         }
 
         fn on_close(&self, handler: CloseHandler) {
-            let was_closed = self.shared.closed.load(Ordering::SeqCst);
-            let deliberate = self.shared.deliberate.load(Ordering::SeqCst);
-            *self.shared.close_handler.lock().expect("control close lock") = Some(handler);
-            if was_closed && !deliberate {
+            let mut slot = self.shared.close_handler.lock().expect("control close lock");
+            if self.shared.closed.load(Ordering::SeqCst) {
+                if self.shared.deliberate.load(Ordering::SeqCst) {
+                    return;
+                }
+                *slot = Some(handler);
+                drop(slot);
                 let _ = self.shared.dispatch_tx.try_send(Dispatch::Closed);
+            } else {
+                *slot = Some(handler);
             }
         }
 

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -12,6 +12,7 @@ pub const CONTROL_TIMEOUT_MS: u64 = 3_000;
 const MAX_CONTROL_LINE_BYTES: usize = 1_048_576;
 const MAX_WRITER_QUEUE: usize = 256;
 const MAX_PENDING_REQUESTS: usize = 256;
+const MAX_EVENT_QUEUE: usize = 1_024;
 
 pub type EventHandler = Box<dyn Fn(&Value) + Send + Sync>;
 pub type CloseHandler = Box<dyn Fn() + Send + Sync>;
@@ -62,7 +63,7 @@ mod unix {
 
     struct Shared {
         pending: Mutex<HashMap<u64, oneshot::Sender<Value>>>,
-        event_handler: Mutex<Option<EventHandler>>,
+        event_handler: Mutex<Option<Arc<dyn Fn(&Value) + Send + Sync>>>,
         close_handler: Mutex<Option<CloseHandler>>,
         closed: AtomicBool,
         deliberate: AtomicBool,
@@ -78,7 +79,7 @@ mod unix {
 
     enum Dispatch {
         Event(Value),
-        Close(CloseHandler),
+        Closed,
     }
 
     impl Shared {
@@ -92,12 +93,7 @@ mod unix {
             // broadcast wakeup so either task can observe closure without
             // consuming the other's permit.
             self.closed_notify.notify_waiters();
-            if self.deliberate.load(Ordering::SeqCst) {
-                return;
-            }
-            if let Some(handler) = self.close_handler.lock().expect("control close lock").take() {
-                let _ = self.dispatch_tx.try_send(Dispatch::Close(handler));
-            }
+            let _ = self.dispatch_tx.try_send(Dispatch::Closed);
         }
     }
 
@@ -131,7 +127,7 @@ mod unix {
             stream.as_raw_fd()
         };
         let (read_half, write_half) = stream.into_split();
-        let (dispatch_tx, dispatch_rx) = std::sync::mpsc::sync_channel(1024);
+        let (dispatch_tx, dispatch_rx) = std::sync::mpsc::sync_channel(MAX_EVENT_QUEUE);
         let shared = Arc::new(Shared {
             pending: Mutex::new(HashMap::new()),
             event_handler: Mutex::new(None),
@@ -152,16 +148,23 @@ mod unix {
             .name("chatmux-relay-control-events".to_owned())
             .spawn(move || {
                 while let Ok(dispatch) = dispatch_rx.recv() {
-                    match dispatch {
-                        Dispatch::Event(event) => {
-                            let Some(shared) = weak_shared.upgrade() else { break };
-                            if let Some(handler) =
-                                shared.event_handler.lock().expect("control event lock").as_ref()
-                            {
-                                handler(&event);
+                    let Some(shared) = weak_shared.upgrade() else { break };
+                    if shared.closed.load(Ordering::SeqCst) {
+                        if !shared.deliberate.load(Ordering::SeqCst) {
+                            let handler =
+                                shared.close_handler.lock().expect("control close lock").take();
+                            if let Some(handler) = handler {
+                                handler();
                             }
                         }
-                        Dispatch::Close(handler) => handler(),
+                        break;
+                    }
+                    if let Dispatch::Event(event) = dispatch {
+                        let handler =
+                            shared.event_handler.lock().expect("control event lock").clone();
+                        if let Some(handler) = handler {
+                            handler(&event);
+                        }
                     }
                 }
             })
@@ -396,11 +399,17 @@ mod unix {
         }
 
         fn on_event(&self, handler: EventHandler) {
-            *self.shared.event_handler.lock().expect("control event lock") = Some(handler);
+            *self.shared.event_handler.lock().expect("control event lock") =
+                Some(Arc::from(handler));
         }
 
         fn on_close(&self, handler: CloseHandler) {
+            let was_closed = self.shared.closed.load(Ordering::SeqCst);
+            let deliberate = self.shared.deliberate.load(Ordering::SeqCst);
             *self.shared.close_handler.lock().expect("control close lock") = Some(handler);
+            if was_closed && !deliberate {
+                let _ = self.shared.dispatch_tx.try_send(Dispatch::Closed);
+            }
         }
 
         fn pause(&self) {

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -44,7 +44,7 @@ mod unix {
     use super::*;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, Weak};
     use std::time::Duration;
 
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -73,6 +73,12 @@ mod unix {
         read_done: Notify,
         #[cfg(test)]
         read_waiting: Mutex<Option<oneshot::Sender<()>>>,
+        dispatch_tx: std::sync::mpsc::SyncSender<Dispatch>,
+    }
+
+    enum Dispatch {
+        Event(Value),
+        Close(CloseHandler),
     }
 
     impl Shared {
@@ -86,11 +92,11 @@ mod unix {
             // broadcast wakeup so either task can observe closure without
             // consuming the other's permit.
             self.closed_notify.notify_waiters();
-            if !self.deliberate.load(Ordering::SeqCst)
-                && let Some(handler) =
-                    self.close_handler.lock().expect("control close lock").as_ref()
-            {
-                handler();
+            if self.deliberate.load(Ordering::SeqCst) {
+                return;
+            }
+            if let Some(handler) = self.close_handler.lock().expect("control close lock").take() {
+                let _ = self.dispatch_tx.try_send(Dispatch::Close(handler));
             }
         }
     }
@@ -125,6 +131,7 @@ mod unix {
             stream.as_raw_fd()
         };
         let (read_half, write_half) = stream.into_split();
+        let (dispatch_tx, dispatch_rx) = std::sync::mpsc::sync_channel(1024);
         let shared = Arc::new(Shared {
             pending: Mutex::new(HashMap::new()),
             event_handler: Mutex::new(None),
@@ -138,7 +145,27 @@ mod unix {
             read_done: Notify::new(),
             #[cfg(test)]
             read_waiting: Mutex::new(None),
+            dispatch_tx,
         });
+        let weak_shared: Weak<Shared> = Arc::downgrade(&shared);
+        std::thread::Builder::new()
+            .name("chatmux-relay-control-events".to_owned())
+            .spawn(move || {
+                while let Ok(dispatch) = dispatch_rx.recv() {
+                    match dispatch {
+                        Dispatch::Event(event) => {
+                            let Some(shared) = weak_shared.upgrade() else { break };
+                            if let Some(handler) =
+                                shared.event_handler.lock().expect("control event lock").as_ref()
+                            {
+                                handler(&event);
+                            }
+                        }
+                        Dispatch::Close(handler) => handler(),
+                    }
+                }
+            })
+            .expect("spawn control event worker");
         // Keep one async writer for every connection. The queue makes the
         // synchronous `send` API safe without spawning one task per input;
         // `write_all` below waits for socket backpressure and never exposes a
@@ -267,11 +294,11 @@ mod unix {
                 });
                 if let Some(sender) = waiting {
                     let _ = sender.send(parsed);
-                } else if parsed.get("event").and_then(Value::as_str).is_some()
-                    && let Some(handler) =
-                        shared.event_handler.lock().expect("control event lock").as_ref()
-                {
-                    handler(&parsed);
+                } else if parsed.get("event").and_then(Value::as_str).is_some() {
+                    if shared.dispatch_tx.try_send(Dispatch::Event(parsed)).is_err() {
+                        shared.settle_closed();
+                        break 'read_loop;
+                    }
                 }
                 // Responses to fire-and-forget sends fall through silently.
             }
@@ -403,7 +430,7 @@ mod unix {
 mod tests {
     use super::*;
     use serde_json::json;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _};
     use tokio::net::UnixListener;
@@ -486,6 +513,61 @@ mod tests {
             .await
             .expect("second waiter wakes")
             .expect("second waiter joins");
+    }
+
+    #[tokio::test]
+    async fn event_callbacks_run_in_wire_order() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-events-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control event test socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept control event socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for event handler");
+            stream
+                .write_all(b"{\"event\":\"first\"}\n{\"event\":\"second\"}\n")
+                .await
+                .expect("write control events");
+            let mut bytes = Vec::new();
+            stream.read_to_end(&mut bytes).await.expect("read client close");
+        });
+
+        let control =
+            connect_control(&socket_path, 3_000).await.expect("connect control event test socket");
+        accepted_rx.await.expect("wait for control event server");
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (done_tx, done_rx) = oneshot::channel();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+        let seen_for_handler = Arc::clone(&seen);
+        let done_tx_for_handler = Arc::clone(&done_tx);
+        control.on_event(Box::new(move |event| {
+            let mut seen = seen_for_handler.lock().expect("event record lock");
+            seen.push(event["event"].as_str().expect("event name").to_owned());
+            if seen.len() == 2 {
+                if let Some(done_tx) = done_tx_for_handler.lock().expect("event done lock").take() {
+                    let _ = done_tx.send(());
+                }
+            }
+        }));
+        start_tx.send(()).expect("start control event stream");
+
+        tokio::time::timeout(Duration::from_secs(1), done_rx)
+            .await
+            .expect("ordered event callbacks complete")
+            .expect("ordered event callback signal");
+        assert_eq!(
+            *seen.lock().expect("event record lock"),
+            vec!["first".to_owned(), "second".to_owned()]
+        );
+        control.end();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server observes client close")
+            .expect("join control event server");
+        let _ = std::fs::remove_file(socket_path);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -21,10 +21,11 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::ThreadId;
-use tokio::sync::Notify;
+use std::time::Duration;
+use tokio::sync::{Notify, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use async_trait::async_trait;
@@ -55,6 +56,8 @@ const MAX_ALLOWED_ROOTS: usize = 32;
 const MAX_ALLOWED_ROOT_BYTES: usize = 16 * 1024;
 const MAX_ENUM_SURFACES: usize = 8;
 const RAW_ATTACH_BACKLOG_CAP: usize = 1024 * 1024;
+const MAX_OUTPUT_CHUNK_BYTES: usize = 256 * 1024;
+const CONTROL_OPERATION_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 const PTY_INPUT_B64_CAP: usize = 4 * 1024 * 1024;
 
 /// Random lowercase-hex identity for transports and tunnel attachments.
@@ -287,11 +290,6 @@ pub struct FrameContext {
     pub cancellation: CancellationToken,
 }
 
-/// Reconciled machine authority at a single route decision.
-///
-/// The version makes a route snapshot explicit. Roots are checked again for
-/// every output/control operation, so a root rotation cannot leave an old PTY
-/// usable merely because its trust level stayed unchanged.
 #[derive(Clone, Debug, Default)]
 pub struct LiveAuth {
     pub trust: String,
@@ -349,13 +347,15 @@ struct ShellInner {
 }
 
 /// A reentrant publication gate for one attachment generation. The gate
-/// serializes route publication and control operations across threads while
-/// allowing an outbound/control callback to synchronously re-enter the same
-/// route (for example, a test sink that closes the PTY). A callback must not
-/// synchronously wait for another thread that needs this same gate.
+/// serializes route publication and control-operation admission across
+/// threads while allowing an outbound/control callback to synchronously
+/// re-enter the same route (for example, a test sink that closes the PTY).
+/// A callback must not synchronously wait for another thread that needs this
+/// same gate.
 struct RouteGate {
     state: Mutex<RouteGateState>,
     changed: Condvar,
+    async_changed: Notify,
 }
 
 #[derive(Default)]
@@ -371,7 +371,11 @@ struct RouteGuard<'a> {
 
 impl RouteGate {
     fn new() -> Self {
-        Self { state: Mutex::new(RouteGateState::default()), changed: Condvar::new() }
+        Self {
+            state: Mutex::new(RouteGateState::default()),
+            changed: Condvar::new(),
+            async_changed: Notify::new(),
+        }
     }
 
     fn lock(&self) -> RouteGuard<'_> {
@@ -384,6 +388,28 @@ impl RouteGate {
         state.depth += 1;
         drop(state);
         RouteGuard { gate: self, owner }
+    }
+
+    /// Acquire the gate without blocking a Tokio worker. The critical
+    /// sections protected by this gate never await, so the polling thread is
+    /// stable for the lifetime of the guard and can safely re-enter through a
+    /// synchronous callback.
+    async fn lock_async(&self) -> RouteGuard<'_> {
+        loop {
+            let owner = std::thread::current().id();
+            let notified = self.async_changed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            {
+                let mut state = self.state.lock().expect("route gate lock");
+                if state.owner.is_none_or(|current| current == owner) {
+                    state.owner = Some(owner);
+                    state.depth += 1;
+                    return RouteGuard { gate: self, owner };
+                }
+            }
+            notified.await;
+        }
     }
 
     fn held_by_current_thread(&self) -> bool {
@@ -403,6 +429,7 @@ impl Drop for RouteGuard<'_> {
         if state.depth == 0 {
             state.owner = None;
             self.gate.changed.notify_all();
+            self.gate.async_changed.notify_waiters();
         }
     }
 }
@@ -410,6 +437,7 @@ impl Drop for RouteGuard<'_> {
 #[derive(Clone)]
 struct Attachment {
     closing: Arc<AtomicBool>,
+    close_pending: Arc<AtomicBool>,
     /// Releases this attachment (detach a viewer, close a control stream,
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
@@ -420,6 +448,103 @@ struct Attachment {
     transport_id: Option<String>,
     generation: u64,
     publication_gate: Arc<RouteGate>,
+    control_ops: Arc<ControlOperationState>,
+}
+
+struct ControlOperationState {
+    active: AtomicUsize,
+    wait_lock: Mutex<()>,
+    owners: Mutex<HashMap<ThreadId, usize>>,
+    changed: Condvar,
+    async_changed: Notify,
+}
+
+impl ControlOperationState {
+    fn new() -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            wait_lock: Mutex::new(()),
+            owners: Mutex::new(HashMap::new()),
+            changed: Condvar::new(),
+            async_changed: Notify::new(),
+        }
+    }
+
+    fn begin(&self) {
+        let _wait = self.wait_lock.lock().expect("control operation wait lock");
+        self.active.fetch_add(1, Ordering::AcqRel);
+        let owner = std::thread::current().id();
+        *self.owners.lock().expect("control operation owners lock").entry(owner).or_default() += 1;
+    }
+
+    fn end(&self) {
+        let _wait = self.wait_lock.lock().expect("control operation wait lock");
+        let owner = std::thread::current().id();
+        let mut owners = self.owners.lock().expect("control operation owners lock");
+        if let Some(count) = owners.get_mut(&owner) {
+            *count -= 1;
+            if *count == 0 {
+                owners.remove(&owner);
+            }
+        }
+        if self.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.changed.notify_all();
+            self.async_changed.notify_waiters();
+        }
+    }
+
+    fn owned_by_current_thread(&self) -> bool {
+        self.owners
+            .lock()
+            .expect("control operation owners lock")
+            .contains_key(&std::thread::current().id())
+    }
+
+    fn wait_sync_timeout(&self, timeout: Option<Duration>) -> bool {
+        if self.owned_by_current_thread() {
+            return true;
+        }
+        let mut guard = self.wait_lock.lock().expect("control operation wait lock");
+        while self.active.load(Ordering::Acquire) != 0 {
+            if let Some(timeout) = timeout {
+                let (next, result) =
+                    self.changed.wait_timeout(guard, timeout).expect("control operation wait");
+                guard = next;
+                if result.timed_out() {
+                    return false;
+                }
+            } else {
+                guard = self.changed.wait(guard).expect("control operation wait");
+            }
+        }
+        true
+    }
+
+    async fn wait_async(&self) {
+        if self.owned_by_current_thread() {
+            return;
+        }
+        loop {
+            if self.active.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            let notified = self.async_changed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.active.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct ControlOperationLease(Arc<ControlOperationState>);
+
+impl Drop for ControlOperationLease {
+    fn drop(&mut self) {
+        self.0.end();
+    }
 }
 
 struct Inner {
@@ -553,15 +678,17 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
-                    self.inner.with_live_attachment(
-                        pty_id,
-                        &attachment,
-                        context,
-                        "input",
-                        |control| {
-                            control.write(&data);
-                        },
-                    );
+                    self.inner
+                        .with_live_attachment_async(
+                            pty_id,
+                            &attachment,
+                            context,
+                            "input",
+                            |control| {
+                                control.write(&data);
+                            },
+                        )
+                        .await;
                 }
             }
             "pty_resize" => {
@@ -575,15 +702,17 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
-                    self.inner.with_live_attachment(
-                        pty_id,
-                        &attachment,
-                        context,
-                        "resize",
-                        |control| {
-                            control.resize(cols, rows);
-                        },
-                    );
+                    self.inner
+                        .with_live_attachment_async(
+                            pty_id,
+                            &attachment,
+                            context,
+                            "resize",
+                            |control| {
+                                control.resize(cols, rows);
+                            },
+                        )
+                        .await;
                 }
             }
             "pty_flow" => {
@@ -593,19 +722,21 @@ impl PtyManager {
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
-                    self.inner.with_live_attachment(
-                        pty_id,
-                        &attachment,
-                        context,
-                        "flow",
-                        |control| {
-                            if pause {
-                                control.pause();
-                            } else {
-                                control.resume();
-                            }
-                        },
-                    );
+                    self.inner
+                        .with_live_attachment_async(
+                            pty_id,
+                            &attachment,
+                            context,
+                            "flow",
+                            |control| {
+                                if pause {
+                                    control.pause();
+                                } else {
+                                    control.resume();
+                                }
+                            },
+                        )
+                        .await;
                 }
             }
             "pty_close" => {
@@ -613,7 +744,7 @@ impl PtyManager {
                 if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
                     return;
                 }
-                self.inner.close_authorized(pty_id, context);
+                self.inner.close_authorized_async(pty_id, context).await;
             }
             "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
             _ => {}
@@ -656,6 +787,12 @@ impl PtyManager {
         self.detach_matching(|owner| owner == Some(transport_id));
     }
 
+    /// Async transport teardown. Gate contention yields to Tokio instead of
+    /// blocking the connection worker while a publication callback finishes.
+    pub async fn detach_transport_async(&self, transport_id: &str) {
+        self.detach_matching_async(|owner| owner == Some(transport_id)).await;
+    }
+
     fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
         // Openings first: close() records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
@@ -681,6 +818,32 @@ impl PtyManager {
         ids.extend(attachment_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())));
         for (id, owner, generation) in ids {
             self.inner.close_if_transport(&id, owner.as_deref(), Some(generation));
+        }
+    }
+
+    async fn detach_matching_async(&self, owns: impl Fn(Option<&str>) -> bool) {
+        let opening_ids: Vec<(String, Option<String>, u64)> = {
+            let opening = self.inner.opening_state.lock().expect("opening state lock");
+            opening
+                .ids
+                .iter()
+                .map(|(id, entry)| (id.clone(), entry.transport_id.clone(), entry.generation))
+                .collect()
+        };
+        let attachment_ids: Vec<(String, Option<String>, u64)> = {
+            let attachments = self.inner.attachments.lock().expect("attach lock");
+            attachments
+                .iter()
+                .map(|(id, attachment)| {
+                    (id.clone(), attachment.transport_id.clone(), attachment.generation)
+                })
+                .collect()
+        };
+        let mut ids: Vec<(String, Option<String>, u64)> =
+            opening_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())).collect();
+        ids.extend(attachment_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())));
+        for (id, owner, generation) in ids {
+            self.inner.close_if_transport_async(&id, owner.as_deref(), Some(generation)).await;
         }
     }
 }
@@ -730,9 +893,6 @@ impl Inner {
             return;
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
-        // One monotonic domain spans reservation and attachment publication.
-        // A generation can therefore never be mistaken for a different phase
-        // of the same PTY id.
         let opening_generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         // Do not inspect the route gate while holding the attachment map. The
         // normal publication path takes RouteGate -> attachments, so this
@@ -755,18 +915,13 @@ impl Inner {
         } else {
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let attachments = self.attachments.lock().expect("attach lock");
-            let attached = attachments
-                .get(&pty_id)
-                .is_some_and(|attachment| !attachment.closing.load(Ordering::SeqCst));
+            let attached = attachments.get(&pty_id).is_some_and(|attachment| {
+                !attachment.closing.load(Ordering::SeqCst)
+                    || attachment.close_pending.load(Ordering::SeqCst)
+            });
             if attached || opening.ids.contains_key(&pty_id) {
                 Err(("bad_request", "ptyId is already attached".to_owned()))
-            } else if attachments
-                .values()
-                .filter(|attachment| !attachment.closing.load(Ordering::SeqCst))
-                .count()
-                + opening.ids.len()
-                >= self.max_ptys
-            {
+            } else if attachments.values().count() + opening.ids.len() >= self.max_ptys {
                 Err((
                     "session_limit",
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
@@ -941,10 +1096,6 @@ impl Inner {
             }
         };
 
-        // A provider may ignore the cancellation token while opening. Never
-        // publish a PTY after its transport has gone away; `Opened::drop`
-        // closes the provider handle and `OpeningReservation::drop` releases
-        // the id reservation.
         if context.cancellation.is_cancelled() {
             return;
         }
@@ -960,6 +1111,7 @@ impl Inner {
             opening.ids.remove(&pty_id);
             drop(opening);
             drop(attachments);
+            reservation.active = false;
             opened.closing.store(true, Ordering::SeqCst);
             opened.control.kill();
             return;
@@ -972,7 +1124,7 @@ impl Inner {
         {
             drop(attachments);
             drop(opening);
-            let _previous_publication = previous_gate.lock();
+            let _previous_publication = previous_gate.lock_async().await;
             opening = self.opening_state.lock().expect("opening state lock");
             attachments = self.attachments.lock().expect("attach lock");
             if opening.cancelled.get(&pty_id) == Some(&opening_generation) {
@@ -1007,6 +1159,7 @@ impl Inner {
             pty_id.clone(),
             Attachment {
                 closing: opened.closing,
+                close_pending: Arc::new(AtomicBool::new(false)),
                 control: Arc::clone(&opened.control),
                 actor_id: actor.to_owned(),
                 cwd: cwd.clone(),
@@ -1014,6 +1167,7 @@ impl Inner {
                 transport_id: context.transport_id.clone(),
                 generation: opened.generation,
                 publication_gate: Arc::clone(&opened.publication_gate),
+                control_ops: Arc::new(ControlOperationState::new()),
             },
         );
         opening.ids.remove(&pty_id);
@@ -1023,8 +1177,6 @@ impl Inner {
             previous.closing.store(true, Ordering::SeqCst);
             previous.control.kill();
         }
-        // Ownership transferred to the attachment. The guard remains on the
-        // Opened value only to keep the deferred start closure alive.
         opened.cleanup.claimed.store(true, Ordering::Release);
         reservation.active = false;
         let mut opened_frame = serde_json::Map::new();
@@ -1042,7 +1194,19 @@ impl Inner {
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
-        (opened.start)();
+        let start = opened.start;
+        // Do not hold the frame handler open for the lifetime of a live PTY
+        // stream. Wait only until the sink is installed, then let the
+        // generation fence and control kill own its lifecycle.
+        let (started_tx, started_rx) = oneshot::channel();
+        let _ = std::thread::Builder::new().name("chatmux-relay-pty-start".to_owned()).spawn(
+            move || {
+                start(Box::new(move || {
+                    let _ = started_tx.send(());
+                }));
+            },
+        );
+        let _ = started_rx.await;
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
@@ -1088,18 +1252,12 @@ impl Inner {
         generation: u64,
         publication_gate: &Arc<RouteGate>,
     ) {
-        let mut auth = Self::auth_snapshot(context);
-        if self
-            .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
-            .is_none()
-        {
-            return;
-        }
         let gate = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || (context.transport_id.is_some() && current.transport_id != context.transport_id)
             {
                 return;
             }
@@ -1143,13 +1301,24 @@ impl Inner {
             );
             return;
         }
-        auth = live_auth;
         // Zero-byte chunks carry nothing and historically crashed the web
         // terminal's write path (D-R6-1); never put an empty frame on the wire.
         if chunk.is_empty() {
             return;
         }
-        let buffered = (auth.buffered_amount)();
+        if chunk.len() > MAX_OUTPUT_CHUNK_BYTES {
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                generation,
+                publication_gate,
+                "failed",
+                "pty output chunk exceeds the relay frame budget",
+            );
+            return;
+        }
+        let buffered = (live_auth.buffered_amount)();
         // Admit the complete frame before sending it. The socket may accept a
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
@@ -1168,7 +1337,7 @@ impl Inner {
             );
             return;
         }
-        (auth.send)(json!({
+        (live_auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
             "ptyId": pty_id,
@@ -1272,6 +1441,51 @@ impl Inner {
         self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
             send_pty_error(context, pty_id, code, message);
         });
+    }
+
+    async fn emit_error_for_generation_async(
+        &self,
+        context: &FrameContext,
+        pty_id: &str,
+        generation: u64,
+        publication_gate: &Arc<RouteGate>,
+        code: &str,
+        message: &str,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock_async().await;
+        let attachment = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.closing.store(true, Ordering::SeqCst);
+            current.clone()
+        };
+        send_pty_error(context, pty_id, code, message);
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        if attachments.get(pty_id).is_some_and(|current| {
+            current.generation == generation
+                && Arc::ptr_eq(&current.publication_gate, publication_gate)
+        }) {
+            attachments.remove(pty_id);
+        }
+        drop(attachments);
+        drop(_publication);
+        attachment.control.kill();
     }
 
     fn emit_terminal_for_generation(
@@ -1437,6 +1651,7 @@ impl Inner {
             if current.generation != attachment.generation
                 || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
             {
                 return;
             }
@@ -1454,6 +1669,48 @@ impl Inner {
             );
             return;
         }
+        attachment.control_ops.begin();
+        let _operation = ControlOperationLease(Arc::clone(&attachment.control_ops));
+        operation(attachment.control.as_ref());
+    }
+
+    async fn with_live_attachment_async(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        context: &FrameContext,
+        action: &str,
+        operation: impl FnOnce(&dyn PtyControl),
+    ) {
+        let _publication = attachment.publication_gate.lock_async().await;
+        {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
+            {
+                return;
+            }
+        }
+        let live_auth = Self::auth_snapshot(context);
+        if !self.auth_allows(&live_auth, attachment) {
+            drop(_publication);
+            self.emit_error_for_generation_async(
+                context,
+                pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
+            )
+            .await;
+            return;
+        }
+        attachment.control_ops.begin();
+        let _operation = ControlOperationLease(Arc::clone(&attachment.control_ops));
+        drop(_publication);
         operation(attachment.control.as_ref());
     }
 
@@ -1559,6 +1816,80 @@ impl Inner {
         self.close_exact_authorized(pty_id, &attachment, context);
     }
 
+    async fn close_authorized_async(&self, pty_id: &str, context: &FrameContext) {
+        let auth = Self::auth_snapshot(context);
+        let attachment = match self
+            .authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
+        {
+            Ok(attachment) => attachment,
+            Err(NonterminalAuthorizationFailure::Denied) => return,
+            Err(NonterminalAuthorizationFailure::Missing) => {
+                self.close_if_transport_async(pty_id, context.transport_id.as_deref(), None).await;
+                return;
+            }
+        };
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return;
+        }
+        self.close_exact_authorized_async(pty_id, &attachment, context).await;
+    }
+
+    async fn close_if_transport_async(
+        &self,
+        pty_id: &str,
+        transport_id: Option<&str>,
+        generation: Option<u64>,
+    ) {
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        if let Some(entry) = opening.ids.get(pty_id) {
+            let owns_opening =
+                transport_id.is_none() || entry.transport_id.as_deref() == transport_id;
+            if generation.is_none_or(|expected| entry.generation == expected) && owns_opening {
+                opening.cancelled.insert(pty_id.to_owned(), entry.generation);
+            }
+        }
+        drop(opening);
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if generation.is_none_or(|expected| attachment.generation == expected)
+            && attachment.transport_id.as_deref() == transport_id
+        {
+            let publication_gate = Arc::clone(&attachment.publication_gate);
+            let _publication = publication_gate.lock_async().await;
+            let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+            else {
+                return;
+            };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                || current.transport_id.as_deref() != transport_id
+            {
+                return;
+            }
+            current.close_pending.store(true, Ordering::SeqCst);
+            drop(_publication);
+            let _ = tokio::time::timeout(
+                CONTROL_OPERATION_DRAIN_TIMEOUT,
+                attachment.control_ops.wait_async(),
+            )
+            .await;
+            let _publication = publication_gate.lock_async().await;
+            let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+            else {
+                return;
+            };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                || !current.close_pending.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            self.close_exact(pty_id, generation, Some(&publication_gate));
+        }
+    }
+
     fn close_exact_authorized(
         &self,
         pty_id: &str,
@@ -1589,22 +1920,25 @@ impl Inner {
         };
         let live_auth = Self::auth_snapshot(context);
         if !self.auth_allows(&live_auth, &current) {
-            drop(_publication);
-            self.emit_error_for_generation(
+            current.close_pending.store(false, Ordering::SeqCst);
+            send_pty_error(
                 context,
                 pty_id,
-                attachment.generation,
-                &attachment.publication_gate,
                 "trust_revoked",
                 "PTY close refused after trust change",
             );
             return;
         }
+        current.close_pending.store(true, Ordering::SeqCst);
+        drop(_publication);
+        let _ = current.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
+        let _publication = gate.lock();
         let removed = {
             let mut attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != attachment.generation
                 || !Arc::ptr_eq(&current.publication_gate, &gate)
+                || !current.close_pending.load(Ordering::SeqCst)
                 || current.closing.load(Ordering::SeqCst)
             {
                 return;
@@ -1613,8 +1947,55 @@ impl Inner {
             removed.closing.store(true, Ordering::SeqCst);
             removed
         };
-        drop(_publication);
         removed.control.kill();
+    }
+
+    async fn close_exact_authorized_async(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        context: &FrameContext,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock_async().await;
+        let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if current.generation != attachment.generation
+            || !Arc::ptr_eq(&current.publication_gate, &gate)
+            || current.closing.load(Ordering::SeqCst)
+        {
+            return;
+        }
+        current.close_pending.store(true, Ordering::SeqCst);
+        drop(_publication);
+        let _ = tokio::time::timeout(
+            CONTROL_OPERATION_DRAIN_TIMEOUT,
+            attachment.control_ops.wait_async(),
+        )
+        .await;
+        let _publication = gate.lock_async().await;
+        let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if current.generation != attachment.generation
+            || !Arc::ptr_eq(&current.publication_gate, &gate)
+            || !current.close_pending.load(Ordering::SeqCst)
+        {
+            return;
+        }
+        self.close_exact_authorized(pty_id, attachment, context);
     }
 
     fn close_if_generation(&self, pty_id: &str, generation: u64) {
@@ -1657,6 +2038,7 @@ impl Inner {
             attachment.closing.store(true, Ordering::SeqCst);
             attachment
         };
+        let _ = attachment.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
         attachment.control.kill();
     }
 }
@@ -1670,7 +2052,7 @@ struct Opened {
     generation: u64,
     publication_gate: Arc<RouteGate>,
     cleanup: Arc<OpenedCleanup>,
-    start: Box<dyn FnOnce() + Send>,
+    start: Box<dyn FnOnce(Box<dyn FnOnce() + Send>) + Send>,
 }
 
 struct OpenedCleanup {
@@ -1681,8 +2063,6 @@ struct OpenedCleanup {
 impl Drop for OpenedCleanup {
     fn drop(&mut self) {
         if !self.claimed.swap(true, Ordering::AcqRel) {
-            // Any open that never reaches publication still owns a live PTY.
-            // Drop is the cancellation-safe fallback for every early return.
             self.control.kill();
         }
     }
@@ -1698,21 +2078,28 @@ impl ControlGuard {
         Self(Some(control))
     }
 
+    fn end(&mut self) {
+        if let Some(control) = self.0.take() {
+            control.end();
+        }
+    }
+
     fn disarm(&mut self) -> Arc<dyn ControlHandle> {
         self.0.take().expect("control guard owns a connection")
     }
 }
 
 async fn request_control_with_cancellation(
-    control: &Arc<dyn ControlHandle>,
+    control_guard: &mut ControlGuard,
     cmd: &str,
     params: Value,
     cancellation: &CancellationToken,
 ) -> Option<Value> {
+    let control = control_guard.0.as_ref()?.clone();
     tokio::select! {
         response = control.request(cmd, params) => response,
         _ = cancellation.cancelled() => {
-            control.end();
+            control_guard.end();
             None
         }
     }
@@ -1720,9 +2107,7 @@ async fn request_control_with_cancellation(
 
 impl Drop for ControlGuard {
     fn drop(&mut self) {
-        if let Some(control) = self.0.take() {
-            control.end();
-        }
+        self.end();
     }
 }
 
@@ -1770,59 +2155,71 @@ impl Inner {
                 .connect_control(&ensured.socket_path)
                 .await
                 .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
-            let _control_guard = ControlGuard::new(Arc::clone(&control));
-            let Some(listed) = control.request("list-workspaces", json!({})).await else {
-                control.end();
+            let mut control_guard = ControlGuard::new(Arc::clone(&control));
+            let Some(listed) = request_control_with_cancellation(
+                &mut control_guard,
+                "list-workspaces",
+                json!({}),
+                &context.cancellation,
+            )
+            .await
+            else {
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if listed.get("ok").and_then(Value::as_bool) != Some(true) {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let Some(data) = listed.get("data").and_then(Value::as_object) else {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if !data.get("workspaces").is_some_and(Value::is_array) {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             if !workspace_shape_valid(listed.get("data")) {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let tabs = match collect_pty_tabs_strict(listed.get("data")) {
                 Ok(tabs) => tabs,
                 Err(_) => {
-                    control.end();
+                    control_guard.end();
                     return Err("cannot inspect existing daemon surfaces".to_owned());
                 }
             };
             if tabs.len() > MAX_ENUM_TERMINALS || (tabs.is_empty() && !ensured.created) {
-                control.end();
+                control_guard.end();
                 return Err("cannot prove existing daemon cwd is within allowed roots".to_owned());
             }
             for tab in tabs {
-                let Some(info) =
-                    control.request("process-info", json!({ "surface": tab.surface_id })).await
+                let Some(info) = request_control_with_cancellation(
+                    &mut control_guard,
+                    "process-info",
+                    json!({ "surface": tab.surface_id }),
+                    &context.cancellation,
+                )
+                .await
                 else {
-                    control.end();
+                    control_guard.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 };
                 if info.get("ok").and_then(Value::as_bool) != Some(true) {
-                    control.end();
+                    control_guard.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 }
                 let Some(actual) =
                     info.get("data").and_then(|v| v.get("cwd")).and_then(Value::as_str)
                 else {
-                    control.end();
+                    control_guard.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
                 };
                 if actual.is_empty() || !Path::new(actual).is_absolute() {
-                    control.end();
+                    control_guard.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
@@ -1835,11 +2232,11 @@ impl Inner {
                 )
                 .is_err()
                 {
-                    control.end();
+                    control_guard.end();
                     return Err("existing surface cwd is outside allowed roots".to_owned());
                 }
             }
-            control.end();
+            control_guard.end();
         }
         let mut args = cmux_tui.prefix.clone();
         args.extend([
@@ -1878,7 +2275,10 @@ impl Inner {
                 control: Arc::clone(&control),
                 claimed: AtomicBool::new(false),
             }),
-            start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
+            start: Box::new(move |ready| {
+                ready();
+                drive_handle(output, banner, on_data, on_exit);
+            }),
         })
     }
 
@@ -2031,15 +2431,27 @@ impl Inner {
         });
 
         let start_session = Arc::clone(&shell_session);
-        let start: Box<dyn FnOnce() + Send> = Box::new(move || {
+        let start_gate = Arc::clone(&publication_gate);
+        let start: Box<dyn FnOnce(Box<dyn FnOnce() + Send>) + Send> = Box::new(move |ready| {
+            let _publication = start_gate.lock();
             let (banner, replay, alive) = {
-                let inner = start_session.inner.lock().expect("shell inner lock");
+                let mut inner = start_session.inner.lock().expect("shell inner lock");
                 let banner = created.then(|| start_session.banner.clone()).flatten();
                 let replay = (!created && inner.ring_size > 0).then(|| {
                     inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
                 });
+                if inner.alive && !released.load(Ordering::SeqCst) {
+                    inner.viewers.push(ViewerSink {
+                        id: viewer_id,
+                        on_data: Arc::clone(&on_data),
+                        on_exit: Arc::clone(&on_exit),
+                    });
+                }
                 (banner, replay, inner.alive)
             };
+            // The viewer is installed while the publication gate is held.
+            // Subsequent PTY output therefore waits behind replay callbacks.
+            ready();
             if let Some(banner) = banner {
                 on_data(Bytes::from(banner));
             }
@@ -2052,10 +2464,6 @@ impl Inner {
             if !alive {
                 on_exit(0);
                 return;
-            }
-            let mut inner = start_session.inner.lock().expect("shell inner lock");
-            if !released.load(Ordering::SeqCst) && inner.alive {
-                inner.viewers.push(ViewerSink { id: viewer_id, on_data, on_exit });
             }
         });
 
@@ -2256,6 +2664,15 @@ impl TerminalStream {
         on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
         on_exit: Arc<dyn Fn(i64) + Send + Sync>,
     ) {
+        self.go_live_with_ready(on_data, on_exit, || {});
+    }
+
+    fn go_live_with_ready(
+        &self,
+        on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
+        on_exit: Arc<dyn Fn(i64) + Send + Sync>,
+        ready: impl FnOnce(),
+    ) {
         let should_drain = {
             let mut state = self.state.lock().expect("terminal stream lock");
             state.live_data = Some(Arc::clone(&on_data));
@@ -2263,6 +2680,7 @@ impl TerminalStream {
             state.backlog_bytes = 0;
             Self::start_delivery(&mut state)
         };
+        ready();
         if should_drain {
             self.drain();
         }
@@ -2475,7 +2893,13 @@ impl Inner {
         };
         let mut control_guard = ControlGuard::new(Arc::clone(&control));
 
-        let identify = control.request("identify", json!({})).await;
+        let identify = request_control_with_cancellation(
+            &mut control_guard,
+            "identify",
+            json!({}),
+            &context.cancellation,
+        )
+        .await;
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
         let protocol = info
             .and_then(|v| v.get("data"))
@@ -2483,7 +2907,7 @@ impl Inner {
             .and_then(Value::as_i64)
             .unwrap_or(0);
         if protocol < CONTROL_MIN_PROTOCOL {
-            control.end();
+            control_guard.end();
             return Ok(None);
         }
         let capabilities: Vec<String> = info
@@ -2501,7 +2925,13 @@ impl Inner {
             None
         };
         if surface_id.is_none() {
-            let listed = control.request("list-workspaces", json!({})).await;
+            let listed = request_control_with_cancellation(
+                &mut control_guard,
+                "list-workspaces",
+                json!({}),
+                &context.cancellation,
+            )
+            .await;
             let tabs = listed
                 .as_ref()
                 .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
@@ -2513,7 +2943,7 @@ impl Inner {
                 .map(|tab| tab.surface_id);
         }
         let Some(surface_id) = surface_id else {
-            control.end();
+            control_guard.end();
             // Typed refusal: the terminal died with its process (or its tab
             // closed) — permanent, so clients render an ended state and
             // never offer a retry.
@@ -2528,7 +2958,13 @@ impl Inner {
         let roots_scoped = context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
             || server_roots.is_some_and(|r| !r.is_empty());
         if roots_scoped {
-            let info = control.request("process-info", json!({ "surface": surface_id })).await;
+            let info = request_control_with_cancellation(
+                &mut control_guard,
+                "process-info",
+                json!({ "surface": surface_id }),
+                &context.cancellation,
+            )
+            .await;
             let actual = info
                 .as_ref()
                 .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
@@ -2536,14 +2972,14 @@ impl Inner {
                 .and_then(|v| v.get("cwd"))
                 .and_then(Value::as_str);
             if actual.is_none_or(|value| value.is_empty() || !Path::new(value).is_absolute()) {
-                control.end();
+                control_guard.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
                 ));
             }
             let Some(actual) = actual else {
-                control.end();
+                control_guard.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
@@ -2552,7 +2988,7 @@ impl Inner {
             if scoped_cwd(Some(actual), &self.home, context.local_roots.as_deref(), server_roots)
                 .is_err()
             {
-                control.end();
+                control_guard.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "existing surface cwd is outside allowed roots".to_owned(),
@@ -2592,14 +3028,14 @@ impl Inner {
             json!({ "surface": surface_id })
         };
         let attached = request_control_with_cancellation(
-            &control,
+            &mut control_guard,
             "attach-surface",
             attach_params,
             &context.cancellation,
         )
         .await;
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
-            control.end();
+            control_guard.end();
             let reason = attached
                 .as_ref()
                 .and_then(|v| v.get("error"))
@@ -2652,7 +3088,7 @@ impl Inner {
                 control: Arc::clone(&proxy),
                 claimed: AtomicBool::new(false),
             }),
-            start: Box::new(move || start_stream.go_live(on_data, on_exit)),
+            start: Box::new(move |ready| start_stream.go_live_with_ready(on_data, on_exit, ready)),
         }))
     }
 
@@ -3042,6 +3478,20 @@ mod tests {
         ensure_socket_path: Option<PathBuf>,
         control: Option<Arc<dyn ControlHandle>>,
     ) -> Harness {
+        harness_with_control_and_max_ptys(resolve, read_dir, ensure_socket_path, control, MAX_PTYS)
+    }
+
+    fn harness_with_max_ptys(max_ptys: usize) -> Harness {
+        harness_with_control_and_max_ptys(None, None, None, None, max_ptys)
+    }
+
+    fn harness_with_control_and_max_ptys(
+        resolve: Option<CmuxTui>,
+        read_dir: Option<Vec<String>>,
+        ensure_socket_path: Option<PathBuf>,
+        control: Option<Arc<dyn ControlHandle>>,
+        max_ptys: usize,
+    ) -> Harness {
         let home = TestDirectory::new("harness");
         let home_path = home.path.clone();
         let env = env_map(&home_path);
@@ -3060,7 +3510,7 @@ mod tests {
             deps,
             home_path.clone(),
             env,
-            MAX_PTYS,
+            max_ptys,
             SCROLLBACK_LIMIT,
             OUTPUT_BUFFER_CAP,
         );
@@ -3765,6 +4215,44 @@ mod tests {
         fn end(&self) {}
     }
 
+    struct HangingControl {
+        ended: Arc<AtomicUsize>,
+    }
+
+    impl ControlHandle for HangingControl {
+        fn request(
+            &self,
+            _cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            Box::pin(std::future::pending())
+        }
+        fn send(&self, _cmd: &str, _params: Value) {}
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {
+            self.ended.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_control_request_ends_guard_once() {
+        let ended = Arc::new(AtomicUsize::new(0));
+        let control: Arc<dyn ControlHandle> =
+            Arc::new(HangingControl { ended: Arc::clone(&ended) });
+        let mut guard = ControlGuard::new(control);
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        assert!(
+            request_control_with_cancellation(&mut guard, "identify", Value::Null, &cancellation)
+                .await
+                .is_none()
+        );
+        assert_eq!(ended.load(Ordering::SeqCst), 1);
+    }
+
     #[tokio::test]
     async fn missing_surface_refuses_with_typed_terminal_gone() {
         let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
@@ -3864,6 +4352,12 @@ mod tests {
         let close = serde_json::json!({ "version": 4, "type": "pty_close", "ptyId": "p1" });
         h.manager.handle_frame(&close, &denied).await;
         assert!(h.manager.has_attachment("p1"));
+        assert!(!h.spawned()[0].state.lock().unwrap().killed);
+        assert!(
+            h.sent()
+                .iter()
+                .any(|frame| { frame["type"] == "pty_error" && frame["code"] == "trust_revoked" })
+        );
     }
 
     #[tokio::test]
@@ -4083,6 +4577,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn closing_attachment_counts_toward_capacity_until_publication_returns() {
+        let h = harness_with_max_ptys(1);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let exit = thread::spawn(move || pty.exit(7));
+        entered.wait();
+
+        let replacement = h.context("supervised", h.owner.clone());
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert_eq!(h.manager.attachment_count(), 1);
+        assert!(
+            h.sent()
+                .iter()
+                .any(|frame| { frame["type"] == "pty_error" && frame["code"] == "session_limit" })
+        );
+
+        release.wait();
+        exit.join().expect("exit callback");
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert_eq!(h.manager.attachment_count(), 1);
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test]
     async fn overflow_error_publication_cannot_reach_a_same_id_replacement() {
         let h = harness(None, None);
         let entered = TestArc::new(Barrier::new(2));
@@ -4105,13 +4638,21 @@ mod tests {
         entered.wait();
 
         let replacement = h.context("supervised", h.owner.clone());
-        h.manager.handle_frame(&frame, &replacement).await;
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let replacement_for_task = replacement.clone();
+        let frame_for_replacement = frame.clone();
+        let replacement_task = tokio::spawn(async move {
+            manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!replacement_task.is_finished());
         assert!(!h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
         }));
 
         release.wait();
         output.join().expect("output callback");
+        replacement_task.await.expect("replacement open");
         h.buffered.store(0, Ordering::SeqCst);
         h.manager.handle_frame(&frame, &replacement).await;
         assert!(h.sent().iter().any(|frame| {
@@ -4281,6 +4822,182 @@ mod tests {
         h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
         assert!(h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn async_close_waits_for_control_operation_across_workers() {
+        let h = harness(None, None);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        let pty = h.spawned()[0].clone();
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        {
+            let mut state = pty.state.lock().unwrap();
+            state.write_entered = Some(TestArc::clone(&entered));
+            state.write_release = Some(TestArc::clone(&release));
+        }
+        let input = serde_json::json!({
+            "version": 4,
+            "type": "pty_input",
+            "ptyId": "p1",
+            "dataB64": b64("held"),
+        });
+        let input_task = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = h.context("supervised", h.owner.clone());
+            async move { manager.handle_frame(&input, &context).await }
+        });
+        entered.wait();
+        let close_task = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = h.context("supervised", h.owner.clone());
+            async move {
+                manager
+                    .handle_frame(
+                        &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
+                        &context,
+                    )
+                    .await;
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(!close_task.is_finished(), "close waits for the in-flight control operation");
+        release.wait();
+        input_task.await.expect("input operation");
+        close_task.await.expect("close operation");
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_route_gate_wait_does_not_block_unrelated_tasks() {
+        let gate = Arc::new(RouteGate::new());
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let held_gate = Arc::clone(&gate);
+        let owner = thread::spawn(move || {
+            let _guard = held_gate.lock();
+            entered_tx.send(()).expect("gate owner entered");
+            release_rx.recv().expect("gate owner released");
+        });
+        entered_rx.recv().expect("gate owner entered");
+
+        let waiter_gate = Arc::clone(&gate);
+        let waiter = tokio::spawn(async move {
+            let _guard = waiter_gate.lock_async().await;
+        });
+        let tick = tokio::spawn(async { 17_u8 });
+        assert_eq!(tick.await.expect("unrelated task"), 17);
+        release_tx.send(()).expect("release gate owner");
+        waiter.await.expect("async gate waiter");
+        owner.join().expect("gate owner");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_transport_detach_does_not_block_unrelated_tasks() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let mut context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        context.transport_id = Some("transport-a".to_owned());
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let output = thread::spawn(move || pty.emit("live"));
+        entered.wait();
+
+        let manager = h.manager.clone();
+        let detach = tokio::spawn(async move {
+            manager.detach_transport_async("transport-a").await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!detach.is_finished(), "detach must wait for the publication gate");
+
+        let tick = tokio::spawn(async { 17_u8 });
+        assert_eq!(tick.await.expect("unrelated task"), 17);
+
+        release.wait();
+        output.join().expect("output callback");
+        detach.await.expect("transport detach");
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn long_lived_start_does_not_block_close_or_subsequent_frames() {
+        let h = harness(None, None);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        let shell = h.spawned()[0].clone();
+        shell.emit("replay");
+        h.manager
+            .handle_frame(
+                &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
+                &h.context("supervised", h.owner.clone()),
+            )
+            .await;
+
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let open = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = context.clone();
+            let frame = frame.clone();
+            async move { manager.handle_frame(&frame, &context).await }
+        });
+        open.await.expect("replacement open");
+        entered.wait();
+        let output_during_start = thread::spawn(move || shell.emit("during-start"));
+
+        let close = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = h.context("supervised", h.owner.clone());
+            async move {
+                manager
+                    .handle_frame(
+                        &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
+                        &context,
+                    )
+                    .await;
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(!close.is_finished(), "close must wait for the replay callback");
+
+        release.wait();
+        output_during_start.join().expect("output during start");
+        close.await.expect("close after replay");
+        assert!(!h.manager.has_attachment("p1"));
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_output"
+                && from_b64(frame["dataB64"].as_str().unwrap_or_default()) == "during-start"
         }));
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1194,18 +1194,32 @@ impl Inner {
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
+        let generation = opened.generation;
+        let publication_gate = Arc::clone(&opened.publication_gate);
         let start = opened.start;
         // Do not hold the frame handler open for the lifetime of a live PTY
         // stream. Wait only until the sink is installed, then let the
         // generation fence and control kill own its lifecycle.
         let (started_tx, started_rx) = oneshot::channel();
-        let _ = std::thread::Builder::new().name("chatmux-relay-pty-start".to_owned()).spawn(
-            move || {
+        let start_result = std::thread::Builder::new()
+            .name("chatmux-relay-pty-start".to_owned())
+            .spawn(move || {
                 start(Box::new(move || {
                     let _ = started_tx.send(());
                 }));
-            },
-        );
+            });
+        if start_result.is_err() {
+            self.emit_error_for_generation_async(
+                context,
+                &pty_id,
+                generation,
+                &publication_gate,
+                "failed",
+                "PTY output start could not be scheduled",
+            )
+            .await;
+            return;
+        }
         let _ = started_rx.await;
     }
 
@@ -1533,20 +1547,6 @@ impl Inner {
         // Terminal publication retires the viewer. Killing is idempotent for
         // an already-exited PTY and releases an overflowed or revoked one.
         attachment.control.kill();
-    }
-
-    /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
-    fn close(&self, pty_id: &str) {
-        // Match `open`'s lock order. If opening still owns the reservation,
-        // record cancellation and let it dispose the newly opened PTY.
-        let mut opening = self.opening_state.lock().expect("opening state lock");
-        if opening.ids.contains_key(pty_id) {
-            let generation = opening.ids.get(pty_id).expect("opening entry").generation;
-            opening.cancelled.insert(pty_id.to_owned(), generation);
-            return;
-        }
-        drop(opening);
-        self.close_exact(pty_id, None, None);
     }
 
     fn close_if_transport(
@@ -1996,16 +1996,6 @@ impl Inner {
             return;
         }
         self.close_exact_authorized(pty_id, attachment, context);
-    }
-
-    fn close_if_generation(&self, pty_id: &str, generation: u64) {
-        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
-            return;
-        };
-        if attachment.generation == generation {
-            self.close_exact(pty_id, Some(generation), Some(&attachment.publication_gate));
-        }
     }
 
     fn close_exact(
@@ -4555,10 +4545,12 @@ mod tests {
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
         let replacement_for_task = replacement.clone();
         let frame_for_replacement = frame.clone();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let replacement_task = tokio::spawn(async move {
+            let _ = started.send(());
             manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("replacement task started");
         assert!(
             !replacement_task.is_finished(),
             "same-ID replacement must wait for the closing publication"
@@ -4641,10 +4633,12 @@ mod tests {
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
         let replacement_for_task = replacement.clone();
         let frame_for_replacement = frame.clone();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let replacement_task = tokio::spawn(async move {
+            let _ = started.send(());
             manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("replacement task started");
         assert!(!replacement_task.is_finished());
         assert!(!h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
@@ -4683,7 +4677,13 @@ mod tests {
 
         let close_context = h.context("supervised", h.owner.clone());
         let manager = h.manager.inner.clone();
-        let close = thread::spawn(move || manager.close_authorized("p1", &close_context));
+        let started = TestArc::new(Barrier::new(2));
+        let close_started = TestArc::clone(&started);
+        let close = thread::spawn(move || {
+            close_started.wait();
+            manager.close_authorized("p1", &close_context);
+        });
+        started.wait();
         assert!(!close.is_finished(), "close must wait for the publication gate");
 
         release.wait();
@@ -4806,9 +4806,13 @@ mod tests {
 
         let close_context = h.context("supervised", h.owner.clone());
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let close_started = TestArc::new(Barrier::new(2));
+        let close_started_in_thread = TestArc::clone(&close_started);
         let close = thread::spawn(move || {
+            close_started_in_thread.wait();
             manager.inner.close_authorized("p1", &close_context);
         });
+        close_started.wait();
         assert!(!close.is_finished(), "close must wait for the in-flight control operation");
 
         h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
@@ -4858,10 +4862,13 @@ mod tests {
             async move { manager.handle_frame(&input, &context).await }
         });
         entered.wait();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let close_task = tokio::spawn({
             let manager = h.manager.clone();
             let context = h.context("supervised", h.owner.clone());
+            let started = started;
             async move {
+                let _ = started.send(());
                 manager
                     .handle_frame(
                         &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
@@ -4870,7 +4877,7 @@ mod tests {
                     .await;
             }
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("close task started");
         assert!(!close_task.is_finished(), "close waits for the in-flight control operation");
         release.wait();
         input_task.await.expect("input operation");
@@ -4925,10 +4932,12 @@ mod tests {
         entered.wait();
 
         let manager = h.manager.clone();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let detach = tokio::spawn(async move {
+            let _ = started.send(());
             manager.detach_transport_async("transport-a").await;
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("detach task started");
         assert!(!detach.is_finished(), "detach must wait for the publication gate");
 
         let tick = tokio::spawn(async { 17_u8 });
@@ -4976,10 +4985,12 @@ mod tests {
         entered.wait();
         let output_during_start = thread::spawn(move || shell.emit("during-start"));
 
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let close = tokio::spawn({
             let manager = h.manager.clone();
             let context = h.context("supervised", h.owner.clone());
             async move {
+                let _ = started.send(());
                 manager
                     .handle_frame(
                         &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
@@ -4988,7 +4999,7 @@ mod tests {
                     .await;
             }
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("close task started");
         assert!(!close.is_finished(), "close must wait for the replay callback");
 
         release.wait();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -24,7 +24,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::ThreadId;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{Notify, oneshot};
 use tokio_util::sync::CancellationToken;
 
@@ -504,11 +504,16 @@ impl ControlOperationState {
         if self.owned_by_current_thread() {
             return true;
         }
+        let deadline = timeout.map(|duration| Instant::now() + duration);
         let mut guard = self.wait_lock.lock().expect("control operation wait lock");
         while self.active.load(Ordering::Acquire) != 0 {
-            if let Some(timeout) = timeout {
+            if let Some(deadline) = deadline {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return false;
+                }
                 let (next, result) =
-                    self.changed.wait_timeout(guard, timeout).expect("control operation wait");
+                    self.changed.wait_timeout(guard, remaining).expect("control operation wait");
                 guard = next;
                 if result.timed_out() {
                     return false;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2486,9 +2486,11 @@ impl Inner {
             let (banner, replay, alive) = {
                 let mut inner = start_session.inner.lock().expect("shell inner lock");
                 let banner = created.then(|| start_session.banner.clone()).flatten();
-                let replay = (!created && inner.ring_size > 0).then(|| {
-                    inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
-                });
+                // Clone the retained chunks, not their bytes. `Bytes` clones
+                // share the backing storage, so a large scrollback replay
+                // does not allocate one contiguous buffer before framing.
+                let replay = (!created && inner.ring_size > 0)
+                    .then(|| inner.ring.iter().cloned().collect::<Vec<Bytes>>());
                 if inner.alive && !released.load(Ordering::SeqCst) {
                     inner.viewers.push(ViewerSink {
                         id: viewer_id,
@@ -2505,7 +2507,9 @@ impl Inner {
                 emit_bounded_bytes(&on_data, Bytes::from(banner));
             }
             if let Some(replay) = replay {
-                emit_bounded_bytes(&on_data, Bytes::from(replay));
+                for chunk in replay {
+                    emit_bounded_bytes(&on_data, chunk);
+                }
             }
             if released.load(Ordering::SeqCst) {
                 return;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1886,7 +1886,22 @@ impl Inner {
             {
                 return;
             }
-            self.close_exact(pty_id, generation, Some(&publication_gate));
+            let removed = {
+                let mut attachments = self.attachments.lock().expect("attach lock");
+                let Some(current) = attachments.get(pty_id) else { return };
+                if generation.is_some_and(|expected| current.generation != expected)
+                    || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                    || !current.close_pending.load(Ordering::SeqCst)
+                    || current.closing.load(Ordering::SeqCst)
+                {
+                    return;
+                }
+                let removed = attachments.remove(pty_id).expect("attachment still present");
+                removed.closing.store(true, Ordering::SeqCst);
+                removed
+            };
+            drop(_publication);
+            removed.control.kill();
         }
     }
 
@@ -1995,7 +2010,34 @@ impl Inner {
         {
             return;
         }
-        self.close_exact_authorized(pty_id, attachment, context);
+        let live_auth = Self::auth_snapshot(context);
+        if !self.auth_allows(&live_auth, &current) {
+            current.close_pending.store(false, Ordering::SeqCst);
+            drop(_publication);
+            send_pty_error(
+                context,
+                pty_id,
+                "trust_revoked",
+                "PTY close refused after trust change",
+            );
+            return;
+        }
+        let removed = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+                || !current.close_pending.load(Ordering::SeqCst)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            let removed = attachments.remove(pty_id).expect("attachment still present");
+            removed.closing.store(true, Ordering::SeqCst);
+            removed
+        };
+        drop(_publication);
+        removed.control.kill();
     }
 
     fn close_exact(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2164,9 +2164,18 @@ fn drive_handle(
     on_exit: ExitSink,
 ) {
     if let Some(banner) = banner {
-        on_data(Bytes::from(banner));
+        emit_bounded_bytes(&on_data, Bytes::from(banner));
     }
     output.subscribe(on_data, on_exit);
+}
+
+fn emit_bounded_bytes(on_data: &DataSink, bytes: Bytes) {
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let end = (offset + MAX_OUTPUT_CHUNK_BYTES).min(bytes.len());
+        on_data(bytes.slice(offset..end));
+        offset = end;
+    }
 }
 
 impl Inner {
@@ -2493,10 +2502,10 @@ impl Inner {
             // Subsequent PTY output therefore waits behind replay callbacks.
             ready();
             if let Some(banner) = banner {
-                on_data(Bytes::from(banner));
+                emit_bounded_bytes(&on_data, Bytes::from(banner));
             }
             if let Some(replay) = replay {
-                on_data(Bytes::from(replay));
+                emit_bounded_bytes(&on_data, Bytes::from(replay));
             }
             if released.load(Ordering::SeqCst) {
                 return;
@@ -4114,6 +4123,59 @@ mod tests {
         assert!(replay.len() <= 32 + 20);
         assert!(replay.contains("chunk-9"));
         assert!(!replay.contains("chunk-0"));
+    }
+
+    #[tokio::test]
+    async fn large_scrollback_replay_is_split_into_bounded_frames() {
+        let home = TestDirectory::new("large-scrollback");
+        let home_path = home.path.clone();
+        let env = env_map(&home_path);
+        let recorded = Arc::new(StdMutex::new(Recorded::default()));
+        let deps = Arc::new(FakeDeps {
+            env: env.clone(),
+            recorded: Arc::clone(&recorded),
+            resolve: None,
+            socket_dir: PathBuf::from("/run/cmux-tui-501"),
+            read_dir: None,
+            ensure_socket_path: None,
+            control: None,
+        });
+        let manager = PtyManager::with_limits(
+            deps,
+            home_path.clone(),
+            env,
+            MAX_PTYS,
+            MAX_OUTPUT_CHUNK_BYTES * 2 + 5,
+            OUTPUT_BUFFER_CAP,
+        );
+        let h = Harness {
+            manager,
+            recorded,
+            sent: Arc::new(StdMutex::new(Vec::new())),
+            buffered: Arc::new(AtomicU64::new(0)),
+            owner: Some("user_owner".to_owned()),
+            home: home_path,
+            _home: home,
+        };
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        pty.emit(&"x".repeat(MAX_OUTPUT_CHUNK_BYTES * 2 + 5));
+        let before = h.sent().len();
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let frames: Vec<Value> = h.sent()[before..]
+            .iter()
+            .filter(|frame| frame["type"] == "pty_output")
+            .cloned()
+            .collect();
+        assert!(frames.len() >= 2);
+        assert!(frames.iter().all(|frame| {
+            BASE64
+                .decode(frame["dataB64"].as_str().unwrap_or_default())
+                .map(|bytes| bytes.len() <= MAX_OUTPUT_CHUNK_BYTES)
+                .unwrap_or(false)
+        }));
+        assert!(!h.sent().iter().any(|frame| frame["code"] == "failed"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1936,6 +1936,7 @@ impl Inner {
         let live_auth = Self::auth_snapshot(context);
         if !self.auth_allows(&live_auth, &current) {
             current.close_pending.store(false, Ordering::SeqCst);
+            drop(_publication);
             send_pty_error(
                 context,
                 pty_id,
@@ -1962,6 +1963,7 @@ impl Inner {
             removed.closing.store(true, Ordering::SeqCst);
             removed
         };
+        drop(_publication);
         removed.control.kill();
     }
 
@@ -2071,6 +2073,7 @@ impl Inner {
             attachment
         };
         let _ = attachment.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
+        drop(_publication);
         attachment.control.kill();
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1281,7 +1281,7 @@ async fn relay_session(
     // managed tunnel listener's attachments are another transport's — a
     // reconnect must never detach them (docs/TERMINAL.md).
     #[cfg(unix)]
-    runtime.pty.detach_transport(&transport_id);
+    runtime.pty.detach_transport_async(&transport_id).await;
     result
 }
 


### PR DESCRIPTION
## Summary

Await RouteGate contention from async PTY frame handlers with a Tokio Notify path, while retaining synchronous reentrant callbacks. Dispatch control-socket event and close callbacks on ordered blocking tasks so read-loop workers cannot block on the gate.

## Testing

Static checks only: `git diff --check`. Cargo and Rust tests were not run locally per task constraints. Added current-thread worker-liveness coverage and control event callback ordering coverage.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes relay deadlocks and lost output: PTY close/teardown no longer blocks a Tokio worker, and large output/event delivery no longer stalls or drops frames.

**Changes**
- Async close and transport detach release the route gate, drain in-flight control operations (250ms timeout), then kill the PTY.
- The `pty_open` handler returns once the output sink is installed; banner and scrollback replay run on a dedicated thread, split into 256 KiB frames without one contiguous allocation.
- A PTY stays reserved and counts toward capacity until close side effects finish, so a same-id replacement open waits.
- A dedicated thread dispatches control events from a bounded queue in wire order; close handlers registered after closure still run.
- Output chunks over 256 KiB emit a `pty_error` and close the PTY instead of being sent.

<sup>Written for commit ef30dd37a79ea666f05e97290fa4cdabb4b6b694. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11526?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

