### PR TITLE
Fix transient PTY resizes during workspace reveal

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3955,6 +3955,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private let scrollSpeedAccumulator = TerminalScrollSpeedAccumulator()
     private var visibleInUI: Bool = true
     private var pendingSurfaceSize: CGSize?
+    private var deferSurfaceSizeForPortalGeometrySettlement = false
     private var deferredSurfaceSizeRetryQueued = false, needsSurfaceSizeRetryAfterMetalLayerRealizes = false
     private var deferredSurfaceSizeNonMetalRetryCount = 0
     private var lastDrawableSize: CGSize = .zero
@@ -5017,6 +5018,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     private func activeSurfaceResizeDeferralReason() -> String? {
         if isWindowLiveResizeActive { return nil }
+        if deferSurfaceSizeForPortalGeometrySettlement { return "portalGeometrySettlement" }
         return Self.shouldDeferSurfaceResizeForActiveDrag(in: window) ? "tabDrag" : nil
     }
 
@@ -5179,6 +5181,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     @discardableResult
     fileprivate func pushTargetSurfaceSize(_ size: CGSize) -> Bool {
         updateSurfaceSize(size: size)
+    }
+
+    fileprivate func beginPortalGeometrySettlement() {
+        deferSurfaceSizeForPortalGeometrySettlement = true
+    }
+
+    fileprivate func finishPortalGeometrySettlement() {
+        guard deferSurfaceSizeForPortalGeometrySettlement else { return }
+        deferSurfaceSizeForPortalGeometrySettlement = false
+        _ = updateSurfaceSize()
     }
 
 #if DEBUG
@@ -11429,6 +11441,9 @@ final class GhosttySurfaceScrollView: NSView {
     }
 
     var isVisibleInUI: Bool { surfaceView.isVisibleInUI }
+    func beginPortalGeometrySettlement() { surfaceView.beginPortalGeometrySettlement() }
+    func finishPortalGeometrySettlement() { surfaceView.finishPortalGeometrySettlement() }
+
     func setVisibleInUI(_ visible: Bool) {
         let wasVisible = surfaceView.isVisibleInUI
         // Make the AppKit portal presentable before asking Ghostty to realize its

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1838,6 +1838,10 @@ final class WindowTerminalPortal: NSObject {
                     reason: "portal.deferredFullSync", syncLayout: false
                 )
             }
+            // Deferred full reconciliation is also the bind path's settle
+            // boundary. It runs after the portal's own frame writes, so the
+            // latest pending terminal size can now be applied safely.
+            self.finishVisibleEntryGeometrySettlements()
         }
     }
 

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -703,6 +703,7 @@ final class WindowTerminalPortal: NSObject {
         weak var hostedView: GhosttySurfaceScrollView?
         weak var anchorView: NSView?
         var visibleInUI: Bool
+        var awaitingGeometrySettlement: Bool
         var zPriority: Int
         var transientRecoveryRetriesRemaining: Int
     }
@@ -1024,7 +1025,8 @@ final class WindowTerminalPortal: NSObject {
         }
     }
 
-    private func synchronizeLayoutHierarchy() {
+    @discardableResult
+    private func synchronizeLayoutHierarchy() -> Bool {
         // Idempotence at the choke point. Several paths funnel here (window
         // notifications, anchor geometry callbacks, deferred full syncs,
         // transient recovery), each forcing subtree layout — and each layout
@@ -1035,7 +1037,7 @@ final class WindowTerminalPortal: NSObject {
         // and the echo dies here, whichever path carried it. AppKit still
         // runs pending inner layout before display on its own.
         let signature = externalGeometrySignature()
-        if let last = lastHierarchySyncSignature, last == signature { return }
+        if let last = lastHierarchySyncSignature, last == signature { return true }
 #if DEBUG
         RemoteTmuxSizingDiagnostics.fullHierarchySyncCount += 1
 #endif
@@ -1045,6 +1047,7 @@ final class WindowTerminalPortal: NSObject {
         hostView.layoutSubtreeIfNeeded()
         _ = synchronizeHostFrameToReference()
         lastHierarchySyncSignature = externalGeometrySignature()
+        return false
     }
 
     private var lastHierarchySyncSignature: ExternalGeometrySignature?
@@ -1119,9 +1122,14 @@ final class WindowTerminalPortal: NSObject {
         // here in one cheap comparison; any real change differs somewhere
         // and syncs fully.
         guard ensureInstalled() else { return }
-        synchronizeLayoutHierarchy()
+        let hierarchyWasAlreadySettled = synchronizeLayoutHierarchy()
         synchronizeAllHostedViews(excluding: nil)
         reconcileVisibleHostedViewsAfterGeometrySync(reason: "portal.externalGeometrySync")
+        if hierarchyWasAlreadySettled {
+            finishVisibleEntryGeometrySettlements()
+        } else if entriesByHostedId.values.contains(where: { $0.visibleInUI && $0.awaitingGeometrySettlement }) {
+            scheduleExternalGeometrySynchronize(forceImmediate: false)
+        }
     }
 
 #if DEBUG
@@ -1483,6 +1491,7 @@ final class WindowTerminalPortal: NSObject {
     func hideEntry(forHostedId hostedId: ObjectIdentifier) {
         guard var entry = entriesByHostedId[hostedId] else { return }
         entry.visibleInUI = false
+        entry.awaitingGeometrySettlement = false
         entry.transientRecoveryRetriesRemaining = 0
         entriesByHostedId[hostedId] = entry
         entry.hostedView?.isHidden = true
@@ -1501,7 +1510,14 @@ final class WindowTerminalPortal: NSObject {
         let becameVisible = visibleInUI && !entry.visibleInUI
         let becameHidden = !visibleInUI && entry.visibleInUI
         entry.visibleInUI = visibleInUI
-        if !visibleInUI { entry.transientRecoveryRetriesRemaining = 0 }
+        if becameVisible {
+            entry.awaitingGeometrySettlement = true
+            entry.hostedView?.beginPortalGeometrySettlement()
+        } else if !visibleInUI {
+            entry.awaitingGeometrySettlement = false
+            entry.hostedView?.finishPortalGeometrySettlement()
+            entry.transientRecoveryRetriesRemaining = 0
+        }
         entriesByHostedId[hostedId] = entry
         // A view that just became visible may still hold the frame it was
         // born with (bind can seed from a pre-settle anchor reading, and a
@@ -1615,6 +1631,7 @@ final class WindowTerminalPortal: NSObject {
             hostedView: hostedView,
             anchorView: anchorView,
             visibleInUI: visibleInUI,
+            awaitingGeometrySettlement: visibleInUI,
             zPriority: zPriority,
             transientRecoveryRetriesRemaining: 0
         )
@@ -1624,6 +1641,7 @@ final class WindowTerminalPortal: NSObject {
             return previousAnchor !== anchorView
         }()
         let becameVisible = (previousEntry?.visibleInUI ?? false) == false && visibleInUI
+        if becameVisible { hostedView.beginPortalGeometrySettlement() }
         let priorityIncreased = zPriority > (previousEntry?.zPriority ?? Int.min)
 #if DEBUG
         if previousEntry == nil || didChangeAnchor || becameVisible || priorityIncreased || hostedView.superview !== hostView {
@@ -1785,6 +1803,16 @@ final class WindowTerminalPortal: NSObject {
                     deferSurfaceRefresh(forHostedId: hostedId, reason: reason + ".deferred")
                 }
             }
+        }
+    }
+
+    private func finishVisibleEntryGeometrySettlements() {
+        for hostedId in entriesByHostedId.keys {
+            guard var entry = entriesByHostedId[hostedId], entry.visibleInUI,
+                  entry.awaitingGeometrySettlement, let hostedView = entry.hostedView else { continue }
+            entry.awaitingGeometrySettlement = false
+            entriesByHostedId[hostedId] = entry
+            hostedView.finishPortalGeometrySettlement()
         }
     }
 

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1121,7 +1121,10 @@ final class WindowTerminalPortal: NSObject {
         // carries the exact geometry the last pass left behind, so it dies
         // here in one cheap comparison; any real change differs somewhere
         // and syncs fully.
-        guard ensureInstalled() else { return }
+        guard ensureInstalled() else {
+            finishVisibleEntryGeometrySettlements()
+            return
+        }
         let hierarchyWasAlreadySettled = synchronizeLayoutHierarchy()
         synchronizeAllHostedViews(excluding: nil)
         reconcileVisibleHostedViewsAfterGeometrySync(reason: "portal.externalGeometrySync")
@@ -1513,6 +1516,7 @@ final class WindowTerminalPortal: NSObject {
         let becameHidden = !visibleInUI && entry.visibleInUI
         entry.visibleInUI = visibleInUI
         if becameVisible {
+            lastHierarchySyncSignature = nil
             entry.awaitingGeometrySettlement = true
             entry.hostedView?.beginPortalGeometrySettlement()
         } else if !visibleInUI {
@@ -1643,7 +1647,10 @@ final class WindowTerminalPortal: NSObject {
             return previousAnchor !== anchorView
         }()
         let becameVisible = (previousEntry?.visibleInUI ?? false) == false && visibleInUI
-        if becameVisible { hostedView.beginPortalGeometrySettlement() }
+        if becameVisible {
+            lastHierarchySyncSignature = nil
+            hostedView.beginPortalGeometrySettlement()
+        }
         let priorityIncreased = zPriority > (previousEntry?.zPriority ?? Int.min)
 #if DEBUG
         if previousEntry == nil || didChangeAnchor || becameVisible || priorityIncreased || hostedView.superview !== hostView {
@@ -1832,7 +1839,10 @@ final class WindowTerminalPortal: NSObject {
             // This callback is also the bind path's first settlement pass. Run
             // the hierarchy once and retain its fingerprint result so an
             // unstable first pass cannot flush an intermediate PTY size.
-            guard self.ensureInstalled(syncLayout: false) else { return }
+            guard self.ensureInstalled(syncLayout: false) else {
+                self.finishVisibleEntryGeometrySettlements()
+                return
+            }
             let hierarchyWasAlreadySettled = self.synchronizeLayoutHierarchy()
             self.synchronizeAllHostedViews(excluding: nil, syncLayout: false)
             if reconcileVisible {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1492,7 +1492,7 @@ final class WindowTerminalPortal: NSObject {
     func hideEntry(forHostedId hostedId: ObjectIdentifier) {
         guard var entry = entriesByHostedId[hostedId] else { return }
         entry.visibleInUI = false
-        if entry.awaitingGeometrySettlement { entry.hostedView?.finishPortalGeometrySettlement() }
+        entry.hostedView?.finishPortalGeometrySettlement()
         entry.awaitingGeometrySettlement = false
         entry.transientRecoveryRetriesRemaining = 0
         entriesByHostedId[hostedId] = entry
@@ -1829,7 +1829,12 @@ final class WindowTerminalPortal: NSObject {
             self.hasDeferredFullSyncScheduled = false
             let reconcileVisible = self.deferredFullSyncIncludesVisibleReconcile
             self.deferredFullSyncIncludesVisibleReconcile = false
-            self.synchronizeAllHostedViews(excluding: nil)
+            // This callback is also the bind path's first settlement pass. Run
+            // the hierarchy once and retain its fingerprint result so an
+            // unstable first pass cannot flush an intermediate PTY size.
+            guard self.ensureInstalled(syncLayout: false) else { return }
+            let hierarchyWasAlreadySettled = self.synchronizeLayoutHierarchy()
+            self.synchronizeAllHostedViews(excluding: nil, syncLayout: false)
             if reconcileVisible {
                 // syncLayout false: this runs off a layout callback during
                 // divider/sidebar drags, where a synchronous display wedges
@@ -1838,10 +1843,11 @@ final class WindowTerminalPortal: NSObject {
                     reason: "portal.deferredFullSync", syncLayout: false
                 )
             }
-            // Deferred full reconciliation is also the bind path's settle
-            // boundary. It runs after the portal's own frame writes, so the
-            // latest pending terminal size can now be applied safely.
-            self.finishVisibleEntryGeometrySettlements()
+            if hierarchyWasAlreadySettled {
+                self.finishVisibleEntryGeometrySettlements()
+            } else if self.entriesByHostedId.values.contains(where: { $0.visibleInUI && $0.awaitingGeometrySettlement }) {
+                self.scheduleExternalGeometrySynchronize(forceImmediate: false)
+            }
         }
     }
 

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1476,6 +1476,7 @@ final class WindowTerminalPortal: NSObject {
         )
 #endif
         if let hostedView = entry.hostedView {
+            hostedView.finishPortalGeometrySettlement()
             if let restoredMask = preAdoptionAutoresizingMaskByHostedId.removeValue(forKey: hostedId) {
                 hostedView.autoresizingMask = restoredMask
             }
@@ -1491,6 +1492,7 @@ final class WindowTerminalPortal: NSObject {
     func hideEntry(forHostedId hostedId: ObjectIdentifier) {
         guard var entry = entriesByHostedId[hostedId] else { return }
         entry.visibleInUI = false
+        if entry.awaitingGeometrySettlement { entry.hostedView?.finishPortalGeometrySettlement() }
         entry.awaitingGeometrySettlement = false
         entry.transientRecoveryRetriesRemaining = 0
         entriesByHostedId[hostedId] = entry

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1122,10 +1122,7 @@ final class WindowTerminalPortal: NSObject {
         // carries the exact geometry the last pass left behind, so it dies
         // here in one cheap comparison; any real change differs somewhere
         // and syncs fully.
-        guard ensureInstalled() else {
-            finishVisibleEntryGeometrySettlements()
-            return
-        }
+        guard ensureInstalled() else { return }
         let hierarchyWasAlreadySettled = synchronizeLayoutHierarchy()
         synchronizeAllHostedViews(excluding: nil)
         reconcileVisibleHostedViewsAfterGeometrySync(reason: "portal.externalGeometrySync")
@@ -1654,7 +1651,7 @@ final class WindowTerminalPortal: NSObject {
             return previousAnchor !== anchorView
         }()
         let becameVisible = (previousEntry?.visibleInUI ?? false) == false && visibleInUI
-        if becameVisible {
+        if becameVisible || (visibleInUI && didChangeAnchor) {
             lastHierarchySyncSignature = nil
             geometrySettlementPassesRemaining = 4
             hostedView.beginPortalGeometrySettlement()
@@ -1847,10 +1844,7 @@ final class WindowTerminalPortal: NSObject {
             // This callback is also the bind path's first settlement pass. Run
             // the hierarchy once and retain its fingerprint result so an
             // unstable first pass cannot flush an intermediate PTY size.
-            guard self.ensureInstalled(syncLayout: false) else {
-                self.finishVisibleEntryGeometrySettlements()
-                return
-            }
+            guard self.ensureInstalled(syncLayout: false) else { return }
             let hierarchyWasAlreadySettled = self.synchronizeLayoutHierarchy()
             self.synchronizeAllHostedViews(excluding: nil, syncLayout: false)
             if reconcileVisible {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1051,6 +1051,7 @@ final class WindowTerminalPortal: NSObject {
     }
 
     private var lastHierarchySyncSignature: ExternalGeometrySignature?
+    private var geometrySettlementPassesRemaining = 4
 
     @discardableResult
     private func synchronizeHostFrameToReference() -> Bool {
@@ -1131,7 +1132,12 @@ final class WindowTerminalPortal: NSObject {
         if hierarchyWasAlreadySettled {
             finishVisibleEntryGeometrySettlements()
         } else if entriesByHostedId.values.contains(where: { $0.visibleInUI && $0.awaitingGeometrySettlement }) {
-            scheduleExternalGeometrySynchronize(forceImmediate: false)
+            if geometrySettlementPassesRemaining > 0 {
+                geometrySettlementPassesRemaining -= 1
+                scheduleExternalGeometrySynchronize(forceImmediate: false)
+            } else {
+                finishVisibleEntryGeometrySettlements()
+            }
         }
     }
 
@@ -1517,6 +1523,7 @@ final class WindowTerminalPortal: NSObject {
         entry.visibleInUI = visibleInUI
         if becameVisible {
             lastHierarchySyncSignature = nil
+            geometrySettlementPassesRemaining = 4
             entry.awaitingGeometrySettlement = true
             entry.hostedView?.beginPortalGeometrySettlement()
         } else if !visibleInUI {
@@ -1649,6 +1656,7 @@ final class WindowTerminalPortal: NSObject {
         let becameVisible = (previousEntry?.visibleInUI ?? false) == false && visibleInUI
         if becameVisible {
             lastHierarchySyncSignature = nil
+            geometrySettlementPassesRemaining = 4
             hostedView.beginPortalGeometrySettlement()
         }
         let priorityIncreased = zPriority > (previousEntry?.zPriority ?? Int.min)
@@ -1856,7 +1864,12 @@ final class WindowTerminalPortal: NSObject {
             if hierarchyWasAlreadySettled {
                 self.finishVisibleEntryGeometrySettlements()
             } else if self.entriesByHostedId.values.contains(where: { $0.visibleInUI && $0.awaitingGeometrySettlement }) {
-                self.scheduleExternalGeometrySynchronize(forceImmediate: false)
+                if self.geometrySettlementPassesRemaining > 0 {
+                    self.geometrySettlementPassesRemaining -= 1
+                    self.scheduleExternalGeometrySynchronize(forceImmediate: false)
+                } else {
+                    self.finishVisibleEntryGeometrySettlements()
+                }
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/11504

Workspace reveal can restore split dividers over multiple portal geometry passes. This defers Ghostty grid updates while a visible portal entry is settling, retains the latest pending size, and applies one resize after a pass observes stable hierarchy geometry. The portal schedules a follow-up pass when geometry changed, so no timing delay is used.

Validation: git diff --check. Local Xcode tests were not run per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes https://github.com/manaflow-ai/cmux/issues/11504 by deferring Ghostty surface resizes while a workspace reveal restores split dividers. Previously each geometry pass could send an intermediate PTY size; now the surface keeps the latest pending size and applies one resize only after hierarchy geometry is stable, including after deferred reconciliation and portal rebinds. A visible entry resets its geometry state, so an unstable pass schedules a follow-up check; settlement is bounded to four passes before forcing the resize. Hiding or detaching cancels the pending settlement without a timing delay.

<sup>Written for commit 3e558a312af21c5649fb8133b5e17c15b03623d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal portal resizing during window layout changes.
  * Prevented premature surface size updates while portal geometry settles.
  * Ensured visible terminal views complete geometry updates after layout synchronization.
  * Improved resizing consistency when terminal views are shown, hidden, attached, or detached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->