### PR TITLE
cmux-tui: buffer frame dumps during teardown

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3709,6 +3709,16 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
             continue;
         }
+        let Some(name) = name.to_str() else { continue };
+        let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
+        let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
+            continue;
+        };
+        let process_alive = unsafe { libc::kill(pid, 0) == 0 }
+            || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+        if process_alive {
+            continue;
+        }
         let name = CString::new(name_bytes)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
         let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
@@ -3829,7 +3839,43 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let size = unsafe { libc::flistxattr(directory.as_raw_fd(), std::ptr::null_mut(), 0) };
+    if size < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if size == 0 {
+        return Ok(());
+    }
+    let mut names = vec![0u8; size as usize];
+    let read =
+        unsafe { libc::flistxattr(directory.as_raw_fd(), names.as_mut_ptr().cast(), names.len()) };
+    if read < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    for name in names[..read as usize].split(|byte| *byte == 0) {
+        if name == b"system.posix_acl_access" || name == b"system.posix_acl_default" {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "dump directory has a POSIX ACL",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "linux")))]
+fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "cannot validate dump directory ACLs on this Unix target",
+    ))
+}
+
+#[cfg(not(unix))]
 fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
     Ok(())
 }
@@ -4800,7 +4846,7 @@ mod tests {
     fn private_dump_directory_prunes_stale_temporary_dumps() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
-        let stale_path = dump_path.join(".mirror-1.txt.tmp-123-1");
+        let stale_path = dump_path.join(".mirror-1.txt.tmp-99999999-1");
         let directory = private_dump_directory(&dump_path).unwrap();
         drop(directory);
         fs::write(&stale_path, b"partial secret").unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3618,12 +3618,14 @@ impl Drop for RemoteSession {
 
 fn private_dump_file(path: &Path) -> io::Result<fs::File> {
     let mut options = fs::OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    options.write(true).create(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
+    #[cfg(not(unix))]
+    options.truncate(true);
     let file = options.open(path)?;
     #[cfg(unix)]
     {
@@ -3640,6 +3642,9 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
                 format!("dump target is not a private regular file: {}", path.display()),
             ));
         }
+        // Truncate only after validating the opened descriptor, so a hard
+        // link cannot cause data loss in another file.
+        file.set_len(0)?;
         // `mode` only applies when the file is new. Set permissions through
         // the opened descriptor so existing files are also private without a
         // path-based symlink race.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3630,7 +3630,13 @@ impl Drop for RemoteSession {
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    // Validate existing ancestors before create_dir_all follows them, then
+    // validate again after creation to catch newly created components. A
+    // writable non-sticky ancestor permits another user to replace the dump
+    // directory between path operations and redirect secret-bearing output.
+    validate_dump_ancestors(path)?;
 
     let existed = match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_dir() => true,
@@ -3644,10 +3650,7 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         Err(error) => return Err(error),
     };
     if !existed {
-        if let Some(parent) = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-        {
+        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
             fs::create_dir_all(parent)?;
         }
         let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
@@ -3661,6 +3664,7 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             }
         }
     }
+    validate_dump_ancestors(path)?;
     let directory = fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
@@ -3672,57 +3676,121 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
+    reject_extended_acl(&directory)?;
     if metadata.mode() & 0o077 != 0 {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             format!("dump directory is not private: {}", path.display()),
         ));
     }
-    reject_extended_acl(&directory)?;
     Ok(directory)
+}
+
+#[cfg(unix)]
+fn validate_dump_ancestors(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let mut ancestor = path.parent();
+    while let Some(candidate) = ancestor {
+        if candidate.as_os_str().is_empty() {
+            break;
+        }
+        match fs::symlink_metadata(candidate) {
+            Ok(metadata) => {
+                let resolved = if metadata.file_type().is_symlink() {
+                    if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            format!(
+                                "dump directory ancestor is not trusted: {}",
+                                candidate.display()
+                            ),
+                        ));
+                    }
+                    let resolved = fs::canonicalize(candidate)?;
+                    validate_dump_ancestors(&resolved)?;
+                    resolved
+                } else {
+                    candidate.to_path_buf()
+                };
+                let metadata = fs::symlink_metadata(&resolved)?;
+                if !metadata.is_dir() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "dump directory ancestor is not a directory: {}",
+                            candidate.display()
+                        ),
+                    ));
+                }
+                if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("dump directory ancestor is not trusted: {}", candidate.display()),
+                    ));
+                }
+                let mode = metadata.mode();
+                let sticky = mode & 0o1000 != 0;
+                if mode & 0o022 != 0 && !sticky {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!(
+                            "dump directory ancestor is writable without private protection: {}",
+                            candidate.display()
+                        ),
+                    ));
+                }
+                let directory = fs::OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+                    .open(&resolved)?;
+                reject_extended_acl(&directory)?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        let next = candidate.parent();
+        if next == Some(candidate) {
+            break;
+        }
+        ancestor = next;
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
 fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
-    use std::ptr;
 
-    // Any extended ACL can carry non-owner grants or inheritance. Reject the
-    // directory instead of trying to interpret ACE ordering and masks.
-    let descriptor = directory.as_raw_fd();
-    let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
-    if size < 0 {
+    // `acl_get_fd_np` reads the effective macOS ACL from the opened
+    // descriptor, including inherited ACEs that are not exposed by the mode
+    // bits. Reject any extended ACL instead of attempting to interpret ACE
+    // ordering, principals, and inheritance flags here.
+    unsafe extern "C" {
+        fn acl_get_fd_np(fd: libc::c_int, acl_type: libc::c_int) -> *mut libc::c_void;
+        fn acl_free(object: *mut libc::c_void) -> libc::c_int;
+    }
+
+    const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+    let acl = unsafe { acl_get_fd_np(directory.as_raw_fd(), ACL_TYPE_EXTENDED) };
+    if acl.is_null() {
         let error = io::Error::last_os_error();
-        if matches!(error.raw_os_error(), Some(libc::ENOTSUP) | Some(libc::ENOSYS)) {
+        if matches!(
+            error.raw_os_error(),
+            Some(libc::ENOENT)
+                | Some(libc::ENOATTR)
+                | Some(libc::ENOTSUP)
+                | Some(libc::EOPNOTSUPP)
+                | Some(libc::ENOSYS)
+        ) {
             return Ok(());
         }
         return Err(error);
     }
-    if size == 0 {
-        return Ok(());
+    unsafe {
+        acl_free(acl);
     }
-    let mut names = vec![0_u8; size as usize];
-    let size = unsafe {
-        libc::flistxattr(
-            descriptor,
-            names.as_mut_ptr().cast(),
-            names.len(),
-            0,
-        )
-    };
-    if size < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    if names[..size as usize]
-        .split(|byte| *byte == 0)
-        .any(|name| name == b"com.apple.acl.text")
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "dump directory has an extended ACL",
-        ));
-    }
-    Ok(())
+    Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -3756,9 +3824,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     }
     let file = unsafe { fs::File::from_raw_fd(descriptor) };
     let metadata = file.metadata()?;
-    if !metadata.is_file()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.nlink() != 1
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } || metadata.nlink() != 1
     {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
@@ -4697,8 +4763,9 @@ mod tests {
     #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
         fs::write(&final_path, b"previous").unwrap();
 
         let error = write_private_dump(&directory, "mirror.txt", |_file| {
@@ -4708,19 +4775,22 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
-        assert!(fs::read_dir(root.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .all(|entry| entry.file_name() == "mirror.txt"));
+        assert!(
+            fs::read_dir(&dump_path)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| entry.file_name() == "mirror.txt")
+        );
     }
 
     #[cfg(unix)]
     #[test]
     fn private_dump_replacement_does_not_modify_hard_linked_previous_dump() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
-        let linked_path = root.path().join("mirror-backup.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
+        let linked_path = dump_path.join("mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -4735,9 +4805,10 @@ mod tests {
     #[test]
     fn private_dump_file_rejects_existing_hard_link_without_truncation() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
-        let linked_path = root.path().join("mirror-backup.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
+        let linked_path = dump_path.join("mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -4752,21 +4823,23 @@ mod tests {
     #[test]
     fn private_dump_rename_failure_preserves_previous_directory_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
         fs::create_dir(&final_path).unwrap();
 
-        let error = write_private_dump(&directory, "mirror.txt", |file| {
-            file.write_all(b"replacement")
-        })
-        .unwrap_err();
+        let error =
+            write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"replacement"))
+                .unwrap_err();
 
         assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
         assert!(final_path.is_dir());
-        assert!(fs::read_dir(root.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .all(|entry| entry.file_name() == "mirror.txt"));
+        assert!(
+            fs::read_dir(&dump_path)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| entry.file_name() == "mirror.txt")
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3622,12 +3622,24 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
     let file = options.open(path)?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let metadata = file.metadata()?;
+        // O_NOFOLLOW protects only the final path component. Verify the
+        // opened descriptor as well, so a stale or malicious dump entry
+        // cannot block on a FIFO or redirect output to a device. A link count
+        // above one indicates a hard link, which could otherwise truncate a
+        // different file when the dump is refreshed.
+        if !metadata.is_file() || metadata.nlink() != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("dump target is not a private regular file: {}", path.display()),
+            ));
+        }
         // `mode` only applies when the file is new. Set permissions through
         // the opened descriptor so existing files are also private without a
         // path-based symlink race.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3603,24 +3603,24 @@ impl Drop for RemoteSession {
         #[cfg(unix)]
         {
             let Ok(directory) = private_dump_directory(dir) else { return };
-            let logs = self.frame_logs.lock().unwrap();
-            let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
-            for entry in &logs.entries {
-                entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
+            let mut entries_by_surface: HashMap<SurfaceId, Vec<String>> = HashMap::new();
+            {
+                let logs = self.frame_logs.lock().unwrap();
+                for entry in &logs.entries {
+                    entries_by_surface.entry(entry.surface).or_default().push(entry.line.clone());
+                }
             }
-            for surface in self.surfaces.lock().unwrap().values() {
+            let surfaces: Vec<Arc<RemoteSurface>> =
+                self.surfaces.lock().unwrap().values().cloned().collect();
+            for surface in surfaces {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
-                let mirror = dump_mirror(surface);
+                let mirror = dump_mirror(&surface);
                 let _ = write_private_dump(&directory, &mirror_name, |file| {
                     file.write_all(mirror.as_bytes())
                 });
                 let frames_name = format!("frames-{}.log", surface.id);
-                let _ = write_private_dump(&directory, &frames_name, |file| {
-                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                        writeln!(file, "{line}")?;
-                    }
-                    Ok(())
-                });
+                let lines = entries_by_surface.get(&surface.id).map(Vec::as_slice).unwrap_or(&[]);
+                let _ = write_frame_dump(&directory, &frames_name, lines);
             }
         }
     }
@@ -3917,6 +3917,19 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     // opened, and no previously existing file is truncated.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
+}
+
+#[cfg(unix)]
+fn write_frame_dump(directory: &fs::File, name: &str, lines: &[String]) -> io::Result<()> {
+    use std::io::BufWriter;
+
+    write_private_dump(directory, name, |file| {
+        let mut buffered = BufWriter::new(file);
+        for line in lines {
+            writeln!(buffered, "{line}")?;
+        }
+        buffered.flush()
+    })
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3702,8 +3702,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
         ));
     }
     // Exclusive creation means an existing hard link or symlink is never
-    // opened, and no previously existing file is truncated. The temporary
-    // file is atomically renamed into the deterministic final name below.
+    // opened, and no previously existing file is truncated.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
@@ -3716,47 +3715,26 @@ where
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
 
-    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    let (mut file, temp) = 'allocate: loop {
-        for _ in 0..16 {
-            let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
-            let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
-            let file = match private_dump_file(directory, &temp) {
-                Ok(file) => break 'allocate (file, temp),
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-                Err(error) => return Err(error),
+    let mut file = match private_dump_file(directory, name) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            // Replace only through the validated directory descriptor. This
+            // avoids truncating a hard link and leaves no crash-prone temp
+            // files behind.
+            let status = unsafe {
+                libc::unlinkat(directory.as_raw_fd(), final_name.as_ptr(), 0)
             };
+            if status != 0 {
+                return Err(error);
+            }
+            private_dump_file(directory, name)?
         }
-        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"));
+        Err(error) => return Err(error),
     };
-    let result = (|| {
-        write_contents(&mut file)?;
-        file.sync_all()?;
-        drop(file);
-        let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-        let status = unsafe {
-            libc::renameat(
-                directory.as_raw_fd(),
-                temp_name.as_ptr(),
-                directory.as_raw_fd(),
-                final_name.as_ptr(),
-            )
-        };
-        if status != 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(())
-    })();
-    if result.is_ok() {
-        return Ok(());
-    }
-    let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-    unsafe {
-        libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
-    }
-    result
+    write_contents(&mut file)?;
+    file.sync_all()
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -19,7 +19,7 @@ use cmux_tui_core::{
     MuxEventReceiver, NotificationEvent, NotificationLevel, PairingChallenge, PointerSemanticProbe,
     PointerSnapshotProbe, REMOTE_SESSION_MESSAGE_MAX_BYTES, Rgb, SurfaceId, SurfaceKind,
     TerminalPointerSnapshot,
-    platform::{restrict_directory, transport},
+    platform::transport,
     server::{
         CLEAR_HISTORY_CAPABILITY, CLEAR_HISTORY_KEY_CAPABILITY, CREATION_RECEIPTS_CAPABILITY,
         CREATION_SELECTOR_FALLBACKS_CAPABILITY, GUARDED_BROWSER_POINTER_CAPABILITY,
@@ -3592,69 +3592,101 @@ impl Drop for RemoteSession {
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;
         };
-        let _ = fs::create_dir_all(dir);
-        // Frame mirrors contain terminal output and may include secrets. Keep
-        // the opt-in dump directory and files private even when the process
-        // runs with a permissive umask.
-        let _ = restrict_directory(dir);
-        let logs = self.frame_logs.lock().unwrap();
-        let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
-        for entry in &logs.entries {
-            entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
+        #[cfg(not(unix))]
+        {
+            // Secure descriptor-relative file creation is not available in
+            // this implementation. Do not emit secret-bearing dumps through
+            // path-based APIs on unsupported targets.
+            let _ = dir;
+            return;
         }
-        for surface in self.surfaces.lock().unwrap().values() {
-            let path = dir.join(format!("mirror-{}.txt", surface.id));
-            let _ = write_private_dump(&path, &dump_mirror(surface));
-            let frames = dir.join(format!("frames-{}.log", surface.id));
-            if let Ok(file) = private_dump_file(&frames) {
-                let mut writer = io::BufWriter::new(file);
-                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                    let _ = writeln!(writer, "{line}");
+        #[cfg(unix)]
+        {
+            let Ok(directory) = private_dump_directory(dir) else { return };
+            let logs = self.frame_logs.lock().unwrap();
+            let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
+            for entry in &logs.entries {
+                entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
+            }
+            for surface in self.surfaces.lock().unwrap().values() {
+                let mirror_name = format!("mirror-{}.txt", surface.id);
+                let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
+                let frames_name = format!("frames-{}.log", surface.id);
+                if let Ok(file) = private_dump_file(&directory, &frames_name) {
+                    let mut writer = io::BufWriter::new(file);
+                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                        let _ = writeln!(writer, "{line}");
+                    }
                 }
             }
         }
     }
 }
 
-fn private_dump_file(path: &Path) -> io::Result<fs::File> {
-    let mut options = fs::OpenOptions::new();
-    options.write(true).create(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+#[cfg(unix)]
+fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+
+    fs::create_dir_all(path)?;
+    let directory = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)?;
+    let metadata = directory.metadata()?;
+    if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("dump directory is not private and user-owned: {}", path.display()),
+        ));
     }
-    #[cfg(not(unix))]
-    options.truncate(true);
-    let file = options.open(path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        let metadata = file.metadata()?;
-        // O_NOFOLLOW protects only the final path component. Verify the
-        // opened descriptor as well, so a stale or malicious dump entry
-        // cannot block on a FIFO or redirect output to a device. A link count
-        // above one indicates a hard link, which could otherwise truncate a
-        // different file when the dump is refreshed.
-        if !metadata.is_file() || metadata.nlink() != 1 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("dump target is not a private regular file: {}", path.display()),
-            ));
-        }
-        // Truncate only after validating the opened descriptor, so a hard
-        // link cannot cause data loss in another file.
-        file.set_len(0)?;
-        // `mode` only applies when the file is new. Set permissions through
-        // the opened descriptor so existing files are also private without a
-        // path-based symlink race.
-        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    Ok(directory)
+}
+
+#[cfg(unix)]
+fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let name = CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_WRONLY
+                | libc::O_CREAT
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if descriptor < 0 {
+        return Err(io::Error::last_os_error());
     }
+    let file = unsafe { fs::File::from_raw_fd(descriptor) };
+    let metadata = file.metadata()?;
+    if !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.nlink() != 1
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump target is not a private user-owned regular file",
+        ));
+    }
+    // Truncate only after validating the opened descriptor, so a hard link
+    // cannot cause data loss in another file.
+    file.set_len(0)?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
 
-fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {
-    let mut file = private_dump_file(path)?;
+#[cfg(unix)]
+fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
+    let mut file = private_dump_file(directory, name)?;
     file.write_all(contents.as_bytes())?;
     Ok(())
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4573,6 +4573,18 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_directory_is_private_when_created() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("dumps");
+        let directory = private_dump_directory(&path).unwrap();
+
+        assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+    }
+
     #[test]
     fn disabled_frame_logging_does_not_format_hot_path_messages() {
         struct FormattingProbe(Arc<AtomicBool>);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4680,6 +4680,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_rejects_writable_ancestor_without_sticky_bit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        fs::set_permissions(root.path(), fs::Permissions::from_mode(0o777)).unwrap();
+        let path = root.path().join("dumps");
+
+        let error = private_dump_directory(&path).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
         let directory = private_dump_directory(root.path()).unwrap();
@@ -4714,6 +4729,44 @@ mod tests {
 
         assert_eq!(fs::read(&final_path).unwrap(), b"replacement");
         assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_file_rejects_existing_hard_link_without_truncation() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        let linked_path = root.path().join("mirror-backup.txt");
+        fs::write(&final_path, b"previous").unwrap();
+        fs::hard_link(&final_path, &linked_path).unwrap();
+
+        let error = private_dump_file(&directory, "mirror.txt").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&final_path).unwrap(), b"previous");
+        assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_rename_failure_preserves_previous_directory_and_cleans_temp() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        fs::create_dir(&final_path).unwrap();
+
+        let error = write_private_dump(&directory, "mirror.txt", |file| {
+            file.write_all(b"replacement")
+        })
+        .unwrap_err();
+
+        assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
+        assert!(final_path.is_dir());
+        assert!(fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| entry.file_name() == "mirror.txt"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4858,6 +4858,19 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_frame_dump_preserves_line_format() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let lines = vec!["first".to_owned(), "second".to_owned()];
+
+        write_frame_dump(&directory, "frames.log", &lines).unwrap();
+
+        assert_eq!(fs::read(dump_path.join("frames.log")).unwrap(), b"first\nsecond\n");
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -19,7 +19,7 @@ use cmux_tui_core::{
     MuxEventReceiver, NotificationEvent, NotificationLevel, PairingChallenge, PointerSemanticProbe,
     PointerSnapshotProbe, REMOTE_SESSION_MESSAGE_MAX_BYTES, Rgb, SurfaceId, SurfaceKind,
     TerminalPointerSnapshot,
-    platform::transport,
+    platform::{restrict_directory, transport},
     server::{
         CLEAR_HISTORY_CAPABILITY, CLEAR_HISTORY_KEY_CAPABILITY, CREATION_RECEIPTS_CAPABILITY,
         CREATION_SELECTOR_FALLBACKS_CAPABILITY, GUARDED_BROWSER_POINTER_CAPABILITY,
@@ -3593,6 +3593,10 @@ impl Drop for RemoteSession {
             return;
         };
         let _ = fs::create_dir_all(dir);
+        // Frame mirrors contain terminal output and may include secrets. Keep
+        // the opt-in dump directory and files private even when the process
+        // runs with a permissive umask.
+        let _ = restrict_directory(dir);
         let logs = self.frame_logs.lock().unwrap();
         let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
         for entry in &logs.entries {
@@ -3600,9 +3604,9 @@ impl Drop for RemoteSession {
         }
         for surface in self.surfaces.lock().unwrap().values() {
             let path = dir.join(format!("mirror-{}.txt", surface.id));
-            let _ = fs::write(path, dump_mirror(surface));
+            let _ = write_private_dump(&path, &dump_mirror(surface));
             let frames = dir.join(format!("frames-{}.log", surface.id));
-            if let Ok(file) = fs::File::create(frames) {
+            if let Ok(file) = private_dump_file(&frames) {
                 let mut writer = io::BufWriter::new(file);
                 for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
                     let _ = writeln!(writer, "{line}");
@@ -3610,6 +3614,23 @@ impl Drop for RemoteSession {
             }
         }
     }
+}
+
+fn private_dump_file(path: &Path) -> io::Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(path)
+}
+
+fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {
+    let mut file = private_dump_file(path)?;
+    file.write_all(contents.as_bytes())?;
+    Ok(())
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3610,13 +3610,17 @@ impl Drop for RemoteSession {
             }
             for surface in self.surfaces.lock().unwrap().values() {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
-                let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
+                let mirror = dump_mirror(surface);
+                let _ = write_private_dump(&directory, &mirror_name, |file| {
+                    file.write_all(mirror.as_bytes())
+                });
                 let frames_name = format!("frames-{}.log", surface.id);
-                let mut frames = String::new();
-                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                    let _ = writeln!(frames, "{line}");
-                }
-                let _ = write_private_dump(&directory, &frames_name, &frames);
+                let _ = write_private_dump(&directory, &frames_name, |file| {
+                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                        writeln!(file, "{line}")?;
+                    }
+                    Ok(())
+                });
             }
         }
     }
@@ -3626,6 +3630,17 @@ impl Drop for RemoteSession {
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
+    let existed = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => true,
+        Ok(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("dump path is not a directory: {}", path.display()),
+            ));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
     fs::create_dir_all(path)?;
     let directory = fs::OpenOptions::new()
         .read(true)
@@ -3638,7 +3653,16 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
-    directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    if existed {
+        if metadata.mode() & 0o077 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("dump directory is not private: {}", path.display()),
+            ));
+        }
+    } else {
+        directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    }
     Ok(directory)
 }
 
@@ -3678,56 +3702,61 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
         ));
     }
     // Exclusive creation means an existing hard link or symlink is never
-    // opened, and no previously existing file is truncated. A repeated dump
-    // is skipped when its deterministic name already exists.
+    // opened, and no previously existing file is truncated. The temporary
+    // file is atomically renamed into the deterministic final name below.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
 
 #[cfg(unix)]
-fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
+fn write_private_dump<F>(directory: &fs::File, name: &str, write_contents: F) -> io::Result<()>
+where
+    F: FnOnce(&mut fs::File) -> io::Result<()>,
+{
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    for _ in 0..16 {
-        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
-        let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
-        let mut file = match private_dump_file(directory, &temp) {
-            Ok(file) => file,
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error),
-        };
-        let result = (|| {
-            file.write_all(contents.as_bytes())?;
-            file.sync_all()?;
-            drop(file);
-            let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-            let status = unsafe {
-                libc::renameat(
-                    directory.as_raw_fd(),
-                    temp_name.as_ptr(),
-                    directory.as_raw_fd(),
-                    final_name.as_ptr(),
-                )
+    let (mut file, temp) = 'allocate: loop {
+        for _ in 0..16 {
+            let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+            let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
+            let file = match private_dump_file(directory, &temp) {
+                Ok(file) => break 'allocate (file, temp),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
             };
-            if status != 0 {
-                return Err(io::Error::last_os_error());
-            }
-            Ok(())
-        })();
-        if result.is_ok() {
-            return Ok(());
         }
+        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"));
+    };
+    let result = (|| {
+        write_contents(&mut file)?;
+        file.sync_all()?;
+        drop(file);
         let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-        unsafe {
-            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        let status = unsafe {
+            libc::renameat(
+                directory.as_raw_fd(),
+                temp_name.as_ptr(),
+                directory.as_raw_fd(),
+                final_name.as_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(io::Error::last_os_error());
         }
-        return result;
+        Ok(())
+    })();
+    if result.is_ok() {
+        return Ok(());
     }
-    Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"))
+    let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+    unsafe {
+        libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+    }
+    result
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3657,6 +3657,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
             name.as_ptr(),
             libc::O_WRONLY
                 | libc::O_CREAT
+                | libc::O_EXCL
                 | libc::O_NOFOLLOW
                 | libc::O_NONBLOCK
                 | libc::O_CLOEXEC,
@@ -3677,9 +3678,9 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
             "dump target is not a private user-owned regular file",
         ));
     }
-    // Truncate only after validating the opened descriptor, so a hard link
-    // cannot cause data loss in another file.
-    file.set_len(0)?;
+    // Exclusive creation means an existing hard link or symlink is never
+    // opened, and no previously existing file is truncated. A repeated dump
+    // is skipped when its deterministic name already exists.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3683,7 +3683,43 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private: {}", path.display()),
         ));
     }
+    prune_stale_dump_temps(&directory, path)?;
     Ok(directory)
+}
+
+#[cfg(unix)]
+fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+
+    let uid = unsafe { libc::geteuid() };
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_bytes = name.as_os_str().as_bytes();
+        let is_dump_temp = (name_bytes.starts_with(b".mirror-")
+            || name_bytes.starts_with(b".frames-"))
+            && name_bytes.windows(b".tmp-".len()).any(|part| part == b".tmp-");
+        if !is_dump_temp {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
+            continue;
+        }
+        let name = CString::new(name_bytes)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+        let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(error);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3628,6 +3628,8 @@ impl Drop for RemoteSession {
 
 #[cfg(unix)]
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
     let existed = match fs::symlink_metadata(path) {
@@ -3641,7 +3643,24 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         Err(error) if error.kind() == io::ErrorKind::NotFound => false,
         Err(error) => return Err(error),
     };
-    fs::create_dir_all(path)?;
+    if !existed {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent)?;
+        }
+        let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "invalid dump directory path")
+        })?;
+        let status = unsafe { libc::mkdir(path.as_ptr(), 0o700) };
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::AlreadyExists {
+                return Err(error);
+            }
+        }
+    }
     let directory = fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
@@ -3653,15 +3672,11 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
-    if existed {
-        if metadata.mode() & 0o077 != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("dump directory is not private: {}", path.display()),
-            ));
-        }
-    } else {
-        directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    if metadata.mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("dump directory is not private: {}", path.display()),
+        ));
     }
     Ok(directory)
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4600,6 +4600,44 @@ mod tests {
         assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        fs::write(&final_path, b"previous").unwrap();
+
+        let error = write_private_dump(&directory, "mirror.txt", |_file| {
+            Err(io::Error::other("simulated dump failure"))
+        })
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(fs::read(&final_path).unwrap(), b"previous");
+        assert!(fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| entry.file_name() == "mirror.txt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_replacement_does_not_modify_hard_linked_previous_dump() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        let linked_path = root.path().join("mirror-backup.txt");
+        fs::write(&final_path, b"previous").unwrap();
+        fs::hard_link(&final_path, &linked_path).unwrap();
+
+        write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"replacement"))
+            .unwrap();
+
+        assert_eq!(fs::read(&final_path).unwrap(), b"replacement");
+        assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
     #[test]
     fn disabled_frame_logging_does_not_format_hot_path_messages() {
         struct FormattingProbe(Arc<AtomicBool>);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4761,6 +4761,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_prunes_stale_temporary_dumps() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let stale_path = dump_path.join(".mirror-1.txt.tmp-123-1");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        drop(directory);
+        fs::write(&stale_path, b"partial secret").unwrap();
+
+        let _directory = private_dump_directory(&dump_path).unwrap();
+
+        assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3687,6 +3687,8 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
     use std::ptr;
 
+    // Any extended ACL can carry non-owner grants or inheritance. Reject the
+    // directory instead of trying to interpret ACE ordering and masks.
     let descriptor = directory.as_raw_fd();
     let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
     if size < 0 {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3678,7 +3678,54 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private: {}", path.display()),
         ));
     }
+    reject_extended_acl(&directory)?;
     Ok(directory)
+}
+
+#[cfg(target_os = "macos")]
+fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::ptr;
+
+    let descriptor = directory.as_raw_fd();
+    let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
+    if size < 0 {
+        let error = io::Error::last_os_error();
+        if matches!(error.raw_os_error(), Some(libc::ENOTSUP) | Some(libc::ENOSYS)) {
+            return Ok(());
+        }
+        return Err(error);
+    }
+    if size == 0 {
+        return Ok(());
+    }
+    let mut names = vec![0_u8; size as usize];
+    let size = unsafe {
+        libc::flistxattr(
+            descriptor,
+            names.as_mut_ptr().cast(),
+            names.len(),
+            0,
+        )
+    };
+    if size < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if names[..size as usize]
+        .split(|byte| *byte == 0)
+        .any(|name| name == b"com.apple.acl.text")
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump directory has an extended ACL",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -3732,24 +3779,53 @@ where
 
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    let mut file = match private_dump_file(directory, name) {
-        Ok(file) => file,
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            // Replace only through the validated directory descriptor. This
-            // avoids truncating a hard link and leaves no crash-prone temp
-            // files behind.
-            let status = unsafe {
-                libc::unlinkat(directory.as_raw_fd(), final_name.as_ptr(), 0)
-            };
-            if status != 0 {
-                return Err(error);
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(1);
+    let mut temp_name = None;
+    let mut file = None;
+    for _ in 0..16 {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let candidate = format!(".{name}.tmp-{}-{id}", unsafe { libc::getpid() });
+        match private_dump_file(directory, &candidate) {
+            Ok(candidate_file) => {
+                temp_name = Some(CString::new(candidate).expect("generated temp name is valid"));
+                file = Some(candidate_file);
+                break;
             }
-            private_dump_file(directory, name)?
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
         }
-        Err(error) => return Err(error),
+    }
+    let temp_name = temp_name.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a private dump temporary file",
+        )
+    })?;
+    let mut file = file.expect("temporary file is present when its name is present");
+    let result = write_contents(&mut file).and_then(|()| file.sync_all());
+    drop(file);
+    if let Err(error) = result {
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return Err(error);
+    }
+    let status = unsafe {
+        libc::renameat(
+            directory.as_raw_fd(),
+            temp_name.as_ptr(),
+            directory.as_raw_fd(),
+            final_name.as_ptr(),
+        )
     };
-    write_contents(&mut file)?;
-    file.sync_all()
+    if status != 0 {
+        let error = io::Error::last_os_error();
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return Err(error);
+    }
+    Ok(())
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3612,12 +3612,11 @@ impl Drop for RemoteSession {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
                 let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
                 let frames_name = format!("frames-{}.log", surface.id);
-                if let Ok(file) = private_dump_file(&directory, &frames_name) {
-                    let mut writer = io::BufWriter::new(file);
-                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                        let _ = writeln!(writer, "{line}");
-                    }
+                let mut frames = String::new();
+                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                    let _ = writeln!(frames, "{line}");
                 }
+                let _ = write_private_dump(&directory, &frames_name, &frames);
             }
         }
     }
@@ -3687,9 +3686,48 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
 
 #[cfg(unix)]
 fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
-    let mut file = private_dump_file(directory, name)?;
-    file.write_all(contents.as_bytes())?;
-    Ok(())
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+    let final_name = CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+    for _ in 0..16 {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
+        let mut file = match private_dump_file(directory, &temp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        };
+        let result = (|| {
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()?;
+            drop(file);
+            let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+            let status = unsafe {
+                libc::renameat(
+                    directory.as_raw_fd(),
+                    temp_name.as_ptr(),
+                    directory.as_raw_fd(),
+                    final_name.as_ptr(),
+                )
+            };
+            if status != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        })();
+        if result.is_ok() {
+            return Ok(());
+        }
+        let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return result;
+    }
+    Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"))
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3624,7 +3624,16 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
     }
-    options.open(path)
+    let file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // `mode` only applies when the file is new. Set permissions through
+        // the opened descriptor so existing files are also private without a
+        // path-based symlink race.
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(file)
 }
 
 fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/11458.

Buffers frame-log lines with BufWriter and releases frame-log and surface locks before dump I/O. Atomic temporary-file writes, sync_all, renameat, restrictive directory creation, and descriptor ACL checks remain unchanged.

Test-first commits:
- a8388e5af1 adds frame-log output behavior coverage.
- 6ce254155f adds buffered writes and lock release.

Checks: cargo fmt --check, git diff --check, cmux policy check. Cargo tests/builds were not run per policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Buffers frame dumps during `cmux-tui` session teardown so dump I/O no longer runs while holding the frame-log and surface locks.

- Copies log lines and surface handles under lock, then releases the locks before writing dumps.
- Uses `BufWriter` for frame-log files and flushes before the atomic rename.
- Adds a test that verifies frame dump line formatting is preserved, using a private child dump directory.

<sup>Written for commit 499d9aa28f82a99709ae7425a06a268cc3fe5430. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11562?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

