### PR TITLE
fix: wire and persist teardown hook events

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1162,6 +1162,10 @@ final class ClaudeHookSessionStore {
             guard var record = state.sessions[normalizedSessionId] else { return }
             record.agentLifecycle = .unknown
             if let hookEventName = normalizeOptional(hookEventName) {
+                if record.hookEventName != hookEventName {
+                    record.lastSubtitle = nil
+                    record.lastBody = nil
+                }
                 record.hookEventName = hookEventName
             }
             record.updatedAt = Date().timeIntervalSince1970

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1153,13 +1153,17 @@ final class ClaudeHookSessionStore {
     func clearAgentLifecycleIfPresent(
         sessionId: String,
         workspaceId: String?,
-        surfaceId: String?
+        surfaceId: String?,
+        hookEventName: String? = nil
     ) throws {
         let normalizedSessionId = normalizeSessionId(sessionId)
         guard !normalizedSessionId.isEmpty else { return }
         try withLockedState { state in
             guard var record = state.sessions[normalizedSessionId] else { return }
             record.agentLifecycle = .unknown
+            if let hookEventName = normalizeOptional(hookEventName) {
+                record.hookEventName = hookEventName
+            }
             record.updatedAt = Date().timeIntervalSince1970
             state.sessions[normalizedSessionId] = record
         }
@@ -28287,7 +28291,8 @@ struct CMUXCLI {
                     try? sessionStore.clearAgentLifecycleIfPresent(
                         sessionId: consumedSession.sessionId,
                         workspaceId: consumedSession.workspaceId,
-                        surfaceId: consumedSession.surfaceId
+                        surfaceId: consumedSession.surfaceId,
+                        hookEventName: reportedHookEventName(from: parsedInput) ?? "SessionEnd"
                     )
                     // Lifecycle cleanup is always pane-scoped: a workspace can
                     // host multiple agents whose notifications are independent.
@@ -35241,7 +35246,8 @@ export default CMUXSessionRestore;
                         transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         turnId: input.turnId,
                         pid: pid,
-                        launchCommand: resumeLaunchCommand
+                        launchCommand: resumeLaunchCommand,
+                        hookEventName: persistedHookEventName
                     )) ?? false
                 } else {
                     _ = try? store.upsert(
@@ -36556,6 +36562,7 @@ export default CMUXSessionRestore;
                         transcriptPath: input.transcriptPath ?? mapped.transcriptPath,
                         pid: mapped.pid,
                         launchCommand: mapped.launchCommand,
+                        hookEventName: persistedHookEventName,
                         lastSubtitle: nil,
                         lastBody: nil,
                         autoNameMessages: autoNamingMessages(

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -555,6 +555,7 @@
 		79390011AA11BB22CC33DD11 /* ClaudeHookPIDAuthenticationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79390012AA11BB22CC33DD12 /* ClaudeHookPIDAuthenticationTests.swift */; };
 		89930005AABBCCDDEEFF0001 /* ClaudeHookSessionStore+SupersededCleanup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89930005AABBCCDDEEFF0002 /* ClaudeHookSessionStore+SupersededCleanup.swift */; };
 		89930004AABBCCDDEEFF0001 /* ClaudeHookSessionStoreFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 89930004AABBCCDDEEFF0002 /* ClaudeHookSessionStoreFile.swift */; };
+		B11529000000000000000002 /* ClaudeHookSessionStorePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B11529000000000000000001 /* ClaudeHookSessionStorePersistenceTests.swift */; };
 		A5D41220A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41221A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift */; };
 		A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */; };
 		C7A533000000000000000002 /* ClaudeSessionCanonicalizationContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A533000000000000000001 /* ClaudeSessionCanonicalizationContext.swift */; };
@@ -3638,6 +3639,7 @@
 		79390012AA11BB22CC33DD12 /* ClaudeHookPIDAuthenticationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeHookPIDAuthenticationTests.swift; sourceTree = "<group>"; };
 		89930005AABBCCDDEEFF0002 /* ClaudeHookSessionStore+SupersededCleanup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ClaudeHookSessionStore+SupersededCleanup.swift"; sourceTree = "<group>"; };
 		89930004AABBCCDDEEFF0002 /* ClaudeHookSessionStoreFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeHookSessionStoreFile.swift; sourceTree = "<group>"; };
+		B11529000000000000000001 /* ClaudeHookSessionStorePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeHookSessionStorePersistenceTests.swift; sourceTree = "<group>"; };
 		A5D41221A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeHookSurfaceResolutionSwiftTests.swift; sourceTree = "<group>"; };
 		A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeNotificationStatusLifecycleTests.swift; sourceTree = "<group>"; };
 		C7A533000000000000000001 /* ClaudeSessionCanonicalizationContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "ClaudeSessionCanonicalizationContext.swift"; sourceTree = "<group>"; };
@@ -9039,6 +9041,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				93800002AA11BB22CC33EE02 /* AgentDeliveryTTYBindingTests.swift */,
 				93840006AA11BB22CC33EE06 /* AgentRelayTTYOwnershipTests.swift */,
 				79390012AA11BB22CC33DD12 /* ClaudeHookPIDAuthenticationTests.swift */,
+				B11529000000000000000001 /* ClaudeHookSessionStorePersistenceTests.swift */,
 				C7A534000000000000000001 /* ClaudeHookFeedTelemetrySwiftTests.swift */,
 				A5D41223A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift */,
 				A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */,
@@ -11966,6 +11969,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				79390001AA11BB22CC33DD01 /* ClaudeHookLiveDeliveryTargetTests.swift in Sources */,
 				79390009AA11BB22CC33DD09 /* ClaudeHookLiveDeliveryTargetTestSupport.swift in Sources */,
 				79390011AA11BB22CC33DD11 /* ClaudeHookPIDAuthenticationTests.swift in Sources */,
+				B11529000000000000000002 /* ClaudeHookSessionStorePersistenceTests.swift in Sources */,
 				A5D41220A1B2C3D4E5F60718 /* ClaudeHookSurfaceResolutionSwiftTests.swift in Sources */,
 				A5D41222A1B2C3D4E5F60718 /* ClaudeNotificationStatusLifecycleTests.swift in Sources */,
 				CE7000000000000000000001 /* ClaudeWrapperResumeEnvironmentTests.swift in Sources */,

--- a/cmuxTests/ClaudeHookSessionStorePersistenceTests.swift
+++ b/cmuxTests/ClaudeHookSessionStorePersistenceTests.swift
@@ -77,7 +77,7 @@ import Testing
 
     @Test func lifecycleCleanupPersistsTheTeardownHookEvent() throws {
         let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-hook-store-cleanup-(UUID().uuidString)", isDirectory: true)
+            .appendingPathComponent("cmux-hook-store-cleanup-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: root) }
 

--- a/cmuxTests/ClaudeHookSessionStorePersistenceTests.swift
+++ b/cmuxTests/ClaudeHookSessionStorePersistenceTests.swift
@@ -103,5 +103,7 @@ import Testing
         let ended = try #require(store.lookup(sessionId: "session-1"))
         #expect(ended.agentLifecycle == .unknown)
         #expect(ended.hookEventName == "SessionEnd")
+        #expect(ended.lastSubtitle == nil)
+        #expect(ended.lastBody == nil)
     }
 }

--- a/cmuxTests/ClaudeHookSessionStorePersistenceTests.swift
+++ b/cmuxTests/ClaudeHookSessionStorePersistenceTests.swift
@@ -74,4 +74,34 @@ import Testing
         #expect(decoded.hookEventName == nil)
         #expect(decoded.sessionId == "legacy-session")
     }
+
+    @Test func lifecycleCleanupPersistsTheTeardownHookEvent() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-hook-store-cleanup-(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let statePath = root.appendingPathComponent("sessions.json").path
+        let store = ClaudeHookSessionStore(processEnv: ["CMUX_CLAUDE_HOOK_STATE_PATH": statePath])
+        _ = try store.upsert(
+            sessionId: "session-1",
+            workspaceId: "workspace-1",
+            surfaceId: "surface-1",
+            agentLifecycle: .idle,
+            hookEventName: "Stop",
+            lastSubtitle: "Completed",
+            lastBody: "Finished"
+        )
+
+        try store.clearAgentLifecycleIfPresent(
+            sessionId: "session-1",
+            workspaceId: "workspace-1",
+            surfaceId: "surface-1",
+            hookEventName: "SessionEnd"
+        )
+
+        let ended = try #require(store.lookup(sessionId: "session-1"))
+        #expect(ended.agentLifecycle == .unknown)
+        #expect(ended.hookEventName == "SessionEnd")
+    }
 }


### PR DESCRIPTION
Stacked on #11529.

Fixes audit gaps:
- Wires ClaudeHookSessionStorePersistenceTests.swift into cmuxTests so the regression suite executes.
- Persists SessionEnd when lifecycle cleanup clears a Claude record.
- Persists SessionEnd for generic turn-boundary providers.
- Threads the event through Codex prompt-running updates.

Commits are test-first: the first commit adds the failing teardown persistence test and PBX wiring; the second implements propagation.

No local Xcode tests run per project policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11569"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790919807&installation_model_id=21920&pr_number=11569&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11569&signature=17cebda2111bd35b8045f40cdafc27d976d02ba884affc3904c16f4904420341"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persists teardown hook events when lifecycle cleanup clears a Claude record so `SessionEnd` state survives, and wires the regression test into `cmuxTests`.

**Bug Fixes**
- Threads the persisted hook event through Codex and turn-boundary provider updates, clearing stale summary data on teardown.
- Gives each hook-store test fixture a unique temporary path to prevent collisions.

<sup>Written for commit 54629d55ab11c931dadc7119d3a195066c444a40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

