### PR TITLE
ci: bootstrap trusted CI status validator

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -10,8 +10,12 @@
 # That branch-protection change is the actual gate; this file makes it effective
 # and documents ownership in the meantime.
 
-# All GitHub Actions workflows (all can access secrets).
-/.github/workflows/                     @lawrencecchen
+# The CI router and its required-check validator can change which jobs run.
+# Two trusted maintainers own these files. Branch protection must require an
+# approving code-owner review before the policy is activated.
+/.github/workflows/**                    @austinywang @azooz2003-bit
+/scripts/ci/**                           @austinywang @azooz2003-bit
+/.github/CODEOWNERS                      @austinywang @azooz2003-bit
 
 # iOS TestFlight publish path + App Store Connect config.
 /ios/scripts/upload-testflight.sh       @lawrencecchen

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -41,24 +41,33 @@ jobs:
       - name: Checkout trusted gate
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          ref: ${{ github.event.pull_request.base.sha || github.event.workflow_run.pull_requests[0].base.sha || github.sha }}
+          # Workflow-run payloads for external forks can omit pull_requests.
+          # Use the protected main ref in that case, never the event's default
+          # ref or SHA. Pull-request events still pin the exact base commit.
+          ref: ${{ github.event.pull_request.base.sha || github.event.workflow_run.pull_requests[0].base.sha || 'refs/heads/main' }}
           path: .ci-trusted
           fetch-depth: 1
           persist-credentials: false
 
       - name: Verify trusted gate revision
         env:
-          TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.event.workflow_run.pull_requests[0].base.sha || github.sha }}
+          TRUSTED_REF: ${{ github.event.pull_request.base.sha || github.event.workflow_run.pull_requests[0].base.sha || 'refs/heads/main' }}
         run: |
           set -euo pipefail
-          if [[ ${#TRUSTED_SHA} -ne 40 || "$TRUSTED_SHA" =~ [^0-9a-f] ]]; then
-            echo "::error::Trusted gate SHA is not a full commit SHA" >&2
+          actual_sha="$(git -C .ci-trusted rev-parse --verify 'HEAD^{commit}')"
+          if [[ ! "$actual_sha" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "::error::Trusted gate checkout is not a full commit SHA" >&2
             exit 1
           fi
-          actual_sha="$(git -C .ci-trusted rev-parse --verify 'HEAD^{commit}')"
-          if [[ "$actual_sha" != "$TRUSTED_SHA" ]]; then
-            echo "::error::Trusted gate checkout does not match $TRUSTED_SHA (got $actual_sha)" >&2
-            exit 1
+          if [[ "$TRUSTED_REF" != "refs/heads/main" ]]; then
+            if [[ ! "$TRUSTED_REF" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::Trusted gate ref is not a full commit SHA or refs/heads/main" >&2
+              exit 1
+            fi
+            if [[ "$actual_sha" != "$TRUSTED_REF" ]]; then
+              echo "::error::Trusted gate checkout does not match the requested base commit" >&2
+              exit 1
+            fi
           fi
 
       - name: Evaluate exact CI check runs

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
     types: [opened, edited, reopened, synchronize, ready_for_review]
+  pull_request_review:
+    types: [submitted, dismissed]
   # A PR event can arrive before CI has published its checks. Re-evaluate when
   # the base-owned CI workflow completes so a transient missing-check failure
   # is replaced by the exact-head result.
@@ -17,7 +19,7 @@ on:
 permissions:
   contents: read
   actions: read
-  checks: read
+  checks: write
   pull-requests: read
 
 concurrency:
@@ -26,14 +28,14 @@ concurrency:
 
 jobs:
   ci-status-gate:
-    name: ci-status-gate
-    if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request') }}
+    name: CI status gate publisher
+    if: ${{ github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request') }}
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 10
     permissions:
       contents: read
       actions: read
-      checks: read
+      checks: write
       pull-requests: read
     steps:
       - name: Checkout trusted gate
@@ -71,7 +73,7 @@ jobs:
     # Keep the historical required context until the ruleset switches to
     # ci-status-gate. This alias is also base-owned, so PR workflow edits
     # cannot forge the legacy result.
-    if: ${{ always() && (github.event_name == 'pull_request_target' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request')) }}
+    if: ${{ always() && (github.event_name == 'pull_request_target' || github.event_name == 'pull_request_review' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request')) }}
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 5
     permissions:

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -1,0 +1,66 @@
+name: CI status gate
+
+on:
+  # This workflow is evaluated from the trusted base revision. It never
+  # checks out or executes pull-request files.
+  pull_request_target:
+    branches:
+      - main
+    types: [opened, edited, reopened, synchronize, ready_for_review]
+  # A PR event can arrive before CI has published its checks. Re-evaluate when
+  # the base-owned CI workflow completes so a transient missing-check failure
+  # is replaced by the exact-head result.
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+  actions: read
+  checks: read
+  pull-requests: read
+
+concurrency:
+  group: ci-status-gate-${{ github.event.pull_request.head.sha || github.event.workflow_run.head_sha || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  ci-status-gate:
+    name: ci-status-gate
+    if: ${{ github.event_name == 'pull_request_target' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request') }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      actions: read
+      checks: read
+      pull-requests: read
+    steps:
+      - name: Checkout trusted gate
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.base.sha || github.event.workflow_run.pull_requests[0].base.sha || github.sha }}
+          path: .ci-trusted
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Verify trusted gate revision
+        env:
+          TRUSTED_SHA: ${{ github.event.pull_request.base.sha || github.event.workflow_run.pull_requests[0].base.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ${#TRUSTED_SHA} -ne 40 || "$TRUSTED_SHA" =~ [^0-9a-f] ]]; then
+            echo "::error::Trusted gate SHA is not a full commit SHA" >&2
+            exit 1
+          fi
+          actual_sha="$(git -C .ci-trusted rev-parse --verify 'HEAD^{commit}')"
+          if [[ "$actual_sha" != "$TRUSTED_SHA" ]]; then
+            echo "::error::Trusted gate checkout does not match $TRUSTED_SHA (got $actual_sha)" >&2
+            exit 1
+          fi
+
+      - name: Evaluate exact CI check runs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+        run: python3 .ci-trusted/scripts/ci/ci_status_gate.py

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -64,3 +64,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: python3 .ci-trusted/scripts/ci/ci_status_gate.py
+
+  ci-status:
+    name: ci-status
+    needs: ci-status-gate
+    # Keep the historical required context until the ruleset switches to
+    # ci-status-gate. This alias is also base-owned, so PR workflow edits
+    # cannot forge the legacy result.
+    if: ${{ always() && (github.event_name == 'pull_request_target' || (github.event_name == 'workflow_run' && github.event.workflow_run.event == 'pull_request')) }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Mirror trusted gate result
+        env:
+          GATE_RESULT: ${{ needs.ci-status-gate.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$GATE_RESULT" != "success" ]]; then
+            echo "::error::Legacy ci-status context mirrors ci-status-gate: $GATE_RESULT" >&2
+            exit 1
+          fi

--- a/.github/workflows/ci-status-gate.yml
+++ b/.github/workflows/ci-status-gate.yml
@@ -19,7 +19,7 @@ on:
 permissions:
   contents: read
   actions: read
-  checks: write
+  checks: read
   pull-requests: read
 
 concurrency:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,9 +331,6 @@ jobs:
       - name: Validate bootstrap CI governance
         run: python3 tests/test_ci_governance_bootstrap.py
 
-      - name: Validate release attestation retry guard
-        run: ./tests/test_ci_attestation_retry.sh
-
       - name: Validate Python R2 appcast upload guard
         run: ./tests/test_ci_r2_upload_python.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2405,19 +2405,65 @@ jobs:
       - release-build
     if: ${{ always() }}
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    steps:
+      - name: Check routed CI jobs
+        env:
+          CI_NEEDS: ${{ toJSON(needs) }}
+        run: |
+          python3 - <<'PY'
+          import json
+          import os
+          import sys
+
+          needs = json.loads(os.environ["CI_NEEDS"])
+          allowed = {"success", "skipped"}
+          bad = {
+              name: data["result"]
+              for name, data in sorted(needs.items())
+              if data["result"] not in allowed
+          }
+
+          if bad:
+              for name, result in bad.items():
+                  print(f"{name}: {result}", file=sys.stderr)
+              sys.exit(1)
+
+          for name, data in sorted(needs.items()):
+              print(f"{name}: {data['result']}")
+          PY
+
+  ci-status-validator-canary:
+    needs:
+      - changes
+      - workflow-guard-tests
+      - ghosttykit-release-check
+      - remote-daemon-tests
+      - web-typecheck
+      - react-apps-check
+      - diff-sidecar-check
+      - web-db-migrations
+      - linux-preflight
+      - app-host-unit-tests
+      - tests
+      - swift-package-tests
+      - agent-session-web-resources
+      - tests-build-and-lag
+      - release-build
+    if: ${{ always() }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 5
     permissions:
       contents: read
-    # Bootstrap mode executes the validator from the PR checkout so the new
-    # contract is exercised on real `needs` data. PR11540 hardens this step by
-    # switching it to the exact trusted base revision before activation.
+    # This diagnostic job exercises the new validator with real needs data.
+    # It is intentionally not a required context. PR11540 moves the required
+    # ci-status job to the exact trusted base revision before activation.
     steps:
       - name: Checkout CI status validator
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
-      - name: Check routed CI jobs
+      - name: Check serialized routed jobs
         env:
           CI_NEEDS: ${{ toJSON(needs) }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -592,7 +592,7 @@ jobs:
       - linux-preflight
     # !cancelled() disables the implicit success() gate, which GitHub evaluates
     # over the transitive needs chain: linux-preflight runs behind routed linux
-    # jobs that legitimately skip (web/go/agent-session paths), and that
+    # jobs that legitimately skip (web/agent-session paths), and that
     # transitive skip otherwise marks every macOS job skipped even when
     # linux-preflight itself succeeds. Require the direct needs explicitly.
     if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
@@ -1528,7 +1528,7 @@ jobs:
       - linux-preflight
     # !cancelled() disables the implicit success() gate, which GitHub evaluates
     # over the transitive needs chain: linux-preflight runs behind routed linux
-    # jobs that legitimately skip (web/go/agent-session paths), and that
+    # jobs that legitimately skip (web/agent-session paths), and that
     # transitive skip otherwise marks every macOS job skipped even when
     # linux-preflight itself succeeds. Require the direct needs explicitly.
     if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
@@ -1877,7 +1877,7 @@ jobs:
       - linux-preflight
     # !cancelled() disables the implicit success() gate, which GitHub evaluates
     # over the transitive needs chain: linux-preflight runs behind routed linux
-    # jobs that legitimately skip (web/go/agent-session paths), and that
+    # jobs that legitimately skip (web/agent-session paths), and that
     # transitive skip otherwise marks every macOS job skipped even when
     # linux-preflight itself succeeds. Require the direct needs explicitly.
     if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
@@ -2460,7 +2460,6 @@ jobs:
       - changes
       - workflow-guard-tests
       - ghosttykit-release-check
-      - remote-daemon-tests
       - web-typecheck
       - react-apps-check
       - diff-sidecar-check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2405,29 +2405,20 @@ jobs:
       - release-build
     if: ${{ always() }}
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    # Bootstrap mode executes the validator from the PR checkout so the new
+    # contract is exercised on real `needs` data. PR11540 hardens this step by
+    # switching it to the exact trusted base revision before activation.
     steps:
+      - name: Checkout CI status validator
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
       - name: Check routed CI jobs
         env:
           CI_NEEDS: ${{ toJSON(needs) }}
         run: |
-          python3 - <<'PY'
-          import json
-          import os
-          import sys
-
-          needs = json.loads(os.environ["CI_NEEDS"])
-          allowed = {"success", "skipped"}
-          bad = {
-              name: data["result"]
-              for name, data in sorted(needs.items())
-              if data["result"] not in allowed
-          }
-
-          if bad:
-              for name, result in bad.items():
-                  print(f"{name}: {result}", file=sys.stderr)
-              sys.exit(1)
-
-          for name, data in sorted(needs.items()):
-              print(f"{name}: {data['result']}")
-          PY
+          python3 scripts/ci/check_ci_status.py --phase aggregate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,9 @@ jobs:
       - name: Validate CI status validator
         run: python3 tests/test_ci_status_validator.py
 
+      - name: Validate base-owned CI status gate
+        run: python3 tests/test_ci_status_gate.py
+
       - name: Validate bootstrap CI governance
         run: python3 tests/test_ci_governance_bootstrap.py
 
@@ -2387,7 +2390,7 @@ jobs:
           ./scripts/verify-diff-sidecar-artifact.sh "$DIFF_SIDECAR"
           [[ "$SDK_VERSION" == 26.* ]]
 
-  ci-status:
+  ci-status-advisory:
     needs:
       - changes
       - workflow-guard-tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2435,6 +2435,26 @@ jobs:
               print(f"{name}: {data['result']}")
           PY
 
+  ci-status:
+    needs: ci-status-advisory
+    if: ${{ always() }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    # Keep the historical context until the main ruleset switches atomically
+    # to the base-owned ci-status-gate check. This job is not a security gate.
+    steps:
+      - name: Preserve legacy CI status context
+        env:
+          ADVISORY_RESULT: ${{ needs.ci-status-advisory.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$ADVISORY_RESULT" != "success" ]]; then
+            echo "::error::Legacy ci-status compatibility gate mirrors ci-status-advisory: $ADVISORY_RESULT" >&2
+            exit 1
+          fi
+
   ci-status-validator-canary:
     needs:
       - changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,6 +325,9 @@ jobs:
       - name: Validate CI status validator
         run: python3 tests/test_ci_status_validator.py
 
+      - name: Validate bootstrap CI governance
+        run: python3 tests/test_ci_governance_bootstrap.py
+
       - name: Validate release attestation retry guard
         run: ./tests/test_ci_attestation_retry.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -322,6 +322,12 @@ jobs:
       - name: Validate CI change area filter
         run: python3 tests/test_ci_change_areas.py
 
+      - name: Validate CI status validator
+        run: python3 tests/test_ci_status_validator.py
+
+      - name: Validate release attestation retry guard
+        run: ./tests/test_ci_attestation_retry.sh
+
       - name: Validate Python R2 appcast upload guard
         run: ./tests/test_ci_r2_upload_python.sh
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2435,6 +2435,26 @@ jobs:
               print(f"{name}: {data['result']}")
           PY
 
+  ci-status:
+    needs: ci-status-advisory
+    if: ${{ always() }}
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    # Temporary bootstrap producer. Keep this context until the base-owned
+    # gate is present on main and the ruleset switches atomically.
+    steps:
+      - name: Preserve legacy CI status context
+        env:
+          ADVISORY_RESULT: ${{ needs.ci-status-advisory.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$ADVISORY_RESULT" != "success" ]]; then
+            echo "::error::Legacy ci-status bootstrap context mirrors ci-status-advisory: $ADVISORY_RESULT" >&2
+            exit 1
+          fi
+
   ci-status-validator-canary:
     needs:
       - changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2435,26 +2435,6 @@ jobs:
               print(f"{name}: {data['result']}")
           PY
 
-  ci-status:
-    needs: ci-status-advisory
-    if: ${{ always() }}
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 5
-    permissions:
-      contents: read
-    # Keep the historical context until the main ruleset switches atomically
-    # to the base-owned ci-status-gate check. This job is not a security gate.
-    steps:
-      - name: Preserve legacy CI status context
-        env:
-          ADVISORY_RESULT: ${{ needs.ci-status-advisory.result }}
-        run: |
-          set -euo pipefail
-          if [[ "$ADVISORY_RESULT" != "success" ]]; then
-            echo "::error::Legacy ci-status compatibility gate mirrors ci-status-advisory: $ADVISORY_RESULT" >&2
-            exit 1
-          fi
-
   ci-status-validator-canary:
     needs:
       - changes

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -16,10 +16,11 @@ and `ci-status-validator-canary` job are diagnostic only and must not be added
 to branch protection. The advisory jobs may execute pull-request code, but
 they have read-only permissions and do not control mergeability.
 
-During rollout, the untrusted workflow also publishes the legacy `ci-status`
-context. It mirrors `ci-status-advisory` only so an existing required-check
-rule does not become permanently pending. Remove that compatibility job in the
-same ruleset update that makes `ci-status-gate` required.
+During rollout, the base-owned gate workflow also publishes the legacy
+`ci-status` context. It mirrors `ci-status-gate` only so an existing
+required-check rule does not become permanently pending. Remove that alias in
+the same ruleset update that makes `ci-status-gate` required. The untrusted
+`pull_request` workflow must never publish the `ci-status` name.
 
 The base-owned gate compares the blob SHA for `.github/workflows/ci.yml` at
 the live base and head commits. A changed workflow definition is rejected

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -14,6 +14,11 @@ or update `ci-status-gate` and `ci-status` check runs on that exact head. No
 repository contents are written. Missing, stale, pending, failed, or
 unexpected CI jobs fail closed.
 
+Each published run has a deterministic `external_id` with generation `v2`,
+the check name, and the head SHA. The gate updates only a run with that exact
+identity and refuses a response from another producer. A future migration
+must use a new generation instead of reusing old check runs.
+
 The `pull_request` workflow remains untrusted. Its `ci-status-advisory` job
 and `ci-status-validator-canary` job are diagnostic only and must not be added
 to branch protection. The advisory jobs may execute pull-request code, but

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -1,0 +1,38 @@
+# Required CI checks
+
+`ci-status-gate` is the only check intended for the `main` required-check
+ruleset. It is produced by GitHub Actions app `15368` from
+`.github/workflows/ci-status-gate.yml`.
+
+The gate is base-owned. It runs on `pull_request_target` lifecycle events and
+again when the `CI` workflow completes. It checks the live pull request, pins
+the exact head SHA, reads the matching CI workflow run, and fetches check runs
+for that SHA. It derives the changed-file routes with the trusted base
+classifier, then invokes `scripts/ci/check_ci_status.py` from the trusted base
+revision. Missing, stale, pending, failed, or unexpected CI jobs fail closed.
+
+The `pull_request` workflow remains untrusted. Its `ci-status-advisory` job
+and `ci-status-validator-canary` job are diagnostic only and must not be added
+to branch protection. The advisory jobs may execute pull-request code, but
+they have read-only permissions and do not control mergeability.
+
+Before activating the rule, merge this bootstrap, rebase the route-aware CI
+change, and observe these cases on fresh pull requests: docs-only, macOS,
+web, Go, agent-session, and workflow changes. Confirm that the base-owned gate
+publishes `ci-status-gate` after CI completion for each case.
+
+The `main` ruleset must require code-owner review for policy inputs, at least
+one approving code-owner review, strict required checks, the exact
+`ci-status-gate` context from integration `15368`, and no bypass actor. The
+CODEOWNERS entries for `/.github/workflows/**`, `/scripts/ci/**`, and
+`/.github/CODEOWNERS` are owned by `@austinywang` and `@azooz2003-bit`.
+
+The gate validates CI conclusions, not the contents of every test process.
+An approved maintainer could still weaken the pull-request workflow. The
+code-owner rule is defense in depth; keep it active and review workflow edits
+as security-sensitive changes.
+
+To roll back, remove only the `ci-status-gate` required-check rule, keep the
+base-owned workflow and validator, and investigate the failing snapshot. Do
+not restore a path-filtered `pull_request` trigger, because that leaves a
+required check permanently pending for unmatched paths.

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -16,6 +16,17 @@ and `ci-status-validator-canary` job are diagnostic only and must not be added
 to branch protection. The advisory jobs may execute pull-request code, but
 they have read-only permissions and do not control mergeability.
 
+During rollout, the untrusted workflow also publishes the legacy `ci-status`
+context. It mirrors `ci-status-advisory` only so an existing required-check
+rule does not become permanently pending. Remove that compatibility job in the
+same ruleset update that makes `ci-status-gate` required.
+
+The base-owned gate compares the blob SHA for `.github/workflows/ci.yml` at
+the live base and head commits. A changed workflow definition is rejected
+unless Austin (`austinywang`, account ID `38676809`) or Aziz
+(`azooz2003-bit`, account ID `67667005`) has an approving human review for the
+exact head commit. Later changes, dismissals, and self-approval do not count.
+
 Before activating the rule, merge this bootstrap, rebase the route-aware CI
 change, and observe these cases on fresh pull requests: docs-only, macOS,
 web, Go, agent-session, and workflow changes. Confirm that the base-owned gate

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -9,7 +9,10 @@ again when the `CI` workflow completes. It checks the live pull request, pins
 the exact head SHA, reads the matching CI workflow run, and fetches check runs
 for that SHA. It derives the changed-file routes with the trusted base
 classifier, then invokes `scripts/ci/check_ci_status.py` from the trusted base
-revision. Missing, stale, pending, failed, or unexpected CI jobs fail closed.
+revision. The publisher uses the narrow `checks: write` permission to create
+or update `ci-status-gate` and `ci-status` check runs on that exact head. No
+repository contents are written. Missing, stale, pending, failed, or
+unexpected CI jobs fail closed.
 
 The `pull_request` workflow remains untrusted. Its `ci-status-advisory` job
 and `ci-status-validator-canary` job are diagnostic only and must not be added
@@ -20,7 +23,11 @@ During rollout, the base-owned gate workflow also publishes the legacy
 `ci-status` context. It mirrors `ci-status-gate` only so an existing
 required-check rule does not become permanently pending. Remove that alias in
 the same ruleset update that makes `ci-status-gate` required. The untrusted
-`pull_request` workflow must never publish the `ci-status` name.
+`pull_request` workflow retains a temporary `ci-status` producer so this
+bootstrap PR can pass the existing rule before the gate workflow is on `main`.
+Remove that producer immediately after the base-owned gate is merged and the
+ruleset switches. The untrusted workflow must never remain a required
+authority.
 
 The base-owned gate compares the blob SHA for `.github/workflows/ci.yml` at
 the live base and head commits. A changed workflow definition is rejected

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -14,6 +14,12 @@ or update `ci-status-gate` and `ci-status` check runs on that exact head. No
 repository contents are written. Missing, stale, pending, failed, or
 unexpected CI jobs fail closed.
 
+For a `workflow_run` event whose API response omits pull-request associations,
+the gate resolves the commit to exactly one open PR targeting this repository's
+`main` branch with the same head SHA. It checks out the explicit protected
+`refs/heads/main` ref for that recovery path and never uses the event default
+ref or SHA as trusted code.
+
 Each published run has a deterministic `external_id` with generation `v2`,
 the check name, and the head SHA. The gate updates only a run with that exact
 identity and refuses a response from another producer. A future migration

--- a/docs/ci-required-checks.md
+++ b/docs/ci-required-checks.md
@@ -42,7 +42,9 @@ CODEOWNERS entries for `/.github/workflows/**`, `/scripts/ci/**`, and
 The gate validates CI conclusions, not the contents of every test process.
 An approved maintainer could still weaken the pull-request workflow. The
 code-owner rule is defense in depth; keep it active and review workflow edits
-as security-sensitive changes.
+as security-sensitive changes. The gate helper itself is imported only from
+the `.ci-trusted` checkout of the base commit, so a pull request cannot replace
+the code that evaluates its own checks.
 
 To roll back, remove only the `ci-status-gate` required-check rule, keep the
 base-owned workflow and validator, and investigate the failing snapshot. Do

--- a/scripts/ci/check_ci_status.py
+++ b/scripts/ci/check_ci_status.py
@@ -11,7 +11,7 @@ from collections.abc import Mapping
 from typing import Any
 
 
-ROUTE_NAMES = ("macos", "web", "go", "agent_session_web")
+ROUTE_NAMES = ("macos", "web", "agent_session_web")
 
 # A job can be selected by more than one route. In particular, the diff
 # sidecar checks both macOS and web changes.
@@ -24,7 +24,6 @@ ROUTE_JOBS: dict[str, tuple[str, ...]] = {
     "react-apps-check": ("web",),
     "diff-sidecar-check": ("macos", "web"),
     "web-db-migrations": ("web",),
-    "remote-daemon-tests": ("go",),
     "agent-session-web-resources": ("agent_session_web",),
 }
 
@@ -42,7 +41,6 @@ ALWAYS_REQUIRED = COMMON_REQUIRED + (
 PREFLIGHT_REQUIRED = COMMON_REQUIRED
 
 PREFLIGHT_ROUTE_JOBS = (
-    "remote-daemon-tests",
     "web-typecheck",
     "react-apps-check",
     "diff-sidecar-check",

--- a/scripts/ci/check_ci_status.py
+++ b/scripts/ci/check_ci_status.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python3
+"""Validate the route-aware CI status contract."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from collections.abc import Mapping
+from typing import Any
+
+
+ROUTE_NAMES = ("macos", "web", "go", "agent_session_web")
+
+# A job can be selected by more than one route. In particular, the diff
+# sidecar checks both macOS and web changes.
+ROUTE_JOBS: dict[str, tuple[str, ...]] = {
+    "app-host-unit-tests": ("macos",),
+    "tests-build-and-lag": ("macos",),
+    "swift-package-tests": ("macos",),
+    "release-build": ("macos",),
+    "web-typecheck": ("web",),
+    "react-apps-check": ("web",),
+    "diff-sidecar-check": ("macos", "web"),
+    "web-db-migrations": ("web",),
+    "remote-daemon-tests": ("go",),
+    "agent-session-web-resources": ("agent_session_web",),
+}
+
+COMMON_REQUIRED = (
+    "changes",
+    "workflow-guard-tests",
+    "ghosttykit-release-check",
+)
+
+ALWAYS_REQUIRED = COMMON_REQUIRED + (
+    "linux-preflight",
+    "tests",
+)
+
+PREFLIGHT_REQUIRED = COMMON_REQUIRED
+
+PREFLIGHT_ROUTE_JOBS = (
+    "remote-daemon-tests",
+    "web-typecheck",
+    "react-apps-check",
+    "diff-sidecar-check",
+    "web-db-migrations",
+    "agent-session-web-resources",
+)
+
+AGGREGATE_ROUTE_JOBS = tuple(ROUTE_JOBS)
+
+PHASE_CONTRACTS = {
+    "preflight": (PREFLIGHT_REQUIRED, PREFLIGHT_ROUTE_JOBS),
+    "aggregate": (ALWAYS_REQUIRED, AGGREGATE_ROUTE_JOBS),
+}
+
+
+def _job_result(needs: Mapping[str, Any], name: str, failures: list[str]) -> str | None:
+    value = needs.get(name)
+    if not isinstance(value, Mapping):
+        failures.append(f"{name}: missing job result")
+        return None
+    result = value.get("result")
+    if not isinstance(result, str):
+        failures.append(f"{name}: missing job result")
+        return None
+    return result
+
+
+def _route_outputs(needs: Mapping[str, Any], failures: list[str]) -> Mapping[str, Any]:
+    changes = needs.get("changes")
+    if not isinstance(changes, Mapping):
+        failures.append("changes: missing job result")
+        return {}
+    outputs = changes.get("outputs")
+    if not isinstance(outputs, Mapping):
+        failures.append("changes: missing route outputs")
+        return {}
+    for route in ROUTE_NAMES:
+        if outputs.get(route) not in {"true", "false"}:
+            failures.append(f"changes.outputs.{route}: expected true or false")
+    return outputs
+
+
+def _expected_jobs(phase: str) -> tuple[str, ...]:
+    required, route_jobs = PHASE_CONTRACTS[phase]
+    return required + route_jobs
+
+
+def _validate_job_set(
+    needs: Mapping[str, Any], expected: set[str], failures: list[str]
+) -> None:
+    for name in sorted(expected - set(needs)):
+        failures.append(f"{name}: missing job result")
+    for name in sorted(set(needs) - expected):
+        failures.append(f"{name}: unexpected job in CI contract")
+
+
+def _validate_required_jobs(
+    needs: Mapping[str, Any], names: tuple[str, ...], failures: list[str]
+) -> None:
+    for name in names:
+        result = _job_result(needs, name, failures)
+        if result is not None and result != "success":
+            failures.append(f"{name}: expected success, got {result}")
+
+
+def _validate_route_jobs(
+    needs: Mapping[str, Any],
+    outputs: Mapping[str, Any],
+    names: tuple[str, ...],
+    failures: list[str],
+) -> None:
+    for name in names:
+        result = _job_result(needs, name, failures)
+        if result is None:
+            continue
+        routes = ROUTE_JOBS[name]
+        selected = any(outputs.get(route) == "true" for route in routes)
+        if selected and result != "success":
+            route_label = " or ".join(routes)
+            failures.append(f"{name}: required for route {route_label}, got {result}")
+        elif not selected and result not in {"success", "skipped"}:
+            failures.append(f"{name}: unexpected result for inactive route, got {result}")
+
+
+def validate_needs(needs: Mapping[str, Any], *, phase: str = "aggregate") -> list[str]:
+    """Return contract violations for a serialized GitHub ``needs`` object."""
+
+    if phase not in {"preflight", "aggregate"}:
+        raise ValueError(f"unsupported phase: {phase}")
+    failures: list[str] = []
+
+    if not isinstance(needs, Mapping):
+        return ["needs: expected an object"]
+
+    required, route_jobs = PHASE_CONTRACTS[phase]
+    expected_set = set(_expected_jobs(phase))
+    _validate_job_set(needs, expected_set, failures)
+
+    outputs = _route_outputs(needs, failures)
+    _validate_required_jobs(needs, required, failures)
+    _validate_route_jobs(needs, outputs, route_jobs, failures)
+
+    return failures
+
+
+def _load_needs(raw: str | None) -> Mapping[str, Any]:
+    if not raw:
+        raise ValueError("CI_NEEDS is empty")
+    value = json.loads(raw)
+    if not isinstance(value, Mapping):
+        raise ValueError("CI_NEEDS must be a JSON object")
+    return value
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--phase",
+        choices=("preflight", "aggregate"),
+        default="aggregate",
+        help="Which CI dependency set to validate.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        needs = _load_needs(os.environ.get("CI_NEEDS"))
+    except (json.JSONDecodeError, ValueError) as error:
+        print(f"CI status contract input error: {error}", file=sys.stderr)
+        return 2
+
+    failures = validate_needs(needs, phase=args.phase)
+    if failures:
+        print(f"CI status contract failed ({args.phase}):", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+
+    print(f"CI status contract passed ({args.phase}).")
+    for name in sorted(needs):
+        result = needs[name].get("result") if isinstance(needs[name], Mapping) else None
+        print(f"{name}: {result}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -31,6 +31,9 @@ CHECK_NAME_ALIASES = {"GhosttyKit release check": "ghosttykit-release-check"}
 ADVISORY_CHECKS = {"ci-status", "ci-status-advisory", "ci-status-validator-canary"}
 ROUTE_NAMES = contract.ROUTE_NAMES
 PUBLISHED_CHECKS = ("ci-status-gate", "ci-status")
+# Bump this whenever ownership or semantics of a published context change.
+# The generation prevents a migration from updating an older producer's run.
+PUBLISHER_GENERATION = "v2"
 TRUSTED_REVIEWER_IDS = {
     38676809: "austinywang",
     67667005: "azooz2003-bit",
@@ -216,6 +219,7 @@ class GitHubAPI:
             raise GateError("published check conclusion is malformed")
         if not isinstance(summary, str) or not summary:
             raise GateError("published check summary is malformed")
+        external_id = _publisher_external_id(name, head_sha)
         payload = self.get(
             f"repos/{self.repository}/commits/{head_sha}/check-runs?check_name={name}&per_page=100",
             paginate=True,
@@ -226,6 +230,7 @@ class GitHubAPI:
             for row in rows
             if row.get("name") == name
             and row.get("head_sha") == head_sha
+            and row.get("external_id") == external_id
             and isinstance(row.get("app"), Mapping)
             and row["app"].get("id") == ACTIONS_APP_ID
             and isinstance(row.get("id"), int)
@@ -246,7 +251,7 @@ class GitHubAPI:
                 "head_sha": head_sha,
                 "status": "completed",
                 "conclusion": conclusion,
-                "external_id": f"cmux-{name}-{head_sha}",
+                "external_id": external_id,
                 "output": {"title": name, "summary": summary},
             },
         )
@@ -254,9 +259,20 @@ class GitHubAPI:
             raise GateError("GitHub returned a malformed published check")
         if response.get("name") != name or response.get("head_sha") != head_sha:
             raise GateError("published check does not target the exact PR head")
+        if response.get("external_id") != external_id:
+            raise GateError("published check has an unexpected external ID")
         app = response.get("app")
         if not isinstance(app, Mapping) or app.get("id") != ACTIONS_APP_ID:
             raise GateError("published check was created by an unexpected app")
+
+
+def _publisher_external_id(name: str, head_sha: str) -> str:
+    """Build the stable identity for this generation's check producer."""
+
+    if name not in PUBLISHED_CHECKS:
+        raise GateError("unsupported published check name")
+    head_sha = _as_sha(head_sha, "published check head SHA")
+    return f"cmux-ci-status-{PUBLISHER_GENERATION}-{name}-{head_sha}"
 
 
 def _workflow_blob_sha(api: GitHubAPI, revision: str) -> str:

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -625,7 +625,7 @@ def _pr_files(api: GitHubAPI, number: int, expected_count: object) -> list[str]:
     payload = api.get(
         f"repos/{api.repository}/pulls/{number}/files?per_page=100", paginate=True
     )
-    rows = _page_rows(payload, "files")
+    rows = _array_rows(payload, "pull-request files")
     files: list[str] = []
     for row in rows:
         filename = row.get("filename")

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -123,7 +123,7 @@ def _array_rows(payload: object, label: str) -> list[Mapping[str, Any]]:
 
 
 class GitHubAPI:
-    """Small read-only wrapper around the runner's authenticated gh client."""
+    """Small wrapper around the runner's authenticated gh client."""
 
     def __init__(self, repository: str, token: str | None = None) -> None:
         if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -516,6 +516,20 @@ def _validate_commit_pull(
     return _pr_number(row, "commit")
 
 
+def _resolve_commit_pull_number(api: GitHubAPI, head_sha: str) -> int:
+    """Resolve one exact open PR when GitHub omits run associations."""
+
+    head_sha = _as_sha(head_sha, "workflow run head SHA")
+    payload = api.get(
+        f"repos/{api.repository}/commits/{head_sha}/pulls?per_page=100",
+        paginate=True,
+    )
+    rows = _array_rows(payload, "commit pull requests")
+    if len(rows) != 1:
+        raise GateError("commit must resolve to exactly one pull request")
+    return _validate_commit_pull(rows[0], api.repository, head_sha)
+
+
 def _event_target(
     api: GitHubAPI, event_name: str, event: Mapping[str, Any]
 ) -> tuple[Mapping[str, Any], str, int, int | None]:
@@ -556,18 +570,7 @@ def _event_target(
         if pull_requests:
             pr_number = _single_pr_number(pull_requests, "workflow run")
         else:
-            pull_payload = api.get(
-                f"repos/{api.repository}/commits/{event_head}/pulls?per_page=100",
-                paginate=True,
-            )
-            commit_rows = _array_rows(pull_payload, "commit pull requests")
-            if len(commit_rows) != 1:
-                raise GateError(
-                    "commit must resolve to exactly one pull request"
-                )
-            pr_number = _validate_commit_pull(
-                commit_rows[0], api.repository, event_head
-            )
+            pr_number = _resolve_commit_pull_number(api, event_head)
     else:
         raise GateError(f"unsupported event {event_name or 'unknown'}")
 
@@ -612,19 +615,21 @@ def _select_ci_run(
 
     valid: list[Mapping[str, Any]] = []
     pr_number = pull.get("number")
+    if not isinstance(pr_number, int) or isinstance(pr_number, bool) or pr_number <= 0:
+        raise GateError("pull request number is malformed")
     for run in candidates:
         if run.get("path") != CI_WORKFLOW_PATH or run.get("event") != "pull_request":
             continue
         if run.get("head_sha") != head_sha:
             continue
         pull_requests = run.get("pull_requests")
-        if isinstance(pull_requests, list):
-            if pull_requests and not any(
-                isinstance(item, Mapping) and item.get("number") == pr_number
-                for item in pull_requests
-            ):
+        if pull_requests is None or pull_requests == []:
+            if _resolve_commit_pull_number(api, head_sha) != pr_number:
                 continue
-        elif pull_requests is not None:
+        elif isinstance(pull_requests, list):
+            if _single_pr_number(pull_requests, "CI workflow run") != pr_number:
+                continue
+        else:
             raise GateError("CI workflow run pull request association is malformed")
         valid.append(run)
     if not valid:

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -547,6 +547,9 @@ def _event_target(
         run = api.get(f"repos/{api.repository}/actions/runs/{raw_id}")
         if not isinstance(run, Mapping):
             raise GateError("workflow run API response is not an object")
+        run_head = _as_sha(run.get("head_sha"), "workflow run API head SHA")
+        if run_head != event_head:
+            raise GateError("workflow run head changed after the event; wait for a new run")
         pull_requests = run.get("pull_requests")
         if not isinstance(pull_requests, list):
             raise GateError("workflow run API response is missing pull requests")

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -462,9 +462,14 @@ def _single_pr_number(rows: object, source: str) -> int:
         raise GateError(f"{source} pull request association is malformed")
     if not rows:
         raise GateError(f"{source} is not associated with a pull request")
-    if len(rows) > 1:
+    numbers: list[int] = []
+    for row in rows:
+        number = _pr_number(row, source)
+        if number not in numbers:
+            numbers.append(number)
+    if len(numbers) > 1:
         raise GateError(f"{source} is associated with multiple pull requests")
-    return _pr_number(rows[0], source)
+    return numbers[0]
 
 
 def _pr_number(row: object, source: str) -> int:

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -772,7 +772,6 @@ def build_needs(
     outputs = {
         "macos": "true" if areas.macos else "false",
         "web": "true" if areas.web else "false",
-        "go": "true" if areas.go else "false",
         "agent_session_web": "true" if areas.agent_session_web else "false",
     }
     needs: dict[str, dict[str, Any]] = {

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -347,8 +347,18 @@ def has_trusted_workflow_review(
 
     head_sha = _as_sha(head_sha, "head SHA")
     author = pull.get("user")
-    author_id = author.get("id") if isinstance(author, Mapping) else None
-    author_login = author.get("login") if isinstance(author, Mapping) else None
+    if not isinstance(author, Mapping):
+        raise GateError("pull request author identity is malformed")
+    author_id = author.get("id")
+    author_login = author.get("login")
+    if (
+        not isinstance(author_id, int)
+        or isinstance(author_id, bool)
+        or author_id <= 0
+        or not isinstance(author_login, str)
+        or not author_login.strip()
+    ):
+        raise GateError("pull request author identity is malformed")
     latest: dict[int, tuple[tuple[dt.datetime, int], Mapping[str, Any]]] = {}
     seen_review_ids: set[int] = set()
 

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -340,6 +340,21 @@ def verify_ci_workflow_revision(
     )
 
 
+def _dedupe_pr_numbers(numbers: Iterable[object]) -> list[int]:
+    """Keep one unambiguous PR number and reject cross-PR workflow runs."""
+
+    unique = list(
+        dict.fromkeys(
+            number
+            for number in numbers
+            if isinstance(number, int) and not isinstance(number, bool) and number > 0
+        )
+    )
+    if len(unique) > 1:
+        raise GateError("workflow run is associated with multiple pull requests")
+    return unique
+
+
 def _event_target(
     api: GitHubAPI, event_name: str, event: Mapping[str, Any]
 ) -> tuple[Mapping[str, Any], str, int, int | None]:
@@ -372,20 +387,17 @@ def _event_target(
         pull_requests = run.get("pull_requests")
         if not isinstance(pull_requests, list):
             raise GateError("workflow run API response is missing pull requests")
-        numbers = [item.get("number") for item in pull_requests if isinstance(item, Mapping)]
-        numbers = [number for number in numbers if isinstance(number, int) and not isinstance(number, bool)]
+        numbers = _dedupe_pr_numbers(
+            item.get("number") for item in pull_requests if isinstance(item, Mapping)
+        )
         if not numbers:
             pull_payload = api.get(
                 f"repos/{api.repository}/commits/{event_head}/pulls?per_page=100"
             )
             if isinstance(pull_payload, list):
-                numbers = [
-                    item.get("number")
-                    for item in pull_payload
-                    if isinstance(item, Mapping)
-                    and isinstance(item.get("number"), int)
-                    and not isinstance(item.get("number"), bool)
-                ]
+                numbers = _dedupe_pr_numbers(
+                    item.get("number") for item in pull_payload if isinstance(item, Mapping)
+                )
         if not numbers:
             raise GateError("workflow run is not associated with a pull request")
         pr_number = numbers[0]

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -634,6 +634,12 @@ def validate_snapshot(
 
 
 def _pr_files(api: GitHubAPI, number: int, expected_count: object) -> list[str]:
+    if (
+        not isinstance(expected_count, int)
+        or isinstance(expected_count, bool)
+        or expected_count < 0
+    ):
+        raise GateError("pull request file count is malformed")
     payload = api.get(
         f"repos/{api.repository}/pulls/{number}/files?per_page=100", paginate=True
     )
@@ -644,7 +650,7 @@ def _pr_files(api: GitHubAPI, number: int, expected_count: object) -> list[str]:
         if not isinstance(filename, str) or not filename:
             raise GateError("GitHub returned a pull request file without a filename")
         files.append(filename)
-    if isinstance(expected_count, int) and len(files) < expected_count:
+    if len(files) != expected_count:
         raise GateError("GitHub returned an incomplete pull request file list")
     return files
 

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -1,0 +1,468 @@
+#!/usr/bin/env python3
+"""Evaluate CI checks for one pull request from a trusted workflow."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from collections.abc import Iterable, Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
+
+import check_ci_status as contract  # noqa: E402
+import detect_ci_change_areas as change_areas  # noqa: E402
+
+
+CI_WORKFLOW_PATH = ".github/workflows/ci.yml"
+ACTIONS_APP_ID = 15368
+APP_HOST_SHARDS = 6
+MATRIX_PATTERN = re.compile(r"^app-host unit tests \((\d+)/(\d+)\)$")
+CHECK_NAME_ALIASES = {"GhosttyKit release check": "ghosttykit-release-check"}
+ADVISORY_CHECKS = {"ci-status", "ci-status-advisory", "ci-status-validator-canary"}
+ROUTE_NAMES = contract.ROUTE_NAMES
+
+
+class GateError(RuntimeError):
+    """Describe an input, API, or provenance error that must fail closed."""
+
+
+def _is_sha(value: object) -> bool:
+    return isinstance(value, str) and bool(re.fullmatch(r"[0-9a-f]{40}", value))
+
+
+def _as_sha(value: object, label: str) -> str:
+    if not _is_sha(value):
+        raise GateError(f"{label} is not a full lowercase commit SHA")
+    return str(value)
+
+
+def parse_event(raw: str) -> Mapping[str, Any]:
+    """Parse one GitHub event payload and reject non-object JSON."""
+
+    try:
+        event = json.loads(raw)
+    except json.JSONDecodeError as error:
+        raise GateError(f"event payload is not valid JSON: {error.msg}") from error
+    if not isinstance(event, Mapping):
+        raise GateError("event payload must be a JSON object")
+    return event
+
+
+def _page_rows(payload: object, key: str) -> list[Mapping[str, Any]]:
+    """Flatten a regular or --slurp GitHub API response."""
+
+    pages = payload if isinstance(payload, list) else [payload]
+    rows: list[Mapping[str, Any]] = []
+    for page in pages:
+        if not isinstance(page, Mapping):
+            raise GateError(f"GitHub API page for {key} is not an object")
+        values = page.get(key)
+        if not isinstance(values, list):
+            raise GateError(f"GitHub API page is missing {key}")
+        if any(not isinstance(value, Mapping) for value in values):
+            raise GateError(f"GitHub API page for {key} contains a malformed row")
+        rows.extend(values)
+    return rows
+
+
+class GitHubAPI:
+    """Small read-only wrapper around the runner's authenticated gh client."""
+
+    def __init__(self, repository: str, token: str | None = None) -> None:
+        if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repository):
+            raise GateError("GITHUB_REPOSITORY is malformed")
+        self.repository = repository
+        self.token = token or os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+
+    def get(self, endpoint: str, *, paginate: bool = False) -> object:
+        """Fetch JSON without invoking a shell or exposing the token."""
+
+        args = ["gh", "api", endpoint, "--header", "Accept: application/vnd.github+json"]
+        if paginate:
+            args.extend(["--paginate", "--slurp"])
+        environment = os.environ.copy()
+        if self.token:
+            environment["GH_TOKEN"] = self.token
+        try:
+            result = subprocess.run(
+                args,
+                check=False,
+                env=environment,
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise GateError(f"GitHub API request failed: {error}") from error
+        if result.returncode != 0:
+            detail = result.stderr.strip().splitlines()[-1:] or ["unknown API error"]
+            raise GateError(f"GitHub API request failed: {detail[0]}")
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            raise GateError("GitHub API returned invalid JSON") from error
+
+
+def _event_target(
+    api: GitHubAPI, event_name: str, event: Mapping[str, Any]
+) -> tuple[Mapping[str, Any], str, int, int | None]:
+    """Resolve and validate the live pull request and optional CI run ID."""
+
+    workflow_run_id: int | None = None
+    if event_name == "pull_request_target":
+        pull = event.get("pull_request")
+        number = event.get("number")
+        if not isinstance(pull, Mapping) or not isinstance(number, int) or isinstance(number, bool):
+            raise GateError("pull_request_target payload is missing pull request data")
+        event_head_data = pull.get("head")
+        event_head = _as_sha(
+            event_head_data.get("sha") if isinstance(event_head_data, Mapping) else None,
+            "event head SHA",
+        )
+        pr_number = number
+    elif event_name == "workflow_run":
+        run_event = event.get("workflow_run")
+        if not isinstance(run_event, Mapping):
+            raise GateError("workflow_run payload is missing workflow data")
+        raw_id = run_event.get("id")
+        if not isinstance(raw_id, int) or isinstance(raw_id, bool):
+            raise GateError("workflow_run payload is missing a numeric run ID")
+        workflow_run_id = raw_id
+        event_head = _as_sha(run_event.get("head_sha"), "workflow run head SHA")
+        run = api.get(f"repos/{api.repository}/actions/runs/{raw_id}")
+        if not isinstance(run, Mapping):
+            raise GateError("workflow run API response is not an object")
+        pull_requests = run.get("pull_requests")
+        if not isinstance(pull_requests, list):
+            raise GateError("workflow run API response is missing pull requests")
+        numbers = [item.get("number") for item in pull_requests if isinstance(item, Mapping)]
+        numbers = [number for number in numbers if isinstance(number, int) and not isinstance(number, bool)]
+        if not numbers:
+            pull_payload = api.get(
+                f"repos/{api.repository}/commits/{event_head}/pulls?per_page=100"
+            )
+            if isinstance(pull_payload, list):
+                numbers = [
+                    item.get("number")
+                    for item in pull_payload
+                    if isinstance(item, Mapping)
+                    and isinstance(item.get("number"), int)
+                    and not isinstance(item.get("number"), bool)
+                ]
+        if not numbers:
+            raise GateError("workflow run is not associated with a pull request")
+        pr_number = numbers[0]
+    else:
+        raise GateError(f"unsupported event {event_name or 'unknown'}")
+
+    pull = api.get(f"repos/{api.repository}/pulls/{pr_number}")
+    if not isinstance(pull, Mapping):
+        raise GateError("pull request API response is not an object")
+    if pull.get("state") != "open":
+        raise GateError("pull request is not open")
+    base = pull.get("base")
+    head = pull.get("head")
+    if not isinstance(base, Mapping) or not isinstance(head, Mapping):
+        raise GateError("pull request is missing base or head data")
+    if base.get("ref") != "main":
+        raise GateError("pull request base is not main")
+    base_repo = base.get("repo")
+    if not isinstance(base_repo, Mapping) or base_repo.get("full_name") != api.repository:
+        raise GateError("pull request targets a different repository")
+    live_head = _as_sha(head.get("sha"), "live pull request head SHA")
+    if live_head != event_head:
+        raise GateError("pull request head changed after the event; wait for a new run")
+    return pull, live_head, pr_number, workflow_run_id
+
+
+def _select_ci_run(
+    api: GitHubAPI,
+    pull: Mapping[str, Any],
+    head_sha: str,
+    workflow_run_id: int | None,
+) -> Mapping[str, Any]:
+    """Select one completed CI workflow run for exactly this PR head."""
+
+    if workflow_run_id is not None:
+        candidate = api.get(f"repos/{api.repository}/actions/runs/{workflow_run_id}")
+        candidates = [candidate] if isinstance(candidate, Mapping) else []
+    else:
+        payload = api.get(
+            f"repos/{api.repository}/actions/runs?event=pull_request&head_sha={head_sha}&per_page=100"
+        )
+        candidates = []
+        if isinstance(payload, Mapping) and isinstance(payload.get("workflow_runs"), list):
+            candidates = [item for item in payload["workflow_runs"] if isinstance(item, Mapping)]
+
+    valid: list[Mapping[str, Any]] = []
+    pr_number = pull.get("number")
+    for run in candidates:
+        if run.get("path") != CI_WORKFLOW_PATH or run.get("event") != "pull_request":
+            continue
+        if run.get("head_sha") != head_sha:
+            continue
+        pull_requests = run.get("pull_requests")
+        if isinstance(pull_requests, list) and isinstance(pr_number, int):
+            if not any(
+                isinstance(item, Mapping) and item.get("number") == pr_number
+                for item in pull_requests
+            ):
+                continue
+        valid.append(run)
+    if not valid:
+        raise GateError("no CI workflow run exists for this exact pull request head")
+    def run_key(run: Mapping[str, Any]) -> tuple[str, int]:
+        raw_id = run.get("id")
+        if not isinstance(raw_id, int) or isinstance(raw_id, bool):
+            return (str(run.get("created_at", "")), 0)
+        return (str(run.get("created_at", "")), raw_id)
+
+    selected = max(valid, key=run_key)
+    if not isinstance(selected.get("id"), int) or isinstance(selected.get("id"), bool):
+        raise GateError("CI workflow run has no numeric ID")
+    if selected.get("status") != "completed":
+        raise GateError("CI workflow is still running; gate will rerun on completion")
+    return selected
+
+
+def _check_run_id(url: object) -> int | None:
+    if not isinstance(url, str):
+        return None
+    match = re.search(r"/check-runs/(\d+)$", url)
+    return int(match.group(1)) if match else None
+
+
+def _run_check_ids(jobs: Sequence[Mapping[str, Any]], head_sha: str) -> set[int]:
+    ids: set[int] = set()
+    for job in jobs:
+        if job.get("head_sha") != head_sha:
+            raise GateError(f"CI job {job.get('name', '<unnamed>')} has a stale head SHA")
+        check_id = _check_run_id(job.get("check_run_url"))
+        if check_id is None:
+            raise GateError(f"CI job {job.get('name', '<unnamed>')} has no check-run ID")
+        ids.add(check_id)
+    if not ids:
+        raise GateError("CI workflow has no check runs")
+    return ids
+
+
+def _check_result(check: Mapping[str, Any]) -> str:
+    status = check.get("status")
+    if status != "completed":
+        return status if isinstance(status, str) else "missing"
+    conclusion = check.get("conclusion")
+    return conclusion if isinstance(conclusion, str) else "missing"
+
+
+def _job_id(display_name: object) -> str | None:
+    if not isinstance(display_name, str):
+        return None
+    alias = CHECK_NAME_ALIASES.get(display_name)
+    if alias:
+        return alias
+    if display_name in contract.PHASE_CONTRACTS["aggregate"][0] + contract.AGGREGATE_ROUTE_JOBS:
+        return display_name
+    return "app-host-unit-tests" if MATRIX_PATTERN.fullmatch(display_name) else None
+
+
+def _matrix_status(matrix: Mapping[int, str]) -> str:
+    expected = set(range(1, APP_HOST_SHARDS + 1))
+    if set(matrix) != expected:
+        return "missing"
+    results = [matrix[index] for index in sorted(matrix)]
+    if all(result == "success" for result in results):
+        return "success"
+    if all(result == "skipped" for result in results):
+        return "skipped"
+    if any(result not in {"success", "skipped"} for result in results):
+        return next(result for result in results if result not in {"success", "skipped"})
+    return "mixed"
+
+
+def normalize_check_runs(
+    check_runs: Iterable[Mapping[str, Any]],
+    *,
+    head_sha: str,
+    expected_check_ids: set[int] | None = None,
+) -> tuple[dict[str, str], list[str]]:
+    """Map exact trusted Actions checks to the validator's job IDs."""
+
+    _as_sha(head_sha, "head SHA")
+    latest: dict[str, Mapping[str, Any]] = {}
+    matrix: dict[int, Mapping[str, Any]] = {}
+    unknown: list[str] = []
+    for check in check_runs:
+        if not isinstance(check, Mapping) or check.get("head_sha") != head_sha:
+            continue
+        app = check.get("app")
+        if not isinstance(app, Mapping) or app.get("id") != ACTIONS_APP_ID:
+            continue
+        check_id = check.get("id")
+        if not isinstance(check_id, int):
+            continue
+        if expected_check_ids is not None and check_id not in expected_check_ids:
+            continue
+        name = check.get("name")
+        if not isinstance(name, str):
+            continue
+        match = MATRIX_PATTERN.fullmatch(name)
+        if match:
+            shard, denominator = (int(match.group(1)), int(match.group(2)))
+            if denominator != APP_HOST_SHARDS:
+                unknown.append(name)
+                continue
+            current = matrix.get(shard)
+            current_id = current.get("id") if current is not None else None
+            if current is None or not isinstance(current_id, int) or check_id > current_id:
+                matrix[shard] = check
+            continue
+        job_id = _job_id(name)
+        if job_id is None:
+            if name not in ADVISORY_CHECKS:
+                unknown.append(name)
+            continue
+        current = latest.get(job_id)
+        current_id = current.get("id") if current is not None else None
+        if current is None or not isinstance(current_id, int) or check_id > current_id:
+            latest[job_id] = check
+
+    statuses = {
+        job: _check_result(latest[job]) if job in latest else "missing"
+        for job in contract.PHASE_CONTRACTS["aggregate"][0] + contract.AGGREGATE_ROUTE_JOBS
+    }
+    statuses["app-host-unit-tests"] = _matrix_status(
+        {index: _check_result(check) for index, check in matrix.items()}
+    )
+    return statuses, sorted(set(unknown))
+
+
+def build_needs(
+    check_runs: Iterable[Mapping[str, Any]],
+    changed_files: Iterable[str],
+    *,
+    head_sha: str,
+    expected_check_ids: set[int] | None = None,
+) -> tuple[dict[str, dict[str, Any]], list[str]]:
+    """Build the validator input using routes derived from live PR files."""
+
+    statuses, unknown = normalize_check_runs(
+        check_runs,
+        head_sha=head_sha,
+        expected_check_ids=expected_check_ids,
+    )
+    areas = change_areas.classify_files(changed_files)
+    outputs = {
+        "macos": "true" if areas.macos else "false",
+        "web": "true" if areas.web else "false",
+        "go": "true" if areas.go else "false",
+        "agent_session_web": "true" if areas.agent_session_web else "false",
+    }
+    needs: dict[str, dict[str, Any]] = {
+        job: {"result": result} for job, result in statuses.items()
+    }
+    needs["changes"] = {"result": statuses["changes"], "outputs": outputs}
+    return needs, unknown
+
+
+def validate_snapshot(
+    check_runs: Iterable[Mapping[str, Any]],
+    changed_files: Iterable[str],
+    *,
+    head_sha: str,
+    expected_check_ids: set[int] | None = None,
+) -> list[str]:
+    """Return all fail-closed violations for one exact PR snapshot."""
+
+    needs, unknown = build_needs(
+        check_runs,
+        changed_files,
+        head_sha=head_sha,
+        expected_check_ids=expected_check_ids,
+    )
+    failures = [f"{name}: unexpected CI job" for name in unknown]
+    failures.extend(contract.validate_needs(needs, phase="aggregate"))
+    return failures
+
+
+def _pr_files(api: GitHubAPI, number: int, expected_count: object) -> list[str]:
+    payload = api.get(
+        f"repos/{api.repository}/pulls/{number}/files?per_page=100", paginate=True
+    )
+    rows = _page_rows(payload, "files")
+    files: list[str] = []
+    for row in rows:
+        filename = row.get("filename")
+        if not isinstance(filename, str) or not filename:
+            raise GateError("GitHub returned a pull request file without a filename")
+        files.append(filename)
+    if isinstance(expected_count, int) and len(files) < expected_count:
+        raise GateError("GitHub returned an incomplete pull request file list")
+    return files
+
+
+def _run_gate(api: GitHubAPI, event_name: str, event: Mapping[str, Any]) -> int:
+    pull, head_sha, number, workflow_run_id = _event_target(api, event_name, event)
+    ci_run = _select_ci_run(api, pull, head_sha, workflow_run_id)
+    jobs_payload = api.get(
+        f"repos/{api.repository}/actions/runs/{ci_run['id']}/jobs?per_page=100", paginate=True
+    )
+    jobs = _page_rows(jobs_payload, "jobs")
+    run_check_ids = _run_check_ids(jobs, head_sha)
+    checks_payload = api.get(
+        f"repos/{api.repository}/commits/{head_sha}/check-runs?per_page=100", paginate=True
+    )
+    checks = _page_rows(checks_payload, "check_runs")
+    files = _pr_files(api, number, pull.get("changed_files"))
+    failures = validate_snapshot(
+        checks,
+        files,
+        head_sha=head_sha,
+        expected_check_ids=run_check_ids,
+    )
+    print(f"CI status gate for PR #{number}, head {head_sha}")
+    if failures:
+        print("CI status gate failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"- {failure}", file=sys.stderr)
+        return 1
+    print("CI status gate passed.")
+    return 0
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--event-file",
+        type=Path,
+        default=Path(os.environ.get("GITHUB_EVENT_PATH", "")) if os.environ.get("GITHUB_EVENT_PATH") else None,
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    if args.event_file is None:
+        print("CI status gate input error: GITHUB_EVENT_PATH is missing", file=sys.stderr)
+        return 2
+    try:
+        event = parse_event(args.event_file.read_text(encoding="utf-8"))
+        repository = os.environ.get("GITHUB_REPOSITORY", "")
+        api = GitHubAPI(repository)
+        return _run_gate(api, os.environ.get("GITHUB_EVENT_NAME", ""), event)
+    except (GateError, OSError) as error:
+        print(f"CI status gate input error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
 import os
 import re
@@ -29,10 +30,30 @@ MATRIX_PATTERN = re.compile(r"^app-host unit tests \((\d+)/(\d+)\)$")
 CHECK_NAME_ALIASES = {"GhosttyKit release check": "ghosttykit-release-check"}
 ADVISORY_CHECKS = {"ci-status", "ci-status-advisory", "ci-status-validator-canary"}
 ROUTE_NAMES = contract.ROUTE_NAMES
+TRUSTED_REVIEWER_IDS = {
+    38676809: "austinywang",
+    67667005: "azooz2003-bit",
+}
+TRUSTED_REVIEWER_LOGINS = frozenset(TRUSTED_REVIEWER_IDS.values())
+TRUSTED_REVIEWER_LOGIN_KEYS = frozenset(
+    name.casefold() for name in TRUSTED_REVIEWER_LOGINS
+)
+REVIEW_STATES = frozenset(
+    {"APPROVED", "CHANGES_REQUESTED", "DISMISSED", "COMMENTED", "PENDING"}
+)
+REVIEW_TIMESTAMP = re.compile(
+    r"^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z$"
+)
+MAX_REVIEW_ID = 2**63 - 1
+MAX_REVIEW_PAGES = 100
 
 
 class GateError(RuntimeError):
     """Describe an input, API, or provenance error that must fail closed."""
+
+
+class WorkflowDefinitionError(GateError):
+    """The pull request changed CI policy without the required approval."""
 
 
 def _is_sha(value: object) -> bool:
@@ -74,6 +95,32 @@ def _page_rows(payload: object, key: str) -> list[Mapping[str, Any]]:
     return rows
 
 
+def _array_rows(payload: object, label: str) -> list[Mapping[str, Any]]:
+    """Flatten a regular or --slurp response whose pages are arrays."""
+
+    if not isinstance(payload, list):
+        raise GateError(f"GitHub API response for {label} is not an array")
+    if not payload:
+        return []
+    pages: list[object]
+    if all(isinstance(value, Mapping) for value in payload):
+        pages = [payload]
+    else:
+        pages = payload
+    if len(pages) > MAX_REVIEW_PAGES:
+        raise GateError(f"GitHub API returned too many {label} pages")
+    rows: list[Mapping[str, Any]] = []
+    for page in pages:
+        if not isinstance(page, list):
+            raise GateError(f"GitHub API page for {label} is not an array")
+        if len(page) > 100:
+            raise GateError(f"GitHub API page for {label} is too large")
+        if any(not isinstance(value, Mapping) for value in page):
+            raise GateError(f"GitHub API page for {label} contains a malformed row")
+        rows.extend(page)
+    return rows
+
+
 class GitHubAPI:
     """Small read-only wrapper around the runner's authenticated gh client."""
 
@@ -111,6 +158,186 @@ class GitHubAPI:
             return json.loads(result.stdout)
         except json.JSONDecodeError as error:
             raise GateError("GitHub API returned invalid JSON") from error
+
+
+def _workflow_blob_sha(api: GitHubAPI, revision: str) -> str:
+    """Return the immutable blob SHA for the CI workflow at one revision."""
+
+    revision = _as_sha(revision, "workflow revision")
+    payload = api.get(
+        f"repos/{api.repository}/contents/{CI_WORKFLOW_PATH}?ref={revision}"
+    )
+    if not isinstance(payload, Mapping):
+        raise GateError("GitHub returned a malformed CI workflow definition")
+    if payload.get("type") != "file" or payload.get("path") != CI_WORKFLOW_PATH:
+        raise GateError("GitHub returned a non-file CI workflow definition")
+    return _as_sha(payload.get("sha"), "CI workflow blob SHA")
+
+
+def _review_order(review: Mapping[str, Any]) -> tuple[dt.datetime, int]:
+    """Build a deterministic order for one trusted review decision."""
+
+    review_id = review.get("id")
+    if not isinstance(review_id, int) or isinstance(review_id, bool):
+        raise GateError("trusted review ID is malformed")
+    if review_id <= 0 or review_id > MAX_REVIEW_ID:
+        raise GateError("trusted review ID is malformed")
+    submitted_at = review.get("submitted_at")
+    if not isinstance(submitted_at, str) or not REVIEW_TIMESTAMP.fullmatch(submitted_at):
+        raise GateError("trusted review timestamp is malformed")
+    try:
+        timestamp = dt.datetime.fromisoformat(submitted_at.replace("Z", "+00:00"))
+    except ValueError as error:
+        raise GateError("trusted review timestamp is malformed") from error
+    if timestamp.tzinfo is None:
+        raise GateError("trusted review timestamp is malformed")
+    return timestamp, review_id
+
+
+def _trusted_reviewer_id(review: Mapping[str, Any]) -> int | None:
+    """Identify a trusted human reviewer, rejecting ambiguous identities."""
+
+    user = review.get("user")
+    if not isinstance(user, Mapping):
+        return None
+    user_id = user.get("id")
+    login = user.get("login")
+    trusted_by_login = isinstance(login, str) and login.casefold() in TRUSTED_REVIEWER_LOGIN_KEYS
+    if not isinstance(user_id, int) or isinstance(user_id, bool):
+        if trusted_by_login:
+            raise GateError("trusted reviewer identity is missing an account ID")
+        return None
+    expected_login = TRUSTED_REVIEWER_IDS.get(user_id)
+    if expected_login is None:
+        return None
+    if not isinstance(login, str) or login.casefold() != expected_login.casefold():
+        raise GateError("trusted reviewer identity does not match its account ID")
+    if user.get("type") != "User":
+        raise GateError("trusted reviewer is not a human account")
+    return user_id
+
+
+def _review_rows(payload: object) -> list[Mapping[str, Any]]:
+    """Read review pages returned by ``gh api --paginate --slurp``."""
+
+    return _array_rows(payload, "pull-request reviews")
+
+
+def has_trusted_workflow_review(
+    reviews: Iterable[Mapping[str, Any]],
+    pull: Mapping[str, Any],
+    head_sha: str,
+) -> bool:
+    """Return whether Austin or Aziz approved the exact workflow revision."""
+
+    head_sha = _as_sha(head_sha, "head SHA")
+    author = pull.get("user")
+    author_id = author.get("id") if isinstance(author, Mapping) else None
+    author_login = author.get("login") if isinstance(author, Mapping) else None
+    latest: dict[int, tuple[tuple[dt.datetime, int], Mapping[str, Any]]] = {}
+    seen_review_ids: set[int] = set()
+
+    for review in reviews:
+        if not isinstance(review, Mapping):
+            raise GateError("pull-request review entry is malformed")
+        raw_id = review.get("id")
+        user = review.get("user")
+        user_id = user.get("id") if isinstance(user, Mapping) else None
+        login = user.get("login") if isinstance(user, Mapping) else None
+        trusted_hint = (
+            isinstance(user_id, int)
+            and not isinstance(user_id, bool)
+            and user_id in TRUSTED_REVIEWER_IDS
+        ) or (
+            isinstance(login, str)
+            and login.casefold() in TRUSTED_REVIEWER_LOGIN_KEYS
+        )
+        if not isinstance(raw_id, int) or isinstance(raw_id, bool) or raw_id <= 0:
+            if trusted_hint:
+                raise GateError("trusted review ID is malformed")
+            continue
+        if raw_id > MAX_REVIEW_ID:
+            raise GateError("pull-request review ID is malformed")
+        if raw_id in seen_review_ids:
+            raise GateError("pull-request review pagination repeated an entry")
+        seen_review_ids.add(raw_id)
+
+        reviewer_id = _trusted_reviewer_id(review)
+        if reviewer_id is None:
+            continue
+        state = review.get("state")
+        if not isinstance(state, str) or state not in REVIEW_STATES:
+            raise GateError("trusted review state is malformed")
+        if state in {"COMMENTED", "PENDING"}:
+            continue
+        order = _review_order(review)
+        # A dismissed approval is not an approval, even if GitHub leaves the
+        # original state in the response while dismissal metadata propagates.
+        effective_state = "DISMISSED" if review.get("dismissed_at") is not None else state
+        if effective_state == "APPROVED":
+            commit_id = review.get("commit_id")
+            _as_sha(commit_id, "trusted review commit SHA")
+        previous = latest.get(reviewer_id)
+        if previous is None or order > previous[0]:
+            latest[reviewer_id] = (order, {**review, "state": effective_state})
+
+    for _reviewer_id, (_order, review) in latest.items():
+        if review.get("state") != "APPROVED":
+            continue
+        if review.get("commit_id") != head_sha:
+            continue
+        if review.get("dismissed_at") is not None:
+            continue
+        reviewed_user = review.get("user")
+        reviewed_id = reviewed_user.get("id") if isinstance(reviewed_user, Mapping) else None
+        reviewed_login = reviewed_user.get("login") if isinstance(reviewed_user, Mapping) else None
+        if reviewed_id == author_id or (
+            isinstance(reviewed_login, str)
+            and isinstance(author_login, str)
+            and reviewed_login.casefold() == author_login.casefold()
+        ):
+            continue
+        return True
+    return False
+
+
+def verify_ci_workflow_revision(
+    api: GitHubAPI,
+    pull: Mapping[str, Any],
+    head_sha: str,
+) -> None:
+    """Require trusted approval when the PR changes the CI workflow bytes."""
+
+    base = pull.get("base")
+    base_sha = _as_sha(
+        base.get("sha") if isinstance(base, Mapping) else None,
+        "pull request base SHA",
+    )
+    head_sha = _as_sha(head_sha, "pull request head SHA")
+    base_blob = _workflow_blob_sha(api, base_sha)
+    head_blob = _workflow_blob_sha(api, head_sha)
+    if base_blob == head_blob:
+        return
+
+    number = pull.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+        raise GateError("pull request number is malformed")
+    reviews = _review_rows(
+        api.get(
+            f"repos/{api.repository}/pulls/{number}/reviews?per_page=100",
+            paginate=True,
+        )
+    )
+    if has_trusted_workflow_review(reviews, pull, head_sha):
+        print(
+            "CI workflow definition changed, exact-head trusted review verified.",
+            file=sys.stderr,
+        )
+        return
+    raise WorkflowDefinitionError(
+        "CI workflow definition differs from the base revision; "
+        "an exact-head approval from Austin or Aziz is required"
+    )
 
 
 def _event_target(
@@ -412,6 +639,12 @@ def _pr_files(api: GitHubAPI, number: int, expected_count: object) -> list[str]:
 
 def _run_gate(api: GitHubAPI, event_name: str, event: Mapping[str, Any]) -> int:
     pull, head_sha, number, workflow_run_id = _event_target(api, event_name, event)
+    try:
+        verify_ci_workflow_revision(api, pull, head_sha)
+    except WorkflowDefinitionError as error:
+        print("CI status gate failed:", file=sys.stderr)
+        print(f"- {error}", file=sys.stderr)
+        return 1
     ci_run = _select_ci_run(api, pull, head_sha, workflow_run_id)
     jobs_payload = api.get(
         f"repos/{api.repository}/actions/runs/{ci_run['id']}/jobs?per_page=100", paginate=True

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -30,6 +30,7 @@ MATRIX_PATTERN = re.compile(r"^app-host unit tests \((\d+)/(\d+)\)$")
 CHECK_NAME_ALIASES = {"GhosttyKit release check": "ghosttykit-release-check"}
 ADVISORY_CHECKS = {"ci-status", "ci-status-advisory", "ci-status-validator-canary"}
 ROUTE_NAMES = contract.ROUTE_NAMES
+PUBLISHED_CHECKS = ("ci-status-gate", "ci-status")
 TRUSTED_REVIEWER_IDS = {
     38676809: "austinywang",
     67667005: "azooz2003-bit",
@@ -158,6 +159,104 @@ class GitHubAPI:
             return json.loads(result.stdout)
         except json.JSONDecodeError as error:
             raise GateError("GitHub API returned invalid JSON") from error
+
+    def write(self, method: str, endpoint: str, payload: Mapping[str, Any]) -> object:
+        """Send one narrow Checks API write using the trusted workflow token."""
+
+        if method not in {"POST", "PATCH"}:
+            raise GateError("unsupported GitHub API write method")
+        args = [
+            "gh",
+            "api",
+            endpoint,
+            "--method",
+            method,
+            "--header",
+            "Accept: application/vnd.github+json",
+            "--input",
+            "-",
+        ]
+        environment = os.environ.copy()
+        if self.token:
+            environment["GH_TOKEN"] = self.token
+        try:
+            result = subprocess.run(
+                args,
+                check=False,
+                env=environment,
+                input=json.dumps(payload, separators=(",", ":")),
+                text=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                timeout=30,
+            )
+        except (OSError, subprocess.TimeoutExpired) as error:
+            raise GateError(f"GitHub API write failed: {error}") from error
+        if result.returncode != 0:
+            detail = result.stderr.strip().splitlines()[-1:] or ["unknown API error"]
+            raise GateError(f"GitHub API write failed: {detail[0]}")
+        try:
+            return json.loads(result.stdout)
+        except json.JSONDecodeError as error:
+            raise GateError("GitHub API write returned invalid JSON") from error
+
+    def publish_check(
+        self,
+        name: str,
+        head_sha: str,
+        conclusion: str,
+        summary: str,
+    ) -> None:
+        """Create or update one Actions check run on the exact PR head."""
+
+        if name not in PUBLISHED_CHECKS:
+            raise GateError("unsupported published check name")
+        head_sha = _as_sha(head_sha, "published check head SHA")
+        if conclusion not in {"success", "failure"}:
+            raise GateError("published check conclusion is malformed")
+        if not isinstance(summary, str) or not summary:
+            raise GateError("published check summary is malformed")
+        payload = self.get(
+            f"repos/{self.repository}/commits/{head_sha}/check-runs?check_name={name}&per_page=100",
+            paginate=True,
+        )
+        rows = _page_rows(payload, "check_runs")
+        candidates = [
+            row
+            for row in rows
+            if row.get("name") == name
+            and row.get("head_sha") == head_sha
+            and isinstance(row.get("app"), Mapping)
+            and row["app"].get("id") == ACTIONS_APP_ID
+            and isinstance(row.get("id"), int)
+            and not isinstance(row.get("id"), bool)
+        ]
+        latest = max(candidates, key=lambda row: row["id"]) if candidates else None
+        endpoint = (
+            f"repos/{self.repository}/check-runs/{latest['id']}"
+            if latest is not None
+            else f"repos/{self.repository}/check-runs"
+        )
+        method = "PATCH" if latest is not None else "POST"
+        response = self.write(
+            method,
+            endpoint,
+            {
+                "name": name,
+                "head_sha": head_sha,
+                "status": "completed",
+                "conclusion": conclusion,
+                "external_id": f"cmux-{name}-{head_sha}",
+                "output": {"title": name, "summary": summary},
+            },
+        )
+        if not isinstance(response, Mapping):
+            raise GateError("GitHub returned a malformed published check")
+        if response.get("name") != name or response.get("head_sha") != head_sha:
+            raise GateError("published check does not target the exact PR head")
+        app = response.get("app")
+        if not isinstance(app, Mapping) or app.get("id") != ACTIONS_APP_ID:
+            raise GateError("published check was created by an unexpected app")
 
 
 def _workflow_blob_sha(api: GitHubAPI, revision: str) -> str:
@@ -361,11 +460,13 @@ def _event_target(
     """Resolve and validate the live pull request and optional CI run ID."""
 
     workflow_run_id: int | None = None
-    if event_name == "pull_request_target":
+    if event_name in {"pull_request_target", "pull_request_review"}:
         pull = event.get("pull_request")
-        number = event.get("number")
+        number = event.get("number") if event_name == "pull_request_target" else None
+        if number is None and isinstance(pull, Mapping):
+            number = pull.get("number")
         if not isinstance(pull, Mapping) or not isinstance(number, int) or isinstance(number, bool):
-            raise GateError("pull_request_target payload is missing pull request data")
+            raise GateError(f"{event_name} payload is missing pull request data")
         event_head_data = pull.get("head")
         event_head = _as_sha(
             event_head_data.get("sha") if isinstance(event_head_data, Mapping) else None,
@@ -451,12 +552,14 @@ def _select_ci_run(
         if run.get("head_sha") != head_sha:
             continue
         pull_requests = run.get("pull_requests")
-        if isinstance(pull_requests, list) and isinstance(pr_number, int):
-            if not any(
+        if isinstance(pull_requests, list):
+            if pull_requests and not any(
                 isinstance(item, Mapping) and item.get("number") == pr_number
                 for item in pull_requests
             ):
                 continue
+        elif pull_requests is not None:
+            raise GateError("CI workflow run pull request association is malformed")
         valid.append(run)
     if not valid:
         raise GateError("no CI workflow run exists for this exact pull request head")
@@ -655,39 +758,78 @@ def _pr_files(api: GitHubAPI, number: int, expected_count: object) -> list[str]:
     return files
 
 
-def _run_gate(api: GitHubAPI, event_name: str, event: Mapping[str, Any]) -> int:
+def _publish_gate_checks(
+    api: GitHubAPI,
+    head_sha: str,
+    conclusion: str,
+    summary: str,
+) -> None:
+    """Publish both the new and legacy contexts for one exact head."""
+
+    for name in PUBLISHED_CHECKS:
+        api.publish_check(name, head_sha, conclusion, summary)
+
+
+def _run_gate(
+    api: GitHubAPI,
+    event_name: str,
+    event: Mapping[str, Any],
+    *,
+    publish: bool = False,
+) -> int:
+    """Evaluate one event and optionally publish head-targeted check runs."""
+
     pull, head_sha, number, workflow_run_id = _event_target(api, event_name, event)
+    print(f"CI status gate for PR #{number}, head {head_sha}")
+    result = 1
     try:
         verify_ci_workflow_revision(api, pull, head_sha)
+        ci_run = _select_ci_run(api, pull, head_sha, workflow_run_id)
+        jobs_payload = api.get(
+            f"repos/{api.repository}/actions/runs/{ci_run['id']}/jobs?per_page=100",
+            paginate=True,
+        )
+        jobs = _page_rows(jobs_payload, "jobs")
+        run_check_ids = _run_check_ids(jobs, head_sha)
+        checks_payload = api.get(
+            f"repos/{api.repository}/commits/{head_sha}/check-runs?per_page=100",
+            paginate=True,
+        )
+        checks = _page_rows(checks_payload, "check_runs")
+        files = _pr_files(api, number, pull.get("changed_files"))
+        failures = validate_snapshot(
+            checks,
+            files,
+            head_sha=head_sha,
+            expected_check_ids=run_check_ids,
+        )
     except WorkflowDefinitionError as error:
-        print("CI status gate failed:", file=sys.stderr)
-        print(f"- {error}", file=sys.stderr)
-        return 1
-    ci_run = _select_ci_run(api, pull, head_sha, workflow_run_id)
-    jobs_payload = api.get(
-        f"repos/{api.repository}/actions/runs/{ci_run['id']}/jobs?per_page=100", paginate=True
-    )
-    jobs = _page_rows(jobs_payload, "jobs")
-    run_check_ids = _run_check_ids(jobs, head_sha)
-    checks_payload = api.get(
-        f"repos/{api.repository}/commits/{head_sha}/check-runs?per_page=100", paginate=True
-    )
-    checks = _page_rows(checks_payload, "check_runs")
-    files = _pr_files(api, number, pull.get("changed_files"))
-    failures = validate_snapshot(
-        checks,
-        files,
-        head_sha=head_sha,
-        expected_check_ids=run_check_ids,
-    )
-    print(f"CI status gate for PR #{number}, head {head_sha}")
+        failures = [str(error)]
+    except GateError as error:
+        failures = [f"gate input error: {error}"]
+
     if failures:
         print("CI status gate failed:", file=sys.stderr)
         for failure in failures:
             print(f"- {failure}", file=sys.stderr)
-        return 1
-    print("CI status gate passed.")
-    return 0
+        summary = "CI status validation failed. See the base-owned gate log for details."
+    else:
+        result = 0
+        print("CI status gate passed.")
+        summary = "CI checks passed for the exact pull request head."
+
+    if publish:
+        try:
+            _publish_gate_checks(
+                api,
+                head_sha,
+                "success" if result == 0 else "failure",
+                summary,
+            )
+        except GateError as error:
+            print(f"CI status check publication failed: {error}", file=sys.stderr)
+            return 2
+    return result
 
 
 def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
@@ -709,7 +851,12 @@ def main(argv: list[str] | None = None) -> int:
         event = parse_event(args.event_file.read_text(encoding="utf-8"))
         repository = os.environ.get("GITHUB_REPOSITORY", "")
         api = GitHubAPI(repository)
-        return _run_gate(api, os.environ.get("GITHUB_EVENT_NAME", ""), event)
+        return _run_gate(
+            api,
+            os.environ.get("GITHUB_EVENT_NAME", ""),
+            event,
+            publish=True,
+        )
     except (GateError, OSError) as error:
         print(f"CI status gate input error: {error}", file=sys.stderr)
         return 2

--- a/scripts/ci/ci_status_gate.py
+++ b/scripts/ci/ci_status_gate.py
@@ -439,19 +439,50 @@ def verify_ci_workflow_revision(
     )
 
 
-def _dedupe_pr_numbers(numbers: Iterable[object]) -> list[int]:
-    """Keep one unambiguous PR number and reject cross-PR workflow runs."""
+def _single_pr_number(rows: object, source: str) -> int:
+    """Return one well-formed PR number, rejecting missing or ambiguous rows."""
 
-    unique = list(
-        dict.fromkeys(
-            number
-            for number in numbers
-            if isinstance(number, int) and not isinstance(number, bool) and number > 0
-        )
+    if not isinstance(rows, list):
+        raise GateError(f"{source} pull request association is malformed")
+    if not rows:
+        raise GateError(f"{source} is not associated with a pull request")
+    if len(rows) > 1:
+        raise GateError(f"{source} is associated with multiple pull requests")
+    return _pr_number(rows[0], source)
+
+
+def _pr_number(row: object, source: str) -> int:
+    """Read one positive PR number from a validated association row."""
+
+    if not isinstance(row, Mapping):
+        raise GateError(f"{source} pull request association is malformed")
+    number = row.get("number")
+    if not isinstance(number, int) or isinstance(number, bool) or number <= 0:
+        raise GateError(f"{source} pull request number is malformed")
+    return number
+
+
+def _validate_commit_pull(
+    row: Mapping[str, Any], repository: str, head_sha: str
+) -> int:
+    """Validate one commit-to-PR association before using its number."""
+
+    if row.get("state") != "open":
+        raise GateError("commit is not associated with an open pull request")
+    base = row.get("base")
+    if not isinstance(base, Mapping) or base.get("ref") != "main":
+        raise GateError("commit pull request base is not main")
+    base_repo = base.get("repo")
+    if not isinstance(base_repo, Mapping) or base_repo.get("full_name") != repository:
+        raise GateError("commit pull request targets a different repository")
+    head = row.get("head")
+    row_head = _as_sha(
+        head.get("sha") if isinstance(head, Mapping) else None,
+        "commit pull request head SHA",
     )
-    if len(unique) > 1:
-        raise GateError("workflow run is associated with multiple pull requests")
-    return unique
+    if row_head != head_sha:
+        raise GateError("commit pull request head does not match the workflow run")
+    return _pr_number(row, "commit")
 
 
 def _event_target(
@@ -488,20 +519,21 @@ def _event_target(
         pull_requests = run.get("pull_requests")
         if not isinstance(pull_requests, list):
             raise GateError("workflow run API response is missing pull requests")
-        numbers = _dedupe_pr_numbers(
-            item.get("number") for item in pull_requests if isinstance(item, Mapping)
-        )
-        if not numbers:
+        if pull_requests:
+            pr_number = _single_pr_number(pull_requests, "workflow run")
+        else:
             pull_payload = api.get(
-                f"repos/{api.repository}/commits/{event_head}/pulls?per_page=100"
+                f"repos/{api.repository}/commits/{event_head}/pulls?per_page=100",
+                paginate=True,
             )
-            if isinstance(pull_payload, list):
-                numbers = _dedupe_pr_numbers(
-                    item.get("number") for item in pull_payload if isinstance(item, Mapping)
+            commit_rows = _array_rows(pull_payload, "commit pull requests")
+            if len(commit_rows) != 1:
+                raise GateError(
+                    "commit must resolve to exactly one pull request"
                 )
-        if not numbers:
-            raise GateError("workflow run is not associated with a pull request")
-        pr_number = numbers[0]
+            pr_number = _validate_commit_pull(
+                commit_rows[0], api.repository, event_head
+            )
     else:
         raise GateError(f"unsupported event {event_name or 'unknown'}")
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -856,6 +856,18 @@ def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> N
     assert "if: ${{ needs.changes.outputs.agent_session_web == 'true' }}" in block
 
 
+def test_legacy_ci_status_context_is_preserved_during_gate_migration() -> None:
+    advisory = workflow_job_block("ci-status-advisory")
+    compatibility = workflow_job_block("ci-status")
+
+    assert "ci-status-validator-canary" not in advisory
+    assert "if: ${{ always() }}" in compatibility
+    assert "needs: ci-status-advisory" in compatibility
+    assert "timeout-minutes: 5" in compatibility
+    assert "ADVISORY_RESULT" in compatibility
+    assert "exit 1" in compatibility
+
+
 def test_perf_activation_workflow_keeps_required_status_while_gating_benchmark() -> None:
     result, outputs = run_detect_step_for_paths(["docs/ci-runners.md"], PERF_ACTIVATION_WORKFLOW)
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -15,6 +15,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "scripts" / "ci" / "detect_ci_change_areas.py"
 CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
+GATE_WORKFLOW = ROOT / ".github" / "workflows" / "ci-status-gate.yml"
 PERF_ACTIVATION_WORKFLOW = ROOT / ".github" / "workflows" / "perf-activation.yml"
 
 spec = importlib.util.spec_from_file_location("detect_ci_change_areas", HELPER)
@@ -858,13 +859,14 @@ def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> N
 
 def test_legacy_ci_status_context_is_preserved_during_gate_migration() -> None:
     advisory = workflow_job_block("ci-status-advisory")
-    compatibility = workflow_job_block("ci-status")
+    compatibility = workflow_job_block("ci-status", GATE_WORKFLOW)
 
     assert "ci-status-validator-canary" not in advisory
-    assert "if: ${{ always() }}" in compatibility
-    assert "needs: ci-status-advisory" in compatibility
+    assert "ci-status:" not in CI_WORKFLOW.read_text(encoding="utf-8")
+    assert "if: ${{ always() &&" in compatibility
+    assert "needs: ci-status-gate" in compatibility
     assert "timeout-minutes: 5" in compatibility
-    assert "ADVISORY_RESULT" in compatibility
+    assert "GATE_RESULT" in compatibility
     assert "exit 1" in compatibility
 
 

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -859,15 +859,18 @@ def test_agent_session_web_resources_runs_only_for_agent_session_web_area() -> N
 
 def test_legacy_ci_status_context_is_preserved_during_gate_migration() -> None:
     advisory = workflow_job_block("ci-status-advisory")
-    compatibility = workflow_job_block("ci-status", GATE_WORKFLOW)
+    compatibility = workflow_job_block("ci-status")
+    trusted_alias = workflow_job_block("ci-status", GATE_WORKFLOW)
 
     assert "ci-status-validator-canary" not in advisory
-    assert "ci-status:" not in CI_WORKFLOW.read_text(encoding="utf-8")
-    assert "if: ${{ always() &&" in compatibility
-    assert "needs: ci-status-gate" in compatibility
+    assert "if: ${{ always() }}" in compatibility
+    assert "needs: ci-status-advisory" in compatibility
     assert "timeout-minutes: 5" in compatibility
-    assert "GATE_RESULT" in compatibility
+    assert "ADVISORY_RESULT" in compatibility
     assert "exit 1" in compatibility
+    assert "if: ${{ always() &&" in trusted_alias
+    assert "needs: ci-status-gate" in trusted_alias
+    assert "GATE_RESULT" in trusted_alias
 
 
 def test_perf_activation_workflow_keeps_required_status_while_gating_benchmark() -> None:

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -654,8 +654,8 @@ def test_non_pr_events_run_all_areas() -> None:
     assert "Resolved areas: macos=true web=true agent_session_web=true" in result.stdout
 
 
-def test_ci_status_job_accepts_skipped_routed_jobs() -> None:
-    block = workflow_job_block("ci-status")
+def test_ci_status_advisory_job_accepts_skipped_routed_jobs() -> None:
+    block = workflow_job_block("ci-status-advisory")
 
     for job_name in [
         "changes",

--- a/tests/test_ci_governance_bootstrap.py
+++ b/tests/test_ci_governance_bootstrap.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Check ownership of the trusted CI policy inputs."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
+TRUSTED_OWNERS = {"@austinywang", "@azooz2003-bit"}
+SENSITIVE_PATTERNS = ("/.github/workflows/**", "/scripts/ci/**", "/.github/CODEOWNERS")
+
+
+def _entries() -> dict[str, set[str]]:
+    entries: dict[str, set[str]] = {}
+    for raw_line in CODEOWNERS.read_text(encoding="utf-8").splitlines():
+        line = raw_line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        pattern, *owners = line.split()
+        entries[pattern] = set(owners)
+    return entries
+
+
+def test_sensitive_ci_inputs_have_two_trusted_owners() -> None:
+    entries = _entries()
+    for pattern in SENSITIVE_PATTERNS:
+        assert entries.get(pattern) == TRUSTED_OWNERS, pattern
+
+
+if __name__ == "__main__":
+    test_sensitive_ci_inputs_have_two_trusted_owners()
+    print("PASS: bootstrap CI governance contract")

--- a/tests/test_ci_governance_bootstrap.py
+++ b/tests/test_ci_governance_bootstrap.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[1]
 CODEOWNERS = ROOT / ".github" / "CODEOWNERS"
+GATE_WORKFLOW = ROOT / ".github" / "workflows" / "ci-status-gate.yml"
 TRUSTED_OWNERS = {"@austinywang", "@azooz2003-bit"}
 SENSITIVE_PATTERNS = ("/.github/workflows/**", "/scripts/ci/**", "/.github/CODEOWNERS")
 
@@ -27,6 +28,20 @@ def test_sensitive_ci_inputs_have_two_trusted_owners() -> None:
     entries = _entries()
     for pattern in SENSITIVE_PATTERNS:
         assert entries.get(pattern) == TRUSTED_OWNERS, pattern
+
+
+def test_gate_workflow_is_read_only_and_has_both_lifecycle_triggers() -> None:
+    text = GATE_WORKFLOW.read_text(encoding="utf-8")
+    assert "pull_request_target:" in text
+    assert "workflow_run:" in text
+    assert "workflows: [CI]" in text
+    assert "ci-status-gate:" in text
+    assert "actions: read" in text
+    assert "checks: read" in text
+    assert "pull-requests: read" in text
+    assert "contents: write" not in text
+    assert "persist-credentials: false" in text
+    assert ".ci-trusted/scripts/ci/ci_status_gate.py" in text
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_governance_bootstrap.py
+++ b/tests/test_ci_governance_bootstrap.py
@@ -46,4 +46,5 @@ def test_gate_workflow_is_read_only_and_has_both_lifecycle_triggers() -> None:
 
 if __name__ == "__main__":
     test_sensitive_ci_inputs_have_two_trusted_owners()
+    test_gate_workflow_is_read_only_and_has_both_lifecycle_triggers()
     print("PASS: bootstrap CI governance contract")

--- a/tests/test_ci_governance_bootstrap.py
+++ b/tests/test_ci_governance_bootstrap.py
@@ -30,7 +30,7 @@ def test_sensitive_ci_inputs_have_two_trusted_owners() -> None:
         assert entries.get(pattern) == TRUSTED_OWNERS, pattern
 
 
-def test_gate_workflow_is_read_only_and_has_both_lifecycle_triggers() -> None:
+def test_gate_workflow_is_base_owned_and_limited() -> None:
     text = GATE_WORKFLOW.read_text(encoding="utf-8")
     assert "pull_request_target:" in text
     assert "pull_request_review:" in text
@@ -47,5 +47,5 @@ def test_gate_workflow_is_read_only_and_has_both_lifecycle_triggers() -> None:
 
 if __name__ == "__main__":
     test_sensitive_ci_inputs_have_two_trusted_owners()
-    test_gate_workflow_is_read_only_and_has_both_lifecycle_triggers()
+    test_gate_workflow_is_base_owned_and_limited()
     print("PASS: bootstrap CI governance contract")

--- a/tests/test_ci_governance_bootstrap.py
+++ b/tests/test_ci_governance_bootstrap.py
@@ -33,11 +33,12 @@ def test_sensitive_ci_inputs_have_two_trusted_owners() -> None:
 def test_gate_workflow_is_read_only_and_has_both_lifecycle_triggers() -> None:
     text = GATE_WORKFLOW.read_text(encoding="utf-8")
     assert "pull_request_target:" in text
+    assert "pull_request_review:" in text
     assert "workflow_run:" in text
     assert "workflows: [CI]" in text
     assert "ci-status-gate:" in text
     assert "actions: read" in text
-    assert "checks: read" in text
+    assert "checks: write" in text
     assert "pull-requests: read" in text
     assert "contents: write" not in text
     assert "persist-credentials: false" in text

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -20,6 +20,7 @@ spec.loader.exec_module(module)
 
 
 HEAD_SHA = "a" * 40
+BASE_SHA = "c" * 40
 
 
 def check(
@@ -82,7 +83,12 @@ class FakeAPI:
                 "number": 1,
                 "state": "open",
                 "changed_files": 1,
-                "base": {"ref": "main", "repo": {"full_name": self.repository}},
+                "user": {"login": "contributor"},
+                "base": {
+                    "ref": "main",
+                    "sha": BASE_SHA,
+                    "repo": {"full_name": self.repository},
+                },
                 "head": {"sha": HEAD_SHA},
             }
         if "/actions/runs?event=" in endpoint:
@@ -112,6 +118,10 @@ class FakeAPI:
             return [{"jobs": jobs}]
         if "/commits/" in endpoint and "/check-runs" in endpoint:
             return [{"check_runs": self.checks}]
+        if "/contents/.github/workflows/ci.yml?ref=" in endpoint:
+            return {"sha": BASE_SHA}
+        if endpoint.endswith("/pulls/1/reviews?per_page=100"):
+            return []
         if endpoint.endswith("/pulls/1/files?per_page=100"):
             return [{"files": [{"filename": "README.md"}]}]
         raise AssertionError(f"unexpected API endpoint: {endpoint}")
@@ -224,6 +234,35 @@ def test_gate_queries_exact_head_and_ci_run_jobs() -> None:
         for request in api.requests
     )
     assert "CI status gate passed." in stdout.getvalue()
+
+
+def test_workflow_definition_mismatch_requires_trusted_review() -> None:
+    class WorkflowAPI(FakeAPI):
+        def __init__(self, *, approved: bool) -> None:
+            super().__init__(complete_checks())
+            self.approved = approved
+
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if "/contents/.github/workflows/ci.yml?ref=" in endpoint:
+                return {"sha": BASE_SHA if f"ref={BASE_SHA}" in endpoint else "d" * 40}
+            if endpoint.endswith("/pulls/1/reviews?per_page=100"):
+                return (
+                    [{"user": {"login": "austinywang"}, "state": "APPROVED", "commit_id": HEAD_SHA}]
+                    if self.approved
+                    else []
+                )
+            return super().get(endpoint, paginate=paginate)
+
+    unapproved = WorkflowAPI(approved=False)
+    pull = {"number": 1, "user": {"login": "contributor"}, "base": {"sha": BASE_SHA}}
+    try:
+        module.verify_ci_workflow_revision(unapproved, pull, HEAD_SHA)
+    except module.GateError as error:
+        assert "workflow definition" in str(error)
+    else:
+        raise AssertionError("unreviewed workflow change was accepted")
+
+    module.verify_ci_workflow_revision(WorkflowAPI(approved=True), pull, HEAD_SHA)
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -199,6 +199,7 @@ def test_unexpected_ci_job_is_rejected() -> None:
 def test_workflow_is_base_owned_and_read_only() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "pull_request_target:" in text
+    assert "pull_request_review:" in text
     assert "workflow_run:" in text
     assert "pull_request:" not in text
     assert "ci-status-gate:" in text
@@ -206,7 +207,7 @@ def test_workflow_is_base_owned_and_read_only() -> None:
     assert "needs: ci-status-gate" in text
     assert "GATE_RESULT" in text
     assert "actions: read" in text
-    assert "checks: read" in text
+    assert "checks: write" in text
     assert "pull-requests: read" in text
     assert "contents: write" not in text
     assert ".ci-trusted/scripts/ci/ci_status_gate.py" in text
@@ -219,6 +220,19 @@ def test_event_payload_parser_rejects_invalid_json() -> None:
         assert "event payload" in str(error)
     else:
         raise AssertionError("invalid event payload was accepted")
+
+
+def test_pull_request_review_event_resolves_live_head() -> None:
+    api = FakeAPI(complete_checks())
+    pull, head, number, workflow_run_id = module._event_target(
+        api,
+        "pull_request_review",
+        {"pull_request": {"number": 1, "head": {"sha": HEAD_SHA}}},
+    )
+    assert pull["number"] == 1
+    assert head == HEAD_SHA
+    assert number == 1
+    assert workflow_run_id is None
 
 
 def test_workflow_run_with_multiple_pull_requests_fails_closed() -> None:
@@ -240,6 +254,34 @@ def test_workflow_run_with_multiple_pull_requests_fails_closed() -> None:
         raise AssertionError("ambiguous workflow run was accepted")
 
 
+def test_external_fork_workflow_run_fallback_keeps_empty_association() -> None:
+    class ForkRunAPI(FakeAPI):
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if endpoint.endswith("/actions/runs/900"):
+                return {
+                    "id": 900,
+                    "path": module.CI_WORKFLOW_PATH,
+                    "event": "pull_request",
+                    "head_sha": HEAD_SHA,
+                    "status": "completed",
+                    "created_at": "2026-09-01T00:00:00Z",
+                    "pull_requests": [],
+                }
+            if endpoint.endswith(f"/commits/{HEAD_SHA}/pulls?per_page=100"):
+                return [{"number": 1}]
+            return super().get(endpoint, paginate=paginate)
+
+    api = ForkRunAPI(complete_checks())
+    pull, head, number, workflow_run_id = module._event_target(
+        api,
+        "workflow_run",
+        {"workflow_run": {"id": 900, "head_sha": HEAD_SHA}},
+    )
+    selected = module._select_ci_run(api, pull, head, workflow_run_id)
+    assert number == 1
+    assert selected["id"] == 900
+
+
 def test_gate_queries_exact_head_and_ci_run_jobs() -> None:
     api = FakeAPI(complete_checks())
     stdout = StringIO()
@@ -256,6 +298,31 @@ def test_gate_queries_exact_head_and_ci_run_jobs() -> None:
         for request in api.requests
     )
     assert "CI status gate passed." in stdout.getvalue()
+
+
+def test_gate_publisher_targets_both_contexts_on_exact_head() -> None:
+    class PublishingAPI(FakeAPI):
+        def __init__(self) -> None:
+            super().__init__(complete_checks())
+            self.published: list[tuple[str, str, str]] = []
+
+        def publish_check(
+            self, name: str, head_sha: str, conclusion: str, summary: str
+        ) -> None:
+            self.published.append((name, head_sha, conclusion))
+
+    api = PublishingAPI()
+    result = module._run_gate(
+        api,
+        "pull_request_target",
+        {"number": 1, "pull_request": {"head": {"sha": HEAD_SHA}}},
+        publish=True,
+    )
+    assert result == 0
+    assert api.published == [
+        ("ci-status-gate", HEAD_SHA, "success"),
+        ("ci-status", HEAD_SHA, "success"),
+    ]
 
 
 def test_pr_file_pagination_accepts_slurped_array_pages() -> None:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -241,7 +241,10 @@ def test_workflow_run_with_multiple_pull_requests_fails_closed() -> None:
     class AmbiguousAPI(FakeAPI):
         def get(self, endpoint: str, *, paginate: bool = False) -> object:
             if endpoint.endswith("/actions/runs/900"):
-                return {"pull_requests": [{"number": 1}, {"number": 2}]}
+                return {
+                    "head_sha": HEAD_SHA,
+                    "pull_requests": [{"number": 1}, {"number": 2}],
+                }
             return super().get(endpoint, paginate=paginate)
 
     try:
@@ -260,7 +263,10 @@ def test_workflow_run_duplicate_association_is_deduplicated() -> None:
     class DuplicateAPI(FakeAPI):
         def get(self, endpoint: str, *, paginate: bool = False) -> object:
             if endpoint.endswith("/actions/runs/900"):
-                return {"pull_requests": [{"number": 1}, {"number": 1}]}
+                return {
+                    "head_sha": HEAD_SHA,
+                    "pull_requests": [{"number": 1}, {"number": 1}],
+                }
             return super().get(endpoint, paginate=paginate)
 
     pull, head, number, workflow_run_id = module._event_target(

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -443,6 +443,78 @@ def test_gate_queries_exact_head_and_ci_run_jobs() -> None:
     assert "CI status gate passed." in stdout.getvalue()
 
 
+def test_ci_run_selection_binds_empty_associations_to_live_pr() -> None:
+    class UnassociatedRunAPI(FakeAPI):
+        def __init__(self, association: object) -> None:
+            super().__init__(complete_checks())
+            self.association = association
+
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if "/actions/runs?event=" in endpoint:
+                run: dict[str, object] = {
+                    "id": 901,
+                    "path": module.CI_WORKFLOW_PATH,
+                    "event": "pull_request",
+                    "head_sha": HEAD_SHA,
+                    "status": "completed",
+                    "created_at": "2026-09-01T00:00:00Z",
+                }
+                if self.association is not None:
+                    run["pull_requests"] = self.association
+                return {"workflow_runs": [run]}
+            if endpoint.endswith(f"/commits/{HEAD_SHA}/pulls?per_page=100"):
+                return [[_valid_commit_pull(number=2)]]
+            return super().get(endpoint, paginate=paginate)
+
+    api = UnassociatedRunAPI([])
+    pull = api.get("repos/manaflow-ai/cmux/pulls/1")
+    assert isinstance(pull, dict)
+    try:
+        module._select_ci_run(api, pull, HEAD_SHA, None)
+    except module.GateError as error:
+        assert "pull request" in str(error)
+    else:
+        raise AssertionError("CI run for another PR was accepted")
+
+    absent = UnassociatedRunAPI(None)
+    pull = absent.get("repos/manaflow-ai/cmux/pulls/1")
+    assert isinstance(pull, dict)
+    try:
+        module._select_ci_run(absent, pull, HEAD_SHA, None)
+    except module.GateError as error:
+        assert "pull request" in str(error)
+    else:
+        raise AssertionError("CI run with absent PR association was accepted")
+
+
+def test_ci_run_selection_accepts_valid_empty_association_fallback() -> None:
+    class ValidFallbackAPI(FakeAPI):
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if "/actions/runs?event=" in endpoint:
+                return {
+                    "workflow_runs": [
+                        {
+                            "id": 901,
+                            "path": module.CI_WORKFLOW_PATH,
+                            "event": "pull_request",
+                            "head_sha": HEAD_SHA,
+                            "status": "completed",
+                            "created_at": "2026-09-01T00:00:00Z",
+                            "pull_requests": [],
+                        }
+                    ]
+                }
+            if endpoint.endswith(f"/commits/{HEAD_SHA}/pulls?per_page=100"):
+                return [[_valid_commit_pull()]]
+            return super().get(endpoint, paginate=paginate)
+
+    api = ValidFallbackAPI(complete_checks())
+    pull = api.get("repos/manaflow-ai/cmux/pulls/1")
+    assert isinstance(pull, dict)
+    selected = module._select_ci_run(api, pull, HEAD_SHA, None)
+    assert selected["id"] == 901
+
+
 def test_gate_publisher_targets_both_contexts_on_exact_head() -> None:
     class PublishingAPI(FakeAPI):
         def __init__(self) -> None:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -202,6 +202,9 @@ def test_workflow_is_base_owned_and_read_only() -> None:
     assert "workflow_run:" in text
     assert "pull_request:" not in text
     assert "ci-status-gate:" in text
+    assert "ci-status:" in text
+    assert "needs: ci-status-gate" in text
+    assert "GATE_RESULT" in text
     assert "actions: read" in text
     assert "checks: read" in text
     assert "pull-requests: read" in text

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""Behavior tests for the base-owned CI status gate."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+GATE = ROOT / "scripts" / "ci" / "ci_status_gate.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "ci-status-gate.yml"
+
+spec = importlib.util.spec_from_file_location("ci_status_gate", GATE)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+HEAD_SHA = "a" * 40
+
+
+def check(
+    name: str,
+    *,
+    number: int,
+    status: str = "completed",
+    conclusion: str = "success",
+    head_sha: str = HEAD_SHA,
+    app_id: int = 15368,
+) -> dict[str, object]:
+    return {
+        "id": number,
+        "name": name,
+        "status": status,
+        "conclusion": conclusion if status == "completed" else None,
+        "head_sha": head_sha,
+        "app": {"id": app_id},
+    }
+
+
+def complete_checks() -> list[dict[str, object]]:
+    names = [
+        "changes",
+        "workflow-guard-tests",
+        "GhosttyKit release check",
+        "linux-preflight",
+        "tests",
+        "tests-build-and-lag",
+        "swift-package-tests",
+        "release-build",
+        "web-typecheck",
+        "react-apps-check",
+        "diff-sidecar-check",
+        "web-db-migrations",
+        "remote-daemon-tests",
+        "agent-session-web-resources",
+    ]
+    checks = [check(name, number=index + 1) for index, name in enumerate(names)]
+    checks.extend(
+        check(f"app-host unit tests ({index}/6)", number=100 + index)
+        for index in range(1, 7)
+    )
+    return checks
+
+
+ALL_FALSE = {route: False for route in module.ROUTE_NAMES}
+
+
+def test_docs_only_snapshot_accepts_skipped_routes() -> None:
+    failures = module.validate_snapshot(
+        complete_checks(),
+        ["docs/ci-required-checks.md"],
+        head_sha=HEAD_SHA,
+    )
+    assert failures == []
+
+
+def test_web_snapshot_requires_web_jobs() -> None:
+    checks = complete_checks()
+    checks[8]["conclusion"] = "failure"
+    failures = module.validate_snapshot(
+        checks,
+        ["web/app/page.tsx"],
+        head_sha=HEAD_SHA,
+    )
+    assert any("web-typecheck" in failure for failure in failures)
+
+
+def test_missing_matrix_shard_fails_closed() -> None:
+    checks = [
+        item
+        for item in complete_checks()
+        if item["name"] != "app-host unit tests (6/6)"
+    ]
+    failures = module.validate_snapshot(
+        checks,
+        ["Sources/AppDelegate.swift"],
+        head_sha=HEAD_SHA,
+    )
+    assert any("app-host-unit-tests" in failure for failure in failures)
+
+
+def test_pending_check_does_not_pass() -> None:
+    checks = complete_checks()
+    checks[0] = check("changes", number=1, status="in_progress")
+    failures = module.validate_snapshot(
+        checks,
+        ["README.md"],
+        head_sha=HEAD_SHA,
+    )
+    assert any("changes" in failure for failure in failures)
+
+
+def test_stale_or_untrusted_app_checks_are_not_accepted() -> None:
+    checks = complete_checks()
+    checks[0] = check("changes", number=1, head_sha="b" * 40)
+    checks[1] = check("workflow-guard-tests", number=2, app_id=999)
+    failures = module.validate_snapshot(
+        checks,
+        ["README.md"],
+        head_sha=HEAD_SHA,
+    )
+    assert any("changes" in failure for failure in failures)
+    assert any("workflow-guard-tests" in failure for failure in failures)
+
+
+def test_unexpected_ci_job_is_rejected() -> None:
+    checks = complete_checks()
+    checks.append(check("unreviewed-job", number=999))
+    failures = module.validate_snapshot(
+        checks,
+        ["README.md"],
+        head_sha=HEAD_SHA,
+    )
+    assert any("unreviewed-job" in failure for failure in failures)
+
+
+def test_workflow_is_base_owned_and_read_only() -> None:
+    text = WORKFLOW.read_text(encoding="utf-8")
+    assert "pull_request_target:" in text
+    assert "workflow_run:" in text
+    assert "pull_request:" not in text
+    assert "ci-status-gate:" in text
+    assert "actions: read" in text
+    assert "checks: read" in text
+    assert "pull-requests: read" in text
+    assert "contents: write" not in text
+    assert ".ci-trusted/scripts/ci/ci_status_gate.py" in text
+
+
+def test_event_payload_parser_rejects_invalid_json() -> None:
+    try:
+        module.parse_event("not-json")
+    except module.GateError as error:
+        assert "event payload" in str(error)
+    else:
+        raise AssertionError("invalid event payload was accepted")
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_") and callable(value):
+            value()
+    print("PASS: base-owned CI status gate")

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -202,6 +202,8 @@ def test_workflow_is_base_owned_with_limited_check_publication() -> None:
     assert "pull_request_review:" in text
     assert "workflow_run:" in text
     assert "pull_request:" not in text
+    assert "refs/heads/main" in text
+    assert "github.sha" not in text
     assert "ci-status-gate:" in text
     assert "ci-status:" in text
     assert "needs: ci-status-gate" in text

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -256,6 +256,24 @@ def test_workflow_run_with_multiple_pull_requests_fails_closed() -> None:
         raise AssertionError("ambiguous workflow run was accepted")
 
 
+def test_workflow_run_duplicate_association_is_deduplicated() -> None:
+    class DuplicateAPI(FakeAPI):
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if endpoint.endswith("/actions/runs/900"):
+                return {"pull_requests": [{"number": 1}, {"number": 1}]}
+            return super().get(endpoint, paginate=paginate)
+
+    pull, head, number, workflow_run_id = module._event_target(
+        DuplicateAPI(complete_checks()),
+        "workflow_run",
+        {"workflow_run": {"id": 900, "head_sha": HEAD_SHA}},
+    )
+    assert pull["number"] == 1
+    assert head == HEAD_SHA
+    assert number == 1
+    assert workflow_run_id == 900
+
+
 def test_external_fork_workflow_run_fallback_keeps_empty_association() -> None:
     class ForkRunAPI(FakeAPI):
         def get(self, endpoint: str, *, paginate: bool = False) -> object:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -196,7 +196,7 @@ def test_unexpected_ci_job_is_rejected() -> None:
     assert any("unreviewed-job" in failure for failure in failures)
 
 
-def test_workflow_is_base_owned_and_read_only() -> None:
+def test_workflow_is_base_owned_with_limited_check_publication() -> None:
     text = WORKFLOW.read_text(encoding="utf-8")
     assert "pull_request_target:" in text
     assert "pull_request_review:" in text
@@ -323,6 +323,50 @@ def test_gate_publisher_targets_both_contexts_on_exact_head() -> None:
         ("ci-status-gate", HEAD_SHA, "success"),
         ("ci-status", HEAD_SHA, "success"),
     ]
+
+
+def test_check_publisher_updates_only_our_exact_head_run() -> None:
+    class CheckAPI(module.GitHubAPI):
+        def __init__(self) -> None:
+            super().__init__("manaflow-ai/cmux", token="test")
+            self.writes: list[tuple[str, str, dict[str, object]]] = []
+            self.existing = False
+
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            assert "check_name=ci-status-gate" in endpoint
+            if self.existing:
+                return [
+                    {
+                        "check_runs": [
+                            {
+                                "id": 77,
+                                "name": "ci-status-gate",
+                                "head_sha": HEAD_SHA,
+                                "app": {"id": module.ACTIONS_APP_ID},
+                            }
+                        ]
+                    }
+                ]
+            return [{"check_runs": []}]
+
+        def write(
+            self, method: str, endpoint: str, payload: dict[str, object]
+        ) -> object:
+            self.writes.append((method, endpoint, payload))
+            return {
+                "name": payload["name"],
+                "head_sha": payload["head_sha"],
+                "app": {"id": module.ACTIONS_APP_ID},
+            }
+
+    api = CheckAPI()
+    api.publish_check("ci-status-gate", HEAD_SHA, "success", "ok")
+    assert api.writes[0][0] == "POST"
+    assert api.writes[0][2]["head_sha"] == HEAD_SHA
+    api.existing = True
+    api.publish_check("ci-status-gate", HEAD_SHA, "failure", "bad")
+    assert api.writes[1][0] == "PATCH"
+    assert api.writes[1][1].endswith("/check-runs/77")
 
 
 def test_pr_file_pagination_accepts_slurped_array_pages() -> None:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -274,6 +274,33 @@ def test_workflow_run_duplicate_association_is_deduplicated() -> None:
     assert workflow_run_id == 900
 
 
+def test_workflow_run_api_head_must_match_event_head() -> None:
+    class DriftAPI(FakeAPI):
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if endpoint.endswith("/actions/runs/900"):
+                return {
+                    "id": 900,
+                    "path": module.CI_WORKFLOW_PATH,
+                    "event": "pull_request",
+                    "head_sha": "b" * 40,
+                    "status": "completed",
+                    "created_at": "2026-09-01T00:00:00Z",
+                    "pull_requests": [{"number": 1}],
+                }
+            return super().get(endpoint, paginate=paginate)
+
+    try:
+        module._event_target(
+            DriftAPI(complete_checks()),
+            "workflow_run",
+            {"workflow_run": {"id": 900, "head_sha": HEAD_SHA}},
+        )
+    except module.GateError as error:
+        assert "head" in str(error)
+    else:
+        raise AssertionError("workflow run head drift was accepted")
+
+
 def test_external_fork_workflow_run_fallback_keeps_empty_association() -> None:
     class ForkRunAPI(FakeAPI):
         def get(self, endpoint: str, *, paginate: bool = False) -> object:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -4,7 +4,8 @@
 from __future__ import annotations
 
 import importlib.util
-import json
+from contextlib import redirect_stderr, redirect_stdout
+from io import StringIO
 from pathlib import Path
 
 
@@ -65,7 +66,55 @@ def complete_checks() -> list[dict[str, object]]:
     return checks
 
 
-ALL_FALSE = {route: False for route in module.ROUTE_NAMES}
+class FakeAPI:
+    """In-memory GitHub API fixture for the end-to-end gate path."""
+
+    repository = "manaflow-ai/cmux"
+
+    def __init__(self, checks: list[dict[str, object]]) -> None:
+        self.checks = checks
+        self.requests: list[str] = []
+
+    def get(self, endpoint: str, *, paginate: bool = False) -> object:
+        self.requests.append(endpoint)
+        if endpoint.endswith("/pulls/1"):
+            return {
+                "number": 1,
+                "state": "open",
+                "changed_files": 1,
+                "base": {"ref": "main", "repo": {"full_name": self.repository}},
+                "head": {"sha": HEAD_SHA},
+            }
+        if "/actions/runs?event=" in endpoint:
+            return {
+                "workflow_runs": [
+                    {
+                        "id": 900,
+                        "path": module.CI_WORKFLOW_PATH,
+                        "event": "pull_request",
+                        "head_sha": HEAD_SHA,
+                        "status": "completed",
+                        "created_at": "2026-09-01T00:00:00Z",
+                        "pull_requests": [{"number": 1}],
+                    }
+                ]
+            }
+        if endpoint.endswith("/actions/runs/900/jobs?per_page=100"):
+            jobs = []
+            for item in self.checks:
+                jobs.append(
+                    {
+                        "name": item["name"],
+                        "head_sha": HEAD_SHA,
+                        "check_run_url": f"https://api.github.com/repos/manaflow-ai/cmux/check-runs/{item['id']}",
+                    }
+                )
+            return [{"jobs": jobs}]
+        if "/commits/" in endpoint and "/check-runs" in endpoint:
+            return [{"check_runs": self.checks}]
+        if endpoint.endswith("/pulls/1/files?per_page=100"):
+            return [{"files": [{"filename": "README.md"}]}]
+        raise AssertionError(f"unexpected API endpoint: {endpoint}")
 
 
 def test_docs_only_snapshot_accepts_skipped_routes() -> None:
@@ -157,6 +206,24 @@ def test_event_payload_parser_rejects_invalid_json() -> None:
         assert "event payload" in str(error)
     else:
         raise AssertionError("invalid event payload was accepted")
+
+
+def test_gate_queries_exact_head_and_ci_run_jobs() -> None:
+    api = FakeAPI(complete_checks())
+    stdout = StringIO()
+    stderr = StringIO()
+    with redirect_stdout(stdout), redirect_stderr(stderr):
+        result = module._run_gate(
+            api,
+            "pull_request_target",
+            {"number": 1, "pull_request": {"head": {"sha": HEAD_SHA}}},
+        )
+    assert result == 0, stderr.getvalue()
+    assert any(
+        f"/commits/{HEAD_SHA}/check-runs?per_page=100" in request
+        for request in api.requests
+    )
+    assert "CI status gate passed." in stdout.getvalue()
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -582,7 +582,11 @@ def test_workflow_definition_mismatch_requires_trusted_review() -> None:
             return super().get(endpoint, paginate=paginate)
 
     unapproved = WorkflowAPI(approved=False)
-    pull = {"number": 1, "user": {"login": "contributor"}, "base": {"sha": BASE_SHA}}
+    pull = {
+        "number": 1,
+        "user": {"id": 424242, "login": "contributor"},
+        "base": {"sha": BASE_SHA},
+    }
     try:
         module.verify_ci_workflow_revision(unapproved, pull, HEAD_SHA)
     except module.GateError as error:
@@ -602,6 +606,25 @@ def test_workflow_definition_mismatch_requires_trusted_review() -> None:
         assert "workflow definition" in str(error)
     else:
         raise AssertionError("self-approval was accepted")
+
+    for malformed_author in (
+        None,
+        {},
+        {"id": 424242},
+        {"login": "contributor"},
+        {"id": 0, "login": "contributor"},
+        {"id": True, "login": "contributor"},
+        {"id": 424242, "login": "   "},
+    ):
+        malformed_pull = {**pull, "user": malformed_author}
+        try:
+            module.verify_ci_workflow_revision(
+                WorkflowAPI(approved=True), malformed_pull, HEAD_SHA
+            )
+        except module.GateError as error:
+            assert "author" in str(error)
+        else:
+            raise AssertionError("malformed PR author identity was accepted")
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -221,6 +221,25 @@ def test_event_payload_parser_rejects_invalid_json() -> None:
         raise AssertionError("invalid event payload was accepted")
 
 
+def test_workflow_run_with_multiple_pull_requests_fails_closed() -> None:
+    class AmbiguousAPI(FakeAPI):
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if endpoint.endswith("/actions/runs/900"):
+                return {"pull_requests": [{"number": 1}, {"number": 2}]}
+            return super().get(endpoint, paginate=paginate)
+
+    try:
+        module._event_target(
+            AmbiguousAPI(complete_checks()),
+            "workflow_run",
+            {"workflow_run": {"id": 900, "head_sha": HEAD_SHA}},
+        )
+    except module.GateError as error:
+        assert "multiple pull requests" in str(error)
+    else:
+        raise AssertionError("ambiguous workflow run was accepted")
+
+
 def test_gate_queries_exact_head_and_ci_run_jobs() -> None:
     api = FakeAPI(complete_checks())
     stdout = StringIO()
@@ -283,6 +302,17 @@ def test_workflow_definition_mismatch_requires_trusted_review() -> None:
         raise AssertionError("unreviewed workflow change was accepted")
 
     module.verify_ci_workflow_revision(WorkflowAPI(approved=True), pull, HEAD_SHA)
+
+    self_authored = {
+        **pull,
+        "user": {"id": 38676809, "login": "austinywang"},
+    }
+    try:
+        module.verify_ci_workflow_revision(WorkflowAPI(approved=True), self_authored, HEAD_SHA)
+    except module.GateError as error:
+        assert "workflow definition" in str(error)
+    else:
+        raise AssertionError("self-approval was accepted")
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -268,7 +268,17 @@ def test_external_fork_workflow_run_fallback_keeps_empty_association() -> None:
                     "pull_requests": [],
                 }
             if endpoint.endswith(f"/commits/{HEAD_SHA}/pulls?per_page=100"):
-                return [{"number": 1}]
+                return [
+                    {
+                        "number": 1,
+                        "state": "open",
+                        "base": {
+                            "ref": "main",
+                            "repo": {"full_name": self.repository},
+                        },
+                        "head": {"sha": HEAD_SHA},
+                    }
+                ]
             return super().get(endpoint, paginate=paginate)
 
     api = ForkRunAPI(complete_checks())
@@ -280,6 +290,87 @@ def test_external_fork_workflow_run_fallback_keeps_empty_association() -> None:
     selected = module._select_ci_run(api, pull, head, workflow_run_id)
     assert number == 1
     assert selected["id"] == 900
+
+
+def _fallback_run_api(rows: object) -> FakeAPI:
+    class FallbackRunAPI(FakeAPI):
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            if endpoint.endswith("/actions/runs/900"):
+                return {
+                    "id": 900,
+                    "path": module.CI_WORKFLOW_PATH,
+                    "event": "pull_request",
+                    "head_sha": HEAD_SHA,
+                    "status": "completed",
+                    "created_at": "2026-09-01T00:00:00Z",
+                    "pull_requests": [],
+                }
+            if endpoint.endswith(f"/commits/{HEAD_SHA}/pulls?per_page=100"):
+                return rows
+            return super().get(endpoint, paginate=paginate)
+
+    return FallbackRunAPI(complete_checks())
+
+
+def _valid_commit_pull(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "number": 1,
+        "state": "open",
+        "base": {"ref": "main", "repo": {"full_name": "manaflow-ai/cmux"}},
+        "head": {"sha": HEAD_SHA},
+    }
+    value.update(overrides)
+    return value
+
+
+def test_empty_workflow_run_fallback_rejects_wrong_base() -> None:
+    api = _fallback_run_api(
+        [_valid_commit_pull(base={"ref": "release", "repo": {"full_name": "manaflow-ai/cmux"}})]
+    )
+    try:
+        module._event_target(
+            api,
+            "workflow_run",
+            {"workflow_run": {"id": 900, "head_sha": HEAD_SHA}},
+        )
+    except module.GateError as error:
+        assert "base" in str(error)
+    else:
+        raise AssertionError("wrong-base commit association was accepted")
+
+
+def test_empty_workflow_run_fallback_rejects_multiple_matches() -> None:
+    api = _fallback_run_api(
+        [_valid_commit_pull(), _valid_commit_pull(number=2)]
+    )
+    try:
+        module._event_target(
+            api,
+            "workflow_run",
+            {"workflow_run": {"id": 900, "head_sha": HEAD_SHA}},
+        )
+    except module.GateError as error:
+        assert "multiple" in str(error) or "exactly one" in str(error)
+    else:
+        raise AssertionError("multiple commit associations were accepted")
+
+
+def test_empty_workflow_run_fallback_rejects_stale_or_closed_match() -> None:
+    for row in (
+        _valid_commit_pull(head={"sha": "b" * 40}),
+        _valid_commit_pull(state="closed"),
+        _valid_commit_pull(base={"ref": "main", "repo": {"full_name": "other/repo"}}),
+    ):
+        api = _fallback_run_api([row])
+        try:
+            module._event_target(
+                api,
+                "workflow_run",
+                {"workflow_run": {"id": 900, "head_sha": HEAD_SHA}},
+            )
+        except module.GateError:
+            continue
+        raise AssertionError("ambiguous commit association was accepted")
 
 
 def test_gate_queries_exact_head_and_ci_run_jobs() -> None:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -119,7 +119,7 @@ class FakeAPI:
         if "/commits/" in endpoint and "/check-runs" in endpoint:
             return [{"check_runs": self.checks}]
         if "/contents/.github/workflows/ci.yml?ref=" in endpoint:
-            return {"sha": BASE_SHA}
+            return {"type": "file", "path": module.CI_WORKFLOW_PATH, "sha": BASE_SHA}
         if endpoint.endswith("/pulls/1/reviews?per_page=100"):
             return []
         if endpoint.endswith("/pulls/1/files?per_page=100"):
@@ -244,10 +244,22 @@ def test_workflow_definition_mismatch_requires_trusted_review() -> None:
 
         def get(self, endpoint: str, *, paginate: bool = False) -> object:
             if "/contents/.github/workflows/ci.yml?ref=" in endpoint:
-                return {"sha": BASE_SHA if f"ref={BASE_SHA}" in endpoint else "d" * 40}
+                return {
+                    "type": "file",
+                    "path": module.CI_WORKFLOW_PATH,
+                    "sha": BASE_SHA if f"ref={BASE_SHA}" in endpoint else "d" * 40,
+                }
             if endpoint.endswith("/pulls/1/reviews?per_page=100"):
                 return (
-                    [{"user": {"login": "austinywang"}, "state": "APPROVED", "commit_id": HEAD_SHA}]
+                    [
+                        {
+                            "id": 1,
+                            "user": {"id": 38676809, "login": "austinywang", "type": "User"},
+                            "state": "APPROVED",
+                            "commit_id": HEAD_SHA,
+                            "submitted_at": "2026-09-01T00:00:00Z",
+                        }
+                    ]
                     if self.approved
                     else []
                 )

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -56,7 +56,6 @@ def complete_checks() -> list[dict[str, object]]:
         "react-apps-check",
         "diff-sidecar-check",
         "web-db-migrations",
-        "remote-daemon-tests",
         "agent-session-web-resources",
     ]
     checks = [check(name, number=index + 1) for index, name in enumerate(names)]

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -436,6 +436,9 @@ def test_check_publisher_updates_only_our_exact_head_run() -> None:
                                 "name": "ci-status-gate",
                                 "head_sha": HEAD_SHA,
                                 "app": {"id": module.ACTIONS_APP_ID},
+                                "external_id": module._publisher_external_id(
+                                    "ci-status-gate", HEAD_SHA
+                                ),
                             }
                         ]
                     }
@@ -450,6 +453,7 @@ def test_check_publisher_updates_only_our_exact_head_run() -> None:
                 "name": payload["name"],
                 "head_sha": payload["head_sha"],
                 "app": {"id": module.ACTIONS_APP_ID},
+                "external_id": payload["external_id"],
             }
 
     api = CheckAPI()
@@ -460,6 +464,58 @@ def test_check_publisher_updates_only_our_exact_head_run() -> None:
     api.publish_check("ci-status-gate", HEAD_SHA, "failure", "bad")
     assert api.writes[1][0] == "PATCH"
     assert api.writes[1][1].endswith("/check-runs/77")
+
+
+def test_check_publisher_ignores_foreign_producer_and_rejects_race() -> None:
+    class ForeignCheckAPI(module.GitHubAPI):
+        def __init__(self, response_external_id: str | None = None) -> None:
+            super().__init__("manaflow-ai/cmux", token="test")
+            self.response_external_id = response_external_id
+            self.writes: list[tuple[str, str, dict[str, object]]] = []
+
+        def get(self, endpoint: str, *, paginate: bool = False) -> object:
+            return [
+                {
+                    "check_runs": [
+                        {
+                            "id": 78,
+                            "name": "ci-status-gate",
+                            "head_sha": HEAD_SHA,
+                            "app": {"id": module.ACTIONS_APP_ID},
+                            "external_id": "legacy-or-foreign-producer",
+                        }
+                    ]
+                }
+            ]
+
+        def write(
+            self, method: str, endpoint: str, payload: dict[str, object]
+        ) -> object:
+            self.writes.append((method, endpoint, payload))
+            return {
+                "name": payload["name"],
+                "head_sha": payload["head_sha"],
+                "app": {"id": module.ACTIONS_APP_ID},
+                "external_id": self.response_external_id
+                if self.response_external_id is not None
+                else payload["external_id"],
+            }
+
+    api = ForeignCheckAPI()
+    api.publish_check("ci-status-gate", HEAD_SHA, "success", "ok")
+    assert api.writes[0][0] == "POST"
+    assert api.writes[0][1].endswith("/check-runs")
+    assert api.writes[0][2]["external_id"] == module._publisher_external_id(
+        "ci-status-gate", HEAD_SHA
+    )
+
+    raced = ForeignCheckAPI(response_external_id="legacy-or-foreign-producer")
+    try:
+        raced.publish_check("ci-status-gate", HEAD_SHA, "success", "ok")
+    except module.GateError as error:
+        assert "external ID" in str(error)
+    else:
+        raise AssertionError("publisher accepted a foreign response after a race")
 
 
 def test_pr_file_pagination_accepts_slurped_array_pages() -> None:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -263,6 +263,17 @@ def test_pr_file_pagination_accepts_slurped_array_pages() -> None:
     assert module._pr_files(api, 1, 1) == ["README.md"]
 
 
+def test_pr_file_count_must_be_present_and_exact() -> None:
+    api = FakeAPI(complete_checks())
+    for expected_count in (None, 0, 2):
+        try:
+            module._pr_files(api, 1, expected_count)
+        except module.GateError as error:
+            assert "pull request file" in str(error)
+        else:
+            raise AssertionError("incomplete pull request file metadata was accepted")
+
+
 def test_workflow_definition_mismatch_requires_trusted_review() -> None:
     class WorkflowAPI(FakeAPI):
         def __init__(self, *, approved: bool) -> None:

--- a/tests/test_ci_status_gate.py
+++ b/tests/test_ci_status_gate.py
@@ -123,7 +123,7 @@ class FakeAPI:
         if endpoint.endswith("/pulls/1/reviews?per_page=100"):
             return []
         if endpoint.endswith("/pulls/1/files?per_page=100"):
-            return [{"files": [{"filename": "README.md"}]}]
+            return [[{"filename": "README.md"}]]
         raise AssertionError(f"unexpected API endpoint: {endpoint}")
 
 
@@ -237,6 +237,11 @@ def test_gate_queries_exact_head_and_ci_run_jobs() -> None:
         for request in api.requests
     )
     assert "CI status gate passed." in stdout.getvalue()
+
+
+def test_pr_file_pagination_accepts_slurped_array_pages() -> None:
+    api = FakeAPI(complete_checks())
+    assert module._pr_files(api, 1, 1) == ["README.md"]
 
 
 def test_workflow_definition_mismatch_requires_trusted_review() -> None:

--- a/tests/test_ci_status_validator.py
+++ b/tests/test_ci_status_validator.py
@@ -108,9 +108,9 @@ def test_shared_route_job_is_required_for_either_route() -> None:
 
 def test_inactive_failure_is_not_ignored() -> None:
     failures = module.validate_needs(
-        needs(ALL_FALSE, results={"remote-daemon-tests": "failure"})
+        needs(ALL_FALSE, results={"web-typecheck": "failure"})
     )
-    assert "remote-daemon-tests: unexpected result for inactive route, got failure" in failures
+    assert "web-typecheck: unexpected result for inactive route, got failure" in failures
 
 
 def test_missing_or_malformed_route_data_fails_closed() -> None:
@@ -134,12 +134,12 @@ def test_workflow_fails_when_serialized_selected_job_is_skipped() -> None:
 
 
 def test_preflight_requires_selected_linux_routes() -> None:
-    outputs = {**ALL_FALSE, "go": "true"}
+    outputs = {**ALL_FALSE, "web": "true"}
     failures = module.validate_needs(
         {name: data for name, data in needs(outputs).items() if name not in {"linux-preflight", "tests"}},
         phase="preflight",
     )
-    assert "remote-daemon-tests: required for route go, got skipped" in failures
+    assert "web-typecheck: required for route web, got skipped" in failures
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_status_validator.py
+++ b/tests/test_ci_status_validator.py
@@ -4,11 +4,17 @@
 from __future__ import annotations
 
 import importlib.util
+import json
+import os
+import shutil
+import subprocess
+import tempfile
 from pathlib import Path
 
 
 ROOT = Path(__file__).resolve().parents[1]
 HELPER = ROOT / "scripts" / "ci" / "check_ci_status.py"
+CI_WORKFLOW = ROOT / ".github" / "workflows" / "ci.yml"
 spec = importlib.util.spec_from_file_location("check_ci_status", HELPER)
 assert spec and spec.loader
 module = importlib.util.module_from_spec(spec)
@@ -21,6 +27,7 @@ COMMON = tuple(module.COMMON_REQUIRED)
 
 def needs(outputs: dict[str, str], *, results: dict[str, str] | None = None) -> dict[str, object]:
     results = results or {}
+    outputs = dict(outputs)
     names = COMMON + ("linux-preflight", "tests") + ROUTE_JOBS
     return {
         name: {
@@ -37,6 +44,46 @@ def needs(outputs: dict[str, str], *, results: dict[str, str] | None = None) -> 
 
 
 ALL_FALSE = {route: "false" for route in module.ROUTE_NAMES}
+
+
+def _ci_status_script() -> str:
+    lines = CI_WORKFLOW.read_text(encoding="utf-8").splitlines()
+    in_job = False
+    for index, line in enumerate(lines):
+        if line == "  ci-status:":
+            in_job = True
+            continue
+        if in_job and line.startswith("  ") and not line.startswith("    ") and line.strip():
+            break
+        if in_job and line == "      - name: Check routed CI jobs":
+            for run_index in range(index + 1, len(lines)):
+                if lines[run_index] == "        run: |":
+                    body: list[str] = []
+                    for body_line in lines[run_index + 1 :]:
+                        if body_line.startswith("          "):
+                            body.append(body_line[10:])
+                            continue
+                        if not body_line.strip():
+                            body.append("")
+                            continue
+                        break
+                    return "\n".join(body)
+    raise AssertionError("ci-status invocation not found")
+
+
+def run_ci_status(needs_data: dict[str, object]) -> subprocess.CompletedProcess[str]:
+    with tempfile.TemporaryDirectory() as temp_dir:
+        helper = Path(temp_dir) / "scripts" / "ci" / "check_ci_status.py"
+        helper.parent.mkdir(parents=True)
+        shutil.copy2(HELPER, helper)
+        return subprocess.run(
+            ["bash", "-c", _ci_status_script()],
+            cwd=temp_dir,
+            env={**os.environ, "CI_NEEDS": json.dumps(needs_data)},
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
 
 
 def test_docs_only_allows_inactive_routes_to_skip() -> None:
@@ -71,6 +118,19 @@ def test_missing_or_malformed_route_data_fails_closed() -> None:
     del malformed["changes"]["outputs"]["web"]
     failures = module.validate_needs(malformed)
     assert "changes.outputs.web: expected true or false" in failures
+
+
+def test_workflow_passes_serialized_needs_to_validator() -> None:
+    result = run_ci_status(needs(ALL_FALSE))
+    assert result.returncode == 0, result.stderr
+    assert "CI status contract passed (aggregate)." in result.stdout
+
+
+def test_workflow_fails_when_serialized_selected_job_is_skipped() -> None:
+    outputs = {**ALL_FALSE, "web": "true"}
+    result = run_ci_status(needs(outputs, results={"web-typecheck": "skipped"}))
+    assert result.returncode != 0
+    assert "web-typecheck: required for route web, got skipped" in result.stderr
 
 
 def test_preflight_requires_selected_linux_routes() -> None:

--- a/tests/test_ci_status_validator.py
+++ b/tests/test_ci_status_validator.py
@@ -27,7 +27,7 @@ COMMON = tuple(module.COMMON_REQUIRED)
 
 def needs(outputs: dict[str, str], *, results: dict[str, str] | None = None) -> dict[str, object]:
     results = results or {}
-    outputs = dict(outputs)
+    route_outputs = dict(outputs)
     names = COMMON + ("linux-preflight", "tests") + ROUTE_JOBS
     return {
         name: {
@@ -37,7 +37,7 @@ def needs(outputs: dict[str, str], *, results: dict[str, str] | None = None) -> 
                 if name in COMMON or name in {"linux-preflight", "tests"}
                 else "skipped",
             ),
-            "outputs": outputs if name == "changes" else {},
+            "outputs": dict(route_outputs) if name == "changes" else {},
         }
         for name in names
     }

--- a/tests/test_ci_status_validator.py
+++ b/tests/test_ci_status_validator.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Behavior tests for the trusted CI status validator."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+HELPER = ROOT / "scripts" / "ci" / "check_ci_status.py"
+spec = importlib.util.spec_from_file_location("check_ci_status", HELPER)
+assert spec and spec.loader
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)
+
+
+ROUTE_JOBS = tuple(module.ROUTE_JOBS)
+COMMON = tuple(module.COMMON_REQUIRED)
+
+
+def needs(outputs: dict[str, str], *, results: dict[str, str] | None = None) -> dict[str, object]:
+    results = results or {}
+    names = COMMON + ("linux-preflight", "tests") + ROUTE_JOBS
+    return {
+        name: {
+            "result": results.get(
+                name,
+                "success"
+                if name in COMMON or name in {"linux-preflight", "tests"}
+                else "skipped",
+            ),
+            "outputs": outputs if name == "changes" else {},
+        }
+        for name in names
+    }
+
+
+ALL_FALSE = {route: "false" for route in module.ROUTE_NAMES}
+
+
+def test_docs_only_allows_inactive_routes_to_skip() -> None:
+    assert module.validate_needs(needs(ALL_FALSE)) == []
+
+
+def test_selected_route_must_succeed() -> None:
+    outputs = {**ALL_FALSE, "web": "true"}
+    failures = module.validate_needs(
+        needs(outputs, results={"web-typecheck": "skipped"})
+    )
+    assert "web-typecheck: required for route web, got skipped" in failures
+
+
+def test_shared_route_job_is_required_for_either_route() -> None:
+    outputs = {**ALL_FALSE, "macos": "true"}
+    failures = module.validate_needs(
+        needs(outputs, results={"diff-sidecar-check": "failure"})
+    )
+    assert "diff-sidecar-check: required for route macos or web, got failure" in failures
+
+
+def test_inactive_failure_is_not_ignored() -> None:
+    failures = module.validate_needs(
+        needs(ALL_FALSE, results={"remote-daemon-tests": "failure"})
+    )
+    assert "remote-daemon-tests: unexpected result for inactive route, got failure" in failures
+
+
+def test_missing_or_malformed_route_data_fails_closed() -> None:
+    malformed = needs(ALL_FALSE)
+    del malformed["changes"]["outputs"]["web"]
+    failures = module.validate_needs(malformed)
+    assert "changes.outputs.web: expected true or false" in failures
+
+
+def test_preflight_requires_selected_linux_routes() -> None:
+    outputs = {**ALL_FALSE, "go": "true"}
+    failures = module.validate_needs(
+        {name: data for name, data in needs(outputs).items() if name not in {"linux-preflight", "tests"}},
+        phase="preflight",
+    )
+    assert "remote-daemon-tests: required for route go, got skipped" in failures
+
+
+if __name__ == "__main__":
+    for name, value in sorted(globals().items()):
+        if name.startswith("test_") and callable(value):
+            value()
+    print("PASS: trusted CI status validator")

--- a/tests/test_ci_status_validator.py
+++ b/tests/test_ci_status_validator.py
@@ -50,12 +50,12 @@ def _ci_status_script() -> str:
     lines = CI_WORKFLOW.read_text(encoding="utf-8").splitlines()
     in_job = False
     for index, line in enumerate(lines):
-        if line == "  ci-status:":
+        if line == "  ci-status-validator-canary:":
             in_job = True
             continue
         if in_job and line.startswith("  ") and not line.startswith("    ") and line.strip():
             break
-        if in_job and line == "      - name: Check routed CI jobs":
+        if in_job and line == "      - name: Check serialized routed jobs":
             for run_index in range(index + 1, len(lines)):
                 if lines[run_index] == "        run: |":
                     body: list[str] = []


### PR DESCRIPTION
Bootstraps the route-aware CI validator before the aggregate workflow uses it from a trusted base revision.

Changes:
- Adds scripts/ci/check_ci_status.py with fail-closed route and phase contracts.
- Adds direct behavior tests plus tests that execute a non-required canary job with serialized real needs data.
- Adds trusted Austin and Aziz CODEOWNERS for workflow and CI policy files.
- Leaves the existing ci-status inline gate unchanged.

The `ci-status-validator-canary` check is diagnostic only and is not a required context. It uses the PR checkout to exercise the contract without granting merge authority. https://github.com/manaflow-ai/cmux/pull/11540 changes the real `ci-status` job to an exact base-SHA checkout, then the branch ruleset can require it. Merge this PR first, rebase PR11540 onto main, run canaries, and activate the required check only after the trusted-base job is green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a trusted pull request status gate that validates CI results against the exact commit.
  - Added route-aware validation for required checks, including safeguards for missing, stale, pending, failed, or unexpected results.
  - Preserved a legacy CI status indicator during the transition.
  - Added required review controls for changes to CI-critical workflows and scripts.

- **Documentation**
  - Added guidance for required checks, workflow governance, ownership, configuration, and rollback procedures.

- **Tests**
  - Expanded coverage for CI status validation, governance, workflow changes, and pull request scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->