### PR TITLE
fix(cmux-tui): preserve detached child after setup timeout

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -985,4 +985,39 @@ mod tests {
         }
         assert_eq!(std::fs::read_to_string(marker).unwrap(), "survived");
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn setup_handoff_timeout_releases_a_late_child() {
+        use std::process::{Command, Stdio};
+        use std::sync::{Arc, Barrier};
+
+        let root = tempfile::tempdir().unwrap();
+        let marker = root.path().join("survived");
+        let child = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("read ignored; printf survived > \"$CMUX_TUI_TEST_MARKER\"")
+            .env("CMUX_TUI_TEST_MARKER", &marker)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut guard = DetachedChildGuard::new(child);
+        let stdout = guard.child_mut().stdout.take().unwrap();
+        let barrier = Arc::new(Barrier::new(2));
+        let worker_barrier = barrier.clone();
+
+        let setup = setup_handoff(Some(Instant::now() + Duration::from_millis(20)), move || {
+            worker_barrier.wait();
+            Ok((guard, stdout))
+        });
+        assert!(setup.is_none(), "setup should time out before the worker handoff");
+
+        barrier.wait();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !marker.exists() && Instant::now() < deadline {
+            std::thread::yield_now();
+        }
+        assert_eq!(std::fs::read_to_string(marker).unwrap(), "survived");
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -935,4 +935,33 @@ mod tests {
 
         assert!(matches!(result, Err(AppendAttemptError::Fatal(_))));
     }
+
+    #[cfg(unix)]
+    #[test]
+    fn setup_send_failure_releases_a_successfully_spawned_child() {
+        use std::process::{Command, Stdio};
+        use std::sync::mpsc;
+
+        let root = tempfile::tempdir().unwrap();
+        let marker = root.path().join("survived");
+        let child = Command::new("/bin/sh")
+            .arg("-c")
+            .arg("sleep 0.1; printf survived > \"$CMUX_TUI_TEST_MARKER\"")
+            .env("CMUX_TUI_TEST_MARKER", &marker)
+            .stdout(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let mut guard = DetachedChildGuard::new(child);
+        let stdout = guard.child_mut().stdout.take().unwrap();
+        let (sender, receiver) = mpsc::sync_channel(1);
+        drop(receiver);
+
+        forward_setup_result(sender, Ok((guard, stdout)));
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        while !marker.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(std::fs::read_to_string(marker).unwrap(), "survived");
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -688,7 +688,11 @@ mod detach {
         unsafe {
             command.pre_exec(detach_session);
         }
-        let (sender, receiver) = mpsc::sync_channel(1);
+        // A rendezvous channel makes setup ownership transfer atomic with the
+        // timeout decision. A queued result could otherwise be dropped after
+        // `recv_timeout` returns, which would drop the guard and kill the
+        // successfully spawned child.
+        let (sender, receiver) = mpsc::sync_channel(0);
         let request_id = request_id.to_owned();
         let encoded = encoded.to_owned();
         std::thread::spawn(move || {
@@ -781,7 +785,10 @@ mod detach {
             .stdout(Stdio::piped())
             .stderr(Stdio::null());
         command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
-        let (sender, receiver) = mpsc::sync_channel(1);
+        // Keep setup ownership as a rendezvous with the timeout path. There
+        // must be no queued successful handoff for a timed-out receiver to
+        // drop later.
+        let (sender, receiver) = mpsc::sync_channel(0);
         let request_id = request_id.to_owned();
         let encoded = encoded.to_owned();
         std::thread::spawn(move || {
@@ -967,7 +974,7 @@ mod tests {
             .unwrap();
         let mut guard = DetachedChildGuard::new(child);
         let stdout = guard.child_mut().stdout.take().unwrap();
-        let (sender, receiver) = mpsc::sync_channel(1);
+        let (sender, receiver) = mpsc::sync_channel(0);
         drop(receiver);
 
         forward_setup_result(sender, Ok((guard, stdout)));

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -171,6 +171,22 @@ fn forward_setup_result(sender: std::sync::mpsc::SyncSender<SetupResult>, result
     }
 }
 
+/// Run setup on a worker and transfer successful child ownership through a
+/// rendezvous. A timed-out receiver cannot leave a queued guard to be dropped.
+fn setup_handoff<F>(deadline: Option<Instant>, setup: F) -> Option<SetupResult>
+where
+    F: FnOnce() -> SetupResult + Send + 'static,
+{
+    let (sender, receiver) = std::sync::mpsc::sync_channel(0);
+    std::thread::spawn(move || forward_setup_result(sender, setup()));
+    match deadline {
+        Some(deadline) => receiver
+            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
+            .ok(),
+        None => receiver.recv().ok(),
+    }
+}
+
 /// Settle the parent-side ownership before the provider-facing process
 /// returns. A child that already exited is reaped and its stdout reader is
 /// joined. A child that is still running must continue waiting for its receipt,
@@ -688,49 +704,34 @@ mod detach {
         unsafe {
             command.pre_exec(detach_session);
         }
-        // A rendezvous channel makes setup ownership transfer atomic with the
-        // timeout decision. A queued result could otherwise be dropped after
-        // `recv_timeout` returns, which would drop the guard and kill the
-        // successfully spawned child.
-        let (sender, receiver) = mpsc::sync_channel(0);
         let request_id = request_id.to_owned();
         let encoded = encoded.to_owned();
-        std::thread::spawn(move || {
-            let result =
-                (|| -> anyhow::Result<(super::DetachedChildGuard, std::process::ChildStdout)> {
-                    let mut child = super::DetachedChildGuard::new(
-                        command.spawn().context("spawn detached hook child")?,
-                    );
-                    let mut stdin = child
-                        .child_mut()
-                        .stdin
-                        .take()
-                        .context("detached hook child has no stdin")?;
-                    stdin.write_all(request_id.as_bytes())?;
-                    stdin.write_all(b"\n")?;
-                    stdin.write_all(&encoded)?;
-                    stdin.flush()?;
-                    drop(stdin);
-                    let stdout = child
-                        .child_mut()
-                        .stdout
-                        .take()
-                        .context("detached hook child has no stdout")?;
-                    Ok((child, stdout))
-                })();
-            super::forward_setup_result(sender, result);
+        let setup = super::setup_handoff(deadline, move || {
+            (|| -> anyhow::Result<(super::DetachedChildGuard, std::process::ChildStdout)> {
+                let mut child = super::DetachedChildGuard::new(
+                    command.spawn().context("spawn detached hook child")?,
+                );
+                let mut stdin = child
+                    .child_mut()
+                    .stdin
+                    .take()
+                    .context("detached hook child has no stdin")?;
+                stdin.write_all(request_id.as_bytes())?;
+                stdin.write_all(b"\n")?;
+                stdin.write_all(&encoded)?;
+                stdin.flush()?;
+                drop(stdin);
+                let stdout = child
+                    .child_mut()
+                    .stdout
+                    .take()
+                    .context("detached hook child has no stdout")?;
+                Ok((child, stdout))
+            })()
         });
-        let setup = || {
-            deadline.map_or(None, |deadline| {
-                Some(deadline.saturating_duration_since(std::time::Instant::now()))
-            })
-        };
-        let (mut child, mut stdout) = match match setup() {
-            Some(remaining) => receiver.recv_timeout(remaining).map_err(|_| ()),
-            None => receiver.recv().map_err(|_| ()),
-        } {
-            Ok(result) => result?,
-            Err(_) => return Ok(Handoff::TimedOut),
+        let (mut child, mut stdout) = match setup {
+            Some(result) => result?,
+            None => return Ok(Handoff::TimedOut),
         };
         let (sender, receiver) = mpsc::channel();
         let reader = std::thread::spawn(move || {
@@ -785,46 +786,34 @@ mod detach {
             .stdout(Stdio::piped())
             .stderr(Stdio::null());
         command.creation_flags(DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP);
-        // Keep setup ownership as a rendezvous with the timeout path. There
-        // must be no queued successful handoff for a timed-out receiver to
-        // drop later.
-        let (sender, receiver) = mpsc::sync_channel(0);
         let request_id = request_id.to_owned();
         let encoded = encoded.to_owned();
-        std::thread::spawn(move || {
-            let result =
-                (|| -> anyhow::Result<(super::DetachedChildGuard, std::process::ChildStdout)> {
-                    let mut child = super::DetachedChildGuard::new(
-                        command.spawn().context("spawn detached hook child")?,
-                    );
-                    let mut stdin = child
-                        .child_mut()
-                        .stdin
-                        .take()
-                        .context("detached hook child has no stdin")?;
-                    stdin.write_all(request_id.as_bytes())?;
-                    stdin.write_all(b"\n")?;
-                    stdin.write_all(&encoded)?;
-                    stdin.flush()?;
-                    drop(stdin);
-                    let stdout = child
-                        .child_mut()
-                        .stdout
-                        .take()
-                        .context("detached hook child has no stdout")?;
-                    Ok((child, stdout))
-                })();
-            super::forward_setup_result(sender, result);
+        let setup = super::setup_handoff(deadline, move || {
+            (|| -> anyhow::Result<(super::DetachedChildGuard, std::process::ChildStdout)> {
+                let mut child = super::DetachedChildGuard::new(
+                    command.spawn().context("spawn detached hook child")?,
+                );
+                let mut stdin = child
+                    .child_mut()
+                    .stdin
+                    .take()
+                    .context("detached hook child has no stdin")?;
+                stdin.write_all(request_id.as_bytes())?;
+                stdin.write_all(b"\n")?;
+                stdin.write_all(&encoded)?;
+                stdin.flush()?;
+                drop(stdin);
+                let stdout = child
+                    .child_mut()
+                    .stdout
+                    .take()
+                    .context("detached hook child has no stdout")?;
+                Ok((child, stdout))
+            })()
         });
-        let setup = match deadline {
-            Some(deadline) => receiver
-                .recv_timeout(deadline.saturating_duration_since(std::time::Instant::now()))
-                .map_err(|_| ()),
-            None => receiver.recv().map_err(|_| ()),
-        };
         let (mut child, mut stdout) = match setup {
-            Ok(result) => result?,
-            Err(_) => return Ok(Handoff::TimedOut),
+            Some(result) => result?,
+            None => return Ok(Handoff::TimedOut),
         };
         // Pipe reads have no timeout on Windows; a reader thread plus a
         // bounded channel wait gives the same absolute deadline as poll(2).

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -180,9 +180,9 @@ where
     let (sender, receiver) = std::sync::mpsc::sync_channel(0);
     std::thread::spawn(move || forward_setup_result(sender, setup()));
     match deadline {
-        Some(deadline) => receiver
-            .recv_timeout(deadline.saturating_duration_since(Instant::now()))
-            .ok(),
+        Some(deadline) => {
+            receiver.recv_timeout(deadline.saturating_duration_since(Instant::now())).ok()
+        }
         None => receiver.recv().ok(),
     }
 }
@@ -711,21 +711,15 @@ mod detach {
                 let mut child = super::DetachedChildGuard::new(
                     command.spawn().context("spawn detached hook child")?,
                 );
-                let mut stdin = child
-                    .child_mut()
-                    .stdin
-                    .take()
-                    .context("detached hook child has no stdin")?;
+                let mut stdin =
+                    child.child_mut().stdin.take().context("detached hook child has no stdin")?;
                 stdin.write_all(request_id.as_bytes())?;
                 stdin.write_all(b"\n")?;
                 stdin.write_all(&encoded)?;
                 stdin.flush()?;
                 drop(stdin);
-                let stdout = child
-                    .child_mut()
-                    .stdout
-                    .take()
-                    .context("detached hook child has no stdout")?;
+                let stdout =
+                    child.child_mut().stdout.take().context("detached hook child has no stdout")?;
                 Ok((child, stdout))
             })()
         });
@@ -793,21 +787,15 @@ mod detach {
                 let mut child = super::DetachedChildGuard::new(
                     command.spawn().context("spawn detached hook child")?,
                 );
-                let mut stdin = child
-                    .child_mut()
-                    .stdin
-                    .take()
-                    .context("detached hook child has no stdin")?;
+                let mut stdin =
+                    child.child_mut().stdin.take().context("detached hook child has no stdin")?;
                 stdin.write_all(request_id.as_bytes())?;
                 stdin.write_all(b"\n")?;
                 stdin.write_all(&encoded)?;
                 stdin.flush()?;
                 drop(stdin);
-                let stdout = child
-                    .child_mut()
-                    .stdout
-                    .take()
-                    .context("detached hook child has no stdout")?;
+                let stdout =
+                    child.child_mut().stdout.take().context("detached hook child has no stdout")?;
                 Ok((child, stdout))
             })()
         });

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -977,7 +977,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn setup_handoff_timeout_releases_a_late_child() {
+    fn append_detached_setup_timeout_releases_a_late_child() {
         use std::process::{Command, Stdio};
         use std::sync::{Arc, Barrier};
 

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -157,6 +157,20 @@ impl Drop for DetachedChildGuard {
     }
 }
 
+type SetupResult = anyhow::Result<(DetachedChildGuard, std::process::ChildStdout)>;
+
+/// Forward setup ownership to the provider-facing path. If that path has
+/// already timed out, recover a successful handoff from `SendError` and
+/// release the child instead of dropping the guard, which would terminate it.
+fn forward_setup_result(sender: std::sync::mpsc::SyncSender<SetupResult>, result: SetupResult) {
+    if let Err(error) = sender.send(result) {
+        if let Ok((child, stdout)) = error.0 {
+            child.release();
+            drop(stdout);
+        }
+    }
+}
+
 /// Settle the parent-side ownership before the provider-facing process
 /// returns. A child that already exited is reaped and its stdout reader is
 /// joined. A child that is still running must continue waiting for its receipt,
@@ -700,7 +714,7 @@ mod detach {
                         .context("detached hook child has no stdout")?;
                     Ok((child, stdout))
                 })();
-            let _ = sender.send(result);
+            super::forward_setup_result(sender, result);
         });
         let setup = || {
             deadline.map_or(None, |deadline| {
@@ -793,7 +807,7 @@ mod detach {
                         .context("detached hook child has no stdout")?;
                     Ok((child, stdout))
                 })();
-            let _ = sender.send(result);
+            super::forward_setup_result(sender, result);
         });
         let setup = match deadline {
             Some(deadline) => receiver


### PR DESCRIPTION
## Summary

Stacked on [#11545](https://github.com/manaflow-ai/cmux/pull/11545).

When the provider-facing setup deadline expires, the setup thread can later send a successful `(DetachedChildGuard, ChildStdout)` handoff to a dropped receiver. The old ignored `SendError` dropped the guard, which killed and waited for the detached child. This follow-up recovers that owned handoff and releases the child. Spawn and setup errors still drop their guard and clean up.

## Test plan

- Added a Unix behavior test that closes the receiver and verifies the spawned child writes a marker after the send failure.
- Static `git diff --check` passed.
- Local Cargo/Xcode tests were not run per repository policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in `cmux-tui` where a detached child was killed after the provider-facing setup deadline expired. The old code ignored the `SendError` from a dropped receiver and dropped the guard, killing and waiting for the child; now the successful handoff is recovered and the child is released. The handoff uses a rendezvous channel on both Unix and Windows so no successful setup can be queued behind an expired timeout, and spawn and setup errors still drop their guard and clean up. Adds Unix tests covering both the send-failure and setup-timeout paths.

<sup>Written for commit ccc9a69f48fbf31185949680bd9360e24979fc9e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

