### PR TITLE
cmux-tui: bound SocketStartLock retry sleep by deadline

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4896,6 +4896,15 @@ pub struct SocketStartLock {
     _file: std::fs::File,
 }
 
+const SOCKET_START_LOCK_RETRY_INTERVAL: Duration = Duration::from_millis(25);
+
+/// Return the next retry wait without extending the caller's deadline.
+/// `try_lock` remains non-blocking; only this retry delay is bounded.
+fn socket_start_lock_retry_delay(now: Instant, deadline: Instant) -> Option<Duration> {
+    let remaining = deadline.checked_duration_since(now)?;
+    (!remaining.is_zero()).then_some(SOCKET_START_LOCK_RETRY_INTERVAL.min(remaining))
+}
+
 impl SocketStartLock {
     pub fn acquire(socket: &Path, deadline: Instant) -> std::io::Result<Self> {
         let mut name = socket.file_name().unwrap_or_default().to_os_string();
@@ -4948,13 +4957,13 @@ impl SocketStartLock {
                 Err(fs4::TryLockError::WouldBlock) => {}
                 Err(fs4::TryLockError::Error(error)) => return Err(error),
             }
-            if Instant::now() >= deadline {
+            let Some(retry_delay) = socket_start_lock_retry_delay(Instant::now(), deadline) else {
                 return Err(std::io::Error::new(
                     std::io::ErrorKind::TimedOut,
                     "timed out waiting for a concurrent session-server start",
                 ));
-            }
-            std::thread::sleep(Duration::from_millis(25));
+            };
+            std::thread::sleep(retry_delay);
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -13309,6 +13309,30 @@ mod tests {
         assert_eq!(error.raw_os_error(), Some(libc::ELOOP));
     }
 
+    #[test]
+    fn socket_start_lock_retry_delay_never_exceeds_remaining_deadline() {
+        let now = Instant::now();
+        let short_deadline = now + Duration::from_millis(10);
+        let delay = socket_start_lock_retry_delay(now, short_deadline)
+            .expect("a future deadline should permit a retry");
+        assert_eq!(delay, Duration::from_millis(10));
+        assert!(delay <= short_deadline.duration_since(now));
+
+        let long_deadline = now + Duration::from_secs(1);
+        assert_eq!(
+            socket_start_lock_retry_delay(now, long_deadline),
+            Some(Duration::from_millis(25))
+        );
+        assert_eq!(socket_start_lock_retry_delay(short_deadline, short_deadline), None);
+        assert_eq!(
+            socket_start_lock_retry_delay(
+                short_deadline + Duration::from_millis(1),
+                short_deadline
+            ),
+            None
+        );
+    }
+
     #[cfg(unix)]
     #[test]
     fn socket_start_lock_rejects_a_fifo_without_blocking() {

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -4905,6 +4905,13 @@ fn socket_start_lock_retry_delay(now: Instant, deadline: Instant) -> Option<Dura
     (!remaining.is_zero()).then_some(SOCKET_START_LOCK_RETRY_INTERVAL.min(remaining))
 }
 
+fn socket_start_lock_timeout() -> std::io::Error {
+    std::io::Error::new(
+        std::io::ErrorKind::TimedOut,
+        "timed out waiting for a concurrent session-server start",
+    )
+}
+
 impl SocketStartLock {
     pub fn acquire(socket: &Path, deadline: Instant) -> std::io::Result<Self> {
         let mut name = socket.file_name().unwrap_or_default().to_os_string();
@@ -4958,12 +4965,12 @@ impl SocketStartLock {
                 Err(fs4::TryLockError::Error(error)) => return Err(error),
             }
             let Some(retry_delay) = socket_start_lock_retry_delay(Instant::now(), deadline) else {
-                return Err(std::io::Error::new(
-                    std::io::ErrorKind::TimedOut,
-                    "timed out waiting for a concurrent session-server start",
-                ));
+                return Err(socket_start_lock_timeout());
             };
             std::thread::sleep(retry_delay);
+            if Instant::now() >= deadline {
+                return Err(socket_start_lock_timeout());
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/11506

SocketStartLock::acquire now caps each 25 ms retry sleep at the remaining deadline. try_lock remains non-blocking; only the retry wait is bounded. The helper returns no delay at or after the deadline and preserves the existing TimedOut error.

Regression coverage is the first commit and fix is the second commit.

Checks: rustfmt --check --edition 2024; git diff --check. Cargo tests/builds were not run on macOS per cmux-tui AGENTS.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #11506. `SocketStartLock::acquire` no longer sleeps past its deadline while retrying a busy socket lock, so startup no longer waits beyond the caller's deadline.

- Caps each retry sleep at the time remaining before the deadline.
- Returns `TimedOut` immediately once the deadline is reached or passed.
- Keeps `try_lock` non-blocking; only the retry wait is bounded.
- Adds unit coverage for short, normal, and expired deadlines.

<sup>Written for commit 01c91085b0a3c8d7c777a31e9caf933a88a7779f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11541?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved socket startup retry behavior by respecting caller-defined timeouts.
  * Retry waits are now bounded by the remaining timeout period.
  * Retry attempts stop promptly and return a timeout error when the deadline is reached.

* **Tests**
  * Added coverage for retry delay and timeout handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->