### PR TITLE
refactor(tui): simplify capability token comparison

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host.rs
@@ -144,8 +144,8 @@ impl CapabilityToken {
 
     fn constant_time_eq(&self, other: &Self) -> bool {
         let mut difference = 0u8;
-        for index in 0..CAPABILITY_TOKEN_LEN {
-            difference |= self.0[index] ^ other.0[index];
+        for (&left, &right) in self.0.iter().zip(other.0.iter()) {
+            difference |= left ^ right;
         }
         difference == 0
     }


### PR DESCRIPTION
## Summary
- compare capability-token bytes through paired iterators
- remove duplicated array indexing while preserving the full constant-time accumulation

## Testing
- `git diff --check`
- static review only, as requested; no Cargo or Rust test commands ran

## References
- Rust `Iterator::zip`: https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.zip
- Rust slice `iter`: https://doc.rust-lang.org/std/primitive.slice.html#method.iter

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11533"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790906300&installation_model_id=21920&pr_number=11533&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11533&signature=d4b7c1405e42fdcca7a26a8948887f2cddf0844f5f22031af7ed4772937eac57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies capability token comparison in `cmux-tui-core` to use paired iterators instead of manual array indexing. No behavior change; the constant-time equality check still works exactly as before.

<sup>Written for commit 5e2d5c94c42d308065eea2108d550630fd98bfe7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Internal comparison logic was simplified without changing behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->