### PR TITLE
test(tui): extend Unicode corpus conformance coverage

### DIFF
--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -65,7 +65,7 @@ const UNICODE_CORPUS: &[CorpusCase] = &[
         id: "emoji-variation-selector",
         category: "variation-selector",
         text: "☕️",
-        width: WidthExpectation::Policy,
+        width: WidthExpectation::Wide,
     },
     CorpusCase {
         id: "regional-indicator-flag",
@@ -257,7 +257,9 @@ fn unicode_corpus_preserves_text_and_cell_geometry() {
         let frame = corpus_case_frame(case, TEST_COLUMNS);
         let row = frame.styled_row(0).unwrap();
         assert_eq!(row.len(), usize::from(TEST_COLUMNS), "case {} changed viewport width", case.id);
-        assert_eq!(row_text(row), case.text, "case {} changed grapheme text", case.id);
+        let occupied: Vec<&Cell> = row.iter().filter(|cell| !cell.text.is_empty()).collect();
+        assert_eq!(occupied.len(), 1, "case {} split grapheme text across cells", case.id);
+        assert_eq!(occupied[0].text, case.text, "case {} changed grapheme text", case.id);
         assert!(
             row.iter().all(|cell| !cell.text.contains('\u{FFFD}')),
             "case {} introduced U+FFFD in rendered cells",

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -1,6 +1,63 @@
-use ghostty_vt::{Callbacks, CellWidth, RenderState, Terminal, rows_to_runs};
+use ghostty_vt::{Callbacks, Cell, CellWidth, RenderState, Terminal, rows_to_runs};
 
 const TEST_COLUMNS: u16 = 16;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum WidthExpectation {
+    Narrow,
+    Wide,
+    /// East Asian Width is ambiguous. The active terminal policy decides the
+    /// cell count, so this corpus only checks that Ghostty reports one of the
+    /// two valid lead-cell roles.
+    Policy,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct CorpusCase {
+    id: &'static str,
+    category: &'static str,
+    text: &'static str,
+    width: WidthExpectation,
+}
+
+const UNICODE_CORPUS: &[CorpusCase] = &[
+    CorpusCase { id: "latin-combining-acute", category: "latin-combining", text: "e\u{301}", width: WidthExpectation::Narrow },
+    CorpusCase { id: "latin-nfc", category: "nfc-nfd", text: "é", width: WidthExpectation::Narrow },
+    CorpusCase { id: "latin-nfd", category: "nfc-nfd", text: "e\u{301}", width: WidthExpectation::Narrow },
+    CorpusCase { id: "hangul-syllable", category: "hangul", text: "한", width: WidthExpectation::Wide },
+    CorpusCase { id: "cjk-han", category: "cjk", text: "界", width: WidthExpectation::Wide },
+    CorpusCase { id: "emoji-presentation", category: "emoji-presentation", text: "😀", width: WidthExpectation::Wide },
+    CorpusCase { id: "emoji-zwj-star-wars-regression", category: "emoji-zwj", text: "🧑‍🚀", width: WidthExpectation::Wide },
+    CorpusCase { id: "emoji-zwj-family", category: "emoji-zwj", text: "👨‍👩‍👧‍👦", width: WidthExpectation::Wide },
+    CorpusCase { id: "emoji-variation-selector", category: "variation-selector", text: "☕️", width: WidthExpectation::Policy },
+    CorpusCase { id: "regional-indicator-flag", category: "regional-indicator", text: "🇺🇸", width: WidthExpectation::Wide },
+    CorpusCase { id: "zero-width-joiner", category: "zero-width-joiner", text: "👩‍💻", width: WidthExpectation::Wide },
+    CorpusCase { id: "devanagari-conjunct", category: "devanagari", text: "क्ष", width: WidthExpectation::Wide },
+    CorpusCase { id: "thai", category: "thai", text: "ก", width: WidthExpectation::Narrow },
+    CorpusCase { id: "arabic", category: "arabic", text: "م", width: WidthExpectation::Narrow },
+    CorpusCase { id: "box-drawing", category: "box-drawing", text: "┌", width: WidthExpectation::Policy },
+    CorpusCase { id: "east-asian-ambiguous-middle-dot", category: "east-asian-ambiguous", text: "·", width: WidthExpectation::Policy },
+];
+
+fn cell_columns(cell: &Cell) -> u16 {
+    match cell.width {
+        CellWidth::Wide => 2,
+        CellWidth::SpacerTail => 0,
+        CellWidth::Narrow | CellWidth::SpacerHead => 1,
+    }
+}
+
+fn row_text(row: &[Cell]) -> String {
+    row.iter().filter(|cell| !cell.text.is_empty()).map(|cell| cell.text.as_str()).collect()
+}
+
+fn row_signature(row: &[Cell]) -> Vec<(String, CellWidth)> {
+    row.iter().map(|cell| (cell.text.clone(), cell.width)).collect()
+}
+
+fn corpus_case_frame(case: CorpusCase, cols: u16) -> ghostty_vt::RenderFrame {
+    frame_for(&format!("\x1b[?2027h{}", case.text), cols)
+}
 
 fn frame_for(input: &str, cols: u16) -> ghostty_vt::RenderFrame {
     let mut terminal = Terminal::new(cols, 2, 0, Callbacks::default()).unwrap();
@@ -105,4 +162,115 @@ fn unicode_conformance_utf8_chunking_preserves_rendered_text() {
             .any(|(text, width)| text.is_empty() && *width == CellWidth::SpacerTail),
         "expected fixture must retain the empty spacer tail cell"
     );
+}
+
+#[test]
+fn unicode_corpus_preserves_text_and_cell_geometry() {
+    let required_categories = [
+        "latin-combining",
+        "nfc-nfd",
+        "hangul",
+        "cjk",
+        "emoji-presentation",
+        "emoji-zwj",
+        "variation-selector",
+        "regional-indicator",
+        "zero-width-joiner",
+        "devanagari",
+        "thai",
+        "arabic",
+        "box-drawing",
+        "east-asian-ambiguous",
+    ];
+
+    for category in required_categories {
+        assert!(
+            UNICODE_CORPUS.iter().any(|case| case.category == category),
+            "reviewed corpus is missing category {category}"
+        );
+    }
+
+    for &case in UNICODE_CORPUS {
+        assert!(!case.text.contains('\u{FFFD}'), "corpus case {} contains U+FFFD", case.id);
+        let frame = corpus_case_frame(case, TEST_COLUMNS);
+        let row = frame.styled_row(0).unwrap();
+        assert_eq!(row.len(), usize::from(TEST_COLUMNS), "case {} changed viewport width", case.id);
+        assert_eq!(row_text(row), case.text, "case {} changed grapheme text", case.id);
+        assert!(
+            row.iter().all(|cell| !cell.text.contains('\u{FFFD}')),
+            "case {} introduced U+FFFD in rendered cells",
+            case.id
+        );
+        assert_eq!(
+            row.iter().map(cell_columns).sum::<u16>(),
+            TEST_COLUMNS,
+            "case {} has inconsistent cell-column accounting",
+            case.id
+        );
+
+        let lead = row.iter().find(|cell| !cell.text.is_empty()).unwrap_or_else(|| {
+            panic!("case {} produced no lead cell", case.id)
+        });
+        match case.width {
+            WidthExpectation::Narrow => assert_eq!(lead.width, CellWidth::Narrow, "case {}", case.id),
+            WidthExpectation::Wide => assert_eq!(lead.width, CellWidth::Wide, "case {}", case.id),
+            WidthExpectation::Policy => {
+                assert!(
+                    matches!(lead.width, CellWidth::Narrow | CellWidth::Wide),
+                    "case {} has invalid policy-selected lead role {:?}",
+                    case.id,
+                    lead.width
+                );
+            }
+        }
+
+        if lead.width == CellWidth::Wide {
+            let lead_index = row.iter().position(|cell| !cell.text.is_empty()).unwrap();
+            let tail = row.get(lead_index + 1).unwrap_or_else(|| {
+                panic!("case {} wide lead has no spacer tail", case.id)
+            });
+            assert_eq!(tail.width, CellWidth::SpacerTail, "case {}", case.id);
+            assert!(tail.text.is_empty(), "case {} spacer tail contains text", case.id);
+        }
+    }
+}
+
+#[test]
+fn unicode_corpus_resize_and_replay_preserve_cells() {
+    let transcript = UNICODE_CORPUS
+        .iter()
+        .map(|case| case.text)
+        .collect::<Vec<_>>()
+        .join("\r\n");
+
+    let mut source = Terminal::new(32, 4, 0, Callbacks::default()).unwrap();
+    source.vt_write(format!("\x1b[?2027h{transcript}").as_bytes());
+    source.resize(20, 4, 8, 16).unwrap();
+
+    let mut source_state = RenderState::new().unwrap();
+    source_state.update(&mut source).unwrap();
+    let source_frame = source_state.build_frame().unwrap();
+    let replay = source.vt_replay().unwrap();
+
+    let mut restored = Terminal::new(20, 4, 0, Callbacks::default()).unwrap();
+    restored.apply_vt_replay(&replay).unwrap();
+    let mut restored_state = RenderState::new().unwrap();
+    restored_state.update(&mut restored).unwrap();
+    let restored_frame = restored_state.build_frame().unwrap();
+
+    assert_eq!(restored_frame.size, source_frame.size);
+    assert_eq!(restored_frame.styled_rows().len(), source_frame.styled_rows().len());
+    for (row_index, (source_row, restored_row)) in source_frame
+        .styled_rows()
+        .iter()
+        .zip(restored_frame.styled_rows())
+        .enumerate()
+    {
+        assert_eq!(
+            row_signature(restored_row),
+            row_signature(source_row),
+            "resize/replay changed cell roles in row {row_index}"
+        );
+        assert!(!row_text(restored_row).contains('\u{FFFD}'), "resize/replay introduced U+FFFD in row {row_index}");
+    }
 }

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -302,36 +302,46 @@ fn unicode_corpus_preserves_text_and_cell_geometry() {
 
 #[test]
 fn unicode_corpus_resize_and_replay_preserve_cells() {
-    let transcript = UNICODE_CORPUS.iter().map(|case| case.text).collect::<Vec<_>>().join("\r\n");
+    for &case in UNICODE_CORPUS {
+        // Keep each case isolated. A zero-scrollback terminal would otherwise
+        // evict earlier rows from a multi-case transcript before replay.
+        let mut source = Terminal::new(32, 4, 0, Callbacks::default()).unwrap();
+        source.vt_write(format!("\x1b[?2027h{}", case.text).as_bytes());
+        source.resize(20, 4, 8, 16).unwrap();
 
-    let mut source = Terminal::new(32, 4, 0, Callbacks::default()).unwrap();
-    source.vt_write(format!("\x1b[?2027h{transcript}").as_bytes());
-    source.resize(20, 4, 8, 16).unwrap();
+        let mut source_state = RenderState::new().unwrap();
+        source_state.update(&mut source).unwrap();
+        let source_frame = source_state.build_frame().unwrap();
+        assert_eq!(row_text(source_frame.styled_row(0).unwrap()), case.text, "case {}", case.id);
 
-    let mut source_state = RenderState::new().unwrap();
-    source_state.update(&mut source).unwrap();
-    let source_frame = source_state.build_frame().unwrap();
-    let replay = source.vt_replay().unwrap();
+        let replay = source.vt_replay().unwrap();
+        let mut restored = Terminal::new(20, 4, 0, Callbacks::default()).unwrap();
+        restored.apply_vt_replay(&replay).unwrap();
+        let mut restored_state = RenderState::new().unwrap();
+        restored_state.update(&mut restored).unwrap();
+        let restored_frame = restored_state.build_frame().unwrap();
 
-    let mut restored = Terminal::new(20, 4, 0, Callbacks::default()).unwrap();
-    restored.apply_vt_replay(&replay).unwrap();
-    let mut restored_state = RenderState::new().unwrap();
-    restored_state.update(&mut restored).unwrap();
-    let restored_frame = restored_state.build_frame().unwrap();
-
-    assert_eq!(restored_frame.size, source_frame.size);
-    assert_eq!(restored_frame.styled_rows().len(), source_frame.styled_rows().len());
-    for (row_index, (source_row, restored_row)) in
-        source_frame.styled_rows().iter().zip(restored_frame.styled_rows()).enumerate()
-    {
+        assert_eq!(restored_frame.size, source_frame.size, "case {}", case.id);
         assert_eq!(
-            row_signature(restored_row),
-            row_signature(source_row),
-            "resize/replay changed cell roles in row {row_index}"
+            restored_frame.styled_rows().len(),
+            source_frame.styled_rows().len(),
+            "case {} row count",
+            case.id
         );
-        assert!(
-            !row_text(restored_row).contains('\u{FFFD}'),
-            "resize/replay introduced U+FFFD in row {row_index}"
-        );
+        for (row_index, (source_row, restored_row)) in
+            source_frame.styled_rows().iter().zip(restored_frame.styled_rows()).enumerate()
+        {
+            assert_eq!(
+                row_signature(restored_row),
+                row_signature(source_row),
+                "case {} resize/replay changed cell roles in row {row_index}",
+                case.id
+            );
+            assert!(
+                !row_text(restored_row).contains('\u{FFFD}'),
+                "case {} resize/replay introduced U+FFFD in row {row_index}",
+                case.id
+            );
+        }
     }
 }

--- a/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
+++ b/cmux-tui/crates/ghostty-vt/tests/unicode_glyphs.rs
@@ -21,22 +21,84 @@ struct CorpusCase {
 }
 
 const UNICODE_CORPUS: &[CorpusCase] = &[
-    CorpusCase { id: "latin-combining-acute", category: "latin-combining", text: "e\u{301}", width: WidthExpectation::Narrow },
-    CorpusCase { id: "latin-nfc", category: "nfc-nfd", text: "é", width: WidthExpectation::Narrow },
-    CorpusCase { id: "latin-nfd", category: "nfc-nfd", text: "e\u{301}", width: WidthExpectation::Narrow },
-    CorpusCase { id: "hangul-syllable", category: "hangul", text: "한", width: WidthExpectation::Wide },
+    CorpusCase {
+        id: "latin-combining-acute",
+        category: "latin-combining",
+        text: "e\u{301}",
+        width: WidthExpectation::Narrow,
+    },
+    CorpusCase {
+        id: "latin-nfc", category: "nfc-nfd", text: "é", width: WidthExpectation::Narrow
+    },
+    CorpusCase {
+        id: "latin-nfd",
+        category: "nfc-nfd",
+        text: "e\u{301}",
+        width: WidthExpectation::Narrow,
+    },
+    CorpusCase {
+        id: "hangul-syllable",
+        category: "hangul",
+        text: "한",
+        width: WidthExpectation::Wide,
+    },
     CorpusCase { id: "cjk-han", category: "cjk", text: "界", width: WidthExpectation::Wide },
-    CorpusCase { id: "emoji-presentation", category: "emoji-presentation", text: "😀", width: WidthExpectation::Wide },
-    CorpusCase { id: "emoji-zwj-star-wars-regression", category: "emoji-zwj", text: "🧑‍🚀", width: WidthExpectation::Wide },
-    CorpusCase { id: "emoji-zwj-family", category: "emoji-zwj", text: "👨‍👩‍👧‍👦", width: WidthExpectation::Wide },
-    CorpusCase { id: "emoji-variation-selector", category: "variation-selector", text: "☕️", width: WidthExpectation::Policy },
-    CorpusCase { id: "regional-indicator-flag", category: "regional-indicator", text: "🇺🇸", width: WidthExpectation::Wide },
-    CorpusCase { id: "zero-width-joiner", category: "zero-width-joiner", text: "👩‍💻", width: WidthExpectation::Wide },
-    CorpusCase { id: "devanagari-conjunct", category: "devanagari", text: "क्ष", width: WidthExpectation::Wide },
+    CorpusCase {
+        id: "emoji-presentation",
+        category: "emoji-presentation",
+        text: "😀",
+        width: WidthExpectation::Wide,
+    },
+    CorpusCase {
+        id: "emoji-zwj-star-wars-regression",
+        category: "emoji-zwj",
+        text: "🧑‍🚀",
+        width: WidthExpectation::Wide,
+    },
+    CorpusCase {
+        id: "emoji-zwj-family",
+        category: "emoji-zwj",
+        text: "👨‍👩‍👧‍👦",
+        width: WidthExpectation::Wide,
+    },
+    CorpusCase {
+        id: "emoji-variation-selector",
+        category: "variation-selector",
+        text: "☕️",
+        width: WidthExpectation::Policy,
+    },
+    CorpusCase {
+        id: "regional-indicator-flag",
+        category: "regional-indicator",
+        text: "🇺🇸",
+        width: WidthExpectation::Wide,
+    },
+    CorpusCase {
+        id: "zero-width-joiner",
+        category: "zero-width-joiner",
+        text: "👩‍💻",
+        width: WidthExpectation::Wide,
+    },
+    CorpusCase {
+        id: "devanagari-conjunct",
+        category: "devanagari",
+        text: "क्ष",
+        width: WidthExpectation::Wide,
+    },
     CorpusCase { id: "thai", category: "thai", text: "ก", width: WidthExpectation::Narrow },
     CorpusCase { id: "arabic", category: "arabic", text: "م", width: WidthExpectation::Narrow },
-    CorpusCase { id: "box-drawing", category: "box-drawing", text: "┌", width: WidthExpectation::Policy },
-    CorpusCase { id: "east-asian-ambiguous-middle-dot", category: "east-asian-ambiguous", text: "·", width: WidthExpectation::Policy },
+    CorpusCase {
+        id: "box-drawing",
+        category: "box-drawing",
+        text: "┌",
+        width: WidthExpectation::Policy,
+    },
+    CorpusCase {
+        id: "east-asian-ambiguous-middle-dot",
+        category: "east-asian-ambiguous",
+        text: "·",
+        width: WidthExpectation::Policy,
+    },
 ];
 
 fn cell_columns(cell: &Cell) -> u16 {
@@ -208,11 +270,14 @@ fn unicode_corpus_preserves_text_and_cell_geometry() {
             case.id
         );
 
-        let lead = row.iter().find(|cell| !cell.text.is_empty()).unwrap_or_else(|| {
-            panic!("case {} produced no lead cell", case.id)
-        });
+        let lead = row
+            .iter()
+            .find(|cell| !cell.text.is_empty())
+            .unwrap_or_else(|| panic!("case {} produced no lead cell", case.id));
         match case.width {
-            WidthExpectation::Narrow => assert_eq!(lead.width, CellWidth::Narrow, "case {}", case.id),
+            WidthExpectation::Narrow => {
+                assert_eq!(lead.width, CellWidth::Narrow, "case {}", case.id)
+            }
             WidthExpectation::Wide => assert_eq!(lead.width, CellWidth::Wide, "case {}", case.id),
             WidthExpectation::Policy => {
                 assert!(
@@ -226,9 +291,9 @@ fn unicode_corpus_preserves_text_and_cell_geometry() {
 
         if lead.width == CellWidth::Wide {
             let lead_index = row.iter().position(|cell| !cell.text.is_empty()).unwrap();
-            let tail = row.get(lead_index + 1).unwrap_or_else(|| {
-                panic!("case {} wide lead has no spacer tail", case.id)
-            });
+            let tail = row
+                .get(lead_index + 1)
+                .unwrap_or_else(|| panic!("case {} wide lead has no spacer tail", case.id));
             assert_eq!(tail.width, CellWidth::SpacerTail, "case {}", case.id);
             assert!(tail.text.is_empty(), "case {} spacer tail contains text", case.id);
         }
@@ -237,11 +302,7 @@ fn unicode_corpus_preserves_text_and_cell_geometry() {
 
 #[test]
 fn unicode_corpus_resize_and_replay_preserve_cells() {
-    let transcript = UNICODE_CORPUS
-        .iter()
-        .map(|case| case.text)
-        .collect::<Vec<_>>()
-        .join("\r\n");
+    let transcript = UNICODE_CORPUS.iter().map(|case| case.text).collect::<Vec<_>>().join("\r\n");
 
     let mut source = Terminal::new(32, 4, 0, Callbacks::default()).unwrap();
     source.vt_write(format!("\x1b[?2027h{transcript}").as_bytes());
@@ -260,17 +321,17 @@ fn unicode_corpus_resize_and_replay_preserve_cells() {
 
     assert_eq!(restored_frame.size, source_frame.size);
     assert_eq!(restored_frame.styled_rows().len(), source_frame.styled_rows().len());
-    for (row_index, (source_row, restored_row)) in source_frame
-        .styled_rows()
-        .iter()
-        .zip(restored_frame.styled_rows())
-        .enumerate()
+    for (row_index, (source_row, restored_row)) in
+        source_frame.styled_rows().iter().zip(restored_frame.styled_rows()).enumerate()
     {
         assert_eq!(
             row_signature(restored_row),
             row_signature(source_row),
             "resize/replay changed cell roles in row {row_index}"
         );
-        assert!(!row_text(restored_row).contains('\u{FFFD}'), "resize/replay introduced U+FFFD in row {row_index}");
+        assert!(
+            !row_text(restored_row).contains('\u{FFFD}'),
+            "resize/replay introduced U+FFFD in row {row_index}"
+        );
     }
 }


### PR DESCRIPTION
Adds a bounded reviewed corpus to the existing ghostty-vt Unicode behavior tests.

- Covers combining/NFC/NFD, Hangul/CJK, emoji presentation and ZWJ (including the Star Wars regression sequence), variation selectors, regional indicators, Devanagari/Thai/Arabic, box drawing, and ambiguous symbols.
- Rejects U+FFFD in corpus input and rendered cells, and checks cell-column accounting.
- Verifies resize then VT replay preserves rendered cells and width roles.

Focused hosted verification: `./scripts/verify-cmux-tui-hosted.sh --filter unicode_corpus`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11534"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790906311&installation_model_id=21920&pr_number=11534&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11534&signature=b1bcf9981a67b895db2b0c1f0921e96e16e24c504783e3392537af77dcde6db7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the reviewed Unicode corpus from issue-11027 to the `ghostty-vt` Unicode conformance tests.

- Covers combining marks, NFC/NFD, Hangul/CJK, emoji presentation and ZWJ sequences, variation selectors, regional indicators, Devanagari/Thai/Arabic, box drawing, and ambiguous-width characters.
- Verifies each case preserves text and cell-column accounting without U+FFFD, checks lead-cell width roles, and keeps identical cell roles after resize plus VT replay.

<sup>Written for commit 4fbbce6a537f99986da76d19fcd39763d3ce5cc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11534?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

