### PR TITLE
Fix Pi reload CSI query response routing

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalInputReportParser.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalInputReportParser.swift
@@ -27,6 +27,7 @@ struct TerminalInputReportParser {
         case 0x6E: return intermediates.isEmpty && (parameters.first == 0x3F || parameters == [0x30] || parameters == [0x33])
         case 0x75: return intermediates.isEmpty && parameters.first == 0x3F
         case 0x79: return intermediates == [0x24] && (parameters.first == 0x3F || ansiModeReport(parameters))
+        case 0x74: return intermediates.isEmpty && cellSizeReport(parameters)
         default: return false
         }
     }
@@ -38,5 +39,22 @@ struct TerminalInputReportParser {
     private func ansiModeReport(_ p: [UInt32]) -> Bool {
         guard let i = p.firstIndex(of: 0x3B), i > 0, i + 1 < p.count else { return false }
         return p[..<i].allSatisfy { (0x30...0x39).contains($0) } && p[(i + 1)...].count == 1 && (0x30...0x34).contains(p[i + 1])
+    }
+
+    private func cellSizeReport(_ p: [UInt32]) -> Bool {
+        var fields: [[UInt32]] = []
+        var field: [UInt32] = []
+        for value in p {
+            if (0x30...0x39).contains(value) {
+                field.append(value)
+            } else {
+                guard value == 0x3B, !field.isEmpty else { return false }
+                fields.append(field)
+                field.removeAll(keepingCapacity: true)
+            }
+        }
+        guard !field.isEmpty else { return false }
+        fields.append(field)
+        return fields.count == 3 && fields[0] == [0x36]
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalInputReportParser.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalInputReportParser.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+struct TerminalInputReportParser {
+    private let scalars: [Unicode.Scalar]
+    private let start: Int
+    init(scalars: [Unicode.Scalar], start: Int) { self.scalars = scalars; self.start = start }
+    func csiSequenceLength() -> Int? {
+        guard start + 1 < scalars.count else { return nil }
+        var cursor = start + 2
+        while cursor < scalars.count {
+            let value = scalars[cursor].value
+            if value >= 0x40, value <= 0x7E { return isReport(bodyStart: start + 2, finalIndex: cursor) ? cursor - start + 1 : nil }
+            guard value >= 0x20, value <= 0x3F else { return nil }
+            cursor += 1
+        }
+        return nil
+    }
+    private func isReport(bodyStart: Int, finalIndex: Int) -> Bool {
+        var parameterEnd = bodyStart
+        while parameterEnd < finalIndex, (0x30...0x3F).contains(scalars[parameterEnd].value) { parameterEnd += 1 }
+        guard scalars[parameterEnd..<finalIndex].allSatisfy({ (0x20...0x2F).contains($0.value) }) else { return false }
+        let parameters = scalars[bodyStart..<parameterEnd].map(\.value)
+        let intermediates = scalars[parameterEnd..<finalIndex].map(\.value)
+        switch scalars[finalIndex].value {
+        case 0x52: return intermediates.isEmpty && cursorReport(parameters)
+        case 0x63: return intermediates.isEmpty && parameters.first.map { $0 == 0x3F || $0 == 0x3E } == true
+        case 0x6E: return intermediates.isEmpty && (parameters.first == 0x3F || parameters == [0x30] || parameters == [0x33])
+        case 0x75: return intermediates.isEmpty && parameters.first == 0x3F
+        case 0x79: return intermediates == [0x24] && (parameters.first == 0x3F || ansiModeReport(parameters))
+        default: return false
+        }
+    }
+    private func cursorReport(_ p: [UInt32]) -> Bool {
+        var fields = 0, digit = false
+        for v in p { if (0x30...0x39).contains(v) { digit = true } else { guard v == 0x3B, digit else { return false }; fields += 1; digit = false } }
+        guard digit else { return false }; return fields + 1 == 2
+    }
+    private func ansiModeReport(_ p: [UInt32]) -> Bool {
+        guard let i = p.firstIndex(of: 0x3B), i > 0, i + 1 < p.count else { return false }
+        return p[..<i].allSatisfy { (0x30...0x39).contains($0) } && p[(i + 1)...].count == 1 && (0x30...0x34).contains(p[i + 1])
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Input.swift
@@ -453,6 +453,8 @@ extension TerminalSurface {
         guard start + 1 < scalars.count, scalars[start].value == 0x1B else { return nil }
 
         switch scalars[start + 1].value {
+        case 0x5B: // CSI terminal reports such as CPR/DA/DSR responses.
+            return TerminalInputReportParser(scalars: scalars, start: start).csiSequenceLength()
         case 0x5D: // OSC: ESC ] ... (BEL | ST)
             return stringControlSequenceLength(scalars, from: start, terminatesWithBEL: true)
         case 0x50, 0x5E, 0x5F: // DCS / PM / APC: ESC P/^/_ ... ST

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceSocketInputParserTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceSocketInputParserTests.swift
@@ -15,7 +15,7 @@ import CmuxTerminalCore
     }
 
     @Test func terminalCSIProbeRepliesStayTerminalBytes() {
-        let replies = ["\u{1B}[?1;2c", "\u{1B}[>0;95;0c", "\u{1B}[0n", "\u{1B}[?997;1n", "\u{1B}[?0u", "\u{1B}[?12;2$y", "\u{1B}[4;1$y"]
+        let replies = ["\u{1B}[?1;2c", "\u{1B}[>0;95;0c", "\u{1B}[0n", "\u{1B}[?997;1n", "\u{1B}[?0u", "\u{1B}[?12;2$y", "\u{1B}[4;1$y", "\u{1B}[6;16;8t"]
         let events = TerminalSurface.parsedSocketInputEvents(for: replies.joined())
         #expect(terminalBytePayloads(in: events) == replies.map { Data($0.utf8) })
         #expect(!containsUserInputEvents(events))

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceSocketInputParserTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceSocketInputParserTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+import CmuxTerminalCore
+@testable import CmuxTerminal
+
+@Suite struct TerminalSurfaceSocketInputParserTests {
+    @Test func osc11AndCPRRepliesStayTerminalBytes() {
+        let firstOSC11 = "\u{1B}]11;rgb:1e1e/1e1e/1e1e\u{1B}\\"
+        let firstCPR = "\u{1B}[50;1R"
+        let secondOSC11 = "\u{1B}]11;rgb:1e1e/1e1e/1e1e\u{1B}\\"
+        let secondCPR = "\u{1B}[50;36R"
+        let events = TerminalSurface.parsedSocketInputEvents(for: firstOSC11 + firstCPR + secondOSC11 + secondCPR)
+        #expect(terminalBytePayloads(in: events) == [Data(firstOSC11.utf8), Data(firstCPR.utf8), Data(secondOSC11.utf8), Data(secondCPR.utf8)])
+        #expect(!containsUserInputEvents(events))
+    }
+
+    @Test func terminalCSIProbeRepliesStayTerminalBytes() {
+        let replies = ["\u{1B}[?1;2c", "\u{1B}[>0;95;0c", "\u{1B}[0n", "\u{1B}[?997;1n", "\u{1B}[?0u", "\u{1B}[?12;2$y", "\u{1B}[4;1$y"]
+        let events = TerminalSurface.parsedSocketInputEvents(for: replies.joined())
+        #expect(terminalBytePayloads(in: events) == replies.map { Data($0.utf8) })
+        #expect(!containsUserInputEvents(events))
+    }
+
+    @Test func keyboardProtocolKeyInputDoesNotBecomeTerminalBytes() {
+        let events = TerminalSurface.parsedSocketInputEvents(for: "\u{1B}[13;2u")
+        #expect(terminalBytePayloads(in: events).isEmpty)
+        #expect(containsUserInputEvents(events))
+    }
+
+    private func terminalBytePayloads(in events: [ParsedSocketInput]) -> [Data] {
+        events.compactMap { if case .terminalBytes(let data) = $0 { data } else { nil } }
+    }
+
+    private func containsUserInputEvents(_ events: [ParsedSocketInput]) -> Bool {
+        events.contains { if case .terminalBytes = $0 { false } else { true } }
+    }
+}


### PR DESCRIPTION
Fixes #10015

Routes recognized CSI terminal reports (CPR, DA, DSR, kitty keyboard mode, and DECRPM) through the terminal-byte path during socket input parsing. This prevents Pi startup/reload replies from entering user input and corrupting subsequent typing.

Regression-first commits:
- a86eeed384 test: cover Pi terminal query response routing
- 726526c563 fix: route terminal CSI reports to owning surface

Static checks: swiftc -parse passed; git diff --check passed. The repository lint script was not executable as invoked and was parsed by Python, so it could not run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #10015 by routing recognized CSI terminal reports to the owning surface's terminal-byte path instead of user input during socket parsing. Pi startup and reload replies previously leaked into user input and corrupted subsequent typing; keyboard protocol key input remains user input.

- Recognizes CPR, DA, DSR, kitty keyboard-mode, DECRPM, and cell-size (`CSI t`) responses by their CSI shape.
- Adds regression coverage for Pi replies, cell-size replies, and non-report keyboard input.

<sup>Written for commit 70e30c42778c0f9f6c3331e40f27d630791132d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11527?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal response sequences are now correctly recognized and preserved as terminal data instead of being interpreted as user input.
  * Improved handling for cursor, device, status, and mode reports.
  * Keyboard protocol input continues to be handled as user input.

* **Tests**
  * Added coverage for terminal responses and keyboard-protocol input parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->