### PR TITLE
Fix live-resize end callback ordering

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Sizing.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Sizing.swift
@@ -5,6 +5,22 @@ public import GhosttyKit
 // MARK: - Surface sizing and scale
 
 extension TerminalSurface {
+    /// Holds surface-size writes while a host is committing an interactive
+    /// geometry transaction. The next size reconciliation after this flag is
+    /// cleared supplies the authoritative frame and renderer drawable size.
+    @MainActor
+    public func setSurfaceSizeUpdatesDeferred(_ deferred: Bool) {
+        surfaceSizeUpdatesDeferred = deferred
+    }
+
+    /// Reports whether the host has explicitly deferred surface size writes.
+    /// The portal owns this phase so the final resize pass does not depend on
+    /// AppKit's `inLiveResize` value, which may clear before that pass runs.
+    @MainActor
+    private var shouldDeferSurfaceSizeUpdates: Bool {
+        surfaceSizeUpdatesDeferred
+    }
+
     /// Match upstream Ghostty AppKit sizing: framebuffer dimensions are derived
     /// from backing-space points and truncated (never rounded up).
     func pixelDimension(from value: CGFloat) -> UInt32 {
@@ -165,7 +181,8 @@ extension TerminalSurface {
     @MainActor
     public func reapplyAssignedGrid() {
         guard ioMode.usesManualIO, lastUncappedPixelWidth > 0, lastUncappedPixelHeight > 0,
-              lastXScale > 0, lastYScale > 0 else { return }
+              lastXScale > 0, lastYScale > 0,
+              !shouldDeferSurfaceSizeUpdates else { return }
         _ = updateSize(
             width: CGFloat(lastUncappedPixelWidth) / lastXScale,
             height: CGFloat(lastUncappedPixelHeight) / lastYScale,
@@ -205,6 +222,7 @@ extension TerminalSurface {
         suppressAssignedGridPin: Bool = false,
         caller: StaticString = #function
     ) -> Bool {
+        guard !shouldDeferSurfaceSizeUpdates else { return false }
         guard let surface = liveSurfaceForGhosttyAccess(reason: "updateSize") else { return false }
         _ = layerScale
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -288,6 +288,10 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// the pinned grid and clips or letterboxes the difference — the same
     /// answer tmux gives a client whose size disagrees with the window.
     var assignedGrid: (columns: Int, rows: Int)?
+    /// Prevents renderer/PTY size writes while a host is committing an
+    /// interactive geometry transaction. The host clears this after its final
+    /// pane frame is installed, then performs one authoritative size update.
+    var surfaceSizeUpdatesDeferred = false
     /// Temporary runtime font-size ownership while a mobile viewport is fitted.
     var mobileViewportFontFitState: MobileViewportFontFitState?
     // Debug metadata is read from debug/CLI paths off the main thread; the

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -10448,6 +10448,19 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.terminalSurface?.forceRefresh(reason: reason)
     }
 
+    /// Resolves the renderer frame during a deferred resize, rejecting a
+    /// degenerate committed size so an early pre-layout pass cannot collapse
+    /// the terminal during a scrollbar-style update.
+    private func resolvedDeferredRendererSize(deferred: Bool, fallback: CGSize) -> CGSize {
+        guard deferred,
+              let committedRendererSize,
+              committedRendererSize.width > 0,
+              committedRendererSize.height > 0 else {
+            return fallback
+        }
+        return committedRendererSize
+    }
+
     /// Synchronizes pane overlays, viewport geometry, and the renderer frame;
     /// live window resize keeps the renderer on its committed inner size.
     @discardableResult
@@ -10483,15 +10496,10 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
-        let rendererSize: CGSize = {
-            guard deferRendererResize else { return targetSize }
-            guard let committedRendererSize,
-                  committedRendererSize.width > 0,
-                  committedRendererSize.height > 0 else {
-                return targetSize
-            }
-            return committedRendererSize
-        }()
+        let rendererSize = resolvedDeferredRendererSize(
+            deferred: deferRendererResize,
+            fallback: targetSize
+        )
         let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: rendererSize)
         _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
         let targetDocumentFrame = CGRect(
@@ -10543,15 +10551,10 @@ final class GhosttySurfaceScrollView: NSView {
         // otherwise a child can briefly grow to the live pane size before the
         // clipping boundary gets a chance to contain it.
         let settledTargetSize = scrollView.bounds.size
-        let settledRendererSize: CGSize = {
-            guard deferRendererResize else { return settledTargetSize }
-            guard let committedRendererSize,
-                  committedRendererSize.width > 0,
-                  committedRendererSize.height > 0 else {
-                return settledTargetSize
-            }
-            return committedRendererSize
-        }()
+        let settledRendererSize = resolvedDeferredRendererSize(
+            deferred: deferRendererResize,
+            fallback: settledTargetSize
+        )
         let committedRendererFrame = CGRect(origin: surfaceView.frame.origin, size: settledRendererSize)
         _ = setFrameIfNeeded(surfaceView, to: committedRendererFrame)
         updateNotificationRingPath()
@@ -13300,7 +13303,10 @@ final class GhosttySurfaceScrollView: NSView {
         scrollView.layoutSubtreeIfNeeded()
         let targetSize = scrollView.contentView.bounds.size
         let deferRendererResize = windowLiveResizeActive
-        let rendererSize = deferRendererResize ? (committedRendererSize ?? targetSize) : targetSize
+        let rendererSize = resolvedDeferredRendererSize(
+            deferred: deferRendererResize,
+            fallback: targetSize
+        )
         let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: rendererSize)
         _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
         let targetDocumentFrame = CGRect(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3955,6 +3955,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     private let scrollSpeedAccumulator = TerminalScrollSpeedAccumulator()
     private var visibleInUI: Bool = true
     private var pendingSurfaceSize: CGSize?
+    /// Portal geometry follows every window-resize tick, but the renderer's
+    /// drawable/grid must remain on the last committed epoch until the end
+    /// pass. The parent portal owns this phase and re-enables updates once the
+    /// final pane frame is installed.
+    private var defersSurfaceSizeDuringWindowLiveResize = false
     private var deferredSurfaceSizeRetryQueued = false, needsSurfaceSizeRetryAfterMetalLayerRealizes = false
     private var deferredSurfaceSizeNonMetalRetryCount = 0
     private var lastDrawableSize: CGSize = .zero
@@ -4018,6 +4023,16 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         visibleInUI = visible
     }
 
+    /// Holds renderer/drawable updates while the portal is committing a live
+    /// window resize. The view frame may move with its pane, but Ghostty must
+    /// not publish a surface for a size that no longer matches that frame.
+    fileprivate func setWindowLiveResizeActive(_ active: Bool) {
+        defersSurfaceSizeDuringWindowLiveResize = active
+        terminalSurface?.setSurfaceSizeUpdatesDeferred(active)
+        clipsToBounds = true
+        layer?.masksToBounds = true
+    }
+
     override init(frame frameRect: NSRect) {
         imageTransferPreparation = nil
         super.init(frame: frameRect)
@@ -4057,11 +4072,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return metalLayer
     }
 
+    /// Installs the layer-backed terminal view and its input/drag plumbing.
     private func setup() {
         selectionAccessibilityNotifier = TerminalSelectionAccessibilityNotifier(element: self, events: selectionAccessibilitySignal.events)
         // GhosttyMetalLayer provides render stats and opt-in frame notifications for
         // input sequencing that needs to wait for terminal redraws.
         wantsLayer = true
+        clipsToBounds = true
         layer?.masksToBounds = true
         setupKeyboardCopyModeCursorOverlay()
         installEventMonitor()
@@ -4970,6 +4987,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override var isOpaque: Bool { false }
 
+    /// Resolves an explicit candidate size, current bounds, or the latest
+    /// pending size in that order.
     private func resolvedSurfaceSize(preferred size: CGSize?) -> CGSize {
         if let size,
            size.width > 0,
@@ -4988,11 +5007,15 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return currentBounds
     }
 
+    /// Reports whether the current drag pasteboard carries a live internal
+    /// tab-transfer payload.
     private static func hasTabDragPasteboardTypes() -> Bool {
         let pasteboard = NSPasteboard(name: .drag)
         return hasLiveInternalDrag(in: pasteboard)
     }
 
+    /// Identifies pointer-drag events that may temporarily defer surface size
+    /// work while a tab transfer is active.
     private static func isDragResizeEvent(_ eventType: NSEvent.EventType?) -> Bool {
         switch eventType {
         case .leftMouseDragged, .rightMouseDragged, .otherMouseDragged:
@@ -5002,6 +5025,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
     }
 
+    /// Determines whether a live native tab drag owns this resize callback.
     private static func shouldDeferSurfaceResizeForActiveDrag(in window: NSWindow?) -> Bool {
         // The drag pasteboard can retain tab-transfer UTIs briefly after a split command
         // or other layout churn. Only defer terminal resizes while an actual drag event
@@ -5015,15 +5039,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return isDragResizeEvent(NSApp.currentEvent?.type)
     }
 
+    /// Returns the non-window interaction that currently defers a surface
+    /// resize, if any.
     private func activeSurfaceResizeDeferralReason() -> String? {
         if isWindowLiveResizeActive { return nil }
         return Self.shouldDeferSurfaceResizeForActiveDrag(in: window) ? "tabDrag" : nil
     }
 
+    /// Whether the portal has propagated the window live-resize phase to this
+    /// surface view.
     private var isWindowLiveResizeActive: Bool {
-        inLiveResize || window?.inLiveResize == true
+        defersSurfaceSizeDuringWindowLiveResize
     }
 
+    /// Schedules one retry when AppKit has not realized a usable terminal
+    /// backing layer yet.
     @discardableResult private func scheduleDeferredSurfaceSizeRetryIfNeeded() -> Bool {
         guard window != nil, !deferredSurfaceSizeRetryQueued else { return false }
         deferredSurfaceSizeRetryQueued = true
@@ -5031,8 +5061,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         return true
     }
 
+    /// Retries a size update after Ghostty's Metal layer has been attached.
     @MainActor fileprivate func reconcileSurfaceSizeAfterMetalLayerAttachIfNeeded() { guard needsSurfaceSizeRetryAfterMetalLayerRealizes else { return }; deferredSurfaceSizeNonMetalRetryCount = 0; _ = updateSurfaceSize() }
 
+    /// Applies the current logical bounds to the Ghostty layer and runtime,
+    /// unless an active live-resize phase is holding the last committed size.
     @discardableResult
     private func updateSurfaceSize(
         size: CGSize? = nil, bypassLiveResizeCoalescing: Bool = false, caller: StaticString = #function
@@ -5055,6 +5088,22 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
         if pendingSurfaceSize != size { deferredSurfaceSizeNonMetalRetryCount = 0 }
         pendingSurfaceSize = size
+        clipsToBounds = true
+        layer?.masksToBounds = true
+        if !bypassLiveResizeCoalescing,
+           defersSurfaceSizeDuringWindowLiveResize {
+#if DEBUG
+            let signature = "windowLiveResize-\(Int(size.width.rounded()))x\(Int(size.height.rounded()))"
+            if lastSizeSkipSignature != signature {
+                cmuxDebugLog(
+                    "surface.size.defer surface=\(terminalSurface.id.uuidString.prefix(5)) " +
+                    "reason=windowLiveResize size=\(String(format: "%.1fx%.1f", size.width, size.height))"
+                )
+                lastSizeSkipSignature = signature
+            }
+#endif
+            return false
+        }
         if let deferralReason = activeSurfaceResizeDeferralReason() {
             scheduleDeferredSurfaceSizeRetryIfNeeded()
 #if DEBUG
@@ -9683,6 +9732,12 @@ final class GhosttySurfaceScrollView: NSView {
     private var activeDropZone: DropZone?
     private var pendingDropZone: DropZone?
     private var sessionContentWidthPresentation = SessionContentWidthPresentation.disabled
+    /// The pane frame follows live window-resize ticks, while this committed
+    /// inner size remains stable until the renderer can consume the final
+    /// drawable dimensions without racing an older IOSurface presentation.
+    private var committedRendererSize: CGSize?
+    /// Whether the pane is in the explicit window live-resize phase.
+    private var windowLiveResizeActive = false
     private var dropZoneOverlayAnimationGeneration: UInt64 = 0
     private var pendingAutomaticFirstResponderApply = false
     private var pendingAutomaticFirstResponderFocusTransactionId: UUID?
@@ -9879,6 +9934,22 @@ final class GhosttySurfaceScrollView: NSView {
         )
     }
 
+    /// Marks the explicit window live-resize phase owned by
+    /// ``WindowTerminalPortal``. The outer pane frame remains live, while the
+    /// inner renderer frame/drawable stays at ``committedRendererSize`` until
+    /// the phase ends. This makes stale asynchronous presents harmless: they
+    /// are still inside a clipped pane and still match the renderer layer's
+    /// last committed size.
+    func setWindowLiveResizeActive(_ active: Bool) {
+        windowLiveResizeActive = active
+        surfaceView.setWindowLiveResizeActive(active)
+        clipsToBounds = true
+        layer?.masksToBounds = true
+        surfaceView.clipsToBounds = true
+        surfaceView.layer?.masksToBounds = true
+    }
+
+    /// Creates the pane host around a Ghostty surface view.
     init(surfaceView: GhosttyNSView) {
         #if DEBUG
         dispatchPrecondition(condition: .onQueue(.main))
@@ -9914,12 +9985,17 @@ final class GhosttySurfaceScrollView: NSView {
         scrollView.surfaceView = surfaceView
 
         documentView = NSView(frame: .zero)
+        surfaceView.autoresizingMask = []
+        surfaceView.translatesAutoresizingMaskIntoConstraints = true
         scrollView.documentView = documentView
         documentView.addSubview(surfaceView)
 
         super.init(frame: .zero)
         wantsLayer = true
+        clipsToBounds = true
         layer?.masksToBounds = true
+        scrollView.clipsToBounds = true
+        documentView.clipsToBounds = true
 
         backgroundView.wantsLayer = true
         backgroundView.layer?.backgroundColor = NSColor.clear.cgColor
@@ -10372,11 +10448,21 @@ final class GhosttySurfaceScrollView: NSView {
         surfaceView.terminalSurface?.forceRefresh(reason: reason)
     }
 
+    /// Synchronizes pane overlays, viewport geometry, and the renderer frame;
+    /// live window resize keeps the renderer on its committed inner size.
     @discardableResult
     private func synchronizeGeometryAndContent(
         forceViewportSync: Bool? = nil,
         preservedReviewOriginY: CGFloat? = nil
     ) -> Bool {
+        clipsToBounds = true
+        layer?.masksToBounds = true
+        scrollView.clipsToBounds = true
+        scrollView.contentView.clipsToBounds = true
+        surfaceView.clipsToBounds = true
+        surfaceView.layer?.masksToBounds = true
+        surfaceView.autoresizingMask = []
+        let deferRendererResize = windowLiveResizeActive
         let preservedReviewOriginY = preservedReviewOriginY ?? {
             guard scrollbackViewportIntent.preservesViewportDuringPendingSync else { return nil }
             return max(scrollView.contentView.bounds.origin.y, 0)
@@ -10397,7 +10483,16 @@ final class GhosttySurfaceScrollView: NSView {
 #if DEBUG
         logLayoutDuringActiveDrag(targetSize: targetSize)
 #endif
-        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: targetSize)
+        let rendererSize: CGSize = {
+            guard deferRendererResize else { return targetSize }
+            guard let committedRendererSize,
+                  committedRendererSize.width > 0,
+                  committedRendererSize.height > 0 else {
+                return targetSize
+            }
+            return committedRendererSize
+        }()
+        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: rendererSize)
         _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
         let targetDocumentFrame = CGRect(
             origin: documentView.frame.origin,
@@ -10443,6 +10538,22 @@ final class GhosttySurfaceScrollView: NSView {
             scrollView.tile()
         }
         scrollView.layoutSubtreeIfNeeded()
+        // NSScrollView may reapply autoresizing/layout state to its document
+        // view during tiling. Reassert the renderer frame after that layout;
+        // otherwise a child can briefly grow to the live pane size before the
+        // clipping boundary gets a chance to contain it.
+        let settledTargetSize = scrollView.bounds.size
+        let settledRendererSize: CGSize = {
+            guard deferRendererResize else { return settledTargetSize }
+            guard let committedRendererSize,
+                  committedRendererSize.width > 0,
+                  committedRendererSize.height > 0 else {
+                return settledTargetSize
+            }
+            return committedRendererSize
+        }()
+        let committedRendererFrame = CGRect(origin: surfaceView.frame.origin, size: settledRendererSize)
+        _ = setFrameIfNeeded(surfaceView, to: committedRendererFrame)
         updateNotificationRingPath()
         updateFlashPath(style: lastFlashStyle)
         updateFlashAppearance(style: lastFlashStyle)
@@ -10451,8 +10562,11 @@ final class GhosttySurfaceScrollView: NSView {
             preservedReviewOriginY: preservedReviewOriginY
         )
         synchronizeSurfaceView()
-        let didCoreSurfaceChange = synchronizeCoreSurface()
-        return !sizeApproximatelyEqual(previousSurfaceSize, targetSize) || didCoreSurfaceChange
+        let didCoreSurfaceChange = deferRendererResize ? false : synchronizeCoreSurface()
+        if !deferRendererResize {
+            committedRendererSize = surfaceView.frame.size
+        }
+        return !sizeApproximatelyEqual(previousSurfaceSize, surfaceView.frame.size) || didCoreSurfaceChange
     }
 
     /// Updates terminal content geometry without shrinking pane-level overlays.
@@ -13180,10 +13294,14 @@ final class GhosttySurfaceScrollView: NSView {
         synchronizeTerminalGeometryAfterScrollerStyleChange()
     }
 
+    /// Retiles terminal content after the system scrollbar preference changes,
+    /// preserving the same live-resize renderer ordering contract.
     private func synchronizeTerminalGeometryAfterScrollerStyleChange() {
         scrollView.layoutSubtreeIfNeeded()
         let targetSize = scrollView.contentView.bounds.size
-        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: targetSize)
+        let deferRendererResize = windowLiveResizeActive
+        let rendererSize = deferRendererResize ? (committedRendererSize ?? targetSize) : targetSize
+        let targetSurfaceFrame = CGRect(origin: surfaceView.frame.origin, size: rendererSize)
         _ = setFrameIfNeeded(surfaceView, to: targetSurfaceFrame)
         let targetDocumentFrame = CGRect(
             origin: documentView.frame.origin,
@@ -13191,7 +13309,10 @@ final class GhosttySurfaceScrollView: NSView {
         )
         _ = setFrameIfNeeded(documentView, to: targetDocumentFrame)
         synchronizeSurfaceView()
-        _ = synchronizeCoreSurface()
+        if !deferRendererResize {
+            _ = synchronizeCoreSurface()
+            committedRendererSize = surfaceView.frame.size
+        }
     }
 
     private func handleTerminalScrollBarPreferenceChange() {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5236,6 +5236,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     fileprivate func debugPendingSurfaceSize() -> CGSize? { pendingSurfaceSize }
     func debugLastDrawableSizeForTesting() -> CGSize { lastDrawableSize }
     func debugDeferredSurfaceSizeRetryQueuedForTesting() -> Bool { deferredSurfaceSizeRetryQueued }
+    func debugIsWindowLiveResizeActiveForTesting() -> Bool { isWindowLiveResizeActive }
     @discardableResult func debugUpdateSurfaceSizeForTesting(_ size: CGSize) -> Bool { updateSurfaceSize(size: size) }
 #endif
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5090,8 +5090,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         pendingSurfaceSize = size
         clipsToBounds = true
         layer?.masksToBounds = true
-        if !bypassLiveResizeCoalescing,
-           defersSurfaceSizeDuringWindowLiveResize {
+        // The portal gate owns publication ordering. The end-live-resize
+        // callback passes bypass=true to disable pixel-only coalescing, but
+        // it must still wait for the portal's final pane geometry commit.
+        if defersSurfaceSizeDuringWindowLiveResize {
 #if DEBUG
             let signature = "windowLiveResize-\(Int(size.width.rounded()))x\(Int(size.height.rounded()))"
             if lastSizeSkipSignature != signature {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5236,12 +5236,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     fileprivate func debugPendingSurfaceSize() -> CGSize? { pendingSurfaceSize }
     func debugLastDrawableSizeForTesting() -> CGSize { lastDrawableSize }
     func debugDeferredSurfaceSizeRetryQueuedForTesting() -> Bool { deferredSurfaceSizeRetryQueued }
-    @discardableResult func debugUpdateSurfaceSizeForTesting(
-        _ size: CGSize,
-        bypassLiveResizeCoalescing: Bool = false
-    ) -> Bool {
-        updateSurfaceSize(size: size, bypassLiveResizeCoalescing: bypassLiveResizeCoalescing)
-    }
+    @discardableResult func debugUpdateSurfaceSizeForTesting(_ size: CGSize) -> Bool { updateSurfaceSize(size: size) }
 #endif
 
     /// Force a full size reconciliation for the current bounds.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3960,6 +3960,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     /// pass. The parent portal owns this phase and re-enables updates once the
     /// final pane frame is installed.
     private var defersSurfaceSizeDuringWindowLiveResize = false
+    /// A portal explicitly owns the live-resize phase for hosted views. Keep
+    /// that state separate from AppKit's native signal so the portal can
+    /// release its final pass before AppKit clears `inLiveResize`, while
+    /// standalone Ghostty views still use the native fallback.
+    private var portalWindowLiveResizeState: Bool?
     private var deferredSurfaceSizeRetryQueued = false, needsSurfaceSizeRetryAfterMetalLayerRealizes = false
     private var deferredSurfaceSizeNonMetalRetryCount = 0
     private var lastDrawableSize: CGSize = .zero
@@ -4027,10 +4032,17 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     /// window resize. The view frame may move with its pane, but Ghostty must
     /// not publish a surface for a size that no longer matches that frame.
     fileprivate func setWindowLiveResizeActive(_ active: Bool) {
+        portalWindowLiveResizeState = active
         defersSurfaceSizeDuringWindowLiveResize = active
         terminalSurface?.setSurfaceSizeUpdatesDeferred(active)
         clipsToBounds = true
         layer?.masksToBounds = true
+    }
+
+    fileprivate func clearWindowLiveResizeStateForPortal() {
+        portalWindowLiveResizeState = nil
+        defersSurfaceSizeDuringWindowLiveResize = false
+        terminalSurface?.setSurfaceSizeUpdatesDeferred(false)
     }
 
     override init(frame frameRect: NSRect) {
@@ -5047,9 +5059,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     /// Whether the portal has propagated the window live-resize phase to this
-    /// surface view.
+    /// surface view. Standalone views retain AppKit's native fallback.
     private var isWindowLiveResizeActive: Bool {
-        defersSurfaceSizeDuringWindowLiveResize
+        portalWindowLiveResizeState
+            ?? (inLiveResize || window?.inLiveResize == true)
     }
 
     /// Schedules one retry when AppKit has not realized a usable terminal
@@ -9950,6 +9963,11 @@ final class GhosttySurfaceScrollView: NSView {
         layer?.masksToBounds = true
         surfaceView.clipsToBounds = true
         surfaceView.layer?.masksToBounds = true
+    }
+
+    func clearWindowLiveResizeStateForPortal() {
+        windowLiveResizeActive = false
+        surfaceView.clearWindowLiveResizeStateForPortal()
     }
 
     /// Creates the pane host around a Ghostty surface view.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -5234,7 +5234,12 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     fileprivate func debugPendingSurfaceSize() -> CGSize? { pendingSurfaceSize }
     func debugLastDrawableSizeForTesting() -> CGSize { lastDrawableSize }
     func debugDeferredSurfaceSizeRetryQueuedForTesting() -> Bool { deferredSurfaceSizeRetryQueued }
-    @discardableResult func debugUpdateSurfaceSizeForTesting(_ size: CGSize) -> Bool { updateSurfaceSize(size: size) }
+    @discardableResult func debugUpdateSurfaceSizeForTesting(
+        _ size: CGSize,
+        bypassLiveResizeCoalescing: Bool = false
+    ) -> Bool {
+        updateSurfaceSize(size: size, bypassLiveResizeCoalescing: bypassLiveResizeCoalescing)
+    }
 #endif
 
     /// Force a full size reconciliation for the current bounds.

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -666,7 +666,20 @@ final class WindowTerminalPortal: NSObject {
     /// transaction can commit — the main thread wedges permanently. These
     /// drain on the next main-queue turn instead.
     private var pendingDeferredSurfaceRefreshes: [ObjectIdentifier: String] = [:]
+    /// Refreshes requested while a window resize transaction is active. They
+    /// are delivered only after the explicit end-resize geometry pass, so a
+    /// stale drawable can never be presented from an intermediate frame.
+    private var pendingLiveResizeSurfaceRefreshes: [ObjectIdentifier: String] = [:]
     private var hasDeferredSurfaceRefreshScheduled = false
+    /// `didEndLiveResize` is delivered after AppKit stops reporting
+    /// `inLiveResize`, but the final portal pass is still queued. Keep the
+    /// renderer phase closed across that gap so an intervening layout cannot
+    /// publish a drawable before the final pane frames are committed.
+    private var liveResizeEndPending = false
+    /// Explicitly tracks the resize phase propagated to hosted views. This is
+    /// separate from AppKit's `inLiveResize`, which can remain true briefly
+    /// after the end notification and must not relatch the final pass.
+    private var liveResizePhaseActive = false
     private var hasExternalGeometrySyncScheduled = false
     private var pendingExternalGeometrySyncRequiresImmediate = false
     /// True while some request since the last executed pass asked for the
@@ -741,10 +754,16 @@ final class WindowTerminalPortal: NSObject {
         }
     }
 
+    /// Creates a portal and installs its host into the window's content overlay.
+    /// When requested, the initial hierarchy is laid out before the first bind.
     init(window: NSWindow, syncLayout: Bool = true) {
         self.window = window
         super.init()
         hostView.wantsLayer = true
+        // The portal is a sibling of the SwiftUI content tree. Keep a
+        // view-level clip as the durable boundary while AppKit and the
+        // layer-hosting terminal descendants change frames during a resize.
+        hostView.clipsToBounds = true
         hostView.layer?.masksToBounds = true
         hostView.postsFrameChangedNotifications = true
         hostView.postsBoundsChangedNotifications = true
@@ -815,6 +834,8 @@ final class WindowTerminalPortal: NSObject {
 #endif
                 guard let self, self.selfFrameWriteDepth == 0 else { return }
                 if self.isWindowLiveResizeActive {
+                    self.liveResizePhaseActive = true
+                    self.setHostedViewsWindowLiveResizeActive(true)
                     // Live resize: run the pass INSIDE this tick so hosted
                     // frames commit together with the window's new size. The
                     // pass forces subtree layout first (fresh anchor frames)
@@ -838,6 +859,8 @@ final class WindowTerminalPortal: NSObject {
         ) { [weak self] _ in
             MainActor.assumeIsolated {
                 guard let self, self.selfFrameWriteDepth == 0 else { return }
+                self.liveResizeEndPending = true
+                self.liveResizePhaseActive = true
                 self.scheduleExternalGeometrySynchronize()
             }
         })
@@ -925,6 +948,20 @@ final class WindowTerminalPortal: NSObject {
         if isWindowLiveResizeActiveOverrideForTesting { return true }
 #endif
         return hostView.inLiveResize || window?.inLiveResize == true
+    }
+
+    /// Whether renderer size writes must wait for the final live-resize pass.
+    private var isRendererResizeDeferred: Bool {
+        liveResizePhaseActive || liveResizeEndPending
+    }
+
+    /// Propagate the window resize phase to each hosted terminal. Pane frames
+    /// may follow every live-resize tick, but renderer/drawable geometry must
+    /// stay on one committed epoch until the final pass.
+    private func setHostedViewsWindowLiveResizeActive(_ active: Bool) {
+        for entry in entriesByHostedId.values {
+            entry.hostedView?.setWindowLiveResizeActive(active)
+        }
     }
 
     /// The portal whose sync pass is currently on the stack, if any. A
@@ -1080,6 +1117,8 @@ final class WindowTerminalPortal: NSObject {
         return frameInContainer.width > 1 && frameInContainer.height > 1
     }
 
+    /// Reconciles the portal hierarchy and every live entry against the latest
+    /// external geometry snapshot, preserving one ordered renderer phase.
     fileprivate func synchronizeAllEntriesFromExternalGeometryChange() {
         if let activePortalId = Self.currentlySynchronizingPortalId {
             if activePortalId == ObjectIdentifier(self) {
@@ -1103,6 +1142,10 @@ final class WindowTerminalPortal: NSObject {
 #endif
         defer {
             Self.currentlySynchronizingPortalId = nil
+            if !isRendererResizeDeferred {
+                setHostedViewsWindowLiveResizeActive(false)
+                flushPendingLiveResizeSurfaceRefreshesIfReady()
+            }
             if resyncRequestedDuringPass {
                 resyncRequestedDuringPass = false
                 DispatchQueue.main.async { [weak self] in
@@ -1118,9 +1161,42 @@ final class WindowTerminalPortal: NSObject {
         // carries the exact geometry the last pass left behind, so it dies
         // here in one cheap comparison; any real change differs somewhere
         // and syncs fully.
-        guard ensureInstalled() else { return }
+        // The end notification is the authoritative phase boundary. Do not
+        // re-check `inLiveResize` here: AppKit can clear that property one
+        // callback later, and waiting for it would leave the renderer gate
+        // latched across the final frame.
+        if isWindowLiveResizeActive, !liveResizeEndPending {
+            liveResizePhaseActive = true
+        }
+        let endingLiveResize = liveResizeEndPending
+        setHostedViewsWindowLiveResizeActive(isRendererResizeDeferred)
+        // Installation only mutates hierarchy here. Flush layout once below,
+        // then reconcile all hosted views against that same geometry snapshot.
+        guard ensureInstalled(syncLayout: false) else {
+            // Keep the explicit phase finite even if AppKit has temporarily
+            // removed the portal target during teardown or reparenting. The
+            // defer block below then releases every hosted renderer and flushes
+            // any refreshes queued for the resize end.
+            if endingLiveResize {
+                liveResizeEndPending = false
+                liveResizePhaseActive = false
+            }
+            return
+        }
         synchronizeLayoutHierarchy()
-        synchronizeAllHostedViews(excluding: nil)
+        if endingLiveResize {
+            // The window's final frame and split-tree layout are now current.
+            // Open the renderer phase only after that geometry is committed;
+            // the per-host pass below applies the final drawable sizes.
+            liveResizeEndPending = false
+            liveResizePhaseActive = false
+            setHostedViewsWindowLiveResizeActive(false)
+        }
+        synchronizeAllHostedViews(
+            excluding: nil,
+            syncLayout: false,
+            portalIsPrepared: true
+        )
         reconcileVisibleHostedViewsAfterGeometrySync(reason: "portal.externalGeometrySync")
     }
 
@@ -1223,9 +1299,16 @@ final class WindowTerminalPortal: NSObject {
         dividerOverlayView.needsDisplay = true
     }
 
+    /// Ensures the portal host is attached at the current content-overlay
+    /// target and restores its clipping/ordering invariants.
     @discardableResult
     private func ensureInstalled(syncLayout: Bool = true) -> Bool {
         guard let window else { return false }
+        // AppKit can re-materialize a layer-backed host while its window is
+        // being resized. Reassert both sides of the clipping contract at the
+        // installation choke point before any child frame is written.
+        hostView.clipsToBounds = true
+        hostView.layer?.masksToBounds = true
         guard let (container, reference) = installedTargetIfStillValid(for: window) ?? installationTarget(for: window)
         else { return false }
         let browserHost = preferredBrowserHost(in: container)
@@ -1562,6 +1645,7 @@ final class WindowTerminalPortal: NSObject {
         )
     }
 
+    /// Binds one hosted terminal to its anchor and seeds a safe initial frame.
     private func bind(
         hostedView: GhosttySurfaceScrollView,
         to anchorView: NSView,
@@ -1570,6 +1654,7 @@ final class WindowTerminalPortal: NSObject {
         syncLayout: Bool
     ) {
         guard ensureInstalled(syncLayout: syncLayout) else { return }
+        hostedView.setWindowLiveResizeActive(isRendererResizeDeferred)
 
         let hostedId = ObjectIdentifier(hostedView)
         let anchorId = ObjectIdentifier(anchorView)
@@ -1695,6 +1780,8 @@ final class WindowTerminalPortal: NSObject {
         pruneDeadEntries()
     }
 
+    /// Reconciles the hosted terminal associated with one anchor, coalescing
+    /// the remaining entries into the portal's single external pass.
     func synchronizeHostedViewForAnchor(_ anchorView: NSView, syncLayout: Bool = true) {
         // Anchor geometry callbacks fire for every layout pass — including
         // the passes our own syncs run — and treating each one as a
@@ -1716,11 +1803,20 @@ final class WindowTerminalPortal: NSObject {
         // changing, and the end-of-resize sync (windowDidEndLiveResize →
         // scheduleExternalGeometrySynchronize) stays unconditional.
         guard TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window) else {
-            if !isWindowLiveResizeActive {
+            if isWindowLiveResizeActive {
+                liveResizePhaseActive = true
+            }
+            if !isRendererResizeDeferred {
                 pruneDeadEntries()
             }
             let anchorId = ObjectIdentifier(anchorView)
             if let hostedId = hostedByAnchorId[anchorId] {
+                // This callback belongs to one anchor. Keep the phase update
+                // O(1); the window resize observer and consolidated pass
+                // propagate it to the remaining entries once per tick.
+                entriesByHostedId[hostedId]?.hostedView?.setWindowLiveResizeActive(
+                    isRendererResizeDeferred
+                )
                 synchronizeHostedView(withId: hostedId, syncLayout: false)
             }
             scheduleExternalGeometrySynchronize(forceImmediate: false)
@@ -1763,6 +1859,8 @@ final class WindowTerminalPortal: NSObject {
         }
     }
 
+    /// Reconciles visible hosted panes and refreshes only after their geometry
+    /// is safe to present.
     private func reconcileVisibleHostedViewsAfterGeometrySync(reason: String, syncLayout: Bool = true) {
         // During a live window resize this pass would re-reconcile every
         // visible surface once per resize tick, right after
@@ -1771,7 +1869,7 @@ final class WindowTerminalPortal: NSObject {
         // mid-resize; the end-of-resize sync (windowDidEndLiveResize →
         // scheduleExternalGeometrySynchronize) runs it unconditionally once
         // live resize is over.
-        guard !isWindowLiveResizeActive else { return }
+        guard !isRendererResizeDeferred else { return }
         for (hostedId, entry) in entriesByHostedId {
             guard entry.visibleInUI, let hostedView = entry.hostedView, !hostedView.isHidden else { continue }
             if hostedView.reconcileGeometryNow() {
@@ -1788,6 +1886,8 @@ final class WindowTerminalPortal: NSObject {
         }
     }
 
+    /// Coalesces a follow-up full hosted-view pass for layout callbacks that
+    /// cannot safely redraw synchronously.
     private func scheduleDeferredFullSynchronizeAll(includeVisibleReconcile: Bool = false) {
         if includeVisibleReconcile {
             deferredFullSyncIncludesVisibleReconcile = true
@@ -1811,7 +1911,31 @@ final class WindowTerminalPortal: NSObject {
         }
     }
 
+    /// Delivers refreshes held during a window resize after the final geometry
+    /// and renderer sizes have committed.
+    private func flushPendingLiveResizeSurfaceRefreshesIfReady() {
+        guard !isRendererResizeDeferred, !pendingLiveResizeSurfaceRefreshes.isEmpty else { return }
+        let pending = pendingLiveResizeSurfaceRefreshes
+        pendingLiveResizeSurfaceRefreshes = [:]
+        for (pendingId, pendingReason) in pending {
+            guard let entry = entriesByHostedId[pendingId],
+                  entry.visibleInUI,
+                  let hostedView = entry.hostedView,
+                  !hostedView.isHidden else { continue }
+            hostedView.refreshSurfaceNow(reason: pendingReason)
+        }
+    }
+
+    /// Queues a surface refresh until it is safe to present against committed
+    /// pane and drawable geometry.
     private func deferSurfaceRefresh(forHostedId hostedId: ObjectIdentifier, reason: String) {
+        if isRendererResizeDeferred {
+            // A refresh requested by a live-resize geometry pass must wait for
+            // the explicit end-resize pass. Delivering it on an arbitrary
+            // queue turn can present an old drawable against a new pane frame.
+            pendingLiveResizeSurfaceRefreshes[hostedId] = reason
+            return
+        }
         pendingDeferredSurfaceRefreshes[hostedId] = reason
         guard !hasDeferredSurfaceRefreshScheduled else { return }
         hasDeferredSurfaceRefreshScheduled = true
@@ -1830,8 +1954,14 @@ final class WindowTerminalPortal: NSObject {
         }
     }
 
-    private func synchronizeAllHostedViews(excluding hostedIdToSkip: ObjectIdentifier?, syncLayout: Bool = true) {
-        guard ensureInstalled(syncLayout: syncLayout) else { return }
+    /// Reconciles all mapped hosted panes after the portal host is prepared.
+    /// `portalIsPrepared` avoids repeating hierarchy work for each entry.
+    private func synchronizeAllHostedViews(
+        excluding hostedIdToSkip: ObjectIdentifier?,
+        syncLayout: Bool = true,
+        portalIsPrepared: Bool = false
+    ) {
+        guard portalIsPrepared || ensureInstalled(syncLayout: false) else { return }
         if syncLayout {
             synchronizeLayoutHierarchy()
         } else {
@@ -1852,8 +1982,14 @@ final class WindowTerminalPortal: NSObject {
                !entry.visibleInUI, entry.hostedView?.isHidden == true {
                 continue
             }
-            synchronizeHostedView(withId: hostedId, syncLayout: syncLayout)
+            synchronizeHostedView(
+                withId: hostedId,
+                syncLayout: syncLayout,
+                portalIsPrepared: true,
+                deferDividerOverlay: true
+            )
         }
+        ensureDividerOverlayOnTop()
     }
 
     private func resetTransientRecoveryRetryIfNeeded(forHostedId hostedId: ObjectIdentifier, entry: inout Entry) {
@@ -1898,8 +2034,15 @@ final class WindowTerminalPortal: NSObject {
         return true
     }
 
-    private func synchronizeHostedView(withId hostedId: ObjectIdentifier, syncLayout: Bool = true) {
-        guard ensureInstalled(syncLayout: syncLayout) else { return }
+    /// Reconciles one hosted pane with its anchor and applies visibility,
+    /// clipping, and renderer-refresh policy for the current resize phase.
+    private func synchronizeHostedView(
+        withId hostedId: ObjectIdentifier,
+        syncLayout: Bool = true,
+        portalIsPrepared: Bool = false,
+        deferDividerOverlay: Bool = false
+    ) {
+        guard portalIsPrepared || ensureInstalled(syncLayout: syncLayout) else { return }
         guard var entry = entriesByHostedId[hostedId] else { return }
         guard let hostedView = entry.hostedView else {
             entriesByHostedId.removeValue(forKey: hostedId)
@@ -2194,7 +2337,7 @@ final class WindowTerminalPortal: NSObject {
                 // pane's Metal layer was even realized — is what made resizing a
                 // window full of mirrored panes drag. The end-of-resize sync runs
                 // after live resize is over and takes this branch normally.
-                if entry.visibleInUI, !shouldHide, !hostedView.isHidden, !isWindowLiveResizeActive {
+                if entry.visibleInUI, !shouldHide, !hostedView.isHidden, !isRendererResizeDeferred {
                     if syncLayout {
                         hostedView.refreshSurfaceNow(reason: "portal.frameChange")
                     } else {
@@ -2237,7 +2380,7 @@ final class WindowTerminalPortal: NSObject {
             // transaction can commit. Unlike the frame-change branch above,
             // a reveal cannot skip its redraw outright — the surface would
             // sit blank until later churn — so defer it one main-queue turn.
-            if syncLayout, !isWindowLiveResizeActive {
+            if syncLayout, !isRendererResizeDeferred {
                 hostedView.refreshSurfaceNow(reason: "portal.reveal")
             } else {
                 deferSurfaceRefresh(forHostedId: hostedId, reason: "portal.reveal.deferred")
@@ -2266,7 +2409,9 @@ final class WindowTerminalPortal: NSObject {
         }
 #endif
 
-        ensureDividerOverlayOnTop()
+        if !deferDividerOverlay {
+            ensureDividerOverlayOnTop()
+        }
     }
 
     private func pruneDeadEntries() {
@@ -2304,7 +2449,13 @@ final class WindowTerminalPortal: NSObject {
         Set(entriesByHostedId.keys)
     }
 
+    /// Releases observers, resize state, and all portal-owned hosted views.
     func tearDown() {
+        liveResizeEndPending = false
+        liveResizePhaseActive = false
+        pendingLiveResizeSurfaceRefreshes.removeAll()
+        pendingDeferredSurfaceRefreshes.removeAll()
+        setHostedViewsWindowLiveResizeActive(false)
         removeGeometryObservers()
         for hostedId in Array(entriesByHostedId.keys) {
             detachHostedView(withId: hostedId)

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -834,6 +834,11 @@ final class WindowTerminalPortal: NSObject {
 #endif
                 guard let self, self.selfFrameWriteDepth == 0 else { return }
                 if self.isWindowLiveResizeActive {
+                    // A rapid second drag can begin before the queued
+                    // didEndLiveResize pass runs. The new active tick is the
+                    // authoritative begin boundary, so do not let the old
+                    // end marker release the renderer gate mid-drag.
+                    self.liveResizeEndPending = false
                     self.liveResizePhaseActive = true
                     self.setHostedViewsWindowLiveResizeActive(true)
                     // Live resize: run the pass INSIDE this tick so hosted

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -797,6 +797,21 @@ final class WindowTerminalPortal: NSObject {
 
         let center = NotificationCenter.default
         geometryObservers.append(center.addObserver(
+            forName: NSWindow.willStartLiveResizeNotification,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, self.selfFrameWriteDepth == 0 else { return }
+                // A new drag is the only authoritative way to replace an end
+                // marker. A late didResize callback after didEnd must leave
+                // the marker intact until its queued final pass runs.
+                self.liveResizeEndPending = false
+                self.liveResizePhaseActive = true
+                self.setHostedViewsWindowLiveResizeActive(true)
+            }
+        })
+        geometryObservers.append(center.addObserver(
             forName: NSWindow.didResizeNotification,
             object: window,
             queue: nil
@@ -834,11 +849,10 @@ final class WindowTerminalPortal: NSObject {
 #endif
                 guard let self, self.selfFrameWriteDepth == 0 else { return }
                 if self.isWindowLiveResizeActive {
-                    // A rapid second drag can begin before the queued
-                    // didEndLiveResize pass runs. The new active tick is the
-                    // authoritative begin boundary, so do not let the old
-                    // end marker release the renderer gate mid-drag.
-                    self.liveResizeEndPending = false
+                    // A rapid second drag clears the old end marker in the
+                    // willStartLiveResize observer above. A frame callback
+                    // that arrives after didEnd while AppKit still reports
+                    // inLiveResize must not cancel that pending final pass.
                     self.liveResizePhaseActive = true
                     self.setHostedViewsWindowLiveResizeActive(true)
                     // Live resize: run the pass INSIDE this tick so hosted
@@ -1559,6 +1573,7 @@ final class WindowTerminalPortal: NSObject {
             if let restoredMask = preAdoptionAutoresizingMaskByHostedId.removeValue(forKey: hostedId) {
                 hostedView.autoresizingMask = restoredMask
             }
+            hostedView.clearWindowLiveResizeStateForPortal()
             if hostedView.superview === hostView {
                 hostedView.removeFromSuperview()
             }

--- a/cmuxTests/GhosttyDrawableSizeRetryTests.swift
+++ b/cmuxTests/GhosttyDrawableSizeRetryTests.swift
@@ -130,10 +130,8 @@ struct GhosttyDrawableSizeRetryTests {
         // not committed its final pane frame yet, so this callback must keep
         // the last drawable epoch instead of publishing targetSize early.
         hostedView.frame.size = targetSize
-        _ = surfaceView.debugUpdateSurfaceSizeForTesting(
-            targetSize,
-            bypassLiveResizeCoalescing: true
-        )
+        surfaceView.frame.size = targetSize
+        surfaceView.viewDidEndLiveResize()
 
         #expect(
             surfaceView.debugLastDrawableSizeForTesting() == initialDrawableSize,

--- a/cmuxTests/GhosttyDrawableSizeRetryTests.swift
+++ b/cmuxTests/GhosttyDrawableSizeRetryTests.swift
@@ -91,6 +91,56 @@ struct GhosttyDrawableSizeRetryTests {
         #expect(realizedLayer.drawableSize == expectedDrawableSize)
     }
 
+    @Test func liveResizeEndBypassDoesNotPublishBeforePortalFinalPass() throws {
+        _ = NSApplication.shared
+
+        let initialSize = CGSize(width: 800, height: 600)
+        let targetSize = CGSize(width: 1296, height: 893)
+        let window = NSWindow(
+            contentRect: NSRect(origin: .zero, size: initialSize),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let terminalSurface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = terminalSurface.hostedView
+        hostedView.frame = NSRect(origin: .zero, size: initialSize)
+        window.contentView?.addSubview(hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        let surfaceView = try #require(findGhosttyNSView(in: hostedView))
+        _ = surfaceView.forceRefreshSurface()
+        let initialDrawableSize = surfaceView.debugLastDrawableSizeForTesting()
+        surfaceView.setWindowLiveResizeActive(true)
+
+        // GhosttyNSView.viewDidEndLiveResize uses bypass=true. The portal has
+        // not committed its final pane frame yet, so this callback must keep
+        // the last drawable epoch instead of publishing targetSize early.
+        hostedView.frame.size = targetSize
+        _ = surfaceView.debugUpdateSurfaceSizeForTesting(
+            targetSize,
+            bypassLiveResizeCoalescing: true
+        )
+
+        #expect(
+            surfaceView.debugLastDrawableSizeForTesting() == initialDrawableSize,
+            "The end callback must not publish a stale size before the portal final pass"
+        )
+    }
+
     private func findGhosttyNSView(in view: NSView) -> GhosttyNSView? {
         if let view = view as? GhosttyNSView {
             return view

--- a/cmuxTests/GhosttyDrawableSizeRetryTests.swift
+++ b/cmuxTests/GhosttyDrawableSizeRetryTests.swift
@@ -139,6 +139,44 @@ struct GhosttyDrawableSizeRetryTests {
         )
     }
 
+    @Test func standaloneSurfaceUsesNativeWindowLiveResizeState() throws {
+        _ = NSApplication.shared
+
+        let window = LiveResizeProbeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer {
+            window.orderOut(nil)
+            window.close()
+        }
+
+        let terminalSurface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = terminalSurface.hostedView
+        hostedView.frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        window.contentView?.addSubview(hostedView)
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        hostedView.layoutSubtreeIfNeeded()
+
+        let surfaceView = try #require(findGhosttyNSView(in: hostedView))
+        _ = surfaceView.forceRefreshSurface()
+
+        // This view is not owned by WindowTerminalPortal, so it has no portal
+        // propagation flag. AppKit's native window state must still defer its
+        // pixel-only resize work during the interactive resize.
+        window.liveResizeActive = true
+        #expect(surfaceView.debugIsWindowLiveResizeActiveForTesting())
+    }
+
     private func findGhosttyNSView(in view: NSView) -> GhosttyNSView? {
         if let view = view as? GhosttyNSView {
             return view
@@ -159,4 +197,10 @@ struct GhosttyDrawableSizeRetryTests {
             RunLoop.current.run(until: Date().addingTimeInterval(0.01))
         }
     }
+}
+
+private final class LiveResizeProbeWindow: NSWindow {
+    var liveResizeActive = false
+
+    override var inLiveResize: Bool { liveResizeActive }
 }

--- a/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
+++ b/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
@@ -10,6 +10,52 @@ import CmuxTerminal
 
 extension TerminalWindowPortalLifecycleTests {
 
+    /// Every AppKit boundary around a portal-hosted Ghostty surface must clip
+    /// its descendants. The renderer replaces the terminal view's backing
+    /// layer with an IOSurface layer, so the view-level clip chain is the
+    /// invariant that survives stale drawables and live-resize frame churn.
+    @MainActor
+    func testPortalHostedTerminalUsesViewLevelClippingAtEveryBoundary() throws {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340)
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let portal = makeTrackedPortal(window: window)
+        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
+        contentView.addSubview(anchor)
+        let surface = makeTrackedTerminalSurface()
+        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        drainMainQueue()
+        realizeWindowLayout(window)
+
+        XCTAssertTrue(
+            portal.hostView.clipsToBounds,
+            "The window-level portal host must clip stale terminal contents to the content region"
+        )
+        XCTAssertTrue(
+            surface.hostedView.clipsToBounds,
+            "Each hosted pane must clip its renderer and overlays to the pane bounds"
+        )
+        XCTAssertTrue(
+            surface.hostedView.surfaceView.clipsToBounds,
+            "The terminal view must keep a view-level clip after Ghostty installs its IOSurface layer"
+        )
+        XCTAssertTrue(portal.hostView.layer?.masksToBounds == true)
+        XCTAssertTrue(surface.hostedView.layer?.masksToBounds == true)
+        XCTAssertTrue(surface.hostedView.surfaceView.layer?.masksToBounds == true)
+        withExtendedLifetime((portal, surface)) {}
+    }
+
     @MainActor
     func testPortalSkipsSynchronousRefreshForHiddenSurfaces() throws {
         let window = makeTestWindow(

--- a/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
+++ b/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
@@ -263,6 +263,126 @@ extension TerminalWindowPortalLifecycleTests {
         withExtendedLifetime(surface) {}
     }
 
+    /// The outer pane must follow a live window-resize tick, but the inner
+    /// Ghostty layer stays on its last committed drawable until resize end.
+    /// This is the ordering invariant that makes an asynchronous old present
+    /// harmless: the pane's view-level clip contains it for the whole drag.
+    @MainActor
+    func testLiveResizeKeepsRendererFrameAtCommittedSizeUntilEnd() throws {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340),
+            styleMask: [.titled, .closable, .resizable]
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let portal = makeTrackedPortal(window: window)
+        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
+        contentView.addSubview(anchor)
+        let surface = makeTrackedTerminalSurface()
+        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        drainMainQueue()
+        realizeWindowLayout(window)
+
+        let committedRendererSize = surface.hostedView.surfaceView.frame.size
+        XCTAssertGreaterThan(committedRendererSize.width, 1)
+        XCTAssertGreaterThan(committedRendererSize.height, 1)
+
+        portal.isWindowLiveResizeActiveOverrideForTesting = true
+        let liveTarget = NSSize(
+            width: max(32, committedRendererSize.width - 80),
+            height: max(24, committedRendererSize.height - 50)
+        )
+        anchor.setFrameSize(liveTarget)
+        portal.synchronizeHostedViewForAnchor(anchor)
+
+        XCTAssertEqual(
+            surface.hostedView.frame.size,
+            liveTarget,
+            "The pane boundary must track the live resize immediately"
+        )
+        XCTAssertEqual(
+            surface.hostedView.surfaceView.frame.size,
+            committedRendererSize,
+            "The renderer frame must not advance to an uncommitted live-resize drawable"
+        )
+
+        portal.isWindowLiveResizeActiveOverrideForTesting = false
+        let finalTarget = NSSize(
+            width: max(24, liveTarget.width - 24),
+            height: max(20, liveTarget.height - 20)
+        )
+        anchor.setFrameSize(finalTarget)
+        NotificationCenter.default.post(name: NSWindow.didEndLiveResizeNotification, object: window)
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(surface.hostedView.frame.size, finalTarget)
+        XCTAssertNotEqual(
+            surface.hostedView.surfaceView.frame.size,
+            committedRendererSize,
+            "Resize end must commit the final renderer frame"
+        )
+        withExtendedLifetime(surface) {}
+    }
+
+    /// A resize-end notification can race portal teardown. Even when the
+    /// target hierarchy is unavailable, the renderer phase must close so a
+    /// later reattachment can resize the surface again.
+    @MainActor
+    func testLiveResizeEndClearsDeferredPhaseWhenPortalInstallationFails() throws {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340),
+            styleMask: [.titled, .closable, .resizable]
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let portal = makeTrackedPortal(window: window)
+        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
+        contentView.addSubview(anchor)
+        let surface = makeTrackedTerminalSurface()
+        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        drainMainQueue()
+        realizeWindowLayout(window)
+
+        portal.isWindowLiveResizeActiveOverrideForTesting = true
+        anchor.setFrameSize(NSSize(width: 200, height: 140))
+        portal.synchronizeHostedViewForAnchor(anchor)
+        portal.isWindowLiveResizeActiveOverrideForTesting = false
+
+        // Force the end pass through ensureInstalled's unavailable-target path.
+        portal.window = nil
+        NotificationCenter.default.post(name: NSWindow.didEndLiveResizeNotification, object: window)
+        drainMainQueue()
+        drainMainQueue()
+
+        // Reattach the same window. A stale deferred phase would keep this
+        // geometry write from reaching the terminal surface.
+        portal.window = window
+        anchor.setFrameSize(NSSize(width: 220, height: 150))
+        portal.synchronizeHostedViewForAnchor(anchor)
+        XCTAssertEqual(surface.hostedView.frame.size, NSSize(width: 220, height: 150))
+        XCTAssertEqual(surface.hostedView.surfaceView.frame.size, NSSize(width: 220, height: 150))
+        withExtendedLifetime(surface) {}
+    }
+
     /// Regression: switching a pane's tab from a terminal to a browser hides
     /// the terminal only through its registry entry — the SwiftUI update that
     /// carries visible=false is dropped by the portal-host ownership gate

--- a/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
+++ b/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
@@ -204,6 +204,63 @@ extension TerminalWindowPortalLifecycleTests {
         withExtendedLifetime((leftSurface, rightSurface)) {}
     }
 
+    @MainActor
+    func testLateDidResizeAfterEndStillRunsFinalLiveResizePass() throws {
+        let window = trackTestWindow(LiveResizeProbeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        ))
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let portal = makeTrackedPortal(window: window)
+        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
+        contentView.addSubview(anchor)
+        let surface = makeTrackedTerminalSurface()
+        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        drainMainQueue()
+        realizeWindowLayout(window)
+
+        let committedRendererSize = surface.hostedView.surfaceView.frame.size
+        window.liveResizeActive = true
+        portal.isWindowLiveResizeActiveOverrideForTesting = true
+        let liveTarget = NSSize(width: 200, height: 140)
+        anchor.setFrameSize(liveTarget)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        XCTAssertEqual(surface.hostedView.surfaceView.frame.size, committedRendererSize)
+
+        // AppKit can deliver a frame callback after didEndLiveResize while
+        // its native flag is still true. That callback must not cancel the
+        // pending end pass.
+        portal.isWindowLiveResizeActiveOverrideForTesting = false
+        NotificationCenter.default.post(name: NSWindow.didEndLiveResizeNotification, object: window)
+        NotificationCenter.default.post(name: NSWindow.didResizeNotification, object: window)
+        window.liveResizeActive = false
+
+        let finalTarget = NSSize(width: 220, height: 150)
+        anchor.setFrameSize(finalTarget)
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(surface.hostedView.frame.size, finalTarget)
+        XCTAssertNotEqual(
+            surface.hostedView.surfaceView.frame.size,
+            committedRendererSize,
+            "A late frame callback must not strand the renderer in the deferred resize phase"
+        )
+        withExtendedLifetime(surface) {}
+    }
+
     /// Regression: during a live window resize, each `didResize` tick must
     /// synchronize hosted terminal frames INSIDE the tick — in the same
     /// transaction that commits the window's new size. The portal's queued
@@ -433,4 +490,10 @@ extension TerminalWindowPortalLifecycleTests {
         )
         withExtendedLifetime(surface) {}
     }
+}
+
+private final class LiveResizeProbeWindow: NSWindow {
+    var liveResizeActive = false
+
+    override var inLiveResize: Bool { liveResizeActive }
 }


### PR DESCRIPTION
Follow-up to #11530.

Adds behavior coverage for `viewDidEndLiveResize()` bypassing pixel coalescing while the portal still holds the live-resize phase, then keeps the portal publication gate authoritative.

Apple documents `viewDidEndLiveResize()` as the post-resize callback: https://developer.apple.com/documentation/appkit/nsview/viewdidendliveresize%28%29

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11570"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790919903&installation_model_id=21920&pr_number=11570&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11570&signature=909ca295c1befe9ae400e8c65fef38d0dc934ba3557d95f7d1f171fd9547fd38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live window-resize end callback ordering so portal-hosted terminals never publish a drawable for an intermediate resize size. Previously `viewDidEndLiveResize()` could bypass pixel coalescing and push a stale surface size before the portal committed its final pane frames; the portal now gates renderer publication until that final pass runs, and standalone views keep AppKit's native live-resize fallback.

**Bug Fixes**
- Pane boundaries follow every live-resize tick while the renderer frame and drawable stay on the last committed size.
- The deferred phase uses portal state for hosted views instead of AppKit's `inLiveResize`, which can clear before the final end pass executes.
- A stale end marker is reset if the next drag begins first or the portal host becomes unavailable mid-teardown.
- Surface size writes and refreshes requested mid-resize are suppressed and flushed only after the final geometry commit.
- View-level clipping is reasserted at the portal host, hosted pane, scroll view, and terminal view so stale async presentations stay contained.
- Adds regression coverage for native fallback and late live-resize end delivery.

<sup>Written for commit 1c29c7664021650bce14ed5f1e8fe9e05425e38b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11570?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal pane behavior during live window resizing.
  - Keeps renderer content at the last committed size until resizing finishes, reducing stale frames and visual glitches.
  - Ensures final pane and surface geometry is applied after resizing, including recovery when a resize pass cannot complete.
  - Preserves clipping boundaries across hosted terminal views and surface updates.

- **Tests**
  - Added regression coverage for live-resize drawable sizing, clipping, deferred updates, and lifecycle recovery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->