### PR TITLE
Make new windows honor configured sidebar width

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9924,9 +9924,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             restoredSessionSnapshotHandler?(restoredPanelIdsByWorkspaceIndex, tabManager)
         }
 
-        let sidebarWidth = sessionWindowSnapshot?.sidebar.width
-            .map { SessionPersistencePolicy.sanitizedSidebarWidth($0) }
-            ?? SessionPersistencePolicy.defaultSidebarWidth
+        let sidebarWidth = SessionPersistencePolicy.sanitizedSidebarWidth(
+            sessionWindowSnapshot?.sidebar.width
+        )
 #if DEBUG
         let shouldStartWithHiddenSidebarForTerminalViewportUITest =
             ProcessInfo.processInfo.environment["CMUX_UI_TEST_TERMINAL_VIEWPORT_HIDE_SIDEBAR"] == "1"

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -40,8 +40,9 @@ enum SessionPersistencePolicy {
 
     static func sanitizedSidebarWidth(_ candidate: Double?, defaults: UserDefaults = .standard) -> Double {
         let resolvedMinimum = resolvedMinimumSidebarWidth(defaults: defaults)
-        let fallback = min(max(defaultSidebarWidth, resolvedMinimum), maximumSidebarWidth)
-        guard let candidate, candidate.isFinite else { return fallback }
+        guard let candidate, candidate.isFinite else {
+            return min(resolvedMinimum, maximumSidebarWidth)
+        }
         return min(max(candidate, resolvedMinimum), maximumSidebarWidth)
     }
 

--- a/cmuxTests/SidebarWidthPolicyTests.swift
+++ b/cmuxTests/SidebarWidthPolicyTests.swift
@@ -3,143 +3,146 @@ import CmuxAppKitSupportUI
 import CmuxFoundation
 import SwiftUI
 import Testing
-import XCTest
 
 #if canImport(cmux_DEV)
-@testable import cmux_DEV
+    @testable import cmux_DEV
 #elseif canImport(cmux)
-@testable import cmux
+    @testable import cmux
 #endif
 
-final class SidebarWidthPolicyTests: XCTestCase {
+@Suite(.serialized)
+struct SidebarWidthPolicyTests {
     private let settingsFileBackupsDefaultsKey = "cmux.settingsFile.backups.v1"
     private let importedManagedDefaultsKey = "cmux.settingsFile.importedManagedDefaults.v1"
 
-    func testDefaultMinimumSidebarWidthIsPersistedProductDefault() {
+    @Test
+    func defaultMinimumSidebarWidthIsPersistedProductDefault() {
         let suiteName = "SidebarWidthPolicyTests.defaultMinimum.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        XCTAssertEqual(
-            SessionPersistencePolicy.defaultMinimumSidebarWidth,
-            240,
-            accuracy: 0.001
-        )
-        XCTAssertEqual(
-            SessionPersistencePolicy.resolvedMinimumSidebarWidth(defaults: defaults),
-            240,
-            accuracy: 0.001
+        #expect(abs(SessionPersistencePolicy.defaultMinimumSidebarWidth - 240) <= 0.001)
+        #expect(
+            abs(SessionPersistencePolicy.resolvedMinimumSidebarWidth(defaults: defaults) - 240) <= 0.001
         )
     }
 
-    func testContentViewClampKeepsMinimumSidebarWidth() {
-        XCTAssertEqual(
-            ContentView.clampedSidebarWidth(184, maximumWidth: 600),
-            CGFloat(SessionPersistencePolicy.minimumSidebarWidth),
-            accuracy: 0.001
+    @Test
+    func contentViewClampKeepsMinimumSidebarWidth() {
+        #expect(
+            abs(
+                ContentView.clampedSidebarWidth(184, maximumWidth: 600)
+                    - CGFloat(SessionPersistencePolicy.minimumSidebarWidth)
+            ) <= 0.001
         )
     }
 
-    func testContentViewClampCanUseSmallerConfiguredMinimumSidebarWidth() {
-        XCTAssertEqual(
-            ContentView.clampedSidebarWidth(184, maximumWidth: 600, minimumWidth: 160),
-            184,
-            accuracy: 0.001
+    @Test
+    func contentViewClampCanUseSmallerConfiguredMinimumSidebarWidth() {
+        #expect(
+            abs(ContentView.clampedSidebarWidth(184, maximumWidth: 600, minimumWidth: 160) - 184) <= 0.001
         )
-        XCTAssertEqual(
-            ContentView.clampedSidebarWidth(140, maximumWidth: 600, minimumWidth: 160),
-            160,
-            accuracy: 0.001
+        #expect(
+            abs(ContentView.clampedSidebarWidth(140, maximumWidth: 600, minimumWidth: 160) - 160) <= 0.001
         )
     }
 
-    func testSessionPersistenceReadsConfiguredMinimumSidebarWidth() {
+    @Test
+    func sessionPersistenceReadsConfiguredMinimumSidebarWidth() {
         let suiteName = "SidebarWidthPolicyTests.minimumSidebarWidth.\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         defaults.set(160.0, forKey: SessionPersistencePolicy.sidebarMinimumWidthKey)
-        XCTAssertEqual(
-            SessionPersistencePolicy.sanitizedSidebarWidth(140, defaults: defaults),
-            160,
-            accuracy: 0.001
+        #expect(
+            abs(SessionPersistencePolicy.sanitizedSidebarWidth(nil, defaults: defaults) - 160) <= 0.001)
+        #expect(
+            abs(SessionPersistencePolicy.sanitizedSidebarWidth(140, defaults: defaults) - 160) <= 0.001)
+        #expect(
+            abs(SessionPersistencePolicy.sanitizedSidebarWidth(184, defaults: defaults) - 184) <= 0.001)
+    }
+
+    @Test
+    func sessionPersistenceFallbackNeverExceedsMaximumSidebarWidth() {
+        let suiteName = "SidebarWidthPolicyTests.maximumSidebarWidth.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(
+            SessionPersistencePolicy.maximumSidebarWidth + 100,
+            forKey: SessionPersistencePolicy.sidebarMinimumWidthKey
         )
-        XCTAssertEqual(
-            SessionPersistencePolicy.sanitizedSidebarWidth(184, defaults: defaults),
-            184,
-            accuracy: 0.001
+        let fallback = SessionPersistencePolicy.sanitizedSidebarWidth(nil, defaults: defaults)
+
+        #expect(fallback <= SessionPersistencePolicy.maximumSidebarWidth)
+    }
+
+    @Test
+    func rightSidebarClampAllowsWideExplorerOnLargeWindows() {
+        #expect(abs(ContentView.clampedRightSidebarWidth(900, availableWidth: 1600) - 900) <= 0.001)
+    }
+
+    @Test
+    func rightSidebarFirstCustomMaximumMatchesBuiltInCap() {
+        #expect(
+            abs(
+                ContentView.clampedRightSidebarWidth(10_000, availableWidth: 10_000)
+                    - CGFloat(RightSidebarWidthSettings.defaultConfiguredMaximumWidth)
+            ) <= 0.001
         )
     }
 
-    func testRightSidebarClampAllowsWideExplorerOnLargeWindows() {
-        XCTAssertEqual(
-            ContentView.clampedRightSidebarWidth(900, availableWidth: 1600),
-            900,
-            accuracy: 0.001
+    @Test
+    func rightSidebarClampLeavesTerminalWidthWhenMaxWidthSettingIsMissing() {
+        #expect(abs(ContentView.clampedRightSidebarWidth(10_000, availableWidth: 1000) - 640) <= 0.001)
+    }
+
+    @Test
+    func rightSidebarConfiguredMaxCanExceedBuiltInDefaultOnWideWindows() {
+        #expect(
+            abs(
+                ContentView.clampedRightSidebarWidth(
+                    10_000,
+                    availableWidth: 2400,
+                    configuredMaximumWidth: 1_500
+                ) - 1_500
+            ) <= 0.001
         )
     }
 
-    func testRightSidebarFirstCustomMaximumMatchesBuiltInCap() {
-        XCTAssertEqual(
-            ContentView.clampedRightSidebarWidth(10_000, availableWidth: 10_000),
-            CGFloat(RightSidebarWidthSettings.defaultConfiguredMaximumWidth),
-            accuracy: 0.001
+    @Test
+    func rightSidebarConfiguredMaxStillLeavesTerminalWidth() {
+        #expect(
+            abs(
+                ContentView.clampedRightSidebarWidth(
+                    10_000,
+                    availableWidth: 1000,
+                    configuredMaximumWidth: 1_400
+                ) - 640
+            ) <= 0.001
         )
     }
 
-    func testRightSidebarClampLeavesTerminalWidthWhenMaxWidthSettingIsMissing() {
-        XCTAssertEqual(
-            ContentView.clampedRightSidebarWidth(10_000, availableWidth: 1000),
-            640,
-            accuracy: 0.001
+    @Test
+    func rightSidebarConfiguredMaxBelowMinimumClampsToMinimumWidth() {
+        #expect(
+            abs(
+                ContentView.clampedRightSidebarWidth(
+                    10_000,
+                    availableWidth: 1000,
+                    configuredMaximumWidth: 120
+                ) - 276
+            ) <= 0.001
         )
     }
 
-    func testRightSidebarConfiguredMaxCanExceedBuiltInDefaultOnWideWindows() {
-        XCTAssertEqual(
-            ContentView.clampedRightSidebarWidth(
-                10_000,
-                availableWidth: 2400,
-                configuredMaximumWidth: 1_500
-            ),
-            1_500,
-            accuracy: 0.001
-        )
+    @Test
+    func rightSidebarClampKeepsMinimumWidth() {
+        #expect(abs(ContentView.clampedRightSidebarWidth(20, availableWidth: 1000) - 276) <= 0.001)
     }
 
-    func testRightSidebarConfiguredMaxStillLeavesTerminalWidth() {
-        XCTAssertEqual(
-            ContentView.clampedRightSidebarWidth(
-                10_000,
-                availableWidth: 1000,
-                configuredMaximumWidth: 1_400
-            ),
-            640,
-            accuracy: 0.001
-        )
-    }
-
-    func testRightSidebarConfiguredMaxBelowMinimumClampsToMinimumWidth() {
-        XCTAssertEqual(
-            ContentView.clampedRightSidebarWidth(
-                10_000,
-                availableWidth: 1000,
-                configuredMaximumWidth: 120
-            ),
-            276,
-            accuracy: 0.001
-        )
-    }
-
-    func testRightSidebarClampKeepsMinimumWidth() {
-        XCTAssertEqual(
-            ContentView.clampedRightSidebarWidth(20, availableWidth: 1000),
-            276,
-            accuracy: 0.001
-        )
-    }
-
-    func testSettingsFileStoreAppliesRightSidebarMaxWidthSetting() throws {
+    @Test
+    func settingsFileStoreAppliesRightSidebarMaxWidthSetting() throws {
         let defaults = UserDefaults.standard
         let managedKey = RightSidebarWidthSettings.maxWidthKey
         let previousValues = [
@@ -186,14 +189,15 @@ final class SidebarWidthPolicyTests: XCTestCase {
             startWatching: false
         )
 
-        XCTAssertEqual(defaults.double(forKey: managedKey), 900, accuracy: 0.001)
-        let configuredMaximumWidth = try XCTUnwrap(
+        #expect(abs(defaults.double(forKey: managedKey) - 900) <= 0.001)
+        let configuredMaximumWidth = try #require(
             RightSidebarWidthSettings().configuredMaximumWidth(from: defaults.double(forKey: managedKey))
         )
-        XCTAssertEqual(configuredMaximumWidth, 900, accuracy: 0.001)
+        #expect(abs(configuredMaximumWidth - 900) <= 0.001)
     }
 
-    func testSettingsFileStoreClampsRightSidebarMaxWidthSetting() throws {
+    @Test
+    func settingsFileStoreClampsRightSidebarMaxWidthSetting() throws {
         let defaults = UserDefaults.standard
         let managedKey = RightSidebarWidthSettings.maxWidthKey
         let previousValues = [
@@ -240,41 +244,80 @@ final class SidebarWidthPolicyTests: XCTestCase {
             startWatching: false
         )
 
-        XCTAssertEqual(
-            defaults.double(forKey: managedKey),
-            RightSidebarWidthSettings.settingsEditorMaximumWidth,
-            accuracy: 0.001
+        #expect(
+            abs(
+                defaults.double(forKey: managedKey)
+                    - RightSidebarWidthSettings.settingsEditorMaximumWidth
+            ) <= 0.001
         )
-        let configuredMaximumWidth = try XCTUnwrap(
+        let configuredMaximumWidth = try #require(
             RightSidebarWidthSettings().configuredMaximumWidth(from: defaults.double(forKey: managedKey))
         )
-        XCTAssertEqual(
-            configuredMaximumWidth,
-            RightSidebarWidthSettings.settingsEditorMaximumWidth,
-            accuracy: 0.001
+        #expect(
+            abs(configuredMaximumWidth - RightSidebarWidthSettings.settingsEditorMaximumWidth) <= 0.001
         )
     }
 
-    func testLeadingSidebarResizeRangeFavorsSidebarSide() {
+    @Test
+    func leadingSidebarResizeRangeFavorsSidebarSide() {
         let range = SidebarResizeInteraction.Edge.leading.hitRange(dividerX: 200)
 
-        XCTAssertEqual(range.lowerBound, 194, accuracy: 0.001)
-        XCTAssertEqual(range.upperBound, 204, accuracy: 0.001)
-        XCTAssertTrue(range.contains(196))
-        XCTAssertTrue(range.contains(202))
-        XCTAssertFalse(range.contains(193.9))
-        XCTAssertFalse(range.contains(204.1))
+        #expect(abs(range.lowerBound - 194) <= 0.001)
+        #expect(abs(range.upperBound - 204) <= 0.001)
+        #expect(range.contains(196))
+        #expect(range.contains(202))
+        #expect(!range.contains(193.9))
+        #expect(!range.contains(204.1))
     }
 
-    func testTrailingSidebarResizeRangeFavorsSidebarSide() {
+    @Test
+    func trailingSidebarResizeRangeFavorsSidebarSide() {
         let range = SidebarResizeInteraction.Edge.trailing.hitRange(dividerX: 680)
 
-        XCTAssertEqual(range.lowerBound, 676, accuracy: 0.001)
-        XCTAssertEqual(range.upperBound, 686, accuracy: 0.001)
-        XCTAssertTrue(range.contains(678))
-        XCTAssertTrue(range.contains(684))
-        XCTAssertFalse(range.contains(675.9))
-        XCTAssertFalse(range.contains(686.1))
+        #expect(abs(range.lowerBound - 676) <= 0.001)
+        #expect(abs(range.upperBound - 686) <= 0.001)
+        #expect(range.contains(678))
+        #expect(range.contains(684))
+        #expect(!range.contains(675.9))
+        #expect(!range.contains(686.1))
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct SidebarWidthWindowCreationTests {
+    @Test func newWindowUsesConfiguredMinimumWhenNoWidthWasPersisted() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            _ = NSApplication.shared
+            let defaults = UserDefaults.standard
+            let key = SessionPersistencePolicy.sidebarMinimumWidthKey
+            let savedValue = defaults.object(forKey: key)
+            let previousAppDelegate = AppDelegate.shared
+
+            defaults.set(160.0, forKey: key)
+            let appDelegate = AppDelegate()
+            AppDelegate.shared = appDelegate
+            var windowId: UUID?
+            defer {
+                if let windowId {
+                    _ = appDelegate.closeMainWindow(windowId: windowId, recordHistory: false)
+                }
+                if let savedValue {
+                    defaults.set(savedValue, forKey: key)
+                } else {
+                    defaults.removeObject(forKey: key)
+                }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let createdWindowId = appDelegate.createMainWindow(shouldActivate: false)
+            windowId = createdWindowId
+            let context = try #require(
+                appDelegate.mainWindowContexts.values.first { $0.windowId == createdWindowId }
+            )
+
+            #expect(context.sidebarState.persistedWidth == 160)
+        }
     }
 }
 
@@ -338,8 +381,10 @@ struct AppWebThemeContrastTests {
     }
 }
 
-final class SidebarWorkspaceSelectionColorTests: XCTestCase {
-    func testSelectedColoredWorkspaceUsesStandardSelectionBackgroundInLightAndDark() {
+@Suite
+struct SidebarWorkspaceSelectionColorTests {
+    @Test
+    func selectedColoredWorkspaceUsesStandardSelectionBackgroundInLightAndDark() {
         for colorScheme in [ColorScheme.light, .dark] {
             let coloredSelected = sidebarWorkspaceRowBackgroundStyle(
                 activeTabIndicatorStyle: .solidFill,
@@ -358,8 +403,8 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
                 sidebarSelectionColorHex: nil
             )
 
-            XCTAssertEqual(coloredSelected.opacity, standardSelected.opacity, accuracy: 0.001)
-            XCTAssertEqual(coloredSelected.opacity, 1, accuracy: 0.001)
+            #expect(abs(coloredSelected.opacity - standardSelected.opacity) <= 0.001)
+            #expect(abs(coloredSelected.opacity - 1) <= 0.001)
             assertColor(coloredSelected.color, equals: standardSelected.color)
 
             let unselectedColored = sidebarWorkspaceRowBackgroundStyle(
@@ -370,15 +415,16 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
                 colorScheme: colorScheme,
                 sidebarSelectionColorHex: nil
             )
-            XCTAssertEqual(unselectedColored.opacity, 0.7, accuracy: 0.001)
-            XCTAssertFalse(
-                colorsAreEqual(coloredSelected.color, unselectedColored.color),
+            #expect(abs(unselectedColored.opacity - 0.7) <= 0.001)
+            #expect(
+                !colorsAreEqual(coloredSelected.color, unselectedColored.color),
                 "Selected row should use the standard selection background, not the workspace tab color"
             )
         }
     }
 
-    func testSelectedColoredWorkspaceUsesConfiguredSelectionBackground() {
+    @Test
+    func selectedColoredWorkspaceUsesConfiguredSelectionBackground() {
         let selectionHex = "#123456"
         let coloredSelected = sidebarWorkspaceRowBackgroundStyle(
             activeTabIndicatorStyle: .solidFill,
@@ -397,41 +443,38 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
             sidebarSelectionColorHex: selectionHex
         )
 
-        XCTAssertEqual(coloredSelected.opacity, 1, accuracy: 0.001)
+        #expect(abs(coloredSelected.opacity - 1) <= 0.001)
         assertColor(coloredSelected.color, equals: standardSelected.color)
         assertColor(coloredSelected.color, equals: NSColor(hex: selectionHex))
     }
 
-    func testDefaultSelectedForegroundFallsBackForPaleSelectionBackground() throws {
-        let background = try XCTUnwrap(NSColor(hex: "#F7F7F7"))
+    @Test
+    func defaultSelectedForegroundFallsBackForPaleSelectionBackground() throws {
+        let background = try #require(NSColor(hex: "#F7F7F7"))
         let foreground = sidebarSelectedWorkspaceForegroundNSColor(
             on: background,
             opacity: 1.0
         )
 
         assertColor(foreground, equals: .black)
-        XCTAssertGreaterThanOrEqual(
-            cmuxContrastRatio(foreground: foreground, background: background),
-            4.5
-        )
+        #expect(cmuxContrastRatio(foreground: foreground, background: background) >= 4.5)
     }
 
-    func testSelectedForegroundPrefersWhiteForSaturatedSelectionBackground() throws {
-        let background = try XCTUnwrap(NSColor(hex: "#0088FF"))
+    @Test
+    func selectedForegroundPrefersWhiteForSaturatedSelectionBackground() throws {
+        let background = try #require(NSColor(hex: "#0088FF"))
         let foreground = sidebarSelectedWorkspaceForegroundNSColor(
             on: background,
             opacity: 1.0
         )
 
         assertColor(foreground, equals: .white)
-        XCTAssertGreaterThanOrEqual(
-            cmuxContrastRatio(foreground: foreground, background: background),
-            3.0
-        )
+        #expect(cmuxContrastRatio(foreground: foreground, background: background) >= 3.0)
     }
 
-    func testSelectedForegroundKeepsWhiteForStandardInactiveSelectionBlue() throws {
-        let background = try XCTUnwrap(NSColor(hex: "#6795F5"))
+    @Test
+    func selectedForegroundKeepsWhiteForStandardInactiveSelectionBlue() throws {
+        let background = try #require(NSColor(hex: "#6795F5"))
         let foreground = sidebarSelectedWorkspaceForegroundNSColor(
             on: background,
             opacity: 0.75
@@ -440,8 +483,9 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
         assertColor(foreground, equals: NSColor.white.withAlphaComponent(0.75))
     }
 
-    func testTitlebarControlForegroundContrastsWithLightTerminalBackground() throws {
-        let background = try XCTUnwrap(NSColor(hex: "#F7F7F7"))
+    @Test
+    func titlebarControlForegroundContrastsWithLightTerminalBackground() throws {
+        let background = try #require(NSColor(hex: "#F7F7F7"))
         let snapshot = makeWindowAppearanceSnapshot(background: background)
         let foreground = titlebarControlForegroundNSColor(
             opacity: 1.0,
@@ -449,32 +493,27 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
         )
 
         assertColor(foreground, equals: .black)
-        XCTAssertGreaterThanOrEqual(
+        #expect(
             cmuxContrastRatio(
                 foreground: foreground,
                 background: snapshot.compositedTerminalBackgroundColor
-            ),
-            4.5
+            ) >= 4.5
         )
     }
 
     private func assertColor(
         _ actual: NSColor?,
         equals expected: NSColor?,
-        file: StaticString = #filePath,
-        line: UInt = #line
     ) {
         guard let actual, let expected else {
-            XCTAssertNotNil(actual, file: file, line: line)
-            XCTAssertNotNil(expected, file: file, line: line)
+            #expect(actual != nil)
+            #expect(expected != nil)
             return
         }
 
-        XCTAssertTrue(
+        #expect(
             colorsAreEqual(actual, expected),
-            "Expected \(colorDescription(actual)) to equal \(colorDescription(expected))",
-            file: file,
-            line: line
+            "Expected \(colorDescription(actual)) to equal \(colorDescription(expected))"
         )
     }
 
@@ -513,7 +552,8 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
             return lhs == nil && rhs == nil
         }
         guard let lhsRGB = lhs.usingColorSpace(.sRGB),
-              let rhsRGB = rhs.usingColorSpace(.sRGB) else {
+            let rhsRGB = rhs.usingColorSpace(.sRGB)
+        else {
             return false
         }
 
@@ -528,10 +568,8 @@ final class SidebarWorkspaceSelectionColorTests: XCTestCase {
         lhsRGB.getRed(&lhsRed, green: &lhsGreen, blue: &lhsBlue, alpha: &lhsAlpha)
         rhsRGB.getRed(&rhsRed, green: &rhsGreen, blue: &rhsBlue, alpha: &rhsAlpha)
 
-        return abs(lhsRed - rhsRed) <= 0.001 &&
-            abs(lhsGreen - rhsGreen) <= 0.001 &&
-            abs(lhsBlue - rhsBlue) <= 0.001 &&
-            abs(lhsAlpha - rhsAlpha) <= 0.001
+        return abs(lhsRed - rhsRed) <= 0.001 && abs(lhsGreen - rhsGreen) <= 0.001
+            && abs(lhsBlue - rhsBlue) <= 0.001 && abs(lhsAlpha - rhsAlpha) <= 0.001
     }
 
     private func colorDescription(_ color: NSColor) -> String {


### PR DESCRIPTION
## Summary

New windows now honor the configured minimum sidebar width when no sidebar width is persisted. Explicit persisted widths still use the existing clamp policy.

## Verification

- git diff --check
- ./scripts/lint-pbxproj-test-wiring.sh
- python3 scripts/check-package-resolved-policy.py
- swiftc -parse Sources/SessionPersistence.swift Sources/AppDelegate.swift cmuxTests/SidebarWidthPolicyTests.swift

The history is test-first: the first commit adds behavior coverage, and the second commit applies the fix. Replaces #11111 after rebasing onto 5a453950ea.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
New windows now honor the configured minimum sidebar width when no width was persisted. Previously they fell back to the default sidebar width; explicit persisted widths still use the existing clamp policy.

- New-window creation now goes through `sanitizedSidebarWidth`, whose fallback is the configured minimum capped at the maximum width.
- Adds tests for new-window creation with a configured minimum and for the fallback cap.
- Converts `SidebarWidthPolicyTests` and `SidebarWorkspaceSelectionColorTests` from XCTest to Swift Testing.

<sup>Written for commit 76f7e7d30c5c3b99ba68efffe715a5ceec68d839. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11539?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar width restoration when no valid saved width is available.
  - Ensured restored and newly opened windows respect the configured minimum and maximum sidebar width limits.
  - Prevented sidebar sizing from exceeding the maximum width or falling below the minimum configured width.
- **Quality Improvements**
  - Expanded coverage for sidebar resizing, width limits, and new-window behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->