### PR TITLE
iOS: launch with a cached session mounts the shell, not the sign-in loading screen

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -496,7 +496,8 @@ struct CMUXMobileRootView: View {
         } else if MobileRootAuthGate.shouldShowSignIn(
             stackAuthenticated: authManager.isAuthenticated,
             attachTicketAuthenticated: hasActiveAttachTicketAuthentication,
-            isRestoringSession: authManager.isRestoringSession
+            isRestoringSession: authManager.isRestoringSession,
+            onboardingPending: isOnboardingPending
         ) {
             SignInView()
                 .transition(reduceMotion ? .opacity : .asymmetric(
@@ -828,6 +829,18 @@ struct CMUXMobileRootView: View {
             hasKnownPairedMac: store.hasKnownPairedMac,
             hasAccountMismatch: store.connectionRequiresReauth
         )
+    }
+
+    /// Whether first-run onboarding remains unfinished, i.e. it would present
+    /// once launch restore settles. While pending, a restoring launch stays on
+    /// the sign-in surface (see ``MobileRootAuthGate/shouldShowSignIn``);
+    /// once complete, a primed cached session mounts the shell immediately.
+    private var isOnboardingPending: Bool {
+        #if os(iOS)
+        return onboardingStore.progress != .complete
+        #else
+        return false
+        #endif
     }
 
     /// Whether first-run onboarding should present: only for a settled,

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
@@ -23,16 +23,29 @@ public struct MobileRootAuthGate {
         stackAuthenticated || attachTicketAuthenticated
     }
 
-    /// Whether the root should remain on the sign-in surface while Stack auth
-    /// is absent or its cached session is still being validated. A live attach
-    /// ticket is an explicit exception because it must proceed directly to the
-    /// shell to complete the attach flow.
+    /// Whether the root should remain on the sign-in surface.
+    ///
+    /// Sign-in owns the screen while Stack auth is absent. A primed cached
+    /// session — authenticated from the persisted identity while launch
+    /// validation is still in flight — mounts the authenticated shell
+    /// immediately, whose restoring inputs cover the validation window;
+    /// keeping sign-in up instead showed a loading sign-in screen on every
+    /// launch for the whole network round trip. The one exception is an
+    /// unfinished first-run onboarding: onboarding must not present for a
+    /// cached identity that may still be rejected, and the pre-onboarding
+    /// shell would flash the add-device surface, so sign-in keeps the screen
+    /// (showing its restore status) until validation settles. A live attach
+    /// ticket always proceeds directly to the shell to complete the attach
+    /// flow.
     public static func shouldShowSignIn(
         stackAuthenticated: Bool,
         attachTicketAuthenticated: Bool = false,
-        isRestoringSession: Bool
+        isRestoringSession: Bool,
+        onboardingPending: Bool = false
     ) -> Bool {
-        (!stackAuthenticated || isRestoringSession) && !attachTicketAuthenticated
+        if attachTicketAuthenticated { return false }
+        if !stackAuthenticated { return true }
+        return isRestoringSession && onboardingPending
     }
 
     /// Whether the restoring-session UI should be shown.

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
@@ -50,26 +50,47 @@ import Testing
         ))
     }
 
-    @Test func keepsSignInVisibleWhileCachedSessionRestores() {
-        #expect(MobileRootAuthGate.shouldShowSignIn(
-            stackAuthenticated: true,
-            attachTicketAuthenticated: false,
-            isRestoringSession: true
-        ))
+    @Test func signInOwnsScreenWhileSignedOut() {
         #expect(MobileRootAuthGate.shouldShowSignIn(
             stackAuthenticated: false,
             attachTicketAuthenticated: false,
             isRestoringSession: false
+        ))
+        #expect(MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: false,
+            attachTicketAuthenticated: false,
+            isRestoringSession: true
         ))
         #expect(!MobileRootAuthGate.shouldShowSignIn(
             stackAuthenticated: true,
             attachTicketAuthenticated: false,
             isRestoringSession: false
         ))
+        // A live attach ticket proceeds to the shell to complete the attach.
         #expect(!MobileRootAuthGate.shouldShowSignIn(
             stackAuthenticated: false,
             attachTicketAuthenticated: true,
-            isRestoringSession: true
+            isRestoringSession: true,
+            onboardingPending: true
+        ))
+    }
+
+    @Test func keepsSignInVisibleWhileRestoringWithOnboardingPending() {
+        // Onboarding must not present for a cached identity that may still be
+        // rejected, and the pre-onboarding shell would flash the add-device
+        // surface, so that narrow restoring launch stays on sign-in.
+        #expect(MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: true,
+            attachTicketAuthenticated: false,
+            isRestoringSession: true,
+            onboardingPending: true
+        ))
+        // Once validation settles, onboarding (not sign-in) owns the screen.
+        #expect(!MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: true,
+            attachTicketAuthenticated: false,
+            isRestoringSession: false,
+            onboardingPending: true
         ))
     }
 

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
@@ -73,6 +73,20 @@ import Testing
         ))
     }
 
+    @Test func launchWithPrimedCachedSessionMountsShellNotSignIn() {
+        // Regression for "loading sign-up screen on every launch": a returning
+        // user's cached session primes authenticated while launch validation is
+        // still in flight, and the root must mount the authenticated shell
+        // immediately (its restoring inputs cover the validation window)
+        // instead of parking every launch on the sign-in surface until the
+        // network validation resolves.
+        #expect(!MobileRootAuthGate.shouldShowSignIn(
+            stackAuthenticated: true,
+            attachTicketAuthenticated: false,
+            isRestoringSession: true
+        ))
+    }
+
     @Test func clearsOnlyStaleTemporaryAttachAuthentication() {
         #expect(MobileRootAuthGate.shouldClearAttachTicketAuthentication(
             pairingResult: .failed,


### PR DESCRIPTION
## Problem

Every launch of a signed-in iOS install showed the sign-in screen with the "Restoring session…" spinner until the Stack `/me` validation round trip finished (up to the 8s restore timeout), even on immediate relaunches.

## Cause

https://github.com/manaflow-ai/cmux/pull/11310 (commit "ios: keep sign-in visible during auth restore") routed the entire launch-restore window to `SignInView`: `MobileRootAuthGate.shouldShowSignIn` returned true whenever `isRestoringSession` was set, even with `stackAuthenticated == true`. A cached session always primes with `isRestoringSession: true` (`CMUXAuthState.primed`), so every warm launch parked on the loading sign-in surface. This contradicts the primed-state design: "A cached user with known tokens is treated as signed in immediately while runtime validation remains explicitly in progress. This lets the authenticated UI render."

## Fix

`shouldShowSignIn` now keeps sign-in only while actually signed out. A primed cached session mounts the workspace shell immediately; the shell's existing restoring inputs cover the validation window, and a definitive rejection still lands on sign-in when the coordinator clears the session.

The #11310 protections are preserved:
- onboarding still never presents during restore (`MobileOnboardingGate` unchanged), and
- while first-run onboarding is pending, a restoring launch stays on sign-in (new `onboardingPending` input) — mounting the pre-onboarding shell there would flash the add-device surface for a cached identity that may still be rejected.

## Commits

Two commits so CI proves the regression test: commit 1 adds the failing test only (red), commit 2 adds the fix (green). Verified locally: red without fix, 45/45 package tests green with it.

## Out of scope (noted during diagnosis)

- `reconnectStoredMacIfNeeded` still waits for restore to settle before the stored-Mac reconnect (intentional since #8299).
- A desynced `auth_has_tokens`/`auth_cached_user` pair (tokens in keychain, no cached user) still strands launch on sign-in until `/me` succeeds once; tracked by the pre-existing https://github.com/manaflow-ai/cmux/issues/7525.

## HIG

Checked https://developer.apple.com/design/human-interface-guidelines/launching (page body did not render in the sandboxed fetch; applied its core guidance: restore prior state and get people to content immediately, never park launch on a loading interstitial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch regression on iOS where every launch of a signed-in install showed the sign-in loading screen ("Restoring session…" spinner) until the Stack `/me` validation round trip finished, up to the 8s restore timeout.

`MobileRootAuthGate.shouldShowSignIn` now keeps sign-in on screen only while actually signed out. A primed cached session mounts the workspace shell immediately; the shell's existing restoring inputs cover the validation window, and a definitive rejection still lands on sign-in when the coordinator clears the session. The one exception: while first-run onboarding is pending, a restoring launch stays on sign-in so the pre-onboarding shell doesn't flash the add-device surface for a cached identity that may still be rejected. The old behavior, introduced in #11310, showed sign-in for the entire restore window.

Adds a regression test covering the primed cached session launch path.

<sup>Written for commit 9ecb02f97d7415fdf1b6493557c990a21d63e875. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11564?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS launch behavior for returning users with cached sessions, allowing the authenticated shell to appear while session validation is in progress.
  * Kept the sign-in screen visible when first-run onboarding remains incomplete.
  * Ensured attach-ticket users continue directly to the shell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->