### PR TITLE
fix: roll back orphan task dispatch workspaces

### DIFF
--- a/Sources/TerminalController+ControlWorkspaceTodoContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceTodoContext.swift
@@ -607,7 +607,13 @@ extension TerminalController: ControlWorkspaceTaskQueueContext {
             toWorkspace: createdID,
             agent: target.agentName,
             at: Date()
-        ) else { return .notFound }
+        ) else {
+            // Workspace creation and checklist binding are separate mutations.
+            // If the source row changed between them, remove the unowned
+            // target so a retry cannot create duplicate agent workspaces.
+            _ = Self.rollbackTaskDispatchWorkspace(id: createdID, in: sourceManager)
+            return .notFound
+        }
         FeedCoordinator.shared.registerDispatchedTask(
             itemID: itemID,
             sourceWorkspaceID: source.id,
@@ -625,6 +631,16 @@ extension TerminalController: ControlWorkspaceTaskQueueContext {
             createdWorkspaceID: createdID,
             windowID: app.windowId(for: owner)
         )
+    }
+
+    /// Removes a target created for a task when its source binding cannot be
+    /// committed. This keeps failed dispatches atomic from the user's view.
+    @MainActor
+    static func rollbackTaskDispatchWorkspace(id: UUID, in tabManager: TabManager) -> Bool {
+        guard let workspace = tabManager.tabs.first(where: { $0.id == id }) else {
+            return false
+        }
+        return tabManager.closeWorkspaceNonInteractively(workspace, allowPinned: true)
     }
 
     func controlWorkspaceTaskQueueReveal(

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -12,6 +12,31 @@ import CmuxWorkspaces
 
 @Suite("Feed coordinator", .serialized)
 struct FeedCoordinatorTests {
+    @MainActor
+    @Test("Failed task binding can roll back the created workspace")
+    func failedTaskBindingRollsBackCreatedWorkspace() throws {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        AppDelegate.shared = appDelegate
+        appDelegate.tabManager = manager
+        appDelegate.didAttemptStartupSessionRestore = true
+        let source = manager.addWorkspace(title: "Source", select: true)
+        let target = manager.addWorkspace(title: "Created target", select: false)
+        defer {
+            manager.tabs.forEach { $0.teardownAllPanels() }
+            appDelegate.tabManager = nil
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        #expect(TerminalController.rollbackTaskDispatchWorkspace(
+            id: target.id,
+            in: manager
+        ))
+        #expect(manager.tabs.contains(where: { $0.id == source.id }))
+        #expect(!manager.tabs.contains(where: { $0.id == target.id }))
+    }
+
     @Test("Workspace-only blocking events retain their session surface")
     func workspaceOnlyAttentionUsesSessionSurface() {
         let workspaceID = UUID()


### PR DESCRIPTION
Fixes a lifecycle hole in #11510. workspace.create can succeed before source checklist binding commits; a failed bind previously left an unowned target workspace running and allowed duplicate dispatches.

This PR closes the newly created target through the existing non-interactive workspace teardown path when binding fails. The regression test verifies the created target is removed while the source remains.

Verification: swiftc -frontend -parse -parse-as-library for the changed Swift files; git diff --check. No local xcodebuild tests were run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11571"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790919977&installation_model_id=21920&pr_number=11571&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11571&signature=f275009b01f5715f291922929948b13e98e373cf784cab420f5d69c1c45df68b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tracks Claude Code task-tool calls into workspace checklists and adds a cross-workspace task queue for dispatching queued items to new agent workspaces.

**New Features**
- Ingests `TodoWrite`, `TaskCreate`, `TaskUpdate`, `TaskGet`, and `TaskList` hook events into checklist rows, treating `PostToolUseFailure` as an error completion so provisional rows roll back.
- Adds a Task Queue window listing checklist items across all workspaces with status filters, dispatch, reveal, and target binding.
- Adds `todo queue`, `todo refresh`, `todo dispatch`, `todo reveal`, and `todo target` CLI subcommands that are focus-safe.
- Persists agent task refs, dispatch targets, bound workspace IDs, bound agents, and last activity timestamps on checklist items.
- Treats task-tool events as session-critical so deltas are not dropped from the feed.

**Bug Fixes**
- Closes a lifecycle hole where a failed source-checklist binding left an unowned target workspace running and allowed duplicate dispatches; the created target is now torn down through the existing non-interactive teardown path.
- Recovers stale task-hook state after restart, deduplicates post-first task hooks, and fails closed on partial task snapshots and unknown active session IDs.

<sup>Written for commit 372cf82a20acb89d10d716dcb71e7990740de5ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11571?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cross-workspace Task Queue window with filtering, sorting, refresh, reveal, and dispatch controls.
  * Added Task Queue access from the Window menu and command palette.
  * Expanded `cmux todo` with queue management commands and dispatch options for commands, working directories, and agents.
  * Agent task updates now synchronize with workspace checklists, including task status, ownership, activity, and dispatch details.
* **Bug Fixes**
  * Improved handling of failed task operations and session recovery.
  * Added localized Task Queue and CLI messages in English and Japanese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->