### PR TITLE
fix(cmux-tui): propagate PTY session scan read errors

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -9,6 +9,7 @@
 #![cfg(unix)]
 
 use std::collections::{HashMap, VecDeque};
+use std::future::Future;
 use std::fs::File;
 use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
@@ -38,6 +39,18 @@ const PIPE_READ_POLL_MS: i32 = 100;
 // `lifecycle_ready` was added to the cmux-tui control protocol at version 12.
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
+
+async fn collect_dir_names<F, Fut>(mut next_entry: F) -> Result<Vec<String>, ()>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<Option<String>, ()>>,
+{
+    let mut names = Vec::new();
+    while let Ok(Some(name)) = next_entry().await {
+        names.push(name);
+    }
+    Ok(names)
+}
 
 async fn control_ready(control: &Arc<dyn ControlHandle>, session: &str) -> bool {
     control.request("identify", serde_json::Value::Null).await.is_some_and(|response| {
@@ -957,11 +970,14 @@ impl PtyDeps for RealPtyDeps {
 
     async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()> {
         let mut entries = tokio::fs::read_dir(path).await.map_err(|_| ())?;
-        let mut names = Vec::new();
-        while let Ok(Some(entry)) = entries.next_entry().await {
-            names.push(entry.file_name().to_string_lossy().into_owned());
-        }
-        Ok(names)
+        collect_dir_names(|| async {
+            entries
+                .next_entry()
+                .await
+                .map(|entry| entry.map(|entry| entry.file_name().to_string_lossy().into_owned()))
+                .map_err(|_| ())
+        })
+        .await
     }
 
     fn socket_dir(&self) -> PathBuf {
@@ -1044,6 +1060,19 @@ mod tests {
         let error = session_socket_path(Path::new("/run/cmux-tui-501"), 501, "bad/name")
             .expect_err("path separator must be rejected");
         assert!(error.contains("invalid session"));
+    }
+
+    #[tokio::test]
+    async fn directory_entry_read_errors_fail_closed() {
+        let mut calls = 0;
+        let result = collect_dir_names(|| {
+            calls += 1;
+            async { Err::<Option<String>, ()>(()) }
+        })
+        .await;
+
+        assert_eq!(result, Err(()));
+        assert_eq!(calls, 1, "stop after the first directory read error");
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -9,8 +9,8 @@
 #![cfg(unix)]
 
 use std::collections::{HashMap, VecDeque};
-use std::future::Future;
 use std::fs::File;
+use std::future::Future;
 use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
 use std::os::fd::AsRawFd;
@@ -46,8 +46,11 @@ where
     Fut: Future<Output = Result<Option<String>, ()>>,
 {
     let mut names = Vec::new();
-    while let Ok(Some(name)) = next_entry().await {
-        names.push(name);
+    loop {
+        match next_entry().await? {
+            Some(name) => names.push(name),
+            None => break,
+        }
     }
     Ok(names)
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -10,7 +10,6 @@
 
 use std::collections::{HashMap, VecDeque};
 use std::fs::File;
-use std::future::Future;
 use std::io::{Read, Write};
 use std::mem::{offset_of, size_of};
 use std::os::fd::AsRawFd;
@@ -40,19 +39,14 @@ const PIPE_READ_POLL_MS: i32 = 100;
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
 
-async fn collect_dir_names<F, Fut>(mut next_entry: F) -> Result<Vec<String>, ()>
-where
-    F: FnMut() -> Fut,
-    Fut: Future<Output = Result<Option<String>, ()>>,
-{
-    let mut names = Vec::new();
-    loop {
-        match next_entry().await? {
-            Some(name) => names.push(name),
-            None => break,
+fn append_dir_name(names: &mut Vec<String>, entry: Result<Option<String>, ()>) -> Result<bool, ()> {
+    match entry? {
+        Some(name) => {
+            names.push(name);
+            Ok(true)
         }
+        None => Ok(false),
     }
-    Ok(names)
 }
 
 async fn control_ready(control: &Arc<dyn ControlHandle>, session: &str) -> bool {
@@ -973,14 +967,18 @@ impl PtyDeps for RealPtyDeps {
 
     async fn read_dir(&self, path: &Path) -> Result<Vec<String>, ()> {
         let mut entries = tokio::fs::read_dir(path).await.map_err(|_| ())?;
-        collect_dir_names(|| async {
-            entries
+        let mut names = Vec::new();
+        loop {
+            let entry = entries
                 .next_entry()
                 .await
                 .map(|entry| entry.map(|entry| entry.file_name().to_string_lossy().into_owned()))
-                .map_err(|_| ())
-        })
-        .await
+                .map_err(|_| ());
+            if !append_dir_name(&mut names, entry)? {
+                break;
+            }
+        }
+        Ok(names)
     }
 
     fn socket_dir(&self) -> PathBuf {
@@ -1065,17 +1063,13 @@ mod tests {
         assert!(error.contains("invalid session"));
     }
 
-    #[tokio::test]
-    async fn directory_entry_read_errors_fail_closed() {
-        let mut calls = 0;
-        let result = collect_dir_names(|| {
-            calls += 1;
-            async { Err::<Option<String>, ()>(()) }
-        })
-        .await;
+    #[test]
+    fn directory_entry_read_errors_fail_closed() {
+        let mut names = vec!["before-error".to_owned()];
+        let result = append_dir_name(&mut names, Err(()));
 
         assert_eq!(result, Err(()));
-        assert_eq!(calls, 1, "stop after the first directory read error");
+        assert_eq!(names, vec!["before-error".to_owned()]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Propagate `ReadDir::next_entry` failures instead of returning a partial session-name scan.
- Add a behavior test with an injected directory-entry read error.

## Testing
- `CMUX_ALLOW_LOW_SPACE_BUILD=1 cargo fmt --all -- --check`
- `git diff --check`
- `cmux-policy-check --mode branch --base origin/main`
- Local Cargo tests were not run.

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/11401

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates directory read errors during PTY session scanning so partial session lists are no longer treated as success. Previously, `read_dir` swallowed errors and returned whatever entries were read; now the first read error aborts the scan and returns an error. Adds a test for the fail-closed behavior.

<sup>Written for commit fac6cbb6815c7e96469e308f3ffea71b0fad1cad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11555?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Directory listings now correctly report errors encountered while reading entries instead of silently stopping early.
  - Partial directory results are no longer returned when an entry-reading failure occurs, preventing incomplete data from being treated as a successful result.
  - Improved error handling ensures callers receive a clear failure signal when directory contents cannot be read reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->