### PR TITLE
fix(cmux-tui): clear owner identity on ownerless reconnect

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -104,6 +104,19 @@ fn reconcile_owner_user_id(config: &mut Config, owner_user_id: Option<String>) {
     config.owner_user_id = owner_user_id;
 }
 
+fn reconcile_owner_user_id_and_persist(
+    config: &mut Config,
+    owner_user_id: Option<String>,
+    config_path: &Path,
+    managed: bool,
+) {
+    let changed = config.owner_user_id != owner_user_id;
+    reconcile_owner_user_id(config, owner_user_id);
+    if changed && !managed {
+        save(config, config_path);
+    }
+}
+
 pub(crate) struct OutboundFrame {
     pub(crate) text: String,
     pub(crate) live: Option<Arc<AtomicBool>>,
@@ -895,7 +908,12 @@ async fn relay_session(
                             config.pending_trust = Some(local_trust.as_str().to_owned());
                             save(config, config_path);
                         }
-                        reconcile_owner_user_id(config, hello.owner_user_id);
+                        reconcile_owner_user_id_and_persist(
+                            config,
+                            hello.owner_user_id,
+                            config_path,
+                            state.managed,
+                        );
                         if state.managed {
                             match hello
                                 .managed_session_token

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1301,6 +1301,24 @@ mod tests {
 }
 
 #[cfg(test)]
+mod owner_identity_tests {
+    use super::reconcile_owner_user_id;
+    use crate::config::Config;
+
+    #[test]
+    fn reconnect_without_owner_clears_previous_owner() {
+        let mut config = Config {
+            owner_user_id: Some("previous-owner".to_owned()),
+            ..Config::default()
+        };
+
+        reconcile_owner_user_id(&mut config, None);
+
+        assert_eq!(config.owner_user_id, None);
+    }
+}
+
+#[cfg(test)]
 mod liveness_tests {
     use super::{
         PRE_HELLO_READ_DEADLINE, READ_LIVENESS_GRACE, SUSPEND_CLOCK_JUMP, clock_jumped,

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1307,8 +1307,8 @@ mod tests {
 
 #[cfg(test)]
 mod owner_identity_tests {
-    use super::reconcile_owner_user_id;
-    use crate::config::Config;
+    use super::{reconcile_owner_user_id, reconcile_owner_user_id_and_persist};
+    use crate::config::{Config, load_config, save_config};
 
     #[test]
     fn reconnect_without_owner_clears_previous_owner() {
@@ -1320,6 +1320,27 @@ mod owner_identity_tests {
         reconcile_owner_user_id(&mut config, None);
 
         assert_eq!(config.owner_user_id, None);
+    }
+
+    #[test]
+    fn ownerless_reconnect_persists_before_restart() {
+        let path = std::env::temp_dir().join(format!(
+            "chatmux-relay-owner-reconnect-{}.json",
+            std::process::id()
+        ));
+        let mut config = Config {
+            device_id: "device".to_owned(),
+            token: "token".to_owned(),
+            owner_user_id: Some("previous-owner".to_owned()),
+            ..Config::default()
+        };
+        save_config(&path, &config).expect("initial config saves");
+
+        reconcile_owner_user_id_and_persist(&mut config, None, &path, false);
+
+        let reloaded = load_config(&path).expect("persisted config loads");
+        assert_eq!(reloaded.owner_user_id, None);
+        std::fs::remove_file(path).ok();
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -97,6 +97,13 @@ struct AuthSnapshot {
     owner: Option<String>,
 }
 
+/// Replace the persisted owner with the identity from the latest hello.
+/// An omitted owner is an explicit absence, so retaining a prior value would
+/// carry authority across reconnects.
+fn reconcile_owner_user_id(config: &mut Config, owner_user_id: Option<String>) {
+    config.owner_user_id = owner_user_id;
+}
+
 pub(crate) struct OutboundFrame {
     pub(crate) text: String,
     pub(crate) live: Option<Arc<AtomicBool>>,
@@ -888,9 +895,7 @@ async fn relay_session(
                             config.pending_trust = Some(local_trust.as_str().to_owned());
                             save(config, config_path);
                         }
-                        if let Some(owner) = hello.owner_user_id {
-                            config.owner_user_id = Some(owner);
-                        }
+                        reconcile_owner_user_id(config, hello.owner_user_id);
                         if state.managed {
                             match hello
                                 .managed_session_token


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11401.

When hello_accepted omits ownerUserId, clear the prior owner_user_id before publishing AuthSnapshot. This prevents stale owner authority from surviving a reconnect. The first commit adds a regression test; the second applies the fail-closed reset.

Base: 0247f51a1f30308df595606d0951c802ec038550.

Hosted cmux-tui verification is required; no local Rust tests were run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the persisted owner identity when a reconnect’s `hello_accepted` omits `ownerUserId`, instead of retaining stale owner authority from the previous session. Unmanaged sessions persist the changed identity immediately so the reset survives restarts.

- Adds regression tests for in-memory clearing and persistence across restart.
- Requires hosted `cmux-tui` verification; no local Rust tests were run.

<sup>Written for commit aa1f2135c8b88faa7d51c164a59556ed9dd07f0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11558?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Relay ownership now updates to match the latest connection identity.
  * Stale ownership is cleared when no owner is provided.
  * Ownership changes persist correctly across reconnects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->