### PR TITLE
ci: require a route-aware aggregate status

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,12 @@
 # That branch-protection change is the actual gate; this file makes it effective
 # and documents ownership in the meantime.
 
-# All GitHub Actions workflows (all can access secrets).
-/.github/workflows/                     @lawrencecchen
+# The CI router and its required-check validator can change which jobs run.
+# Two trusted maintainers own these files. Branch protection must require an
+# approving code-owner review before the policy is activated.
+/.github/workflows/**                    @austinywang @azooz2003-bit
+/scripts/ci/**                           @austinywang @azooz2003-bit
+/.github/CODEOWNERS                      @austinywang @azooz2003-bit
 
 # iOS TestFlight publish path + App Store Connect config.
 /ios/scripts/upload-testflight.sh       @lawrencecchen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ on:
       - tests/test_cla_rerun_workflow.sh
       - tests/test_cla_lock_workflow.sh
       - tests/test_cla_trigger_gate.sh
+      - tests/test_ci_status.py
   workflow_dispatch:
 
 permissions:
@@ -324,6 +325,9 @@ jobs:
 
       - name: Validate CI change area filter
         run: python3 tests/test_ci_change_areas.py
+
+      - name: Validate CI status contract
+        run: python3 tests/test_ci_status.py
 
       - name: Validate release attestation retry guard
         run: ./tests/test_ci_attestation_retry.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,9 @@ jobs:
       - name: Validate CI status contract
         run: python3 tests/test_ci_status.py
 
+      - name: Validate CI governance contract
+        run: python3 tests/test_ci_governance.py
+
       - name: Validate release attestation retry guard
         run: ./tests/test_ci_attestation_retry.sh
 
@@ -1823,17 +1826,39 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout CI contract
+      # This job is a required gate. Never execute its validator from the PR
+      # checkout, because a PR can change that file. The base commit is the
+      # trusted revision until the PR merges.
+      - name: Checkout trusted CI contract
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: .ci-trusted
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Verify trusted CI contract revision
+        env:
+          TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ${#TRUSTED_SHA} -ne 40 || "$TRUSTED_SHA" =~ [^0-9a-f] ]]; then
+            echo "::error::Trusted CI contract SHA is not a full commit SHA" >&2
+            exit 1
+          fi
+          actual_sha="$(git -C .ci-trusted rev-parse --verify 'HEAD^{commit}')"
+          if [[ "$actual_sha" != "$TRUSTED_SHA" ]]; then
+            echo "::error::Trusted CI contract checkout does not match $TRUSTED_SHA (got $actual_sha)" >&2
+            exit 1
+          fi
+          test -f .ci-trusted/scripts/ci/check_ci_status.py
 
       - name: Check cheap CI layer before macOS runners
         env:
           CI_NEEDS: ${{ toJSON(needs) }}
         run: |
-          python3 scripts/ci/check_ci_status.py --phase preflight
+          python3 .ci-trusted/scripts/ci/check_ci_status.py --phase preflight
 
   tests-build-and-lag:
     needs:
@@ -2376,14 +2401,36 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout CI contract
+      # This job is a required gate. Never execute its validator from the PR
+      # checkout, because a PR can change that file. The base commit is the
+      # trusted revision until the PR merges.
+      - name: Checkout trusted CI contract
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: .ci-trusted
           fetch-depth: 1
           persist-credentials: false
+
+      - name: Verify trusted CI contract revision
+        env:
+          TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ${#TRUSTED_SHA} -ne 40 || "$TRUSTED_SHA" =~ [^0-9a-f] ]]; then
+            echo "::error::Trusted CI contract SHA is not a full commit SHA" >&2
+            exit 1
+          fi
+          actual_sha="$(git -C .ci-trusted rev-parse --verify 'HEAD^{commit}')"
+          if [[ "$actual_sha" != "$TRUSTED_SHA" ]]; then
+            echo "::error::Trusted CI contract checkout does not match $TRUSTED_SHA (got $actual_sha)" >&2
+            exit 1
+          fi
+          test -f .ci-trusted/scripts/ci/check_ci_status.py
 
       - name: Check routed CI jobs
         env:
           CI_NEEDS: ${{ toJSON(needs) }}
         run: |
-          python3 scripts/ci/check_ci_status.py --phase aggregate
+          python3 .ci-trusted/scripts/ci/check_ci_status.py --phase aggregate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     # Every PR must publish the aggregate `ci-status` check. The jobs below
     # still route expensive suites by changed area, so this trigger avoids a
     # permanently pending required check without running every suite twice.
-    types: [opened, reopened, synchronize, ready_for_review]
+    types: [opened, edited, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,11 @@
 name: CI
 
 on:
-  # Keep the full suite available for explicit validation, while always
-  # running the lightweight GhosttyKit provenance check when its pointer,
-  # checksum, or helper changes in a PR.
   pull_request:
-    paths:
-      - ghostty
-      - scripts/download-prebuilt-ghosttykit.sh
-      - scripts/validate-xcframework-archive.py
-      - scripts/ghosttykit-checksums.txt
-      - tests/test_ci_ghosttykit_release_check.sh
-      - tests/test_ci_change_areas.py
-      - .github/workflows/cla.yml
-      - .github/workflows/ci.yml
-      - .github/scripts/rerun-failed-cla.sh
-      - tests/test_cla_rerun_workflow.sh
-      - tests/test_cla_lock_workflow.sh
-      - tests/test_cla_trigger_gate.sh
-      - tests/test_ci_status.py
+    # Every PR must publish the aggregate `ci-status` check. The jobs below
+    # still route expensive suites by changed area, so this trigger avoids a
+    # permanently pending required check without running every suite twice.
+    types: [opened, reopened, synchronize, ready_for_review]
   workflow_dispatch:
 
 permissions:
@@ -400,8 +387,8 @@ jobs:
     name: GhosttyKit release check
     permissions:
       contents: read
-    # The pull_request trigger is path-scoped to GhosttyKit provenance inputs;
-    # workflow_dispatch keeps the same guard available for explicit CI runs.
+    # This guard runs for every pull request and remains available through
+    # workflow_dispatch for explicit validation.
     if: ${{ github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' }}
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
@@ -1833,66 +1820,20 @@ jobs:
     if: ${{ always() }}
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 5
+    permissions:
+      contents: read
     steps:
+      - name: Checkout CI contract
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Check cheap CI layer before macOS runners
         env:
-          PREFLIGHT_NEEDS: ${{ toJSON(needs) }}
+          CI_NEEDS: ${{ toJSON(needs) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          needs = json.loads(os.environ["PREFLIGHT_NEEDS"])
-          required = ("changes", "workflow-guard-tests", "ghosttykit-release-check")
-          allowed_routed = {
-              "remote-daemon-tests",
-              "web-typecheck",
-              "react-apps-check",
-              "diff-sidecar-check",
-              "web-db-migrations",
-              "agent-session-web-resources",
-          }
-
-          bad = {}
-          for name in required:
-              result = needs[name]["result"]
-              if result != "success":
-                  bad[name] = result
-
-          outputs = needs["changes"].get("outputs", {})
-          routed_outputs = {
-              "remote-daemon-tests": "go",
-              "web-typecheck": "web",
-              "react-apps-check": "web",
-              "diff-sidecar-check": "macos",
-              "web-db-migrations": "web",
-              "agent-session-web-resources": "agent_session_web",
-          }
-          for name in sorted(allowed_routed):
-              result = needs[name]["result"]
-              route = routed_outputs[name]
-              if outputs.get(route) == "true":
-                  if result != "success":
-                      bad[name] = f"{result} (route {route}=true)"
-              elif result not in {"success", "skipped"}:
-                  bad[name] = result
-
-          if bad:
-              for name, result in bad.items():
-                  print(f"{name}: {result}", file=sys.stderr)
-              sys.exit(1)
-
-          print(
-              "routes: "
-              f"macos={outputs.get('macos')} "
-              f"web={outputs.get('web')} "
-              f"go={outputs.get('go')} "
-              f"agent_session_web={outputs.get('agent_session_web')}"
-          )
-          for name, data in sorted(needs.items()):
-              print(f"{name}: {data['result']}")
-          PY
+          python3 scripts/ci/check_ci_status.py --phase preflight
 
   tests-build-and-lag:
     needs:
@@ -2432,29 +2373,17 @@ jobs:
       - release-build
     if: ${{ always() }}
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    permissions:
+      contents: read
     steps:
+      - name: Checkout CI contract
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
       - name: Check routed CI jobs
         env:
           CI_NEEDS: ${{ toJSON(needs) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          needs = json.loads(os.environ["CI_NEEDS"])
-          allowed = {"success", "skipped"}
-          bad = {
-              name: data["result"]
-              for name, data in sorted(needs.items())
-              if data["result"] not in allowed
-          }
-
-          if bad:
-              for name, result in bad.items():
-                  print(f"{name}: {result}", file=sys.stderr)
-              sys.exit(1)
-
-          for name, data in sorted(needs.items()):
-              print(f"{name}: {data['result']}")
-          PY
+          python3 scripts/ci/check_ci_status.py --phase aggregate

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -1,0 +1,46 @@
+# Required CI checks
+
+The `ci-status` job is the single required status for pull requests. It reads
+the results of the routed jobs and fails when a selected route is skipped or
+fails. Its check is produced by GitHub Actions app `15368`.
+
+## Trust boundary
+
+`ci-status` and `linux-preflight` check out the pull request base commit into
+`.ci-trusted`, verify that the checkout has the exact base SHA, and execute
+`scripts/ci/check_ci_status.py` from that checkout. This keeps the validator
+fixed while a pull request is under review. The `/.github/workflows/**` and
+`/scripts/ci/**` patterns in `.github/CODEOWNERS` are owned by
+`@austinywang` and `@azooz2003-bit`.
+
+Before making `ci-status` required, the `main` branch ruleset must set
+`require_code_owner_review=true` and require at least one approving review
+(`required_approving_review_count >= 1`). The ruleset must require the exact
+`ci-status` context from Actions app `15368`, with no bypass actor. CODEOWNERS
+declares who may approve policy changes; only the branch ruleset enforces that
+review requirement.
+
+## Rollout
+
+1. Merge the workflow, validator, tests, and CODEOWNERS change.
+2. Wait for a pull request run to publish `ci-status` for each route. Include
+   docs-only, macOS, web, Go, agent-session, and workflow changes in the canary
+   set.
+3. Confirm the `main` ruleset has code-owner review enabled, one approving
+   review, strict required checks, and no bypass for `ci-status`.
+4. Add a separate active ruleset for `refs/heads/main` with the required
+   `ci-status` context and Actions app ID `15368`. This GitHub administration
+   step is separate from this source change.
+5. Verify a new pull request cannot merge when `ci-status` is missing, skipped,
+   or failed, and that an unrelated route may still skip its expensive jobs.
+
+The first rollout has a bootstrap dependency: the trusted base commit must
+contain `scripts/ci/check_ci_status.py`. Merge this source change before
+activating the required-check ruleset, or stage the validator in an earlier
+trusted commit. Activating the ruleset before that commit exists would make
+every pull request fail closed.
+
+To roll back, disable or remove only the new `ci-status` ruleset, keep the
+workflow and CODEOWNERS files, and investigate the failed contract. Do not
+restore a path-filtered pull-request trigger, because GitHub then leaves a
+required check pending for paths that do not match the filter.

--- a/scripts/ci/check_ci_status.py
+++ b/scripts/ci/check_ci_status.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Validate the route-aware CI status contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+
+ROUTE_NAMES = ("macos", "web", "go", "agent_session_web")
+
+# A job can be selected by more than one route. In particular, the diff
+# sidecar checks both macOS and web changes.
+ROUTE_JOBS: dict[str, tuple[str, ...]] = {
+    "app-host-unit-tests": ("macos",),
+    "tests-build-and-lag": ("macos",),
+    "swift-package-tests": ("macos",),
+    "release-build": ("macos",),
+    "web-typecheck": ("web",),
+    "react-apps-check": ("web",),
+    "diff-sidecar-check": ("macos", "web"),
+    "web-db-migrations": ("web",),
+    "remote-daemon-tests": ("go",),
+    "agent-session-web-resources": ("agent_session_web",),
+}
+
+COMMON_REQUIRED = (
+    "changes",
+    "workflow-guard-tests",
+    "ghosttykit-release-check",
+)
+
+ALWAYS_REQUIRED = COMMON_REQUIRED + (
+    "linux-preflight",
+    "tests",
+)
+
+PREFLIGHT_REQUIRED = COMMON_REQUIRED
+
+PREFLIGHT_ROUTE_JOBS = (
+    "remote-daemon-tests",
+    "web-typecheck",
+    "react-apps-check",
+    "diff-sidecar-check",
+    "web-db-migrations",
+    "agent-session-web-resources",
+)
+
+AGGREGATE_ROUTE_JOBS = tuple(ROUTE_JOBS)
+
+PHASE_CONTRACTS = {
+    "preflight": (PREFLIGHT_REQUIRED, PREFLIGHT_ROUTE_JOBS),
+    "aggregate": (ALWAYS_REQUIRED, AGGREGATE_ROUTE_JOBS),
+}
+
+
+def _job_result(needs: Mapping[str, Any], name: str, failures: list[str]) -> str | None:
+    value = needs.get(name)
+    if not isinstance(value, Mapping):
+        failures.append(f"{name}: missing job result")
+        return None
+    result = value.get("result")
+    if not isinstance(result, str):
+        failures.append(f"{name}: missing job result")
+        return None
+    return result
+
+
+def _route_outputs(needs: Mapping[str, Any], failures: list[str]) -> Mapping[str, Any]:
+    changes = needs.get("changes")
+    if not isinstance(changes, Mapping):
+        failures.append("changes: missing job result")
+        return {}
+    outputs = changes.get("outputs")
+    if not isinstance(outputs, Mapping):
+        failures.append("changes: missing route outputs")
+        return {}
+    for route in ROUTE_NAMES:
+        if outputs.get(route) not in {"true", "false"}:
+            failures.append(f"changes.outputs.{route}: expected true or false")
+    return outputs
+
+
+def _expected_jobs(phase: str) -> tuple[str, ...]:
+    required, route_jobs = PHASE_CONTRACTS[phase]
+    return required + route_jobs
+
+
+def _validate_job_set(
+    needs: Mapping[str, Any], expected: set[str], failures: list[str]
+) -> None:
+    for name in sorted(expected - set(needs)):
+        failures.append(f"{name}: missing job result")
+    for name in sorted(set(needs) - expected):
+        failures.append(f"{name}: unexpected job in CI contract")
+
+
+def _validate_required_jobs(
+    needs: Mapping[str, Any], names: tuple[str, ...], failures: list[str]
+) -> None:
+    for name in names:
+        result = _job_result(needs, name, failures)
+        if result is not None and result != "success":
+            failures.append(f"{name}: expected success, got {result}")
+
+
+def _validate_route_jobs(
+    needs: Mapping[str, Any],
+    outputs: Mapping[str, Any],
+    names: tuple[str, ...],
+    failures: list[str],
+) -> None:
+    for name in names:
+        result = _job_result(needs, name, failures)
+        if result is None:
+            continue
+        routes = ROUTE_JOBS[name]
+        selected = any(outputs.get(route) == "true" for route in routes)
+        if selected and result != "success":
+            route_label = " or ".join(routes)
+            failures.append(f"{name}: required for route {route_label}, got {result}")
+        elif not selected and result not in {"success", "skipped"}:
+            failures.append(f"{name}: unexpected result for inactive route, got {result}")
+
+
+def validate_needs(needs: Mapping[str, Any], *, phase: str = "aggregate") -> list[str]:
+    """Return contract violations for a serialized GitHub ``needs`` object."""
+
+    if phase not in {"preflight", "aggregate"}:
+        raise ValueError(f"unsupported phase: {phase}")
+    failures: list[str] = []
+
+    if not isinstance(needs, Mapping):
+        return ["needs: expected an object"]
+
+    required, route_jobs = PHASE_CONTRACTS[phase]
+    expected_set = set(_expected_jobs(phase))
+    _validate_job_set(needs, expected_set, failures)
+
+    outputs = _route_outputs(needs, failures)
+    _validate_required_jobs(needs, required, failures)
+    _validate_route_jobs(needs, outputs, route_jobs, failures)
+
+    return failures
+
+
+def _load_needs(raw: str | None) -> Mapping[str, Any]:
+    if not raw:
+        raise ValueError("CI_NEEDS is empty")
+    value = json.loads(raw)
+    if not isinstance(value, Mapping):
+        raise ValueError("CI_NEEDS must be a JSON object")
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--phase",
+        choices=("preflight", "aggregate"),
+        default="aggregate",
+        help="Which CI dependency set to validate.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        needs = _load_needs(os.environ.get("CI_NEEDS"))
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"CI status contract input error: {error}", file=sys.stderr)
+        return 2
+
+    failures = validate_needs(needs, phase=args.phase)
+    if failures:
+        print(f"CI status contract failed ({args.phase}):", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print(f"CI status contract passed ({args.phase}).")
+    for name in sorted(needs):
+        result = needs[name].get("result") if isinstance(needs[name], Mapping) else None
+        print(f"{name}: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -223,14 +224,18 @@ def workflow_job_step_script(job_name: str, step_name: str, workflow_path: Path 
 def run_linux_preflight(needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
     script = workflow_job_step_script("linux-preflight", "Check cheap CI layer before macOS runners")
     env = {**os.environ, "CI_NEEDS": json.dumps(needs)}
-    return subprocess.run(
-        ["bash", "-c", script],
-        cwd=ROOT,
-        env=env,
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trusted_helper = Path(temp_dir) / ".ci-trusted" / "scripts" / "ci" / "check_ci_status.py"
+        trusted_helper.parent.mkdir(parents=True)
+        shutil.copy2(ROOT / "scripts" / "ci" / "check_ci_status.py", trusted_helper)
+        return subprocess.run(
+            ["bash", "-c", script],
+            cwd=temp_dir,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
 
 def run_app_host_unit_test_step(
@@ -710,7 +715,7 @@ def test_ci_status_job_wires_route_contract() -> None:
     assert "if: ${{ always() }}" in block
     assert "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" in block
     assert "persist-credentials: false" in block
-    assert "python3 scripts/ci/check_ci_status.py --phase aggregate" in block
+    assert "python3 .ci-trusted/scripts/ci/check_ci_status.py --phase aggregate" in block
 
 
 def test_required_tests_status_waits_for_app_host_matrix() -> None:
@@ -769,7 +774,7 @@ def test_linux_preflight_blocks_macos_on_cheap_layer_failure() -> None:
     assert "if: ${{ always() }}" in block
     assert "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" in block
     assert "CI_NEEDS: ${{ toJSON(needs) }}" in block
-    assert "python3 scripts/ci/check_ci_status.py --phase preflight" in block
+    assert "python3 .ci-trusted/scripts/ci/check_ci_status.py --phase preflight" in block
 
 
 def test_linux_preflight_fails_when_routed_job_skips() -> None:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -222,7 +222,7 @@ def workflow_job_step_script(job_name: str, step_name: str, workflow_path: Path 
 
 def run_linux_preflight(needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
     script = workflow_job_step_script("linux-preflight", "Check cheap CI layer before macOS runners")
-    env = {**os.environ, "PREFLIGHT_NEEDS": json.dumps(needs)}
+    env = {**os.environ, "CI_NEEDS": json.dumps(needs)}
     return subprocess.run(
         ["bash", "-c", script],
         cwd=ROOT,
@@ -688,7 +688,7 @@ def test_non_pr_events_run_all_areas() -> None:
     assert "Resolved areas: macos=true web=true go=true agent_session_web=true" in result.stdout
 
 
-def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
+def test_ci_status_job_wires_route_contract() -> None:
     block = workflow_job_block("ci-status")
 
     for job_name in [
@@ -708,7 +708,9 @@ def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
         assert f"      - {job_name}" in block
 
     assert "if: ${{ always() }}" in block
-    assert 'allowed = {"success", "skipped"}' in block
+    assert "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" in block
+    assert "persist-credentials: false" in block
+    assert "python3 scripts/ci/check_ci_status.py --phase aggregate" in block
 
 
 def test_required_tests_status_waits_for_app_host_matrix() -> None:
@@ -765,10 +767,9 @@ def test_linux_preflight_blocks_macos_on_cheap_layer_failure() -> None:
     assert "      - web-db-migrations" in block
     assert "      - agent-session-web-resources" in block
     assert "if: ${{ always() }}" in block
-    assert 'required = ("changes", "workflow-guard-tests", "ghosttykit-release-check")' in block
-    assert 'allowed_routed = {' in block
-    assert 'routed_outputs = {' in block
-    assert 'bad[name] = f"{result} (route {route}=true)"' in block
+    assert "uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd" in block
+    assert "CI_NEEDS: ${{ toJSON(needs) }}" in block
+    assert "python3 scripts/ci/check_ci_status.py --phase preflight" in block
 
 
 def test_linux_preflight_fails_when_routed_job_skips() -> None:
@@ -777,7 +778,7 @@ def test_linux_preflight_fails_when_routed_job_skips() -> None:
     )
 
     assert result.returncode != 0
-    assert "remote-daemon-tests: skipped (route go=true)" in result.stderr
+    assert "remote-daemon-tests: required for route go, got skipped" in result.stderr
 
 
 def test_linux_preflight_allows_unrouted_job_skip() -> None:

--- a/tests/test_ci_governance.py
+++ b/tests/test_ci_governance.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+"""Behavioral checks for the required-CI governance contract.
+
+CODEOWNERS and the rollout document are policy inputs, so this small test
+checks their effective entries and required activation terms.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
+DOC = ROOT / "docs" / "ci-required-checks.md"
+TRUSTED_OWNERS = {"@austinywang", "@azooz2003-bit"}
+
+
+def _entries() -> dict[str, set[str]]:
+    entries: dict[str, set[str]] = {}
+    for raw_line in CODEOWNERS.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        pattern, *owners = line.split()
+        entries[pattern] = set(owners)
+    return entries
+
+
+def test_sensitive_ci_paths_have_trusted_owners() -> None:
+    entries = _entries()
+    for pattern in ("/.github/workflows/**", "/scripts/ci/**", "/.github/CODEOWNERS"):
+        assert entries.get(pattern) == TRUSTED_OWNERS, pattern
+
+
+def test_rollout_requires_code_owner_protection() -> None:
+    text = DOC.read_text(encoding="utf-8")
+    required_terms = (
+        "ci-status",
+        "15368",
+        "require_code_owner_review=true",
+        "required_approving_review_count >= 1",
+        "separate active ruleset",
+    )
+    for term in required_terms:
+        assert term in text, term
+
+
+if __name__ == "__main__":
+    test_sensitive_ci_paths_have_trusted_owners()
+    test_rollout_requires_code_owner_protection()
+    print("PASS: CI governance contract")

--- a/tests/test_ci_status.py
+++ b/tests/test_ci_status.py
@@ -8,7 +8,6 @@ import json
 import os
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 
 
@@ -112,15 +111,42 @@ def ci_needs(paths: list[str], *, results: dict[str, str] | None = None) -> dict
 
 def run_ci_status(needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
     script = workflow_job_step_script("ci-status", "Check routed CI jobs")
-    with tempfile.TemporaryDirectory() as temp_dir:
-        return subprocess.run(
-            ["bash", "-c", script],
-            cwd=ROOT,
-            env={**os.environ, "CI_NEEDS": json.dumps(needs)},
-            text=True,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=ROOT,
+        env={**os.environ, "CI_NEEDS": json.dumps(needs)},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def run_linux_preflight(needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    script = workflow_job_step_script("linux-preflight", "Check cheap CI layer before macOS runners")
+    return subprocess.run(
+        ["bash", "-c", script],
+        cwd=ROOT,
+        env={**os.environ, "CI_NEEDS": json.dumps(needs)},
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+
+
+def preflight_needs(paths: list[str], *, results: dict[str, str] | None = None) -> dict[str, object]:
+    all_needs = ci_needs(paths, results=results)
+    names = (
+        "changes",
+        "workflow-guard-tests",
+        "ghosttykit-release-check",
+        "remote-daemon-tests",
+        "web-typecheck",
+        "react-apps-check",
+        "diff-sidecar-check",
+        "web-db-migrations",
+        "agent-session-web-resources",
+    )
+    return {name: all_needs[name] for name in names}
 
 
 def test_docs_only_contract_passes() -> None:
@@ -175,6 +201,30 @@ def test_unexpected_failure_blocks_even_when_route_is_off() -> None:
         ci_needs(["docs/ci.md"], results={"remote-daemon-tests": "failure"})
     )
     assert result.returncode != 0
+
+
+def test_web_route_requires_diff_sidecar_in_preflight() -> None:
+    result = run_linux_preflight(
+        preflight_needs(["web/app/page.tsx"], results={"diff-sidecar-check": "skipped"})
+    )
+    assert result.returncode != 0
+    assert "diff-sidecar-check: required for route macos or web" in result.stderr
+
+
+def test_missing_route_output_fails_closed() -> None:
+    needs = ci_needs(["docs/ci.md"])
+    del needs["changes"]["outputs"]["web"]
+    result = run_ci_status(needs)
+    assert result.returncode != 0
+    assert "changes.outputs.web: expected true or false" in result.stderr
+
+
+def test_unexpected_dependency_fails_closed() -> None:
+    needs = ci_needs(["docs/ci.md"])
+    needs["new-ci-job"] = {"result": "success"}
+    result = run_ci_status(needs)
+    assert result.returncode != 0
+    assert "new-ci-job: unexpected job in CI contract" in result.stderr
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_status.py
+++ b/tests/test_ci_status.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Behavioral tests for the CI aggregate status contract."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+AREA_HELPER = ROOT / "scripts" / "ci" / "detect_ci_change_areas.py"
+
+spec = importlib.util.spec_from_file_location("detect_ci_change_areas", AREA_HELPER)
+assert spec and spec.loader
+areas_module = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = areas_module
+spec.loader.exec_module(areas_module)
+
+
+ROUTE_JOBS = {
+    "macos": (
+        "app-host-unit-tests",
+        "tests-build-and-lag",
+        "swift-package-tests",
+        "release-build",
+    ),
+    "web": (
+        "web-typecheck",
+        "react-apps-check",
+        "diff-sidecar-check",
+        "web-db-migrations",
+    ),
+    "go": ("remote-daemon-tests",),
+    "agent_session_web": ("agent-session-web-resources",),
+}
+
+ALWAYS_REQUIRED = (
+    "changes",
+    "workflow-guard-tests",
+    "ghosttykit-release-check",
+    "linux-preflight",
+    "tests",
+)
+
+
+def workflow_job_step_script(job_name: str, step_name: str) -> str:
+    lines = CI_WORKFLOW.read_text(encoding="utf-8").splitlines()
+    job_marker = f"  {job_name}:"
+    step_marker = f"      - name: {step_name}"
+    in_job = False
+    for index, line in enumerate(lines):
+        if line == job_marker:
+            in_job = True
+            continue
+        if in_job and line.startswith("  ") and not line.startswith("    ") and line.strip():
+            break
+        if in_job and line == step_marker:
+            for run_index in range(index + 1, len(lines)):
+                if lines[run_index] == "        run: |":
+                    body: list[str] = []
+                    for body_line in lines[run_index + 1 :]:
+                        if body_line.startswith("          "):
+                            body.append(body_line[10:])
+                            continue
+                        if not body_line.strip():
+                            body.append("")
+                            continue
+                        break
+                    return "\n".join(body)
+            break
+    raise AssertionError(f"{step_name} run block not found in {job_name}")
+
+
+def _route_outputs(paths: list[str]) -> dict[str, str]:
+    areas = areas_module.classify_files(paths)
+    return {
+        "macos": "true" if areas.macos else "false",
+        "web": "true" if areas.web else "false",
+        "go": "true" if areas.go else "false",
+        "agent_session_web": "true" if areas.agent_session_web else "false",
+    }
+
+
+def _job_routes() -> dict[str, tuple[str, ...]]:
+    return {
+        job: routes
+        for route, jobs in ROUTE_JOBS.items()
+        for job in jobs
+        for routes in [(route,)]
+    } | {"diff-sidecar-check": ("macos", "web")}
+
+
+def ci_needs(paths: list[str], *, results: dict[str, str] | None = None) -> dict[str, object]:
+    outputs = _route_outputs(paths)
+    job_routes = _job_routes()
+    statuses = {name: "success" for name in ALWAYS_REQUIRED}
+    for job, routes in job_routes.items():
+        statuses[job] = "success" if any(outputs[route] == "true" for route in routes) else "skipped"
+    if results:
+        statuses.update(results)
+    return {
+        name: {"result": result, "outputs": outputs if name == "changes" else {}}
+        for name, result in statuses.items()
+    }
+
+
+def run_ci_status(needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    script = workflow_job_step_script("ci-status", "Check routed CI jobs")
+    with tempfile.TemporaryDirectory() as temp_dir:
+        return subprocess.run(
+            ["bash", "-c", script],
+            cwd=ROOT,
+            env={**os.environ, "CI_NEEDS": json.dumps(needs)},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+
+def test_docs_only_contract_passes() -> None:
+    result = run_ci_status(ci_needs(["docs/ci.md", "README.md"]))
+    assert result.returncode == 0, result.stderr
+
+
+def test_macos_contract_passes() -> None:
+    result = run_ci_status(ci_needs(["Sources/AppDelegate.swift"]))
+    assert result.returncode == 0, result.stderr
+
+
+def test_web_contract_passes_and_runs_diff_sidecar() -> None:
+    needs = ci_needs(["web/app/page.tsx"])
+    assert needs["diff-sidecar-check"]["result"] == "success"
+    result = run_ci_status(needs)
+    assert result.returncode == 0, result.stderr
+
+
+def test_go_contract_passes() -> None:
+    result = run_ci_status(ci_needs(["daemon/remote/main.go"]))
+    assert result.returncode == 0, result.stderr
+
+
+def test_agent_session_contract_passes() -> None:
+    result = run_ci_status(ci_needs(["Resources/agent-session-react/index.js"]))
+    assert result.returncode == 0, result.stderr
+
+
+def test_workflow_contract_runs_every_area() -> None:
+    needs = ci_needs([".github/workflows/ci.yml"])
+    assert all(data["result"] == "success" for name, data in needs.items() if name != "changes")
+    result = run_ci_status(needs)
+    assert result.returncode == 0, result.stderr
+
+
+def test_required_route_cannot_be_skipped() -> None:
+    cases = {
+        "Sources/AppDelegate.swift": ROUTE_JOBS["macos"],
+        "web/app/page.tsx": ROUTE_JOBS["web"],
+        "daemon/remote/main.go": ROUTE_JOBS["go"],
+        "Resources/agent-session-react/index.js": ROUTE_JOBS["agent_session_web"],
+    }
+    for path, jobs in cases.items():
+        for job in jobs:
+            result = run_ci_status(ci_needs([path], results={job: "skipped"}))
+            assert result.returncode != 0, (path, job, result.stdout, result.stderr)
+
+
+def test_unexpected_failure_blocks_even_when_route_is_off() -> None:
+    result = run_ci_status(
+        ci_needs(["docs/ci.md"], results={"remote-daemon-tests": "failure"})
+    )
+    assert result.returncode != 0
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_") and callable(value):
+            value()
+    print("PASS: CI status contract")

--- a/tests/test_ci_status.py
+++ b/tests/test_ci_status.py
@@ -6,8 +6,10 @@ from __future__ import annotations
 import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 from pathlib import Path
 
 
@@ -111,26 +113,34 @@ def ci_needs(paths: list[str], *, results: dict[str, str] | None = None) -> dict
 
 def run_ci_status(needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
     script = workflow_job_step_script("ci-status", "Check routed CI jobs")
-    return subprocess.run(
-        ["bash", "-c", script],
-        cwd=ROOT,
-        env={**os.environ, "CI_NEEDS": json.dumps(needs)},
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trusted_helper = Path(temp_dir) / ".ci-trusted" / "scripts" / "ci" / "check_ci_status.py"
+        trusted_helper.parent.mkdir(parents=True)
+        shutil.copy2(ROOT / "scripts" / "ci" / "check_ci_status.py", trusted_helper)
+        return subprocess.run(
+            ["bash", "-c", script],
+            cwd=temp_dir,
+            env={**os.environ, "CI_NEEDS": json.dumps(needs)},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
 
 def run_linux_preflight(needs: dict[str, object]) -> subprocess.CompletedProcess[str]:
     script = workflow_job_step_script("linux-preflight", "Check cheap CI layer before macOS runners")
-    return subprocess.run(
-        ["bash", "-c", script],
-        cwd=ROOT,
-        env={**os.environ, "CI_NEEDS": json.dumps(needs)},
-        text=True,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.PIPE,
-    )
+    with tempfile.TemporaryDirectory() as temp_dir:
+        trusted_helper = Path(temp_dir) / ".ci-trusted" / "scripts" / "ci" / "check_ci_status.py"
+        trusted_helper.parent.mkdir(parents=True)
+        shutil.copy2(ROOT / "scripts" / "ci" / "check_ci_status.py", trusted_helper)
+        return subprocess.run(
+            ["bash", "-c", script],
+            cwd=temp_dir,
+            env={**os.environ, "CI_NEEDS": json.dumps(needs)},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
 
 def preflight_needs(paths: list[str], *, results: dict[str, str] | None = None) -> dict[str, object]:

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -38,7 +38,16 @@ grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
 grep -Fq 'sparse-checkout: .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
 grep -Fq 'bash .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
 grep -Fq "COMMENT_ID: \${{ github.event.comment.id }}" "$WORKFLOW"
-grep -Fq '      - .github/scripts/rerun-failed-cla.sh' "$ROOT_DIR/.github/workflows/ci.yml"
+grep -Fq 'types: [opened, reopened, synchronize, ready_for_review]' "$ROOT_DIR/.github/workflows/ci.yml"
+if awk '
+  /^  pull_request:[[:space:]]*$/ { in_pull_request=1; next }
+  in_pull_request && /^  [^[:space:]]/ { in_pull_request=0 }
+  in_pull_request && /^[[:space:]]+paths:/ { found=1 }
+  END { exit found ? 0 : 1 }
+' "$ROOT_DIR/.github/workflows/ci.yml"; then
+  echo 'CI pull_request trigger must not use a path filter' >&2
+  exit 1
+fi
 if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
   echo 'FAIL: CLA rerun checkout must never use a pull-request ref' >&2
   exit 1

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -38,7 +38,7 @@ grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
 grep -Fq 'sparse-checkout: .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
 grep -Fq 'bash .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
 grep -Fq "COMMENT_ID: \${{ github.event.comment.id }}" "$WORKFLOW"
-grep -Fq 'types: [opened, reopened, synchronize, ready_for_review]' "$ROOT_DIR/.github/workflows/ci.yml"
+grep -Fq 'types: [opened, edited, reopened, synchronize, ready_for_review]' "$ROOT_DIR/.github/workflows/ci.yml"
 if awk '
   /^  pull_request:[[:space:]]*$/ { in_pull_request=1; next }
   in_pull_request && /^  [^[:space:]]/ { in_pull_request=0 }


### PR DESCRIPTION
## Summary

- run the CI workflow for every pull request so `ci-status` is never missing
- validate the routed dependency contract in one tested Python helper
- fail closed on missing routes, unexpected dependencies, failed jobs, and skipped selected jobs

The two commits are test-first (`14ef129292`) and implementation (`467cd867d8`). The first commit fails because the old aggregate accepted a skipped selected job.

## Verification

- `python3 tests/test_ci_status.py`
- `python3 tests/test_ci_change_areas.py`
- `bash tests/test_ci_self_hosted_guard.sh`
- `actionlint .github/workflows/ci.yml`
- Python compile and `git diff --check`

## Rollout

After this merges, run docs, macOS, web, Go, agent-session, and workflow-edit canaries. Then add a separate main ruleset requiring context `ci-status` from GitHub Actions app `15368`, with no bypass actors. Existing rulesets stay unchanged.

Residual risk: the workflow and helper execute from the pull request merge ref. CODEOWNERS review for workflow edits must be required before treating this check as a security boundary.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Runs CI for every pull request and enforces a route-aware aggregate status so `ci-status` never stays pending and skipped or failed routed jobs can't pass. The validator now runs from the pull request's base commit, and the CI policy files are owned by two trusted maintainers.

- Replaces inline status checks in `ci.yml` with shared `scripts/ci/check_ci_status.py` that fails closed on missing routes, unexpected dependencies, failed jobs, and skipped selected jobs.
- Expands `ci-status` and `linux-preflight` to require every route's jobs to succeed before publishing the check.
- Re-runs the aggregate whenever a pull request is opened, edited, reopened, synchronized, or marked ready for review.
- Adds behavioral tests for the route contract, governance, and the unfiltered pull-request trigger.

**Migration**
- After merge, run docs, macOS, web, Go, agent-session, and workflow-edit canaries, then enable code-owner review on main and add a ruleset requiring `ci-status` from GitHub Actions app `15368` with no bypass actors.

<sup>Written for commit 06abbae57651137999d7fa6de0d8eb2af76c72f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Pull requests now receive consistent CI coverage without path-based trigger exclusions.
  * Added centralized validation for required checks, route selection, job results, and unexpected workflow states.
  * CI validation now uses trusted configuration and clearer permissions safeguards.

* **Documentation**
  * Added guidance for required CI checks, ownership, activation, rollout, and rollback procedures.

* **Tests**
  * Expanded coverage for CI routing, governance requirements, workflow configuration, and failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->