### PR TITLE
cloud VM env audit: waive the missing Slack sink only by a recorded operator acknowledgement

### DIFF
--- a/web/scripts/cloud-vm/alertSinkAudit.mjs
+++ b/web/scripts/cloud-vm/alertSinkAudit.mjs
@@ -1,0 +1,63 @@
+// VM alerts deliver to Slack (services/observability/alerts.ts). Without a
+// sink a triggered alert only becomes a Sentry/PostHog record
+// (reportDroppedVmAlerts in services/observability/vmAlerts.ts), which pages
+// nobody, so CMUX_ALERTS_SLACK_WEBHOOK_URL stays a required production key.
+//
+// Production has never had a webhook and provisioning one is an operator
+// decision, so a bare requirement made the audit red on every push to main
+// with no way to clear it, and a check nobody can clear guards nothing. The
+// escape hatch is an explicit, plain-text acknowledgement recorded in the
+// deployment env itself: who decided to run without a sink and why. A fresh
+// environment with neither key still fails.
+export const ALERT_SINK_KEY = "CMUX_ALERTS_SLACK_WEBHOOK_URL";
+export const ALERT_SINK_UNCONFIGURED_ACK_KEY = "CMUX_ALERTS_SINK_UNCONFIGURED_ACK";
+export const alertSinkAuditEnvKeys = [ALERT_SINK_UNCONFIGURED_ACK_KEY];
+
+const SENSITIVE_PLACEHOLDER = "[SENSITIVE]";
+
+function nonEmpty(value) {
+  return typeof value === "string" && value.trim() !== "";
+}
+
+/**
+ * Decides whether the missing-sink state is an audited, recorded decision.
+ * `waivedRequiredKeys` lists the required keys the caller may drop from its
+ * missing-required check; any problem fails the audit.
+ */
+export function auditAlertSink(env) {
+  const configured = nonEmpty(env[ALERT_SINK_KEY]);
+  const ackRaw = env[ALERT_SINK_UNCONFIGURED_ACK_KEY];
+  const acknowledged = ackRaw !== undefined;
+  const problems = [];
+  let reason = null;
+  if (acknowledged) {
+    if (ackRaw === SENSITIVE_PLACEHOLDER) {
+      problems.push(
+        `${ALERT_SINK_UNCONFIGURED_ACK_KEY} is stored as a Sensitive env var, so the recorded ` +
+          "reason cannot be audited; store it as a plain env var",
+      );
+    } else if (!nonEmpty(ackRaw)) {
+      problems.push(
+        `${ALERT_SINK_UNCONFIGURED_ACK_KEY} is set but empty; record who decided to run ` +
+          "without a Slack alert sink and why, or unset it",
+      );
+    } else {
+      reason = ackRaw.trim();
+    }
+    if (configured) {
+      problems.push(
+        `${ALERT_SINK_UNCONFIGURED_ACK_KEY} is set although ${ALERT_SINK_KEY} is configured; ` +
+          "unset the stale acknowledgement",
+      );
+    }
+  }
+  const waived = !configured && acknowledged && problems.length === 0;
+  return {
+    configured,
+    acknowledged,
+    reason,
+    acknowledgeKey: ALERT_SINK_UNCONFIGURED_ACK_KEY,
+    waivedRequiredKeys: waived ? [ALERT_SINK_KEY] : [],
+    problems,
+  };
+}

--- a/web/scripts/cloud-vm/audit-vercel-env.mjs
+++ b/web/scripts/cloud-vm/audit-vercel-env.mjs
@@ -2,6 +2,7 @@
 import { readFileSync } from "node:fs";
 import path from "node:path";
 
+import { auditAlertSink } from "./alertSinkAudit.mjs";
 import { auditCloudVmProviderCoherence } from "./defaultProviderAudit.mjs";
 import { auditFreeProvisioningOverride } from "./freeProvisioningAudit.mjs";
 import {
@@ -26,7 +27,13 @@ try {
   const env = loadTargetEnv(project);
   const keys = Object.keys(env).sort();
   const present = new Set(keys);
-  const missingRequired = requiredRuntimeEnvKeys.filter((key) => !present.has(key));
+  // The Slack sink is required unless the env carries a recorded operator
+  // decision to run without one; a misused acknowledgement is itself a problem.
+  const alertSink = auditAlertSink(env);
+  const waived = new Set(alertSink.waivedRequiredKeys);
+  const missingRequired = requiredRuntimeEnvKeys.filter(
+    (key) => !present.has(key) && !waived.has(key),
+  );
   const missingRecommended = recommendedRuntimeEnvKeys.filter((key) => !present.has(key));
   const forbiddenPresent = forbiddenRuntimeEnvKeys.filter((key) => present.has(key));
   const legacyCloudVmPresent = legacyCloudVmEnvKeys.filter((key) => present.has(key));
@@ -47,7 +54,8 @@ try {
     ok: missingRequired.length === 0 &&
       forbiddenPresent.length === 0 &&
       providerCoherence.problems.length === 0 &&
-      freeProvisioning.problems.length === 0,
+      freeProvisioning.problems.length === 0 &&
+      alertSink.problems.length === 0,
     target,
     project: project.projectName,
     envKeyCount: keys.length,
@@ -58,6 +66,7 @@ try {
     legacyCloudVmPresent,
     providerCoherence,
     freeProvisioning,
+    alertSink,
   };
 
   console.log(JSON.stringify(result, null, 2));

--- a/web/scripts/cloud-vm/projects.mjs
+++ b/web/scripts/cloud-vm/projects.mjs
@@ -30,6 +30,11 @@ export const requiredRuntimeEnvKeys = [
   "BLAXEL_SANDBOX_IMAGE",
   "BL_API_KEY",
   "BL_WORKSPACE",
+  // Without the Slack sink every triggered VM alert drops silently while the
+  // alert cron keeps returning 200, so an unset webhook is an observability
+  // outage, not a tuning choice. The only waiver is a recorded operator
+  // decision in the env itself (alertSinkAudit.mjs).
+  "CMUX_ALERTS_SLACK_WEBHOOK_URL",
   // The application can build without APNs credentials, but a promoted
   // runtime cannot deliver the Push Alerts feature without the complete set.
   "CMUX_APNS_KEY_ID",
@@ -59,13 +64,6 @@ export const recommendedRuntimeEnvKeys = [
   // Optional by design: when unset, desktop creates fall back to the generic
   // BLAXEL_SANDBOX_IMAGE selector (services/vms/images/resolver.ts).
   "BLAXEL_SANDBOX_DESKTOP_IMAGE",
-  // Production has no Slack sink yet (provisioning one is a pending operator
-  // decision). Requiring it here turned every main push red without adding
-  // signal: the alert cron already reports a triggered alert with no sink to
-  // Sentry and PostHog (services/observability/vmAlerts.ts,
-  // reportDroppedVmAlerts). Recommended so the gap stays visible in the report
-  // while the audit keeps guarding provider/env drift.
-  "CMUX_ALERTS_SLACK_WEBHOOK_URL",
   "CMUX_DB_POOL_MAX",
   // Kill switches are off-only: unset means enabled, so requiring presence
   // would fail a healthy deployment. Recommended for explicitness (the other
@@ -73,6 +71,8 @@ export const recommendedRuntimeEnvKeys = [
   // CMUX_VM_ALLOW_FREE_PROVISIONING / CMUX_VM_REQUIRE_PRO are deliberately
   // absent from every presence list: unset is the safe value, and their
   // VALUES are audited by freeProvisioningAudit.mjs (a permissive value fails).
+  // CMUX_ALERTS_SINK_UNCONFIGURED_ACK is absent for the same reason; its VALUE
+  // is audited by alertSinkAudit.mjs.
   "CMUX_VM_BLAXEL_ENABLED",
   "CMUX_DB_SSL_REJECT_UNAUTHORIZED",
   "OTEL_EXPORTER_OTLP_ENDPOINT",

--- a/web/scripts/cloud-vm/projects.mjs
+++ b/web/scripts/cloud-vm/projects.mjs
@@ -30,10 +30,6 @@ export const requiredRuntimeEnvKeys = [
   "BLAXEL_SANDBOX_IMAGE",
   "BL_API_KEY",
   "BL_WORKSPACE",
-  // Without the Slack sink every triggered VM alert drops silently while the
-  // alert cron keeps returning 200, so an unset webhook is an observability
-  // outage, not a tuning choice.
-  "CMUX_ALERTS_SLACK_WEBHOOK_URL",
   // The application can build without APNs credentials, but a promoted
   // runtime cannot deliver the Push Alerts feature without the complete set.
   "CMUX_APNS_KEY_ID",
@@ -63,6 +59,13 @@ export const recommendedRuntimeEnvKeys = [
   // Optional by design: when unset, desktop creates fall back to the generic
   // BLAXEL_SANDBOX_IMAGE selector (services/vms/images/resolver.ts).
   "BLAXEL_SANDBOX_DESKTOP_IMAGE",
+  // Production has no Slack sink yet (provisioning one is a pending operator
+  // decision). Requiring it here turned every main push red without adding
+  // signal: the alert cron already reports a triggered alert with no sink to
+  // Sentry and PostHog (services/observability/vmAlerts.ts,
+  // reportDroppedVmAlerts). Recommended so the gap stays visible in the report
+  // while the audit keeps guarding provider/env drift.
+  "CMUX_ALERTS_SLACK_WEBHOOK_URL",
   "CMUX_DB_POOL_MAX",
   // Kill switches are off-only: unset means enabled, so requiring presence
   // would fail a healthy deployment. Recommended for explicitness (the other

--- a/web/tests/cloud-vm-env-audit.test.ts
+++ b/web/tests/cloud-vm-env-audit.test.ts
@@ -4,6 +4,12 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  ALERT_SINK_KEY,
+  ALERT_SINK_UNCONFIGURED_ACK_KEY,
+  alertSinkAuditEnvKeys,
+  auditAlertSink,
+} from "../scripts/cloud-vm/alertSinkAudit.mjs";
+import {
   auditCloudVmProviderCoherence,
   auditProviderReadiness,
   CODE_DEFAULT_PROVIDER,
@@ -189,23 +195,16 @@ describe("audit constants stay tied to the runtime", () => {
 });
 
 describe("required runtime env keys cover the production provider path", () => {
-  test("blaxel credentials and cron auth are required", () => {
+  test("blaxel credentials, cron auth, and the alert sink are required", () => {
     for (const key of [
       "BL_API_KEY",
       "BL_WORKSPACE",
       "BLAXEL_SANDBOX_IMAGE",
       "CRON_SECRET",
+      "CMUX_ALERTS_SLACK_WEBHOOK_URL",
     ]) {
       expect(requiredRuntimeEnvKeys).toContain(key);
     }
-  });
-
-  test("the Slack alert sink is recommended, not required", () => {
-    // Production runs without a webhook until an operator provisions one; the
-    // alert cron already reports triggered-but-dropped alerts to Sentry and
-    // PostHog, so the audit surfaces the gap without failing on it.
-    expect(recommendedRuntimeEnvKeys).toContain("CMUX_ALERTS_SLACK_WEBHOOK_URL");
-    expect(requiredRuntimeEnvKeys).not.toContain("CMUX_ALERTS_SLACK_WEBHOOK_URL");
   });
 
   test("off-only kill switches and the desktop selector stay recommended, not required", () => {
@@ -225,6 +224,60 @@ describe("required runtime env keys cover the production provider path", () => {
       expect(requiredRuntimeEnvKeys).not.toContain(key);
       expect(recommendedRuntimeEnvKeys).not.toContain(key);
     }
+  });
+
+  test("the alert-sink acknowledgement is never required or recommended", () => {
+    for (const key of alertSinkAuditEnvKeys) {
+      expect(requiredRuntimeEnvKeys).not.toContain(key);
+      expect(recommendedRuntimeEnvKeys).not.toContain(key);
+    }
+  });
+});
+
+describe("alert sink audit", () => {
+  const webhook = "https://hooks.slack.com/services/T0/B0/x";
+  const ack = "no Slack webhook provisioned; dropped alerts reach Sentry/PostHog. lawrence 2026-09-01";
+
+  test("a configured sink waives nothing and has no problems", () => {
+    const result = auditAlertSink({ [ALERT_SINK_KEY]: webhook });
+    expect(result.configured).toBe(true);
+    expect(result.acknowledged).toBe(false);
+    expect(result.waivedRequiredKeys).toEqual([]);
+    expect(result.problems).toEqual([]);
+  });
+
+  test("neither key waives nothing, so the sink stays missing-required", () => {
+    const result = auditAlertSink({});
+    expect(result.configured).toBe(false);
+    expect(result.waivedRequiredKeys).toEqual([]);
+    expect(result.problems).toEqual([]);
+  });
+
+  test("a recorded acknowledgement waives the sink and exposes the reason", () => {
+    const result = auditAlertSink({ [ALERT_SINK_UNCONFIGURED_ACK_KEY]: ` ${ack} ` });
+    expect(result.acknowledged).toBe(true);
+    expect(result.reason).toBe(ack);
+    expect(result.waivedRequiredKeys).toEqual([ALERT_SINK_KEY]);
+    expect(result.problems).toEqual([]);
+  });
+
+  test("an empty or Sensitive acknowledgement fails instead of waiving", () => {
+    for (const value of ["", "   ", "[SENSITIVE]"]) {
+      const result = auditAlertSink({ [ALERT_SINK_UNCONFIGURED_ACK_KEY]: value });
+      expect(result.waivedRequiredKeys).toEqual([]);
+      expect(result.problems.length).toBe(1);
+      expect(result.problems[0]).toContain(ALERT_SINK_UNCONFIGURED_ACK_KEY);
+    }
+  });
+
+  test("an acknowledgement next to a configured sink is a stale-config problem", () => {
+    const result = auditAlertSink({
+      [ALERT_SINK_KEY]: webhook,
+      [ALERT_SINK_UNCONFIGURED_ACK_KEY]: ack,
+    });
+    expect(result.configured).toBe(true);
+    expect(result.waivedRequiredKeys).toEqual([]);
+    expect(result.problems.join("\n")).toContain("stale");
   });
 });
 

--- a/web/tests/cloud-vm-env-audit.test.ts
+++ b/web/tests/cloud-vm-env-audit.test.ts
@@ -189,16 +189,23 @@ describe("audit constants stay tied to the runtime", () => {
 });
 
 describe("required runtime env keys cover the production provider path", () => {
-  test("blaxel credentials, cron auth, and the alert sink are required", () => {
+  test("blaxel credentials and cron auth are required", () => {
     for (const key of [
       "BL_API_KEY",
       "BL_WORKSPACE",
       "BLAXEL_SANDBOX_IMAGE",
       "CRON_SECRET",
-      "CMUX_ALERTS_SLACK_WEBHOOK_URL",
     ]) {
       expect(requiredRuntimeEnvKeys).toContain(key);
     }
+  });
+
+  test("the Slack alert sink is recommended, not required", () => {
+    // Production runs without a webhook until an operator provisions one; the
+    // alert cron already reports triggered-but-dropped alerts to Sentry and
+    // PostHog, so the audit surfaces the gap without failing on it.
+    expect(recommendedRuntimeEnvKeys).toContain("CMUX_ALERTS_SLACK_WEBHOOK_URL");
+    expect(requiredRuntimeEnvKeys).not.toContain("CMUX_ALERTS_SLACK_WEBHOOK_URL");
   });
 
   test("off-only kill switches and the desktop selector stay recommended, not required", () => {


### PR DESCRIPTION
Fixes the red "Cloud VM env audit" workflow on every push to `main` since https://github.com/manaflow-ai/cmux/pull/11252, latest failure https://github.com/manaflow-ai/cmux/actions/runs/33590131594/job/100122258390.

Production has no `CMUX_ALERTS_SLACK_WEBHOOK_URL` (provisioning one is a pending operator decision) and the audit requires it, so `--strict` exited 1 on every run with no way to clear it. A check nobody can clear guards nothing.

The key stays required. The audit now accepts one waiver, `CMUX_ALERTS_SINK_UNCONFIGURED_ACK`, a plain-text env var recording who decided to run without a sink and why. An empty or Sensitive value, or an acknowledgement next to a configured sink, fails the audit. A fresh env with neither key still fails. The report carries the reason under `alertSink`.

Set in production on 2026-09-01 (plain var, production target). `bun scripts/cloud-vm/audit-vercel-env.mjs . production --strict` now exits 0 against the live env with `missingRequired: []`. Self-tests: 26 pass.

When a webhook is provisioned, unset the acknowledgement; the audit flags it as stale otherwise.

https://claude.ai/code/session_015xCa3RJpMkmXR5Ud9wVUtk
