### PR TITLE
ci: run releases from protected main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,7 @@ on:
       - tests/test_ci_ghosttykit_release_check.sh
       - .github/workflows/release-trusted.yml
       - tests/test_release_trusted_workflow.py
+      - scripts/ci/select_latest_stable_release.py
       - tests/test_ci_change_areas.py
       - .github/workflows/cla.yml
       - .github/workflows/ci.yml
@@ -153,6 +154,14 @@ jobs:
 
       - name: Validate macOS runner guards
         run: ./tests/test_ci_self_hosted_guard.sh
+
+      - name: Set up Python for release workflow contract tests
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
+        with:
+          python-version: "3.12"
+
+      - name: Install release workflow contract dependencies
+        run: python3 -m pip install --disable-pip-version-check --no-input PyYAML==6.0.3
 
       - name: Validate protected-main release dispatcher
         run: python3 tests/test_release_trusted_workflow.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,8 @@ on:
       - scripts/validate-xcframework-archive.py
       - scripts/ghosttykit-checksums.txt
       - tests/test_ci_ghosttykit_release_check.sh
+      - .github/workflows/release-trusted.yml
+      - tests/test_release_trusted_workflow.py
       - tests/test_ci_change_areas.py
       - .github/workflows/cla.yml
       - .github/workflows/ci.yml
@@ -151,6 +153,9 @@ jobs:
 
       - name: Validate macOS runner guards
         run: ./tests/test_ci_self_hosted_guard.sh
+
+      - name: Validate protected-main release dispatcher
+        run: python3 tests/test_release_trusted_workflow.py
 
       - name: Validate release SDK build lane
         run: ./tests/test_ci_release_sdk_lane.sh

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -608,7 +608,7 @@ jobs:
           # search list. It contains paths only, never key material.
           security list-keychains -d user > "$keychain_list_backup"
           KEYCHAIN_PASSWORD="$(uuidgen)"
-          printf '%s' "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$cert_path"
+          printf '%s' "$APPLE_CERTIFICATE_BASE64" | base64 -D > "$cert_path"
           chmod 600 "$cert_path"
           keychain_dir="$(mktemp -d "$runner_temp/cmux-signing-keychain.XXXXXX")"
           [[ -d "$keychain_dir" && ! -L "$keychain_dir" ]] || {
@@ -747,7 +747,7 @@ jobs:
           TMP_PROFILE="$(mktemp /tmp/cmux-release-profile.XXXXXX)"
           TMP_PLIST="$(mktemp /tmp/cmux-release-profile.XXXXXX.plist)"
           trap 'rm -f "$TMP_PROFILE" "$TMP_PLIST"' EXIT
-          echo "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$TMP_PROFILE"
+          echo "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" | base64 -D > "$TMP_PROFILE"
           security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
           APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"
           if [ "$APP_ID" != "7WLXT3NR37.com.cmuxterm.app" ]; then

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -84,35 +84,32 @@ jobs:
               return Buffer.from(file.content.replace(/\s/g, ''), 'base64').toString('utf8');
             };
             const assertObserverContract = (content) => {
-              if (content.length > 2048) fail('Release trigger workflow is larger than the observer contract');
-              const requiredLines = [
-                /^name:\s*Release macOS app trigger\s*$/m,
-                /^on:\s*$/m,
-                /^\s+push:\s*$/m,
-                /^\s+tags:\s*$/m,
-                /^\s+-\s+["']v\*["']\s*$/m,
-                /^permissions:\s*\{\s*\}\s*$/m,
-                /^jobs:\s*$/m,
-                /^\s+announce:\s*$/m,
-                /^\s+runs-on:\s+ubuntu-24\.04(?:\s+#.*)?\s*$/m,
-                /^\s+permissions:\s*\{\s*\}\s*$/m,
-                /^\s+steps:\s*$/m,
-                /^\s+-\s+name:\s+Emit queued release event\s*$/m,
-                /^\s+run:\s+\|\s*$/m,
-                /echo ["']Tag event queued for trusted protected-main release dispatcher: \$\{GITHUB_REF_NAME\}["']/,
-              ];
-              for (const line of requiredLines) if (!line.test(content)) {
-                fail('Release trigger workflow is not the minimal unprivileged observer');
-              }
-              if (/workflow_dispatch|workflow_call|repository_dispatch|actions\/|uses:\s|secrets\.|GITHUB_TOKEN|github\.token|contents:\s*(?:write|read-write)|id-token|attestations|environment\s*:|with\s*:/m.test(content)) {
-                fail('Release trigger workflow is not the minimal unprivileged observer');
-              }
-              const permissionLines = content.match(/^\s*permissions\s*:[^\n]*$/gm) || [];
-              if (permissionLines.some((line) => !/:\s*\{\s*\}\s*$/.test(line))) {
-                fail('Release trigger workflow grants token permissions');
-              }
-              const runBlocks = content.match(/^\s+run:\s+\|\s*$/gm) || [];
-              if (runBlocks.length !== 1) fail('Release trigger workflow must have one completion step');
+              // Keep the tag-side file byte-for-byte canonical. This is a
+              // deliberately tiny allowlist: alternate YAML forms (including
+              // `run: >`, extra triggers, or extra jobs) cannot execute.
+              const expected = [
+                'name: Release macOS app trigger',
+                '',
+                'on:',
+                '  push:',
+                '    tags:',
+                '      - "v*"',
+                '',
+                'permissions: {}',
+                '',
+                'jobs:',
+                '  announce:',
+                '    runs-on: ubuntu-24.04 # github-hosted-required: unprivileged tag observer',
+                '    permissions: {}',
+                '    timeout-minutes: 2',
+                '    steps:',
+                '      - name: Emit queued release event',
+                '        run: |',
+                '          set -euo pipefail',
+                '          echo "Tag event queued for trusted protected-main release dispatcher: ${GITHUB_REF_NAME}"',
+                '',
+              ].join('\n');
+              if (content !== expected) fail('Release trigger workflow is not the minimal unprivileged observer');
             };
 
             requireText('Release dispatcher repository', repository, expectedRepository);
@@ -351,6 +348,7 @@ jobs:
             const tag = process.env.RELEASE_TAG;
             core.setOutput('skip_all', 'false');
             core.setOutput('skip_upload', 'false');
+            core.setOutput('skip_r2_upload', 'false');
             core.setOutput('release_state', 'clear');
             if (!tag) {
               core.setFailed('Release asset guard did not receive the validated release tag');
@@ -389,6 +387,10 @@ jobs:
                 );
                 core.setOutput('skip_all', 'true');
                 core.setOutput('skip_upload', 'true');
+                // Existing immutable assets mean the build and GitHub asset
+                // upload are complete. Keep the mutable R2 appcast lane live
+                // so a transient upload failure can be repaired by rerun.
+                core.setOutput('skip_r2_upload', 'false');
                 return;
               }
 
@@ -400,6 +402,20 @@ jobs:
               }
               throw error;
             }
+
+      - name: Restore appcast for a publication retry
+        if: steps.guard_release_assets.outputs.skip_all == 'true' && steps.guard_release_assets.outputs.skip_r2_upload != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          rm -f appcast.xml
+          gh release download "$RELEASE_TAG" \
+            --repo manaflow-ai/cmux \
+            --pattern appcast.xml \
+            --output appcast.xml \
+            --clobber
+          test -s appcast.xml
 
       - name: Select Xcode
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -788,8 +804,41 @@ jobs:
             remote-daemon-assets/cmuxd-remote-checksums.txt
             remote-daemon-assets/cmuxd-remote-manifest.json
 
-      - name: Upload release asset
+      - name: Revalidate release tag before GitHub publication
+        id: revalidate-release-tag
         if: steps.guard_release_assets.outputs.skip_upload != 'true'
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
+          EXPECTED_SHA: ${{ needs.validate-source.outputs.source_sha }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const tag = process.env.RELEASE_TAG;
+            const expectedSha = process.env.EXPECTED_SHA;
+            const shaPattern = /^[0-9a-f]{40}$/;
+            if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(tag || '')) {
+              core.setFailed(`Invalid validated release tag: ${tag}`);
+              return;
+            }
+            if (!shaPattern.test(expectedSha || '')) {
+              core.setFailed('Validated release source is not a commit SHA');
+              return;
+            }
+            const ref = await github.rest.git.getRef({ owner, repo, ref: `tags/${tag}` });
+            let tagSha = ref.data.object?.sha;
+            if (ref.data.object?.type === 'tag') {
+              tagSha = (await github.rest.git.getTag({ owner, repo, tag_sha: tagSha })).data.object?.sha;
+            }
+            if (tagSha !== expectedSha) {
+              core.setFailed(`Release tag ${tag} changed from ${expectedSha} to ${tagSha}`);
+              return;
+            }
+            core.setOutput('verified', 'true');
+            core.notice(`Revalidated ${tag} at ${expectedSha} immediately before GitHub publication`);
+
+      - name: Upload release asset
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' && steps.revalidate-release-tag.outputs.verified == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
@@ -805,8 +854,29 @@ jobs:
           overwrite_files: false
           tag_name: ${{ needs.validate-source.outputs.tag_name }}
 
+      - name: Revalidate release tag before R2 publication
+        id: revalidate-r2-tag
+        if: steps.guard_release_assets.outputs.skip_r2_upload != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
+          EXPECTED_SHA: ${{ needs.validate-source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          tag_object="$(gh api "repos/manaflow-ai/cmux/git/ref/tags/$RELEASE_TAG")"
+          tag_type="$(jq -r '.object.type' <<<"$tag_object")"
+          tag_sha="$(jq -r '.object.sha' <<<"$tag_object")"
+          if [ "$tag_type" = tag ]; then
+            tag_sha="$(gh api "repos/manaflow-ai/cmux/git/tags/$tag_sha" --jq '.object.sha')"
+          fi
+          if [ "$tag_sha" != "$EXPECTED_SHA" ]; then
+            echo "Release tag $RELEASE_TAG changed from $EXPECTED_SHA to $tag_sha" >&2
+            exit 1
+          fi
+          echo "verified=true" >> "$GITHUB_OUTPUT"
+
       - name: Upload release appcast to R2
-        if: steps.guard_release_assets.outputs.skip_upload != 'true'
+        if: steps.guard_release_assets.outputs.skip_r2_upload != 'true' && steps.revalidate-r2-tag.outputs.verified == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -416,10 +416,6 @@ jobs:
           script: |
             const { evaluateReleaseAssetGuard } = require('./scripts/release_asset_guard');
             const tag = process.env.RELEASE_TAG;
-            core.setOutput('skip_all', 'false');
-            core.setOutput('skip_upload', 'false');
-            core.setOutput('skip_r2_upload', 'false');
-            core.setOutput('release_state', 'clear');
             if (!tag) {
               core.setFailed('Release asset guard did not receive the validated release tag');
               return;
@@ -434,12 +430,9 @@ jobs:
               const {
                 conflicts,
                 missingImmutableAssets,
-                guardState,
                 hasPartialConflict,
                 shouldSkipBuildAndUpload,
               } = evaluateReleaseAssetGuard({ existingAssetNames });
-
-              core.setOutput('release_state', guardState);
 
               if (hasPartialConflict) {
                 core.setFailed(
@@ -468,7 +461,7 @@ jobs:
             }
 
       - name: Select Xcode
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           set -euo pipefail
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
@@ -496,17 +489,17 @@ jobs:
       # on PATH, which breaks the pinned create-dmg install below. setup-node
       # guarantees node/npm regardless of which runner picks up the job.
       - name: Set up Node
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "20"
 
       - name: Setup Bun
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
 
       - name: Install build deps
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           ./scripts/install-rust-ci.sh
           CMUX_NODE_BIN="$(command -v node)"
@@ -523,12 +516,12 @@ jobs:
           echo "$wrapper_dir" >> "$GITHUB_PATH"
 
       - name: Download pre-built GhosttyKit.xcframework
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Cache Swift packages
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .spm-cache
@@ -536,18 +529,18 @@ jobs:
           restore-keys: spm-
 
       - name: Sanitize Swift package cache
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
 
       - name: Setup Go
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: daemon/remote/go.mod
           cache-dependency-path: daemon/remote/go.sum
 
       - name: Derive Sparkle public key from private key
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
@@ -560,7 +553,7 @@ jobs:
           echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
 
       - name: Build universal app (Release)
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
             -destination 'generic/platform=macOS' \
@@ -570,7 +563,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO build
 
       - name: Import signing cert
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -636,7 +629,7 @@ jobs:
           security list-keychains -d user -s "$keychain_path"
 
       - name: Start Computer Use helper notarization
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
@@ -652,14 +645,14 @@ jobs:
             "$APPLE_SIGNING_IDENTITY"
 
       - name: Download universal Ghostty CLI helper
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:
           name: cmux-ghostty-cli-helper
           path: ghostty-cli-helper
 
       - name: Install universal Ghostty CLI helper
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           set -euo pipefail
           ./scripts/install-prebuilt-ghostty-cli-helper.sh \
@@ -668,7 +661,7 @@ jobs:
           ./scripts/install-cmux-tui-client.sh build-universal/Build/Products/Release/cmux.app
 
       - name: Verify binary architectures
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           set -euo pipefail
           APP_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/MacOS/cmux"
@@ -690,7 +683,7 @@ jobs:
           [[ "$SDK_VERSION" == 26.* ]]
 
       - name: Build remote daemon release assets and inject manifest
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           set -euo pipefail
           APP_PLIST="build-universal/Build/Products/Release/cmux.app/Contents/Info.plist"
@@ -705,7 +698,7 @@ jobs:
           plutil -insert CMUXRemoteDaemonManifestJSON -string "$MANIFEST_JSON" "$APP_PLIST"
 
       - name: Run CLI version memory guard regression
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           set -euo pipefail
           CLI_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux"
@@ -713,14 +706,14 @@ jobs:
           CMUX_CLI_BIN="$CLI_BINARY" python3 tests/test_cli_version_memory_guard.py
 
       - name: Verify bundled Ghostty theme picker helper
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           set -euo pipefail
           HELPER_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/ghostty"
           [ -x "$HELPER_BINARY" ] || { echo "Ghostty theme picker helper not found at $HELPER_BINARY" >&2; exit 1; }
 
       - name: Inject Sparkle keys into Info.plist
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: |
           APP_PLIST="build-universal/Build/Products/Release/cmux.app/Contents/Info.plist"
           /usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$APP_PLIST" >/dev/null 2>&1 || true
@@ -734,7 +727,7 @@ jobs:
           /usr/libexec/PlistBuddy -c "Print :SUFeedURL" "$APP_PLIST"
 
       - name: Embed release provisioning profile
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           APPLE_RELEASE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 }}
         run: |
@@ -767,11 +760,11 @@ jobs:
           cp "$TMP_PROFILE" "$PROFILE_PATH"
 
       - name: Strip release binaries
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         run: ./scripts/strip-release-bundle.sh "build-universal/Build/Products/Release/cmux.app"
 
       - name: Codesign app
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
         run: |
@@ -787,7 +780,7 @@ jobs:
             "$APPLE_SIGNING_IDENTITY"
 
       - name: Notarize app
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           APPLE_ID: ${{ secrets.APPLE_ID }}
           APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
@@ -846,7 +839,7 @@ jobs:
           xcrun stapler validate "$DMG_RELEASE"
 
       - name: Upload dSYMs to Sentry
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
           SENTRY_ORG: manaflow
@@ -860,7 +853,7 @@ jobs:
           "$SENTRY_CLI" debug-files upload --include-sources build-universal/Build/Products/Release/
 
       - name: Generate Sparkle appcast
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         env:
           SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
         run: |
@@ -872,7 +865,7 @@ jobs:
 
       - name: Attest remote daemon release assets
         id: attest-remote-daemon-release-assets
-        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        if: success()
         continue-on-error: true
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
@@ -885,7 +878,7 @@ jobs:
             remote-daemon-assets/cmuxd-remote-manifest.json
 
       - name: Retry remote daemon release asset attestation
-        if: steps.guard_release_assets.outputs.skip_all != 'true' && steps.attest-remote-daemon-release-assets.outcome == 'failure'
+        if: success() && steps.attest-remote-daemon-release-assets.outcome == 'failure'
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
         with:
           subject-path: |
@@ -898,7 +891,7 @@ jobs:
 
       - name: Revalidate release tag before GitHub publication
         id: revalidate-release-tag
-        if: steps.guard_release_assets.outputs.skip_upload != 'true'
+        if: success()
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
@@ -930,7 +923,7 @@ jobs:
             core.notice(`Revalidated ${tag} at ${expectedSha} immediately before GitHub publication`);
 
       - name: Upload release asset
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' && steps.revalidate-release-tag.outputs.verified == 'true'
+        if: success() && steps.revalidate-release-tag.outputs.verified == 'true'
         uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         with:
           files: |
@@ -950,7 +943,7 @@ jobs:
 
       - name: Revalidate release tag before R2 publication
         id: revalidate-r2-tag
-        if: steps.guard_release_assets.outputs.skip_r2_upload != 'true'
+        if: success()
         env:
           GH_TOKEN: ${{ github.token }}
           RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
@@ -970,7 +963,7 @@ jobs:
           echo "verified=true" >> "$GITHUB_OUTPUT"
 
       - name: Upload release appcast to R2
-        if: steps.guard_release_assets.outputs.skip_r2_upload != 'true' && steps.revalidate-r2-tag.outputs.verified == 'true'
+        if: success() && steps.revalidate-r2-tag.outputs.verified == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
           EXPECTED_SHA: ${{ needs.validate-source.outputs.source_sha }}

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -472,42 +472,27 @@ jobs:
         if: success()
         run: |
           set -euo pipefail
-          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
-            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
-          else
-            XCODE_APP=""
-            XCODE_VERSION=""
-            for candidate in /Applications/Xcode*.app; do
-              [[ -d "$candidate/Contents/Developer" ]] || continue
-              candidate_version="$(
-                DEVELOPER_DIR="$candidate/Contents/Developer" xcodebuild -version 2>/dev/null \
-                  | awk '$1 == "Xcode" { print $2; exit }' \
-                  || true
-              )"
-              [[ "$candidate_version" =~ ^[0-9]+(\.[0-9]+)*$ ]] || continue
-              if [[ -z "$XCODE_APP" ]] || awk -v candidate="$candidate_version" -v selected="$XCODE_VERSION" '
-                BEGIN {
-                  split(candidate, c, ".")
-                  split(selected, s, ".")
-                  for (i = 1; i <= 4; i++) {
-                    if ((c[i] + 0) > (s[i] + 0)) exit 0
-                    if ((c[i] + 0) < (s[i] + 0)) exit 1
-                  }
-                  exit 1
-                }
-              '; then
-                XCODE_APP="$candidate"
-                XCODE_VERSION="$candidate_version"
-              fi
-            done
-            if [ -n "$XCODE_APP" ]; then
-              XCODE_DIR="$XCODE_APP/Contents/Developer"
-            else
-              echo "No Xcode.app found under /Applications" >&2
-              exit 1
-            fi
+          expected_xcode_app="/Applications/Xcode_26.5.app"
+          expected_xcode_version="26.5"
+          XCODE_DIR="$expected_xcode_app/Contents/Developer"
+          if [[ ! -d "$expected_xcode_app" || -L "$expected_xcode_app" || ! -d "$XCODE_DIR" || -L "$XCODE_DIR" ]]; then
+            echo "Pinned Xcode app is missing or is a symlink: $expected_xcode_app" >&2
+            exit 1
           fi
-          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          actual_xcode_version="$(
+            DEVELOPER_DIR="$XCODE_DIR" xcodebuild -version 2>/dev/null \
+              | awk '$1 == "Xcode" { print $2; exit }'
+          )"
+          if [[ "$actual_xcode_version" != "$expected_xcode_version" ]]; then
+            echo "Refusing release build with unexpected Xcode version: $actual_xcode_version (expected $expected_xcode_version)" >&2
+            exit 1
+          fi
+          actual_sdk_version="$(DEVELOPER_DIR="$XCODE_DIR" xcrun --sdk macosx --show-sdk-version)"
+          [[ "$actual_sdk_version" == 26.* ]] || {
+            echo "Pinned Xcode has unexpected macOS SDK version: $actual_sdk_version" >&2
+            exit 1
+          }
+          printf 'DEVELOPER_DIR=%s\n' "$XCODE_DIR" >> "$GITHUB_ENV"
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
           xcrun --sdk macosx --show-sdk-path

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -1115,10 +1115,14 @@ jobs:
             keychains=()
             while IFS= read -r entry; do
               # `security list-keychains` prints one quoted path per line.
-              entry="${entry#\"}"
-              entry="${entry%\"}"
+              # Trim indentation before removing the surrounding quotes. The
+              # command emits four leading spaces on macOS.
               entry="${entry#"${entry%%[![:space:]]*}"}"
               entry="${entry%"${entry##*[![:space:]]}"}"
+              if [[ "$entry" == \"* && "$entry" == *\" ]]; then
+                entry="${entry#\"}"
+                entry="${entry%\"}"
+              fi
               [[ -n "$entry" ]] && keychains+=("$entry")
             done < "$backup"
             if ((${#keychains[@]} > 0)); then

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -94,7 +94,7 @@ jobs:
                 /^permissions:\s*\{\s*\}\s*$/m,
                 /^jobs:\s*$/m,
                 /^\s+announce:\s*$/m,
-                /^\s+runs-on:\s+ubuntu-24\.04\s*$/m,
+                /^\s+runs-on:\s+ubuntu-24\.04(?:\s+#.*)?\s*$/m,
                 /^\s+permissions:\s*\{\s*\}\s*$/m,
                 /^\s+steps:\s*$/m,
                 /^\s+-\s+name:\s+Emit queued release event\s*$/m,

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -153,7 +153,10 @@ jobs:
             requireText('Observer source branch', run.head_branch, eventRun.head_branch);
             const tagMatch = tagPattern.exec(run.head_branch || '');
             if (!tagMatch) fail(`Release source is not a semantic version tag: ${run.head_branch}`);
-            const invalidPrereleaseIdentifier = (tagMatch[4] || '')
+            // Read only the prerelease capture. Build metadata may contain
+            // hyphens and must not change the stable/prerelease decision.
+            const prerelease = tagMatch[4] || '';
+            const invalidPrereleaseIdentifier = prerelease
               .split('.')
               .find((identifier) => /^[0-9]+$/.test(identifier) && identifier.length > 1 && identifier.startsWith('0'));
             if (invalidPrereleaseIdentifier) {
@@ -161,7 +164,7 @@ jobs:
                 `Release source has a numeric prerelease identifier with a leading zero: ${invalidPrereleaseIdentifier}`,
               );
             }
-            const isPrerelease = Boolean(tagMatch[4]);
+            const isPrerelease = prerelease.length > 0;
             requireSha('Observer source SHA', run.head_sha);
             requireText('Observer source SHA', run.head_sha, eventRun.head_sha);
             const tagName = run.head_branch;
@@ -328,7 +331,9 @@ jobs:
 
   build-sign-notarize:
     needs: [validate-source, build-ghostty-cli-helper]
-    if: needs.validate-source.result == 'success'
+    if: >-
+      needs.validate-source.result == 'success' &&
+      needs.build-ghostty-cli-helper.result == 'success'
     # Keep R2 publication serialized across retries and release tags. The
     # latest-release check below is valid only while this lock is held.
     concurrency:
@@ -422,7 +427,7 @@ jobs:
           RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
         with:
           script: |
-            const { evaluateReleaseAssetGuard } = require('./scripts/release_asset_guard');
+            const { evaluateReleaseAssetGuard, RELEASE_ASSET_GUARD_STATE } = require('./scripts/release_asset_guard');
             const tag = process.env.RELEASE_TAG;
             if (!tag) {
               core.setFailed('Release asset guard did not receive the validated release tag');
@@ -438,11 +443,10 @@ jobs:
               const {
                 conflicts,
                 missingImmutableAssets,
-                hasPartialConflict,
-                shouldSkipBuildAndUpload,
+                guardState,
               } = evaluateReleaseAssetGuard({ existingAssetNames });
 
-              if (hasPartialConflict) {
+              if (guardState === RELEASE_ASSET_GUARD_STATE.PARTIAL) {
                 core.setFailed(
                   `Release ${tag} has a partial immutable asset state. Existing immutable assets: ` +
                   `${conflicts.join(', ')}. Missing immutable assets: ${missingImmutableAssets.join(', ')}. ` +
@@ -451,7 +455,7 @@ jobs:
                 return;
               }
 
-              if (shouldSkipBuildAndUpload) {
+              if (guardState === RELEASE_ASSET_GUARD_STATE.COMPLETE) {
                 core.setFailed(
                   `Release ${tag} already contains immutable assets (${conflicts.join(', ')}). ` +
                   'Refusing to trust mutable release assets on a retry. Start a fresh validated build to repair publication.'
@@ -937,7 +941,10 @@ jobs:
               core.setFailed(`Invalid validated release tag: ${tag}`);
               return;
             }
-            const invalidPrereleaseIdentifier = (tagMatch[4] || '')
+            // Build metadata is allowed to contain hyphens. Use only the
+            // semantic-version prerelease capture for validation.
+            const prerelease = tagMatch[4] || '';
+            const invalidPrereleaseIdentifier = prerelease
               .split('.')
               .find((identifier) => /^[0-9]+$/.test(identifier) && identifier.length > 1 && identifier.startsWith('0'));
             if (invalidPrereleaseIdentifier) {
@@ -1025,43 +1032,10 @@ jobs:
           fi
 
           # Guard: only upload if this tag is the highest stable SemVer
-          # release. Python provides the same ordering on every runner,
-          # including macOS where BSD sort has no -V option.
+          # release. The checked-in helper provides the same ordering on every
+          # runner and rejects ambiguous build-metadata precedence.
           LATEST=$(gh release list --limit 1000 --exclude-drafts --exclude-pre-releases \
-            --json tagName -q '.[].tagName' | python3 -c '
-            import re
-            import sys
-
-            pattern = re.compile(
-                r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
-                r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
-            )
-            versions_by_core = {}
-            for line in sys.stdin:
-                tag = line.strip()
-                match = pattern.fullmatch(tag)
-                if match:
-                    core = tuple(int(part) for part in match.groups()[:3])
-                    versions_by_core.setdefault(core, []).append(tag)
-            duplicate_core_versions = {
-                core: tags
-                for core, tags in versions_by_core.items()
-                if len(tags) > 1
-            }
-            if duplicate_core_versions:
-                details = "; ".join(
-                    f"{core}: {', '.join(tags)}"
-                    for core, tags in sorted(duplicate_core_versions.items())
-                )
-                print(
-                    "Refusing R2 stable upload: duplicate stable SemVer precedence "
-                    f"({details})",
-                    file=sys.stderr,
-                )
-                raise SystemExit(1)
-            latest_core = max(versions_by_core) if versions_by_core else None
-            print(versions_by_core[latest_core][0] if latest_core is not None else "")
-            ')
+            --json tagName -q '.[].tagName' | python3 scripts/ci/select_latest_stable_release.py)
           if [ -z "$LATEST" ]; then
             echo "Refusing R2 stable upload: no stable release was returned by GitHub" >&2
             exit 1

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -349,6 +349,8 @@ jobs:
             core.setOutput('skip_all', 'false');
             core.setOutput('skip_upload', 'false');
             core.setOutput('skip_r2_upload', 'false');
+            core.setOutput('restore_appcast', 'false');
+            core.setOutput('repair_appcast_asset', 'false');
             core.setOutput('release_state', 'clear');
             if (!tag) {
               core.setFailed('Release asset guard did not receive the validated release tag');
@@ -371,6 +373,21 @@ jobs:
 
               core.setOutput('release_state', guardState);
 
+              const onlyAppcastIsMissing =
+                missingImmutableAssets.length === 1 && missingImmutableAssets[0] === 'appcast.xml';
+              if (onlyAppcastIsMissing) {
+                core.notice(
+                  `Release ${tag} is missing only appcast.xml. ` +
+                  'The existing signed DMG will be used to regenerate the appcast.'
+                );
+                core.setOutput('skip_all', 'true');
+                core.setOutput('skip_upload', 'true');
+                core.setOutput('skip_r2_upload', 'false');
+                core.setOutput('restore_appcast', 'true');
+                core.setOutput('repair_appcast_asset', 'true');
+                return;
+              }
+
               if (hasPartialConflict) {
                 core.setFailed(
                   `Release ${tag} has a partial immutable asset state. Existing immutable assets: ` +
@@ -391,6 +408,7 @@ jobs:
                 // upload are complete. Keep the mutable R2 appcast lane live
                 // so a transient upload failure can be repaired by rerun.
                 core.setOutput('skip_r2_upload', 'false');
+                core.setOutput('restore_appcast', 'true');
                 return;
               }
 
@@ -403,8 +421,8 @@ jobs:
               throw error;
             }
 
-      - name: Restore appcast for a publication retry
-        if: steps.guard_release_assets.outputs.skip_all == 'true' && steps.guard_release_assets.outputs.skip_r2_upload != 'true'
+      - name: Restore existing appcast for a publication retry
+        if: steps.guard_release_assets.outputs.restore_appcast == 'true' && steps.guard_release_assets.outputs.repair_appcast_asset != 'true'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -415,6 +433,26 @@ jobs:
             --pattern appcast.xml \
             --output appcast.xml \
             --clobber
+          test -s appcast.xml
+
+      - name: Regenerate missing appcast for a publication retry
+        if: steps.guard_release_assets.outputs.repair_appcast_asset == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          set -euo pipefail
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "Missing SPARKLE_PRIVATE_KEY for appcast repair" >&2
+            exit 1
+          fi
+          rm -f cmux-macos.dmg appcast.xml
+          gh release download "$RELEASE_TAG" \
+            --repo manaflow-ai/cmux \
+            --pattern cmux-macos.dmg \
+            --output cmux-macos.dmg \
+            --clobber
+          ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$RELEASE_TAG" appcast.xml
           test -s appcast.xml
 
       - name: Select Xcode
@@ -505,7 +543,7 @@ jobs:
             echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
             exit 1
           fi
-          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
+          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift --stdin <<<"$SPARKLE_PRIVATE_KEY")
           echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
           echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
 
@@ -806,7 +844,7 @@ jobs:
 
       - name: Revalidate release tag before GitHub publication
         id: revalidate-release-tag
-        if: steps.guard_release_assets.outputs.skip_upload != 'true'
+        if: steps.guard_release_assets.outputs.skip_upload != 'true' || steps.guard_release_assets.outputs.repair_appcast_asset == 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
@@ -854,6 +892,14 @@ jobs:
           overwrite_files: false
           tag_name: ${{ needs.validate-source.outputs.tag_name }}
 
+      - name: Upload repaired appcast asset
+        if: steps.guard_release_assets.outputs.repair_appcast_asset == 'true' && steps.revalidate-release-tag.outputs.verified == 'true'
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          files: appcast.xml
+          overwrite_files: false
+          tag_name: ${{ needs.validate-source.outputs.tag_name }}
+
       - name: Revalidate release tag before R2 publication
         id: revalidate-r2-tag
         if: steps.guard_release_assets.outputs.skip_r2_upload != 'true'
@@ -885,6 +931,13 @@ jobs:
           R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
         run: |
           set -euo pipefail
+
+          # Prerelease artifacts must never replace the stable appcast. The
+          # GitHub release still receives the signed prerelease assets above.
+          if [[ "$RELEASE_TAG" == *-* ]]; then
+            echo "Skipping R2 stable upload for prerelease $RELEASE_TAG"
+            exit 0
+          fi
 
           # Guard: only upload if this tag is the highest semver release.
           # Prevents a backport tag (e.g. v0.62.1 after v0.63.1) from

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -46,7 +46,7 @@ jobs:
           script: |
             const { owner, repo } = context.repo;
             const shaPattern = /^[0-9a-f]{40}$/;
-            const tagPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+            const tagPattern = /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
             const fail = (message) => {
               core.setFailed(message);
               throw new Error(message);
@@ -151,7 +151,9 @@ jobs:
             requireText('Observer run conclusion', run.conclusion, 'success');
             if (run.id !== runId || eventRun.id !== runId) fail('workflow_run identity changed while reading the API');
             requireText('Observer source branch', run.head_branch, eventRun.head_branch);
-            if (!tagPattern.test(run.head_branch || '')) fail(`Release source is not a semantic version tag: ${run.head_branch}`);
+            const tagMatch = tagPattern.exec(run.head_branch || '');
+            if (!tagMatch) fail(`Release source is not a semantic version tag: ${run.head_branch}`);
+            const isPrerelease = Boolean(tagMatch[4]);
             requireSha('Observer source SHA', run.head_sha);
             requireText('Observer source SHA', run.head_sha, eventRun.head_sha);
             const tagName = run.head_branch;
@@ -217,7 +219,7 @@ jobs:
 
             core.setOutput('source_sha', run.head_sha);
             core.setOutput('tag_name', tagName);
-            core.setOutput('is_prerelease', String(tagName.includes('-')));
+            core.setOutput('is_prerelease', String(isPrerelease));
             core.setOutput('observer_run_id', String(runId));
             core.notice(`Validated protected-main release source ${run.head_sha} for ${tagName}`);
 
@@ -326,6 +328,7 @@ jobs:
       id-token: write
     env:
       RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
+      IS_PRERELEASE: ${{ needs.validate-source.outputs.is_prerelease }}
     # Build the app on macOS 26 so SDK-gated SwiftUI Liquid Glass code compiles
     # into stable releases. The real universal Ghostty CLI helper is built on
     # macOS 15 above because Zig 0.15.2 cannot link it on macOS 26.
@@ -564,6 +567,7 @@ jobs:
           APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
         run: |
+          set -euo pipefail
           if [ -z "$APPLE_CERTIFICATE_BASE64" ]; then
             echo "Missing APPLE_CERTIFICATE_BASE64 secret" >&2
             exit 1
@@ -572,13 +576,38 @@ jobs:
             echo "Missing APPLE_CERTIFICATE_PASSWORD secret" >&2
             exit 1
           fi
+          umask 077
+          runner_temp="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+          [[ -d "$runner_temp" && ! -L "$runner_temp" ]] || {
+            echo "RUNNER_TEMP must be a real directory" >&2
+            exit 1
+          }
+          cert_path="$(mktemp "$runner_temp/cmux-signing-cert.XXXXXX")"
+          [[ -f "$cert_path" && ! -L "$cert_path" ]] || {
+            echo "mktemp did not create a regular certificate file" >&2
+            exit 1
+          }
+          trap 'rm -f -- "$cert_path"' EXIT
+          keychain_list_backup="$(mktemp "$runner_temp/cmux-keychain-list.XXXXXX")"
+          [[ -f "$keychain_list_backup" && ! -L "$keychain_list_backup" ]] || {
+            echo "mktemp did not create a regular keychain-list file" >&2
+            exit 1
+          }
+          # Publish the path before any command that can fail. The always-run
+          # cleanup step then has enough state to restore the search list.
+          echo "CMUX_KEYCHAIN_LIST_BACKUP=$keychain_list_backup" >> "$GITHUB_ENV"
+          # Keep this backup until the final cleanup step restores the user's
+          # search list. It contains paths only, never key material.
+          security list-keychains -d user > "$keychain_list_backup"
           KEYCHAIN_PASSWORD="$(uuidgen)"
-          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > /tmp/cert.p12
+          printf '%s' "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$cert_path"
+          chmod 600 "$cert_path"
           security delete-keychain build.keychain >/dev/null 2>&1 || true
           security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          echo "CMUX_KEYCHAIN_CREATED=true" >> "$GITHUB_ENV"
           security set-keychain-settings -lut 21600 build.keychain
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          security import /tmp/cert.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security import "$cert_path" -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
           ./scripts/import-apple-developer-id-intermediates.sh build.keychain
           security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
           security list-keychains -d user -s build.keychain
@@ -856,7 +885,7 @@ jobs:
             const tag = process.env.RELEASE_TAG;
             const expectedSha = process.env.EXPECTED_SHA;
             const shaPattern = /^[0-9a-f]{40}$/;
-            if (!/^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/.test(tag || '')) {
+            if (!/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/.test(tag || '')) {
               core.setFailed(`Invalid validated release tag: ${tag}`);
               return;
             }
@@ -930,9 +959,12 @@ jobs:
 
           # Prerelease artifacts must never replace the stable appcast. The
           # GitHub release still receives the signed prerelease assets above.
-          if [[ "$RELEASE_TAG" == *-* ]]; then
+          if [[ "${IS_PRERELEASE:-}" == true ]]; then
             echo "Skipping R2 stable upload for prerelease $RELEASE_TAG"
             exit 0
+          elif [[ "${IS_PRERELEASE:-}" != false ]]; then
+            echo "Refusing R2 stable upload: missing or invalid prerelease classification" >&2
+            exit 1
           fi
 
           # Guard: only upload if this tag is the highest stable SemVer
@@ -992,6 +1024,37 @@ jobs:
 
       - name: Cleanup keychain
         if: always()
+        shell: bash
         run: |
-          security delete-keychain build.keychain >/dev/null 2>&1 || true
-          rm -f /tmp/cert.p12
+          set +e
+          restore_status=0
+          backup="${CMUX_KEYCHAIN_LIST_BACKUP:-}"
+          keychain_created="${CMUX_KEYCHAIN_CREATED:-false}"
+          if [[ "$keychain_created" == true ]]; then
+            security delete-keychain build.keychain >/dev/null 2>&1 || true
+          fi
+          if [[ -n "$backup" && -f "$backup" && ! -L "$backup" ]]; then
+            keychains=()
+            while IFS= read -r entry; do
+              # `security list-keychains` prints one quoted path per line.
+              entry="${entry#\"}"
+              entry="${entry%\"}"
+              entry="${entry#"${entry%%[![:space:]]*}"}"
+              entry="${entry%"${entry##*[![:space:]]}"}"
+              [[ -n "$entry" ]] && keychains+=("$entry")
+            done < "$backup"
+            if ((${#keychains[@]} > 0)); then
+              security list-keychains -d user -s "${keychains[@]}" || restore_status=$?
+            else
+              echo "No previous keychain search list was captured" >&2
+              restore_status=1
+            fi
+            rm -f -- "$backup" || restore_status=$?
+          elif [[ -n "$backup" || "$keychain_created" == true ]]; then
+            echo "Cannot restore keychain search list: backup path is missing or not a regular file" >&2
+            restore_status=1
+          fi
+          if ((restore_status != 0)); then
+            echo "Failed to restore the keychain search list" >&2
+            exit "$restore_status"
+          fi

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -468,10 +468,28 @@ jobs:
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
             XCODE_APP=""
+            XCODE_VERSION=""
             for candidate in /Applications/Xcode*.app; do
               [[ -d "$candidate/Contents/Developer" ]] || continue
-              if [[ -z "$XCODE_APP" || "$candidate" > "$XCODE_APP" ]]; then
+              candidate_version="$(
+                DEVELOPER_DIR="$candidate/Contents/Developer" xcodebuild -version 2>/dev/null \
+                  | awk '$1 == "Xcode" { print $2; exit }' \
+                  || true
+              )"
+              [[ "$candidate_version" =~ ^[0-9]+(\.[0-9]+)*$ ]] || continue
+              if [[ -z "$XCODE_APP" ]] || awk -v candidate="$candidate_version" -v selected="$XCODE_VERSION" '
+                BEGIN {
+                  split(candidate, c, ".")
+                  split(selected, s, ".")
+                  for (i = 1; i <= 4; i++) {
+                    if ((c[i] + 0) > (s[i] + 0)) exit 0
+                    if ((c[i] + 0) < (s[i] + 0)) exit 1
+                  }
+                  exit 1
+                }
+              '; then
                 XCODE_APP="$candidate"
+                XCODE_VERSION="$candidate_version"
               fi
             done
             if [ -n "$XCODE_APP" ]; then
@@ -498,6 +516,8 @@ jobs:
       - name: Setup Bun
         if: success()
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
 
       - name: Install build deps
         if: success()

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -257,7 +257,11 @@ jobs:
                 echo "Refusing to remove Git lock not owned by this runner: $lock" >&2
                 return 1
               fi
-              if command -v lsof >/dev/null 2>&1 && lsof -n -t "$lock" 2>/dev/null | grep -q .; then
+              if ! command -v lsof >/dev/null 2>&1; then
+                echo "Refusing to inspect active Git lock because lsof is unavailable: $lock" >&2
+                return 1
+              fi
+              if lsof -n -t "$lock" 2>/dev/null | grep -q .; then
                 echo "Refusing to remove active Git lock: $lock" >&2
                 return 1
               fi
@@ -364,7 +368,11 @@ jobs:
                 echo "Refusing to remove Git lock not owned by this runner: $lock" >&2
                 return 1
               fi
-              if command -v lsof >/dev/null 2>&1 && lsof -n -t "$lock" 2>/dev/null | grep -q .; then
+              if ! command -v lsof >/dev/null 2>&1; then
+                echo "Refusing to inspect active Git lock because lsof is unavailable: $lock" >&2
+                return 1
+              fi
+              if lsof -n -t "$lock" 2>/dev/null | grep -q .; then
                 echo "Refusing to remove active Git lock: $lock" >&2
                 return 1
               fi
@@ -602,15 +610,30 @@ jobs:
           KEYCHAIN_PASSWORD="$(uuidgen)"
           printf '%s' "$APPLE_CERTIFICATE_BASE64" | base64 --decode > "$cert_path"
           chmod 600 "$cert_path"
-          security delete-keychain build.keychain >/dev/null 2>&1 || true
-          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          keychain_dir="$(mktemp -d "$runner_temp/cmux-signing-keychain.XXXXXX")"
+          [[ -d "$keychain_dir" && ! -L "$keychain_dir" ]] || {
+            echo "mktemp did not create a private keychain directory" >&2
+            exit 1
+          }
+          keychain_path="$keychain_dir/build.keychain-db"
+          [[ ! -e "$keychain_path" && ! -L "$keychain_path" ]] || {
+            echo "Keychain path already exists or is a symlink" >&2
+            exit 1
+          }
+          echo "CMUX_KEYCHAIN_DIR=$keychain_dir" >> "$GITHUB_ENV"
+          echo "CMUX_KEYCHAIN_PATH=$keychain_path" >> "$GITHUB_ENV"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"
+          [[ -f "$keychain_path" && ! -L "$keychain_path" ]] || {
+            echo "security did not create a regular keychain file" >&2
+            exit 1
+          }
           echo "CMUX_KEYCHAIN_CREATED=true" >> "$GITHUB_ENV"
-          security set-keychain-settings -lut 21600 build.keychain
-          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
-          security import "$cert_path" -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
-          ./scripts/import-apple-developer-id-intermediates.sh build.keychain
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
-          security list-keychains -d user -s build.keychain
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security import "$cert_path" -k "$keychain_path" -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          ./scripts/import-apple-developer-id-intermediates.sh "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$keychain_path"
+          security list-keychains -d user -s "$keychain_path"
 
       - name: Start Computer Use helper notarization
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -806,7 +829,8 @@ jobs:
             "$APP_PATH" \
             ./
           mv ./cmux*.dmg "$DMG_RELEASE"
-          /usr/bin/codesign --force --timestamp --keychain build.keychain \
+          KEYCHAIN_PATH="${CMUX_KEYCHAIN_PATH:?CMUX_KEYCHAIN_PATH is required}"
+          /usr/bin/codesign --force --timestamp --keychain "$KEYCHAIN_PATH" \
             --sign "$APPLE_SIGNING_IDENTITY" \
             "$DMG_RELEASE"
           /usr/bin/codesign --verify --verbose=2 "$DMG_RELEASE"
@@ -979,13 +1003,31 @@ jobs:
                 r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
                 r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
             )
-            versions = []
+            versions_by_core = {}
             for line in sys.stdin:
                 tag = line.strip()
                 match = pattern.fullmatch(tag)
                 if match:
-                    versions.append((tuple(int(part) for part in match.groups()[:3]), tag))
-            print(max(versions, key=lambda item: (item[0], item[1]))[1] if versions else "")
+                    core = tuple(int(part) for part in match.groups()[:3])
+                    versions_by_core.setdefault(core, []).append(tag)
+            duplicate_core_versions = {
+                core: tags
+                for core, tags in versions_by_core.items()
+                if len(tags) > 1
+            }
+            if duplicate_core_versions:
+                details = "; ".join(
+                    f"{core}: {', '.join(tags)}"
+                    for core, tags in sorted(duplicate_core_versions.items())
+                )
+                print(
+                    "Refusing R2 stable upload: duplicate stable SemVer precedence "
+                    f"({details})",
+                    file=sys.stderr,
+                )
+                raise SystemExit(1)
+            latest_core = max(versions_by_core) if versions_by_core else None
+            print(versions_by_core[latest_core][0] if latest_core is not None else "")
             ')
           if [ -z "$LATEST" ]; then
             echo "Refusing R2 stable upload: no stable release was returned by GitHub" >&2
@@ -1030,8 +1072,15 @@ jobs:
           restore_status=0
           backup="${CMUX_KEYCHAIN_LIST_BACKUP:-}"
           keychain_created="${CMUX_KEYCHAIN_CREATED:-false}"
+          keychain_path="${CMUX_KEYCHAIN_PATH:-}"
+          keychain_dir="${CMUX_KEYCHAIN_DIR:-}"
           if [[ "$keychain_created" == true ]]; then
-            security delete-keychain build.keychain >/dev/null 2>&1 || true
+            if [[ -z "$keychain_path" || ! -f "$keychain_path" || -L "$keychain_path" ]]; then
+              echo "Cannot remove signing keychain: path is missing or not a regular file" >&2
+              restore_status=1
+            else
+              security delete-keychain "$keychain_path" >/dev/null 2>&1 || restore_status=$?
+            fi
           fi
           if [[ -n "$backup" && -f "$backup" && ! -L "$backup" ]]; then
             keychains=()
@@ -1053,6 +1102,18 @@ jobs:
           elif [[ -n "$backup" || "$keychain_created" == true ]]; then
             echo "Cannot restore keychain search list: backup path is missing or not a regular file" >&2
             restore_status=1
+          fi
+          if [[ -n "$keychain_dir" ]]; then
+            if [[ ! -d "$keychain_dir" || -L "$keychain_dir" ]]; then
+              echo "Cannot remove signing keychain directory: path is missing or a symlink" >&2
+              restore_status=1
+            elif [[ -n "$keychain_path" && -e "$keychain_path" ]]; then
+              echo "Refusing to remove non-empty signing keychain directory" >&2
+              restore_status=1
+            elif ! rmdir "$keychain_dir"; then
+              echo "Failed to remove signing keychain directory" >&2
+              restore_status=1
+            fi
           fi
           if ((restore_status != 0)); then
             echo "Failed to restore the keychain search list" >&2

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -153,6 +153,14 @@ jobs:
             requireText('Observer source branch', run.head_branch, eventRun.head_branch);
             const tagMatch = tagPattern.exec(run.head_branch || '');
             if (!tagMatch) fail(`Release source is not a semantic version tag: ${run.head_branch}`);
+            const invalidPrereleaseIdentifier = (tagMatch[4] || '')
+              .split('.')
+              .find((identifier) => /^[0-9]+$/.test(identifier) && identifier.length > 1 && identifier.startsWith('0'));
+            if (invalidPrereleaseIdentifier) {
+              fail(
+                `Release source has a numeric prerelease identifier with a leading zero: ${invalidPrereleaseIdentifier}`,
+              );
+            }
             const isPrerelease = Boolean(tagMatch[4]);
             requireSha('Observer source SHA', run.head_sha);
             requireText('Observer source SHA', run.head_sha, eventRun.head_sha);
@@ -938,8 +946,19 @@ jobs:
             const tag = process.env.RELEASE_TAG;
             const expectedSha = process.env.EXPECTED_SHA;
             const shaPattern = /^[0-9a-f]{40}$/;
-            if (!/^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/.test(tag || '')) {
+            const tagPattern = /^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(?:-([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$/;
+            const tagMatch = tagPattern.exec(tag || '');
+            if (!tagMatch) {
               core.setFailed(`Invalid validated release tag: ${tag}`);
+              return;
+            }
+            const invalidPrereleaseIdentifier = (tagMatch[4] || '')
+              .split('.')
+              .find((identifier) => /^[0-9]+$/.test(identifier) && identifier.length > 1 && identifier.startsWith('0'));
+            if (invalidPrereleaseIdentifier) {
+              core.setFailed(
+                `Validated release tag has a numeric prerelease identifier with a leading zero: ${invalidPrereleaseIdentifier}`,
+              );
               return;
             }
             if (!shaPattern.test(expectedSha || '')) {

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -232,13 +232,39 @@ jobs:
       - name: Clear stale git locks (self-hosted reused workspace)
         shell: bash
         run: |
-          # Self-hosted macOS runners reuse the workspace. A job cancelled or
-          # killed mid-checkout can leave a stale .git/modules/*/index.lock that
-          # fails every later submodule checkout (e.g. ghostty). Clear them first.
-          ws="${GITHUB_WORKSPACE:-$PWD}"
-          rm -f "$ws/.git/index.lock" 2>/dev/null || true
-          if [ -d "$ws/.git/modules" ]; then
-            find "$ws/.git/modules" -type f -name "*.lock" -delete 2>/dev/null || true
+          # Self-hosted macOS runners can reuse a workspace. Remove only
+          # runner-owned, inactive index locks. Refuse unknown owners and
+          # active locks so a concurrent Git process cannot be corrupted.
+          set -euo pipefail
+          ws="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+          git_dir="$ws/.git"
+          if [[ -d "$git_dir" ]]; then
+            runner_uid="$(id -u)"
+            remove_owned_lock() {
+              local lock="$1"
+              [[ -f "$lock" ]] || return 0
+              local owner
+              if stat -c '%u' "$lock" >/dev/null 2>&1; then
+                owner="$(stat -c '%u' "$lock")"
+              else
+                owner="$(stat -f '%u' "$lock")"
+              fi
+              if [[ "$owner" != "$runner_uid" ]]; then
+                echo "Refusing to remove Git lock not owned by this runner: $lock" >&2
+                return 1
+              fi
+              if command -v lsof >/dev/null 2>&1 && lsof -n -t "$lock" 2>/dev/null | grep -q .; then
+                echo "Refusing to remove active Git lock: $lock" >&2
+                return 1
+              fi
+              rm -f -- "$lock"
+            }
+            remove_owned_lock "$git_dir/index.lock"
+            if [[ -d "$git_dir/modules" ]]; then
+              while IFS= read -r -d '' lock; do
+                remove_owned_lock "$lock"
+              done < <(find -P "$git_dir/modules" -type f -name index.lock -print0)
+            fi
           fi
 
       - name: Checkout
@@ -287,6 +313,11 @@ jobs:
   build-sign-notarize:
     needs: [validate-source, build-ghostty-cli-helper]
     if: needs.validate-source.result == 'success'
+    # Keep R2 publication serialized across retries and release tags. The
+    # latest-release check below is valid only while this lock is held.
+    concurrency:
+      group: cmux-release-stable-r2
+      cancel-in-progress: false
     permissions:
       contents: write
       attestations: write
@@ -307,13 +338,39 @@ jobs:
       - name: Clear stale git locks (self-hosted reused workspace)
         shell: bash
         run: |
-          # Self-hosted macOS runners reuse the workspace. A job cancelled or
-          # killed mid-checkout can leave a stale .git/modules/*/index.lock that
-          # fails every later submodule checkout (e.g. ghostty). Clear them first.
-          ws="${GITHUB_WORKSPACE:-$PWD}"
-          rm -f "$ws/.git/index.lock" 2>/dev/null || true
-          if [ -d "$ws/.git/modules" ]; then
-            find "$ws/.git/modules" -type f -name "*.lock" -delete 2>/dev/null || true
+          # Self-hosted macOS runners can reuse a workspace. Remove only
+          # runner-owned, inactive index locks. Refuse unknown owners and
+          # active locks so a concurrent Git process cannot be corrupted.
+          set -euo pipefail
+          ws="${GITHUB_WORKSPACE:?GITHUB_WORKSPACE is required}"
+          git_dir="$ws/.git"
+          if [[ -d "$git_dir" ]]; then
+            runner_uid="$(id -u)"
+            remove_owned_lock() {
+              local lock="$1"
+              [[ -f "$lock" ]] || return 0
+              local owner
+              if stat -c '%u' "$lock" >/dev/null 2>&1; then
+                owner="$(stat -c '%u' "$lock")"
+              else
+                owner="$(stat -f '%u' "$lock")"
+              fi
+              if [[ "$owner" != "$runner_uid" ]]; then
+                echo "Refusing to remove Git lock not owned by this runner: $lock" >&2
+                return 1
+              fi
+              if command -v lsof >/dev/null 2>&1 && lsof -n -t "$lock" 2>/dev/null | grep -q .; then
+                echo "Refusing to remove active Git lock: $lock" >&2
+                return 1
+              fi
+              rm -f -- "$lock"
+            }
+            remove_owned_lock "$git_dir/index.lock"
+            if [[ -d "$git_dir/modules" ]]; then
+              while IFS= read -r -d '' lock; do
+                remove_owned_lock "$lock"
+              done < <(find -P "$git_dir/modules" -type f -name index.lock -print0)
+            fi
           fi
 
       - name: Checkout
@@ -925,6 +982,7 @@ jobs:
         if: steps.guard_release_assets.outputs.skip_r2_upload != 'true' && steps.revalidate-r2-tag.outputs.verified == 'true'
         env:
           GH_TOKEN: ${{ github.token }}
+          EXPECTED_SHA: ${{ needs.validate-source.outputs.source_sha }}
           AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
           AWS_DEFAULT_REGION: auto
@@ -939,14 +997,47 @@ jobs:
             exit 0
           fi
 
-          # Guard: only upload if this tag is the highest semver release.
-          # Prevents a backport tag (e.g. v0.62.1 after v0.63.1) from
-          # overwriting the stable appcast with an older version.
-          LATEST=$(gh release list --exclude-drafts --exclude-pre-releases \
-            --json tagName -q '.[].tagName' | sort -V | tail -1)
-          if [ -n "$LATEST" ] && [ "$LATEST" != "$RELEASE_TAG" ]; then
+          # Guard: only upload if this tag is the highest stable SemVer
+          # release. Python provides the same ordering on every runner,
+          # including macOS where BSD sort has no -V option.
+          LATEST=$(gh release list --limit 1000 --exclude-drafts --exclude-pre-releases \
+            --json tagName -q '.[].tagName' | python3 -c '
+            import re
+            import sys
+
+            pattern = re.compile(
+                r"^v(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)"
+                r"(?:\+([0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+            )
+            versions = []
+            for line in sys.stdin:
+                tag = line.strip()
+                match = pattern.fullmatch(tag)
+                if match:
+                    versions.append((tuple(int(part) for part in match.groups()[:3]), tag))
+            print(max(versions, key=lambda item: (item[0], item[1]))[1] if versions else "")
+            ')
+          if [ -z "$LATEST" ]; then
+            echo "Refusing R2 stable upload: no stable release was returned by GitHub" >&2
+            exit 1
+          fi
+          if [ "$LATEST" != "$RELEASE_TAG" ]; then
             echo "Skipping R2 stable upload: $RELEASE_TAG is not the latest release ($LATEST)"
             exit 0
+          fi
+
+          # Bind the latest-release decision to the immutable source SHA. The
+          # release list is a tag-name view, so resolve that tag again and
+          # reject a moved tag before the object write.
+          latest_object="$(gh api "repos/manaflow-ai/cmux/git/ref/tags/$LATEST")"
+          latest_type="$(jq -r '.object.type' <<<"$latest_object")"
+          latest_sha="$(jq -r '.object.sha' <<<"$latest_object")"
+          if [ "$latest_type" = tag ]; then
+            latest_sha="$(gh api "repos/manaflow-ai/cmux/git/tags/$latest_sha" --jq '.object.sha')"
+          fi
+          if [ "$latest_sha" != "$EXPECTED_SHA" ]; then
+            echo "Latest release $LATEST resolves to $latest_sha, expected immutable source $EXPECTED_SHA" >&2
+            exit 1
           fi
 
           # Upload after GitHub Release publish so the appcast never references

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -1,0 +1,845 @@
+name: Release macOS app
+
+# GitHub resolves workflow_run workflows from the default branch. Keep this
+# file on protected main so a tag-controlled workflow can never supply the
+# privileged release definition.
+on:
+  workflow_run:
+    workflows: ["Release macOS app trigger"]
+    types: [completed]
+
+permissions: {}
+
+env:
+  CREATE_DMG_VERSION: 8.0.0
+
+jobs:
+  # This job is the only code path that receives the workflow-run event. It
+  # validates the untrusted observer run before any source checkout or secret.
+  validate-source:
+    runs-on: ubuntu-24.04 # github-hosted-required: source trust gate requires an isolated runner
+    timeout-minutes: 10
+    permissions:
+      actions: read
+      contents: read
+    outputs:
+      source_sha: ${{ steps.source.outputs.source_sha }}
+      tag_name: ${{ steps.source.outputs.tag_name }}
+      observer_run_id: ${{ steps.source.outputs.observer_run_id }}
+    steps:
+      - name: Validate protected dispatcher source
+        id: source
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          REPOSITORY: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_REF: ${{ github.ref }}
+          EVENT_REF_TYPE: ${{ github.ref_type }}
+          EVENT_SHA: ${{ github.sha }}
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          WORKFLOW_REF: ${{ github.workflow_ref }}
+          WORKFLOW_REPOSITORY: ${{ github.repository }}
+          REF_PROTECTED: ${{ github.ref_protected }}
+          WORKFLOW_RUN_JSON: ${{ toJSON(github.event.workflow_run) }}
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const shaPattern = /^[0-9a-f]{40}$/;
+            const tagPattern = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z][0-9A-Za-z.-]*)?(?:\+[0-9A-Za-z][0-9A-Za-z.-]*)?$/;
+            const fail = (message) => {
+              core.setFailed(message);
+              throw new Error(message);
+            };
+            const expectedRepository = 'manaflow-ai/cmux';
+            const expectedObserverName = 'Release macOS app trigger';
+            const observerPath = '.github/workflows/release.yml';
+            const trustedPath = '.github/workflows/release-trusted.yml';
+            const repository = process.env.REPOSITORY;
+            const eventName = process.env.EVENT_NAME;
+            const eventRef = process.env.EVENT_REF;
+            const eventRefType = process.env.EVENT_REF_TYPE;
+            const eventSha = process.env.EVENT_SHA;
+            const workflowSha = process.env.WORKFLOW_SHA;
+            const workflowRef = process.env.WORKFLOW_REF;
+            const workflowRepository = process.env.WORKFLOW_REPOSITORY;
+            const refProtected = process.env.REF_PROTECTED === 'true';
+            const eventRun = JSON.parse(process.env.WORKFLOW_RUN_JSON || '{}');
+
+            const requireSha = (label, value) => {
+              if (!shaPattern.test(value || '')) fail(`${label} is not a 40-character commit SHA`);
+            };
+            const requireText = (label, actual, expected) => {
+              if (actual !== expected) fail(`${label} ${actual || '<missing>'} does not match ${expected}`);
+            };
+            const requireFile = (label, response) => {
+              if (!response || Array.isArray(response.data) || response.data.type !== 'file') {
+                fail(`${label} is missing or is not a file`);
+              }
+              return response.data;
+            };
+            const decodeFile = (file) => {
+              if (file.encoding !== 'base64' || typeof file.content !== 'string') {
+                fail('Dispatcher source workflow content is not base64 encoded');
+              }
+              return Buffer.from(file.content.replace(/\s/g, ''), 'base64').toString('utf8');
+            };
+            const assertObserverContract = (content) => {
+              if (content.length > 2048) fail('Release trigger workflow is larger than the observer contract');
+              const requiredLines = [
+                /^name:\s*Release macOS app trigger\s*$/m,
+                /^on:\s*$/m,
+                /^\s+push:\s*$/m,
+                /^\s+tags:\s*$/m,
+                /^\s+-\s+["']v\*["']\s*$/m,
+                /^permissions:\s*\{\s*\}\s*$/m,
+                /^jobs:\s*$/m,
+                /^\s+announce:\s*$/m,
+                /^\s+runs-on:\s+ubuntu-24\.04\s*$/m,
+                /^\s+permissions:\s*\{\s*\}\s*$/m,
+                /^\s+steps:\s*$/m,
+                /^\s+-\s+name:\s+Emit queued release event\s*$/m,
+                /^\s+run:\s+\|\s*$/m,
+                /echo ["']Tag event queued for trusted protected-main release dispatcher: \$\{GITHUB_REF_NAME\}["']/,
+              ];
+              for (const line of requiredLines) if (!line.test(content)) {
+                fail('Release trigger workflow is not the minimal unprivileged observer');
+              }
+              if (/workflow_dispatch|workflow_call|repository_dispatch|actions\/|uses:\s|secrets\.|GITHUB_TOKEN|github\.token|contents:\s*(?:write|read-write)|id-token|attestations|environment\s*:|with\s*:/m.test(content)) {
+                fail('Release trigger workflow is not the minimal unprivileged observer');
+              }
+              const permissionLines = content.match(/^\s*permissions\s*:[^\n]*$/gm) || [];
+              if (permissionLines.some((line) => !/:\s*\{\s*\}\s*$/.test(line))) {
+                fail('Release trigger workflow grants token permissions');
+              }
+              const runBlocks = content.match(/^\s+run:\s+\|\s*$/gm) || [];
+              if (runBlocks.length !== 1) fail('Release trigger workflow must have one completion step');
+            };
+
+            requireText('Release dispatcher repository', repository, expectedRepository);
+            requireText('Release dispatcher context repository', `${owner}/${repo}`, expectedRepository);
+            requireText('Release dispatcher event', eventName, 'workflow_run');
+            requireText('Release dispatcher ref', eventRef, 'refs/heads/main');
+            requireText('Release dispatcher ref type', eventRefType, 'branch');
+            if (!refProtected) fail('Release dispatcher must run on protected main');
+            requireSha('Dispatcher event SHA', eventSha);
+            requireSha('Dispatcher workflow SHA', workflowSha);
+            requireText('Release dispatcher workflow repository', workflowRepository, expectedRepository);
+            requireText(
+              'Release dispatcher workflow identity',
+              workflowRef,
+              `${expectedRepository}/${trustedPath}@refs/heads/main`,
+            );
+
+            const runId = Number(eventRun.id);
+            if (!Number.isSafeInteger(runId) || runId <= 0) fail('workflow_run.id is invalid');
+            const run = (await github.rest.actions.getWorkflowRun({
+              owner,
+              repo,
+              run_id: runId,
+            })).data;
+            const observerWorkflow = (await github.rest.actions.getWorkflow({
+              owner,
+              repo,
+              workflow_id: run.workflow_id,
+            })).data;
+            requireText('Observer workflow name', run.name, expectedObserverName);
+            requireText('Observer workflow path', run.path, observerPath);
+            requireText('Observer workflow API identity', observerWorkflow.name, expectedObserverName);
+            requireText('Observer workflow API path', observerWorkflow.path, observerPath);
+            requireText('Observer run repository', run.repository?.full_name, expectedRepository);
+            requireText('Observer source repository', run.head_repository?.full_name, expectedRepository);
+            requireText('Observer run event', run.event, 'push');
+            requireText('Observer run status', run.status, 'completed');
+            requireText('Observer run conclusion', run.conclusion, 'success');
+            if (run.id !== runId || eventRun.id !== runId) fail('workflow_run identity changed while reading the API');
+            requireText('Observer source branch', run.head_branch, eventRun.head_branch);
+            if (!tagPattern.test(run.head_branch || '')) fail(`Release source is not a semantic version tag: ${run.head_branch}`);
+            requireSha('Observer source SHA', run.head_sha);
+            requireText('Observer source SHA', run.head_sha, eventRun.head_sha);
+            const tagName = run.head_branch;
+
+            const mainBranch = (await github.rest.repos.getBranch({
+              owner,
+              repo,
+              branch: 'main',
+            })).data;
+            if (mainBranch.protected !== true) fail('Protected main branch policy is not active');
+            const mainSha = mainBranch.commit?.sha;
+            requireSha('Protected main SHA', mainSha);
+            const trustedLineage = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: workflowSha,
+              head: mainSha,
+            });
+            if (!['ahead', 'identical'].includes(trustedLineage.data.status)) {
+              fail(`Trusted dispatcher ${workflowSha} is not an ancestor of protected main ${mainSha}`);
+            }
+            const sourceLineage = await github.rest.repos.compareCommits({
+              owner,
+              repo,
+              base: run.head_sha,
+              head: mainSha,
+            });
+            if (!['ahead', 'identical'].includes(sourceLineage.data.status)) {
+              fail(`Release tag ${tagName} does not point to a commit on protected main`);
+            }
+
+            const trustedAtWorkflow = requireFile(
+              'Trusted dispatcher definition',
+              await github.rest.repos.getContent({ owner, repo, path: trustedPath, ref: workflowSha }),
+            );
+            const trustedAtMain = requireFile(
+              'Protected-main dispatcher definition',
+              await github.rest.repos.getContent({ owner, repo, path: trustedPath, ref: mainSha }),
+            );
+            if (trustedAtWorkflow.sha !== trustedAtMain.sha) {
+              fail('Trusted dispatcher definition changed after the workflow was resolved');
+            }
+
+            const observerAtSource = requireFile(
+              'Dispatcher source workflow',
+              await github.rest.repos.getContent({ owner, repo, path: observerPath, ref: run.head_sha }),
+            );
+            const observerAtMain = requireFile(
+              'Protected-main source workflow',
+              await github.rest.repos.getContent({ owner, repo, path: observerPath, ref: mainSha }),
+            );
+            if (observerAtSource.sha !== observerAtMain.sha) {
+              fail('Dispatcher source workflow changed between the tag and protected main');
+            }
+            assertObserverContract(decodeFile(observerAtSource));
+            const tagRef = await github.rest.git.getRef({ owner, repo, ref: `tags/${tagName}` });
+            let tagSha = tagRef.data.object?.sha;
+            if (tagRef.data.object?.type === 'tag') {
+              tagSha = (await github.rest.git.getTag({ owner, repo, tag_sha: tagSha })).data.object?.sha;
+            }
+            requireSha('Release tag target SHA', tagSha);
+            if (tagSha !== run.head_sha) fail(`Release tag ${tagName} moved after the observer run completed`);
+
+            core.setOutput('source_sha', run.head_sha);
+            core.setOutput('tag_name', tagName);
+            core.setOutput('observer_run_id', String(runId));
+            core.notice(`Validated protected-main release source ${run.head_sha} for ${tagName}`);
+
+  build-ghostty-cli-helper:
+    needs: validate-source
+    if: needs.validate-source.result == 'success'
+    permissions:
+      contents: read
+    env:
+      RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+    timeout-minutes: 20
+    steps:
+      - name: Clear stale git locks (self-hosted reused workspace)
+        shell: bash
+        run: |
+          # Self-hosted macOS runners reuse the workspace. A job cancelled or
+          # killed mid-checkout can leave a stale .git/modules/*/index.lock that
+          # fails every later submodule checkout (e.g. ghostty). Clear them first.
+          ws="${GITHUB_WORKSPACE:-$PWD}"
+          rm -f "$ws/.git/index.lock" 2>/dev/null || true
+          if [ -d "$ws/.git/modules" ]; then
+            find "$ws/.git/modules" -type f -name "*.lock" -delete 2>/dev/null || true
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-source.outputs.source_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Verify immutable checkout
+        env:
+          EXPECTED_SHA: ${{ needs.validate-source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          [[ "$actual_sha" == "$EXPECTED_SHA" ]] || {
+            echo "Checkout $actual_sha does not match validated source $EXPECTED_SHA" >&2
+            exit 1
+          }
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Cache Zig packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/zig
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
+
+      - name: Build universal Ghostty CLI helper
+        run: |
+          set -euo pipefail
+          mkdir -p ghostty-cli-helper
+          ./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty
+          lipo ghostty-cli-helper/ghostty -verify_arch arm64 x86_64
+
+      - name: Upload universal Ghostty CLI helper
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-ghostty-cli-helper
+          path: ghostty-cli-helper/ghostty
+          if-no-files-found: error
+          retention-days: 3
+
+  build-sign-notarize:
+    needs: [validate-source, build-ghostty-cli-helper]
+    if: needs.validate-source.result == 'success'
+    permissions:
+      contents: write
+      attestations: write
+      id-token: write
+    env:
+      RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
+    # Build the app on macOS 26 so SDK-gated SwiftUI Liquid Glass code compiles
+    # into stable releases. The real universal Ghostty CLI helper is built on
+    # macOS 15 above because Zig 0.15.2 cannot link it on macOS 26.
+    # Import the Apple Developer ID intermediate chain into the build keychain
+    # below so signing does not depend on mutable runner login-keychain state.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'blacksmith-6vcpu-macos-26' }}
+    # Notarization wait times vary on Apple's side. The standalone Computer Use
+    # helper starts as soon as the unsigned app exists and overlaps the remaining
+    # release preparation; the outer app and final DMG still serialize afterward.
+    timeout-minutes: 60
+    steps:
+      - name: Clear stale git locks (self-hosted reused workspace)
+        shell: bash
+        run: |
+          # Self-hosted macOS runners reuse the workspace. A job cancelled or
+          # killed mid-checkout can leave a stale .git/modules/*/index.lock that
+          # fails every later submodule checkout (e.g. ghostty). Clear them first.
+          ws="${GITHUB_WORKSPACE:-$PWD}"
+          rm -f "$ws/.git/index.lock" 2>/dev/null || true
+          if [ -d "$ws/.git/modules" ]; then
+            find "$ws/.git/modules" -type f -name "*.lock" -delete 2>/dev/null || true
+          fi
+
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.validate-source.outputs.source_sha }}
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Verify immutable checkout
+        env:
+          EXPECTED_SHA: ${{ needs.validate-source.outputs.source_sha }}
+        run: |
+          set -euo pipefail
+          actual_sha="$(git rev-parse HEAD)"
+          [[ "$actual_sha" == "$EXPECTED_SHA" ]] || {
+            echo "Checkout $actual_sha does not match validated source $EXPECTED_SHA" >&2
+            exit 1
+          }
+
+      - name: Validate Sparkle build number is monotonic
+        run: ./tests/test_ci_sparkle_build_monotonic.sh
+
+      - name: Guard immutable release assets
+        id: guard_release_assets
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
+        with:
+          script: |
+            const { evaluateReleaseAssetGuard } = require('./scripts/release_asset_guard');
+            const tag = process.env.RELEASE_TAG;
+            core.setOutput('skip_all', 'false');
+            core.setOutput('skip_upload', 'false');
+            core.setOutput('release_state', 'clear');
+            if (!tag) {
+              core.setFailed('Release asset guard did not receive the validated release tag');
+              return;
+            }
+            try {
+              const release = await github.rest.repos.getReleaseByTag({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                tag,
+              });
+              const existingAssetNames = (release.data.assets || []).map((asset) => asset.name);
+              const {
+                conflicts,
+                missingImmutableAssets,
+                guardState,
+                hasPartialConflict,
+                shouldSkipBuildAndUpload,
+              } = evaluateReleaseAssetGuard({ existingAssetNames });
+
+              core.setOutput('release_state', guardState);
+
+              if (hasPartialConflict) {
+                core.setFailed(
+                  `Release ${tag} has a partial immutable asset state. Existing immutable assets: ` +
+                  `${conflicts.join(', ')}. Missing immutable assets: ${missingImmutableAssets.join(', ')}. ` +
+                  'Resolve release assets manually before rerunning.'
+                );
+                return;
+              }
+
+              if (shouldSkipBuildAndUpload) {
+                core.notice(
+                  `Release ${tag} already contains immutable assets (${conflicts.join(', ')}). ` +
+                  'Skipping build, notarization, and upload to preserve existing signed artifacts.'
+                );
+                core.setOutput('skip_all', 'true');
+                core.setOutput('skip_upload', 'true');
+                return;
+              }
+
+              core.notice(`Release ${tag} exists but has no immutable release assets yet; continuing.`);
+            } catch (error) {
+              if (error.status === 404) {
+                core.notice(`Release ${tag} does not exist yet; safe to build and publish assets.`);
+                return;
+              }
+              throw error;
+            }
+
+      - name: Select Xcode
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
+            XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
+          else
+            XCODE_APP="$(
+              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
+                | sort \
+                | tail -n 1 \
+                || true
+            )"
+            if [ -n "$XCODE_APP" ]; then
+              XCODE_DIR="$XCODE_APP/Contents/Developer"
+            else
+              echo "No Xcode.app found under /Applications" >&2
+              exit 1
+            fi
+          fi
+          echo "DEVELOPER_DIR=$XCODE_DIR" >> "$GITHUB_ENV"
+          export DEVELOPER_DIR="$XCODE_DIR"
+          xcodebuild -version
+          xcrun --sdk macosx --show-sdk-path
+
+      # Same self-sufficiency as nightly: a self-hosted macOS runner may lack npm
+      # on PATH, which breaks the pinned create-dmg install below. setup-node
+      # guarantees node/npm regardless of which runner picks up the job.
+      - name: Set up Node
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "20"
+
+      - name: Setup Bun
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install build deps
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          ./scripts/install-rust-ci.sh
+          CMUX_NODE_BIN="$(command -v node)"
+          export npm_config_prefix="$RUNNER_TEMP/npm-global"
+          mkdir -p "$npm_config_prefix"
+          npm install --global "create-dmg@${CREATE_DMG_VERSION}"
+          wrapper_dir="$RUNNER_TEMP/create-dmg-wrapper"
+          mkdir -p "$wrapper_dir"
+          cat > "$wrapper_dir/create-dmg" <<EOF
+          #!/usr/bin/env bash
+          exec "$CMUX_NODE_BIN" "$npm_config_prefix/lib/node_modules/create-dmg/cli.js" "\$@"
+          EOF
+          chmod +x "$wrapper_dir/create-dmg"
+          echo "$wrapper_dir" >> "$GITHUB_PATH"
+
+      - name: Download pre-built GhosttyKit.xcframework
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Cache Swift packages
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .spm-cache
+          key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-
+
+      - name: Sanitize Swift package cache
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
+      - name: Setup Go
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version-file: daemon/remote/go.mod
+          cache-dependency-path: daemon/remote/go.sum
+
+      - name: Derive Sparkle public key from private key
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
+            exit 1
+          fi
+          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
+          echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
+          echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
+
+      - name: Build universal app (Release)
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
+            -destination 'generic/platform=macOS' \
+            -clonedSourcePackagesDirPath .spm-cache \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            CODE_SIGNING_ALLOWED=NO build
+
+      - name: Import signing cert
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          APPLE_CERTIFICATE_BASE64: ${{ secrets.APPLE_CERTIFICATE_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          if [ -z "$APPLE_CERTIFICATE_BASE64" ]; then
+            echo "Missing APPLE_CERTIFICATE_BASE64 secret" >&2
+            exit 1
+          fi
+          if [ -z "$APPLE_CERTIFICATE_PASSWORD" ]; then
+            echo "Missing APPLE_CERTIFICATE_PASSWORD secret" >&2
+            exit 1
+          fi
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          echo "$APPLE_CERTIFICATE_BASE64" | base64 --decode > /tmp/cert.p12
+          security delete-keychain build.keychain >/dev/null 2>&1 || true
+          security create-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security set-keychain-settings -lut 21600 build.keychain
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" build.keychain
+          security import /tmp/cert.p12 -k build.keychain -P "$APPLE_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          ./scripts/import-apple-developer-id-intermediates.sh build.keychain
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" build.keychain
+          security list-keychains -d user -s build.keychain
+
+      - name: Start Computer Use helper notarization
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          state="$RUNNER_TEMP/cmux-computer-use-notarization.state"
+          rm -f "$state"
+          ./scripts/ci/notarize-computer-use-helper.sh \
+            --start "$state" \
+            "build-universal/Build/Products/Release/cmux.app" \
+            cmux.release.entitlements \
+            "$APPLE_SIGNING_IDENTITY"
+
+      - name: Download universal Ghostty CLI helper
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: cmux-ghostty-cli-helper
+          path: ghostty-cli-helper
+
+      - name: Install universal Ghostty CLI helper
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          ./scripts/install-prebuilt-ghostty-cli-helper.sh \
+            ghostty-cli-helper/ghostty \
+            build-universal/Build/Products/Release/cmux.app
+          ./scripts/install-cmux-tui-client.sh build-universal/Build/Products/Release/cmux.app
+
+      - name: Verify binary architectures
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          APP_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/MacOS/cmux"
+          CLI_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux"
+          HELPER_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/ghostty"
+          DIFF_SIDECAR="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux-diff-sidecar"
+          APP_ARCHS="$(lipo -archs "$APP_BINARY")"
+          CLI_ARCHS="$(lipo -archs "$CLI_BINARY")"
+          HELPER_ARCHS="$(lipo -archs "$HELPER_BINARY")"
+          SDK_VERSION="$(otool -l "$APP_BINARY" | awk '/LC_BUILD_VERSION/ { in_version=1; next } in_version && /sdk / { print $2; exit }')"
+          echo "App binary architectures: $APP_ARCHS"
+          echo "CLI binary architectures: $CLI_ARCHS"
+          echo "Ghostty helper architectures: $HELPER_ARCHS"
+          echo "App SDK version: $SDK_VERSION"
+          [[ "$APP_ARCHS" == *arm64* && "$APP_ARCHS" == *x86_64* ]]
+          [[ "$CLI_ARCHS" == *arm64* && "$CLI_ARCHS" == *x86_64* ]]
+          [[ "$HELPER_ARCHS" == *arm64* && "$HELPER_ARCHS" == *x86_64* ]]
+          ./scripts/verify-diff-sidecar-artifact.sh "$DIFF_SIDECAR"
+          [[ "$SDK_VERSION" == 26.* ]]
+
+      - name: Build remote daemon release assets and inject manifest
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          APP_PLIST="build-universal/Build/Products/Release/cmux.app/Contents/Info.plist"
+          APP_VERSION=$(/usr/libexec/PlistBuddy -c "Print :CFBundleShortVersionString" "$APP_PLIST")
+          ./scripts/build_remote_daemon_release_assets.sh \
+            --version "$APP_VERSION" \
+            --release-tag "$RELEASE_TAG" \
+            --repo "manaflow-ai/cmux" \
+            --output-dir "remote-daemon-assets"
+          MANIFEST_JSON="$(python3 -c 'import json,sys; print(json.dumps(json.load(open(sys.argv[1], encoding="utf-8")), separators=(",",":")))' remote-daemon-assets/cmuxd-remote-manifest.json)"
+          plutil -remove CMUXRemoteDaemonManifestJSON "$APP_PLIST" >/dev/null 2>&1 || true
+          plutil -insert CMUXRemoteDaemonManifestJSON -string "$MANIFEST_JSON" "$APP_PLIST"
+
+      - name: Run CLI version memory guard regression
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          CLI_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/cmux"
+          [ -x "$CLI_BINARY" ] || { echo "cmux CLI binary not found at $CLI_BINARY" >&2; exit 1; }
+          CMUX_CLI_BIN="$CLI_BINARY" python3 tests/test_cli_version_memory_guard.py
+
+      - name: Verify bundled Ghostty theme picker helper
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          set -euo pipefail
+          HELPER_BINARY="build-universal/Build/Products/Release/cmux.app/Contents/Resources/bin/ghostty"
+          [ -x "$HELPER_BINARY" ] || { echo "Ghostty theme picker helper not found at $HELPER_BINARY" >&2; exit 1; }
+
+      - name: Inject Sparkle keys into Info.plist
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: |
+          APP_PLIST="build-universal/Build/Products/Release/cmux.app/Contents/Info.plist"
+          /usr/libexec/PlistBuddy -c "Delete :SUPublicEDKey" "$APP_PLIST" >/dev/null 2>&1 || true
+          /usr/libexec/PlistBuddy -c "Delete :SUFeedURL" "$APP_PLIST" >/dev/null 2>&1 || true
+          echo "Adding SUPublicEDKey to Info.plist..."
+          /usr/libexec/PlistBuddy -c "Add :SUPublicEDKey string ${SPARKLE_PUBLIC_KEY}" "$APP_PLIST"
+          echo "Adding SUFeedURL to Info.plist..."
+          /usr/libexec/PlistBuddy -c "Add :SUFeedURL string https://github.com/manaflow-ai/cmux/releases/latest/download/appcast.xml" "$APP_PLIST"
+          echo "Verifying:"
+          /usr/libexec/PlistBuddy -c "Print :SUPublicEDKey" "$APP_PLIST"
+          /usr/libexec/PlistBuddy -c "Print :SUFeedURL" "$APP_PLIST"
+
+      - name: Embed release provisioning profile
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          APPLE_RELEASE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 }}
+        run: |
+          if [ -z "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" ]; then
+            echo "Missing APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 secret" >&2
+            exit 1
+          fi
+          APP_PATH="build-universal/Build/Products/Release/cmux.app"
+          PROFILE_PATH="$APP_PATH/Contents/embedded.provisionprofile"
+          TMP_PROFILE="$(mktemp /tmp/cmux-release-profile.XXXXXX)"
+          TMP_PLIST="$(mktemp /tmp/cmux-release-profile.XXXXXX.plist)"
+          trap 'rm -f "$TMP_PROFILE" "$TMP_PLIST"' EXIT
+          echo "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$TMP_PROFILE"
+          security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
+          APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"
+          if [ "$APP_ID" != "7WLXT3NR37.com.cmuxterm.app" ]; then
+            echo "Release provisioning profile targets unexpected app ID: $APP_ID" >&2
+            exit 1
+          fi
+          WEBAUTHN_ENTITLEMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.web-browser.public-key-credential" "$TMP_PLIST")"
+          if [ "$WEBAUTHN_ENTITLEMENT" != "true" ]; then
+            echo "Release provisioning profile missing WebAuthn browser entitlement" >&2
+            exit 1
+          fi
+          PROVISIONS_ALL_DEVICES="$(/usr/libexec/PlistBuddy -c "Print :ProvisionsAllDevices" "$TMP_PLIST")"
+          if [ "$PROVISIONS_ALL_DEVICES" != "true" ]; then
+            echo "Release provisioning profile is not a Developer ID all-devices profile" >&2
+            exit 1
+          fi
+          cp "$TMP_PROFILE" "$PROFILE_PATH"
+
+      - name: Strip release binaries
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        run: ./scripts/strip-release-bundle.sh "build-universal/Build/Products/Release/cmux.app"
+
+      - name: Codesign app
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          if [ -z "$APPLE_SIGNING_IDENTITY" ]; then
+            echo "Missing APPLE_SIGNING_IDENTITY secret" >&2
+            exit 1
+          fi
+          APP_PATH="build-universal/Build/Products/Release/cmux.app"
+          CMUX_SIGN_MODE=all-except-computer-use \
+            ./scripts/sign-cmux-bundle.sh \
+            "$APP_PATH" \
+            cmux.release.entitlements \
+            "$APPLE_SIGNING_IDENTITY"
+
+      - name: Notarize app
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_SIGNING_IDENTITY: ${{ secrets.APPLE_SIGNING_IDENTITY }}
+        run: |
+          if [ -z "$APPLE_ID" ] || [ -z "$APPLE_APP_SPECIFIC_PASSWORD" ] || [ -z "$APPLE_TEAM_ID" ]; then
+            echo "Missing notarization secrets (APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, APPLE_TEAM_ID)" >&2
+            exit 1
+          fi
+          APP_PATH="build-universal/Build/Products/Release/cmux.app"
+          ZIP_SUBMIT="cmux-notary.zip"
+          DMG_RELEASE="cmux-macos.dmg"
+          ./scripts/ci/notarize-computer-use-helper.sh \
+            --finish "$RUNNER_TEMP/cmux-computer-use-notarization.state" \
+            "$APP_PATH" \
+            cmux.release.entitlements \
+            "$APPLE_SIGNING_IDENTITY"
+          ditto -c -k --sequesterRsrc --keepParent "$APP_PATH" "$ZIP_SUBMIT"
+          APP_SUBMIT_JSON="$(xcrun notarytool submit "$ZIP_SUBMIT" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
+          APP_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$APP_SUBMIT_JSON")"
+          APP_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$APP_SUBMIT_JSON")"
+          if [ "$APP_STATUS" != "Accepted" ]; then
+            echo "App notarization failed with status: $APP_STATUS" >&2
+            xcrun notarytool log "$APP_SUBMIT_ID" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+            exit 1
+          fi
+          xcrun stapler staple "$APP_PATH"
+          xcrun stapler validate "$APP_PATH"
+          spctl -a -vv --type execute "$APP_PATH"
+          CMUX_SMOKE_ALLOW_UNSUPPORTED_GUI=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$APP_PATH"
+          CMUX_SMOKE_DIRECT_EXEC=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$APP_PATH"
+          ./scripts/verify-app-bundle-channel-metadata.sh "$APP_PATH" stable
+          ./scripts/verify-app-bundle-licenses.sh "$APP_PATH"
+          rm -f "$ZIP_SUBMIT"
+          # create-dmg generates a styled drag-to-install DMG
+          create-dmg \
+            --no-code-sign \
+            "$APP_PATH" \
+            ./
+          mv ./cmux*.dmg "$DMG_RELEASE"
+          /usr/bin/codesign --force --timestamp --keychain build.keychain \
+            --sign "$APPLE_SIGNING_IDENTITY" \
+            "$DMG_RELEASE"
+          /usr/bin/codesign --verify --verbose=2 "$DMG_RELEASE"
+          DMG_SUBMIT_JSON="$(xcrun notarytool submit "$DMG_RELEASE" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
+          DMG_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$DMG_SUBMIT_JSON")"
+          DMG_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$DMG_SUBMIT_JSON")"
+          if [ "$DMG_STATUS" != "Accepted" ]; then
+            echo "DMG notarization failed with status: $DMG_STATUS" >&2
+            xcrun notarytool log "$DMG_SUBMIT_ID" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+            exit 1
+          fi
+          xcrun stapler staple "$DMG_RELEASE"
+          xcrun stapler validate "$DMG_RELEASE"
+
+      - name: Upload dSYMs to Sentry
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: manaflow
+          SENTRY_PROJECT: cmuxterm-macos
+        run: |
+          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
+            echo "SENTRY_AUTH_TOKEN not set, skipping dSYM upload"
+            exit 0
+          fi
+          SENTRY_CLI="$(./scripts/ensure-sentry-cli.sh)"
+          "$SENTRY_CLI" debug-files upload --include-sources build-universal/Build/Products/Release/
+
+      - name: Generate Sparkle appcast
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
+            exit 1
+          fi
+          ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$RELEASE_TAG" appcast.xml
+
+      - name: Attest remote daemon release assets
+        id: attest-remote-daemon-release-assets
+        if: steps.guard_release_assets.outputs.skip_all != 'true'
+        continue-on-error: true
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            remote-daemon-assets/cmuxd-remote-darwin-arm64
+            remote-daemon-assets/cmuxd-remote-darwin-amd64
+            remote-daemon-assets/cmuxd-remote-linux-arm64
+            remote-daemon-assets/cmuxd-remote-linux-amd64
+            remote-daemon-assets/cmuxd-remote-checksums.txt
+            remote-daemon-assets/cmuxd-remote-manifest.json
+
+      - name: Retry remote daemon release asset attestation
+        if: steps.guard_release_assets.outputs.skip_all != 'true' && steps.attest-remote-daemon-release-assets.outcome == 'failure'
+        uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0
+        with:
+          subject-path: |
+            remote-daemon-assets/cmuxd-remote-darwin-arm64
+            remote-daemon-assets/cmuxd-remote-darwin-amd64
+            remote-daemon-assets/cmuxd-remote-linux-arm64
+            remote-daemon-assets/cmuxd-remote-linux-amd64
+            remote-daemon-assets/cmuxd-remote-checksums.txt
+            remote-daemon-assets/cmuxd-remote-manifest.json
+
+      - name: Upload release asset
+        if: steps.guard_release_assets.outputs.skip_upload != 'true'
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
+        with:
+          files: |
+            cmux-macos.dmg
+            appcast.xml
+            remote-daemon-assets/cmuxd-remote-darwin-arm64
+            remote-daemon-assets/cmuxd-remote-darwin-amd64
+            remote-daemon-assets/cmuxd-remote-linux-arm64
+            remote-daemon-assets/cmuxd-remote-linux-amd64
+            remote-daemon-assets/cmuxd-remote-checksums.txt
+            remote-daemon-assets/cmuxd-remote-manifest.json
+          generate_release_notes: true
+          overwrite_files: false
+          tag_name: ${{ needs.validate-source.outputs.tag_name }}
+
+      - name: Upload release appcast to R2
+        if: steps.guard_release_assets.outputs.skip_upload != 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.CF_R2_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.CF_R2_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          R2_ENDPOINT: "https://${{ secrets.CF_R2_ACCOUNT_ID }}.r2.cloudflarestorage.com"
+        run: |
+          set -euo pipefail
+
+          # Guard: only upload if this tag is the highest semver release.
+          # Prevents a backport tag (e.g. v0.62.1 after v0.63.1) from
+          # overwriting the stable appcast with an older version.
+          LATEST=$(gh release list --exclude-drafts --exclude-pre-releases \
+            --json tagName -q '.[].tagName' | sort -V | tail -1)
+          if [ -n "$LATEST" ] && [ "$LATEST" != "$RELEASE_TAG" ]; then
+            echo "Skipping R2 stable upload: $RELEASE_TAG is not the latest release ($LATEST)"
+            exit 0
+          fi
+
+          # Upload after GitHub Release publish so the appcast never references
+          # a DMG that doesn't exist yet. R2 PutObject is atomic, so the appcast
+          # is either the old version or the new one, never missing.
+          python3 scripts/ci/upload-r2-object.py \
+            --file appcast.xml \
+            --endpoint-url "$R2_ENDPOINT" \
+            --bucket cmux-binaries \
+            --key stable/appcast.xml \
+            --cache-control "no-cache, no-store, must-revalidate"
+
+          echo "R2 appcast upload complete: https://files.cmux.com/stable/appcast.xml"
+
+      - name: Cleanup keychain
+        if: always()
+        run: |
+          security delete-keychain build.keychain >/dev/null 2>&1 || true
+          rm -f /tmp/cert.p12

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -467,12 +467,13 @@ jobs:
           if [ -d "/Applications/Xcode.app/Contents/Developer" ]; then
             XCODE_DIR="/Applications/Xcode.app/Contents/Developer"
           else
-            XCODE_APP="$(
-              find /Applications -maxdepth 1 -name 'Xcode*.app' -print 2>/dev/null \
-                | sort \
-                | tail -n 1 \
-                || true
-            )"
+            XCODE_APP=""
+            for candidate in /Applications/Xcode*.app; do
+              [[ -d "$candidate/Contents/Developer" ]] || continue
+              if [[ -z "$XCODE_APP" || "$candidate" > "$XCODE_APP" ]]; then
+                XCODE_APP="$candidate"
+              fi
+            done
             if [ -n "$XCODE_APP" ]; then
               XCODE_DIR="$XCODE_APP/Contents/Developer"
             else
@@ -731,15 +732,30 @@ jobs:
         env:
           APPLE_RELEASE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 }}
         run: |
+          set -euo pipefail
           if [ -z "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" ]; then
             echo "Missing APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 secret" >&2
             exit 1
           fi
+          umask 077
+          runner_temp="${RUNNER_TEMP:?RUNNER_TEMP is required}"
+          [[ -d "$runner_temp" && ! -L "$runner_temp" ]] || {
+            echo "RUNNER_TEMP must be a real directory" >&2
+            exit 1
+          }
           APP_PATH="build-universal/Build/Products/Release/cmux.app"
           PROFILE_PATH="$APP_PATH/Contents/embedded.provisionprofile"
-          TMP_PROFILE="$(mktemp /tmp/cmux-release-profile.XXXXXX)"
-          TMP_PLIST="$(mktemp /tmp/cmux-release-profile.XXXXXX.plist)"
-          trap 'rm -f "$TMP_PROFILE" "$TMP_PLIST"' EXIT
+          TMP_PROFILE="$(mktemp "$runner_temp/cmux-release-profile.XXXXXX")"
+          TMP_PLIST="$(mktemp "$runner_temp/cmux-release-plist.XXXXXX")"
+          [[ -f "$TMP_PROFILE" && ! -L "$TMP_PROFILE" ]] || {
+            echo "mktemp did not create a regular provisioning profile file" >&2
+            exit 1
+          }
+          [[ -f "$TMP_PLIST" && ! -L "$TMP_PLIST" ]] || {
+            echo "mktemp did not create a regular provisioning plist file" >&2
+            exit 1
+          }
+          trap 'rm -f -- "$TMP_PROFILE" "$TMP_PLIST"' EXIT
           echo "$APPLE_RELEASE_PROVISIONING_PROFILE_BASE64" | base64 -D > "$TMP_PROFILE"
           security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
           APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.application-identifier" "$TMP_PLIST")"

--- a/.github/workflows/release-trusted.yml
+++ b/.github/workflows/release-trusted.yml
@@ -25,6 +25,7 @@ jobs:
     outputs:
       source_sha: ${{ steps.source.outputs.source_sha }}
       tag_name: ${{ steps.source.outputs.tag_name }}
+      is_prerelease: ${{ steps.source.outputs.is_prerelease }}
       observer_run_id: ${{ steps.source.outputs.observer_run_id }}
     steps:
       - name: Validate protected dispatcher source
@@ -216,6 +217,7 @@ jobs:
 
             core.setOutput('source_sha', run.head_sha);
             core.setOutput('tag_name', tagName);
+            core.setOutput('is_prerelease', String(tagName.includes('-')));
             core.setOutput('observer_run_id', String(runId));
             core.notice(`Validated protected-main release source ${run.head_sha} for ${tagName}`);
 
@@ -406,8 +408,6 @@ jobs:
             core.setOutput('skip_all', 'false');
             core.setOutput('skip_upload', 'false');
             core.setOutput('skip_r2_upload', 'false');
-            core.setOutput('restore_appcast', 'false');
-            core.setOutput('repair_appcast_asset', 'false');
             core.setOutput('release_state', 'clear');
             if (!tag) {
               core.setFailed('Release asset guard did not receive the validated release tag');
@@ -430,42 +430,20 @@ jobs:
 
               core.setOutput('release_state', guardState);
 
-              const onlyAppcastIsMissing =
-                missingImmutableAssets.length === 1 && missingImmutableAssets[0] === 'appcast.xml';
-              if (onlyAppcastIsMissing) {
-                core.notice(
-                  `Release ${tag} is missing only appcast.xml. ` +
-                  'The existing signed DMG will be used to regenerate the appcast.'
-                );
-                core.setOutput('skip_all', 'true');
-                core.setOutput('skip_upload', 'true');
-                core.setOutput('skip_r2_upload', 'false');
-                core.setOutput('restore_appcast', 'true');
-                core.setOutput('repair_appcast_asset', 'true');
-                return;
-              }
-
               if (hasPartialConflict) {
                 core.setFailed(
                   `Release ${tag} has a partial immutable asset state. Existing immutable assets: ` +
                   `${conflicts.join(', ')}. Missing immutable assets: ${missingImmutableAssets.join(', ')}. ` +
-                  'Resolve release assets manually before rerunning.'
+                  'Refusing to download or sign release assets. Remove the incomplete release and rerun a fresh validated build.'
                 );
                 return;
               }
 
               if (shouldSkipBuildAndUpload) {
-                core.notice(
+                core.setFailed(
                   `Release ${tag} already contains immutable assets (${conflicts.join(', ')}). ` +
-                  'Skipping build, notarization, and upload to preserve existing signed artifacts.'
+                  'Refusing to trust mutable release assets on a retry. Start a fresh validated build to repair publication.'
                 );
-                core.setOutput('skip_all', 'true');
-                core.setOutput('skip_upload', 'true');
-                // Existing immutable assets mean the build and GitHub asset
-                // upload are complete. Keep the mutable R2 appcast lane live
-                // so a transient upload failure can be repaired by rerun.
-                core.setOutput('skip_r2_upload', 'false');
-                core.setOutput('restore_appcast', 'true');
                 return;
               }
 
@@ -477,40 +455,6 @@ jobs:
               }
               throw error;
             }
-
-      - name: Restore existing appcast for a publication retry
-        if: steps.guard_release_assets.outputs.restore_appcast == 'true' && steps.guard_release_assets.outputs.repair_appcast_asset != 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          rm -f appcast.xml
-          gh release download "$RELEASE_TAG" \
-            --repo manaflow-ai/cmux \
-            --pattern appcast.xml \
-            --output appcast.xml \
-            --clobber
-          test -s appcast.xml
-
-      - name: Regenerate missing appcast for a publication retry
-        if: steps.guard_release_assets.outputs.repair_appcast_asset == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: |
-          set -euo pipefail
-          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
-            echo "Missing SPARKLE_PRIVATE_KEY for appcast repair" >&2
-            exit 1
-          fi
-          rm -f cmux-macos.dmg appcast.xml
-          gh release download "$RELEASE_TAG" \
-            --repo manaflow-ai/cmux \
-            --pattern cmux-macos.dmg \
-            --output cmux-macos.dmg \
-            --clobber
-          ./scripts/sparkle_generate_appcast.sh cmux-macos.dmg "$RELEASE_TAG" appcast.xml
-          test -s appcast.xml
 
       - name: Select Xcode
         if: steps.guard_release_assets.outputs.skip_all != 'true'
@@ -901,7 +845,7 @@ jobs:
 
       - name: Revalidate release tag before GitHub publication
         id: revalidate-release-tag
-        if: steps.guard_release_assets.outputs.skip_upload != 'true' || steps.guard_release_assets.outputs.repair_appcast_asset == 'true'
+        if: steps.guard_release_assets.outputs.skip_upload != 'true'
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           RELEASE_TAG: ${{ needs.validate-source.outputs.tag_name }}
@@ -948,14 +892,8 @@ jobs:
           generate_release_notes: true
           overwrite_files: false
           tag_name: ${{ needs.validate-source.outputs.tag_name }}
-
-      - name: Upload repaired appcast asset
-        if: steps.guard_release_assets.outputs.repair_appcast_asset == 'true' && steps.revalidate-release-tag.outputs.verified == 'true'
-        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
-        with:
-          files: appcast.xml
-          overwrite_files: false
-          tag_name: ${{ needs.validate-source.outputs.tag_name }}
+          prerelease: ${{ needs.validate-source.outputs.is_prerelease == 'true' }}
+          make_latest: ${{ needs.validate-source.outputs.is_prerelease != 'true' }}
 
       - name: Revalidate release tag before R2 publication
         id: revalidate-r2-tag

--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -90,6 +90,18 @@ runs. `test-e2e.yml` also exposes `tart-canary`, `tart-dual`, and `tart-small`
 for targeted fleet validation. These choices are available only through
 `workflow_dispatch`.
 
+## Protected release tags
+
+The `release.yml` tag workflow is an unprivileged observer. The protected-main
+`release-trusted.yml` workflow performs every checkout, signing operation, and
+publication. Repository administrators must keep an active ruleset for
+`refs/tags/v*` that grants release-tag create, update, and delete operations
+only to the release authority, and rejects force-updates. The ruleset is a
+deployment prerequisite because the workflow token cannot prove tag-policy
+state. The dispatcher still resolves the tag to an immutable commit SHA and
+requires that SHA to be an ancestor of protected `main`; a tag-policy failure
+must stop a release before any secret-bearing job runs.
+
 ## Guard
 
 `tests/test_ci_self_hosted_guard.sh` (run by the `workflow-guard-tests` job)

--- a/scripts/ci/select_latest_stable_release.py
+++ b/scripts/ci/select_latest_stable_release.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Select the highest unambiguous stable cmux release from tag names."""
+
+import re
+import sys
+
+
+STABLE_TAG = re.compile(
+    r"^v(?P<major>0|[1-9][0-9]*)\.(?P<minor>0|[1-9][0-9]*)\.(?P<patch>0|[1-9][0-9]*)"
+    r"(?:\+(?P<build>[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*))?$"
+)
+
+
+def select_latest(tags):
+    versions = {}
+    for raw_tag in tags:
+        tag = raw_tag.strip()
+        match = STABLE_TAG.fullmatch(tag)
+        if not match:
+            continue
+        core = tuple(int(match.group(name)) for name in ("major", "minor", "patch"))
+        versions.setdefault(core, []).append(tag)
+
+    duplicates = {core: tags for core, tags in versions.items() if len(tags) > 1}
+    if duplicates:
+        details = "; ".join(
+            f"{core}: {', '.join(tags)}" for core, tags in sorted(duplicates.items())
+        )
+        raise ValueError(f"duplicate stable SemVer precedence ({details})")
+
+    if not versions:
+        return ""
+    return versions[max(versions)][0]
+
+
+def main():
+    try:
+        latest = select_latest(sys.stdin)
+    except ValueError as error:
+        print(f"Refusing R2 stable upload: {error}", file=sys.stderr)
+        return 1
+    print(latest)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/derive_sparkle_public_key.swift
+++ b/scripts/derive_sparkle_public_key.swift
@@ -5,13 +5,23 @@ import Foundation
 // Derives the Ed25519 public key from a Sparkle private key (base64-encoded).
 // Supports both new format (32-byte seed) and old format (96-byte key+pub).
 
-guard CommandLine.arguments.count > 1 else {
-    fputs("Usage: derive_sparkle_public_key.swift <base64-private-key>\n", stderr)
+guard CommandLine.arguments.count == 1 || CommandLine.arguments.count == 2 else {
+    fputs("Usage: derive_sparkle_public_key.swift [<base64-private-key> | --stdin]\n", stderr)
     exit(1)
 }
 
 // Pad base64 string if needed (Sparkle keys may be stored without padding)
-var b64 = CommandLine.arguments[1]
+let b64Input: String
+if CommandLine.arguments.count == 2 && CommandLine.arguments[1] != "--stdin" {
+    b64Input = CommandLine.arguments[1]
+} else {
+    guard let stdin = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) else {
+        fputs("Error: stdin is not valid UTF-8\n", stderr)
+        exit(1)
+    }
+    b64Input = stdin.trimmingCharacters(in: .whitespacesAndNewlines)
+}
+var b64 = b64Input
 while b64.count % 4 != 0 {
     b64 += "="
 }

--- a/scripts/release_asset_guard.js
+++ b/scripts/release_asset_guard.js
@@ -33,9 +33,6 @@ function evaluateReleaseAssetGuard({ existingAssetNames, immutableAssetNames = I
     conflicts,
     missingImmutableAssets,
     guardState,
-    hasPartialConflict: guardState === RELEASE_ASSET_GUARD_STATE.PARTIAL,
-    shouldSkipBuildAndUpload: guardState === RELEASE_ASSET_GUARD_STATE.COMPLETE,
-    shouldSkipUpload: guardState === RELEASE_ASSET_GUARD_STATE.COMPLETE,
   };
 }
 

--- a/scripts/release_asset_guard.test.js
+++ b/scripts/release_asset_guard.test.js
@@ -9,7 +9,7 @@ const {
   evaluateReleaseAssetGuard,
 } = require("./release_asset_guard");
 
-test("marks guard as complete and skips build/upload when all immutable assets already exist", () => {
+test("marks guard as complete when all immutable assets already exist", () => {
   const result = evaluateReleaseAssetGuard({
     existingAssetNames: [...IMMUTABLE_RELEASE_ASSETS, "notes.txt"],
   });
@@ -17,9 +17,7 @@ test("marks guard as complete and skips build/upload when all immutable assets a
   assert.deepEqual(result.conflicts, IMMUTABLE_RELEASE_ASSETS);
   assert.deepEqual(result.missingImmutableAssets, []);
   assert.equal(result.guardState, RELEASE_ASSET_GUARD_STATE.COMPLETE);
-  assert.equal(result.hasPartialConflict, false);
-  assert.equal(result.shouldSkipBuildAndUpload, true);
-  assert.equal(result.shouldSkipUpload, true);
+  assert.deepEqual(Object.keys(result).sort(), ["conflicts", "guardState", "missingImmutableAssets"]);
 });
 
 test("marks guard as clear when immutable assets are not present", () => {
@@ -30,9 +28,6 @@ test("marks guard as clear when immutable assets are not present", () => {
   assert.deepEqual(result.conflicts, []);
   assert.deepEqual(result.missingImmutableAssets, IMMUTABLE_RELEASE_ASSETS);
   assert.equal(result.guardState, RELEASE_ASSET_GUARD_STATE.CLEAR);
-  assert.equal(result.hasPartialConflict, false);
-  assert.equal(result.shouldSkipBuildAndUpload, false);
-  assert.equal(result.shouldSkipUpload, false);
 });
 
 test("marks guard as partial when only some immutable assets exist", () => {
@@ -47,7 +42,4 @@ test("marks guard as partial when only some immutable assets exist", () => {
     IMMUTABLE_RELEASE_ASSETS.filter((assetName) => !partialAssets.includes(assetName)),
   );
   assert.equal(result.guardState, RELEASE_ASSET_GUARD_STATE.PARTIAL);
-  assert.equal(result.hasPartialConflict, true);
-  assert.equal(result.shouldSkipBuildAndUpload, false);
-  assert.equal(result.shouldSkipUpload, false);
 });

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -183,6 +183,22 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         ):
             self.assertIn(required, policy)
 
+    def test_sparkle_private_key_is_streamed_to_the_derivation_helper(self) -> None:
+        workflow_text = WORKFLOW.read_text(encoding="utf-8")
+        helper_text = (ROOT / "scripts" / "derive_sparkle_public_key.swift").read_text(
+            encoding="utf-8"
+        )
+        self.assertIn(
+            'swift scripts/derive_sparkle_public_key.swift --stdin <<<"$SPARKLE_PRIVATE_KEY"',
+            workflow_text,
+        )
+        self.assertNotIn(
+            'swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY"',
+            workflow_text,
+        )
+        self.assertIn("FileHandle.standardInput", helper_text)
+        self.assertIn("--stdin", helper_text)
+
     def test_workflow_run_is_resolved_from_protected_main(self) -> None:
         document = load()
         event = triggers(document)

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -13,6 +13,7 @@ import json
 import pathlib
 import re
 import subprocess
+import tempfile
 import unittest
 
 import yaml
@@ -385,6 +386,44 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         ):
             self.assertIn(required, cleanup_run)
         self.assertIn("CMUX_KEYCHAIN_CREATED", cleanup_run)
+
+    def test_keychain_cleanup_parses_indented_quoted_paths(self) -> None:
+        document = load()
+        cleanup_step = next(
+            step
+            for step in document["jobs"]["build-sign-notarize"]["steps"]
+            if step.get("name") == "Cleanup keychain"
+        )
+        cleanup_run = cleanup_step["run"]
+        parser_start = cleanup_run.index("  keychains=()")
+        parser_end = cleanup_run.index(
+            "  if ((${#keychains[@]} > 0));", parser_start
+        )
+        parser = cleanup_run[parser_start:parser_end]
+        with tempfile.NamedTemporaryFile("w", encoding="utf-8") as backup:
+            backup.write(
+                '    "/Users/runner/Library/Keychains/login.keychain-db"\n'
+                '    "/Library/Keychains/System.keychain"\n'
+            )
+            backup.flush()
+            harness = f'''\
+set -euo pipefail
+backup="$1"
+{parser}
+printf '<%s>\\n' "${{keychains[@]}}"
+'''
+            result = subprocess.run(
+                ["bash", "-c", harness, "keychain-parser", backup.name],
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            result.stdout,
+            "</Users/runner/Library/Keychains/login.keychain-db>\n"
+            "</Library/Keychains/System.keychain>\n",
+        )
 
     def test_release_asset_guard_uses_step_success_without_dead_outputs(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -323,9 +323,16 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             '[[ -f "$cert_path" && ! -L "$cert_path" ]]',
             "trap 'rm -f -- \"$cert_path\"' EXIT",
             'chmod 600 "$cert_path"',
+            'base64 -D > "$cert_path"',
         ):
             self.assertIn(required, import_run)
         self.assertNotIn("/tmp/cert.p12", import_run)
+
+        profile_step = next(
+            step for step in sign_steps if step.get("name") == "Embed release provisioning profile"
+        )
+        self.assertIn("base64 -D > \"$TMP_PROFILE\"", profile_step["run"])
+        self.assertNotIn("base64 --decode", WORKFLOW.read_text(encoding="utf-8"))
 
     def test_keychain_search_list_is_restored_and_cleanup_is_fail_closed(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -621,7 +621,7 @@ printf '<%s>\\n' "${{keychains[@]}}"
             tag_name="v1.2.3-01",
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("semantic version", result.stderr.lower())
+        self.assertRegex(result.stderr.lower(), r"semantic version|leading zero")
 
 
 if __name__ == "__main__":

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -349,6 +349,49 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             self.assertIn(required, cleanup_run)
         self.assertIn("CMUX_KEYCHAIN_CREATED", cleanup_run)
 
+    def test_signing_keychain_is_unique_and_cleanup_is_owned(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        import_step = next(step for step in sign_steps if step.get("name") == "Import signing cert")
+        cleanup_step = next(step for step in sign_steps if step.get("name") == "Cleanup keychain")
+        import_run = import_step["run"]
+        cleanup_run = cleanup_step["run"]
+        for required in (
+            'keychain_dir="$(mktemp -d "$runner_temp/cmux-signing-keychain.',
+            '[[ -d "$keychain_dir" && ! -L "$keychain_dir" ]]',
+            'keychain_path="$keychain_dir/build.keychain-db"',
+            'CMUX_KEYCHAIN_PATH=$keychain_path',
+            'security create-keychain -p "$KEYCHAIN_PASSWORD" "$keychain_path"',
+        ):
+            self.assertIn(required, import_run)
+        self.assertNotIn("security delete-keychain build.keychain", import_run)
+        self.assertIn('keychain_path="${CMUX_KEYCHAIN_PATH:-}"', cleanup_run)
+        self.assertIn('security delete-keychain "$keychain_path"', cleanup_run)
+        self.assertIn('rmdir "$keychain_dir"', cleanup_run)
+        self.assertNotIn('security delete-keychain build.keychain', cleanup_run)
+
+    def test_lock_cleanup_fails_closed_when_lsof_is_unavailable(self) -> None:
+        document = load()
+        for job_name in ("build-ghostty-cli-helper", "build-sign-notarize"):
+            cleanup = next(
+                step for step in document["jobs"][job_name]["steps"]
+                if step.get("name") == "Clear stale git locks (self-hosted reused workspace)"
+            )
+            cleanup_run = cleanup["run"]
+            self.assertIn('if ! command -v lsof >/dev/null 2>&1; then', cleanup_run)
+            self.assertIn("Refusing to inspect active Git lock", cleanup_run)
+            self.assertIn("return 1", cleanup_run)
+
+    def test_r2_latest_release_rejects_equal_core_versions_with_build_metadata(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
+        r2_run = r2_upload["run"]
+        self.assertIn("duplicate stable SemVer precedence", r2_run)
+        self.assertIn("duplicate_core_versions", r2_run)
+        self.assertIn("len(tags) > 1", r2_run)
+        self.assertNotIn("max(versions, key=lambda item: (item[0], item[1]))", r2_run)
+
         # A reused self-hosted workspace must never delete another process's
         # lock. The pre-checkout cleanup is intentionally duplicated in each
         # privileged job so source-controlled code cannot weaken the guard.

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -171,6 +171,18 @@ process.env.WORKFLOW_RUN_JSON = JSON.stringify(context.payload.workflow_run);
 
 
 class ReleaseTrustedWorkflowTests(unittest.TestCase):
+    def test_release_tag_policy_is_documented_as_a_deployment_prerequisite(self) -> None:
+        policy = (ROOT / "docs" / "ci-runners.md").read_text(encoding="utf-8")
+        for required in (
+            "Protected release tags",
+            "refs/tags/v*",
+            "create, update, and delete",
+            "only to the release authority",
+            "rejects force-updates",
+            "deployment prerequisite",
+        ):
+            self.assertIn(required, policy)
+
     def test_workflow_run_is_resolved_from_protected_main(self) -> None:
         document = load()
         event = triggers(document)
@@ -233,6 +245,10 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
                 self.assertIs(checkout.get("with", {}).get("persist-credentials"), False)
 
         sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        self.assertEqual(
+            document["jobs"]["build-sign-notarize"]["concurrency"],
+            {"group": "cmux-release-stable-r2", "cancel-in-progress": False},
+        )
         sign_text = "\n".join(str(step) for step in sign_steps)
         for required in (
             "skip_r2_upload",
@@ -251,6 +267,26 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         self.assertIn("skip_r2_upload", r2_recheck["if"])
         r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
         self.assertIn('RELEASE_TAG" == *-*', r2_upload["run"])
+        self.assertNotIn("sort -V", r2_upload["run"])
+        self.assertIn("python3 -c", r2_upload["run"])
+        self.assertIn("gh release list --limit 1000", r2_upload["run"])
+        self.assertIn("latest_sha", r2_upload["run"])
+        self.assertIn("EXPECTED_SHA", r2_upload["run"])
+
+        # A reused self-hosted workspace must never delete another process's
+        # lock. The pre-checkout cleanup is intentionally duplicated in each
+        # privileged job so source-controlled code cannot weaken the guard.
+        for job_name in ("build-ghostty-cli-helper", "build-sign-notarize"):
+            cleanup = next(
+                step for step in document["jobs"][job_name]["steps"]
+                if step.get("name") == "Clear stale git locks (self-hosted reused workspace)"
+            )
+            cleanup_run = cleanup["run"]
+            self.assertIn("stat -c '%u'", cleanup_run)
+            self.assertIn("stat -f '%u'", cleanup_run)
+            self.assertIn("lsof -n -t", cleanup_run)
+            self.assertIn("find -P", cleanup_run)
+            self.assertNotIn('find "$git_dir/modules" -type f -name "*.lock" -delete', cleanup_run)
 
     def test_adversarial_tag_workflow_is_rejected_before_release(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -82,6 +82,8 @@ def run_guard_fixture(
     main_blob: str,
     source_content: str | None = None,
     main_content: str | None = None,
+    tag_object_type: str = "commit",
+    tag_ref_sha: str | None = None,
     tag_target_sha: str | None = None,
     tag_name: str = "v1.2.3",
 ) -> subprocess.CompletedProcess[str]:
@@ -105,6 +107,7 @@ def run_guard_fixture(
     )
     source_content_b64 = base64.b64encode(source_content.encode()).decode()
     main_content_b64 = base64.b64encode(main_content.encode()).decode()
+    tag_ref_sha = tag_ref_sha or source_sha
     tag_target_sha = tag_target_sha or source_sha
     tag_name_literal = json.dumps(tag_name)
     harness = f"""
@@ -145,7 +148,8 @@ const github = {{ rest: {{
     }},
   }},
   git: {{
-    getRef: async () => ({{ data: {{ object: {{ type: 'commit', sha: '{tag_target_sha}' }} }} }}),
+    getRef: async () => ({{ data: {{ object: {{ type: '{tag_object_type}', sha: '{tag_ref_sha}' }} }} }}),
+    getTag: async () => ({{ data: {{ object: {{ sha: '{tag_target_sha}' }} }} }}),
   }},
 }} }};
 process.env.REPOSITORY = 'manaflow-ai/cmux';
@@ -275,7 +279,6 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         )
         sign_text = "\n".join(str(step) for step in sign_steps)
         for required in (
-            "skip_r2_upload",
             "Refusing to download or sign release assets",
             "Refusing to trust mutable release assets on a retry",
             "Revalidate release tag before GitHub publication",
@@ -284,7 +287,7 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             self.assertIn(required, sign_text)
         r2_recheck = next(step for step in sign_steps if step.get("name") == "Revalidate release tag before R2 publication")
         self.assertIn("gh api", r2_recheck["run"])
-        self.assertIn("skip_r2_upload", r2_recheck["if"])
+        self.assertEqual(r2_recheck["if"], "success()")
         r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
         self.assertIn('[[ "${IS_PRERELEASE:-}" == true ]]', r2_upload["run"])
         self.assertNotIn('RELEASE_TAG" == *-*', r2_upload["run"])
@@ -355,6 +358,50 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         ):
             self.assertIn(required, cleanup_run)
         self.assertIn("CMUX_KEYCHAIN_CREATED", cleanup_run)
+
+    def test_release_asset_guard_uses_step_success_without_dead_outputs(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        guard = next(step for step in sign_steps if step.get("name") == "Guard immutable release assets")
+        guard_script = guard["with"]["script"]
+        for output_name in ("skip_all", "skip_upload", "skip_r2_upload", "release_state"):
+            self.assertNotIn(f"setOutput('{output_name}'", guard_script)
+        for step in sign_steps:
+            condition = str(step.get("if", ""))
+            self.assertNotIn("steps.guard_release_assets.outputs.skip_", condition)
+        r2_recheck = next(step for step in sign_steps if step.get("name") == "Revalidate release tag before R2 publication")
+        self.assertEqual(r2_recheck["if"], "success()")
+
+    def test_annotated_release_tag_target_is_bound_before_publication(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+            tag_object_type="tag",
+            tag_ref_sha="d" * 40,
+            tag_target_sha="a" * 40,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_moved_annotated_release_tag_is_rejected_before_publication(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+            tag_object_type="tag",
+            tag_ref_sha="d" * 40,
+            tag_ref_sha="c" * 40,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("moved", result.stderr.lower())
 
     def test_signing_keychain_is_unique_and_cleanup_is_owned(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -609,6 +609,20 @@ printf '<%s>\\n' "${{keychains[@]}}"
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("semantic version", result.stderr.lower())
 
+    def test_leading_zero_numeric_prerelease_identifier_is_rejected(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+            tag_name="v1.2.3-01",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("semantic version", result.stderr.lower())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -286,7 +286,7 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         self.assertIn("gh api", r2_recheck["run"])
         self.assertIn("skip_r2_upload", r2_recheck["if"])
         r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
-        self.assertIn('[[ "$IS_PRERELEASE" == true ]]', r2_upload["run"])
+        self.assertIn('[[ "${IS_PRERELEASE:-}" == true ]]', r2_upload["run"])
         self.assertNotIn('RELEASE_TAG" == *-*', r2_upload["run"])
 
         release_upload = next(step for step in sign_steps if step.get("name") == "Upload release asset")

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -230,6 +230,7 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             "protected",
             "source_sha",
             "tag_name",
+            "is_prerelease",
             "minimal unprivileged observer",
         ):
             self.assertIn(required, script)
@@ -270,21 +271,28 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         sign_text = "\n".join(str(step) for step in sign_steps)
         for required in (
             "skip_r2_upload",
-            "restore_appcast",
-            "repair_appcast_asset",
-            "Restore existing appcast for a publication retry",
-            "Regenerate missing appcast for a publication retry",
+            "Refusing to download or sign release assets",
+            "Refusing to trust mutable release assets on a retry",
             "Revalidate release tag before GitHub publication",
             "Revalidate release tag before R2 publication",
         ):
             self.assertIn(required, sign_text)
-        restore = next(step for step in sign_steps if step.get("name") == "Restore existing appcast for a publication retry")
-        self.assertIn("gh release download", restore["run"])
         r2_recheck = next(step for step in sign_steps if step.get("name") == "Revalidate release tag before R2 publication")
         self.assertIn("gh api", r2_recheck["run"])
         self.assertIn("skip_r2_upload", r2_recheck["if"])
         r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
         self.assertIn('RELEASE_TAG" == *-*', r2_upload["run"])
+
+        release_upload = next(step for step in sign_steps if step.get("name") == "Upload release asset")
+        self.assertEqual(
+            release_upload["with"]["prerelease"],
+            "${{ needs.validate-source.outputs.is_prerelease == 'true' }}",
+        )
+        self.assertEqual(
+            release_upload["with"]["make_latest"],
+            "${{ needs.validate-source.outputs.is_prerelease != 'true' }}",
+        )
+        self.assertNotIn("gh release download", sign_text)
         self.assertNotIn("sort -V", r2_upload["run"])
         self.assertIn("python3 -c", r2_upload["run"])
         self.assertIn("gh release list --limit 1000", r2_upload["run"])

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -365,6 +365,18 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         setup_bun = next(step for step in sign_steps if step.get("name") == "Setup Bun")
         self.assertEqual(setup_bun.get("with", {}).get("bun-version"), "1.3.14")
 
+    def test_release_xcode_version_is_exactly_pinned(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        select_step = next(step for step in sign_steps if step.get("name") == "Select Xcode")
+        select_run = select_step["run"]
+        self.assertIn("/Applications/Xcode_26.5.app/Contents/Developer", select_run)
+        self.assertIn('expected_xcode_version="26.5"', select_run)
+        self.assertIn("actual_xcode_version", select_run)
+        self.assertIn("xcodebuild -version", select_run)
+        self.assertIn("Refusing release build with unexpected Xcode version", select_run)
+        self.assertNotIn("for candidate in /Applications/Xcode*.app", select_run)
+
     def test_keychain_search_list_is_restored_and_cleanup_is_fail_closed(self) -> None:
         document = load()
         sign_steps = document["jobs"]["build-sign-notarize"]["steps"]

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -334,8 +334,26 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         profile_step = next(
             step for step in sign_steps if step.get("name") == "Embed release provisioning profile"
         )
-        self.assertIn("base64 -D > \"$TMP_PROFILE\"", profile_step["run"])
+        profile_run = profile_step["run"]
+        for required in (
+            "umask 077",
+            'runner_temp="${RUNNER_TEMP:?RUNNER_TEMP is required}"',
+            'TMP_PROFILE="$(mktemp "$runner_temp/cmux-release-profile.XXXXXX")"',
+            'TMP_PLIST="$(mktemp "$runner_temp/cmux-release-plist.XXXXXX")"',
+            'base64 -D > "$TMP_PROFILE"',
+        ):
+            self.assertIn(required, profile_run)
+        self.assertNotIn("/tmp/cmux-release-profile", profile_run)
         self.assertNotIn("base64 --decode", WORKFLOW.read_text(encoding="utf-8"))
+
+    def test_xcode_fallback_uses_bsd_compatible_glob(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        select_step = next(step for step in sign_steps if step.get("name") == "Select Xcode")
+        select_run = select_step["run"]
+        self.assertIn("for candidate in /Applications/Xcode*.app", select_run)
+        self.assertIn('[[ -d "$candidate/Contents/Developer" ]]', select_run)
+        self.assertNotIn("-maxdepth", select_run)
 
     def test_keychain_search_list_is_restored_and_cleanup_is_fail_closed(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -93,13 +93,16 @@ const context = {{
   }} }},
 }};
 const github = {{ rest: {{
-  actions: {{ getWorkflowRun: async () => ({{ data: context.payload.workflow_run }}) }},
+  actions: {{
+    getWorkflowRun: async () => ({{ data: {{ ...context.payload.workflow_run, workflow_id: 77, repository: {{ full_name: 'manaflow-ai/cmux' }} }} }}),
+    getWorkflow: async () => ({{ data: {{ name: 'Release macOS app trigger', path: '{TRIGGER_PATH}' }} }}),
+  }},
   repos: {{
     getBranch: async () => ({{ data: {{ protected: true, commit: {{ sha: '{main_sha}' }} }} }}),
     compareCommits: async () => ({{ data: {{ status: 'ahead' }} }}),
     getContent: async ({{ path, ref }}) => {{
-      if (path === '{TRIGGER_PATH}') return {{ data: {{ type: 'file', sha: ref === '{main_sha}' ? '{main_blob}' : '{wrapper_blob}', content: ref === '{main_sha}' ? '{main_content}' : '{wrapper_content}' }} }};
-      return {{ data: {{ type: 'file', sha: 'trusted-workflow-blob', content: '' }} }};
+      if (path === '{TRIGGER_PATH}') return {{ data: {{ type: 'file', sha: ref === '{main_sha}' ? '{main_blob}' : '{wrapper_blob}', encoding: 'base64', content: ref === '{main_sha}' ? '{main_content}' : '{wrapper_content}' }} }};
+      return {{ data: {{ type: 'file', sha: 'trusted-workflow-blob', encoding: 'base64', content: '' }} }};
     }},
   }},
   git: {{
@@ -115,6 +118,7 @@ process.env.WORKFLOW_SHA = '{main_sha}';
 process.env.WORKFLOW_REF = 'manaflow-ai/cmux/{WORKFLOW_PATH}@refs/heads/main';
 process.env.REF_PROTECTED = 'true';
 process.env.WORKFLOW_REPOSITORY = 'manaflow-ai/cmux';
+process.env.WORKFLOW_RUN_JSON = JSON.stringify(context.payload.workflow_run);
 (async () => {{
   try {{
 {script}
@@ -158,8 +162,8 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             "compareCommits",
             "getRef",
             "getTag",
-            "workflowAtSource",
-            "workflowAtMain",
+            "trustedAtWorkflow",
+            "trustedAtMain",
             "protected",
             "source_sha",
             "tag_name",
@@ -206,7 +210,7 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertRegex(
             result.stderr,
-            r"(?:minimal unprivileged observer|dispatcher source workflow changed|workflow definition)",
+            r"(?i)(?:minimal unprivileged observer|dispatcher source workflow changed|workflow definition)",
         )
 
 

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -23,6 +23,30 @@ WORKFLOW_PATH = ".github/workflows/release-trusted.yml"
 TRIGGER_PATH = ".github/workflows/release.yml"
 SHA = re.compile(r"^[0-9a-f]{40}$")
 ACTION_SHA = re.compile(r"@[0-9a-f]{40}(?:\s+#.*)?$")
+OBSERVER_CONTENT = "\n".join(
+    (
+        "name: Release macOS app trigger",
+        "",
+        "on:",
+        "  push:",
+        "    tags:",
+        '      - "v*"',
+        "",
+        "permissions: {}",
+        "",
+        "jobs:",
+        "  announce:",
+        "    runs-on: ubuntu-24.04 # github-hosted-required: unprivileged tag observer",
+        "    permissions: {}",
+        "    timeout-minutes: 2",
+        "    steps:",
+        "      - name: Emit queued release event",
+        "        run: |",
+        "          set -euo pipefail",
+        '          echo "Tag event queued for trusted protected-main release dispatcher: ${GITHUB_REF_NAME}"',
+        "",
+    )
+)
 
 
 def load() -> dict:
@@ -50,7 +74,14 @@ def checkout_steps(job: dict) -> list[dict]:
     ]
 
 
-def run_guard_fixture(script: str, *, wrapper_blob: str, main_blob: str) -> subprocess.CompletedProcess[str]:
+def run_guard_fixture(
+    script: str,
+    *,
+    wrapper_blob: str,
+    main_blob: str,
+    source_content: str | None = None,
+    main_content: str | None = None,
+) -> subprocess.CompletedProcess[str]:
     """Exercise the real guard with a tag-controlled workflow mutation.
 
     The event payload claims a successful observer run, while the observer
@@ -61,14 +92,16 @@ def run_guard_fixture(script: str, *, wrapper_blob: str, main_blob: str) -> subp
     source_sha = "a" * 40
     main_sha = "b" * 40
     observer_run_id = 123456
-    wrapper_content = base64.b64encode(
-        b"name: Release macOS app trigger\n"
-        b"permissions: { contents: write }\n"
-        b"jobs:\n  attacker:\n    run: exfiltrate\n"
-    ).decode()
-    main_content = base64.b64encode(
-        b"name: Release macOS app trigger\npermissions: {}\njobs: {}\n"
-    ).decode()
+    source_content = source_content or (
+        "name: Release macOS app trigger\n"
+        "permissions: { contents: write }\n"
+        "jobs:\n  attacker:\n    run: exfiltrate\n"
+    )
+    main_content = main_content or (
+        "name: Release macOS app trigger\npermissions: {}\njobs: {}\n"
+    )
+    source_content_b64 = base64.b64encode(source_content.encode()).decode()
+    main_content_b64 = base64.b64encode(main_content.encode()).decode()
     harness = f"""
 const core = {{
   setFailed(message) {{ throw new Error(message); }},
@@ -101,7 +134,7 @@ const github = {{ rest: {{
     getBranch: async () => ({{ data: {{ protected: true, commit: {{ sha: '{main_sha}' }} }} }}),
     compareCommits: async () => ({{ data: {{ status: 'ahead' }} }}),
     getContent: async ({{ path, ref }}) => {{
-      if (path === '{TRIGGER_PATH}') return {{ data: {{ type: 'file', sha: ref === '{main_sha}' ? '{main_blob}' : '{wrapper_blob}', encoding: 'base64', content: ref === '{main_sha}' ? '{main_content}' : '{wrapper_content}' }} }};
+      if (path === '{TRIGGER_PATH}') return {{ data: {{ type: 'file', sha: ref === '{main_sha}' ? '{main_blob}' : '{wrapper_blob}', encoding: 'base64', content: ref === '{main_sha}' ? '{main_content_b64}' : '{source_content_b64}' }} }};
       return {{ data: {{ type: 'file', sha: 'trusted-workflow-blob', encoding: 'base64', content: '' }} }};
     }},
   }},
@@ -199,6 +232,21 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
                 )
                 self.assertIs(checkout.get("with", {}).get("persist-credentials"), False)
 
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        sign_text = "\n".join(str(step) for step in sign_steps)
+        for required in (
+            "skip_r2_upload",
+            "Restore appcast for a publication retry",
+            "Revalidate release tag before GitHub publication",
+            "Revalidate release tag before R2 publication",
+        ):
+            self.assertIn(required, sign_text)
+        restore = next(step for step in sign_steps if step.get("name") == "Restore appcast for a publication retry")
+        self.assertIn("gh release download", restore["run"])
+        r2_recheck = next(step for step in sign_steps if step.get("name") == "Revalidate release tag before R2 publication")
+        self.assertIn("gh api", r2_recheck["run"])
+        self.assertIn("skip_r2_upload", r2_recheck["if"])
+
     def test_adversarial_tag_workflow_is_rejected_before_release(self) -> None:
         document = load()
         script = script_for(document["jobs"]["validate-source"])
@@ -212,6 +260,32 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             result.stderr,
             r"(?i)(?:minimal unprivileged observer|dispatcher source workflow changed|workflow definition)",
         )
+
+    def test_observer_rejects_alternate_yaml_run_syntax(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        alternate = OBSERVER_CONTENT.replace("        run: |", "        run: >")
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=alternate,
+            main_content=OBSERVER_CONTENT,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("minimal unprivileged observer", result.stderr)
+
+    def test_canonical_observer_passes_full_provenance_guard(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -236,16 +236,21 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         sign_text = "\n".join(str(step) for step in sign_steps)
         for required in (
             "skip_r2_upload",
-            "Restore appcast for a publication retry",
+            "restore_appcast",
+            "repair_appcast_asset",
+            "Restore existing appcast for a publication retry",
+            "Regenerate missing appcast for a publication retry",
             "Revalidate release tag before GitHub publication",
             "Revalidate release tag before R2 publication",
         ):
             self.assertIn(required, sign_text)
-        restore = next(step for step in sign_steps if step.get("name") == "Restore appcast for a publication retry")
+        restore = next(step for step in sign_steps if step.get("name") == "Restore existing appcast for a publication retry")
         self.assertIn("gh release download", restore["run"])
         r2_recheck = next(step for step in sign_steps if step.get("name") == "Revalidate release tag before R2 publication")
         self.assertIn("gh api", r2_recheck["run"])
         self.assertIn("skip_r2_upload", r2_recheck["if"])
+        r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
+        self.assertIn('RELEASE_TAG" == *-*', r2_upload["run"])
 
     def test_adversarial_tag_workflow_is_rejected_before_release(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -347,35 +347,24 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         self.assertNotIn("/tmp/cmux-release-profile", profile_run)
         self.assertNotIn("base64 --decode", WORKFLOW.read_text(encoding="utf-8"))
 
-    def test_xcode_fallback_uses_bsd_compatible_glob(self) -> None:
+    def test_release_xcode_selection_uses_exact_pinned_toolchain(self) -> None:
         document = load()
         sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
         select_step = next(step for step in sign_steps if step.get("name") == "Select Xcode")
         select_run = select_step["run"]
-        self.assertIn("for candidate in /Applications/Xcode*.app", select_run)
-        self.assertIn('[[ -d "$candidate/Contents/Developer" ]]', select_run)
-        self.assertIn('DEVELOPER_DIR="$candidate/Contents/Developer" xcodebuild -version', select_run)
-        self.assertIn("candidate_version", select_run)
-        self.assertNotIn("-maxdepth", select_run)
-        self.assertNotIn('"$candidate" > "$XCODE_APP"', select_run)
+        self.assertIn('expected_xcode_app="/Applications/Xcode_26.5.app"', select_run)
+        self.assertIn('XCODE_DIR="$expected_xcode_app/Contents/Developer"', select_run)
+        self.assertIn('expected_xcode_version="26.5"', select_run)
+        self.assertIn("actual_xcode_version", select_run)
+        self.assertIn("xcodebuild -version", select_run)
+        self.assertIn("Refusing release build with unexpected Xcode version", select_run)
+        self.assertNotIn("for candidate in /Applications/Xcode*.app", select_run)
 
     def test_release_bun_version_is_pinned(self) -> None:
         document = load()
         sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
         setup_bun = next(step for step in sign_steps if step.get("name") == "Setup Bun")
         self.assertEqual(setup_bun.get("with", {}).get("bun-version"), "1.3.14")
-
-    def test_release_xcode_version_is_exactly_pinned(self) -> None:
-        document = load()
-        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
-        select_step = next(step for step in sign_steps if step.get("name") == "Select Xcode")
-        select_run = select_step["run"]
-        self.assertIn("/Applications/Xcode_26.5.app/Contents/Developer", select_run)
-        self.assertIn('expected_xcode_version="26.5"', select_run)
-        self.assertIn("actual_xcode_version", select_run)
-        self.assertIn("xcodebuild -version", select_run)
-        self.assertIn("Refusing release build with unexpected Xcode version", select_run)
-        self.assertNotIn("for candidate in /Applications/Xcode*.app", select_run)
 
     def test_keychain_search_list_is_restored_and_cleanup_is_fail_closed(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -9,6 +9,7 @@ protected default branch.
 from __future__ import annotations
 
 import base64
+import json
 import pathlib
 import re
 import subprocess
@@ -82,6 +83,7 @@ def run_guard_fixture(
     source_content: str | None = None,
     main_content: str | None = None,
     tag_target_sha: str | None = None,
+    tag_name: str = "v1.2.3",
 ) -> subprocess.CompletedProcess[str]:
     """Exercise the real guard with a tag-controlled workflow mutation.
 
@@ -104,10 +106,12 @@ def run_guard_fixture(
     source_content_b64 = base64.b64encode(source_content.encode()).decode()
     main_content_b64 = base64.b64encode(main_content.encode()).decode()
     tag_target_sha = tag_target_sha or source_sha
+    tag_name_literal = json.dumps(tag_name)
     harness = f"""
+const outputs = {{}};
 const core = {{
   setFailed(message) {{ throw new Error(message); }},
-  setOutput() {{}},
+  setOutput(name, value) {{ outputs[name] = value; }},
   notice() {{}},
 }};
 const context = {{
@@ -122,7 +126,7 @@ const context = {{
     event: 'push',
     status: 'completed',
     conclusion: 'success',
-    head_branch: 'v1.2.3',
+    head_branch: {tag_name_literal},
     head_sha: '{source_sha}',
     head_repository: {{ full_name: 'manaflow-ai/cmux' }},
   }} }},
@@ -157,6 +161,7 @@ process.env.WORKFLOW_RUN_JSON = JSON.stringify(context.payload.workflow_run);
 (async () => {{
   try {{
 {script}
+    process.stdout.write(JSON.stringify(outputs));
   }} catch (error) {{
     console.error(error.message);
     process.exitCode = 1;
@@ -281,7 +286,8 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         self.assertIn("gh api", r2_recheck["run"])
         self.assertIn("skip_r2_upload", r2_recheck["if"])
         r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
-        self.assertIn('RELEASE_TAG" == *-*', r2_upload["run"])
+        self.assertIn('[[ "$IS_PRERELEASE" == true ]]', r2_upload["run"])
+        self.assertNotIn('RELEASE_TAG" == *-*', r2_upload["run"])
 
         release_upload = next(step for step in sign_steps if step.get("name") == "Upload release asset")
         self.assertEqual(
@@ -298,6 +304,50 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         self.assertIn("gh release list --limit 1000", r2_upload["run"])
         self.assertIn("latest_sha", r2_upload["run"])
         self.assertIn("EXPECTED_SHA", r2_upload["run"])
+
+        self.assertEqual(
+            document["jobs"]["build-sign-notarize"]["env"]["IS_PRERELEASE"],
+            "${{ needs.validate-source.outputs.is_prerelease }}",
+        )
+
+    def test_signing_certificate_tempfile_is_private_and_symlink_safe(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        import_step = next(step for step in sign_steps if step.get("name") == "Import signing cert")
+        import_run = import_step["run"]
+        for required in (
+            "umask 077",
+            'runner_temp="${RUNNER_TEMP:?RUNNER_TEMP is required}"',
+            '[[ -d "$runner_temp" && ! -L "$runner_temp" ]]',
+            'cert_path="$(mktemp "$runner_temp/cmux-signing-cert.',
+            '[[ -f "$cert_path" && ! -L "$cert_path" ]]',
+            "trap 'rm -f -- \"$cert_path\"' EXIT",
+            'chmod 600 "$cert_path"',
+        ):
+            self.assertIn(required, import_run)
+        self.assertNotIn("/tmp/cert.p12", import_run)
+
+    def test_keychain_search_list_is_restored_and_cleanup_is_fail_closed(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        import_step = next(step for step in sign_steps if step.get("name") == "Import signing cert")
+        cleanup_step = next(step for step in sign_steps if step.get("name") == "Cleanup keychain")
+        import_run = import_step["run"]
+        cleanup_run = cleanup_step["run"]
+        self.assertIn('keychain_list_backup="$(mktemp "$runner_temp/cmux-keychain-list.', import_run)
+        self.assertIn('[[ -f "$keychain_list_backup" && ! -L "$keychain_list_backup" ]]', import_run)
+        self.assertIn('security list-keychains -d user > "$keychain_list_backup"', import_run)
+        self.assertIn("CMUX_KEYCHAIN_LIST_BACKUP", import_run)
+        self.assertEqual(cleanup_step["if"], "always()")
+        for required in (
+            'backup="${CMUX_KEYCHAIN_LIST_BACKUP:-}"',
+            '[[ -n "$backup" && -f "$backup" && ! -L "$backup" ]]',
+            "security list-keychains -d user -s",
+            'rm -f -- "$backup"',
+            "Failed to restore the keychain search list",
+        ):
+            self.assertIn(required, cleanup_run)
+        self.assertIn("CMUX_KEYCHAIN_CREATED", cleanup_run)
 
         # A reused self-hosted workspace must never delete another process's
         # lock. The pre-checkout cleanup is intentionally duplicated in each
@@ -367,6 +417,34 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("moved", result.stderr.lower())
+
+    def test_build_metadata_hyphen_is_not_a_prerelease(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+            tag_name="v1.2.3+build-1",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"is_prerelease":"false"', result.stdout)
+
+    def test_leading_zero_semver_core_is_rejected(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+            tag_name="v01.2.3",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("semantic version", result.stderr.lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -21,8 +21,10 @@ import yaml
 
 ROOT = pathlib.Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "release-trusted.yml"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 WORKFLOW_PATH = ".github/workflows/release-trusted.yml"
 TRIGGER_PATH = ".github/workflows/release.yml"
+LATEST_RELEASE_SELECTOR = ROOT / "scripts" / "ci" / "select_latest_stable_release.py"
 SHA = re.compile(r"^[0-9a-f]{40}$")
 ACTION_SHA = re.compile(r"@[0-9a-f]{40}(?:\s+#.*)?$")
 OBSERVER_CONTENT = "\n".join(
@@ -56,6 +58,11 @@ def load() -> dict:
     return document
 
 
+def load_ci() -> dict:
+    document = yaml.safe_load(CI_WORKFLOW.read_text(encoding="utf-8"))
+    return document
+
+
 def triggers(document: dict) -> dict:
     # PyYAML 1.1 treats the YAML 1.2 ``on`` key as a boolean.
     return document.get("on", document.get(True, {}))
@@ -74,6 +81,16 @@ def checkout_steps(job: dict) -> list[dict]:
         for step in job.get("steps", [])
         if "actions/checkout@" in str(step.get("uses", ""))
     ]
+
+
+def run_latest_release_selector(tags: list[str]) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["python3", str(LATEST_RELEASE_SELECTOR)],
+        input="\n".join(tags) + "\n",
+        text=True,
+        capture_output=True,
+        check=False,
+    )
 
 
 def run_guard_fixture(
@@ -250,6 +267,21 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         self.assertIn("github.workflow_sha", env)
         self.assertIn("github.ref_protected", env)
 
+    def test_release_contract_dependencies_are_installed_before_the_test(self) -> None:
+        steps = load_ci()["jobs"]["workflow-guard-tests"]["steps"]
+        names = [step.get("name") for step in steps]
+        contract_index = names.index("Validate protected-main release dispatcher")
+        setup_index = names.index("Set up Python for release workflow contract tests")
+        dependency_index = names.index("Install release workflow contract dependencies")
+        self.assertLess(setup_index, contract_index)
+        self.assertLess(dependency_index, contract_index)
+
+    def test_build_sign_notarize_requires_the_helper_job_to_succeed(self) -> None:
+        condition = str(load()["jobs"]["build-sign-notarize"]["if"])
+        normalized = re.sub(r"\s+", "", condition)
+        self.assertIn("needs.validate-source.result=='success'", normalized)
+        self.assertIn("needs.build-ghostty-cli-helper.result=='success'", normalized)
+
     def test_privileged_jobs_require_guard_and_immutable_source(self) -> None:
         document = load()
         for job_name, job in document["jobs"].items():
@@ -304,7 +336,6 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         )
         self.assertNotIn("gh release download", sign_text)
         self.assertNotIn("sort -V", r2_upload["run"])
-        self.assertIn("python3 -c", r2_upload["run"])
         self.assertIn("gh release list --limit 1000", r2_upload["run"])
         self.assertIn("latest_sha", r2_upload["run"])
         self.assertIn("EXPECTED_SHA", r2_upload["run"])
@@ -433,6 +464,10 @@ printf '<%s>\\n' "${{keychains[@]}}"
         guard_script = guard["with"]["script"]
         for output_name in ("skip_all", "skip_upload", "skip_r2_upload", "release_state"):
             self.assertNotIn(f"setOutput('{output_name}'", guard_script)
+        self.assertIn("guardState", guard_script)
+        self.assertIn("RELEASE_ASSET_GUARD_STATE", guard_script)
+        self.assertNotIn("shouldSkipBuildAndUpload", guard_script)
+        self.assertNotIn("shouldSkipUpload", guard_script)
         for step in sign_steps:
             condition = str(step.get("if", ""))
             self.assertNotIn("steps.guard_release_assets.outputs.skip_", condition)
@@ -508,10 +543,18 @@ printf '<%s>\\n' "${{keychains[@]}}"
         sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
         r2_upload = next(step for step in sign_steps if step.get("name") == "Upload release appcast to R2")
         r2_run = r2_upload["run"]
-        self.assertIn("duplicate stable SemVer precedence", r2_run)
-        self.assertIn("duplicate_core_versions", r2_run)
-        self.assertIn("len(tags) > 1", r2_run)
-        self.assertNotIn("max(versions, key=lambda item: (item[0], item[1]))", r2_run)
+        self.assertIn("scripts/ci/select_latest_stable_release.py", r2_run)
+        self.assertNotIn("python3 -c", r2_run)
+
+        selected = run_latest_release_selector(
+            ["v1.2.0", "v1.10.0", "v1.9.0", "v2.0.0-rc.1", "v1.2.3+exp-1"]
+        )
+        self.assertEqual(selected.returncode, 0, selected.stderr)
+        self.assertEqual(selected.stdout, "v1.10.0\n")
+
+        duplicate = run_latest_release_selector(["v1.2.3", "v1.2.3+exp-1"])
+        self.assertNotEqual(duplicate.returncode, 0)
+        self.assertIn("duplicate stable SemVer precedence", duplicate.stderr)
 
         # A reused self-hosted workspace must never delete another process's
         # lock. The pre-checkout cleanup is intentionally duplicated in each
@@ -595,6 +638,20 @@ printf '<%s>\\n' "${{keychains[@]}}"
         )
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn('"is_prerelease":"false"', result.stdout)
+
+    def test_semver_prerelease_classification_ignores_build_metadata_hyphens(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+            tag_name="v1.2.3-rc.1+build-1",
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn('"is_prerelease":"true"', result.stdout)
 
     def test_leading_zero_semver_core_is_rejected(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -81,6 +81,7 @@ def run_guard_fixture(
     main_blob: str,
     source_content: str | None = None,
     main_content: str | None = None,
+    tag_target_sha: str | None = None,
 ) -> subprocess.CompletedProcess[str]:
     """Exercise the real guard with a tag-controlled workflow mutation.
 
@@ -102,6 +103,7 @@ def run_guard_fixture(
     )
     source_content_b64 = base64.b64encode(source_content.encode()).decode()
     main_content_b64 = base64.b64encode(main_content.encode()).decode()
+    tag_target_sha = tag_target_sha or source_sha
     harness = f"""
 const core = {{
   setFailed(message) {{ throw new Error(message); }},
@@ -139,7 +141,7 @@ const github = {{ rest: {{
     }},
   }},
   git: {{
-    getRef: async () => ({{ data: {{ object: {{ type: 'commit', sha: '{source_sha}' }} }} }}),
+    getRef: async () => ({{ data: {{ object: {{ type: 'commit', sha: '{tag_target_sha}' }} }} }}),
   }},
 }} }};
 process.env.REPOSITORY = 'manaflow-ai/cmux';
@@ -343,6 +345,20 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             main_content=OBSERVER_CONTENT,
         )
         self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_moved_tag_is_rejected_before_release(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="same-protected-blob",
+            main_blob="same-protected-blob",
+            source_content=OBSERVER_CONTENT,
+            main_content=OBSERVER_CONTENT,
+            tag_target_sha="c" * 40,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("moved", result.stderr.lower())
 
 
 if __name__ == "__main__":

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -1,0 +1,214 @@
+#!/usr/bin/env python3
+"""Contract tests for the protected-main release dispatcher.
+
+The tag workflow is deliberately only an event source.  All privileged work
+must live in the ``workflow_run`` workflow that GitHub resolves from the
+protected default branch.
+"""
+
+from __future__ import annotations
+
+import base64
+import pathlib
+import re
+import subprocess
+import unittest
+
+import yaml
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "release-trusted.yml"
+WORKFLOW_PATH = ".github/workflows/release-trusted.yml"
+TRIGGER_PATH = ".github/workflows/release.yml"
+SHA = re.compile(r"^[0-9a-f]{40}$")
+ACTION_SHA = re.compile(r"@[0-9a-f]{40}(?:\s+#.*)?$")
+
+
+def load() -> dict:
+    document = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return document
+
+
+def triggers(document: dict) -> dict:
+    # PyYAML 1.1 treats the YAML 1.2 ``on`` key as a boolean.
+    return document.get("on", document.get(True, {}))
+
+
+def script_for(job: dict) -> str:
+    return "\n".join(
+        str(step.get("with", {}).get("script", ""))
+        for step in job.get("steps", [])
+    )
+
+
+def checkout_steps(job: dict) -> list[dict]:
+    return [
+        step
+        for step in job.get("steps", [])
+        if "actions/checkout@" in str(step.get("uses", ""))
+    ]
+
+
+def run_guard_fixture(script: str, *, wrapper_blob: str, main_blob: str) -> subprocess.CompletedProcess[str]:
+    """Exercise the real guard with a tag-controlled workflow mutation.
+
+    The event payload claims a successful observer run, while the observer
+    definition at that source SHA contains a different blob from protected
+    ``main``.  The guard must fail before any privileged job can run.
+    """
+
+    source_sha = "a" * 40
+    main_sha = "b" * 40
+    observer_run_id = 123456
+    wrapper_content = base64.b64encode(
+        b"name: Release macOS app trigger\n"
+        b"permissions: { contents: write }\n"
+        b"jobs:\n  attacker:\n    run: exfiltrate\n"
+    ).decode()
+    main_content = base64.b64encode(
+        b"name: Release macOS app trigger\npermissions: {}\njobs: {}\n"
+    ).decode()
+    harness = f"""
+const core = {{
+  setFailed(message) {{ throw new Error(message); }},
+  setOutput() {{}},
+  notice() {{}},
+}};
+const context = {{
+  repo: {{ owner: 'manaflow-ai', repo: 'cmux' }},
+  eventName: 'workflow_run',
+  ref: 'refs/heads/main',
+  ref_type: 'branch',
+  payload: {{ workflow_run: {{
+    id: {observer_run_id},
+    name: 'Release macOS app trigger',
+    path: '{TRIGGER_PATH}',
+    event: 'push',
+    status: 'completed',
+    conclusion: 'success',
+    head_branch: 'v1.2.3',
+    head_sha: '{source_sha}',
+    head_repository: {{ full_name: 'manaflow-ai/cmux' }},
+  }} }},
+}};
+const github = {{ rest: {{
+  actions: {{ getWorkflowRun: async () => ({{ data: context.payload.workflow_run }}) }},
+  repos: {{
+    getBranch: async () => ({{ data: {{ protected: true, commit: {{ sha: '{main_sha}' }} }} }}),
+    compareCommits: async () => ({{ data: {{ status: 'ahead' }} }}),
+    getContent: async ({{ path, ref }}) => {{
+      if (path === '{TRIGGER_PATH}') return {{ data: {{ type: 'file', sha: ref === '{main_sha}' ? '{main_blob}' : '{wrapper_blob}', content: ref === '{main_sha}' ? '{main_content}' : '{wrapper_content}' }} }};
+      return {{ data: {{ type: 'file', sha: 'trusted-workflow-blob', content: '' }} }};
+    }},
+  }},
+  git: {{
+    getRef: async () => ({{ data: {{ object: {{ type: 'commit', sha: '{source_sha}' }} }} }}),
+  }},
+}} }};
+process.env.REPOSITORY = 'manaflow-ai/cmux';
+process.env.EVENT_NAME = 'workflow_run';
+process.env.EVENT_REF = 'refs/heads/main';
+process.env.EVENT_REF_TYPE = 'branch';
+process.env.EVENT_SHA = '{main_sha}';
+process.env.WORKFLOW_SHA = '{main_sha}';
+process.env.WORKFLOW_REF = 'manaflow-ai/cmux/{WORKFLOW_PATH}@refs/heads/main';
+process.env.REF_PROTECTED = 'true';
+process.env.WORKFLOW_REPOSITORY = 'manaflow-ai/cmux';
+(async () => {{
+  try {{
+{script}
+  }} catch (error) {{
+    console.error(error.message);
+    process.exitCode = 1;
+  }}
+}})();
+"""
+    return subprocess.run(
+        ["node", "--input-type=module"],
+        input=harness,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+class ReleaseTrustedWorkflowTests(unittest.TestCase):
+    def test_workflow_run_is_resolved_from_protected_main(self) -> None:
+        document = load()
+        event = triggers(document)
+        self.assertEqual(event["workflow_run"]["types"], ["completed"])
+        self.assertEqual(event["workflow_run"]["workflows"], ["Release macOS app trigger"])
+        self.assertNotIn("push", event)
+        self.assertNotIn("workflow_dispatch", event)
+        self.assertEqual(document["permissions"], {})
+        guard = document["jobs"]["validate-source"]
+        self.assertEqual(guard["runs-on"], "ubuntu-24.04")
+        self.assertEqual(guard["permissions"], {"actions": "read", "contents": "read"})
+        script = script_for(guard)
+        for required in (
+            "workflow_run",
+            "getWorkflowRun",
+            "head_repository",
+            "head_branch",
+            "head_sha",
+            "conclusion",
+            "completed",
+            "getBranch",
+            "compareCommits",
+            "getRef",
+            "getTag",
+            "workflowAtSource",
+            "workflowAtMain",
+            "protected",
+            "source_sha",
+            "tag_name",
+            "minimal unprivileged observer",
+        ):
+            self.assertIn(required, script)
+        env = "\n".join(str(step.get("env", {})) for step in guard.get("steps", []))
+        self.assertIn("github.event.workflow_run", env)
+        self.assertIn("github.workflow_ref", env)
+        self.assertIn("github.workflow_sha", env)
+        self.assertIn("github.ref_protected", env)
+
+    def test_privileged_jobs_require_guard_and_immutable_source(self) -> None:
+        document = load()
+        for job_name, job in document["jobs"].items():
+            self.assertIn("permissions", job, job_name)
+            for step in job.get("steps", []):
+                uses = str(step.get("uses", ""))
+                if uses and not uses.startswith("./"):
+                    self.assertRegex(uses, ACTION_SHA)
+        for job_name in ("build-ghostty-cli-helper", "build-sign-notarize"):
+            job = document["jobs"][job_name]
+            needs = job.get("needs", [])
+            needs = {needs} if isinstance(needs, str) else set(needs)
+            self.assertIn("validate-source", needs)
+            self.assertIn("needs.validate-source.result", job["if"])
+            checkouts = checkout_steps(job)
+            self.assertTrue(checkouts)
+            for checkout in checkouts:
+                self.assertEqual(
+                    checkout.get("with", {}).get("ref"),
+                    "${{ needs.validate-source.outputs.source_sha }}",
+                )
+                self.assertIs(checkout.get("with", {}).get("persist-credentials"), False)
+
+    def test_adversarial_tag_workflow_is_rejected_before_release(self) -> None:
+        document = load()
+        script = script_for(document["jobs"]["validate-source"])
+        result = run_guard_fixture(
+            script,
+            wrapper_blob="tag-controlled-wrapper",
+            main_blob="protected-main-wrapper",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertRegex(
+            result.stderr,
+            r"(?:minimal unprivileged observer|dispatcher source workflow changed|workflow definition)",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -353,7 +353,16 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
         select_run = select_step["run"]
         self.assertIn("for candidate in /Applications/Xcode*.app", select_run)
         self.assertIn('[[ -d "$candidate/Contents/Developer" ]]', select_run)
+        self.assertIn('DEVELOPER_DIR="$candidate/Contents/Developer" xcodebuild -version', select_run)
+        self.assertIn("candidate_version", select_run)
         self.assertNotIn("-maxdepth", select_run)
+        self.assertNotIn('"$candidate" > "$XCODE_APP"', select_run)
+
+    def test_release_bun_version_is_pinned(self) -> None:
+        document = load()
+        sign_steps = document["jobs"]["build-sign-notarize"]["steps"]
+        setup_bun = next(step for step in sign_steps if step.get("name") == "Setup Bun")
+        self.assertEqual(setup_bun.get("with", {}).get("bun-version"), "1.3.14")
 
     def test_keychain_search_list_is_restored_and_cleanup_is_fail_closed(self) -> None:
         document = load()

--- a/tests/test_release_trusted_workflow.py
+++ b/tests/test_release_trusted_workflow.py
@@ -398,7 +398,7 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             main_content=OBSERVER_CONTENT,
             tag_object_type="tag",
             tag_ref_sha="d" * 40,
-            tag_ref_sha="c" * 40,
+            tag_target_sha="c" * 40,
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("moved", result.stderr.lower())
@@ -510,7 +510,7 @@ class ReleaseTrustedWorkflowTests(unittest.TestCase):
             main_blob="same-protected-blob",
             source_content=OBSERVER_CONTENT,
             main_content=OBSERVER_CONTENT,
-            tag_target_sha="c" * 40,
+            tag_ref_sha="c" * 40,
         )
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("moved", result.stderr.lower())


### PR DESCRIPTION
## Summary

- add a protected-main `workflow_run` release dispatcher
- validate the completed tag observer through the Actions and Git APIs before any source checkout or secret-bearing job
- bind the tag, source commit, observer workflow identity, protected-main ancestry, and immutable workflow blobs
- require the tag workflow to remain a minimal no-token observer
- keep all release checkouts pinned to the validated source SHA with persisted credentials disabled
- run the contract and adversarial provenance fixture in the required workflow guard job

## Security topology

The follow-up tag wrapper is intentionally separate. It emits a completion event with no token permissions. This workflow is resolved from protected `main` by GitHub's `workflow_run` semantics and owns all signing, notarization, publication, and release credentials. Merge this PR before the wrapper PR so the first wrapper events remain unprivileged and have no release listener.

## Verification

- `python3 tests/test_release_trusted_workflow.py -v`
- `actionlint .github/workflows/release-trusted.yml .github/workflows/ci.yml`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11537"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790909645&installation_model_id=21920&pr_number=11537&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11537&signature=157dcfd961e92306afe0230178ff1ad31c68633764715416d8749f8f265a7564"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves privileged macOS release work from tag-controlled workflow content to a protected-main `workflow_run` dispatcher, so release credentials and publication logic cannot be changed by a tag. The dispatcher validates provenance before checkout or secret use; until the follow-up no-token observer is merged, tag pushes will not start releases.

**Security**
- Requires protected `main`, expected workflow identity and immutable workflow blobs, canonical observer content, SemVer tags with no numeric prerelease leading zeros, and main ancestry.
- Pins checkouts to the validated source SHA with persisted credentials disabled, and documents the `refs/tags/v*` ruleset as a deployment prerequisite.
- Reads the Sparkle private key from stdin, uses symlink-safe temporary certificate and keychain files, uses macOS-compatible `base64` decoding, a pinned Xcode 26.5 and Bun 1.3.14 toolchain, and restores quoted keychain search-list paths during cleanup.
- CI installs PyYAML and runs contract tests when the dispatcher or release selector changes.

**Publication**
- Rechecks the tag target immediately before GitHub and R2 writes.
- Serializes stable R2 publication, skips R2 for prereleases, and only publishes the highest stable version, refusing duplicate SemVer precedence.
- Uses a state-only immutable-asset guard that fails partial or complete retry states instead of trusting mutable release files.

<sup>Written for commit 1b8212aa3f973e3340aeb3b228344f939c2a4ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11537?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a protected release workflow for macOS app builds, signing, notarization, validation, and publication.
  - Releases verify protected-source ancestry, immutable version tags, and release configuration before publication.
  - Stable app updates are published only for the highest valid stable version.

- **Documentation**
  - Documented protected release-tag requirements and deployment prerequisites.

- **Improvements**
  - Sparkle public-key derivation accepts input via command argument or standard input.
  - Added automated validation for release workflows and safeguards.
  - CI now runs protected-release validation when related workflow or test files change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->