### PR TITLE
fix(cmux-tui): make canceled raw attaches lease-safe

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -420,7 +420,7 @@ mod tests {
     use tokio::sync::{Notify, oneshot};
 
     #[tokio::test]
-    async fn end_wakes_paused_reader_and_closes_socket() {
+    async fn drop_wakes_paused_reader_and_closes_socket() {
         let socket_path = std::env::temp_dir()
             .join(format!("chatmux-relay-control-close-{}.sock", std::process::id()));
         let _ = std::fs::remove_file(&socket_path);
@@ -451,7 +451,7 @@ mod tests {
         let waiter_control = Arc::clone(&control);
         let reader_done = tokio::spawn(async move { waiter_control.wait_reader_done().await });
         tokio::task::yield_now().await;
-        control.end();
+        drop(control);
 
         tokio::time::timeout(Duration::from_secs(1), reader_done)
             .await

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -397,6 +397,16 @@ mod unix {
             }
         }
     }
+
+    // A cancelled request can drop its last Arc<dyn ControlHandle> while the
+    // reader and writer tasks still own their socket halves. End the protocol
+    // explicitly so those tasks wake, close, and release any daemon-side
+    // attachment instead of surviving the request future.
+    impl Drop for UnixControl {
+        fn drop(&mut self) {
+            self.end();
+        }
+    }
 }
 
 #[cfg(all(test, unix))]

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -27,7 +27,7 @@ pub trait ControlHandle: Send + Sync {
         params: Value,
     ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>>;
     /// Fire-and-forget (input/resize hot paths); the response line drops.
-    fn send(&self, cmd: &str, params: Value);
+    fn send(&self, cmd: &str, params: Value) -> bool;
     fn on_event(&self, handler: EventHandler);
     /// Fires on unexpected close only (not after `end()`).
     fn on_close(&self, handler: CloseHandler);
@@ -368,12 +368,12 @@ mod unix {
             })
         }
 
-        fn send(&self, cmd: &str, params: Value) {
+        fn send(&self, cmd: &str, params: Value) -> bool {
             if self.shared.closed.load(Ordering::SeqCst) {
-                return;
+                return false;
             }
             let id = self.next_id.fetch_add(1, Ordering::SeqCst);
-            let _ = self.enqueue_line(id, cmd, params, None);
+            self.enqueue_line(id, cmd, params, None)
         }
 
         fn on_event(&self, handler: EventHandler) {
@@ -528,7 +528,7 @@ mod tests {
         accepted_rx.await.expect("wait for control test server");
         let payload = "x".repeat(128 * 1024);
         for index in 0..8 {
-            control.send("send", json!({ "index": index, "payload": payload.clone() }));
+            let _ = control.send("send", json!({ "index": index, "payload": payload.clone() }));
         }
         release_tx.send(()).expect("release control test reader");
         let response = control.request("probe", json!({})).await;

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -443,20 +443,13 @@ mod tests {
         accepted_rx.await.expect("wait for control close test server");
         control.pause();
 
-        // Register both waiters before end() so the test deterministically
-        // exercises the paused-reader branch and the close wakeup.
+        // Register the paused-reader waiter before dropping the last control
+        // Arc so the test exercises the RAII close path.
         let read_waiting = control.arm_reader_waiting();
         paused_tx.send(()).expect("tell server that reader is paused");
         read_waiting.await.expect("paused reader entered wait");
-        let waiter_control = Arc::clone(&control);
-        let reader_done = tokio::spawn(async move { waiter_control.wait_reader_done().await });
-        tokio::task::yield_now().await;
         drop(control);
 
-        tokio::time::timeout(Duration::from_secs(1), reader_done)
-            .await
-            .expect("paused reader exits after end")
-            .expect("join paused reader waiter");
         tokio::time::timeout(Duration::from_secs(1), server)
             .await
             .expect("server observes client close")

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -6,6 +6,7 @@
 //! reading so PTY backpressure applies naturally.
 
 use serde_json::Value;
+use std::future::Future;
 
 /// Per-request budget on a cmux-tui control connection.
 pub const CONTROL_TIMEOUT_MS: u64 = 3_000;
@@ -28,6 +29,16 @@ pub trait ControlHandle: Send + Sync {
     ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>>;
     /// Fire-and-forget (input/resize hot paths); the response line drops.
     fn send(&self, cmd: &str, params: Value) -> bool;
+    /// Enqueue a fire-and-forget command with backpressure. The future
+    /// resolves after the writer accepts the line.
+    fn send_reliable(
+        &self,
+        cmd: &str,
+        params: Value,
+    ) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+        let accepted = self.send(cmd, params);
+        Box::pin(async move { accepted })
+    }
     fn on_event(&self, handler: EventHandler);
     /// Fires on unexpected close only (not after `end()`).
     fn on_close(&self, handler: CloseHandler);
@@ -391,6 +402,32 @@ mod unix {
             }
             let id = self.next_id.fetch_add(1, Ordering::SeqCst);
             self.enqueue_line(id, cmd, params, None)
+        }
+
+        fn send_reliable(
+            &self,
+            cmd: &str,
+            params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+            let cmd = cmd.to_owned();
+            Box::pin(async move {
+                if self.shared.closed.load(Ordering::SeqCst) {
+                    return false;
+                }
+                let (written, result) = oneshot::channel();
+                if self
+                    .writer_tx
+                    .send(OutboundLine {
+                        bytes: Self::encode_line(0, &cmd, params),
+                        written: Some(written),
+                    })
+                    .await
+                    .is_err()
+                {
+                    return false;
+                }
+                result.await.unwrap_or(false)
+            })
         }
 
         fn on_event(&self, handler: EventHandler) {

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -98,7 +98,6 @@ mod unix {
     pub struct UnixControl {
         shared: Arc<Shared>,
         writer_tx: Sender<OutboundLine>,
-        raw_fd: std::os::fd::RawFd,
         next_id: AtomicU64,
         timeout_ms: u64,
     }
@@ -120,10 +119,6 @@ mod unix {
             .await
             .map_err(|_| format!("cmux-tui control connect timed out ({})", socket_path.display()))?
             .map_err(|error| error.to_string())?;
-        let raw_fd = {
-            use std::os::fd::AsRawFd as _;
-            stream.as_raw_fd()
-        };
         let (read_half, write_half) = stream.into_split();
         let shared = Arc::new(Shared {
             pending: Mutex::new(HashMap::new()),
@@ -147,13 +142,7 @@ mod unix {
         let (writer_tx, writer_rx) = mpsc::channel(MAX_WRITER_QUEUE);
         tokio::spawn(write_loop(writer, writer_rx, Arc::clone(&shared)));
         tokio::spawn(read_loop(read_half, Arc::clone(&shared)));
-        Ok(Arc::new(UnixControl {
-            shared,
-            writer_tx,
-            raw_fd,
-            next_id: AtomicU64::new(1),
-            timeout_ms,
-        }))
+        Ok(Arc::new(UnixControl { shared, writer_tx, next_id: AtomicU64::new(1), timeout_ms }))
     }
 
     #[cfg(test)]
@@ -191,7 +180,20 @@ mod unix {
             }
             let result = {
                 let mut writer = writer.lock().await;
-                writer.write_all(&line.bytes).await
+                let closed = shared.closed_notify.notified();
+                tokio::pin!(closed);
+                closed.as_mut().enable();
+                let (result, closed_by_end) = tokio::select! {
+                    result = writer.write_all(&line.bytes) => (result, false),
+                    _ = closed => (Err(std::io::Error::other("control closed")), true),
+                };
+                if closed_by_end {
+                    if let Some(written) = line.written {
+                        let _ = written.send(false);
+                    }
+                    break;
+                }
+                result
             };
             let succeeded = result.is_ok();
             if let Some(written) = line.written {
@@ -241,9 +243,15 @@ mod unix {
                     _ = closed => break 'read_loop,
                 }
             }
-            let count = match reader.read(&mut chunk).await {
-                Ok(0) | Err(_) => break,
-                Ok(count) => count,
+            let closed = shared.closed_notify.notified();
+            tokio::pin!(closed);
+            closed.as_mut().enable();
+            let count = tokio::select! {
+                result = reader.read(&mut chunk) => match result {
+                    Ok(0) | Err(_) => break,
+                    Ok(count) => count,
+                },
+                _ = closed => break,
             };
             buffer.extend_from_slice(&chunk[..count]);
             if buffer.len() > MAX_CONTROL_LINE_BYTES {
@@ -388,13 +396,6 @@ mod unix {
         fn end(&self) {
             self.shared.deliberate.store(true, Ordering::SeqCst);
             self.shared.settle_closed();
-            // Shut both directions so the read loop sees EOF and any blocked
-            // writer unblocks; the halves drop and close the fd afterwards.
-            // SAFETY: shutdown on a socket fd this handle owns for the split
-            // stream's lifetime; a failure (already closed) is harmless.
-            unsafe {
-                libc::shutdown(self.raw_fd, libc::SHUT_RDWR);
-            }
         }
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -95,6 +95,20 @@ mod unix {
         }
     }
 
+    // `ControlHandle::request` futures can be dropped by `tokio::select!`
+    // while they wait for a write acknowledgement or response. Retire the
+    // registration from `Drop`, rather than relying on a timeout or `end()`.
+    struct PendingRequestGuard {
+        shared: Arc<Shared>,
+        id: u64,
+    }
+
+    impl Drop for PendingRequestGuard {
+        fn drop(&mut self) {
+            self.shared.pending.lock().expect("control pending lock").remove(&self.id);
+        }
+    }
+
     pub struct UnixControl {
         shared: Arc<Shared>,
         writer_tx: Sender<OutboundLine>,
@@ -302,6 +316,11 @@ mod unix {
             receiver
         }
 
+        #[cfg(test)]
+        pub(crate) fn pending_len(&self) -> usize {
+            self.shared.pending.lock().expect("control pending lock").len()
+        }
+
         fn encode_line(id: u64, cmd: &str, params: Value) -> Vec<u8> {
             let mut frame = match params {
                 Value::Object(map) => map,
@@ -347,22 +366,20 @@ mod unix {
                     }
                     pending.insert(id, sender);
                 }
+                let _pending_guard = PendingRequestGuard { shared: Arc::clone(&self.shared), id };
                 let deadline = tokio::time::Instant::now() + Duration::from_millis(self.timeout_ms);
                 let (written, write_result) = oneshot::channel();
                 if !self.enqueue_line(id, &cmd, params, Some(written)) {
-                    self.shared.pending.lock().expect("control pending lock").remove(&id);
                     return None;
                 }
                 let write_ok =
                     matches!(tokio::time::timeout_at(deadline, write_result).await, Ok(Ok(true)));
                 if !write_ok {
-                    self.shared.pending.lock().expect("control pending lock").remove(&id);
                     return None;
                 }
                 if let Ok(Ok(value)) = tokio::time::timeout_at(deadline, receiver).await {
                     Some(value)
                 } else {
-                    self.shared.pending.lock().expect("control pending lock").remove(&id);
                     None
                 }
             })
@@ -490,6 +507,58 @@ mod tests {
             .await
             .expect("second waiter wakes")
             .expect("second waiter joins");
+    }
+
+    #[tokio::test]
+    async fn dropped_request_retires_pending_entry() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-cancel-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control cancel test socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (request_seen_tx, request_seen_rx) = oneshot::channel();
+        let (release_tx, release_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept control cancel test socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            let (read_half, write_half) = stream.into_split();
+            let mut reader = tokio::io::BufReader::new(read_half);
+            let mut line = String::new();
+            reader.read_line(&mut line).await.expect("read in-flight control request");
+            let request: Value =
+                serde_json::from_str(line.trim_end()).expect("decode in-flight control request");
+            assert_eq!(request.get("cmd").and_then(Value::as_str), Some("attach-surface"));
+            request_seen_tx.send(()).expect("tell client request is in flight");
+            release_rx.await.expect("release control cancel test socket");
+            drop(write_half);
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect control cancel test socket");
+        accepted_rx.await.expect("wait for control cancel test server");
+        let request_control = Arc::clone(&control);
+        let request = tokio::spawn(async move {
+            request_control.request("attach-surface", json!({ "surface": 7 })).await
+        });
+        request_seen_rx.await.expect("wait for in-flight control request");
+        assert_eq!(control.pending_len(), 1, "request must register before it is canceled");
+
+        request.abort();
+        let join = tokio::time::timeout(Duration::from_secs(1), request)
+            .await
+            .expect("canceled request task must finish promptly")
+            .expect_err("aborting the request task must report cancellation");
+        assert!(join.is_cancelled());
+        assert_eq!(control.pending_len(), 0, "dropping the request must retire its map entry");
+
+        release_tx.send(()).expect("release control cancel test socket");
+        control.end();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("join control cancel test server")
+            .expect("control cancel test server must not panic");
+        let _ = std::fs::remove_file(socket_path);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -29,8 +29,9 @@ pub trait ControlHandle: Send + Sync {
     ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>>;
     /// Fire-and-forget (input/resize hot paths); the response line drops.
     fn send(&self, cmd: &str, params: Value) -> bool;
-    /// Enqueue a fire-and-forget command with backpressure. The future
-    /// resolves after the writer accepts the line.
+    /// Enqueue a fire-and-forget command with backpressure. Implementations
+    /// that override this method resolve after the writer accepts the line.
+    /// The default implementation only reports queue admission, like `send`.
     fn send_reliable(
         &self,
         cmd: &str,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -312,7 +312,7 @@ fn parse_allowed_roots(frame: &Value) -> Result<Option<Vec<String>>, &'static st
 /// semantics vary by mode: viewer PTYs detach, shell proxies release a
 /// viewer, control handles close the stream.
 pub trait PtyControl: Send + Sync {
-    fn write(&self, data: &[u8]);
+    fn write(&self, data: &[u8]) -> bool;
     fn resize(&self, cols: u16, rows: u16);
     fn pause(&self);
     fn resume(&self);
@@ -574,9 +574,20 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
-                    self.inner.with_live_attachment(pty_id, &attachment, |control| {
-                        control.write(&data);
-                    });
+                    let accepted =
+                        self.inner.with_live_attachment(pty_id, &attachment, |control| {
+                            control.write(&data)
+                        });
+                    if accepted == Some(false) {
+                        self.inner.emit_error_for_generation(
+                            context,
+                            pty_id,
+                            attachment.generation,
+                            &attachment.publication_gate,
+                            "input_overflow",
+                            "terminal input queue is full; retry input",
+                        );
+                    }
                 }
             }
             "pty_resize" => {
@@ -590,7 +601,7 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
-                    self.inner.with_live_attachment(pty_id, &attachment, |control| {
+                    let _ = self.inner.with_live_attachment(pty_id, &attachment, |control| {
                         control.resize(cols, rows);
                     });
                 }
@@ -602,7 +613,7 @@ impl PtyManager {
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
-                    self.inner.with_live_attachment(pty_id, &attachment, |control| {
+                    let _ = self.inner.with_live_attachment(pty_id, &attachment, |control| {
                         if pause {
                             control.pause();
                         } else {
@@ -1227,24 +1238,24 @@ impl Inner {
         self.authorize_snapshot_for_generation(pty_id, auth, context, action, 0)
     }
 
-    fn with_live_attachment(
+    fn with_live_attachment<R>(
         &self,
         pty_id: &str,
         attachment: &Attachment,
-        operation: impl FnOnce(&dyn PtyControl),
-    ) {
+        operation: impl FnOnce(&dyn PtyControl) -> R,
+    ) -> Option<R> {
         let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
         {
             let attachments = self.attachments.lock().expect("attach lock");
-            let Some(current) = attachments.get(pty_id) else { return };
+            let Some(current) = attachments.get(pty_id) else { return None };
             if current.generation != attachment.generation
                 || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
                 || current.closing.load(Ordering::SeqCst)
             {
-                return;
+                return None;
             }
         }
-        operation(attachment.control.as_ref());
+        Some(operation(attachment.control.as_ref()))
     }
 
     fn authorize_snapshot_for_generation(
@@ -1737,8 +1748,8 @@ impl ShellViewerControl {
 }
 
 impl PtyControl for ShellViewerControl {
-    fn write(&self, data: &[u8]) {
-        self.session.control.write(data);
+    fn write(&self, data: &[u8]) -> bool {
+        self.session.control.write(data)
     }
     fn resize(&self, cols: u16, rows: u16) {
         self.session.control.resize(cols, rows);
@@ -1922,9 +1933,10 @@ struct ControlTerminalControl {
 }
 
 impl PtyControl for ControlTerminalControl {
-    fn write(&self, data: &[u8]) {
+    fn write(&self, data: &[u8]) -> bool {
         self.control
             .send("send", json!({ "surface": self.surface_id, "bytes": BASE64.encode(data) }));
+        true
     }
     fn resize(&self, cols: u16, rows: u16) {
         self.control.send(
@@ -2543,7 +2555,7 @@ mod tests {
     }
 
     impl PtyControl for FakePty {
-        fn write(&self, data: &[u8]) {
+        fn write(&self, data: &[u8]) -> bool {
             let (entered, release) = {
                 let state = self.state.lock().unwrap();
                 (state.write_entered.clone(), state.write_release.clone())
@@ -2555,6 +2567,7 @@ mod tests {
                 release.wait();
             }
             self.state.lock().unwrap().written.push(data.to_vec());
+            true
         }
         fn resize(&self, cols: u16, rows: u16) {
             self.state.lock().unwrap().resized.push((cols, rows));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3539,7 +3539,7 @@ mod tests {
         context
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "current_thread")]
     async fn exit_publication_retains_closing_id_until_frame_is_sent() {
         let h = harness(None, None);
         let entered = TestArc::new(Barrier::new(2));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -460,11 +460,17 @@ struct Inner {
     scrollback_limit: usize,
     output_cap: u64,
     attachments: Mutex<HashMap<String, Attachment>>,
-    /// ptyId -> transport that reserved it (None = legacy whole-manager owner).
-    opening_ids: Mutex<HashMap<String, Option<String>>>,
-    cancelled_openings: Mutex<std::collections::HashSet<String>>,
+    /// Reservation state is one lock so close/open/drop cannot leave a stale
+    /// cancellation marker between the id and marker updates.
+    opening_state: Mutex<OpeningState>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
+}
+
+#[derive(Default)]
+struct OpeningState {
+    ids: HashMap<String, Option<String>>,
+    cancelled: std::collections::HashSet<String>,
 }
 
 struct ShellStartReservation {
@@ -491,8 +497,9 @@ struct OpeningReservation {
 impl Drop for OpeningReservation {
     fn drop(&mut self) {
         if self.active {
-            self.inner.opening_ids.lock().expect("opening lock").remove(&self.id);
-            self.inner.cancelled_openings.lock().expect("cancelled openings lock").remove(&self.id);
+            let mut state = self.inner.opening_state.lock().expect("opening state lock");
+            state.ids.remove(&self.id);
+            state.cancelled.remove(&self.id);
         }
     }
 }
@@ -512,8 +519,7 @@ impl PtyManager {
                 scrollback_limit: SCROLLBACK_LIMIT,
                 output_cap: OUTPUT_BUFFER_CAP,
                 attachments: Mutex::new(HashMap::new()),
-                opening_ids: Mutex::new(HashMap::new()),
-                cancelled_openings: Mutex::new(std::collections::HashSet::new()),
+                opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
             }),
@@ -537,8 +543,7 @@ impl PtyManager {
                 scrollback_limit,
                 output_cap,
                 attachments: Mutex::new(HashMap::new()),
-                opening_ids: Mutex::new(HashMap::new()),
-                cancelled_openings: Mutex::new(std::collections::HashSet::new()),
+                opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
             }),
@@ -621,7 +626,7 @@ impl PtyManager {
 
     #[cfg(test)]
     pub(crate) fn opening_count(&self) -> usize {
-        self.inner.opening_ids.lock().expect("opening lock").len()
+        self.inner.opening_state.lock().expect("opening state lock").ids.len()
     }
 
     /// The relay socket dropped: release every attachment (sessions live on).
@@ -642,8 +647,9 @@ impl PtyManager {
         // Openings first: close() records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
         let mut ids: Vec<String> = {
-            let opening = self.inner.opening_ids.lock().expect("opening lock");
+            let opening = self.inner.opening_state.lock().expect("opening state lock");
             opening
+                .ids
                 .iter()
                 .filter(|(_, owner)| owns(owner.as_deref()))
                 .map(|(id, _)| id.clone())
@@ -708,19 +714,20 @@ impl Inner {
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
         let reservation_result = {
-            let mut opening = self.opening_ids.lock().expect("opening lock");
-            let attached = self.attachments.lock().expect("attach lock").contains_key(&pty_id);
-            if attached || opening.contains_key(&pty_id) {
+            // Keep the global lock order attachments -> opening_state. The
+            // transport ownership check uses the same order.
+            let attachments = self.attachments.lock().expect("attach lock");
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            let attached = attachments.contains_key(&pty_id);
+            if attached || opening.ids.contains_key(&pty_id) {
                 Err(("bad_request", "ptyId is already attached".to_owned()))
-            } else if self.attachments.lock().expect("attach lock").len() + opening.len()
-                >= self.max_ptys
-            {
+            } else if attachments.len() + opening.ids.len() >= self.max_ptys {
                 Err((
                     "session_limit",
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
                 ))
             } else {
-                opening.insert(pty_id.clone(), context.transport_id.clone());
+                opening.ids.insert(pty_id.clone(), context.transport_id.clone());
                 Ok(())
             }
         };
@@ -887,21 +894,22 @@ impl Inner {
             return;
         }
 
-        // Keep the opening reservation held until the attachment is installed.
-        // `close` takes this lock first, so it cannot observe a gap between
+        // Keep both locks held until the attachment is installed. `close`
+        // takes opening_state first, so it cannot observe a gap between
         // removing the opening marker and inserting the attachment.
-        let mut opening = self.opening_ids.lock().expect("opening lock");
-        let cancelled =
-            self.cancelled_openings.lock().expect("cancelled openings lock").remove(&pty_id);
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        let cancelled = opening.cancelled.remove(&pty_id);
         if cancelled {
-            opening.remove(&pty_id);
+            opening.ids.remove(&pty_id);
             drop(opening);
+            drop(attachments);
             reservation.active = false;
             opened.closing.store(true, Ordering::SeqCst);
             opened.control.kill();
             return;
         }
-        let previous = self.attachments.lock().expect("attach lock").insert(
+        let previous = attachments.insert(
             pty_id.clone(),
             Attachment {
                 closing: opened.closing,
@@ -914,8 +922,9 @@ impl Inner {
             previous.closing.store(true, Ordering::SeqCst);
             previous.control.kill();
         }
-        opening.remove(&pty_id);
+        opening.ids.remove(&pty_id);
         drop(opening);
+        drop(attachments);
         reservation.active = false;
         let mut opened_frame = serde_json::Map::new();
         opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
@@ -1013,12 +1022,9 @@ impl Inner {
     fn close(&self, pty_id: &str) {
         // Match `open`'s lock order. If opening still owns the reservation,
         // record cancellation and let it dispose the newly opened PTY.
-        let opening = self.opening_ids.lock().expect("opening lock");
-        if opening.contains_key(pty_id) {
-            self.cancelled_openings
-                .lock()
-                .expect("cancelled openings lock")
-                .insert(pty_id.to_owned());
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        if opening.ids.contains_key(pty_id) {
+            opening.cancelled.insert(pty_id.to_owned());
             return;
         }
         drop(opening);
@@ -1037,7 +1043,8 @@ impl Inner {
         if let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id) {
             return attachment.transport_id.as_deref() == Some(transport_id);
         }
-        if let Some(owner) = self.opening_ids.lock().expect("opening lock").get(pty_id) {
+        if let Some(owner) = self.opening_state.lock().expect("opening state lock").ids.get(pty_id)
+        {
             return owner.as_deref() == Some(transport_id);
         }
         true

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -462,7 +462,6 @@ struct Inner {
     cancelled_openings: Mutex<std::collections::HashSet<String>>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
-    auth: Mutex<Option<AuthSnapshot>>,
 }
 
 struct ShellStartReservation {
@@ -514,7 +513,6 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
             }),
         }
     }
@@ -540,19 +538,12 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
             }),
         }
     }
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        *self.inner.auth.lock().expect("auth lock") = Some(AuthSnapshot {
-            trust: context.trust.clone(),
-            owner_user_id: context.owner_user_id.clone(),
-            send: Arc::clone(&context.send),
-            buffered_amount: Arc::clone(&context.buffered_amount),
-        });
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,
@@ -697,6 +688,15 @@ fn send_typed_pty_error(
 }
 
 impl Inner {
+    fn auth_snapshot(context: &FrameContext) -> AuthSnapshot {
+        AuthSnapshot {
+            trust: context.trust.clone(),
+            owner_user_id: context.owner_user_id.clone(),
+            send: Arc::clone(&context.send),
+            buffered_amount: Arc::clone(&context.buffered_amount),
+        }
+    }
+
     async fn open(self: Arc<Self>, frame: &Value, context: &FrameContext) {
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
         if pty_id.is_empty() {
@@ -936,7 +936,7 @@ impl Inner {
     }
 
     fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
+        let auth = Self::auth_snapshot(context);
         if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
             return;
         }
@@ -971,7 +971,7 @@ impl Inner {
     }
 
     fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
+        let auth = Self::auth_snapshot(context);
         if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
             return;
         }
@@ -1025,7 +1025,7 @@ impl Inner {
     }
 
     fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
-        let auth = self.auth.lock().expect("auth lock").clone()?;
+        let auth = Self::auth_snapshot(context);
         self.authorize_snapshot(pty_id, &auth, context, action)
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -55,6 +55,8 @@ pub const OUTPUT_BUFFER_CAP: u64 = 1024 * 1024;
 const CONTROL_MIN_PROTOCOL: i64 = 5;
 const VIEW_ATTACHMENT_LEASE_CAPABILITY: &str = "view-attachment-lease-v1";
 const VIEW_ATTACHMENT_DETACH_CAPABILITY: &str = "view-attachment-detach-v1";
+const RAW_ATTACH_UNAVAILABLE_MESSAGE: &str =
+    "this terminal cannot be attached; update cmux-tui and try again";
 /// Inner terminals listed per session (surface_list stays bounded).
 const MAX_ENUM_TERMINALS: usize = 8;
 const MAX_ALLOWED_ROOTS: usize = 32;
@@ -904,12 +906,12 @@ impl Inner {
         // OWNER's terminal. Any trust level admits the owner.
         // Only locally established trust is authoritative. Missing local
         // state fails closed; the untrusted frame cannot elevate access.
-        let trust = context.trust.clone();
+        let (trust, owner_user_id) = (context.live_auth)();
         if trust.is_empty() {
             fail("trust_refused", "terminal trust is not established");
             return;
         }
-        let owner = context.owner_user_id.as_deref();
+        let owner = owner_user_id.as_deref();
         let actor = frame.get("actorId").and_then(Value::as_str).unwrap_or_default();
         if trust == "observe" && (owner.is_none() || Some(actor) != owner) {
             fail(
@@ -1499,21 +1501,6 @@ struct Opened {
     start: Box<dyn FnOnce() + Send>,
 }
 
-/// Own a control connection while an OPEN operation performs cancellable
-/// discovery and attach requests. Dropping the request must close the socket
-/// even when no `Opened` value has been returned yet.
-struct ControlGuard(Option<Arc<dyn ControlHandle>>);
-
-impl ControlGuard {
-    fn new(control: Arc<dyn ControlHandle>) -> Self {
-        Self(Some(control))
-    }
-
-    fn disarm(&mut self) -> Arc<dyn ControlHandle> {
-        self.0.take().expect("control guard owns a connection")
-    }
-}
-
 async fn request_control_with_cancellation(
     control: &Arc<dyn ControlHandle>,
     cmd: &str,
@@ -1526,14 +1513,6 @@ async fn request_control_with_cancellation(
     // Once queued, let the mutation finish. Dropping this future cannot
     // retract an attach request, so cancellation cleanup uses its lease.
     control.request(cmd, params).await
-}
-
-impl Drop for ControlGuard {
-    fn drop(&mut self) {
-        // Callers explicitly choose `end_control_if_unshared` on every
-        // failure path. An unconditional end here could tear down a control
-        // connection that already has other attachment leases.
-    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1579,7 +1558,6 @@ impl Inner {
                 .connect_control(&ensured.socket_path)
                 .await
                 .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
-            let _control_guard = ControlGuard::new(Arc::clone(&control));
             let Some(listed) = control.request("list-workspaces", json!({})).await else {
                 control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
@@ -2283,8 +2261,6 @@ impl Inner {
             Ok(control) => control,
             Err(_) => return Ok(None), // degrade to the whole-session attach
         };
-        let mut control_guard = ControlGuard::new(Arc::clone(&control));
-
         let identify = control.request("identify", json!({})).await;
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
         let protocol = info
@@ -2319,11 +2295,11 @@ impl Inner {
             false
         };
         if scoped_detach_advertised && !detach_supported {
+            eprintln!(
+                "raw terminal attach rejected: required capabilities {VIEW_ATTACHMENT_LEASE_CAPABILITY} and {VIEW_ATTACHMENT_DETACH_CAPABILITY}"
+            );
             self.end_control_if_unshared(&control);
-            return Err((
-                RelayPtyErrorCode::Failed,
-                "control does not support scoped attachment detach".to_owned(),
-            ));
+            return Err((RelayPtyErrorCode::Failed, RAW_ATTACH_UNAVAILABLE_MESSAGE.to_owned()));
         }
 
         // Resolve the ref: numeric surface id directly, else via the tree.
@@ -2465,14 +2441,13 @@ impl Inner {
             return Err((RelayPtyErrorCode::Failed, "attachment canceled".to_owned()));
         }
         if scoped_detach_advertised && lease.is_none() {
+            eprintln!(
+                "raw terminal attach returned no lease from attach-surface for surface {surface_id}"
+            );
             self.end_control_if_unshared(&control);
-            return Err((
-                RelayPtyErrorCode::Failed,
-                "attach-surface returned no attachment lease".to_owned(),
-            ));
+            return Err((RelayPtyErrorCode::Failed, RAW_ATTACH_UNAVAILABLE_MESSAGE.to_owned()));
         }
 
-        let control = control_guard.disarm();
         let user = self.register_control_user(&control);
         let proxy =
             Arc::new(ControlTerminalControl { control, surface_id, lease, detach_supported, user });
@@ -3987,7 +3962,7 @@ mod tests {
         context
     }
 
-    #[tokio::test(flavor = "current_thread")]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn exit_publication_retains_closing_id_until_frame_is_sent() {
         let h = harness(None, None);
         let entered = TestArc::new(Barrier::new(2));
@@ -4012,10 +3987,13 @@ mod tests {
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
         let replacement_for_task = replacement.clone();
         let frame_for_replacement = frame.clone();
-        let replacement_task = tokio::spawn(async move {
-            manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
+        let runtime = tokio::runtime::Handle::current();
+        let replacement_task = thread::spawn(move || {
+            runtime.block_on(async move {
+                manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
+            });
         });
-        tokio::task::yield_now().await;
+        std::thread::yield_now();
         assert!(
             !replacement_task.is_finished(),
             "same-ID replacement must wait for the closing publication"
@@ -4031,14 +4009,14 @@ mod tests {
 
         release.wait();
         exit.join().expect("exit callback");
-        replacement_task.await.expect("replacement open");
+        replacement_task.join().expect("replacement open");
         h.manager.handle_frame(&frame, &replacement).await;
         assert!(h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
         }));
     }
 
-    #[tokio::test]
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn overflow_error_publication_cannot_reach_a_same_id_replacement() {
         let h = harness(None, None);
         let entered = TestArc::new(Barrier::new(2));
@@ -4061,13 +4039,27 @@ mod tests {
         entered.wait();
 
         let replacement = h.context("supervised", h.owner.clone());
-        h.manager.handle_frame(&frame, &replacement).await;
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let frame_for_replacement = frame.clone();
+        let replacement_for_task = replacement.clone();
+        let runtime = tokio::runtime::Handle::current();
+        let replacement_task = thread::spawn(move || {
+            runtime.block_on(async move {
+                manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
+            });
+        });
+        std::thread::yield_now();
+        assert!(
+            !replacement_task.is_finished(),
+            "same-ID replacement must wait for the closing publication"
+        );
         assert!(!h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
         }));
 
         release.wait();
         output.join().expect("output callback");
+        replacement_task.join().expect("replacement open");
         h.buffered.store(0, Ordering::SeqCst);
         h.manager.handle_frame(&frame, &replacement).await;
         assert!(h.sent().iter().any(|frame| {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -660,7 +660,7 @@ impl PtyManager {
     }
 
     fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
-        // Openings first: close() records cancellation for a reserved id, so
+        // Openings first: close_if_transport records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
         let mut ids: Vec<(String, Option<String>)> = {
             let opening = self.inner.opening_state.lock().expect("opening state lock");
@@ -1172,19 +1172,6 @@ impl Inner {
         attachment.control.kill();
     }
 
-    /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
-    fn close(&self, pty_id: &str) {
-        // Match `open`'s lock order. If opening still owns the reservation,
-        // record cancellation and let it dispose the newly opened PTY.
-        let mut opening = self.opening_state.lock().expect("opening state lock");
-        if opening.ids.contains_key(pty_id) {
-            opening.cancelled.insert(pty_id.to_owned());
-            return;
-        }
-        drop(opening);
-        self.close_exact(pty_id, None, None);
-    }
-
     fn close_if_transport(&self, pty_id: &str, transport_id: Option<&str>) {
         let mut opening = self.opening_state.lock().expect("opening state lock");
         if let Some(owner) = opening.ids.get(pty_id) {
@@ -1306,16 +1293,6 @@ impl Inner {
             return;
         }
         self.close_exact(pty_id, Some(attachment.generation), Some(&attachment.publication_gate));
-    }
-
-    fn close_if_generation(&self, pty_id: &str, generation: u64) {
-        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
-            return;
-        };
-        if attachment.generation == generation {
-            self.close_exact(pty_id, Some(generation), Some(&attachment.publication_gate));
-        }
     }
 
     fn close_exact(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -490,6 +490,7 @@ impl Drop for OpeningReservation {
     fn drop(&mut self) {
         if self.active {
             self.inner.opening_ids.lock().expect("opening lock").remove(&self.id);
+            self.inner.cancelled_openings.lock().expect("cancelled openings lock").remove(&self.id);
         }
     }
 }
@@ -1069,6 +1070,29 @@ struct Opened {
     start: Box<dyn FnOnce() + Send>,
 }
 
+/// Own a control connection while an OPEN operation performs cancellable
+/// discovery and attach requests. Dropping the request must close the socket
+/// even when no `Opened` value has been returned yet.
+struct ControlGuard(Option<Arc<dyn ControlHandle>>);
+
+impl ControlGuard {
+    fn new(control: Arc<dyn ControlHandle>) -> Self {
+        Self(Some(control))
+    }
+
+    fn disarm(&mut self) -> Arc<dyn ControlHandle> {
+        self.0.take().expect("control guard owns a connection")
+    }
+}
+
+impl Drop for ControlGuard {
+    fn drop(&mut self) {
+        if let Some(control) = self.0.take() {
+            control.end();
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // A viewer PTY control that pumps its events into the framing sinks
 // ---------------------------------------------------------------------------
@@ -1112,6 +1136,7 @@ impl Inner {
                 .connect_control(&ensured.socket_path)
                 .await
                 .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
+            let _control_guard = ControlGuard::new(Arc::clone(&control));
             let Some(listed) = control.request("list-workspaces", json!({})).await else {
                 control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
@@ -1790,6 +1815,7 @@ impl Inner {
             Ok(control) => control,
             Err(_) => return Ok(None), // degrade to the whole-session attach
         };
+        let mut control_guard = ControlGuard::new(Arc::clone(&control));
 
         let identify = control.request("identify", json!({})).await;
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
@@ -1921,7 +1947,8 @@ impl Inner {
             ));
         }
 
-        let proxy = Arc::new(ControlTerminalControl { control, surface_id });
+        let proxy =
+            Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
         let (on_data, _) = self.sinks(pty_id, context);
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -450,6 +450,7 @@ struct Attachment {
     actor_id: String,
     /// Transport that opened this attachment (see FrameContext::transport_id).
     transport_id: Option<String>,
+    generation: u64,
 }
 
 struct Inner {
@@ -465,6 +466,7 @@ struct Inner {
     opening_state: Mutex<OpeningState>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
+    next_generation: AtomicU64,
 }
 
 #[derive(Default)]
@@ -522,6 +524,7 @@ impl PtyManager {
                 opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
+                next_generation: AtomicU64::new(1),
             }),
         }
     }
@@ -546,6 +549,7 @@ impl PtyManager {
                 opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
+                next_generation: AtomicU64::new(1),
             }),
         }
     }
@@ -646,13 +650,13 @@ impl PtyManager {
     fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
         // Openings first: close() records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
-        let mut ids: Vec<String> = {
+        let mut ids: Vec<(String, Option<String>)> = {
             let opening = self.inner.opening_state.lock().expect("opening state lock");
             opening
                 .ids
                 .iter()
                 .filter(|(_, owner)| owns(owner.as_deref()))
-                .map(|(id, _)| id.clone())
+                .map(|(id, owner)| (id.clone(), owner.clone()))
                 .collect()
         };
         {
@@ -661,11 +665,11 @@ impl PtyManager {
                 attachments
                     .iter()
                     .filter(|(_, attachment)| owns(attachment.transport_id.as_deref()))
-                    .map(|(id, _)| id.clone()),
+                    .map(|(id, attachment)| (id.clone(), attachment.transport_id.clone())),
             );
         }
-        for id in ids {
-            self.inner.close(&id);
+        for (id, owner) in ids {
+            self.inner.close_if_transport(&id, owner.as_deref());
         }
     }
 }
@@ -916,6 +920,7 @@ impl Inner {
                 control: opened.control,
                 actor_id: actor.to_owned(),
                 transport_id: context.transport_id.clone(),
+                generation: opened.generation,
             },
         );
         if let Some(previous) = previous {
@@ -945,27 +950,52 @@ impl Inner {
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
-    fn sinks(self: &Arc<Self>, pty_id: &str, context: &FrameContext) -> (DataSink, ExitSink) {
+    fn sinks(
+        self: &Arc<Self>,
+        pty_id: &str,
+        context: &FrameContext,
+        generation: u64,
+    ) -> (DataSink, ExitSink) {
         let on_data = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            Arc::new(move |chunk: Bytes| inner.emit_output(&pty_id, &chunk, &context))
-                as Arc<dyn Fn(Bytes) + Send + Sync>
+            Arc::new(move |chunk: Bytes| {
+                inner.emit_output_for_generation(&pty_id, &chunk, &context, generation)
+            }) as Arc<dyn Fn(Bytes) + Send + Sync>
         };
         let on_exit = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context))
-                as Arc<dyn Fn(i64) + Send + Sync>
+            Arc::new(move |code: i64| {
+                inner.emit_exit_for_generation(&pty_id, code, &context, generation)
+            }) as Arc<dyn Fn(i64) + Send + Sync>
         };
         (on_data, on_exit)
     }
 
-    fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
+    fn emit_output_for_generation(
+        &self,
+        pty_id: &str,
+        chunk: &Bytes,
+        context: &FrameContext,
+        generation: u64,
+    ) {
+        if !self
+            .attachments
+            .lock()
+            .expect("attach lock")
+            .get(pty_id)
+            .is_some_and(|a| a.generation == generation)
+        {
+            return;
+        }
         let auth = Self::auth_snapshot(context);
-        if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
+        if self
+            .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
+            .is_none()
+        {
             return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
@@ -978,7 +1008,7 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            self.close(pty_id);
+            self.close_if_generation(pty_id, generation);
             send_pty_error(
                 context,
                 pty_id,
@@ -998,14 +1028,25 @@ impl Inner {
         }));
     }
 
-    fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
+    fn emit_exit_for_generation(
+        &self,
+        pty_id: &str,
+        code: i64,
+        context: &FrameContext,
+        generation: u64,
+    ) {
         let auth = Self::auth_snapshot(context);
-        if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
+        if self
+            .authorize_snapshot_for_generation(pty_id, &auth, context, "exit", generation)
+            .is_none()
+        {
             return;
         }
         let mut attachments = self.attachments.lock().expect("attach lock");
         match attachments.get(pty_id) {
-            Some(attachment) if !attachment.closing.load(Ordering::SeqCst) => {}
+            Some(attachment)
+                if attachment.generation == generation
+                    && !attachment.closing.load(Ordering::SeqCst) => {}
             _ => return,
         }
         attachments.remove(pty_id);
@@ -1035,6 +1076,25 @@ impl Inner {
         }
     }
 
+    fn close_if_transport(&self, pty_id: &str, transport_id: Option<&str>) {
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        if let Some(owner) = opening.ids.get(pty_id) {
+            if owner.as_deref() == transport_id {
+                opening.cancelled.insert(pty_id.to_owned());
+            }
+            return;
+        }
+        drop(opening);
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        let Some(attachment) = attachments.get(pty_id) else { return };
+        if attachment.transport_id.as_deref() != transport_id {
+            return;
+        }
+        let attachment = attachments.remove(pty_id).expect("attachment still present");
+        attachment.closing.store(true, Ordering::SeqCst);
+        attachment.control.kill();
+    }
+
     /// Frame-level transport fence. Unknown ids retain the protocol's silent
     /// no-op behavior; once an id is reserved or attached, a different
     /// transport may not act on it. A `None` caller owns everything (legacy).
@@ -1062,7 +1122,24 @@ impl Inner {
         context: &FrameContext,
         action: &str,
     ) -> Option<Attachment> {
+        self.authorize_snapshot_for_generation(pty_id, auth, context, action, 0)
+    }
+
+    fn authorize_snapshot_for_generation(
+        &self,
+        pty_id: &str,
+        auth: &AuthSnapshot,
+        context: &FrameContext,
+        action: &str,
+        generation: u64,
+    ) -> Option<Attachment> {
         let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
+        if generation != 0 && attachment.generation != generation {
+            return None;
+        }
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return None;
+        }
         let owner = auth.owner_user_id.as_deref();
         let allowed = !auth.trust.is_empty()
             && (auth.trust != "observe"
@@ -1070,7 +1147,11 @@ impl Inner {
         if allowed {
             Some(attachment)
         } else {
-            self.close(pty_id);
+            if generation == 0 {
+                self.close(pty_id);
+            } else {
+                self.close_if_generation(pty_id, generation);
+            }
             send_pty_error(
                 context,
                 pty_id,
@@ -1082,8 +1163,29 @@ impl Inner {
     }
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
-        let _ = self.authorize(pty_id, context, "close");
-        self.close(pty_id);
+        let auth = Self::auth_snapshot(context);
+        if self.authorize_snapshot_for_generation(pty_id, &auth, context, "close", 0).is_none() {
+            return;
+        }
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        let Some(attachment) = attachments.get(pty_id) else { return };
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return;
+        }
+        let attachment = attachments.remove(pty_id).expect("attachment still present");
+        attachment.closing.store(true, Ordering::SeqCst);
+        attachment.control.kill();
+    }
+
+    fn close_if_generation(&self, pty_id: &str, generation: u64) {
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        let Some(attachment) = attachments.get(pty_id) else { return };
+        if attachment.generation != generation {
+            return;
+        }
+        let attachment = attachments.remove(pty_id).expect("attachment still present");
+        attachment.closing.store(true, Ordering::SeqCst);
+        attachment.control.kill();
     }
 }
 
@@ -1093,6 +1195,7 @@ struct Opened {
     surface: Option<String>,
     control: Arc<dyn PtyControl>,
     closing: Arc<AtomicBool>,
+    generation: u64,
     start: Box<dyn FnOnce() + Send>,
 }
 
@@ -1271,12 +1374,14 @@ impl Inner {
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
-        let (on_data, on_exit) = self.sinks(pty_id, context);
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let (on_data, on_exit) = self.sinks(pty_id, context, generation);
         Ok(Opened {
             created: ensured.created,
             surface: None,
             control,
             closing: Arc::new(AtomicBool::new(false)),
+            generation,
             start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
         })
     }
@@ -1416,7 +1521,8 @@ impl Inner {
         let viewer_id = next_viewer_id();
         let released = Arc::new(AtomicBool::new(false));
         let closing = Arc::new(AtomicBool::new(false));
-        let (on_data, on_exit) = self.sinks(pty_id, context);
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let (on_data, on_exit) = self.sinks(pty_id, context, generation);
 
         // The per-attachment control proxies onto the session pty but its
         // kill() only unhooks this viewer (release), never the session.
@@ -1455,7 +1561,7 @@ impl Inner {
             }
         });
 
-        Ok(Opened { created, surface: None, control: proxy, closing, start })
+        Ok(Opened { created, surface: None, control: proxy, closing, generation, start })
     }
 }
 
@@ -1996,14 +2102,15 @@ impl Inner {
 
         let proxy =
             Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
-        let (on_data, _) = self.sinks(pty_id, context);
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let (on_data, _) = self.sinks(pty_id, context, generation);
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
         let pty_id_for_exit = pty_id.to_owned();
         let stream_for_exit = Arc::clone(&stream);
         let on_exit: ExitSink = Arc::new(move |code| {
             if stream_for_exit.overflowed() {
-                relay.close(&pty_id_for_exit);
+                relay.close_if_generation(&pty_id_for_exit, generation);
                 send_pty_error(
                     &context_for_exit,
                     &pty_id_for_exit,
@@ -2011,7 +2118,12 @@ impl Inner {
                     "pty output backlog overflowed; reattach to continue receiving output",
                 );
             } else {
-                relay.emit_exit(&pty_id_for_exit, code, &context_for_exit);
+                relay.emit_exit_for_generation(
+                    &pty_id_for_exit,
+                    code,
+                    &context_for_exit,
+                    generation,
+                );
             }
         });
         let start_stream = Arc::clone(&stream);
@@ -2020,6 +2132,7 @@ impl Inner {
             surface: Some(surface_ref.to_owned()),
             control: proxy,
             closing: Arc::new(AtomicBool::new(false)),
+            generation,
             start: Box::new(move || start_stream.go_live(on_data, on_exit)),
         }))
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3569,6 +3569,11 @@ mod tests {
             !replacement_task.is_finished(),
             "same-ID replacement must wait for the closing publication"
         );
+        assert!(
+            !h.sent()
+                .iter()
+                .any(|frame| { frame["type"] == "pty_error" && frame["code"] == "bad_request" })
+        );
         assert!(!h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
         }));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1523,9 +1523,9 @@ async fn request_control_with_cancellation(
 
 impl Drop for ControlGuard {
     fn drop(&mut self) {
-        if let Some(control) = self.0.take() {
-            control.end();
-        }
+        // Callers explicitly choose `end_control_if_unshared` on every
+        // failure path. An unconditional end here could tear down a control
+        // connection that already has other attachment leases.
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -872,6 +872,21 @@ impl Inner {
             }
         };
 
+        // Re-read authority after slow daemon/PTY work. A trust downgrade can
+        // arrive while OPEN is pending, so the original frame context is not
+        // sufficient to admit the attachment.
+        let live_auth = Self::auth_snapshot(context);
+        if live_auth.trust.is_empty()
+            || (live_auth.trust == "observe"
+                && (live_auth.owner_user_id.is_none()
+                    || Some(actor) != live_auth.owner_user_id.as_deref()))
+        {
+            opened.closing.store(true, Ordering::SeqCst);
+            opened.control.kill();
+            fail("trust_revoked", "terminal trust changed while opening");
+            return;
+        }
+
         // Keep the opening reservation held until the attachment is installed.
         // `close` takes this lock first, so it cannot observe a gap between
         // removing the opening marker and inserting the attachment.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -925,6 +925,27 @@ impl Inner {
             opened.control.kill();
             return;
         }
+        // A terminal callback locks its publication gate before it rechecks
+        // the attachment map. Acquire the previous generation's gate before
+        // replacing it, otherwise a same-ID open can overtake a blocked exit.
+        if let Some(previous_gate) =
+            attachments.get(&pty_id).map(|previous| Arc::clone(&previous.publication_gate))
+        {
+            drop(attachments);
+            drop(opening);
+            let _previous_publication = previous_gate.lock().expect("attachment publication lock");
+            attachments = self.attachments.lock().expect("attach lock");
+            opening = self.opening_state.lock().expect("opening state lock");
+            if opening.cancelled.remove(&pty_id) {
+                opening.ids.remove(&pty_id);
+                drop(opening);
+                drop(attachments);
+                reservation.active = false;
+                opened.closing.store(true, Ordering::SeqCst);
+                opened.control.kill();
+                return;
+            }
+        }
         let previous = attachments.insert(
             pty_id.clone(),
             Attachment {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -386,6 +386,9 @@ pub struct FrameContext {
     pub trust: String,
     pub local_roots: Option<Vec<String>>,
     pub owner_user_id: Option<String>,
+    /// Read current trust and owner for an attachment. Session transports
+    /// update this closure's backing state after trust acknowledgements.
+    pub live_auth: Arc<dyn Fn() -> (String, Option<String>) + Send + Sync>,
     /// Identity of the transport this frame arrived on. The PtyManager is
     /// shared between the relay WebSocket and the managed tunnel listener;
     /// an attachment may only be written to, resized, flow-controlled, or
@@ -689,9 +692,10 @@ fn send_typed_pty_error(
 
 impl Inner {
     fn auth_snapshot(context: &FrameContext) -> AuthSnapshot {
+        let (trust, owner_user_id) = (context.live_auth)();
         AuthSnapshot {
-            trust: context.trust.clone(),
-            owner_user_id: context.owner_user_id.clone(),
+            trust,
+            owner_user_id,
             send: Arc::clone(&context.send),
             buffered_amount: Arc::clone(&context.buffered_amount),
         }
@@ -2412,12 +2416,15 @@ mod tests {
         fn context(&self, trust: &str, owner: Option<String>) -> FrameContext {
             let sent = Arc::clone(&self.sent);
             let buffered = Arc::clone(&self.buffered);
+            let live_trust = trust.to_owned();
+            let live_owner = owner.clone();
             FrameContext {
                 send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
                 trust: trust.to_owned(),
                 local_roots: None,
                 owner_user_id: owner,
+                live_auth: Arc::new(move || (live_trust.clone(), live_owner.clone())),
                 transport_id: None,
                 cancellation: CancellationToken::new(),
             }
@@ -2640,6 +2647,31 @@ mod tests {
             h.owner.clone(),
         )
         .await;
+        pty.emit("secret");
+        assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
+    }
+
+    #[tokio::test]
+    async fn output_after_live_trust_downgrade_is_not_forwarded() {
+        let h = harness(None, None);
+        let live_auth = Arc::new(StdMutex::new(("supervised".to_owned(), h.owner.clone())));
+        let mut context = h.context("supervised", h.owner.clone());
+        let live_auth_for_context = Arc::clone(&live_auth);
+        context.live_auth = Arc::new(move || live_auth_for_context.lock().unwrap().clone());
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_other",
+            "trust": "supervised",
+            "allowedRoots": Value::Null,
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        live_auth.lock().unwrap().0 = "observe".to_owned();
         pty.emit("secret");
         assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2448,10 +2448,12 @@ impl Inner {
         if context.cancellation.is_cancelled() {
             if detach_supported {
                 if let Some(lease) = lease.as_deref() {
-                    let _ = control.send(
-                        "detach-attached-view",
-                        json!({ "surface": surface_id, "lease": lease }),
-                    );
+                    let _ = control
+                        .send_reliable(
+                            "detach-attached-view",
+                            json!({ "surface": surface_id, "lease": lease }),
+                        )
+                        .await;
                 }
             }
             self.end_control_if_unshared(&control);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1461,10 +1461,12 @@ async fn request_control_with_cancellation(
     params: Value,
     cancellation: &CancellationToken,
 ) -> Option<Value> {
-    tokio::select! {
-        response = control.request(cmd, params) => response,
-        _ = cancellation.cancelled() => None,
+    if cancellation.is_cancelled() {
+        return None;
     }
+    // Once queued, let the mutation finish. Dropping this future cannot
+    // retract an attach request, so cancellation cleanup uses its lease.
+    control.request(cmd, params).await
 }
 
 impl Drop for ControlGuard {
@@ -2369,10 +2371,6 @@ impl Inner {
             &context.cancellation,
         )
         .await;
-        if context.cancellation.is_cancelled() {
-            self.end_control_if_unshared(&control);
-            return Err((RelayPtyErrorCode::Failed, "attachment canceled".to_owned()));
-        }
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
             self.end_control_if_unshared(&control);
             let reason = attached
@@ -2393,6 +2391,18 @@ impl Inner {
             .and_then(Value::as_str)
             .filter(|v| !v.is_empty())
             .map(str::to_owned);
+        if context.cancellation.is_cancelled() {
+            if detach_supported {
+                if let Some(lease) = lease.as_deref() {
+                    let _ = control.send(
+                        "detach-attached-view",
+                        json!({ "surface": surface_id, "lease": lease }),
+                    );
+                }
+            }
+            self.end_control_if_unshared(&control);
+            return Err((RelayPtyErrorCode::Failed, "attachment canceled".to_owned()));
+        }
         if scoped_detach_advertised && lease.is_none() {
             self.end_control_if_unshared(&control);
             return Err((

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2734,6 +2734,7 @@ mod tests {
             let live_owner = owner.clone();
             let live_trust_for_auth = live_trust.clone();
             let live_owner_for_auth = live_owner.clone();
+            let observe_trust = trust == "observe";
             FrameContext {
                 send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
@@ -2743,7 +2744,7 @@ mod tests {
                 live_auth: Arc::new(move || (live_trust.clone(), live_owner.clone())),
                 live_authorized: Arc::new(move |actor| {
                     !live_trust_for_auth.is_empty()
-                        && (trust != "observe" || live_owner_for_auth.as_deref() == Some(actor))
+                        && (!observe_trust || live_owner_for_auth.as_deref() == Some(actor))
                 }),
                 transport_id: None,
                 cancellation: CancellationToken::new(),

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1001,6 +1001,13 @@ impl Inner {
         generation: u64,
         publication_gate: &Arc<Mutex<()>>,
     ) {
+        let auth = Self::auth_snapshot(context);
+        if self
+            .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
+            .is_none()
+        {
+            return;
+        }
         let attachments = self.attachments.lock().expect("attach lock");
         let Some(current) = attachments.get(pty_id) else { return };
         if current.generation != generation
@@ -1010,13 +1017,6 @@ impl Inner {
         }
         let _publication = publication_gate.lock().expect("attachment publication lock");
         drop(attachments);
-        let auth = Self::auth_snapshot(context);
-        if self
-            .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
-            .is_none()
-        {
-            return;
-        }
         // Zero-byte chunks carry nothing and historically crashed the web
         // terminal's write path (D-R6-1); never put an empty frame on the wire.
         if chunk.is_empty() {
@@ -1027,6 +1027,7 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
+            drop(_publication);
             self.close_if_generation(pty_id, generation);
             send_pty_error(
                 context,
@@ -1055,15 +1056,6 @@ impl Inner {
         generation: u64,
         publication_gate: &Arc<Mutex<()>>,
     ) {
-        let attachments = self.attachments.lock().expect("attach lock");
-        let Some(current) = attachments.get(pty_id) else { return };
-        if current.generation != generation
-            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
-        {
-            return;
-        }
-        let _publication = publication_gate.lock().expect("attachment publication lock");
-        drop(attachments);
         let auth = Self::auth_snapshot(context);
         if self
             .authorize_snapshot_for_generation(pty_id, &auth, context, "exit", generation)
@@ -1072,6 +1064,13 @@ impl Inner {
             return;
         }
         let mut attachments = self.attachments.lock().expect("attach lock");
+        let Some(current) = attachments.get(pty_id) else { return };
+        if current.generation != generation
+            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+        {
+            return;
+        }
+        let _publication = publication_gate.lock().expect("attachment publication lock");
         match attachments.get(pty_id) {
             Some(attachment)
                 if attachment.generation == generation

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3110,6 +3110,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn open_uses_live_auth_for_initial_admission() {
+        let h = harness(None, None);
+        let live_auth =
+            Arc::new(StdMutex::new(("observe".to_owned(), Some("different-owner".to_owned()))));
+        let mut context = h.context("supervised", h.owner.clone());
+        let live_auth_for_context = Arc::clone(&live_auth);
+        context.live_auth = Arc::new(move || live_auth_for_context.lock().unwrap().clone());
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+
+        h.manager.handle_frame(&frame, &context).await;
+
+        let sent = h.sent();
+        assert_eq!(sent.len(), 1);
+        assert_eq!(sent[0]["type"], "pty_error");
+        assert_eq!(sent[0]["code"], "trust_refused");
+        assert_eq!(h.manager.opening_count(), 0);
+    }
+
+    #[tokio::test]
     async fn shell_open_output_input_resize_flow_round_trip() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
@@ -3434,10 +3461,99 @@ mod tests {
         assert_eq!(h.sent()[0]["type"], "pty_opened");
     }
 
+    #[tokio::test]
+    async fn raw_attach_capability_error_is_product_facing() {
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let control: Arc<dyn ControlHandle> = Arc::new(AttachFailureControl {
+            set_client_info_ok: false,
+            include_lease: false,
+            ended: Arc::new(AtomicUsize::new(0)),
+        });
+        let h = harness_with_control(Some(cmux), None, None, Some(control));
+        h.open("p1", "work", serde_json::json!({ "surface": "7" }), "supervised", h.owner.clone())
+            .await;
+
+        let error = h.sent().into_iter().find(|frame| ty(frame) == "pty_error").unwrap();
+        assert_eq!(
+            error["message"],
+            "this terminal cannot be attached; update cmux-tui and try again"
+        );
+        assert!(!error["message"].as_str().unwrap().contains("control"));
+        assert!(!error["message"].as_str().unwrap().contains("view-attachment"));
+    }
+
+    #[tokio::test]
+    async fn raw_attach_missing_lease_error_is_product_facing() {
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let control: Arc<dyn ControlHandle> = Arc::new(AttachFailureControl {
+            set_client_info_ok: true,
+            include_lease: false,
+            ended: Arc::new(AtomicUsize::new(0)),
+        });
+        let h = harness_with_control(Some(cmux), None, None, Some(control));
+        h.open("p1", "work", serde_json::json!({ "surface": "7" }), "supervised", h.owner.clone())
+            .await;
+
+        let error = h.sent().into_iter().find(|frame| ty(frame) == "pty_error").unwrap();
+        assert_eq!(
+            error["message"],
+            "this terminal cannot be attached; update cmux-tui and try again"
+        );
+        assert!(!error["message"].as_str().unwrap().contains("attach-surface"));
+    }
+
     /// Scripted control plane: identifies at the protocol floor and lists a
     /// workspace tree WITHOUT the requested terminal — the JS harness's
     /// "closed tab" shape.
     struct GoneControl;
+
+    struct AttachFailureControl {
+        set_client_info_ok: bool,
+        include_lease: bool,
+        ended: Arc<AtomicUsize>,
+    }
+
+    impl ControlHandle for AttachFailureControl {
+        fn request(
+            &self,
+            cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            let response = match cmd {
+                "identify" => Some(json!({
+                    "ok": true,
+                    "data": {
+                        "protocol": CONTROL_MIN_PROTOCOL,
+                        "capabilities": [
+                            VIEW_ATTACHMENT_LEASE_CAPABILITY,
+                            VIEW_ATTACHMENT_DETACH_CAPABILITY,
+                        ],
+                    },
+                })),
+                "set-client-info" => Some(json!({ "ok": self.set_client_info_ok })),
+                "attach-surface" => {
+                    let data =
+                        if self.include_lease { json!({ "lease": "lease-a" }) } else { json!({}) };
+                    Some(json!({ "ok": true, "data": data }))
+                }
+                _ => None,
+            };
+            Box::pin(async move { response })
+        }
+
+        fn send(&self, _cmd: &str, _params: Value) -> bool {
+            true
+        }
+
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+
+        fn end(&self) {
+            self.ended.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
 
     impl ControlHandle for GoneControl {
         fn request(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -579,11 +579,9 @@ impl PtyManager {
                             control.write(&data)
                         });
                     if accepted == Some(false) {
-                        self.inner.emit_error_for_generation(
+                        send_pty_error(
                             context,
                             pty_id,
-                            attachment.generation,
-                            &attachment.publication_gate,
                             "input_overflow",
                             "terminal input queue is full; retry input",
                         );

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -511,24 +511,24 @@ impl ControlLease {
         if !Arc::ptr_eq(&state.control, &self.control) {
             return;
         }
+        drop(users);
         if detach_supported && let Some(lease) = lease {
-            // The detach command is idempotent and queued before the control
-            // is closed. This handles an attach response racing cancellation.
+            // Await writer acceptance before the final lease closes the
+            // socket. Otherwise end() can discard a queued detach line.
             let params = json!({ "surface": surface_id, "lease": lease });
-            if !self.control.send("detach-attached-view", params.clone()) {
-                drop(users);
-                if let Ok(handle) = tokio::runtime::Handle::try_current() {
-                    let control = Arc::clone(&self.control);
-                    let lease = Arc::clone(self);
-                    handle.spawn(async move {
-                        let _ = control.send_reliable("detach-attached-view", params).await;
-                        lease.finish_count();
-                    });
-                }
+            if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                let control = Arc::clone(&self.control);
+                let lease = Arc::clone(self);
+                handle.spawn(async move {
+                    let _ = control.send_reliable("detach-attached-view", params).await;
+                    lease.finish_count();
+                });
+                return;
+            }
+            if !self.control.send("detach-attached-view", params) {
                 return;
             }
         }
-        drop(users);
         self.finish_count();
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2393,6 +2393,8 @@ mod tests {
         on_data: Option<DataSink>,
         on_exit: Option<ExitSink>,
         written: Vec<Vec<u8>>,
+        write_entered: Option<TestArc<Barrier>>,
+        write_release: Option<TestArc<Barrier>>,
         resized: Vec<(u16, u16)>,
         paused: bool,
         killed: bool,
@@ -2426,6 +2428,16 @@ mod tests {
 
     impl PtyControl for FakePty {
         fn write(&self, data: &[u8]) {
+            let (entered, release) = {
+                let state = self.state.lock().unwrap();
+                (state.write_entered.clone(), state.write_release.clone())
+            };
+            if let Some(entered) = entered {
+                entered.wait();
+            }
+            if let Some(release) = release {
+                release.wait();
+            }
             self.state.lock().unwrap().written.push(data.to_vec());
         }
         fn resize(&self, cols: u16, rows: u16) {
@@ -3389,5 +3401,185 @@ mod tests {
         let frame = harness.sent().pop().unwrap();
         assert_eq!(frame["type"], "pty_error");
         assert_eq!(frame["code"], "overflow");
+    }
+
+    fn blocking_terminal_context(
+        harness: &Harness,
+        entered: TestArc<Barrier>,
+        release: TestArc<Barrier>,
+    ) -> FrameContext {
+        let mut context = harness.context("supervised", harness.owner.clone());
+        let sent = TestArc::clone(&harness.sent);
+        context.send = TestArc::new(move |frame| {
+            if matches!(
+                frame.get("type").and_then(Value::as_str),
+                Some("pty_output" | "pty_exit" | "pty_error")
+            ) {
+                entered.wait();
+                release.wait();
+            }
+            sent.lock().expect("sent lock").push(frame);
+        });
+        context
+    }
+
+    #[tokio::test]
+    async fn exit_publication_retains_closing_id_until_frame_is_sent() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let exit = thread::spawn(move || pty.exit(7));
+        entered.wait();
+
+        let replacement = h.context("supervised", h.owner.clone());
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert!(!h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+
+        release.wait();
+        exit.join().expect("exit callback");
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test]
+    async fn overflow_error_publication_cannot_reach_a_same_id_replacement() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        h.buffered.store(OUTPUT_BUFFER_CAP + 1, Ordering::SeqCst);
+        let output = thread::spawn(move || pty.emit("overflow"));
+        entered.wait();
+
+        let replacement = h.context("supervised", h.owner.clone());
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert!(!h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+
+        release.wait();
+        output.join().expect("output callback");
+        h.buffered.store(0, Ordering::SeqCst);
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test]
+    async fn direct_close_waits_for_an_in_flight_publication() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let output = thread::spawn(move || pty.emit("live"));
+        entered.wait();
+
+        let close_context = h.context("supervised", h.owner.clone());
+        let manager = h.manager.inner.clone();
+        let close = thread::spawn(move || manager.close_authorized("p1", &close_context));
+        assert!(!close.is_finished(), "close must wait for the publication gate");
+
+        release.wait();
+        output.join().expect("output callback");
+        close.join().expect("close callback");
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test]
+    async fn input_operation_waits_before_close_can_retire_its_generation() {
+        let h = harness(None, None);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        let pty = h.spawned()[0].clone();
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        {
+            let mut state = pty.state.lock().unwrap();
+            state.write_entered = Some(TestArc::clone(&entered));
+            state.write_release = Some(TestArc::clone(&release));
+        }
+
+        let input = serde_json::json!({
+            "version": 4,
+            "type": "pty_input",
+            "ptyId": "p1",
+            "dataB64": b64("stale"),
+        });
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let input_context = h.context("supervised", h.owner.clone());
+        let runtime = tokio::runtime::Handle::current();
+        let input_task =
+            thread::spawn(move || runtime.block_on(manager.handle_frame(&input, &input_context)));
+        entered.wait();
+
+        let close_context = h.context("supervised", h.owner.clone());
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let close = thread::spawn(move || {
+            manager.inner.close_authorized("p1", &close_context);
+        });
+        assert!(!close.is_finished(), "close must wait for the in-flight control operation");
+
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        assert!(!h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+
+        release.wait();
+        input_task.join().expect("input operation");
+        close.join().expect("close operation");
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -487,7 +487,21 @@ struct ControlLease {
 }
 
 impl ControlLease {
-    fn release(&self, surface_id: i64, lease: Option<&str>, detach_supported: bool) {
+    fn finish_count(&self) {
+        let Some(inner) = self.inner.upgrade() else { return };
+        let mut users = inner.control_users.lock().expect("control users lock");
+        let Some(state) = users.get_mut(&self.key) else { return };
+        if !Arc::ptr_eq(&state.control, &self.control) {
+            return;
+        }
+        state.count = state.count.saturating_sub(1);
+        if state.count == 0 {
+            users.remove(&self.key);
+            self.control.end();
+        }
+    }
+
+    fn release(self: &Arc<Self>, surface_id: i64, lease: Option<&str>, detach_supported: bool) {
         if self.released.swap(true, Ordering::SeqCst) {
             return;
         }
@@ -500,15 +514,22 @@ impl ControlLease {
         if detach_supported && let Some(lease) = lease {
             // The detach command is idempotent and queued before the control
             // is closed. This handles an attach response racing cancellation.
-            let _ = self
-                .control
-                .send("detach-attached-view", json!({ "surface": surface_id, "lease": lease }));
+            let params = json!({ "surface": surface_id, "lease": lease });
+            if !self.control.send("detach-attached-view", params.clone()) {
+                drop(users);
+                if let Ok(handle) = tokio::runtime::Handle::try_current() {
+                    let control = Arc::clone(&self.control);
+                    let lease = Arc::clone(self);
+                    handle.spawn(async move {
+                        let _ = control.send_reliable("detach-attached-view", params).await;
+                        lease.finish_count();
+                    });
+                }
+                return;
+            }
         }
-        state.count = state.count.saturating_sub(1);
-        if state.count == 0 {
-            users.remove(&self.key);
-            self.control.end();
-        }
+        drop(users);
+        self.finish_count();
     }
 }
 
@@ -1361,6 +1382,15 @@ impl Inner {
         // revoked context cannot send a control operation to the old
         // attachment generation.
         if !(context.live_authorized)(&actor_id) {
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
+                "trust_revoked",
+                "PTY control operation refused after trust change",
+            );
             return None;
         }
         Some(operation(attachment.control.as_ref()))

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -52,6 +52,8 @@ pub const SCROLLBACK_LIMIT: usize = 256 * 1024;
 pub const OUTPUT_BUFFER_CAP: u64 = 1024 * 1024;
 /// cmux-tui control protocol floor for attach-surface/send.
 const CONTROL_MIN_PROTOCOL: i64 = 5;
+const VIEW_ATTACHMENT_LEASE_CAPABILITY: &str = "view-attachment-lease-v1";
+const VIEW_ATTACHMENT_DETACH_CAPABILITY: &str = "view-attachment-detach-v1";
 /// Inner terminals listed per session (surface_list stays bounded).
 const MAX_ENUM_TERMINALS: usize = 8;
 const MAX_ALLOWED_ROOTS: usize = 32;
@@ -469,6 +471,45 @@ struct Inner {
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
     next_generation: AtomicU64,
+    control_users: Mutex<HashMap<usize, ControlUsers>>,
+}
+
+struct ControlUsers {
+    control: Arc<dyn ControlHandle>,
+    count: usize,
+}
+
+struct ControlLease {
+    inner: std::sync::Weak<Inner>,
+    key: usize,
+    control: Arc<dyn ControlHandle>,
+    released: AtomicBool,
+}
+
+impl ControlLease {
+    fn release(&self, surface_id: i64, lease: Option<&str>, detach_supported: bool) {
+        if self.released.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let Some(inner) = self.inner.upgrade() else { return };
+        let mut users = inner.control_users.lock().expect("control users lock");
+        let Some(state) = users.get_mut(&self.key) else { return };
+        if !Arc::ptr_eq(&state.control, &self.control) {
+            return;
+        }
+        if detach_supported && let Some(lease) = lease {
+            // The detach command is idempotent and queued before the control
+            // is closed. This handles an attach response racing cancellation.
+            let _ = self
+                .control
+                .send("detach-attached-view", json!({ "surface": surface_id, "lease": lease }));
+        }
+        state.count = state.count.saturating_sub(1);
+        if state.count == 0 {
+            users.remove(&self.key);
+            self.control.end();
+        }
+    }
 }
 
 #[derive(Default)]
@@ -527,6 +568,7 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 next_generation: AtomicU64::new(1),
+                control_users: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -552,6 +594,7 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 next_generation: AtomicU64::new(1),
+                control_users: Mutex::new(HashMap::new()),
             }),
         }
     }
@@ -725,6 +768,45 @@ fn send_typed_pty_error(
 }
 
 impl Inner {
+    fn control_key(control: &Arc<dyn ControlHandle>) -> usize {
+        Arc::as_ptr(control) as *const () as usize
+    }
+
+    fn register_control_user(
+        self: &Arc<Self>,
+        control: &Arc<dyn ControlHandle>,
+    ) -> Arc<ControlLease> {
+        let key = Self::control_key(control);
+        let mut users = self.control_users.lock().expect("control users lock");
+        let replace = users.get(&key).is_some_and(|state| !Arc::ptr_eq(&state.control, control));
+        // A live map entry owns the Arc, so allocator address reuse cannot
+        // alias a different control. Replace a stale entry defensively.
+        if replace {
+            users.insert(key, ControlUsers { control: Arc::clone(control), count: 0 });
+        }
+        let state = users.get_mut(&key).expect("control users entry");
+        state.count += 1;
+        Arc::new(ControlLease {
+            inner: Arc::downgrade(self),
+            key,
+            control: Arc::clone(control),
+            released: AtomicBool::new(false),
+        })
+    }
+
+    fn end_control_if_unshared(&self, control: &Arc<dyn ControlHandle>) {
+        let key = Self::control_key(control);
+        let mut users = self.control_users.lock().expect("control users lock");
+        if let Some(state) = users.get(&key)
+            && Arc::ptr_eq(&state.control, control)
+            && state.count > 0
+        {
+            return;
+        }
+        users.remove(&key);
+        control.end();
+    }
+
     fn auth_snapshot(context: &FrameContext) -> AuthSnapshot {
         let (trust, owner_user_id) = (context.live_auth)();
         AuthSnapshot {
@@ -1381,10 +1463,7 @@ async fn request_control_with_cancellation(
 ) -> Option<Value> {
     tokio::select! {
         response = control.request(cmd, params) => response,
-        _ = cancellation.cancelled() => {
-            control.end();
-            None
-        }
+        _ = cancellation.cancelled() => None,
     }
 }
 
@@ -1934,6 +2013,9 @@ impl TerminalStream {
 struct ControlTerminalControl {
     control: Arc<dyn ControlHandle>,
     surface_id: i64,
+    lease: Option<String>,
+    detach_supported: bool,
+    user: Arc<ControlLease>,
 }
 
 impl PtyControl for ControlTerminalControl {
@@ -1954,7 +2036,13 @@ impl PtyControl for ControlTerminalControl {
         self.control.resume();
     }
     fn kill(&self) {
-        self.control.end(); // detach only; the daemon keeps the terminal
+        self.user.release(self.surface_id, self.lease.as_deref(), self.detach_supported);
+    }
+}
+
+impl Drop for ControlTerminalControl {
+    fn drop(&mut self) {
+        self.user.release(self.surface_id, self.lease.as_deref(), self.detach_supported);
     }
 }
 
@@ -2144,7 +2232,7 @@ impl Inner {
             .and_then(Value::as_i64)
             .unwrap_or(0);
         if protocol < CONTROL_MIN_PROTOCOL {
-            control.end();
+            self.end_control_if_unshared(&control);
             return Ok(None);
         }
         let capabilities: Vec<String> = info
@@ -2154,6 +2242,28 @@ impl Inner {
             .into_iter()
             .filter_map(|v| v.as_str().map(str::to_owned))
             .collect();
+        let scoped_detach_advertised =
+            capabilities.iter().any(|c| c == VIEW_ATTACHMENT_LEASE_CAPABILITY)
+                && capabilities.iter().any(|c| c == VIEW_ATTACHMENT_DETACH_CAPABILITY);
+        let detach_supported = if scoped_detach_advertised {
+            let params = json!({
+                "capabilities": [VIEW_ATTACHMENT_LEASE_CAPABILITY, VIEW_ATTACHMENT_DETACH_CAPABILITY],
+            });
+            control
+                .request("set-client-info", params)
+                .await
+                .as_ref()
+                .is_some_and(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
+        } else {
+            false
+        };
+        if scoped_detach_advertised && !detach_supported {
+            self.end_control_if_unshared(&control);
+            return Err((
+                RelayPtyErrorCode::Failed,
+                "control does not support scoped attachment detach".to_owned(),
+            ));
+        }
 
         // Resolve the ref: numeric surface id directly, else via the tree.
         let mut surface_id: Option<i64> = if surface_ref.bytes().all(|b| b.is_ascii_digit()) {
@@ -2174,7 +2284,7 @@ impl Inner {
                 .map(|tab| tab.surface_id);
         }
         let Some(surface_id) = surface_id else {
-            control.end();
+            self.end_control_if_unshared(&control);
             // Typed refusal: the terminal died with its process (or its tab
             // closed) — permanent, so clients render an ended state and
             // never offer a retry.
@@ -2197,14 +2307,14 @@ impl Inner {
                 .and_then(|v| v.get("cwd"))
                 .and_then(Value::as_str);
             if actual.is_none_or(|value| value.is_empty() || !Path::new(value).is_absolute()) {
-                control.end();
+                self.end_control_if_unshared(&control);
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
                 ));
             }
             let Some(actual) = actual else {
-                control.end();
+                self.end_control_if_unshared(&control);
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
@@ -2213,7 +2323,7 @@ impl Inner {
             if scoped_cwd(Some(actual), &self.home, context.local_roots.as_deref(), server_roots)
                 .is_err()
             {
-                control.end();
+                self.end_control_if_unshared(&control);
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "existing surface cwd is outside allowed roots".to_owned(),
@@ -2259,8 +2369,12 @@ impl Inner {
             &context.cancellation,
         )
         .await;
+        if context.cancellation.is_cancelled() {
+            self.end_control_if_unshared(&control);
+            return Err((RelayPtyErrorCode::Failed, "attachment canceled".to_owned()));
+        }
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
-            control.end();
+            self.end_control_if_unshared(&control);
             let reason = attached
                 .as_ref()
                 .and_then(|v| v.get("error"))
@@ -2272,8 +2386,25 @@ impl Inner {
             ));
         }
 
+        let lease = attached
+            .as_ref()
+            .and_then(|v| v.get("data"))
+            .and_then(|v| v.get("lease"))
+            .and_then(Value::as_str)
+            .filter(|v| !v.is_empty())
+            .map(str::to_owned);
+        if scoped_detach_advertised && lease.is_none() {
+            self.end_control_if_unshared(&control);
+            return Err((
+                RelayPtyErrorCode::Failed,
+                "attach-surface returned no attachment lease".to_owned(),
+            ));
+        }
+
+        let control = control_guard.disarm();
+        let user = self.register_control_user(&control);
         let proxy =
-            Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
+            Arc::new(ControlTerminalControl { control, surface_id, lease, detach_supported, user });
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let publication_gate = Arc::new(Mutex::new(()));
         let (on_data, _) = self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
@@ -3262,6 +3393,52 @@ mod tests {
         fn pause(&self) {}
         fn resume(&self) {}
         fn end(&self) {}
+    }
+
+    struct LeaseControl {
+        ended: Arc<AtomicUsize>,
+        detached: Arc<AtomicUsize>,
+    }
+
+    impl ControlHandle for LeaseControl {
+        fn request(
+            &self,
+            _cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            Box::pin(async { Some(json!({ "ok": true })) })
+        }
+        fn send(&self, cmd: &str, _params: Value) -> bool {
+            if cmd == "detach-attached-view" {
+                self.detached.fetch_add(1, AtomicOrdering::SeqCst);
+            }
+            true
+        }
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {
+            self.ended.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
+
+    #[test]
+    fn control_leases_detach_each_surface_and_end_once_after_last_release() {
+        let h = harness(None, None);
+        let ended = Arc::new(AtomicUsize::new(0));
+        let detached = Arc::new(AtomicUsize::new(0));
+        let control: Arc<dyn ControlHandle> =
+            Arc::new(LeaseControl { ended: Arc::clone(&ended), detached: Arc::clone(&detached) });
+        let first = h.manager.inner.register_control_user(&control);
+        let second = h.manager.inner.register_control_user(&control);
+        first.release(7, Some("lease-a"), true);
+        assert_eq!(detached.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(ended.load(AtomicOrdering::SeqCst), 0);
+        second.release(8, Some("lease-b"), true);
+        assert_eq!(detached.load(AtomicOrdering::SeqCst), 2);
+        assert_eq!(ended.load(AtomicOrdering::SeqCst), 1);
+        assert!(h.manager.inner.control_users.lock().unwrap().is_empty());
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1057,6 +1057,7 @@ impl Inner {
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || !(context.live_authorized)(&current.actor_id)
             {
                 return;
             }
@@ -1085,7 +1086,7 @@ impl Inner {
             );
             return;
         }
-        (auth.send)(json!({
+        (context.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
             "ptyId": pty_id,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3152,6 +3152,8 @@ mod tests {
         live_auth.lock().unwrap().0 = "observe".to_owned();
         pty.emit("secret");
         assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
+        assert!(h.sent().iter().any(|f| f["code"] == "trust_revoked"));
+        assert!(!h.manager.has_attachment("p1"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -576,7 +576,7 @@ impl PtyManager {
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
                     let accepted =
-                        self.inner.with_live_attachment(pty_id, &attachment, |control| {
+                        self.inner.with_live_attachment(pty_id, &attachment, context, |control| {
                             control.write(&data)
                         });
                     if accepted == Some(false) {
@@ -600,9 +600,10 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
-                    let _ = self.inner.with_live_attachment(pty_id, &attachment, |control| {
-                        control.resize(cols, rows);
-                    });
+                    let _ =
+                        self.inner.with_live_attachment(pty_id, &attachment, context, |control| {
+                            control.resize(cols, rows)
+                        });
                 }
             }
             "pty_flow" => {
@@ -612,13 +613,14 @@ impl PtyManager {
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
-                    let _ = self.inner.with_live_attachment(pty_id, &attachment, |control| {
-                        if pause {
-                            control.pause();
-                        } else {
-                            control.resume();
-                        }
-                    });
+                    let _ =
+                        self.inner.with_live_attachment(pty_id, &attachment, context, |control| {
+                            if pause {
+                                control.pause();
+                            } else {
+                                control.resume();
+                            }
+                        });
                 }
             }
             "pty_close" => {
@@ -1235,10 +1237,11 @@ impl Inner {
         &self,
         pty_id: &str,
         attachment: &Attachment,
+        context: &FrameContext,
         operation: impl FnOnce(&dyn PtyControl) -> R,
     ) -> Option<R> {
         let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
-        {
+        let actor_id = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return None };
             if current.generation != attachment.generation
@@ -1247,6 +1250,14 @@ impl Inner {
             {
                 return None;
             }
+            current.actor_id.clone()
+        };
+        // Authorization can change after the initial frame snapshot. Recheck
+        // it while the publication gate excludes detach and replacement, so a
+        // revoked context cannot send a control operation to the old
+        // attachment generation.
+        if !(context.live_authorized)(&actor_id) {
+            return None;
         }
         Some(operation(attachment.control.as_ref()))
     }
@@ -2979,6 +2990,11 @@ mod tests {
         let mut context = h.context("supervised", h.owner.clone());
         let live_auth_for_context = Arc::clone(&live_auth);
         context.live_auth = Arc::new(move || live_auth_for_context.lock().unwrap().clone());
+        let live_auth_for_authorized = Arc::clone(&live_auth);
+        context.live_authorized = Arc::new(move |actor| {
+            let (trust, owner) = live_auth_for_authorized.lock().unwrap().clone();
+            !trust.is_empty() && (trust != "observe" || owner.as_deref() == Some(actor))
+        });
         let frame = serde_json::json!({
             "version": 4,
             "type": "pty_open",

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -27,6 +27,7 @@ use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
+use std::time::Duration;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
@@ -37,7 +38,7 @@ use bytes::Bytes;
 use serde_json::{Value, json};
 
 use crate::actions::{expand_path, scrubbed_env, validate_request_path};
-use crate::control::ControlHandle;
+use crate::control::{CONTROL_TIMEOUT_MS, ControlHandle};
 use crate::relay_wire::RelayPtyErrorCode;
 
 pub const PTY_PROTOCOL_VERSION: u64 = 4;
@@ -520,7 +521,11 @@ impl ControlLease {
                 let control = Arc::clone(&self.control);
                 let lease = Arc::clone(self);
                 handle.spawn(async move {
-                    let _ = control.send_reliable("detach-attached-view", params).await;
+                    let _ = tokio::time::timeout(
+                        Duration::from_millis(CONTROL_TIMEOUT_MS),
+                        control.send_reliable("detach-attached-view", params),
+                    )
+                    .await;
                     lease.finish_count();
                 });
                 return;
@@ -2682,7 +2687,6 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
     use std::thread;
-    use std::time::Duration;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -624,6 +624,11 @@ impl PtyManager {
         self.inner.attachments.lock().expect("attach lock").len()
     }
 
+    #[cfg(test)]
+    pub(crate) fn opening_count(&self) -> usize {
+        self.inner.opening_ids.lock().expect("opening lock").len()
+    }
+
     /// The relay socket dropped: release every attachment (sessions live on).
     /// Callers that own the whole manager only; a per-connection transport
     /// must use `detach_transport` so it cannot detach attachments the

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -389,6 +389,7 @@ pub struct FrameContext {
     /// Read current trust and owner for an attachment. Session transports
     /// update this closure's backing state after trust acknowledgements.
     pub live_auth: Arc<dyn Fn() -> (String, Option<String>) + Send + Sync>,
+    pub live_authorized: Arc<dyn Fn(&str) -> bool + Send + Sync>,
     /// Identity of the transport this frame arrived on. The PtyManager is
     /// shared between the relay WebSocket and the managed tunnel listener;
     /// an attachment may only be written to, resized, flow-controlled, or
@@ -1038,18 +1039,12 @@ impl Inner {
         generation: u64,
         publication_gate: &Arc<Mutex<()>>,
     ) {
-        let auth = Self::auth_snapshot(context);
-        if self
-            .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
-            .is_none()
-        {
-            return;
-        }
         let gate = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || !(context.live_authorized)(&current.actor_id)
             {
                 return;
             }
@@ -1071,7 +1066,7 @@ impl Inner {
         if chunk.is_empty() {
             return;
         }
-        let buffered = (auth.buffered_amount)();
+        let buffered = (context.buffered_amount)();
         // Admit the complete frame before sending it. The socket may accept a
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
@@ -1114,7 +1109,7 @@ impl Inner {
             return;
         }
         self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
-            (auth.send)(json!({
+            (context.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
             "ptyId": pty_id,
@@ -2737,6 +2732,8 @@ mod tests {
             let buffered = Arc::clone(&self.buffered);
             let live_trust = trust.to_owned();
             let live_owner = owner.clone();
+            let live_trust_for_auth = live_trust.clone();
+            let live_owner_for_auth = live_owner.clone();
             FrameContext {
                 send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
@@ -2744,6 +2741,10 @@ mod tests {
                 local_roots: None,
                 owner_user_id: owner,
                 live_auth: Arc::new(move || (live_trust.clone(), live_owner.clone())),
+                live_authorized: Arc::new(move |actor| {
+                    !live_trust_for_auth.is_empty()
+                        && (trust != "observe" || live_owner_for_auth.as_deref() == Some(actor))
+                }),
                 transport_id: None,
                 cancellation: CancellationToken::new(),
             }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -574,7 +574,9 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
-                    attachment.control.write(&data);
+                    self.inner.with_live_attachment(pty_id, &attachment, |control| {
+                        control.write(&data);
+                    });
                 }
             }
             "pty_resize" => {
@@ -588,7 +590,9 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
-                    attachment.control.resize(cols, rows);
+                    self.inner.with_live_attachment(pty_id, &attachment, |control| {
+                        control.resize(cols, rows);
+                    });
                 }
             }
             "pty_flow" => {
@@ -598,11 +602,13 @@ impl PtyManager {
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
-                    if pause {
-                        attachment.control.pause();
-                    } else {
-                        attachment.control.resume();
-                    }
+                    self.inner.with_live_attachment(pty_id, &attachment, |control| {
+                        if pause {
+                            control.pause();
+                        } else {
+                            control.resume();
+                        }
+                    });
                 }
             }
             "pty_close" => {
@@ -621,7 +627,12 @@ impl PtyManager {
     /// this after a pty_error reply to tell a fatal refusal (attachment gone,
     /// connection ends) from a non-fatal one (oversized input, stream lives).
     pub fn has_attachment(&self, pty_id: &str) -> bool {
-        self.inner.attachments.lock().expect("attach lock").contains_key(pty_id)
+        self.inner
+            .attachments
+            .lock()
+            .expect("attach lock")
+            .get(pty_id)
+            .is_some_and(|attachment| !attachment.closing.load(Ordering::SeqCst))
     }
 
     /// Live attachment count (viewers, not sessions). Diagnostics and tests.
@@ -914,9 +925,6 @@ impl Inner {
             opened.control.kill();
             return;
         }
-        let previous_gate = attachments.get(&pty_id).map(|a| Arc::clone(&a.publication_gate));
-        let _previous_publication =
-            previous_gate.as_ref().map(|gate| gate.lock().expect("attachment publication lock"));
         let previous = attachments.insert(
             pty_id.clone(),
             Attachment {
@@ -962,6 +970,7 @@ impl Inner {
         generation: u64,
         publication_gate: Arc<Mutex<()>>,
     ) -> (DataSink, ExitSink) {
+        let output_gate = Arc::clone(&publication_gate);
         let on_data = {
             let inner = Arc::clone(self);
             let context = context.clone();
@@ -972,22 +981,17 @@ impl Inner {
                     &chunk,
                     &context,
                     generation,
-                    &publication_gate,
+                    &output_gate,
                 )
             }) as Arc<dyn Fn(Bytes) + Send + Sync>
         };
+        let exit_gate = Arc::clone(&publication_gate);
         let on_exit = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
             Arc::new(move |code: i64| {
-                inner.emit_exit_for_generation(
-                    &pty_id,
-                    code,
-                    &context,
-                    generation,
-                    &publication_gate,
-                )
+                inner.emit_exit_for_generation(&pty_id, code, &context, generation, &exit_gate)
             }) as Arc<dyn Fn(i64) + Send + Sync>
         };
         (on_data, on_exit)
@@ -1008,15 +1012,27 @@ impl Inner {
         {
             return;
         }
-        let attachments = self.attachments.lock().expect("attach lock");
-        let Some(current) = attachments.get(pty_id) else { return };
-        if current.generation != generation
-            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock().expect("attachment publication lock");
         {
-            return;
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
         }
-        let _publication = publication_gate.lock().expect("attachment publication lock");
-        drop(attachments);
         // Zero-byte chunks carry nothing and historically crashed the web
         // terminal's write path (D-R6-1); never put an empty frame on the wire.
         if chunk.is_empty() {
@@ -1028,10 +1044,11 @@ impl Inner {
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
             drop(_publication);
-            self.close_if_generation(pty_id, generation);
-            send_pty_error(
+            self.emit_error_for_generation(
                 context,
                 pty_id,
+                generation,
+                publication_gate,
                 "failed",
                 &format!(
                     "dropped: {buffered} bytes buffered toward the server (cap {})",
@@ -1063,29 +1080,75 @@ impl Inner {
         {
             return;
         }
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        let Some(current) = attachments.get(pty_id) else { return };
-        if current.generation != generation
-            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
-        {
-            return;
-        }
-        let _publication = publication_gate.lock().expect("attachment publication lock");
-        match attachments.get(pty_id) {
-            Some(attachment)
-                if attachment.generation == generation
-                    && Arc::ptr_eq(&attachment.publication_gate, publication_gate)
-                    && !attachment.closing.load(Ordering::SeqCst) => {}
-            _ => return,
-        }
-        attachments.remove(pty_id);
-        drop(attachments);
-        (auth.send)(json!({
+        self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
+            (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
             "ptyId": pty_id,
             "code": code,
-        }));
+            }));
+        });
+    }
+
+    fn emit_error_for_generation(
+        &self,
+        context: &FrameContext,
+        pty_id: &str,
+        generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
+        code: &str,
+        message: &str,
+    ) {
+        self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
+            send_pty_error(context, pty_id, code, message);
+        });
+    }
+
+    fn emit_terminal_for_generation(
+        &self,
+        pty_id: &str,
+        generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
+        publish: impl FnOnce(),
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock().expect("attachment publication lock");
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.closing.store(true, Ordering::SeqCst);
+            current.clone()
+        };
+        // Keep the closing attachment in the map while the terminal frame is
+        // published. A same-ID open therefore cannot overtake this callback.
+        publish();
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        if attachments.get(pty_id).is_some_and(|current| {
+            current.generation == generation
+                && Arc::ptr_eq(&current.publication_gate, publication_gate)
+        }) {
+            attachments.remove(pty_id);
+        }
+        drop(attachments);
+        drop(_publication);
+        // Terminal publication retires the viewer. Killing is idempotent for
+        // an already-exited PTY and releases an overflowed or revoked one.
+        attachment.control.kill();
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
@@ -1098,11 +1161,7 @@ impl Inner {
             return;
         }
         drop(opening);
-        let attachment = self.attachments.lock().expect("attach lock").remove(pty_id);
-        if let Some(attachment) = attachment {
-            attachment.closing.store(true, Ordering::SeqCst);
-            attachment.control.kill();
-        }
+        self.close_exact(pty_id, None, None);
     }
 
     fn close_if_transport(&self, pty_id: &str, transport_id: Option<&str>) {
@@ -1114,14 +1173,17 @@ impl Inner {
             return;
         }
         drop(opening);
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        let Some(attachment) = attachments.get(pty_id) else { return };
-        if attachment.transport_id.as_deref() != transport_id {
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
             return;
+        };
+        if attachment.transport_id.as_deref() == transport_id {
+            self.close_exact(
+                pty_id,
+                Some(attachment.generation),
+                Some(&attachment.publication_gate),
+            );
         }
-        let attachment = attachments.remove(pty_id).expect("attachment still present");
-        attachment.closing.store(true, Ordering::SeqCst);
-        attachment.control.kill();
     }
 
     /// Frame-level transport fence. Unknown ids retain the protocol's silent
@@ -1154,6 +1216,26 @@ impl Inner {
         self.authorize_snapshot_for_generation(pty_id, auth, context, action, 0)
     }
 
+    fn with_live_attachment(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        operation: impl FnOnce(&dyn PtyControl),
+    ) {
+        let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
+        {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+        }
+        operation(attachment.control.as_ref());
+    }
+
     fn authorize_snapshot_for_generation(
         &self,
         pty_id: &str,
@@ -1176,14 +1258,11 @@ impl Inner {
         if allowed {
             Some(attachment)
         } else {
-            if generation == 0 {
-                self.close(pty_id);
-            } else {
-                self.close_if_generation(pty_id, generation);
-            }
-            send_pty_error(
+            self.emit_error_for_generation(
                 context,
                 pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
                 "trust_revoked",
                 &format!("PTY {action} refused after trust change"),
             );
@@ -1193,27 +1272,61 @@ impl Inner {
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
-        if self.authorize_snapshot_for_generation(pty_id, &auth, context, "close", 0).is_none() {
+        let Some(attachment) =
+            self.authorize_snapshot_for_generation(pty_id, &auth, context, "close", 0)
+        else {
+            // A close may race the asynchronous open before its attachment
+            // is published. The transport fence ran at frame dispatch, so
+            // this exact owner can cancel the pending reservation now.
+            self.close_if_transport(pty_id, context.transport_id.as_deref());
             return;
-        }
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        let Some(attachment) = attachments.get(pty_id) else { return };
+        };
         if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
             return;
         }
-        let attachment = attachments.remove(pty_id).expect("attachment still present");
-        attachment.closing.store(true, Ordering::SeqCst);
-        attachment.control.kill();
+        self.close_exact(pty_id, Some(attachment.generation), Some(&attachment.publication_gate));
     }
 
     fn close_if_generation(&self, pty_id: &str, generation: u64) {
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        let Some(attachment) = attachments.get(pty_id) else { return };
-        if attachment.generation != generation {
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
             return;
+        };
+        if attachment.generation == generation {
+            self.close_exact(pty_id, Some(generation), Some(&attachment.publication_gate));
         }
-        let attachment = attachments.remove(pty_id).expect("attachment still present");
-        attachment.closing.store(true, Ordering::SeqCst);
+    }
+
+    fn close_exact(
+        &self,
+        pty_id: &str,
+        generation: Option<u64>,
+        publication_gate: Option<&Arc<Mutex<()>>>,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || publication_gate
+                    .is_some_and(|expected| !Arc::ptr_eq(&current.publication_gate, expected))
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock().expect("attachment publication lock");
+        let attachment = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+            {
+                return;
+            }
+            let attachment = attachments.remove(pty_id).expect("attachment still present");
+            attachment.closing.store(true, Ordering::SeqCst);
+            attachment
+        };
         attachment.control.kill();
     }
 }
@@ -2152,12 +2265,14 @@ impl Inner {
         let context_for_exit = context.clone();
         let pty_id_for_exit = pty_id.to_owned();
         let stream_for_exit = Arc::clone(&stream);
+        let exit_gate = Arc::clone(&publication_gate);
         let on_exit: ExitSink = Arc::new(move |code| {
             if stream_for_exit.overflowed() {
-                relay.close_if_generation(&pty_id_for_exit, generation);
-                send_pty_error(
+                relay.emit_error_for_generation(
                     &context_for_exit,
                     &pty_id_for_exit,
+                    generation,
+                    &exit_gate,
                     "overflow",
                     "pty output backlog overflowed; reattach to continue receiving output",
                 );
@@ -2167,7 +2282,7 @@ impl Inner {
                     code,
                     &context_for_exit,
                     generation,
-                    &publication_gate,
+                    &exit_gate,
                 );
             }
         });

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -914,7 +914,7 @@ impl Inner {
         }
 
         // Keep both locks held until the attachment is installed. `close`
-        // takes opening_state first, so it cannot observe a gap between
+        // `close_if_transport` takes opening_state first, so it cannot observe a gap between
         // removing the opening marker and inserting the attachment.
         let mut attachments = self.attachments.lock().expect("attach lock");
         let mut opening = self.opening_state.lock().expect("opening state lock");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1085,6 +1085,21 @@ impl ControlGuard {
     }
 }
 
+async fn request_control_with_cancellation(
+    control: &Arc<dyn ControlHandle>,
+    cmd: &str,
+    params: Value,
+    cancellation: &CancellationToken,
+) -> Option<Value> {
+    tokio::select! {
+        response = control.request(cmd, params) => response,
+        _ = cancellation.cancelled() => {
+            control.end();
+            None
+        }
+    }
+}
+
 impl Drop for ControlGuard {
     fn drop(&mut self) {
         if let Some(control) = self.0.take() {
@@ -1933,7 +1948,13 @@ impl Inner {
         } else {
             json!({ "surface": surface_id })
         };
-        let attached = control.request("attach-surface", attach_params).await;
+        let attached = request_control_with_cancellation(
+            &control,
+            "attach-surface",
+            attach_params,
+            &context.cancellation,
+        )
+        .await;
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
             control.end();
             let reason = attached

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -451,6 +451,7 @@ struct Attachment {
     /// Transport that opened this attachment (see FrameContext::transport_id).
     transport_id: Option<String>,
     generation: u64,
+    publication_gate: Arc<Mutex<()>>,
 }
 
 struct Inner {
@@ -913,6 +914,9 @@ impl Inner {
             opened.control.kill();
             return;
         }
+        let previous_gate = attachments.get(&pty_id).map(|a| Arc::clone(&a.publication_gate));
+        let _previous_publication =
+            previous_gate.as_ref().map(|gate| gate.lock().expect("attachment publication lock"));
         let previous = attachments.insert(
             pty_id.clone(),
             Attachment {
@@ -921,6 +925,7 @@ impl Inner {
                 actor_id: actor.to_owned(),
                 transport_id: context.transport_id.clone(),
                 generation: opened.generation,
+                publication_gate: Arc::clone(&opened.publication_gate),
             },
         );
         if let Some(previous) = previous {
@@ -955,13 +960,20 @@ impl Inner {
         pty_id: &str,
         context: &FrameContext,
         generation: u64,
+        publication_gate: Arc<Mutex<()>>,
     ) -> (DataSink, ExitSink) {
         let on_data = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
             Arc::new(move |chunk: Bytes| {
-                inner.emit_output_for_generation(&pty_id, &chunk, &context, generation)
+                inner.emit_output_for_generation(
+                    &pty_id,
+                    &chunk,
+                    &context,
+                    generation,
+                    &publication_gate,
+                )
             }) as Arc<dyn Fn(Bytes) + Send + Sync>
         };
         let on_exit = {
@@ -969,7 +981,13 @@ impl Inner {
             let context = context.clone();
             let pty_id = pty_id.to_owned();
             Arc::new(move |code: i64| {
-                inner.emit_exit_for_generation(&pty_id, code, &context, generation)
+                inner.emit_exit_for_generation(
+                    &pty_id,
+                    code,
+                    &context,
+                    generation,
+                    &publication_gate,
+                )
             }) as Arc<dyn Fn(i64) + Send + Sync>
         };
         (on_data, on_exit)
@@ -981,16 +999,17 @@ impl Inner {
         chunk: &Bytes,
         context: &FrameContext,
         generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
     ) {
-        if !self
-            .attachments
-            .lock()
-            .expect("attach lock")
-            .get(pty_id)
-            .is_some_and(|a| a.generation == generation)
+        let attachments = self.attachments.lock().expect("attach lock");
+        let Some(current) = attachments.get(pty_id) else { return };
+        if current.generation != generation
+            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
         {
             return;
         }
+        let _publication = publication_gate.lock().expect("attachment publication lock");
+        drop(attachments);
         let auth = Self::auth_snapshot(context);
         if self
             .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
@@ -1034,7 +1053,17 @@ impl Inner {
         code: i64,
         context: &FrameContext,
         generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
     ) {
+        let attachments = self.attachments.lock().expect("attach lock");
+        let Some(current) = attachments.get(pty_id) else { return };
+        if current.generation != generation
+            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+        {
+            return;
+        }
+        let _publication = publication_gate.lock().expect("attachment publication lock");
+        drop(attachments);
         let auth = Self::auth_snapshot(context);
         if self
             .authorize_snapshot_for_generation(pty_id, &auth, context, "exit", generation)
@@ -1046,6 +1075,7 @@ impl Inner {
         match attachments.get(pty_id) {
             Some(attachment)
                 if attachment.generation == generation
+                    && Arc::ptr_eq(&attachment.publication_gate, publication_gate)
                     && !attachment.closing.load(Ordering::SeqCst) => {}
             _ => return,
         }
@@ -1196,6 +1226,7 @@ struct Opened {
     control: Arc<dyn PtyControl>,
     closing: Arc<AtomicBool>,
     generation: u64,
+    publication_gate: Arc<Mutex<()>>,
     start: Box<dyn FnOnce() + Send>,
 }
 
@@ -1375,13 +1406,16 @@ impl Inner {
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let (on_data, on_exit) = self.sinks(pty_id, context, generation);
+        let publication_gate = Arc::new(Mutex::new(()));
+        let (on_data, on_exit) =
+            self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
         Ok(Opened {
             created: ensured.created,
             surface: None,
             control,
             closing: Arc::new(AtomicBool::new(false)),
             generation,
+            publication_gate,
             start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
         })
     }
@@ -1522,7 +1556,9 @@ impl Inner {
         let released = Arc::new(AtomicBool::new(false));
         let closing = Arc::new(AtomicBool::new(false));
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let (on_data, on_exit) = self.sinks(pty_id, context, generation);
+        let publication_gate = Arc::new(Mutex::new(()));
+        let (on_data, on_exit) =
+            self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
 
         // The per-attachment control proxies onto the session pty but its
         // kill() only unhooks this viewer (release), never the session.
@@ -1561,7 +1597,15 @@ impl Inner {
             }
         });
 
-        Ok(Opened { created, surface: None, control: proxy, closing, generation, start })
+        Ok(Opened {
+            created,
+            surface: None,
+            control: proxy,
+            closing,
+            generation,
+            publication_gate,
+            start,
+        })
     }
 }
 
@@ -2103,7 +2147,8 @@ impl Inner {
         let proxy =
             Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let (on_data, _) = self.sinks(pty_id, context, generation);
+        let publication_gate = Arc::new(Mutex::new(()));
+        let (on_data, _) = self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
         let pty_id_for_exit = pty_id.to_owned();
@@ -2123,6 +2168,7 @@ impl Inner {
                     code,
                     &context_for_exit,
                     generation,
+                    &publication_gate,
                 );
             }
         });
@@ -2133,6 +2179,7 @@ impl Inner {
             control: proxy,
             closing: Arc::new(AtomicBool::new(false)),
             generation,
+            publication_gate,
             start: Box::new(move || start_stream.go_live(on_data, on_exit)),
         }))
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2673,7 +2673,7 @@ impl Inner {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::control::{CloseHandler, EventHandler};
+    use crate::control::{CONTROL_TIMEOUT_MS, CloseHandler, EventHandler};
     use std::future::Future;
     #[cfg(unix)]
     use std::os::unix::fs::MetadataExt;
@@ -2682,6 +2682,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
     use std::thread;
+    use std::time::Duration;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 
@@ -3491,6 +3492,37 @@ mod tests {
         }
     }
 
+    struct StalledDetachControl {
+        ended: Arc<AtomicUsize>,
+    }
+
+    impl ControlHandle for StalledDetachControl {
+        fn request(
+            &self,
+            _cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            Box::pin(async { Some(json!({ "ok": true })) })
+        }
+        fn send(&self, _cmd: &str, _params: Value) -> bool {
+            true
+        }
+        fn send_reliable(
+            &self,
+            _cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = bool> + Send + '_>> {
+            Box::pin(std::future::pending())
+        }
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {
+            self.ended.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+    }
+
     #[test]
     fn control_leases_detach_each_surface_and_end_once_after_last_release() {
         let h = harness(None, None);
@@ -3505,6 +3537,27 @@ mod tests {
         assert_eq!(ended.load(AtomicOrdering::SeqCst), 0);
         second.release(8, Some("lease-b"), true);
         assert_eq!(detached.load(AtomicOrdering::SeqCst), 2);
+        assert_eq!(ended.load(AtomicOrdering::SeqCst), 1);
+        assert!(h.manager.inner.control_users.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn stalled_detach_releases_control_after_deadline() {
+        let h = harness(None, None);
+        let ended = Arc::new(AtomicUsize::new(0));
+        let control: Arc<dyn ControlHandle> =
+            Arc::new(StalledDetachControl { ended: Arc::clone(&ended) });
+        let lease = h.manager.inner.register_control_user(&control);
+
+        lease.release(7, Some("lease-a"), true);
+
+        tokio::time::timeout(Duration::from_millis(CONTROL_TIMEOUT_MS + 500), async {
+            while ended.load(AtomicOrdering::SeqCst) == 0 {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("stalled detach must not retain the control lease");
         assert_eq!(ended.load(AtomicOrdering::SeqCst), 1);
         assert!(h.manager.inner.control_users.lock().unwrap().is_empty());
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3560,13 +3560,24 @@ mod tests {
         entered.wait();
 
         let replacement = h.context("supervised", h.owner.clone());
-        h.manager.handle_frame(&frame, &replacement).await;
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let replacement_for_task = replacement.clone();
+        let frame_for_replacement = frame.clone();
+        let replacement_task = tokio::spawn(async move {
+            manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !replacement_task.is_finished(),
+            "same-ID replacement must wait for the closing publication"
+        );
         assert!(!h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
         }));
 
         release.wait();
         exit.join().expect("exit callback");
+        replacement_task.await.expect("replacement open");
         h.manager.handle_frame(&frame, &replacement).await;
         assert!(h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -734,10 +734,13 @@ impl Inner {
             // transport ownership check uses the same order.
             let attachments = self.attachments.lock().expect("attach lock");
             let mut opening = self.opening_state.lock().expect("opening state lock");
-            let attached = attachments.contains_key(&pty_id);
-            if attached || opening.ids.contains_key(&pty_id) {
+            let attached = attachments.get(&pty_id);
+            let closing = attached
+                .as_ref()
+                .is_some_and(|attachment| attachment.closing.load(Ordering::SeqCst));
+            if (attached.is_some() && !closing) || opening.ids.contains_key(&pty_id) {
                 Err(("bad_request", "ptyId is already attached".to_owned()))
-            } else if attachments.len() + opening.ids.len() >= self.max_ptys {
+            } else if !closing && attachments.len() + opening.ids.len() >= self.max_ptys {
                 Err((
                     "session_limit",
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1933,11 +1933,10 @@ struct ControlTerminalControl {
 impl PtyControl for ControlTerminalControl {
     fn write(&self, data: &[u8]) -> bool {
         self.control
-            .send("send", json!({ "surface": self.surface_id, "bytes": BASE64.encode(data) }));
-        true
+            .send("send", json!({ "surface": self.surface_id, "bytes": BASE64.encode(data) }))
     }
     fn resize(&self, cols: u16, rows: u16) {
-        self.control.send(
+        let _ = self.control.send(
             "resize-surface",
             json!({ "surface": self.surface_id, "cols": cols, "rows": rows }),
         );
@@ -3237,7 +3236,9 @@ mod tests {
             };
             Box::pin(async move { response })
         }
-        fn send(&self, _cmd: &str, _params: Value) {}
+        fn send(&self, _cmd: &str, _params: Value) -> bool {
+            false
+        }
         fn on_event(&self, _handler: EventHandler) {}
         fn on_close(&self, _handler: CloseHandler) {}
         fn pause(&self) {}

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -526,7 +526,9 @@ impl ControlLease {
                 return;
             }
             if !self.control.send("detach-attached-view", params) {
-                return;
+                // No Tokio runtime is available for the reliable path. The
+                // transport is already closing, so retire local ownership.
+                // Runtime callers use send_reliable above before this point.
             }
         }
         self.finish_count();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1123,28 +1123,50 @@ impl Inner {
         generation: u64,
         publication_gate: &Arc<Mutex<()>>,
     ) {
-        let gate = {
+        let (gate, revoked_before_gate) = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
-                || !(context.live_authorized)(&current.actor_id)
             {
                 return;
             }
-            Arc::clone(&current.publication_gate)
+            (Arc::clone(&current.publication_gate), !(context.live_authorized)(&current.actor_id))
         };
+        if revoked_before_gate {
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                generation,
+                publication_gate,
+                "trust_revoked",
+                "PTY output refused after trust change",
+            );
+            return;
+        }
         let _publication = gate.lock().expect("attachment publication lock");
-        {
+        let revoked = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
                 || current.closing.load(Ordering::SeqCst)
-                || !(context.live_authorized)(&current.actor_id)
             {
                 return;
             }
+            !(context.live_authorized)(&current.actor_id)
+        };
+        if revoked {
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                generation,
+                publication_gate,
+                "trust_revoked",
+                "PTY output refused after trust change",
+            );
+            return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
         // terminal's write path (D-R6-1); never put an empty frame on the wire.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1186,7 +1186,6 @@ impl Inner {
             if owner.as_deref() == transport_id {
                 opening.cancelled.insert(pty_id.to_owned());
             }
-            return;
         }
         drop(opening);
         let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -758,9 +758,9 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let exit_completion = Arc::clone(&completion);
     let wait_lifecycle = Arc::clone(&lifecycle);
     std::thread::spawn(move || {
-        let observed_exit = child
-            .process_id()
-            .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok());
+        let process_id = child.process_id().map(|pid| pid as libc::pid_t);
+        let observed_exit =
+            process_id.is_some_and(|pid| wait_for_child_exit_without_reaping(pid).is_ok());
         if observed_exit {
             wait_lifecycle.mark_exited_before_reap();
         } else if wait_lifecycle.begin_termination() {
@@ -768,6 +768,9 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
             // owned child handle to kill. This keeps a late control drop from
             // racing a PID that the eventual wait may release.
             let _ = child.kill();
+            if let Some(pid) = process_id {
+                force_kill_process_group(pid);
+            }
         }
         // Fence all late control cleanup before entering wait. Once wait
         // starts, the child may be reaped and its PID reused, so no later

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1490,6 +1490,14 @@ mod tests {
     }
 
     #[test]
+    fn child_lifecycle_reserves_termination_and_force_kill_together() {
+        let lifecycle = ChildLifecycle::new();
+        assert!(lifecycle.begin_termination_and_force_kill());
+        assert!(!lifecycle.begin_termination());
+        assert!(!lifecycle.begin_force_kill());
+    }
+
+    #[test]
     fn pipe_control_drop_requests_kill_for_owned_child() {
         let (command_tx, command_rx) = mpsc::channel();
         {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -477,6 +477,17 @@ struct MasterControl {
     killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
 }
 
+impl Drop for MasterControl {
+    fn drop(&mut self) {
+        // A cancelled spawn_blocking task can finish after its JoinHandle has
+        // been aborted. Dropping the late handle must still terminate the
+        // child, since the wait thread owns the Child value separately.
+        if let Ok(mut killer) = self.killer.lock() {
+            let _ = killer.kill();
+        }
+    }
+}
+
 impl PtyControl for MasterControl {
     fn write(&self, data: &[u8]) {
         if let Ok(mut writer) = self.writer.lock() {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -470,19 +470,54 @@ impl Drop for SpawnedChildCleanup {
     }
 }
 
+#[derive(Default)]
+struct ChildLifecycleState {
+    exited: bool,
+    termination_started: bool,
+}
+
+/// Coordinates late PTY-control drops with the wait thread. A successful
+/// WNOWAIT observation marks the child exited while its PID is still reserved;
+/// a late control drop then cannot signal a reused PID.
+struct ChildLifecycle {
+    state: Mutex<ChildLifecycleState>,
+}
+
+impl ChildLifecycle {
+    fn new() -> Arc<Self> {
+        Arc::new(Self { state: Mutex::new(ChildLifecycleState::default()) })
+    }
+
+    fn mark_exited_before_reap(&self) {
+        self.state.lock().expect("child lifecycle lock").exited = true;
+    }
+
+    fn begin_termination(&self) -> bool {
+        let mut state = self.state.lock().expect("child lifecycle lock");
+        if state.exited || state.termination_started {
+            return false;
+        }
+        state.termination_started = true;
+        true
+    }
+}
+
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
     killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
+    lifecycle: Arc<ChildLifecycle>,
 }
 
 impl Drop for MasterControl {
     fn drop(&mut self) {
         // A cancelled spawn_blocking task can finish after its JoinHandle has
-        // been aborted. Dropping the late handle must still terminate the
-        // child, since the wait thread owns the Child value separately.
-        if let Ok(mut killer) = self.killer.lock() {
+        // been aborted. Terminate only while the wait thread still owns a
+        // live child, and never after it has observed exit with WNOWAIT.
+        if self.lifecycle.begin_termination()
+            && let Ok(mut killer) = self.killer.lock()
+        {
             let _ = killer.kill();
         }
     }
@@ -503,7 +538,9 @@ impl PtyControl for MasterControl {
     fn pause(&self) {}
     fn resume(&self) {}
     fn kill(&self) {
-        if let Ok(mut killer) = self.killer.lock() {
+        if self.lifecycle.begin_termination()
+            && let Ok(mut killer) = self.killer.lock()
+        {
             let _ = killer.kill();
         }
     }
@@ -545,6 +582,15 @@ impl PtyControl for PipeControl {
             return;
         }
         let _ = self.command_tx.send(PipeChildCommand::Kill);
+    }
+}
+
+impl Drop for PipeControl {
+    fn drop(&mut self) {
+        // The wait thread owns the Child. Send a kill before the command
+        // channel closes, so a late spawn_blocking result cannot leave a
+        // fallback process waiting forever on EOF.
+        self.kill();
     }
 }
 
@@ -604,10 +650,12 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let mut child_cleanup = SpawnedChildCleanup::new(child);
     let writer = master.take_writer()?;
     let killer = child_cleanup.child().clone_killer();
+    let lifecycle = ChildLifecycle::new();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
         writer: Mutex::new(writer),
         killer: Mutex::new(killer),
+        lifecycle: Arc::clone(&lifecycle),
     });
     output.set_overflow_control(&control);
     // Use the same bounded post-exit grace as pipe fallback. A background
@@ -622,8 +670,21 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     // Blocking wait thread -> exit.
     let mut child = child_cleanup.take();
     let exit_completion = Arc::clone(&completion);
+    let wait_lifecycle = Arc::clone(&lifecycle);
     std::thread::spawn(move || {
+        let observed_exit = child
+            .process_id()
+            .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok());
+        if observed_exit {
+            wait_lifecycle.mark_exited_before_reap();
+        } else if wait_lifecycle.begin_termination() {
+            // If WNOWAIT is unavailable, claim termination before asking the
+            // owned child handle to kill. This keeps a late control drop from
+            // racing a PID that the eventual wait may release.
+            let _ = child.kill();
+        }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+        wait_lifecycle.mark_exited_before_reap();
         exit_completion.child_exited(code);
     });
 
@@ -1268,6 +1329,30 @@ mod tests {
 
         assert!(matches!(command_rx.recv(), Ok(PipeChildCommand::Kill)));
         assert!(command_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn child_lifecycle_fences_kill_after_exit_observation() {
+        let lifecycle = ChildLifecycle::new();
+        assert!(lifecycle.begin_termination());
+        assert!(!lifecycle.begin_termination());
+
+        let exited = ChildLifecycle::new();
+        exited.mark_exited_before_reap();
+        assert!(!exited.begin_termination());
+    }
+
+    #[test]
+    fn pipe_control_drop_requests_kill_for_owned_child() {
+        let (command_tx, command_rx) = mpsc::channel();
+        {
+            let control = PipeControl {
+                stdin: Mutex::new(None),
+                command_tx,
+                kill_requested: AtomicBool::new(false),
+            };
+        }
+        assert!(matches!(command_rx.recv(), Ok(PipeChildCommand::Kill)));
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -485,6 +485,7 @@ impl Drop for SpawnedChildCleanup {
 struct ChildLifecycleState {
     exited: bool,
     termination_started: bool,
+    force_kill_started: bool,
 }
 
 /// Coordinates late PTY-control drops with the wait thread. A successful
@@ -511,6 +512,34 @@ impl ChildLifecycle {
         state.termination_started = true;
         true
     }
+
+    fn begin_force_kill(&self) -> bool {
+        let mut state = self.state.lock().expect("child lifecycle lock");
+        if state.exited || state.force_kill_started {
+            return false;
+        }
+        state.force_kill_started = true;
+        true
+    }
+}
+
+fn force_kill_process_group(pid: libc::pid_t) {
+    if pid > 0 {
+        // The wait owner fences this call with ChildLifecycle before reaping,
+        // so the process group still belongs to the spawned child and cannot
+        // be reused by an unrelated process.
+        unsafe {
+            let _ = libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+}
+
+fn force_kill_process(pid: libc::pid_t) {
+    if pid > 0 {
+        unsafe {
+            let _ = libc::kill(pid, libc::SIGKILL);
+        }
+    }
 }
 
 /// A real PTY master behind a mutex; write/resize block briefly.
@@ -520,6 +549,7 @@ struct MasterControl {
     writer_bytes: Arc<AtomicU64>,
     killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
     lifecycle: Arc<ChildLifecycle>,
+    process_group: libc::pid_t,
 }
 
 impl Drop for MasterControl {
@@ -531,6 +561,9 @@ impl Drop for MasterControl {
             && let Ok(mut killer) = self.killer.lock()
         {
             let _ = killer.kill();
+        }
+        if self.lifecycle.begin_force_kill() {
+            force_kill_process_group(self.process_group);
         }
     }
 }
@@ -556,6 +589,9 @@ impl PtyControl for MasterControl {
             && let Ok(mut killer) = self.killer.lock()
         {
             let _ = killer.kill();
+        }
+        if self.lifecycle.begin_force_kill() {
+            force_kill_process_group(self.process_group);
         }
     }
 }
@@ -689,6 +725,8 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         }
     });
     let killer = child_cleanup.child().clone_killer();
+    let pid = child_cleanup.child().process_id().unwrap_or(0) as libc::pid_t;
+    let process_group = master.process_group_leader().unwrap_or(pid);
     let lifecycle = ChildLifecycle::new();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
@@ -696,6 +734,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         writer_bytes,
         killer: Mutex::new(killer),
         lifecycle: Arc::clone(&lifecycle),
+        process_group,
     });
     output.set_overflow_control(&control);
     // Use the same bounded post-exit grace as pipe fallback. A background
@@ -872,10 +911,12 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                         Ok(PipeChildCommand::ExitReady) => exit_ready = true,
                         Ok(PipeChildCommand::ObserveFailed) => {
                             let _ = child.kill();
+                            force_kill_process(pid);
                             exit_ready = true;
                         }
                         Ok(PipeChildCommand::Kill) => {
                             let _ = child.kill();
+                            force_kill_process(pid);
                         }
                         Err(_) => exit_ready = true,
                     }
@@ -1446,6 +1487,12 @@ mod tests {
         let exited = ChildLifecycle::new();
         exited.mark_exited_before_reap();
         assert!(!exited.begin_termination());
+        assert!(!exited.begin_force_kill());
+
+        let force = ChildLifecycle::new();
+        assert!(force.begin_termination());
+        assert!(force.begin_force_kill());
+        assert!(!force.begin_force_kill());
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1093,6 +1093,7 @@ impl PtyDeps for RealPtyDeps {
                 // dead handle immediately; the closure observes cancellation
                 // at its next safe boundary and releases any allocation.
                 task.abort();
+                fallback_output.push_exit(1);
                 PtyHandle { control: Arc::new(DeadControl), output: fallback_output, banner: None }
             }
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -875,19 +875,6 @@ async fn socket_exists(path: &Path) -> bool {
 /// Stop a daemon that was started by `ensure_daemon` but never became ready.
 /// The daemon is placed in its own process group, so cleanup also covers
 /// children it may have spawned before readiness failed.
-async fn cleanup_daemon(mut child: tokio::process::Child) {
-    if let Some(pid) = child.id() {
-        unsafe {
-            let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
-        }
-    }
-    let _ = child.start_kill();
-    // The kill is issued before this owned handle can be dropped by a
-    // cancelled cleanup future. Await only to reap when the runtime remains
-    // alive; the process cannot continue running after the forceful signal.
-    let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
-}
-
 /// Own a newly spawned daemon until readiness is proven. Cancellation drops
 /// this guard, which force-kills the process group and schedules a reap.
 struct DaemonChildGuard {
@@ -903,10 +890,17 @@ impl DaemonChildGuard {
         self.child.take().expect("daemon child guard owns a child")
     }
 
-    async fn cleanup(mut self) {
-        if let Some(child) = self.child.take() {
-            cleanup_daemon(child).await;
+    async fn cleanup(&mut self) {
+        let Some(child) = self.child.as_mut() else { return };
+        if let Some(pid) = child.id() {
+            unsafe {
+                let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+            }
         }
+        let _ = child.start_kill();
+        // Keep the child in this guard while awaiting. If cancellation cuts
+        // this wait short, Drop still owns the handle and schedules a reap.
+        let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -608,10 +608,9 @@ enum PipeChildCommand {
 }
 
 /// A degraded pipe-mode shell (no TTY) used when PTY allocation fails.
-/// The child itself remains owned by the wait thread. The control only sends
-/// commands to that owner and retains the child's stdin for input.
+/// The child itself remains owned by the wait thread. The control queues stdin
+/// writes and sends commands to that owner.
 struct PipeControl {
-    stdin: Mutex<Option<std::process::ChildStdin>>,
     stdin_tx: Option<mpsc::SyncSender<Vec<u8>>>,
     stdin_bytes: Arc<AtomicU64>,
     command_tx: mpsc::Sender<PipeChildCommand>,
@@ -626,13 +625,6 @@ impl PtyControl for PipeControl {
             {
                 self.stdin_bytes.fetch_sub(data.len() as u64, Ordering::AcqRel);
             }
-            return;
-        }
-        if let Ok(mut guard) = self.stdin.lock()
-            && let Some(stdin) = guard.as_mut()
-        {
-            let _ = stdin.write_all(data);
-            let _ = stdin.flush();
         }
     }
     fn resize(&self, _cols: u16, _rows: u16) {}
@@ -817,7 +809,7 @@ fn pump_pty(
     completion.reader_finished();
 }
 
-fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
+fn spawn_pipe_mode(spec: &SpawnSpec, reason: impl std::fmt::Display) -> PtyHandle {
     let output = ThreadOutput::new();
     let mut command = std::process::Command::new(&spec.file);
     command.args(&spec.args).env_clear();
@@ -857,7 +849,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
         Ok(mut child) => {
             let stdin = child.stdin.take();
             let stdin_bytes = Arc::new(AtomicU64::new(0));
-            let (stdin_tx, stdin_for_control) = match stdin {
+            let stdin_tx = match stdin {
                 Some(mut stdin) => {
                     let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(PTY_WRITE_QUEUE_ITEMS);
                     let stdin_bytes_for_thread = Arc::clone(&stdin_bytes);
@@ -871,14 +863,13 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                             stdin_bytes_for_thread.fetch_sub(len, Ordering::AcqRel);
                         }
                     });
-                    (Some(tx), None)
+                    Some(tx)
                 }
-                None => (None, None),
+                None => None,
             };
             let pid = child.id() as libc::pid_t;
             let (command_tx, command_rx) = mpsc::channel();
             let control = Arc::new(PipeControl {
-                stdin: Mutex::new(stdin_for_control),
                 stdin_tx,
                 stdin_bytes,
                 command_tx: command_tx.clone(),
@@ -1059,9 +1050,7 @@ impl PtyDeps for RealPtyDeps {
             }
             let handle = match spawn_real_pty(&spec) {
                 Ok(handle) => handle,
-                Err(error) if !spec.cancellation.is_cancelled() => {
-                    spawn_pipe_mode(&spec, &error.to_string())
-                }
+                Err(error) if !spec.cancellation.is_cancelled() => spawn_pipe_mode(&spec, &error),
                 Err(_) => {
                     task_output.push_exit(1);
                     return PtyHandle {
@@ -1470,7 +1459,6 @@ mod tests {
     fn pipe_control_sends_one_kill_request_to_owned_child() {
         let (command_tx, command_rx) = mpsc::channel();
         let control = PipeControl {
-            stdin: Mutex::new(None),
             stdin_tx: None,
             stdin_bytes: Arc::new(AtomicU64::new(0)),
             command_tx,
@@ -1506,7 +1494,6 @@ mod tests {
         let (command_tx, command_rx) = mpsc::channel();
         {
             let control = PipeControl {
-                stdin: Mutex::new(None),
                 stdin_tx: None,
                 stdin_bytes: Arc::new(AtomicU64::new(0)),
                 command_tx,

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -521,6 +521,16 @@ impl ChildLifecycle {
         state.force_kill_started = true;
         true
     }
+
+    fn begin_termination_and_force_kill(&self) -> bool {
+        let mut state = self.state.lock().expect("child lifecycle lock");
+        if state.exited || state.termination_started || state.force_kill_started {
+            return false;
+        }
+        state.termination_started = true;
+        state.force_kill_started = true;
+        true
+    }
 }
 
 fn force_kill_process_group(pid: libc::pid_t) {
@@ -557,25 +567,25 @@ impl Drop for MasterControl {
         // A cancelled spawn_blocking task can finish after its JoinHandle has
         // been aborted. Terminate only while the wait thread still owns a
         // live child, and never after it has observed exit with WNOWAIT.
-        if self.lifecycle.begin_termination()
-            && let Ok(mut killer) = self.killer.lock()
-        {
-            let _ = killer.kill();
-        }
-        if self.lifecycle.begin_force_kill() {
+        if self.lifecycle.begin_termination_and_force_kill() {
+            if let Ok(mut killer) = self.killer.lock() {
+                let _ = killer.kill();
+            }
             force_kill_process_group(self.process_group);
         }
     }
 }
 
 impl PtyControl for MasterControl {
-    fn write(&self, data: &[u8]) {
+    fn write(&self, data: &[u8]) -> bool {
         if !reserve_write_bytes(&self.writer_bytes, data.len()) {
-            return;
+            return false;
         }
         if self.writer_tx.try_send(data.to_vec()).is_err() {
             self.writer_bytes.fetch_sub(data.len() as u64, Ordering::AcqRel);
+            return false;
         }
+        true
     }
     fn resize(&self, cols: u16, rows: u16) {
         if let Ok(master) = self.master.lock() {
@@ -585,12 +595,10 @@ impl PtyControl for MasterControl {
     fn pause(&self) {}
     fn resume(&self) {}
     fn kill(&self) {
-        if self.lifecycle.begin_termination()
-            && let Ok(mut killer) = self.killer.lock()
-        {
-            let _ = killer.kill();
-        }
-        if self.lifecycle.begin_force_kill() {
+        if self.lifecycle.begin_termination_and_force_kill() {
+            if let Ok(mut killer) = self.killer.lock() {
+                let _ = killer.kill();
+            }
             force_kill_process_group(self.process_group);
         }
     }
@@ -618,14 +626,18 @@ struct PipeControl {
 }
 
 impl PtyControl for PipeControl {
-    fn write(&self, data: &[u8]) {
+    fn write(&self, data: &[u8]) -> bool {
         if let Some(stdin_tx) = &self.stdin_tx {
-            if reserve_write_bytes(&self.stdin_bytes, data.len())
-                && stdin_tx.try_send(data.to_vec()).is_err()
-            {
-                self.stdin_bytes.fetch_sub(data.len() as u64, Ordering::AcqRel);
+            if !reserve_write_bytes(&self.stdin_bytes, data.len()) {
+                return false;
             }
+            if stdin_tx.try_send(data.to_vec()).is_err() {
+                self.stdin_bytes.fetch_sub(data.len() as u64, Ordering::AcqRel);
+                return false;
+            }
+            return true;
         }
+        false
     }
     fn resize(&self, _cols: u16, _rows: u16) {}
     fn pause(&self) {}
@@ -934,7 +946,9 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: impl std::fmt::Display) -> PtyHandl
 
 struct DeadControl;
 impl PtyControl for DeadControl {
-    fn write(&self, _data: &[u8]) {}
+    fn write(&self, _data: &[u8]) -> bool {
+        true
+    }
     fn resize(&self, _cols: u16, _rows: u16) {}
     fn pause(&self) {}
     fn resume(&self) {}
@@ -1273,7 +1287,9 @@ mod tests {
     }
 
     impl PtyControl for TestControl {
-        fn write(&self, _data: &[u8]) {}
+        fn write(&self, _data: &[u8]) -> bool {
+            true
+        }
         fn resize(&self, _cols: u16, _rows: u16) {}
         fn pause(&self) {}
         fn resume(&self) {}

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -552,6 +552,7 @@ impl PtyControl for MasterControl {
 enum PipeChildCommand {
     Kill,
     ExitReady,
+    ObserveFailed,
 }
 
 /// A degraded pipe-mode shell (no TTY) used when PTY allocation fails.
@@ -823,8 +824,12 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
             // signals use the still-owned Child handle.
             let observer_tx = command_tx;
             std::thread::spawn(move || {
-                let _ = wait_for_child_exit_without_reaping(pid);
-                let _ = observer_tx.send(PipeChildCommand::ExitReady);
+                let command = if wait_for_child_exit_without_reaping(pid).is_ok() {
+                    PipeChildCommand::ExitReady
+                } else {
+                    PipeChildCommand::ObserveFailed
+                };
+                let _ = observer_tx.send(command);
             });
             let wait_completion = Arc::clone(&completion);
             std::thread::spawn(move || {
@@ -832,6 +837,10 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
                 while !exit_ready {
                     match command_rx.recv() {
                         Ok(PipeChildCommand::ExitReady) => exit_ready = true,
+                        Ok(PipeChildCommand::ObserveFailed) => {
+                            let _ = child.kill();
+                            exit_ready = true;
+                        }
                         Ok(PipeChildCommand::Kill) => {
                             let _ = child.kill();
                         }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -37,6 +37,16 @@ const THREAD_OUTPUT_OVERFLOW_EXIT: i64 = 75;
 const PIPE_OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(250);
 const PIPE_READ_POLL_MS: i32 = 100;
 const PTY_WRITE_QUEUE_ITEMS: usize = 256;
+const PTY_WRITE_QUEUE_BYTES: u64 = 1_048_576;
+
+fn reserve_write_bytes(queued: &AtomicU64, len: usize) -> bool {
+    let len = len as u64;
+    queued
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+            current.checked_add(len).filter(|total| *total <= PTY_WRITE_QUEUE_BYTES)
+        })
+        .is_ok()
+}
 // `lifecycle_ready` was added to the cmux-tui control protocol at version 12.
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
@@ -507,6 +517,7 @@ impl ChildLifecycle {
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer_tx: mpsc::SyncSender<Vec<u8>>,
+    writer_bytes: Arc<AtomicU64>,
     killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
     lifecycle: Arc<ChildLifecycle>,
 }
@@ -526,7 +537,12 @@ impl Drop for MasterControl {
 
 impl PtyControl for MasterControl {
     fn write(&self, data: &[u8]) {
-        let _ = self.writer_tx.try_send(data.to_vec());
+        if !reserve_write_bytes(&self.writer_bytes, data.len()) {
+            return;
+        }
+        if self.writer_tx.try_send(data.to_vec()).is_err() {
+            self.writer_bytes.fetch_sub(data.len() as u64, Ordering::AcqRel);
+        }
     }
     fn resize(&self, cols: u16, rows: u16) {
         if let Ok(master) = self.master.lock() {
@@ -561,6 +577,7 @@ enum PipeChildCommand {
 struct PipeControl {
     stdin: Mutex<Option<std::process::ChildStdin>>,
     stdin_tx: Option<mpsc::SyncSender<Vec<u8>>>,
+    stdin_bytes: Arc<AtomicU64>,
     command_tx: mpsc::Sender<PipeChildCommand>,
     kill_requested: AtomicBool,
 }
@@ -568,7 +585,11 @@ struct PipeControl {
 impl PtyControl for PipeControl {
     fn write(&self, data: &[u8]) {
         if let Some(stdin_tx) = &self.stdin_tx {
-            let _ = stdin_tx.try_send(data.to_vec());
+            if reserve_write_bytes(&self.stdin_bytes, data.len())
+                && stdin_tx.try_send(data.to_vec()).is_err()
+            {
+                self.stdin_bytes.fetch_sub(data.len() as u64, Ordering::AcqRel);
+            }
             return;
         }
         if let Ok(mut guard) = self.stdin.lock()
@@ -654,12 +675,17 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let mut child_cleanup = SpawnedChildCleanup::new(child);
     let writer = master.take_writer()?;
     let (writer_tx, writer_rx) = mpsc::sync_channel(PTY_WRITE_QUEUE_ITEMS);
+    let writer_bytes = Arc::new(AtomicU64::new(0));
+    let writer_bytes_for_thread = Arc::clone(&writer_bytes);
     std::thread::spawn(move || {
         let mut writer = writer;
         while let Ok(data) = writer_rx.recv() {
+            let len = data.len() as u64;
             if writer.write_all(&data).is_err() || writer.flush().is_err() {
+                writer_bytes_for_thread.fetch_sub(len, Ordering::AcqRel);
                 break;
             }
+            writer_bytes_for_thread.fetch_sub(len, Ordering::AcqRel);
         }
     });
     let killer = child_cleanup.child().clone_killer();
@@ -667,6 +693,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
         writer_tx,
+        writer_bytes,
         killer: Mutex::new(killer),
         lifecycle: Arc::clone(&lifecycle),
     });
@@ -784,14 +811,19 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     match command.spawn() {
         Ok(mut child) => {
             let stdin = child.stdin.take();
+            let stdin_bytes = Arc::new(AtomicU64::new(0));
             let (stdin_tx, stdin_for_control) = match stdin {
                 Some(mut stdin) => {
                     let (tx, rx) = mpsc::sync_channel(PTY_WRITE_QUEUE_ITEMS);
+                    let stdin_bytes_for_thread = Arc::clone(&stdin_bytes);
                     std::thread::spawn(move || {
                         while let Ok(data) = rx.recv() {
+                            let len = data.len() as u64;
                             if stdin.write_all(&data).is_err() || stdin.flush().is_err() {
+                                stdin_bytes_for_thread.fetch_sub(len, Ordering::AcqRel);
                                 break;
                             }
+                            stdin_bytes_for_thread.fetch_sub(len, Ordering::AcqRel);
                         }
                     });
                     (Some(tx), None)
@@ -803,6 +835,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
             let control = Arc::new(PipeControl {
                 stdin: Mutex::new(stdin_for_control),
                 stdin_tx,
+                stdin_bytes,
                 command_tx: command_tx.clone(),
                 kill_requested: AtomicBool::new(false),
             });
@@ -1392,6 +1425,7 @@ mod tests {
         let control = PipeControl {
             stdin: Mutex::new(None),
             stdin_tx: None,
+            stdin_bytes: Arc::new(AtomicU64::new(0)),
             command_tx,
             kill_requested: AtomicBool::new(false),
         };
@@ -1421,6 +1455,7 @@ mod tests {
             let control = PipeControl {
                 stdin: Mutex::new(None),
                 stdin_tx: None,
+                stdin_bytes: Arc::new(AtomicU64::new(0)),
                 command_tx,
                 kill_requested: AtomicBool::new(false),
             };

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1056,7 +1056,8 @@ impl PtyDeps for RealPtyDeps {
         let output = ThreadOutput::new();
         let task_output = Arc::clone(&output);
         let fallback_output = Arc::clone(&output);
-        tokio::task::spawn_blocking(move || {
+        let cancellation = spec.cancellation.clone();
+        let mut task = tokio::task::spawn_blocking(move || {
             if spec.cancellation.is_cancelled() {
                 task_output.push_exit(1);
                 return PtyHandle {
@@ -1081,12 +1082,20 @@ impl PtyDeps for RealPtyDeps {
                 handle.control.kill();
             }
             handle
-        })
-        .await
-        .unwrap_or_else(|_| {
-            fallback_output.push_exit(1);
-            PtyHandle { control: Arc::new(DeadControl), output: fallback_output, banner: None }
-        })
+        });
+        tokio::select! {
+            result = &mut task => result.unwrap_or_else(|_| {
+                fallback_output.push_exit(1);
+                PtyHandle { control: Arc::new(DeadControl), output: fallback_output, banner: None }
+            }),
+            _ = cancellation.cancelled() => {
+                // spawn_blocking cannot stop a running allocator. Return a
+                // dead handle immediately; the closure observes cancellation
+                // at its next safe boundary and releases any allocation.
+                task.abort();
+                PtyHandle { control: Arc::new(DeadControl), output: fallback_output, banner: None }
+            }
+        }
     }
 
     async fn resolve_cmux_tui(&self) -> Option<CmuxTui> {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -16,7 +16,7 @@ use std::os::fd::AsRawFd;
 use std::os::unix::net::UnixStream;
 use std::os::unix::process::CommandExt;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Condvar, Mutex, mpsc};
 use std::time::{Duration, Instant};
 
@@ -710,7 +710,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let cmux_pty::SpawnedPty { master, child } = spawned;
     let mut child_cleanup = SpawnedChildCleanup::new(child);
     let writer = master.take_writer()?;
-    let (writer_tx, writer_rx) = mpsc::sync_channel(PTY_WRITE_QUEUE_ITEMS);
+    let (writer_tx, writer_rx) = mpsc::sync_channel::<Vec<u8>>(PTY_WRITE_QUEUE_ITEMS);
     let writer_bytes = Arc::new(AtomicU64::new(0));
     let writer_bytes_for_thread = Arc::clone(&writer_bytes);
     std::thread::spawn(move || {
@@ -726,7 +726,10 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     });
     let killer = child_cleanup.child().clone_killer();
     let pid = child_cleanup.child().process_id().unwrap_or(0) as libc::pid_t;
-    let process_group = master.process_group_leader().unwrap_or(pid);
+    // cmux-pty starts the child in its own session. Keep the child PID as the
+    // stable process-group target; the foreground group can change when an
+    // interactive job takes control of the terminal.
+    let process_group = pid;
     let lifecycle = ChildLifecycle::new();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
@@ -762,8 +765,11 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
             // racing a PID that the eventual wait may release.
             let _ = child.kill();
         }
-        let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+        // Fence all late control cleanup before entering wait. Once wait
+        // starts, the child may be reaped and its PID reused, so no later
+        // callback may signal the old process group.
         wait_lifecycle.mark_exited_before_reap();
+        let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
         exit_completion.child_exited(code);
     });
 
@@ -853,7 +859,7 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
             let stdin_bytes = Arc::new(AtomicU64::new(0));
             let (stdin_tx, stdin_for_control) = match stdin {
                 Some(mut stdin) => {
-                    let (tx, rx) = mpsc::sync_channel(PTY_WRITE_QUEUE_ITEMS);
+                    let (tx, rx) = mpsc::sync_channel::<Vec<u8>>(PTY_WRITE_QUEUE_ITEMS);
                     let stdin_bytes_for_thread = Arc::clone(&stdin_bytes);
                     std::thread::spawn(move || {
                         while let Ok(data) = rx.recv() {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -878,19 +878,55 @@ async fn socket_exists(path: &Path) -> bool {
 async fn cleanup_daemon(mut child: tokio::process::Child) {
     if let Some(pid) = child.id() {
         unsafe {
-            let _ = libc::kill(-(pid as libc::pid_t), libc::SIGTERM);
-        }
-    }
-    if tokio::time::timeout(Duration::from_millis(250), child.wait()).await.is_ok() {
-        return;
-    }
-    if let Some(pid) = child.id() {
-        unsafe {
             let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
         }
     }
-    let _ = child.kill().await;
+    let _ = child.start_kill();
+    // The kill is issued before this owned handle can be dropped by a
+    // cancelled cleanup future. Await only to reap when the runtime remains
+    // alive; the process cannot continue running after the forceful signal.
     let _ = tokio::time::timeout(Duration::from_secs(1), child.wait()).await;
+}
+
+/// Own a newly spawned daemon until readiness is proven. Cancellation drops
+/// this guard, which force-kills the process group and schedules a reap.
+struct DaemonChildGuard {
+    child: Option<tokio::process::Child>,
+}
+
+impl DaemonChildGuard {
+    fn new(child: tokio::process::Child) -> Self {
+        Self { child: Some(child) }
+    }
+
+    fn disarm(&mut self) -> tokio::process::Child {
+        self.child.take().expect("daemon child guard owns a child")
+    }
+
+    async fn cleanup(mut self) {
+        if let Some(child) = self.child.take() {
+            cleanup_daemon(child).await;
+        }
+    }
+}
+
+impl Drop for DaemonChildGuard {
+    fn drop(&mut self) {
+        let Some(mut child) = self.child.take() else { return };
+        if let Some(pid) = child.id() {
+            // The child is a dedicated process group. Signal the group before
+            // dropping the handle so descendants do not survive cancellation.
+            unsafe {
+                let _ = libc::kill(-(pid as libc::pid_t), libc::SIGKILL);
+            }
+        }
+        let _ = child.start_kill();
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            handle.spawn(async move {
+                let _ = child.wait().await;
+            });
+        }
+    }
 }
 
 #[async_trait]
@@ -1032,6 +1068,7 @@ impl PtyDeps for RealPtyDeps {
         }
         let child =
             command.spawn().map_err(|error| format!("cmux-tui daemon spawn failed: {error}"))?;
+        let mut child_guard = DaemonChildGuard::new(child);
 
         let deadline = Instant::now() + Duration::from_millis(DAEMON_SOCKET_WAIT_MS);
         while Instant::now() < deadline {
@@ -1040,6 +1077,10 @@ impl PtyDeps for RealPtyDeps {
                 while Instant::now() < deadline {
                     match connect_control(&socket_path, CONTROL_TIMEOUT_MS).await {
                         Ok(control) if control_ready(&control, session).await => {
+                            let mut child = child_guard.disarm();
+                            tokio::spawn(async move {
+                                let _ = child.wait().await;
+                            });
                             return Ok(EnsureDaemon { created: true, socket_path });
                         }
                         _ => tokio::time::sleep(Duration::from_millis(50)).await,
@@ -1048,14 +1089,14 @@ impl PtyDeps for RealPtyDeps {
                 // Do not unlink the path here. Another daemon may have won
                 // the socket race after our initial absence check; ownership
                 // of a pathname cannot be proven after the fact.
-                cleanup_daemon(child).await;
+                child_guard.cleanup().await;
                 return Err(format!(
                     "cmux-tui daemon for \"{session}\" did not become control-ready"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(50)).await;
         }
-        cleanup_daemon(child).await;
+        child_guard.cleanup().await;
         Err(format!("cmux-tui daemon for \"{session}\" never created {}", socket_path.display()))
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -36,6 +36,7 @@ const THREAD_OUTPUT_BACKLOG_CAP: usize = 1024 * 1024;
 const THREAD_OUTPUT_OVERFLOW_EXIT: i64 = 75;
 const PIPE_OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(250);
 const PIPE_READ_POLL_MS: i32 = 100;
+const PTY_WRITE_QUEUE_ITEMS: usize = 256;
 // `lifecycle_ready` was added to the cmux-tui control protocol at version 12.
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
@@ -505,7 +506,7 @@ impl ChildLifecycle {
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
-    writer: Mutex<Box<dyn Write + Send>>,
+    writer_tx: mpsc::SyncSender<Vec<u8>>,
     killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
     lifecycle: Arc<ChildLifecycle>,
 }
@@ -525,10 +526,7 @@ impl Drop for MasterControl {
 
 impl PtyControl for MasterControl {
     fn write(&self, data: &[u8]) {
-        if let Ok(mut writer) = self.writer.lock() {
-            let _ = writer.write_all(data);
-            let _ = writer.flush();
-        }
+        let _ = self.writer_tx.try_send(data.to_vec());
     }
     fn resize(&self, cols: u16, rows: u16) {
         if let Ok(master) = self.master.lock() {
@@ -561,12 +559,17 @@ enum PipeChildCommand {
 /// commands to that owner and retains the child's stdin for input.
 struct PipeControl {
     stdin: Mutex<Option<std::process::ChildStdin>>,
+    stdin_tx: Option<mpsc::SyncSender<Vec<u8>>>,
     command_tx: mpsc::Sender<PipeChildCommand>,
     kill_requested: AtomicBool,
 }
 
 impl PtyControl for PipeControl {
     fn write(&self, data: &[u8]) {
+        if let Some(stdin_tx) = &self.stdin_tx {
+            let _ = stdin_tx.try_send(data.to_vec());
+            return;
+        }
         if let Ok(mut guard) = self.stdin.lock()
             && let Some(stdin) = guard.as_mut()
         {
@@ -649,11 +652,20 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let cmux_pty::SpawnedPty { master, child } = spawned;
     let mut child_cleanup = SpawnedChildCleanup::new(child);
     let writer = master.take_writer()?;
+    let (writer_tx, writer_rx) = mpsc::sync_channel(PTY_WRITE_QUEUE_ITEMS);
+    std::thread::spawn(move || {
+        let mut writer = writer;
+        while let Ok(data) = writer_rx.recv() {
+            if writer.write_all(&data).is_err() || writer.flush().is_err() {
+                break;
+            }
+        }
+    });
     let killer = child_cleanup.child().clone_killer();
     let lifecycle = ChildLifecycle::new();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
-        writer: Mutex::new(writer),
+        writer_tx,
         killer: Mutex::new(killer),
         lifecycle: Arc::clone(&lifecycle),
     });
@@ -771,10 +783,25 @@ fn spawn_pipe_mode(spec: &SpawnSpec, reason: &str) -> PtyHandle {
     match command.spawn() {
         Ok(mut child) => {
             let stdin = child.stdin.take();
+            let (stdin_tx, stdin_for_control) = match stdin {
+                Some(mut stdin) => {
+                    let (tx, rx) = mpsc::sync_channel(PTY_WRITE_QUEUE_ITEMS);
+                    std::thread::spawn(move || {
+                        while let Ok(data) = rx.recv() {
+                            if stdin.write_all(&data).is_err() || stdin.flush().is_err() {
+                                break;
+                            }
+                        }
+                    });
+                    (Some(tx), None)
+                }
+                None => (None, None),
+            };
             let pid = child.id() as libc::pid_t;
             let (command_tx, command_rx) = mpsc::channel();
             let control = Arc::new(PipeControl {
-                stdin: Mutex::new(stdin),
+                stdin: Mutex::new(stdin_for_control),
+                stdin_tx,
                 command_tx: command_tx.clone(),
                 kill_requested: AtomicBool::new(false),
             });
@@ -1355,6 +1382,7 @@ mod tests {
         let (command_tx, command_rx) = mpsc::channel();
         let control = PipeControl {
             stdin: Mutex::new(None),
+            stdin_tx: None,
             command_tx,
             kill_requested: AtomicBool::new(false),
         };
@@ -1383,6 +1411,7 @@ mod tests {
         {
             let control = PipeControl {
                 stdin: Mutex::new(None),
+                stdin_tx: None,
                 command_tx,
                 kill_requested: AtomicBool::new(false),
             };

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -568,12 +568,14 @@ fn make_context(
     out: &OutboundSink,
     pending: &Arc<AtomicU64>,
     auth: &AuthSnapshot,
+    live_auth: &Arc<std::sync::Mutex<AuthSnapshot>>,
     transport_id: &str,
     cancellation: &CancellationToken,
 ) -> FrameContext {
     let sender = out.clone();
     let pending_send = Arc::clone(pending);
     let pending_probe = Arc::clone(pending);
+    let live_auth = Arc::clone(live_auth);
     FrameContext {
         send: Arc::new(move |frame: Value| {
             let size = serde_json::to_string(&frame).map(|text| text.len() as u64).unwrap_or(0);
@@ -601,6 +603,10 @@ fn make_context(
         trust: auth.trust.clone(),
         local_roots: auth.roots.clone(),
         owner_user_id: auth.owner.clone(),
+        live_auth: Arc::new(move || {
+            let auth = live_auth.lock().expect("auth lock");
+            (auth.trust.clone(), auth.owner.clone())
+        }),
         transport_id: Some(transport_id.to_owned()),
         cancellation: cancellation.clone(),
     }
@@ -695,7 +701,7 @@ async fn relay_session(
                 };
                 let snapshot = auth.lock().expect("auth lock").clone();
                 let context =
-                    make_context(&out, &pending, &snapshot, &transport, &connection_token);
+                    make_context(&out, &pending, &snapshot, &auth, &transport, &connection_token);
                 tokio::select! {
                     biased;
                     _ = connection_token.cancelled() => break,
@@ -1163,6 +1169,7 @@ async fn relay_session(
                                     &out_tx,
                                     &pending,
                                     &snapshot,
+                                    &auth_direct,
                                     &transport_id,
                                     &connection_cancellation,
                                 );

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -576,6 +576,7 @@ fn make_context(
     let pending_send = Arc::clone(pending);
     let pending_probe = Arc::clone(pending);
     let live_auth = Arc::clone(live_auth);
+    let live_auth_for_auth = Arc::clone(&live_auth);
     FrameContext {
         send: Arc::new(move |frame: Value| {
             let size = serde_json::to_string(&frame).map(|text| text.len() as u64).unwrap_or(0);
@@ -606,6 +607,14 @@ fn make_context(
         live_auth: Arc::new(move || {
             let auth = live_auth.lock().expect("auth lock");
             (auth.trust.clone(), auth.owner.clone())
+        }),
+        live_authorized: Arc::new({
+            let live_auth = live_auth_for_auth;
+            move |actor| {
+                let auth = live_auth.lock().expect("auth lock");
+                !auth.trust.is_empty()
+                    && (auth.trust != "observe" || auth.owner.as_deref() == Some(actor))
+            }
         }),
         transport_id: Some(transport_id.to_owned()),
         cancellation: cancellation.clone(),

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -457,7 +457,7 @@ pub async fn stay_online(
     // connections on loopback 127.0.0.1:9776. Managed sandboxes ONLY — this
     // branch is the gate; paired human machines never start the listener.
     // Best-effort: a failed bind degrades to the relay-socket terminal path.
-    let mut tunnel_listener = None;
+    let mut tunnel_listener: Option<tokio::task::JoinHandle<()>> = None;
     let tunnel_listener_cancel = cancellation.child_token();
     #[cfg(unix)]
     if state.managed {

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -711,10 +711,17 @@ async fn relay_session(
                 let snapshot = auth.lock().expect("auth lock").clone();
                 let context =
                     make_context(&out, &pending, &snapshot, &auth, &transport, &connection_token);
-                tokio::select! {
-                    biased;
-                    _ = connection_token.cancelled() => break,
-                    _ = manager.handle_frame(&frame, &context) => {}
+                // An admitted open may already have queued a remote attach.
+                // Let it finish so its lease cleanup can run; cancellation
+                // still interrupts all later mutations.
+                if frame.get("type").and_then(Value::as_str) == Some("pty_open") {
+                    manager.handle_frame(&frame, &context).await;
+                } else {
+                    tokio::select! {
+                        biased;
+                        _ = connection_token.cancelled() => break,
+                        _ = manager.handle_frame(&frame, &context) => {}
+                    }
                 }
             }
         });

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -457,12 +457,13 @@ pub async fn stay_online(
     // connections on loopback 127.0.0.1:9776. Managed sandboxes ONLY — this
     // branch is the gate; paired human machines never start the listener.
     // Best-effort: a failed bind degrades to the relay-socket terminal path.
-    #[cfg(unix)]
     let mut tunnel_listener = None;
+    let tunnel_listener_cancel = cancellation.child_token();
+    #[cfg(unix)]
     if state.managed {
         match crate::tunnel_terminal::start_tunnel_terminal_listener(
             Arc::clone(&runtime.pty),
-            cancellation.child_token(),
+            tunnel_listener_cancel.clone(),
             crate::tunnel_terminal::TUNNEL_TERMINAL_HOST,
             crate::tunnel_terminal::TUNNEL_TERMINAL_PORT,
         )
@@ -492,8 +493,8 @@ pub async fn stay_online(
                 }
             }
             Err(RelayError::Fatal { message, exit_code }) => {
+                tunnel_listener_cancel.cancel();
                 if let Some(task) = tunnel_listener.take() {
-                    task.abort();
                     let _ = task.await;
                 }
                 return Err(RelayError::Fatal { message, exit_code });

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -492,6 +492,10 @@ pub async fn stay_online(
                 }
             }
             Err(RelayError::Fatal { message, exit_code }) => {
+                if let Some(task) = tunnel_listener.take() {
+                    task.abort();
+                    let _ = task.await;
+                }
                 return Err(RelayError::Fatal { message, exit_code });
             }
             Err(RelayError::WakeRedial { message }) => {
@@ -508,12 +512,18 @@ pub async fn stay_online(
             }
         }
         if cancellation.is_cancelled() {
+            if let Some(task) = tunnel_listener.take() {
+                let _ = task.await;
+            }
             return Ok(());
         }
         let ceiling = 500_u64.saturating_mul(1_u64 << attempt.min(10)).min(30_000);
         attempt = attempt.saturating_add(1);
         let delay = (ceiling as f64 * jitter()).round().max(0.0) as u64;
         if !wait_for_reconnect(&cancellation, Duration::from_millis(delay)).await {
+            if let Some(task) = tunnel_listener.take() {
+                let _ = task.await;
+            }
             return Ok(());
         }
     }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -458,6 +458,7 @@ pub async fn stay_online(
     // branch is the gate; paired human machines never start the listener.
     // Best-effort: a failed bind degrades to the relay-socket terminal path.
     #[cfg(unix)]
+    let mut tunnel_listener = None;
     if state.managed {
         match crate::tunnel_terminal::start_tunnel_terminal_listener(
             Arc::clone(&runtime.pty),
@@ -467,7 +468,10 @@ pub async fn stay_online(
         )
         .await
         {
-            Ok(_) => eprintln!("Tunnel terminal listener is up on loopback."),
+            Ok((_, task)) => {
+                tunnel_listener = Some(task);
+                eprintln!("Tunnel terminal listener is up on loopback.");
+            }
             Err(error) => eprintln!(
                 "Tunnel terminal listener bind failed: {error}. Terminals stay on the relay socket path."
             ),
@@ -476,6 +480,9 @@ pub async fn stay_online(
     let mut attempt: u32 = 0;
     loop {
         if cancellation.is_cancelled() {
+            if let Some(task) = tunnel_listener.take() {
+                let _ = task.await;
+            }
             return Ok(());
         }
         match relay_session(&mut config, config_path, &mut state, &runtime, &cancellation).await {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -285,7 +285,10 @@ struct Connection {
     /// The manager answered pty_opened (clears the open deadline).
     opened_seen: AtomicBool,
     finished: AtomicBool,
+    /// Cancels manager/reader work immediately. Writer drain uses its own
+    /// token so mandatory error/exit frames can flush before socket close.
     done: CancellationToken,
+    writer_done: CancellationToken,
 }
 
 impl Connection {
@@ -485,6 +488,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         opened_seen: AtomicBool::new(false),
         finished: AtomicBool::new(false),
         done: done.clone(),
+        writer_done: CancellationToken::new(),
     });
     let context = connection.frame_context();
 
@@ -528,7 +532,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                     WriterMessage::Frame(frame) => {
                         let written = tokio::select! {
                             result = write_half.write_all(&frame) => result,
-                            _ = connection.done.cancelled() => break,
+                            _ = connection.writer_done.cancelled() => break,
                         };
                         // Every dequeued frame added exactly its length at
                         // enqueue, so this never underflows.
@@ -536,6 +540,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                         let previous = connection.pending_out.fetch_sub(length, Ordering::SeqCst);
                         if written.is_err() {
                             connection.finish();
+                            connection.done.cancel();
                             break;
                         }
                         if previous.saturating_sub(length) < FLOW_RESUME_BYTES
@@ -544,10 +549,18 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             let _ = connection.flow_tx.send(false);
                         }
                     }
-                    WriterMessage::End => break,
+                    WriterMessage::End => {
+                        // `End` is ordered after all mandatory control
+                        // frames. Stop the writer only after it observes the
+                        // marker, so protocol_error/pty_exit cannot be
+                        // discarded by a cancellation race.
+                        connection.writer_done.cancel();
+                        break;
+                    }
                 }
             }
             let _ = write_half.shutdown().await;
+            connection.writer_done.cancel();
         })
     };
 
@@ -604,25 +617,27 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                 match decoder.push(&buffer[..count]) {
                     Ok(frames) => {
                         for frame in frames {
-                            tokio::select! {
-                                biased;
-                                _ = connection.done.cancelled() => break 'reader,
-                                _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
-                                    connection.protocol_error("bad_request", "open timed out");
+                            if connection.done.is_cancelled() {
+                                break 'reader;
+                            }
+                            if !connection.opened_seen.load(Ordering::SeqCst)
+                                && open_deadline.is_elapsed()
+                            {
+                                connection.protocol_error("bad_request", "open timed out");
+                                break 'reader;
+                            }
+                            // `try_send` is synchronous. Keep it outside
+                            // `select!` so the reader never awaits on a full
+                            // queue and remains cancellation responsive.
+                            match dispatch_tx.try_send(frame) {
+                                Ok(()) => {}
+                                Err(mpsc::error::TrySendError::Full(_)) => {
+                                    connection.protocol_error("busy", "terminal request queue is full");
                                     break 'reader;
                                 }
-                                result = dispatch_tx.try_send(frame) => {
-                                    match result {
-                                        Ok(()) => {}
-                                        Err(mpsc::error::TrySendError::Full(_)) => {
-                                            connection.protocol_error("busy", "terminal request queue is full");
-                                            break 'reader;
-                                        }
-                                        Err(mpsc::error::TrySendError::Closed(_)) => {
-                                            connection.finish();
-                                            break 'reader;
-                                        }
-                                    }
+                                Err(mpsc::error::TrySendError::Closed(_)) => {
+                                    connection.finish();
+                                    break 'reader;
                                 }
                             }
                         }
@@ -652,6 +667,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(1), &mut writer).await.is_err() {
+        connection.writer_done.cancel();
         writer.abort();
         let _ = writer.await;
     }
@@ -844,7 +860,16 @@ mod tests {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
         port: u16,
         cancel: CancellationToken,
-        _listener: tokio::task::JoinHandle<()>,
+        _listener: Option<tokio::task::JoinHandle<()>>,
+    }
+
+    impl Rig {
+        async fn shutdown(&mut self) {
+            self.cancel.cancel();
+            if let Some(listener) = self._listener.take() {
+                let _ = listener.await;
+            }
+        }
     }
 
     async fn rig_with_limits(max_ptys: usize) -> Rig {
@@ -877,7 +902,7 @@ mod tests {
         )
         .await
         .expect("bind test listener");
-        Rig { manager, spawned, port, cancel, _listener: listener }
+        Rig { manager, spawned, port, cancel, _listener: Some(listener) }
     }
 
     async fn rig_with_blocked_spawn()
@@ -910,7 +935,7 @@ mod tests {
         .await
         .expect("bind test listener");
         (
-            Rig { manager, spawned, port, cancel, _listener: listener },
+            Rig { manager, spawned, port, cancel, _listener: Some(listener) },
             started,
             gate,
             dropped,
@@ -1108,7 +1133,7 @@ mod tests {
 
     #[tokio::test]
     async fn handshake_streams_both_ways_and_a_drop_detaches_without_killing() {
-        let rig = rig().await;
+        let mut rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
@@ -1174,12 +1199,12 @@ mod tests {
         let reopened = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
         assert_eq!(reopened["t"], "opened");
         assert_eq!(reopened["created"], false);
-        rig.cancel.cancel();
+        rig.shutdown().await;
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn parent_cancellation_closes_a_pending_open() {
-        let (rig, spawn_started, gate, spawn_dropped, spawn_completed) =
+        let (mut rig, spawn_started, gate, spawn_dropped, spawn_completed) =
             rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
@@ -1191,12 +1216,11 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), spawn_started.notified())
             .await
             .expect("open reached the blocked PTY spawn");
-        rig.cancel.cancel();
+        rig.shutdown().await;
 
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await
             .expect("parent cancellation must close the tunnel promptly");
-        gate.notify_one();
         assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
         assert!(
             !spawn_completed.load(Ordering::Acquire),
@@ -1208,7 +1232,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn peer_eof_closes_a_pending_open() {
-        let (rig, spawn_started, gate, spawn_dropped, spawn_completed) =
+        let (mut rig, spawn_started, gate, spawn_dropped, spawn_completed) =
             rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
@@ -1225,17 +1249,16 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await
             .expect("peer EOF must close the tunnel promptly");
-        gate.notify_one();
         assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
         assert!(!spawn_completed.load(Ordering::Acquire), "peer EOF must precede spawn completion");
         assert_eq!(rig.manager.opening_count(), 0, "open reservation must be released");
         assert_eq!(rig.manager.attachment_count(), 0);
-        rig.cancel.cancel();
+        rig.shutdown().await;
     }
 
     #[tokio::test]
     async fn bytes_before_open_are_a_protocol_error() {
-        let rig = rig().await;
+        let mut rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write.write_all(&encode_pty_frame(b"sneaky")).await.unwrap();
@@ -1245,12 +1268,12 @@ mod tests {
         assert_eq!(error["t"], "error");
         assert_eq!(error["code"], "bad_request");
         read_eof(&mut read).await;
-        rig.cancel.cancel();
+        rig.shutdown().await;
     }
 
     #[tokio::test]
     async fn duplicate_open_is_a_protocol_error() {
-        let rig = rig().await;
+        let mut rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         let open = encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 }));
@@ -1267,12 +1290,12 @@ mod tests {
             assert_eq!(frame["t"], "opened");
         }
         read_eof(&mut read).await;
-        rig.cancel.cancel();
+        rig.shutdown().await;
     }
 
     #[tokio::test]
     async fn a_malformed_control_frame_closes_the_connection() {
-        let rig = rig().await;
+        let mut rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write.write_all(&encode_tunnel_frame(FRAME_KIND_CONTROL, b"{not json")).await.unwrap();
@@ -1282,12 +1305,12 @@ mod tests {
         assert_eq!(error["t"], "error");
         assert_eq!(error["code"], "bad_request");
         read_eof(&mut read).await;
-        rig.cancel.cancel();
+        rig.shutdown().await;
     }
 
     #[tokio::test]
     async fn a_pty_exit_reaches_the_client_and_ends_the_connection() {
-        let rig = rig().await;
+        let mut rig = rig().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1303,12 +1326,12 @@ mod tests {
         assert_eq!(exit["t"], "exit");
         assert_eq!(exit["code"], 3);
         read_eof(&mut read).await;
-        rig.cancel.cancel();
+        rig.shutdown().await;
     }
 
     #[tokio::test]
     async fn a_refused_open_maps_the_error_code_and_closes() {
-        let rig = rig_with_limits(0).await;
+        let mut rig = rig_with_limits(0).await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1321,6 +1344,6 @@ mod tests {
         assert_eq!(error["t"], "error");
         assert_eq!(error["code"], "session_limit");
         read_eof(&mut read).await;
-        rig.cancel.cancel();
+        rig.shutdown().await;
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1141,6 +1141,28 @@ mod tests {
         assert_eq!(rig.manager.attachment_count(), 0);
     }
 
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn peer_eof_closes_a_pending_open() {
+        let (rig, spawn_started) = rig_with_blocked_spawn().await;
+        let stream = connect(&rig).await;
+        let (mut read, mut write) = stream.into_split();
+        write
+            .write_all(&encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), spawn_started.notified())
+            .await
+            .expect("open reached the blocked PTY spawn");
+        drop(write);
+
+        tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
+            .await
+            .expect("peer EOF must close the tunnel promptly");
+        assert_eq!(rig.manager.attachment_count(), 0);
+        rig.cancel.cancel();
+    }
+
     #[tokio::test]
     async fn bytes_before_open_are_a_protocol_error() {
         let rig = rig().await;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1166,6 +1166,7 @@ mod tests {
             .await
             .expect("parent cancellation must close the tunnel promptly");
         assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
+        assert_eq!(rig.manager.opening_count(), 0, "open reservation must be released");
         assert_eq!(rig.manager.attachment_count(), 0);
     }
 
@@ -1189,6 +1190,7 @@ mod tests {
             .await
             .expect("peer EOF must close the tunnel promptly");
         assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
+        assert_eq!(rig.manager.opening_count(), 0, "open reservation must be released");
         assert_eq!(rig.manager.attachment_count(), 0);
         rig.cancel.cancel();
     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -658,17 +658,25 @@ pub async fn start_tunnel_terminal_listener(
     let listener = TcpListener::bind((host, port)).await?;
     let bound = listener.local_addr()?.port();
     tokio::spawn(async move {
+        let mut connections = tokio::task::JoinSet::new();
         loop {
             let accepted = tokio::select! {
                 biased;
-                _ = cancellation.cancelled() => break,
+                _ = cancellation.cancelled() => {
+                    // Each connection owns its dispatcher, writer, and flow
+                    // tasks. Wait for their cancellation barriers instead of
+                    // dropping detached JoinHandles during listener shutdown.
+                    while connections.join_next().await.is_some() {}
+                    break;
+                }
+                Some(_) = connections.join_next(), if !connections.is_empty() => continue,
                 accepted = listener.accept() => accepted,
             };
             match accepted {
                 Ok((stream, _)) => {
                     let manager = Arc::clone(&manager);
                     let child = cancellation.child_token();
-                    tokio::spawn(serve_connection(stream, manager, child));
+                    connections.spawn(serve_connection(stream, manager, child));
                 }
                 Err(_) => {
                     // Transient accept errors (EMFILE and friends) must not

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -77,7 +77,9 @@ const FLOW_RESUME_BYTES: u64 = 32_768;
 /// Bound decoded client frames while the ordered dispatcher is waiting for an
 /// open or control operation. The reader must keep observing EOF and
 /// cancellation instead of waiting on an unbounded work queue.
-const TUNNEL_DISPATCH_QUEUE_ITEMS: usize = 64;
+// Eight 1 MiB frames cap each stalled connection's decoded client backlog at
+// roughly 8 MiB. The output path has its separate 1 MiB byte cap.
+const TUNNEL_DISPATCH_QUEUE_ITEMS: usize = 8;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -654,6 +654,10 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                                             break 'reader;
                                         }
                                         _ = connection.done.cancelled() => break 'reader,
+                                        _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
+                                            connection.protocol_error("bad_request", "open timed out");
+                                            break 'reader;
+                                        }
                                         result = dispatch_tx.send(frame) => {
                                             if result.is_err() {
                                                 connection.finish();

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -765,25 +765,32 @@ mod tests {
         spawn_gate: Option<Arc<Notify>>,
         spawn_started: Option<Arc<Notify>>,
         spawn_dropped: Option<Arc<AtomicBool>>,
+        spawn_completed: Option<Arc<AtomicBool>>,
     }
 
-    struct SpawnDrop(Arc<AtomicBool>);
+    struct SpawnDrop {
+        dropped: Arc<AtomicBool>,
+    }
 
     impl Drop for SpawnDrop {
         fn drop(&mut self) {
-            self.0.store(true, Ordering::Release);
+            self.dropped.store(true, Ordering::Release);
         }
     }
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
         async fn spawn_pty(&self, _spec: SpawnSpec) -> PtyHandle {
-            let _spawn_drop = self.spawn_dropped.as_ref().map(|flag| SpawnDrop(Arc::clone(flag)));
+            let _spawn_drop =
+                self.spawn_dropped.as_ref().map(|flag| SpawnDrop { dropped: Arc::clone(flag) });
             if let Some(started) = &self.spawn_started {
                 started.notify_one();
             }
             if let Some(gate) = &self.spawn_gate {
                 gate.notified().await;
+            }
+            if let Some(completed) = &self.spawn_completed {
+                completed.store(true, Ordering::Release);
             }
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
@@ -833,6 +840,7 @@ mod tests {
             spawn_gate: None,
             spawn_started: None,
             spawn_dropped: None,
+            spawn_completed: None,
         });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
@@ -858,16 +866,19 @@ mod tests {
         Rig { manager, spawned, port, cancel }
     }
 
-    async fn rig_with_blocked_spawn() -> (Rig, Arc<Notify>, Arc<Notify>, Arc<AtomicBool>) {
+    async fn rig_with_blocked_spawn()
+    -> (Rig, Arc<Notify>, Arc<Notify>, Arc<AtomicBool>, Arc<AtomicBool>) {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
         let started = Arc::new(Notify::new());
         let gate = Arc::new(Notify::new());
         let dropped = Arc::new(AtomicBool::new(false));
+        let completed = Arc::new(AtomicBool::new(false));
         let deps = Arc::new(FakeDeps {
             spawned: Arc::clone(&spawned),
             spawn_gate: Some(Arc::clone(&gate)),
             spawn_started: Some(Arc::clone(&started)),
             spawn_dropped: Some(Arc::clone(&dropped)),
+            spawn_completed: Some(Arc::clone(&completed)),
         });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
@@ -884,7 +895,7 @@ mod tests {
         )
         .await
         .expect("bind test listener");
-        (Rig { manager, spawned, port, cancel }, started, gate, dropped)
+        (Rig { manager, spawned, port, cancel }, started, gate, dropped, completed)
     }
 
     async fn rig() -> Rig {
@@ -1148,7 +1159,8 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn parent_cancellation_closes_a_pending_open() {
-        let (rig, spawn_started, gate, spawn_dropped) = rig_with_blocked_spawn().await;
+        let (rig, spawn_started, gate, spawn_dropped, spawn_completed) =
+            rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1160,19 +1172,24 @@ mod tests {
             .await
             .expect("open reached the blocked PTY spawn");
         rig.cancel.cancel();
-        gate.notify_one();
 
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await
             .expect("parent cancellation must close the tunnel promptly");
+        gate.notify_one();
         assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
+        assert!(
+            !spawn_completed.load(Ordering::Acquire),
+            "cancellation must precede spawn completion"
+        );
         assert_eq!(rig.manager.opening_count(), 0, "open reservation must be released");
         assert_eq!(rig.manager.attachment_count(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn peer_eof_closes_a_pending_open() {
-        let (rig, spawn_started, gate, spawn_dropped) = rig_with_blocked_spawn().await;
+        let (rig, spawn_started, gate, spawn_dropped, spawn_completed) =
+            rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1184,12 +1201,13 @@ mod tests {
             .await
             .expect("open reached the blocked PTY spawn");
         drop(write);
-        gate.notify_one();
 
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await
             .expect("peer EOF must close the tunnel promptly");
+        gate.notify_one();
         assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
+        assert!(!spawn_completed.load(Ordering::Acquire), "peer EOF must precede spawn completion");
         assert_eq!(rig.manager.opening_count(), 0, "open reservation must be released");
         assert_eq!(rig.manager.attachment_count(), 0);
         rig.cancel.cancel();

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -654,10 +654,10 @@ pub async fn start_tunnel_terminal_listener(
     cancellation: CancellationToken,
     host: &str,
     port: u16,
-) -> std::io::Result<u16> {
+) -> std::io::Result<(u16, tokio::task::JoinHandle<()>)> {
     let listener = TcpListener::bind((host, port)).await?;
     let bound = listener.local_addr()?.port();
-    tokio::spawn(async move {
+    let task = tokio::spawn(async move {
         let mut connections = tokio::task::JoinSet::new();
         loop {
             let accepted = tokio::select! {
@@ -686,7 +686,7 @@ pub async fn start_tunnel_terminal_listener(
             }
         }
     });
-    Ok(bound)
+    Ok((bound, task))
 }
 
 // ---------------------------------------------------------------------------
@@ -831,6 +831,7 @@ mod tests {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
         port: u16,
         cancel: CancellationToken,
+        _listener: tokio::task::JoinHandle<()>,
     }
 
     async fn rig_with_limits(max_ptys: usize) -> Rig {
@@ -855,7 +856,7 @@ mod tests {
             1_048_576,
         ));
         let cancel = CancellationToken::new();
-        let port = start_tunnel_terminal_listener(
+        let (port, listener) = start_tunnel_terminal_listener(
             Arc::clone(&manager),
             cancel.clone(),
             TUNNEL_TERMINAL_HOST,
@@ -863,7 +864,7 @@ mod tests {
         )
         .await
         .expect("bind test listener");
-        Rig { manager, spawned, port, cancel }
+        Rig { manager, spawned, port, cancel, _listener: listener }
     }
 
     async fn rig_with_blocked_spawn()
@@ -887,7 +888,7 @@ mod tests {
         let manager =
             Arc::new(PtyManager::with_limits(deps, std::env::temp_dir(), env, 8, 32, 1_048_576));
         let cancel = CancellationToken::new();
-        let port = start_tunnel_terminal_listener(
+        let (port, listener) = start_tunnel_terminal_listener(
             Arc::clone(&manager),
             cancel.clone(),
             TUNNEL_TERMINAL_HOST,
@@ -895,7 +896,13 @@ mod tests {
         )
         .await
         .expect("bind test listener");
-        (Rig { manager, spawned, port, cancel }, started, gate, dropped, completed)
+        (
+            Rig { manager, spawned, port, cancel, _listener: listener },
+            started,
+            gate,
+            dropped,
+            completed,
+        )
     }
 
     async fn rig() -> Rig {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -416,6 +416,7 @@ impl Connection {
             local_roots: None,
             owner_user_id: None,
             live_auth: Arc::new(|| ("supervised".to_owned(), None)),
+            live_authorized: Arc::new(|_| true),
             transport_id: Some(self.pty_id.clone()),
             cancellation: self.done.clone(),
         }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -74,6 +74,10 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// Bound decoded client frames while the ordered dispatcher is waiting for an
+/// open or control operation. The reader must keep observing EOF and
+/// cancellation instead of waiting on an unbounded work queue.
+const TUNNEL_DISPATCH_QUEUE_ITEMS: usize = 64;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -466,6 +470,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<WriterMessage>();
     let (flow_tx, mut flow_rx) = mpsc::unbounded_channel::<bool>();
+    let done = parent.child_token();
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
@@ -476,9 +481,39 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         open_sent: AtomicBool::new(false),
         opened_seen: AtomicBool::new(false),
         finished: AtomicBool::new(false),
-        done: CancellationToken::new(),
+        done: done.clone(),
     });
     let context = connection.frame_context();
+
+    // Keep socket reads independent from ordered manager work. In particular,
+    // a slow or stalled open must not hide peer EOF or listener cancellation.
+    // The bounded channel applies backpressure to the reader without allowing
+    // decoded frames to accumulate without limit.
+    let (dispatch_tx, mut dispatch_rx) = mpsc::channel::<TunnelFrame>(TUNNEL_DISPATCH_QUEUE_ITEMS);
+    let dispatch_connection = Arc::clone(&connection);
+    let dispatch_context = context.clone();
+    let dispatch_done = connection.done.clone();
+    let mut dispatcher = tokio::spawn(async move {
+        while let Some(frame) = dispatch_rx.recv().await {
+            let operation_connection = Arc::clone(&dispatch_connection);
+            let operation_context = dispatch_context.clone();
+            let mut operation = tokio::spawn(async move {
+                handle_client_frame(&operation_connection, &operation_context, frame).await;
+            });
+            tokio::select! {
+                biased;
+                _ = dispatch_done.cancelled() => {
+                    // A dropped JoinHandle detaches the operation. Abort and
+                    // join it so its cancellation-aware PTY guards reach a
+                    // defined boundary before this connection returns.
+                    operation.abort();
+                    let _ = (&mut operation).await;
+                    break;
+                }
+                _ = &mut operation => {}
+            }
+        }
+    });
 
     // Writer: the only task that touches the write half. Applies the flow
     // water marks as the queue drains.
@@ -538,7 +573,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
     let open_deadline = tokio::time::sleep(OPEN_TIMEOUT);
     tokio::pin!(open_deadline);
-    loop {
+    'reader: loop {
         tokio::select! {
             biased;
             _ = parent.cancelled() => {
@@ -563,7 +598,16 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                 match decoder.push(&buffer[..count]) {
                     Ok(frames) => {
                         for frame in frames {
-                            handle_client_frame(&connection, &context, frame).await;
+                            tokio::select! {
+                                biased;
+                                _ = connection.done.cancelled() => break 'reader,
+                                result = dispatch_tx.send(frame) => {
+                                    if result.is_err() {
+                                        connection.finish();
+                                        break 'reader;
+                                    }
+                                }
+                            }
                         }
                     }
                     Err(_) => {
@@ -575,6 +619,8 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         }
     }
     connection.finish();
+    drop(dispatch_tx);
+    let _ = dispatcher.await;
     // Detach, never kill: the owed close releases only this connection's
     // attachment (transport-fenced), and the session lives on.
     if connection.open_sent.load(Ordering::SeqCst) {
@@ -590,6 +636,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
         writer.abort();
+        let _ = writer.await;
     }
     let _ = flow.await;
 }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -640,14 +640,26 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                                 connection.protocol_error("bad_request", "open timed out");
                                 break 'reader;
                             }
-                            // `try_send` is synchronous. Keep it outside
-                            // `select!` so the reader never awaits on a full
-                            // queue and remains cancellation responsive.
                             match dispatch_tx.try_send(frame) {
                                 Ok(()) => {}
-                                Err(mpsc::error::TrySendError::Full(_)) => {
-                                    connection.protocol_error("busy", "terminal request queue is full");
-                                    break 'reader;
+                                Err(mpsc::error::TrySendError::Full(frame)) => {
+                                    // A decoder burst may contain more frames than the
+                                    // bounded queue. Apply backpressure only when full,
+                                    // while retaining cancellation responsiveness.
+                                    tokio::select! {
+                                        biased;
+                                        _ = parent.cancelled() => {
+                                            connection.finish();
+                                            break 'reader;
+                                        }
+                                        _ = connection.done.cancelled() => break 'reader,
+                                        result = dispatch_tx.send(frame) => {
+                                            if result.is_err() {
+                                                connection.finish();
+                                                break 'reader;
+                                            }
+                                        }
+                                    }
                                 }
                                 Err(mpsc::error::TrySendError::Closed(_)) => {
                                     connection.finish();
@@ -782,8 +794,9 @@ mod tests {
     }
 
     impl PtyControl for FakePty {
-        fn write(&self, data: &[u8]) {
+        fn write(&self, data: &[u8]) -> bool {
             self.state.lock().unwrap().written.push(data.to_vec());
+            true
         }
         fn resize(&self, cols: u16, rows: u16) {
             self.state.lock().unwrap().resized.push((cols, rows));

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -429,6 +429,7 @@ async fn handle_client_frame(
     connection: &Arc<Connection>,
     context: &FrameContext,
     frame: TunnelFrame,
+    parsed: Option<ClientFrame>,
 ) {
     if connection.finished.load(Ordering::SeqCst) {
         return;
@@ -447,7 +448,7 @@ async fn handle_client_frame(
         connection.manager.handle_frame(&input, context).await;
         return;
     }
-    let Some(parsed) = parse_tunnel_client_frame(&frame.payload) else {
+    let Some(parsed) = parsed else {
         connection.protocol_error("bad_request", "invalid terminal request");
         return;
     };
@@ -521,13 +522,14 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let dispatch_done = connection.done.clone();
     let mut dispatcher = tokio::spawn(async move {
         while let Some(frame) = dispatch_rx.recv().await {
-            let admitted_open = frame.kind == FRAME_KIND_CONTROL
-                && parse_tunnel_client_frame(&frame.payload)
-                    .is_some_and(|parsed| matches!(parsed, ClientFrame::Open { .. }));
+            let parsed = (frame.kind == FRAME_KIND_CONTROL)
+                .then(|| parse_tunnel_client_frame(&frame.payload))
+                .flatten();
+            let admitted_open = matches!(parsed.as_ref(), Some(ClientFrame::Open { .. }));
             let operation_connection = Arc::clone(&dispatch_connection);
             let operation_context = dispatch_context.clone();
             let mut operation = tokio::spawn(async move {
-                handle_client_frame(&operation_connection, &operation_context, frame).await;
+                handle_client_frame(&operation_connection, &operation_context, frame, parsed).await;
             });
             if admitted_open {
                 // Once admitted, let OPEN finish so a remote attach receives

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -601,6 +601,10 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             tokio::select! {
                                 biased;
                                 _ = connection.done.cancelled() => break 'reader,
+                                _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
+                                    connection.protocol_error("bad_request", "open timed out");
+                                    break 'reader;
+                                }
                                 result = dispatch_tx.send(frame) => {
                                     if result.is_err() {
                                         connection.finish();
@@ -752,11 +756,21 @@ mod tests {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
         spawn_gate: Option<Arc<Notify>>,
         spawn_started: Option<Arc<Notify>>,
+        spawn_dropped: Option<Arc<AtomicBool>>,
+    }
+
+    struct SpawnDrop(Arc<AtomicBool>);
+
+    impl Drop for SpawnDrop {
+        fn drop(&mut self) {
+            self.0.store(true, Ordering::Release);
+        }
     }
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
         async fn spawn_pty(&self, _spec: SpawnSpec) -> PtyHandle {
+            let _spawn_drop = self.spawn_dropped.as_ref().map(|flag| SpawnDrop(Arc::clone(flag)));
             if let Some(started) = &self.spawn_started {
                 started.notify_one();
             }
@@ -810,6 +824,7 @@ mod tests {
             spawned: Arc::clone(&spawned),
             spawn_gate: None,
             spawn_started: None,
+            spawn_dropped: None,
         });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
@@ -835,13 +850,15 @@ mod tests {
         Rig { manager, spawned, port, cancel }
     }
 
-    async fn rig_with_blocked_spawn() -> (Rig, Arc<Notify>) {
+    async fn rig_with_blocked_spawn() -> (Rig, Arc<Notify>, Arc<AtomicBool>) {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
         let started = Arc::new(Notify::new());
+        let dropped = Arc::new(AtomicBool::new(false));
         let deps = Arc::new(FakeDeps {
             spawned: Arc::clone(&spawned),
             spawn_gate: Some(Arc::new(Notify::new())),
             spawn_started: Some(Arc::clone(&started)),
+            spawn_dropped: Some(Arc::clone(&dropped)),
         });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
@@ -858,7 +875,7 @@ mod tests {
         )
         .await
         .expect("bind test listener");
-        (Rig { manager, spawned, port, cancel }, started)
+        (Rig { manager, spawned, port, cancel }, started, dropped)
     }
 
     async fn rig() -> Rig {
@@ -1122,7 +1139,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn parent_cancellation_closes_a_pending_open() {
-        let (rig, spawn_started) = rig_with_blocked_spawn().await;
+        let (rig, spawn_started, spawn_dropped) = rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1138,12 +1155,13 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await
             .expect("parent cancellation must close the tunnel promptly");
+        assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
         assert_eq!(rig.manager.attachment_count(), 0);
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn peer_eof_closes_a_pending_open() {
-        let (rig, spawn_started) = rig_with_blocked_spawn().await;
+        let (rig, spawn_started, spawn_dropped) = rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1159,6 +1177,7 @@ mod tests {
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await
             .expect("peer EOF must close the tunnel promptly");
+        assert!(spawn_dropped.load(Ordering::Acquire), "blocked open task must be dropped");
         assert_eq!(rig.manager.attachment_count(), 0);
         rig.cancel.cancel();
     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -531,8 +531,22 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
             });
             if admitted_open {
                 // Once admitted, let OPEN finish so a remote attach receives
-                // its lease and can run ordered cancellation cleanup.
-                let _ = (&mut operation).await;
+                // its lease and can run ordered cancellation cleanup. Bound
+                // the handoff so a wedged control socket cannot block shutdown.
+                tokio::select! {
+                    _ = (&mut operation) => {}
+                    _ = dispatch_done.cancelled() => {
+                        let _ = tokio::time::timeout(
+                            Duration::from_millis(crate::control::CONTROL_TIMEOUT_MS + 500),
+                            &mut operation,
+                        ).await;
+                        if !operation.is_finished() {
+                            operation.abort();
+                            let _ = (&mut operation).await;
+                        }
+                        break;
+                    }
+                }
             } else {
                 tokio::select! {
                     biased;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -284,6 +284,8 @@ struct Connection {
     open_sent: AtomicBool,
     /// The manager answered pty_opened (clears the open deadline).
     opened_seen: AtomicBool,
+    /// The ordered open operation returned, including typed failures.
+    open_completed: AtomicBool,
     finished: AtomicBool,
     /// Cancels manager/reader work immediately. Writer drain uses its own
     /// token so mandatory error/exit frames can flush before socket close.
@@ -467,6 +469,7 @@ async fn handle_client_frame(
                 open["surface"] = Value::from(surface);
             }
             connection.manager.handle_frame(&open, context).await;
+            connection.open_completed.store(true, Ordering::SeqCst);
         }
         ClientFrame::Resize { cols, rows } => {
             if !connection.open_sent.load(Ordering::SeqCst) {
@@ -500,6 +503,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
         opened_seen: AtomicBool::new(false),
+        open_completed: AtomicBool::new(false),
         finished: AtomicBool::new(false),
         done: done.clone(),
         writer_done: CancellationToken::new(),
@@ -615,7 +619,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                 break;
             }
             _ = connection.done.cancelled() => break,
-            _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
+            _ = &mut open_deadline, if !connection.open_completed.load(Ordering::SeqCst) => {
                 connection.protocol_error("bad_request", "no open frame");
                 break;
             }
@@ -635,7 +639,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             if connection.done.is_cancelled() {
                                 break 'reader;
                             }
-                            if !connection.opened_seen.load(Ordering::SeqCst)
+                            if !connection.open_completed.load(Ordering::SeqCst)
                                 && open_deadline.is_elapsed()
                             {
                                 connection.protocol_error("bad_request", "open timed out");
@@ -654,7 +658,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                                             break 'reader;
                                         }
                                         _ = connection.done.cancelled() => break 'reader,
-                                        _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
+                                        _ = &mut open_deadline, if !connection.open_completed.load(Ordering::SeqCst) => {
                                             connection.protocol_error("bad_request", "open timed out");
                                             break 'reader;
                                         }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -850,13 +850,14 @@ mod tests {
         Rig { manager, spawned, port, cancel }
     }
 
-    async fn rig_with_blocked_spawn() -> (Rig, Arc<Notify>, Arc<AtomicBool>) {
+    async fn rig_with_blocked_spawn() -> (Rig, Arc<Notify>, Arc<Notify>, Arc<AtomicBool>) {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
         let started = Arc::new(Notify::new());
+        let gate = Arc::new(Notify::new());
         let dropped = Arc::new(AtomicBool::new(false));
         let deps = Arc::new(FakeDeps {
             spawned: Arc::clone(&spawned),
-            spawn_gate: Some(Arc::new(Notify::new())),
+            spawn_gate: Some(Arc::clone(&gate)),
             spawn_started: Some(Arc::clone(&started)),
             spawn_dropped: Some(Arc::clone(&dropped)),
         });
@@ -875,7 +876,7 @@ mod tests {
         )
         .await
         .expect("bind test listener");
-        (Rig { manager, spawned, port, cancel }, started, dropped)
+        (Rig { manager, spawned, port, cancel }, started, gate, dropped)
     }
 
     async fn rig() -> Rig {
@@ -1139,7 +1140,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn parent_cancellation_closes_a_pending_open() {
-        let (rig, spawn_started, spawn_dropped) = rig_with_blocked_spawn().await;
+        let (rig, spawn_started, gate, spawn_dropped) = rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1151,6 +1152,7 @@ mod tests {
             .await
             .expect("open reached the blocked PTY spawn");
         rig.cancel.cancel();
+        gate.notify_one();
 
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await
@@ -1161,7 +1163,7 @@ mod tests {
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn peer_eof_closes_a_pending_open() {
-        let (rig, spawn_started, spawn_dropped) = rig_with_blocked_spawn().await;
+        let (rig, spawn_started, gate, spawn_dropped) = rig_with_blocked_spawn().await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         write
@@ -1173,6 +1175,7 @@ mod tests {
             .await
             .expect("open reached the blocked PTY spawn");
         drop(write);
+        gate.notify_one();
 
         tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
             .await

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -521,22 +521,28 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let dispatch_done = connection.done.clone();
     let mut dispatcher = tokio::spawn(async move {
         while let Some(frame) = dispatch_rx.recv().await {
+            let admitted_open = frame.kind == FRAME_KIND_CONTROL
+                && parse_tunnel_client_frame(&frame.payload)
+                    .is_some_and(|parsed| matches!(parsed, ClientFrame::Open { .. }));
             let operation_connection = Arc::clone(&dispatch_connection);
             let operation_context = dispatch_context.clone();
             let mut operation = tokio::spawn(async move {
                 handle_client_frame(&operation_connection, &operation_context, frame).await;
             });
-            tokio::select! {
-                biased;
-                _ = dispatch_done.cancelled() => {
-                    // A dropped JoinHandle detaches the operation. Abort and
-                    // join it so its cancellation-aware PTY guards reach a
-                    // defined boundary before this connection returns.
-                    operation.abort();
-                    let _ = (&mut operation).await;
-                    break;
+            if admitted_open {
+                // Once admitted, let OPEN finish so a remote attach receives
+                // its lease and can run ordered cancellation cleanup.
+                let _ = (&mut operation).await;
+            } else {
+                tokio::select! {
+                    biased;
+                    _ = dispatch_done.cancelled() => {
+                        operation.abort();
+                        let _ = (&mut operation).await;
+                        break;
+                    }
+                    _ = &mut operation => {}
                 }
-                _ = &mut operation => {}
             }
         }
     });

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -526,7 +526,10 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
             while let Some(message) = writer_rx.recv().await {
                 match message {
                     WriterMessage::Frame(frame) => {
-                        let written = write_half.write_all(&frame).await;
+                        let written = tokio::select! {
+                            result = write_half.write_all(&frame) => result,
+                            _ = connection.done.cancelled() => break,
+                        };
                         // Every dequeued frame added exactly its length at
                         // enqueue, so this never underflows.
                         let length = frame.len() as u64;
@@ -608,10 +611,17 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                                     connection.protocol_error("bad_request", "open timed out");
                                     break 'reader;
                                 }
-                                result = dispatch_tx.send(frame) => {
-                                    if result.is_err() {
-                                        connection.finish();
-                                        break 'reader;
+                                result = dispatch_tx.try_send(frame) => {
+                                    match result {
+                                        Ok(()) => {}
+                                        Err(mpsc::error::TrySendError::Full(_)) => {
+                                            connection.protocol_error("busy", "terminal request queue is full");
+                                            break 'reader;
+                                        }
+                                        Err(mpsc::error::TrySendError::Closed(_)) => {
+                                            connection.finish();
+                                            break 'reader;
+                                        }
                                     }
                                 }
                             }
@@ -641,7 +651,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     flow.abort();
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.
-    if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
+    if tokio::time::timeout(Duration::from_secs(1), &mut writer).await.is_err() {
         writer.abort();
         let _ = writer.await;
     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -648,6 +648,7 @@ mod tests {
     use std::path::{Path, PathBuf};
     use std::sync::Mutex as StdMutex;
     use tokio::net::tcp::OwnedReadHalf;
+    use tokio::sync::Notify;
 
     #[derive(Default)]
     struct FakeState {
@@ -702,11 +703,19 @@ mod tests {
 
     struct FakeDeps {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
+        spawn_gate: Option<Arc<Notify>>,
+        spawn_started: Option<Arc<Notify>>,
     }
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
         async fn spawn_pty(&self, _spec: SpawnSpec) -> PtyHandle {
+            if let Some(started) = &self.spawn_started {
+                started.notify_one();
+            }
+            if let Some(gate) = &self.spawn_gate {
+                gate.notified().await;
+            }
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
             PtyHandle { control: Arc::new(pty.clone()), output: Arc::new(pty), banner: None }
@@ -750,7 +759,11 @@ mod tests {
 
     async fn rig_with_limits(max_ptys: usize) -> Rig {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
-        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned) });
+        let deps = Arc::new(FakeDeps {
+            spawned: Arc::clone(&spawned),
+            spawn_gate: None,
+            spawn_started: None,
+        });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
             ("HOME".to_owned(), std::env::temp_dir().to_string_lossy().into_owned()),
@@ -773,6 +786,32 @@ mod tests {
         .await
         .expect("bind test listener");
         Rig { manager, spawned, port, cancel }
+    }
+
+    async fn rig_with_blocked_spawn() -> (Rig, Arc<Notify>) {
+        let spawned = Arc::new(StdMutex::new(Vec::new()));
+        let started = Arc::new(Notify::new());
+        let deps = Arc::new(FakeDeps {
+            spawned: Arc::clone(&spawned),
+            spawn_gate: Some(Arc::new(Notify::new())),
+            spawn_started: Some(Arc::clone(&started)),
+        });
+        let env = HashMap::from([
+            ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
+            ("HOME".to_owned(), std::env::temp_dir().to_string_lossy().into_owned()),
+        ]);
+        let manager =
+            Arc::new(PtyManager::with_limits(deps, std::env::temp_dir(), env, 8, 32, 1_048_576));
+        let cancel = CancellationToken::new();
+        let port = start_tunnel_terminal_listener(
+            Arc::clone(&manager),
+            cancel.clone(),
+            TUNNEL_TERMINAL_HOST,
+            0,
+        )
+        .await
+        .expect("bind test listener");
+        (Rig { manager, spawned, port, cancel }, started)
     }
 
     async fn rig() -> Rig {
@@ -1032,6 +1071,27 @@ mod tests {
         assert_eq!(reopened["t"], "opened");
         assert_eq!(reopened["created"], false);
         rig.cancel.cancel();
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn parent_cancellation_closes_a_pending_open() {
+        let (rig, spawn_started) = rig_with_blocked_spawn().await;
+        let stream = connect(&rig).await;
+        let (mut read, mut write) = stream.into_split();
+        write
+            .write_all(&encode_control_frame(&json!({ "t": "open", "cols": 80, "rows": 24 })))
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), spawn_started.notified())
+            .await
+            .expect("open reached the blocked PTY spawn");
+        rig.cancel.cancel();
+
+        tokio::time::timeout(Duration::from_secs(1), read_eof(&mut read))
+            .await
+            .expect("parent cancellation must close the tunnel promptly");
+        assert_eq!(rig.manager.attachment_count(), 0);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -289,6 +289,7 @@ struct Connection {
     /// token so mandatory error/exit frames can flush before socket close.
     done: CancellationToken,
     writer_done: CancellationToken,
+    writer_gate: std::sync::Mutex<()>,
 }
 
 impl Connection {
@@ -297,6 +298,7 @@ impl Connection {
     }
 
     fn enqueue(&self, message: WriterMessage) {
+        let _gate = self.writer_gate.lock().expect("writer gate");
         if self.finished.load(Ordering::SeqCst) {
             return;
         }
@@ -311,9 +313,22 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
+        let _gate = self.writer_gate.lock().expect("writer gate");
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
+        let _ = self.writer_tx.send(WriterMessage::End);
+        self.done.cancel();
+    }
+
+    fn finish_with_control(&self, frame: &Value) {
+        let _gate = self.writer_gate.lock().expect("writer gate");
+        if self.finished.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let encoded = encode_control_frame(frame);
+        self.pending_out.fetch_add(encoded.len() as u64, Ordering::SeqCst);
+        let _ = self.writer_tx.send(WriterMessage::Frame(encoded));
         let _ = self.writer_tx.send(WriterMessage::End);
         self.done.cancel();
     }
@@ -322,8 +337,7 @@ impl Connection {
         if self.finished.load(Ordering::SeqCst) {
             return;
         }
-        self.send_control(&json!({ "t": "error", "code": code, "message": message }));
-        self.finish();
+        self.finish_with_control(&json!({ "t": "error", "code": code, "message": message }));
     }
 
     /// The manager's reply sink (FrameContext::send). Synchronous: enqueue
@@ -371,8 +385,7 @@ impl Connection {
             }
             Some("pty_exit") => {
                 let code = frame.get("code").and_then(Value::as_i64).unwrap_or(0);
-                self.send_control(&json!({ "t": "exit", "code": code }));
-                self.finish();
+                self.finish_with_control(&json!({ "t": "exit", "code": code }));
             }
             Some("pty_error") => {
                 let code =
@@ -489,6 +502,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         finished: AtomicBool::new(false),
         done: done.clone(),
         writer_done: CancellationToken::new(),
+        writer_gate: std::sync::Mutex::new(()),
     });
     let context = connection.frame_context();
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -399,6 +399,7 @@ impl Connection {
             trust: "supervised".to_owned(),
             local_roots: None,
             owner_user_id: None,
+            live_auth: Arc::new(|| ("supervised".to_owned(), None)),
             transport_id: Some(self.pty_id.clone()),
             cancellation: self.done.clone(),
         }


### PR DESCRIPTION
Fixes attach cancellation lifecycle from #11466 on current main.

- Preserve admitted attach mutations until their control request settles, then clean up with the per-view lease.
- Reject successful attach responses that omit a lease when scoped detach was advertised.
- Avoid dropping an admitted PTY open when its transport cancellation fires.
- Retire canceled control request registrations on future drop.
- Keep shared controls alive during cancellation and cover lease, pending-request, and concurrent-attachment behavior.

Test-first commits are preserved in the history.

Validation: rustfmt --edition 2024, git diff --check, package policy. Rust builds/tests not run on local Mac per cmux-tui policy.

Tokio reference: https://docs.rs/tokio/latest/tokio/macro.select.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes attach cancellation lifecycle from #11466 across raw PTY attaches, tunnel opens, and relay control connections. Admitted operations now settle or clean up safely instead of being dropped, and canceled raw attaches release per-view leases only after detach and control requests complete.

**Bug Fixes**
- Keeps tunnel readers and pending opens alive through cancellation and peer EOF while fencing late PTY handles and child cleanup.
- Bounds tunnel and PTY input queues; rejected writes report failure without closing the connection.
- Serializes attachment publication, retirement, and replacement while rechecking authorization before PTY control and output publication.
- Retains listener, socket, daemon, and control resources until shutdown cleanup completes, including active tunnel connections.

**Migration**
- Peers advertising lease-based detach must return a lease in `attach-surface` responses; missing leases now fail the attach.

<sup>Written for commit c5ba18973a1ce07f7fca06883260f27b74c98265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when closing relay connections, including pending requests, blocked writes, and paused readers.
  - Prevented stale or unauthorized PTY operations after trust or ownership changes.
  - Improved cleanup of PTY, pipe, daemon, and tunnel-terminal processes during cancellation and shutdown.
  - Reduced the risk of dropped or misordered control messages during connection termination.

- **Improvements**
  - Added backpressure handling for PTY and pipe input, allowing callers to detect when writes cannot be accepted.
  - Improved tunnel-terminal connection management, cancellation behavior, and pending-open handling.
  - Added reliable control-message delivery feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->