### PR TITLE
fix(pipe-io): classify relay startup failures

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1713,6 +1713,13 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
+            // A pipe-IO relay must always finish with a machine-readable
+            // reason. Older daemons cannot scope the event stream, so the
+            // embedder treats this as a lost daemon connection and retries
+            // after the daemon is upgraded or restarted.
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+            }
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -536,6 +536,14 @@ mod tests {
         assert!(parse_request("not json").is_err());
         assert!(parse_request(r#"{"input":"@@not-base64@@"}"#).is_err());
         assert!(parse_request(r#"{"resize":{"cols":100}}"#).is_err());
+        for resize in ["false", "null", "42", "\"30x100\"", "[]"] {
+            assert!(
+                parse_request(&format!(r#"{{"resize":{resize}}}"#)).is_err(),
+                "accepted scalar resize {resize}"
+            );
+        }
+        assert!(parse_request(r#"{"resize":{"cols":"100","rows":30}}"#).is_err());
+        assert!(parse_request(r#"{"resize":{"cols":100,"rows":false}}"#).is_err());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -198,7 +198,7 @@ pub fn run(
             return Ok(PipeIoExitReason::TerminalEnded);
         }
         Ok(PipeIoSurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
-        Err(error) => return Ok(attach_failure_exit_reason(&error, surface)),
+        Err(error) => return Ok(pipe_io_failure_exit_reason(&error, surface)),
     };
     // The daemon resizes a terminal's PTY only for its geometry-authority
     // client (the full TUI client claims this for its active surface). The
@@ -209,6 +209,7 @@ pub fn run(
             "{}",
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
         );
+        return Ok(pipe_io_failure_exit_reason(&error, surface));
     }
     spawn_stdin_pump(handle, lifecycle_sender);
     let reason = pump_events_to_stdout(
@@ -257,7 +258,7 @@ impl Drop for PipeIoTapGuard<'_> {
     }
 }
 
-fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
+fn pipe_io_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
     // A rejected attach naming this exact surface means the terminal ended
     // between the tree lookup and the attach request. Every other failure is
     // reported as retryable daemon loss so the embedder receives the normal
@@ -653,12 +654,15 @@ mod tests {
     fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
         let terminal_ended =
             crate::session::test_remote_rejected_error_with_message("unknown surface 7");
-        assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
+        assert_eq!(
+            pipe_io_failure_exit_reason(&terminal_ended, 7),
+            PipeIoExitReason::TerminalEnded
+        );
 
         let daemon_lost = crate::session::test_remote_transport_error();
-        assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(pipe_io_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
 
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
-        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(pipe_io_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3271,38 +3271,48 @@ impl RemoteSession {
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
         use crossbeam_channel::TrySendError;
-        // Resolve ownership before invoking the closure. The output and
+        // Capture ownership before invoking the closure. The output and
         // replay call sites defer an expensive payload clone in this closure;
-        // sessions without a pipe-IO tap must not pay that cost.
-        let (stalled_token, pipe_io_owned, lifecycle_event) = {
+        // sessions without a pipe-IO tap must not pay that cost. Do not hold
+        // the tap lock while constructing that payload, because a large
+        // replay clone must not block attach or teardown on the reader thread.
+        let tap_token = {
             let tap = self.pipe_io_tap.lock().unwrap();
             let Some(tap) = tap.as_ref() else { return false };
             if tap.surface != surface {
                 return false;
             }
-            let event = event();
-            if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
-                // Keep the token fence while releasing the lock. A stale
-                // lifecycle event must not remove a replacement relay.
-                (None, true, Some((tap.token.clone(), event)))
+            tap.token.clone()
+        };
+        let event = event();
+        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
+            // Keep the token fence while releasing the lock. A stale
+            // lifecycle event must not remove a replacement relay.
+            return self.signal_pipe_io_event(Some(surface), Some(&tap_token), event);
+        }
+        let (stalled_token, pipe_io_owned) = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return false };
+            if tap.surface != surface || !Arc::ptr_eq(&tap.token, &tap_token) {
+                // A replacement relay won the ownership race while the
+                // payload was being built. Drop the stale event rather than
+                // forwarding it to the new relay, but keep the ownership
+                // fence set so the caller does not parse it locally.
+                return true;
+            }
+            let retained_bytes = event.retained_bytes();
+            if !tap.byte_budget.try_reserve(retained_bytes) {
+                (Some(tap.token.clone()), true)
             } else {
-                let retained_bytes = event.retained_bytes();
-                if !tap.byte_budget.try_reserve(retained_bytes) {
-                    (Some(tap.token.clone()), true, None)
-                } else {
-                    match tap.sender.try_send(event) {
-                        Ok(()) => (None, true, None),
-                        Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
-                            tap.byte_budget.release(retained_bytes);
-                            (Some(tap.token.clone()), true, None)
-                        }
+                match tap.sender.try_send(event) {
+                    Ok(()) => (None, true),
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        tap.byte_budget.release(retained_bytes);
+                        (Some(tap.token.clone()), true)
                     }
                 }
             }
         };
-        if let Some((token, event)) = lifecycle_event {
-            return self.signal_pipe_io_event(Some(surface), Some(&token), event);
-        }
         if let Some(token) = stalled_token {
             // Signal only the tap that observed the stall. A replacement tap
             // may have been installed while this reader thread released the
@@ -6862,6 +6872,58 @@ mod tests {
         }));
 
         assert!(!constructed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn pipe_io_forward_constructs_payload_without_holding_tap_lock() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+        let lock_available = Arc::new(AtomicBool::new(false));
+        let marker = lock_available.clone();
+        assert!(session.pipe_io_forward(7, || {
+            marker.store(session.pipe_io_tap.try_lock().is_ok(), Ordering::Release);
+            PipeIoEvent::Output(b"payload".to_vec())
+        }));
+        assert!(lock_available.load(Ordering::Acquire));
+        assert_eq!(receiver.try_recv().unwrap(), PipeIoEvent::Output(b"payload".to_vec()));
+    }
+
+    #[test]
+    fn pipe_io_forward_drops_payload_when_tap_is_replaced_during_construction() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (first_sender, _first_receiver) = crossbeam_channel::bounded(1);
+        let (first_lifecycle_sender, _first_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _first_token = session.install_pipe_io_tap(
+            7,
+            first_sender,
+            first_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+        let (second_sender, second_receiver) = crossbeam_channel::bounded(1);
+        let (second_lifecycle_sender, _second_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let replacement = session.clone();
+
+        assert!(session.pipe_io_forward(7, || {
+            replacement.install_pipe_io_tap(
+                7,
+                second_sender,
+                second_lifecycle_sender,
+                Arc::new(PipeIoByteBudget::new(1024)),
+            );
+            PipeIoEvent::Output(b"stale".to_vec())
+        }));
+        assert!(second_receiver.try_recv().is_err());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3271,29 +3271,38 @@ impl RemoteSession {
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
         use crossbeam_channel::TrySendError;
-        let event = event();
-        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
-            return self.signal_pipe_io_event(Some(surface), None, event);
-        }
-        let (stalled_token, pipe_io_owned) = {
+        // Resolve ownership before invoking the closure. The output and
+        // replay call sites defer an expensive payload clone in this closure;
+        // sessions without a pipe-IO tap must not pay that cost.
+        let (stalled_token, pipe_io_owned, lifecycle_event) = {
             let tap = self.pipe_io_tap.lock().unwrap();
             let Some(tap) = tap.as_ref() else { return false };
             if tap.surface != surface {
                 return false;
             }
-            let retained_bytes = event.retained_bytes();
-            if !tap.byte_budget.try_reserve(retained_bytes) {
-                (Some(tap.token.clone()), true)
+            let event = event();
+            if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
+                // Keep the token fence while releasing the lock. A stale
+                // lifecycle event must not remove a replacement relay.
+                (None, true, Some((tap.token.clone(), event)))
             } else {
-                match tap.sender.try_send(event) {
-                    Ok(()) => (None, true),
-                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
-                        tap.byte_budget.release(retained_bytes);
-                        (Some(tap.token.clone()), true)
+                let retained_bytes = event.retained_bytes();
+                if !tap.byte_budget.try_reserve(retained_bytes) {
+                    (Some(tap.token.clone()), true, None)
+                } else {
+                    match tap.sender.try_send(event) {
+                        Ok(()) => (None, true, None),
+                        Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                            tap.byte_budget.release(retained_bytes);
+                            (Some(tap.token.clone()), true, None)
+                        }
                     }
                 }
             }
         };
+        if let Some((token, event)) = lifecycle_event {
+            return self.signal_pipe_io_event(Some(surface), Some(&token), event);
+        }
         if let Some(token) = stalled_token {
             // Signal only the tap that observed the stall. A replacement tap
             // may have been installed while this reader thread released the

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6840,6 +6840,22 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_forward_does_not_construct_payload_without_matching_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let constructed = Arc::new(AtomicBool::new(false));
+        let marker = constructed.clone();
+
+        assert!(!session.pipe_io_forward(7, || {
+            marker.store(true, Ordering::Release);
+            PipeIoEvent::Output(vec![0; 1024])
+        }));
+
+        assert!(!constructed.load(Ordering::Acquire));
+    }
+
+    #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6927,6 +6927,35 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_forward_does_not_consume_original_surface_for_other_surface_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (first_sender, _first_receiver) = crossbeam_channel::bounded(1);
+        let (first_lifecycle_sender, _first_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _first_token = session.install_pipe_io_tap(
+            7,
+            first_sender,
+            first_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+        let (second_sender, second_receiver) = crossbeam_channel::bounded(1);
+        let (second_lifecycle_sender, _second_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let replacement = session.clone();
+
+        assert!(!session.pipe_io_forward(7, || {
+            replacement.install_pipe_io_tap(
+                8,
+                second_sender,
+                second_lifecycle_sender,
+                Arc::new(PipeIoByteBudget::new(1024)),
+            );
+            PipeIoEvent::Output(b"original-surface".to_vec())
+        }));
+        assert!(second_receiver.try_recv().is_err());
+    }
+
+    #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3293,7 +3293,10 @@ impl RemoteSession {
         let (stalled_token, pipe_io_owned) = {
             let tap = self.pipe_io_tap.lock().unwrap();
             let Some(tap) = tap.as_ref() else { return false };
-            if tap.surface != surface || !Arc::ptr_eq(&tap.token, &tap_token) {
+            if tap.surface != surface {
+                return false;
+            }
+            if !Arc::ptr_eq(&tap.token, &tap_token) {
                 // A replacement relay won the ownership race while the
                 // payload was being built. Drop the stale event rather than
                 // forwarding it to the new relay, but keep the ownership

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4106,6 +4106,7 @@ struct PipeIoRelay {
     stdin: Option<std::process::ChildStdin>,
     stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
     stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    stderr_drain: Option<std::thread::JoinHandle<()>>,
 }
 
 #[cfg(unix)]
@@ -4137,8 +4138,8 @@ impl PipeIoRelay {
         let stdout_sink = stdout.clone();
         std::thread::spawn(move || drain_into(out, stdout_sink));
         let stderr_sink = stderr.clone();
-        std::thread::spawn(move || drain_into(err, stderr_sink));
-        Self { child, stdin, stdout, stderr }
+        let stderr_drain = std::thread::spawn(move || drain_into(err, stderr_sink));
+        Self { child, stdin, stdout, stderr, stderr_drain: Some(stderr_drain) }
     }
 
     fn send_input(&mut self, bytes: &[u8]) {
@@ -4188,8 +4189,11 @@ impl PipeIoRelay {
         let deadline = Instant::now() + Duration::from_secs(20);
         while Instant::now() < deadline {
             if let Some(status) = self.child.try_wait().unwrap() {
-                // Let the drain threads observe EOF.
-                std::thread::sleep(Duration::from_millis(100));
+                // Child EOF closes stderr. Join the drain before parsing so
+                // the final exit record is present deterministically.
+                if let Some(stderr_drain) = self.stderr_drain.take() {
+                    let _ = stderr_drain.join();
+                }
                 let stderr_text =
                     String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
                 let exit_line = stderr_text


### PR DESCRIPTION
Stacked on #11443.

Fixes four runtime/test issues in the manual-IO relay:

- Emit a classified daemon-lost exit record when an older daemon lacks scoped subscription filtering.
- Stop startup when geometry ownership cannot be claimed, with terminal-ended or daemon-lost classification.
- Check tap ownership before constructing output/replay payloads.
- Join the stderr drain thread before parsing the final exit record instead of sleeping.

Includes behavior coverage for strict resize requests and deferred payload construction.

Validation: rustfmt (edition 2024), git diff --check, cmux-policy-check. Cargo/Xcode tests were not run per task instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11552"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790916760&installation_model_id=21920&pr_number=11552&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11552&signature=91f4a613a6b69e60c6375f13ddee69a3ca3880c89455d78c90c56a8c4a1e12e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloud machine terminals now render through a manual-mirror Ghostty surface fed by a `cmux-tui attach --pipe-io` relay instead of running the full TUI in the pane. The relay reports terminal-ended and daemon-lost startup failures so the app can choose teardown or reconnect correctly, while clients without `--pipe-io` still use the existing attach path.

- Older daemons without scoped subscription filtering and failed geometry claims now emit a machine-readable daemon-lost result.
- Output and replay payloads are built only after a matching pipe-IO tap claims ownership, the tap lock is released during construction, and stale events from a replaced tap are dropped without clearing the per-surface ownership fence.
- Invalid resize payloads are rejected, and relay tests join stderr draining before parsing the final exit record.

<sup>Written for commit 04105a905078a86e61f8d1a1d9ce25de79793572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

