### PR TITLE
Make tunnel frame decoding linear

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -124,6 +124,7 @@ pub fn encode_pty_frame(bytes: &[u8]) -> Vec<u8> {
 /// the caller must close the connection.
 pub struct TunnelFrameDecoder {
     buffer: BytesMut,
+    storage_capacity: usize,
     failed: bool,
     max_frame_bytes: usize,
 }
@@ -132,6 +133,7 @@ impl TunnelFrameDecoder {
     pub fn new(max_frame_bytes: usize) -> TunnelFrameDecoder {
         let max_frame_bytes = max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES);
         TunnelFrameDecoder {
+            storage_capacity: max_frame_bytes + HEADER_BYTES,
             buffer: BytesMut::with_capacity(max_frame_bytes + HEADER_BYTES),
             failed: false,
             max_frame_bytes,
@@ -143,6 +145,7 @@ impl TunnelFrameDecoder {
             return Err("decoder_poisoned");
         }
         self.buffer.extend_from_slice(chunk);
+        self.storage_capacity = self.storage_capacity.max(self.buffer.capacity());
         let mut frames = Vec::new();
         while self.buffer.len() >= HEADER_BYTES {
             let length = u32::from_be_bytes([
@@ -171,9 +174,10 @@ impl TunnelFrameDecoder {
         // storage bounded by one maximum-size frame plus its header instead
         // of holding the capacity of that whole read forever.
         let retained_limit = self.max_frame_bytes + HEADER_BYTES;
-        if self.buffer.capacity() > retained_limit && self.buffer.len() <= retained_limit {
+        if self.storage_capacity > retained_limit && self.buffer.len() <= retained_limit {
             let mut compacted = BytesMut::with_capacity(retained_limit);
             compacted.extend_from_slice(&self.buffer);
+            self.storage_capacity = compacted.capacity();
             self.buffer = compacted;
         }
         Ok(frames)
@@ -869,9 +873,9 @@ mod tests {
         }));
         assert!(decoder.buffer.is_empty());
         assert!(
-            decoder.buffer.capacity() <= MAX_FRAME_BYTES + HEADER_BYTES,
+            decoder.storage_capacity <= MAX_FRAME_BYTES + HEADER_BYTES,
             "decoder retained {} bytes for a {} byte max frame",
-            decoder.buffer.capacity(),
+            decoder.storage_capacity,
             MAX_FRAME_BYTES
         );
     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -836,6 +836,36 @@ mod tests {
     }
 
     #[test]
+    fn decoder_handles_many_frames_without_retaining_batch_storage() {
+        const MAX_FRAME_BYTES: usize = 8;
+        const FRAME_COUNT: usize = 2_048;
+
+        let mut stream = Vec::with_capacity(FRAME_COUNT * (HEADER_BYTES + 1));
+        for index in 0..FRAME_COUNT {
+            stream.extend_from_slice(&encode_tunnel_frame(
+                if index % 2 == 0 { FRAME_KIND_CONTROL } else { FRAME_KIND_PTY },
+                &[index as u8],
+            ));
+        }
+
+        let mut decoder = TunnelFrameDecoder::new(MAX_FRAME_BYTES);
+        let frames = decoder.push(&stream).expect("clean stream");
+
+        assert_eq!(frames.len(), FRAME_COUNT);
+        assert!(frames.iter().enumerate().all(|(index, frame)| {
+            frame.kind == if index % 2 == 0 { FRAME_KIND_CONTROL } else { FRAME_KIND_PTY }
+                && frame.payload == [index as u8]
+        }));
+        assert!(decoder.buffer.is_empty());
+        assert!(
+            decoder.buffer.capacity() <= MAX_FRAME_BYTES + HEADER_BYTES,
+            "decoder retained {} bytes for a {} byte max frame",
+            decoder.buffer.capacity(),
+            MAX_FRAME_BYTES
+        );
+    }
+
+    #[test]
     fn oversized_length_poisons_the_decoder() {
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
         let mut header = ((MAX_TUNNEL_FRAME_BYTES + 1) as u32).to_be_bytes().to_vec();

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -44,6 +44,7 @@ use std::time::Duration;
 
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use bytes::{Buf, BytesMut};
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
@@ -122,17 +123,18 @@ pub fn encode_pty_frame(bytes: &[u8]) -> Vec<u8> {
 /// length-prefixed stream that desynced once can never be trusted again, so
 /// the caller must close the connection.
 pub struct TunnelFrameDecoder {
-    buffer: Vec<u8>,
+    buffer: BytesMut,
     failed: bool,
     max_frame_bytes: usize,
 }
 
 impl TunnelFrameDecoder {
     pub fn new(max_frame_bytes: usize) -> TunnelFrameDecoder {
+        let max_frame_bytes = max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES);
         TunnelFrameDecoder {
-            buffer: Vec::new(),
+            buffer: BytesMut::with_capacity(max_frame_bytes + HEADER_BYTES),
             failed: false,
-            max_frame_bytes: max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES),
+            max_frame_bytes,
         }
     }
 
@@ -161,9 +163,18 @@ impl TunnelFrameDecoder {
             if self.buffer.len() < HEADER_BYTES + length {
                 break;
             }
-            let payload = self.buffer[HEADER_BYTES..HEADER_BYTES + length].to_vec();
-            self.buffer.drain(..HEADER_BYTES + length);
+            self.buffer.advance(HEADER_BYTES);
+            let payload = self.buffer.split_to(length).to_vec();
             frames.push(TunnelFrame { kind, payload });
+        }
+        // A single read may contain many frames. Keep the retained decoder
+        // storage bounded by one maximum-size frame plus its header instead
+        // of holding the capacity of that whole read forever.
+        let retained_limit = self.max_frame_bytes + HEADER_BYTES;
+        if self.buffer.capacity() > retained_limit && self.buffer.len() <= retained_limit {
+            let mut compacted = BytesMut::with_capacity(retained_limit);
+            compacted.extend_from_slice(&self.buffer);
+            self.buffer = compacted;
         }
         Ok(frames)
     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -133,8 +133,8 @@ impl TunnelFrameDecoder {
     pub fn new(max_frame_bytes: usize) -> TunnelFrameDecoder {
         let max_frame_bytes = max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES);
         TunnelFrameDecoder {
-            storage_capacity: max_frame_bytes + HEADER_BYTES,
-            buffer: BytesMut::with_capacity(max_frame_bytes + HEADER_BYTES),
+            storage_capacity: 0,
+            buffer: BytesMut::new(),
             failed: false,
             max_frame_bytes,
         }


### PR DESCRIPTION
Replace front-draining Vec buffering with BytesMut advancement and bounded compaction. Add a batched-frame regression test that decodes every frame and verifies retained storage stays within one max frame.

Regression history: first commit adds the behavior test; second commit fixes the decoder.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes tunnel frame decoding linear by advancing a `BytesMut` buffer instead of draining a front `Vec`, reducing work for batched reads and limiting retained storage.

- Tracks backing capacity separately from buffered length and compacts only when retained capacity exceeds one maximum frame plus its header.
- Allocates storage lazily and clamps `max_frame_bytes` to the supported range.
- Adds a regression test that decodes 2,048 batched control and PTY frames and verifies their payloads, kinds, and retained capacity.

<sup>Written for commit 863f968ab4d9891d324805ef535e135cdce2a879. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11565?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved tunnel frame buffering to reduce retained memory after processing large batches of frames.
  * Added safeguards to keep decoder storage bounded while handling multi-frame reads.

* **Tests**
  * Added coverage verifying that buffer capacity remains limited after processing many frames.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->