### PR TITLE
fix(cmux-tui): enforce Codex SessionEnd deadline during setup

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -93,12 +93,18 @@ fn run(args: Args, started: Instant) -> anyhow::Result<()> {
     )?;
     let event = serde_json::to_value(ingress)?;
     let (request_id, encoded) = encode_request(event)?;
-    let deadline = started + handoff_budget(&args.source, &args.native_event);
+    let deadline = (args.source == "codex" && args.native_event == "SessionEnd")
+        .then(|| started + handoff_budget(&args.source, &args.native_event));
     match detach::append_detached(&socket, &request_id, &encoded, deadline)? {
         Handoff::Sent => Ok(()),
         Handoff::ChildExited => bail!("hook child gave up before writing the journal request"),
         Handoff::TimedOut => {
-            bail!("journal request handoff was not confirmed within {} ms", handoff.as_millis())
+            bail!(
+                "journal request handoff was not confirmed before its deadline ({} ms remaining)",
+                deadline.map_or(0, |deadline| deadline
+                    .saturating_duration_since(Instant::now())
+                    .as_millis())
+            )
         }
     }
 }
@@ -643,7 +649,7 @@ mod detach {
         socket: &Path,
         request_id: &str,
         encoded: &[u8],
-        deadline: std::time::Instant,
+        deadline: Option<std::time::Instant>,
     ) -> anyhow::Result<Handoff> {
         use std::os::unix::process::CommandExt;
         let exe = std::env::current_exe().context("locate hook helper")?;
@@ -673,7 +679,7 @@ mod detach {
         let encoded = encoded.to_owned();
         std::thread::spawn(move || {
             let result =
-                (|| -> anyhow::Result<(std::process::Child, std::process::ChildStdout)> {
+                (|| -> anyhow::Result<(super::DetachedChildGuard, std::process::ChildStdout)> {
                     let mut child = super::DetachedChildGuard::new(
                         command.spawn().context("spawn detached hook child")?,
                     );
@@ -692,17 +698,22 @@ mod detach {
                         .stdout
                         .take()
                         .context("detached hook child has no stdout")?;
-                    Ok((child.0.take().expect("child guard occupied"), stdout))
+                    Ok((child, stdout))
                 })();
             let _ = sender.send(result);
         });
-        let (raw_child, mut stdout) = match receiver
-            .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
-        {
+        let setup = || {
+            deadline.map_or(None, |deadline| {
+                Some(deadline.saturating_duration_since(std::time::Instant::now()))
+            })
+        };
+        let (mut child, mut stdout) = match match setup() {
+            Some(remaining) => receiver.recv_timeout(remaining).map_err(|_| ()),
+            None => receiver.recv().map_err(|_| ()),
+        } {
             Ok(result) => result?,
             Err(_) => return Ok(Handoff::TimedOut),
         };
-        let mut child = super::DetachedChildGuard::new(raw_child);
         let (sender, receiver) = mpsc::channel();
         let reader = std::thread::spawn(move || {
             let mut byte = [0_u8; 1];
@@ -713,7 +724,9 @@ mod detach {
             let _ = sender.send(outcome);
         });
         let outcome = receiver
-            .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+            .recv_timeout(deadline.map_or(Duration::from_secs(5), |deadline| {
+                deadline.saturating_duration_since(std::time::Instant::now())
+            }))
             .unwrap_or(Handoff::TimedOut);
         super::settle_detached_child(child, reader);
         Ok(outcome)
@@ -740,7 +753,7 @@ mod detach {
         socket: &Path,
         request_id: &str,
         encoded: &[u8],
-        deadline: std::time::Instant,
+        deadline: Option<std::time::Instant>,
     ) -> anyhow::Result<Handoff> {
         use std::os::windows::process::CommandExt;
         const DETACHED_PROCESS: u32 = 0x0000_0008;
@@ -777,9 +790,14 @@ mod detach {
             };
             let _ = sender.send(outcome);
         });
-        let outcome = receiver
-            .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
-            .unwrap_or(Handoff::TimedOut);
+        let outcome = deadline.map_or_else(
+            || receiver.recv().unwrap_or(Handoff::TimedOut),
+            |deadline| {
+                receiver
+                    .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+                    .unwrap_or(Handoff::TimedOut)
+            },
+        );
         super::settle_detached_child(child, reader);
         Ok(outcome)
     }

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -791,7 +791,7 @@ mod detach {
             let _ = sender.send(outcome);
         });
         let outcome = deadline.map_or_else(
-            || receiver.recv().unwrap_or(Handoff::TimedOut),
+            || receiver.recv_timeout(Duration::from_secs(5)).unwrap_or(Handoff::TimedOut),
             |deadline| {
                 receiver
                     .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -759,13 +759,14 @@ mod detach {
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         let exe = std::env::current_exe().context("locate hook helper")?;
-        let mut command = Command::new(exe)
+        let mut command = Command::new(exe);
+        command
             .arg(DETACHED_MODE_ARG)
             .env("CMUX_TUI_SOCKET", socket)
             .stdin(Stdio::piped())
             .stdout(Stdio::piped())
-            .stderr(Stdio::null())
-            .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+            .stderr(Stdio::null());
+        command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
         let (sender, receiver) = mpsc::sync_channel(1);
         let request_id = request_id.to_owned();
         let encoded = encoded.to_owned();

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -17,11 +17,11 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
-use anyhow::{Context, anyhow, bail};
-use base64::Engine as _;
+use anyhow::{anyhow, bail, Context};
 use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use cmux_tui_core::platform::transport;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 
 const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
@@ -522,7 +522,7 @@ mod detach {
 
     use anyhow::Context;
 
-    use super::{Handoff, append_with_receipt};
+    use super::{append_with_receipt, Handoff};
 
     /// Forks a detached child that performs the append, then returns once the
     /// child has written the request (normally milliseconds) or has given up
@@ -635,7 +635,7 @@ mod detach {
 
 #[cfg(unix)]
 mod detach {
-    use super::{DETACHED_MODE_ARG, Handoff};
+    use super::{Handoff, DETACHED_MODE_ARG};
     use anyhow::Context;
     use std::io::{Read, Write};
     use std::path::Path;
@@ -743,7 +743,7 @@ mod detach {
 
     use anyhow::Context;
 
-    use super::{DETACHED_MODE_ARG, Handoff};
+    use super::{Handoff, DETACHED_MODE_ARG};
 
     /// Respawns this helper detached from the provider's console and process
     /// group with the request on its stdin, then waits (bounded) for the

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -766,9 +766,38 @@ mod tests {
 
     #[test]
     fn codex_session_end_handoff_stays_below_the_codex_hook_cap() {
-        assert!(handoff_wait("codex", "SessionEnd") < Duration::from_secs(3));
-        assert!(handoff_wait("codex", "Stop") > SOCKET_TIMEOUT);
-        assert!(handoff_wait("claude", "SessionEnd") > SOCKET_TIMEOUT);
+        let started = Instant::now();
+        assert_eq!(
+            handoff_wait_from(
+                started,
+                started + Duration::from_millis(100),
+                "codex",
+                "SessionEnd",
+            ),
+            Duration::from_millis(2_400),
+        );
+        assert_eq!(
+            handoff_wait_from(started, started, "codex", "Stop"),
+            HANDOFF_WAIT,
+        );
+        assert_eq!(
+            handoff_wait_from(started, started, "claude", "SessionEnd"),
+            HANDOFF_WAIT,
+        );
+    }
+
+    #[test]
+    fn codex_session_end_handoff_deadline_starts_at_hook_launch() {
+        let started = Instant::now();
+        assert_eq!(
+            handoff_wait_from(
+                started,
+                started + Duration::from_millis(2_600),
+                "codex",
+                "SessionEnd",
+            ),
+            Duration::ZERO,
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -35,7 +35,7 @@ const HANDOFF_WAIT: Duration = Duration::from_secs(5);
 /// codex kills SessionEnd hooks at 3s (its hard cap). The provider-facing
 /// process must report an unconfirmed handoff before that instead of being
 /// killed; the detached child keeps trying to deliver the event regardless.
-const CODEX_SESSION_END_HANDOFF_WAIT: Duration = Duration::from_secs(2);
+const CODEX_SESSION_END_HANDOFF_WAIT: Duration = Duration::from_millis(2_500);
 /// Hidden mode: the detached child on platforms without `fork`. The request id
 /// arrives as the first stdin line and the encoded request follows.
 const DETACHED_MODE_ARG: &str = "__detached-append";
@@ -47,6 +47,7 @@ struct Args {
 }
 
 fn main() -> ExitCode {
+    let started = Instant::now();
     let arguments = env::args().skip(1).collect::<Vec<_>>();
     if arguments.len() == 1 && arguments[0] == DETACHED_MODE_ARG {
         return match detached_child_from_stdin() {
@@ -61,7 +62,7 @@ fn main() -> ExitCode {
         println!("Usage: cmux-tui-hook <agent> <native-event>");
         return ExitCode::SUCCESS;
     }
-    match parse_args(arguments).and_then(run) {
+    match parse_args(arguments).and_then(|args| run(args, started)) {
         Ok(()) => ExitCode::SUCCESS,
         Err(error) => {
             eprintln!("cmux-tui-hook: {error:#}");
@@ -70,7 +71,7 @@ fn main() -> ExitCode {
     }
 }
 
-fn run(args: Args) -> anyhow::Result<()> {
+fn run(args: Args, started: Instant) -> anyhow::Result<()> {
     if shadowed_by_grok(&args.source, env::var_os("GROK_HOOK_EVENT").as_deref()) {
         drain_native_payload()?;
         return Ok(());
@@ -92,8 +93,8 @@ fn run(args: Args) -> anyhow::Result<()> {
     )?;
     let event = serde_json::to_value(ingress)?;
     let (request_id, encoded) = encode_request(event)?;
-    let handoff = handoff_wait(&args.source, &args.native_event);
-    match detach::append_detached(&socket, &request_id, &encoded, handoff)? {
+    let deadline = started + handoff_budget(&args.source, &args.native_event);
+    match detach::append_detached(&socket, &request_id, &encoded, deadline)? {
         Handoff::Sent => Ok(()),
         Handoff::ChildExited => bail!("hook child gave up before writing the journal request"),
         Handoff::TimedOut => {
@@ -184,7 +185,15 @@ fn settle_detached_child(mut child: DetachedChildGuard, reader: std::thread::Joi
     }
 }
 
-fn handoff_wait(source: &str, native_event: &str) -> Duration {
+fn handoff_wait_from(started: Instant, now: Instant, source: &str, native_event: &str) -> Duration {
+    if source == "codex" && native_event == "SessionEnd" {
+        (started + CODEX_SESSION_END_HANDOFF_WAIT).saturating_duration_since(now)
+    } else {
+        HANDOFF_WAIT
+    }
+}
+
+fn handoff_budget(source: &str, native_event: &str) -> Duration {
     if source == "codex" && native_event == "SessionEnd" {
         CODEX_SESSION_END_HANDOFF_WAIT
     } else {
@@ -634,7 +643,7 @@ mod detach {
         socket: &Path,
         request_id: &str,
         encoded: &[u8],
-        handoff_wait: Duration,
+        deadline: std::time::Instant,
     ) -> anyhow::Result<Handoff> {
         use std::os::unix::process::CommandExt;
         let exe = std::env::current_exe().context("locate hook helper")?;
@@ -659,17 +668,41 @@ mod detach {
         unsafe {
             command.pre_exec(detach_session);
         }
-        let mut child =
-            super::DetachedChildGuard::new(command.spawn().context("spawn detached hook child")?);
-        let mut stdin =
-            child.child_mut().stdin.take().context("detached hook child has no stdin")?;
-        stdin.write_all(request_id.as_bytes())?;
-        stdin.write_all(b"\n")?;
-        stdin.write_all(encoded)?;
-        stdin.flush()?;
-        drop(stdin);
-        let mut stdout =
-            child.child_mut().stdout.take().context("detached hook child has no stdout")?;
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let request_id = request_id.to_owned();
+        let encoded = encoded.to_owned();
+        std::thread::spawn(move || {
+            let result =
+                (|| -> anyhow::Result<(std::process::Child, std::process::ChildStdout)> {
+                    let mut child = super::DetachedChildGuard::new(
+                        command.spawn().context("spawn detached hook child")?,
+                    );
+                    let mut stdin = child
+                        .child_mut()
+                        .stdin
+                        .take()
+                        .context("detached hook child has no stdin")?;
+                    stdin.write_all(request_id.as_bytes())?;
+                    stdin.write_all(b"\n")?;
+                    stdin.write_all(&encoded)?;
+                    stdin.flush()?;
+                    drop(stdin);
+                    let stdout = child
+                        .child_mut()
+                        .stdout
+                        .take()
+                        .context("detached hook child has no stdout")?;
+                    Ok((child.0.take().expect("child guard occupied"), stdout))
+                })();
+            let _ = sender.send(result);
+        });
+        let (raw_child, mut stdout) = match receiver
+            .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+        {
+            Ok(result) => result?,
+            Err(_) => return Ok(Handoff::TimedOut),
+        };
+        let mut child = super::DetachedChildGuard::new(raw_child);
         let (sender, receiver) = mpsc::channel();
         let reader = std::thread::spawn(move || {
             let mut byte = [0_u8; 1];
@@ -679,7 +712,9 @@ mod detach {
             };
             let _ = sender.send(outcome);
         });
-        let outcome = receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut);
+        let outcome = receiver
+            .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+            .unwrap_or(Handoff::TimedOut);
         super::settle_detached_child(child, reader);
         Ok(outcome)
     }
@@ -705,7 +740,7 @@ mod detach {
         socket: &Path,
         request_id: &str,
         encoded: &[u8],
-        handoff_wait: Duration,
+        deadline: std::time::Instant,
     ) -> anyhow::Result<Handoff> {
         use std::os::windows::process::CommandExt;
         const DETACHED_PROCESS: u32 = 0x0000_0008;
@@ -742,7 +777,9 @@ mod detach {
             };
             let _ = sender.send(outcome);
         });
-        let outcome = receiver.recv_timeout(handoff_wait).unwrap_or(Handoff::TimedOut);
+        let outcome = receiver
+            .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+            .unwrap_or(Handoff::TimedOut);
         super::settle_detached_child(child, reader);
         Ok(outcome)
     }
@@ -768,22 +805,11 @@ mod tests {
     fn codex_session_end_handoff_stays_below_the_codex_hook_cap() {
         let started = Instant::now();
         assert_eq!(
-            handoff_wait_from(
-                started,
-                started + Duration::from_millis(100),
-                "codex",
-                "SessionEnd",
-            ),
+            handoff_wait_from(started, started + Duration::from_millis(100), "codex", "SessionEnd",),
             Duration::from_millis(2_400),
         );
-        assert_eq!(
-            handoff_wait_from(started, started, "codex", "Stop"),
-            HANDOFF_WAIT,
-        );
-        assert_eq!(
-            handoff_wait_from(started, started, "claude", "SessionEnd"),
-            HANDOFF_WAIT,
-        );
+        assert_eq!(handoff_wait_from(started, started, "codex", "Stop"), HANDOFF_WAIT,);
+        assert_eq!(handoff_wait_from(started, started, "claude", "SessionEnd"), HANDOFF_WAIT,);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -759,7 +759,7 @@ mod detach {
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         let exe = std::env::current_exe().context("locate hook helper")?;
-        let command = Command::new(exe)
+        let mut command = Command::new(exe)
             .arg(DETACHED_MODE_ARG)
             .env("CMUX_TUI_SOCKET", socket)
             .stdin(Stdio::piped())

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -17,11 +17,11 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 use std::time::{Duration, Instant};
 
-use anyhow::{anyhow, bail, Context};
-use base64::engine::general_purpose::STANDARD as BASE64;
+use anyhow::{Context, anyhow, bail};
 use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use cmux_tui_core::platform::transport;
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 
 const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
@@ -522,7 +522,7 @@ mod detach {
 
     use anyhow::Context;
 
-    use super::{append_with_receipt, Handoff};
+    use super::{Handoff, append_with_receipt};
 
     /// Forks a detached child that performs the append, then returns once the
     /// child has written the request (normally milliseconds) or has given up
@@ -635,7 +635,7 @@ mod detach {
 
 #[cfg(unix)]
 mod detach {
-    use super::{Handoff, DETACHED_MODE_ARG};
+    use super::{DETACHED_MODE_ARG, Handoff};
     use anyhow::Context;
     use std::io::{Read, Write};
     use std::path::Path;
@@ -743,7 +743,7 @@ mod detach {
 
     use anyhow::Context;
 
-    use super::{Handoff, DETACHED_MODE_ARG};
+    use super::{DETACHED_MODE_ARG, Handoff};
 
     /// Respawns this helper detached from the provider's console and process
     /// group with the request on its stdin, then waits (bounded) for the

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -759,26 +759,51 @@ mod detach {
         const DETACHED_PROCESS: u32 = 0x0000_0008;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
         let exe = std::env::current_exe().context("locate hook helper")?;
-        let mut child = super::DetachedChildGuard::new(
-            Command::new(exe)
-                .arg(DETACHED_MODE_ARG)
-                .env("CMUX_TUI_SOCKET", socket)
-                .stdin(Stdio::piped())
-                .stdout(Stdio::piped())
-                .stderr(Stdio::null())
-                .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP)
-                .spawn()
-                .context("spawn detached hook child")?,
-        );
-        let mut stdin =
-            child.child_mut().stdin.take().context("detached hook child has no stdin")?;
-        let mut stdout =
-            child.child_mut().stdout.take().context("detached hook child has no stdout")?;
-        stdin.write_all(request_id.as_bytes())?;
-        stdin.write_all(b"\n")?;
-        stdin.write_all(encoded)?;
-        stdin.flush()?;
-        drop(stdin);
+        let command = Command::new(exe)
+            .arg(DETACHED_MODE_ARG)
+            .env("CMUX_TUI_SOCKET", socket)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::null())
+            .creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
+        let (sender, receiver) = mpsc::sync_channel(1);
+        let request_id = request_id.to_owned();
+        let encoded = encoded.to_owned();
+        std::thread::spawn(move || {
+            let result =
+                (|| -> anyhow::Result<(super::DetachedChildGuard, std::process::ChildStdout)> {
+                    let mut child = super::DetachedChildGuard::new(
+                        command.spawn().context("spawn detached hook child")?,
+                    );
+                    let mut stdin = child
+                        .child_mut()
+                        .stdin
+                        .take()
+                        .context("detached hook child has no stdin")?;
+                    stdin.write_all(request_id.as_bytes())?;
+                    stdin.write_all(b"\n")?;
+                    stdin.write_all(&encoded)?;
+                    stdin.flush()?;
+                    drop(stdin);
+                    let stdout = child
+                        .child_mut()
+                        .stdout
+                        .take()
+                        .context("detached hook child has no stdout")?;
+                    Ok((child, stdout))
+                })();
+            let _ = sender.send(result);
+        });
+        let setup = match deadline {
+            Some(deadline) => receiver
+                .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
+                .map_err(|_| ()),
+            None => receiver.recv().map_err(|_| ()),
+        };
+        let (mut child, mut stdout) = match setup {
+            Ok(result) => result?,
+            Err(_) => return Ok(Handoff::TimedOut),
+        };
         // Pipe reads have no timeout on Windows; a reader thread plus a
         // bounded channel wait gives the same absolute deadline as poll(2).
         let (sender, receiver) = mpsc::channel();


### PR DESCRIPTION
Rebased follow-up for #11390.

- Preserves the test-first two-commit order.
- Carries an absolute launch deadline through detached-child spawn, request pipe setup, and handoff wait.
- Setup now runs in a bounded helper thread; the provider path returns when the deadline expires while the detached child continues its own bounded delivery attempt.

Verification: standalone rustfmt, git diff --check, cmux policy check. No local Cargo/Rust tests or builds run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Codex `SessionEnd` hook in `cmux-tui` so setup time can no longer push the handoff past Codex's 3s cap.

- Carries an absolute launch deadline through detached-child spawn, request pipe setup, and handoff wait on Unix and Windows.
- Runs setup in a bounded helper thread; the provider path returns a timeout when the deadline expires while the detached child keeps trying to deliver.
- Raises the `SessionEnd` handoff budget from 2s to 2.5s and makes timeout errors report the deadline instead of a fixed wait.
- Adds tests covering the launch-based deadline.

<sup>Written for commit 0ee64025a243e2654307681c55c0b50ea3299620. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

