### PR TITLE
fix: ingest Claude task tools into workspace todos

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamEvent.swift
@@ -25,6 +25,27 @@ public struct WorkstreamEvent: Codable, Sendable, Equatable {
     public let receivedAt: Date
     public let extraFieldsJSON: String?
 
+    /// The structured result forwarded by a PostToolUse hook, when present.
+    /// Hook producers keep this in the dynamic passthrough fields so older
+    /// wire consumers remain byte-compatible.
+    public var toolResponseJSON: String? {
+        guard let extraFieldsJSON,
+              let data = extraFieldsJSON.data(using: .utf8),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+        else { return nil }
+        for key in ["tool_response", "toolResponse", "tool_result", "toolResult"] {
+            guard let value = object[key] else { continue }
+            if let string = value as? String { return string }
+            if let encoded = try? JSONSerialization.data(
+                withJSONObject: value,
+                options: [.sortedKeys, .fragmentsAllowed]
+            ) {
+                return String(data: encoded, encoding: .utf8)
+            }
+        }
+        return nil
+    }
+
     public init(
         sessionId: String,
         hookEventName: HookEventName,

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
@@ -49,6 +49,13 @@ public final class WorkstreamStore {
     /// carries forward prompt/preamble context from nearby telemetry rows.
     private var lastContextByWorkstream: [String: WorkstreamContext] = [:]
 
+    /// Running task lists keyed by agent workstream. The accumulator is
+    /// bounded and is only a transport projection; workspace checklists stay
+    /// authoritative in the app's `WorkspaceTodoState`.
+    private var taskToolTodosByWorkstream: [String: WorkstreamTaskToolTodos] = [:]
+    private var taskToolWorkstreamsByRecency: [String] = []
+    private static let maxTrackedTaskToolWorkstreams = 64
+
     /// Creates a store for Feed workstream items.
     ///
     /// - Parameters:
@@ -151,6 +158,27 @@ public final class WorkstreamStore {
                 try? await persistence.append(item)
             }
         }
+    }
+
+    /// Returns the task ids this workstream has reported, including ids that
+    /// were deleted from its current list. The latter lets the workspace sync
+    /// retire stale rows without confusing another agent's task.
+    public func ownedTaskIds(forWorkstream workstreamId: String) -> [String] {
+        guard let accumulator = taskToolTodosByWorkstream[workstreamId] else { return [] }
+        return accumulator.ownedIDList
+    }
+
+    /// Seeds task-tool state from persisted workspace rows before applying a
+    /// resumed session's first status-only update.
+    public func seedTaskTodos(
+        forWorkstream workstreamId: String,
+        todos: [WorkstreamTaskTodo]
+    ) {
+        var accumulator = taskToolTodosByWorkstream[workstreamId] ?? WorkstreamTaskToolTodos()
+        accumulator.seed(with: todos)
+        taskToolTodosByWorkstream[workstreamId] = accumulator
+        touchTaskToolWorkstream(workstreamId)
+        trimTaskToolWorkstreams()
     }
 
     // MARK: - Actions
@@ -328,11 +356,48 @@ public final class WorkstreamStore {
                 )
             )
         case .preToolUse:
-            return (.toolUse, .toolUse(toolName: event.toolName ?? "", toolInputJSON: toolInput))
+            let toolName = event.toolName ?? ""
+            if let taskTool = WorkstreamTaskTool(rawValue: toolName) {
+                var accumulator = taskToolTodosByWorkstream[event.sessionId] ?? WorkstreamTaskToolTodos()
+                let outcome: WorkstreamTaskToolOutcome
+                if event.toolResponseJSON != nil {
+                    outcome = accumulator.applyPost(
+                        tool: taskTool,
+                        inputJSON: event.toolInputJSON,
+                        responseJSON: event.toolResponseJSON,
+                        isError: event.isError ?? false
+                    )
+                } else {
+                    outcome = accumulator.applyPre(tool: taskTool, inputJSON: event.toolInputJSON)
+                }
+                taskToolTodosByWorkstream[event.sessionId] = accumulator
+                touchTaskToolWorkstream(event.sessionId)
+                trimTaskToolWorkstreams()
+                if case .list(let todos) = outcome {
+                    return (.todos, .todos(todos))
+                }
+            }
+            return (.toolUse, .toolUse(toolName: toolName, toolInputJSON: toolInput))
         case .postToolUse:
+            let toolName = event.toolName ?? ""
+            if let taskTool = WorkstreamTaskTool(rawValue: toolName) {
+                var accumulator = taskToolTodosByWorkstream[event.sessionId] ?? WorkstreamTaskToolTodos()
+                let outcome = accumulator.applyPost(
+                    tool: taskTool,
+                    inputJSON: event.toolInputJSON,
+                    responseJSON: event.toolResponseJSON,
+                    isError: event.isError ?? false
+                )
+                taskToolTodosByWorkstream[event.sessionId] = accumulator
+                touchTaskToolWorkstream(event.sessionId)
+                trimTaskToolWorkstreams()
+                if case .list(let todos) = outcome {
+                    return (.todos, .todos(todos))
+                }
+            }
             return (
                 .toolResult,
-                .toolResult(toolName: event.toolName ?? "", resultJSON: toolInput, isError: event.isError ?? false)
+                .toolResult(toolName: toolName, resultJSON: toolInput, isError: event.isError ?? false)
             )
         case .postToolUseFailure:
             return (
@@ -366,7 +431,15 @@ public final class WorkstreamStore {
         case .stop:
             return (.stop, .stop(reason: Self.stopReason(from: event.toolInputJSON)))
         case .todoWrite:
-            return (.todos, .todos(Self.todos(from: event.toolInputJSON)))
+            var accumulator = taskToolTodosByWorkstream[event.sessionId] ?? WorkstreamTaskToolTodos()
+            let outcome = accumulator.applyPre(tool: .todoWrite, inputJSON: event.toolInputJSON)
+            taskToolTodosByWorkstream[event.sessionId] = accumulator
+            touchTaskToolWorkstream(event.sessionId)
+            trimTaskToolWorkstreams()
+            if case .list(let todos) = outcome {
+                return (.todos, .todos(todos))
+            }
+            return (.toolUse, .toolUse(toolName: event.hookEventName.rawValue, toolInputJSON: toolInput))
         case .notification:
             return (.toolResult, .toolResult(toolName: "notification", resultJSON: toolInput, isError: false))
         }
@@ -377,6 +450,20 @@ public final class WorkstreamStore {
             return tool
         }
         return titleProvider(event)
+    }
+
+    private func touchTaskToolWorkstream(_ workstreamId: String) {
+        taskToolWorkstreamsByRecency.removeAll { $0 == workstreamId }
+        taskToolWorkstreamsByRecency.append(workstreamId)
+    }
+
+    private func trimTaskToolWorkstreams() {
+        guard taskToolWorkstreamsByRecency.count > Self.maxTrackedTaskToolWorkstreams else { return }
+        let overflow = taskToolWorkstreamsByRecency.count - Self.maxTrackedTaskToolWorkstreams
+        for workstreamId in taskToolWorkstreamsByRecency.prefix(overflow) {
+            taskToolTodosByWorkstream.removeValue(forKey: workstreamId)
+        }
+        taskToolWorkstreamsByRecency.removeFirst(overflow)
     }
 
     private static func jsonObject(from json: String?) -> Any? {
@@ -471,37 +558,4 @@ public final class WorkstreamStore {
         return nil
     }
 
-    private static func todos(from json: String?) -> [WorkstreamTaskTodo] {
-        let rawTodos: [Any]
-        if let dict = jsonObject(from: json) as? [String: Any] {
-            rawTodos = dict["todos"] as? [Any] ?? []
-        } else {
-            rawTodos = jsonObject(from: json) as? [Any] ?? []
-        }
-        return rawTodos.enumerated().compactMap { idx, raw in
-            guard let dict = raw as? [String: Any] else { return nil }
-            let content = (dict["content"] as? String)
-                ?? (dict["text"] as? String)
-                ?? (dict["title"] as? String)
-                ?? ""
-            guard !content.isEmpty else { return nil }
-            let rawState = (dict["state"] as? String)
-                ?? (dict["status"] as? String)
-                ?? "pending"
-            let state: WorkstreamTaskTodo.State
-            switch rawState {
-            case "completed", "done":
-                state = .completed
-            case "inProgress", "in_progress", "active":
-                state = .inProgress
-            default:
-                state = .pending
-            }
-            return WorkstreamTaskTodo(
-                id: (dict["id"] as? String) ?? "todo\(idx)",
-                content: content,
-                state: state
-            )
-        }
-    }
 }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskTodo+ChecklistIdentity.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskTodo+ChecklistIdentity.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+extension WorkstreamTaskTodo {
+    /// Returns a stable identity for this task inside one agent workstream.
+    /// Task ids are only unique within a session, so the workstream id is part
+    /// of the digest before it is mapped to a UUID.
+    public func stableChecklistItemId(workstreamId: String) -> UUID {
+        Self.checklistItemId(workstreamId: workstreamId, taskId: id)
+    }
+
+    /// Returns the stable identity for a task that is no longer in the current
+    /// list (for example, a task removed by `TaskUpdate`).
+    public static func checklistItemId(workstreamId: String, taskId: String) -> UUID {
+        var bytes = Array(repeating: UInt8(0), count: 16)
+        for (index, byte) in Data("cmux.workstream.todo\u{0}\(workstreamId)\u{0}\(taskId)".utf8).enumerated() {
+            let slot = index % bytes.count
+            bytes[slot] = bytes[slot] &+ byte &+ UInt8(truncatingIfNeeded: index * 17)
+            bytes[(slot + 5) % bytes.count] ^= byte &* 31
+        }
+        bytes[6] = (bytes[6] & 0x0F) | 0x40
+        bytes[8] = (bytes[8] & 0x3F) | 0x80
+        return UUID(uuid: (
+            bytes[0], bytes[1], bytes[2], bytes[3], bytes[4], bytes[5], bytes[6], bytes[7],
+            bytes[8], bytes[9], bytes[10], bytes[11], bytes[12], bytes[13], bytes[14], bytes[15]
+        ))
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskTool.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskTool.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A task tool that can contribute to a workstream checklist.
+public enum WorkstreamTaskTool: String, Codable, Sendable, Equatable, CaseIterable {
+    /// The legacy whole-list task tool.
+    case todoWrite = "TodoWrite"
+    /// Claude Code's one-task creation tool.
+    case taskCreate = "TaskCreate"
+    /// Claude Code's one-task update tool.
+    case taskUpdate = "TaskUpdate"
+    /// Optional reconciliation read emitted by newer Claude clients.
+    case taskGet = "TaskGet"
+    /// Optional whole-list reconciliation read emitted by newer Claude clients.
+    case taskList = "TaskList"
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolOutcome.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolOutcome.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+/// The result of applying one task-tool event to a workstream accumulator.
+enum WorkstreamTaskToolOutcome: Equatable {
+    /// The event did not contain a usable task mutation.
+    case ignored
+    /// The complete task list after the mutation, including an empty list when
+    /// the agent deleted its final task.
+    case list([WorkstreamTaskTodo])
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
@@ -1,0 +1,297 @@
+import Foundation
+
+/// Accumulates the delta-shaped task calls emitted by Claude Code.
+///
+/// `TodoWrite` reports a complete list. `TaskCreate` and `TaskUpdate` report
+/// one mutation at a time, and a create's authoritative id may exist only in
+/// the completed tool response. The accumulator accepts both pre- and
+/// post-tool events so older wrappers continue to work while newer wrappers
+/// can reconcile provisional ids with the result returned by Claude.
+struct WorkstreamTaskToolTodos: Sendable {
+    /// Matches the per-workspace checklist cap.
+    static let maxRetainedTodos = 50
+    /// Bounds ownership metadata retained for deleted/evicted tasks.
+    static let maxOwnedIds = 200
+
+    private var todos: [WorkstreamTaskTodo] = []
+    private var ownedIDsInOrder: [String] = []
+    private var ownedIdSet: Set<String> = []
+    private var provisionalIDsBySubject: [String: String] = [:]
+    private var provisionalIDsInOrder: [String] = []
+    private var nextProvisionalID = 0
+
+    var ownedIds: Set<String> { ownedIdSet }
+    var ownedIDList: [String] { ownedIDsInOrder }
+    var isEmpty: Bool { todos.isEmpty && ownedIdSet.isEmpty }
+
+    /// Seeds the accumulator from persisted agent rows after an app restart.
+    mutating func seed(with restored: [WorkstreamTaskTodo]) {
+        todos = restored
+        for todo in restored { claim(todo.id) }
+        trim()
+    }
+
+    /// Applies a pre-execution event. This keeps compatibility with wrappers
+    /// that only forward `PreToolUse`; a later completed event can reconcile a
+    /// provisional create or roll back a failed call.
+    mutating func applyPre(tool: WorkstreamTaskTool, inputJSON: String?) -> WorkstreamTaskToolOutcome {
+        let input = object(from: inputJSON)
+        switch tool {
+        case .todoWrite:
+            guard let parsed = Self.snapshot(from: inputJSON) else { return .ignored }
+            replace(with: parsed)
+            return .list(todos)
+        case .taskCreate:
+            guard let content = content(in: input) else { return .ignored }
+            let id = taskID(in: input) ?? provisionalID(for: content)
+            claim(id)
+            upsert(WorkstreamTaskTodo(id: id, content: content, state: state(in: input) ?? .pending))
+            trim()
+            return .list(todos)
+        case .taskUpdate:
+            guard let id = taskID(in: input) else { return .ignored }
+            return applyUpdate(id: id, input: input, response: nil)
+        case .taskGet, .taskList:
+            guard let parsed = Self.snapshot(from: inputJSON) else { return .ignored }
+            replace(with: parsed)
+            return .list(todos)
+        }
+    }
+
+    /// Applies a completed task-tool event and ignores failed tool calls.
+    mutating func applyPost(
+        tool: WorkstreamTaskTool,
+        inputJSON: String?,
+        responseJSON: String?,
+        isError: Bool
+    ) -> WorkstreamTaskToolOutcome {
+        let input = object(from: inputJSON)
+        let response = object(from: responseJSON)
+        let result = (response?["task"] as? [String: Any]) ?? response
+        if isError || response?["success"] as? Bool == false {
+            if tool == .taskCreate, let subject = content(in: input), let provisional = provisionalIDsBySubject.removeValue(forKey: subject) {
+                todos.removeAll { $0.id == provisional }
+                provisionalIDsInOrder.removeAll { $0 == provisional }
+            }
+            return .ignored
+        }
+
+        switch tool {
+        case .todoWrite:
+            guard let parsed = Self.snapshot(from: inputJSON) else { return .ignored }
+            replace(with: parsed)
+            return .list(todos)
+        case .taskCreate:
+            guard let authoritativeID = taskID(in: result),
+                  let subject = content(in: result) ?? content(in: input) else { return .ignored }
+            let provisional = provisionalIDsBySubject.removeValue(forKey: subject)
+            if let provisional, provisional != authoritativeID {
+                todos.removeAll { $0.id == provisional }
+            }
+            claim(authoritativeID)
+            upsert(WorkstreamTaskTodo(
+                id: authoritativeID,
+                content: subject,
+                state: state(in: result) ?? state(in: input) ?? .pending
+            ))
+            trim()
+            return .list(todos)
+        case .taskUpdate:
+            guard let id = taskID(in: input) ?? taskID(in: result) else { return .ignored }
+            return applyUpdate(id: id, input: input, response: result)
+        case .taskGet, .taskList:
+            let snapshotJSON = responseJSON ?? inputJSON
+            guard let parsed = Self.snapshot(from: snapshotJSON) else { return .ignored }
+            replace(with: parsed)
+            return .list(todos)
+        }
+    }
+
+    private mutating func applyUpdate(
+        id: String,
+        input: [String: Any]?,
+        response: [String: Any]?
+    ) -> WorkstreamTaskToolOutcome {
+        let resolvedID = adoptProvisionalIDIfNeeded(id)
+        let rawStatus = (input?["status"] as? String) ?? (input?["state"] as? String)
+            ?? (response?["status"] as? String) ?? (response?["state"] as? String)
+        if rawStatus == "deleted" || rawStatus == "removed" {
+            guard todos.contains(where: { $0.id == resolvedID }) else { return .ignored }
+            todos.removeAll { $0.id == resolvedID }
+            claim(resolvedID)
+            return .list(todos)
+        }
+
+        let nextState = state(in: input) ?? state(in: response)
+        if let index = todos.firstIndex(where: { $0.id == resolvedID }) {
+            claim(resolvedID)
+            let title = subject(in: response) ?? subject(in: input) ?? todos[index].content
+            todos[index] = WorkstreamTaskTodo(id: resolvedID, content: title, state: nextState ?? todos[index].state)
+            return .list(todos)
+        }
+
+        // Older Claude wrappers expose only PreToolUse. Claude assigns task
+        // ids in creation order, so reconcile a numeric TaskUpdate id with
+        // the corresponding provisional row rather than dropping the delta.
+        if let ordinal = Int(id), ordinal > 0,
+           provisionalIDsInOrder.indices.contains(ordinal - 1) {
+            let provisional = provisionalIDsInOrder[ordinal - 1]
+            if let provisionalIndex = todos.firstIndex(where: { $0.id == provisional }) {
+                let title = subject(in: response) ?? subject(in: input) ?? todos[provisionalIndex].content
+                let updated = WorkstreamTaskTodo(
+                    id: id,
+                    content: title,
+                    state: nextState ?? todos[provisionalIndex].state
+                )
+                todos[provisionalIndex] = updated
+                provisionalIDsInOrder[ordinal - 1] = id
+                provisionalIDsBySubject = provisionalIDsBySubject.reduce(into: [:]) { result, pair in
+                    result[pair.key] = pair.value == provisional ? id : pair.value
+                }
+                claim(id)
+                return .list(todos)
+            }
+        }
+
+        // A resumed session can send an update before cmux saw its create. Do
+        // not claim an id unless the payload also gives us display text.
+        guard let title = content(in: response) ?? content(in: input) else { return .ignored }
+        claim(resolvedID)
+        upsert(WorkstreamTaskTodo(id: resolvedID, content: title, state: nextState ?? .pending))
+        trim()
+        return .list(todos)
+    }
+
+    private mutating func replace(with parsed: [WorkstreamTaskTodo]) {
+        todos = parsed
+        for todo in parsed { claim(todo.id) }
+        trim()
+    }
+
+    private mutating func upsert(_ todo: WorkstreamTaskTodo) {
+        if let index = todos.firstIndex(where: { $0.id == todo.id }) {
+            todos[index] = todo
+        } else {
+            todos.append(todo)
+        }
+    }
+
+    private mutating func claim(_ id: String) {
+        guard ownedIdSet.insert(id).inserted else { return }
+        ownedIDsInOrder.append(id)
+        guard ownedIDsInOrder.count > Self.maxOwnedIds else { return }
+        let overflow = ownedIDsInOrder.count - Self.maxOwnedIds
+        for old in ownedIDsInOrder.prefix(overflow) { ownedIdSet.remove(old) }
+        ownedIDsInOrder.removeFirst(overflow)
+    }
+
+    private mutating func trim() {
+        guard todos.count > Self.maxRetainedTodos else { return }
+        todos.removeFirst(todos.count - Self.maxRetainedTodos)
+    }
+
+    private mutating func provisionalID(for subject: String) -> String {
+        if let existing = provisionalIDsBySubject[subject] { return existing }
+        nextProvisionalID += 1
+        let id = "pending-" + String(nextProvisionalID)
+        provisionalIDsBySubject[subject] = id
+        provisionalIDsInOrder.append(id)
+        return id
+    }
+
+    private mutating func adoptProvisionalIDIfNeeded(_ id: String) -> String {
+        guard todos.contains(where: { $0.id == id }) == false,
+              let ordinal = Int(id), ordinal > 0,
+              provisionalIDsInOrder.indices.contains(ordinal - 1) else {
+            return id
+        }
+        let provisional = provisionalIDsInOrder[ordinal - 1]
+        guard let index = todos.firstIndex(where: { $0.id == provisional }) else { return id }
+        let current = todos[index]
+        todos[index] = WorkstreamTaskTodo(id: id, content: current.content, state: current.state)
+        provisionalIDsInOrder[ordinal - 1] = id
+        provisionalIDsBySubject = provisionalIDsBySubject.reduce(into: [:]) { result, pair in
+            result[pair.key] = pair.value == provisional ? id : pair.value
+        }
+        claim(id)
+        return id
+    }
+
+    private static func object(from json: String?) -> [String: Any]? {
+        guard let json, let data = json.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) as? [String: Any]
+    }
+
+    private func object(from json: String?) -> [String: Any]? { Self.object(from: json) }
+
+    private static func taskID(in object: [String: Any]?) -> String? {
+        guard let object else { return nil }
+        for key in ["taskId", "task_id", "id"] {
+            if let value = object[key] as? String, !value.isEmpty { return value }
+            if let value = object[key] as? Int { return String(value) }
+        }
+        return nil
+    }
+
+    private func taskID(in object: [String: Any]?) -> String? { Self.taskID(in: object) }
+
+    private static func subject(in object: [String: Any]?) -> String? {
+        guard let object else { return nil }
+        for key in ["subject", "content", "title", "text"] {
+            if let value = object[key] as? String {
+                let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty { return trimmed }
+            }
+        }
+        return nil
+    }
+
+    private func subject(in object: [String: Any]?) -> String? { Self.subject(in: object) }
+
+    private static func content(in object: [String: Any]?) -> String? {
+        subject(in: object) ?? (object?["description"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    private func content(in object: [String: Any]?) -> String? { Self.content(in: object) }
+
+    private static func state(in object: [String: Any]?) -> WorkstreamTaskTodo.State? {
+        guard let raw = (object?["status"] as? String) ?? (object?["state"] as? String) else { return nil }
+        switch raw {
+        case "completed", "done": return .completed
+        case "inProgress", "in_progress", "active": return .inProgress
+        case "pending", "todo", "open": return .pending
+        default: return nil
+        }
+    }
+
+    private func state(in object: [String: Any]?) -> WorkstreamTaskTodo.State? { Self.state(in: object) }
+
+    private static func snapshot(from json: String?) -> [WorkstreamTaskTodo]? {
+        guard let json, let data = json.data(using: .utf8),
+              let root = try? JSONSerialization.jsonObject(with: data, options: [.fragmentsAllowed]) else { return nil }
+        let values: [Any]
+        if let dictionary = root as? [String: Any] {
+            guard let todos = (dictionary["todos"] as? [Any])
+                ?? (dictionary["tasks"] as? [Any]) else { return nil }
+            values = todos
+        } else if let array = root as? [Any] {
+            values = array
+        } else {
+            return nil
+        }
+        var occurrences: [String: Int] = [:]
+        return values.compactMap { value in
+            guard let dictionary = value as? [String: Any],
+                  let text = content(in: dictionary) else { return nil }
+            let base = taskID(in: dictionary) ?? ("content-" + text)
+            let count = (occurrences[base] ?? 0) + 1
+            occurrences[base] = count
+            let id = count == 1 ? base : base + "-" + String(count)
+            return WorkstreamTaskTodo(id: id, content: text, state: state(in: dictionary) ?? .pending)
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? { isEmpty ? nil : self }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -1,0 +1,113 @@
+import Foundation
+import Testing
+@testable import CMUXAgentLaunch
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/8960.
+///
+/// Claude Code now reports its checklist through TaskCreate/TaskUpdate instead
+/// of TodoWrite.  The hook events are still ordinary tool events, so the
+/// store must recognize the tool names and accumulate their one-task deltas.
+@MainActor
+@Suite("Workstream task-tool todos")
+struct WorkstreamTaskToolTodoTests {
+    private func toolEvent(
+        sessionId: String,
+        hook: WorkstreamEvent.HookEventName = .preToolUse,
+        tool: String,
+        input: String,
+        response: String? = nil
+    ) -> WorkstreamEvent {
+        WorkstreamEvent(
+            sessionId: sessionId,
+            hookEventName: hook,
+            source: "claude",
+            toolName: tool,
+            toolInputJSON: input,
+            extraFieldsJSON: response.map { value in "{\"tool_response\":\(value)}" }
+        )
+    }
+
+    private func latestTodos(_ store: WorkstreamStore) -> [WorkstreamTaskTodo]? {
+        for item in store.items.reversed() {
+            if case .todos(let todos) = item.payload {
+                return todos
+            }
+        }
+        return nil
+    }
+
+    @Test("TaskCreate and TaskUpdate accumulate into one list")
+    func taskToolsAccumulate() {
+        let store = WorkstreamStore(ringCapacity: 50)
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TaskCreate",
+            input: #"{"subject":"Read the code"}"#,
+            response: #"{"task":{"id":"1","subject":"Read the code"}}"#
+        ))
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TaskCreate",
+            input: #"{"subject":"Write the fix"}"#,
+            response: #"{"task":{"id":"2","subject":"Write the fix"}}"#
+        ))
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TaskUpdate",
+            input: #"{"taskId":"1","status":"completed"}"#,
+            response: #"{"task":{"id":"1","status":"completed"}}"#
+        ))
+
+        guard let todos = latestTodos(store) else {
+            Issue.record("expected a todos payload from TaskCreate/TaskUpdate")
+            return
+        }
+        #expect(todos.map(\.id) == ["1", "2"])
+        #expect(todos.map(\.content) == ["Read the code", "Write the fix"])
+        #expect(todos.map(\.state) == [.completed, .pending])
+    }
+
+    @Test("TaskUpdate deleted removes the task")
+    func taskUpdateDeleteRemoves() {
+        let store = WorkstreamStore(ringCapacity: 50)
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TaskCreate",
+            input: #"{"subject":"keep"}"#,
+            response: #"{"task":{"id":"1","subject":"keep"}}"#
+        ))
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TaskUpdate",
+            input: #"{"taskId":"1","status":"deleted"}"#,
+            response: #"{"task":{"id":"1","status":"deleted"}}"#
+        ))
+
+        #expect(latestTodos(store)?.isEmpty == true)
+    }
+
+    @Test("Legacy TodoWrite remains supported")
+    func todoWriteRemainsSupported() {
+        let store = WorkstreamStore(ringCapacity: 50)
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TodoWrite",
+            input: #"{"todos":[{"id":"a","content":"first","status":"in_progress"}]}"#
+        ))
+
+        #expect(latestTodos(store)?.first?.content == "first")
+        #expect(latestTodos(store)?.first?.state == .inProgress)
+    }
+
+    @Test("Unrelated tools remain tool telemetry")
+    func otherToolsUnaffected() {
+        let store = WorkstreamStore(ringCapacity: 50)
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "Bash",
+            input: #"{"command":"echo hi"}"#
+        ))
+
+        #expect(store.items.last?.kind == .toolUse)
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceAgentChecklistSync.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceAgentChecklistSync.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Produces one authoritative checklist replacement for an agent report.
+/// User rows and rows owned by other workstreams remain untouched; rows owned
+/// by this workstream but absent from the report are retired.
+public struct WorkspaceAgentChecklistSync: Sendable {
+    /// Creates a stateless sync service.
+    public init() {}
+
+    /// Computes the full replacement for one workstream's report.
+    public func replacement(
+        existing: [WorkspaceChecklistItem],
+        agentTasks: [WorkspaceAgentChecklistTask],
+        workstreamId: String
+    ) -> [WorkspaceChecklistReplacementItem]? {
+        let normalized = agentTasks.compactMap { task -> WorkspaceAgentChecklistTask? in
+            guard let text = WorkspaceChecklistItem.normalizedText(task.text) else { return nil }
+            return WorkspaceAgentChecklistTask(
+                id: task.id,
+                ref: task.ref,
+                text: text,
+                state: task.state,
+                lastActivityAt: task.lastActivityAt,
+                agentName: task.agentName
+            )
+        }
+        let retained = existing
+            .filter { $0.agentTaskRef?.workstreamId != workstreamId }
+            .map { item in
+                WorkspaceChecklistReplacementItem(
+                    id: item.id,
+                    text: item.text,
+                    state: item.state,
+                    origin: item.origin,
+                    agentTaskRef: item.agentTaskRef,
+                    dispatchTarget: item.dispatchTarget,
+                    boundWorkspaceID: item.boundWorkspaceID,
+                    boundAgent: item.boundAgent,
+                    lastActivityAt: item.lastActivityAt
+                )
+            }
+        let budget = max(0, WorkspaceChecklistItem.maxChecklistItems - retained.count)
+        let admitted = normalized.suffix(budget)
+        var result = retained
+        result.reserveCapacity(retained.count + admitted.count)
+        for task in admitted {
+            result.append(WorkspaceChecklistReplacementItem(
+                id: task.id,
+                text: task.text,
+                state: task.state,
+                origin: .agent,
+                agentTaskRef: task.ref,
+                dispatchTarget: nil,
+                boundWorkspaceID: nil,
+                boundAgent: task.agentName,
+                lastActivityAt: task.lastActivityAt
+            ))
+        }
+        guard !matches(existing, result) else { return nil }
+        return result
+    }
+
+    private func matches(
+        _ existing: [WorkspaceChecklistItem],
+        _ incoming: [WorkspaceChecklistReplacementItem]
+    ) -> Bool {
+        guard existing.count == incoming.count else { return false }
+        for (current, next) in zip(existing, incoming) {
+            guard current.id == next.id,
+                  current.text == next.text,
+                  current.state == next.state,
+                  current.origin == next.origin,
+                  current.agentTaskRef == next.agentTaskRef,
+                  current.dispatchTarget == next.dispatchTarget,
+                  current.boundWorkspaceID == next.boundWorkspaceID,
+                  current.boundAgent == next.boundAgent,
+                  current.lastActivityAt == next.lastActivityAt else { return false }
+        }
+        return true
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceAgentChecklistTask.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceAgentChecklistTask.swift
@@ -1,0 +1,34 @@
+public import Foundation
+
+/// One normalized task reported by an agent for workspace checklist sync.
+public struct WorkspaceAgentChecklistTask: Sendable, Equatable {
+    /// Stable checklist identity for the task.
+    public let id: UUID
+    /// Persisted ownership reference.
+    public let ref: WorkspaceAgentTaskRef
+    /// Display text.
+    public let text: String
+    /// Reported checklist state.
+    public let state: WorkspaceChecklistItem.State
+    /// Last hook activity associated with the task.
+    public let lastActivityAt: Date?
+    /// Agent/provider display name.
+    public let agentName: String?
+
+    /// Creates an agent checklist task.
+    public init(
+        id: UUID,
+        ref: WorkspaceAgentTaskRef,
+        text: String,
+        state: WorkspaceChecklistItem.State,
+        lastActivityAt: Date? = nil,
+        agentName: String? = nil
+    ) {
+        self.id = id
+        self.ref = ref
+        self.text = text
+        self.state = state
+        self.lastActivityAt = lastActivityAt
+        self.agentName = agentName
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceAgentTaskRef.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceAgentTaskRef.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Identifies the agent task mirrored by a workspace checklist row.
+public struct WorkspaceAgentTaskRef: Codable, Sendable, Hashable {
+    /// The agent workstream/session that owns the task.
+    public var workstreamId: String
+    /// The task id assigned by that agent.
+    public var taskId: String
+
+    /// Creates an agent-task reference.
+    public init(workstreamId: String, taskId: String) {
+        self.workstreamId = workstreamId
+        self.taskId = taskId
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistItem.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistItem.swift
@@ -27,6 +27,16 @@ public struct WorkspaceChecklistItem: Codable, Sendable, Identifiable, Hashable 
     public var origin: Origin
     /// User-owned image files attached to the item.
     public var attachments: [WorkspaceChecklistAttachment]
+    /// The agent task mirrored by this row, when it came from a hook.
+    public var agentTaskRef: WorkspaceAgentTaskRef?
+    /// Optional target used when this row is dispatched as a new agent.
+    public var dispatchTarget: WorkspaceTaskDispatchTarget?
+    /// The workspace created by the last dispatch, when any.
+    public var boundWorkspaceID: UUID?
+    /// The agent/provider bound by the last dispatch or hook update.
+    public var boundAgent: String?
+    /// Last hook or queue mutation timestamp for this row.
+    public var lastActivityAt: Date?
 
     /// Number of attachments available for compact UI counts.
     public var attachmentCount: Int {
@@ -39,13 +49,23 @@ public struct WorkspaceChecklistItem: Codable, Sendable, Identifiable, Hashable 
         text: String,
         state: State = .pending,
         origin: Origin = .user,
-        attachments: [WorkspaceChecklistAttachment] = []
+        attachments: [WorkspaceChecklistAttachment] = [],
+        agentTaskRef: WorkspaceAgentTaskRef? = nil,
+        dispatchTarget: WorkspaceTaskDispatchTarget? = nil,
+        boundWorkspaceID: UUID? = nil,
+        boundAgent: String? = nil,
+        lastActivityAt: Date? = nil
     ) {
         self.id = id
         self.text = text
         self.state = state
         self.origin = origin
         self.attachments = attachments
+        self.agentTaskRef = agentTaskRef
+        self.dispatchTarget = dispatchTarget
+        self.boundWorkspaceID = boundWorkspaceID
+        self.boundAgent = boundAgent
+        self.lastActivityAt = lastActivityAt
     }
 
     /// Checks whether any attachment file is currently missing.
@@ -59,6 +79,11 @@ public struct WorkspaceChecklistItem: Codable, Sendable, Identifiable, Hashable 
         case state
         case origin
         case attachments
+        case agentTaskRef
+        case dispatchTarget
+        case boundWorkspaceID
+        case boundAgent
+        case lastActivityAt
     }
 
     public init(from decoder: any Decoder) throws {
@@ -68,6 +93,11 @@ public struct WorkspaceChecklistItem: Codable, Sendable, Identifiable, Hashable 
         self.state = try container.decode(State.self, forKey: .state)
         self.origin = try container.decode(Origin.self, forKey: .origin)
         self.attachments = (try? container.decode(LossyWorkspaceChecklistAttachments.self, forKey: .attachments))?.attachments ?? []
+        self.agentTaskRef = try container.decodeIfPresent(WorkspaceAgentTaskRef.self, forKey: .agentTaskRef)
+        self.dispatchTarget = try container.decodeIfPresent(WorkspaceTaskDispatchTarget.self, forKey: .dispatchTarget)
+        self.boundWorkspaceID = try container.decodeIfPresent(UUID.self, forKey: .boundWorkspaceID)
+        self.boundAgent = try container.decodeIfPresent(String.self, forKey: .boundAgent)
+        self.lastActivityAt = try container.decodeIfPresent(Date.self, forKey: .lastActivityAt)
     }
 
     public func encode(to encoder: any Encoder) throws {
@@ -76,6 +106,11 @@ public struct WorkspaceChecklistItem: Codable, Sendable, Identifiable, Hashable 
         try container.encode(text, forKey: .text)
         try container.encode(state, forKey: .state)
         try container.encode(origin, forKey: .origin)
+        try container.encodeIfPresent(agentTaskRef, forKey: .agentTaskRef)
+        try container.encodeIfPresent(dispatchTarget, forKey: .dispatchTarget)
+        try container.encodeIfPresent(boundWorkspaceID, forKey: .boundWorkspaceID)
+        try container.encodeIfPresent(boundAgent, forKey: .boundAgent)
+        try container.encodeIfPresent(lastActivityAt, forKey: .lastActivityAt)
         if !attachments.isEmpty {
             try container.encode(attachments, forKey: .attachments)
         }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistReplacement.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceChecklistReplacement.swift
@@ -15,18 +15,38 @@ public struct WorkspaceChecklistReplacementItem: Sendable, Equatable {
     /// The origin for newly created items; `nil` defaults to `.user`.
     /// Matched items always keep their existing origin.
     public let origin: WorkspaceChecklistItem.Origin?
+    /// Agent task ownership to persist on the resulting row.
+    public let agentTaskRef: WorkspaceAgentTaskRef?
+    /// Dispatch target to persist on the resulting row.
+    public let dispatchTarget: WorkspaceTaskDispatchTarget?
+    /// Bound workspace id to persist on the resulting row.
+    public let boundWorkspaceID: UUID?
+    /// Bound agent/provider to persist on the resulting row.
+    public let boundAgent: String?
+    /// Last activity timestamp to persist on the resulting row.
+    public let lastActivityAt: Date?
 
     /// Creates a replacement item.
     public init(
         id: UUID? = nil,
         text: String,
         state: WorkspaceChecklistItem.State? = nil,
-        origin: WorkspaceChecklistItem.Origin? = nil
+        origin: WorkspaceChecklistItem.Origin? = nil,
+        agentTaskRef: WorkspaceAgentTaskRef? = nil,
+        dispatchTarget: WorkspaceTaskDispatchTarget? = nil,
+        boundWorkspaceID: UUID? = nil,
+        boundAgent: String? = nil,
+        lastActivityAt: Date? = nil
     ) {
         self.id = id
         self.text = text
         self.state = state
         self.origin = origin
+        self.agentTaskRef = agentTaskRef
+        self.dispatchTarget = dispatchTarget
+        self.boundWorkspaceID = boundWorkspaceID
+        self.boundAgent = boundAgent
+        self.lastActivityAt = lastActivityAt
     }
 }
 
@@ -85,14 +105,24 @@ extension Array where Element == WorkspaceChecklistItem {
                     text: normalized,
                     state: item.state ?? existing.state,
                     origin: existing.origin,
-                    attachments: existing.attachments
+                    attachments: existing.attachments,
+                    agentTaskRef: item.agentTaskRef ?? existing.agentTaskRef,
+                    dispatchTarget: item.dispatchTarget ?? existing.dispatchTarget,
+                    boundWorkspaceID: item.boundWorkspaceID ?? existing.boundWorkspaceID,
+                    boundAgent: item.boundAgent ?? existing.boundAgent,
+                    lastActivityAt: item.lastActivityAt ?? existing.lastActivityAt
                 ))
             } else {
                 result.append(WorkspaceChecklistItem(
                     id: item.id ?? UUID(),
                     text: normalized,
                     state: item.state ?? .pending,
-                    origin: item.origin ?? .user
+                    origin: item.origin ?? .user,
+                    agentTaskRef: item.agentTaskRef,
+                    dispatchTarget: item.dispatchTarget,
+                    boundWorkspaceID: item.boundWorkspaceID,
+                    boundAgent: item.boundAgent,
+                    lastActivityAt: item.lastActivityAt
                 ))
             }
         }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceTaskDispatchTarget.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Values/WorkspaceTaskDispatchTarget.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+/// The command target attached to a queued checklist item.
+public struct WorkspaceTaskDispatchTarget: Codable, Sendable, Hashable {
+    /// The directory in which the new agent workspace starts, when supplied.
+    public var workingDirectory: String?
+    /// The command sent to the new workspace after creation.
+    public var agentCommand: String
+    /// A display/provider name for the owning agent, when known.
+    public var agentName: String?
+
+    /// Creates a dispatch target.
+    public init(
+        workingDirectory: String? = nil,
+        agentCommand: String,
+        agentName: String? = nil
+    ) {
+        self.workingDirectory = workingDirectory
+        self.agentCommand = agentCommand
+        self.agentName = agentName
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Values/WorkspaceAgentChecklistSyncTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/Values/WorkspaceAgentChecklistSyncTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+@testable import CmuxWorkspaces
+
+@Suite("Workspace agent checklist sync")
+struct WorkspaceAgentChecklistSyncTests {
+    @Test("agent reports replace only their own rows")
+    func preservesUserAndOtherAgentRows() throws {
+        let user = WorkspaceChecklistItem(text: "User note")
+        let otherRef = WorkspaceAgentTaskRef(workstreamId: "other", taskId: "1")
+        let other = WorkspaceChecklistItem(text: "Other task", origin: .agent, agentTaskRef: otherRef)
+        let existing = [user, other]
+        let current = WorkspaceAgentChecklistTask(
+            id: UUID(),
+            ref: WorkspaceAgentTaskRef(workstreamId: "current", taskId: "2"),
+            text: "Current task",
+            state: .inProgress,
+            lastActivityAt: Date(timeIntervalSince1970: 42),
+            agentName: "claude"
+        )
+        let replacements = try #require(WorkspaceAgentChecklistSync().replacement(
+            existing: existing,
+            agentTasks: [current],
+            workstreamId: "current"
+        ))
+        #expect(replacements.map(\.text) == ["User note", "Other task", "Current task"])
+        #expect(replacements.last?.agentTaskRef == current.ref)
+        #expect(replacements.last?.lastActivityAt == Date(timeIntervalSince1970: 42))
+    }
+
+    @Test("an empty report retires only the reporting agent")
+    func emptyReportRetiresRows() throws {
+        let currentRef = WorkspaceAgentTaskRef(workstreamId: "current", taskId: "1")
+        let otherRef = WorkspaceAgentTaskRef(workstreamId: "other", taskId: "1")
+        let existing = [
+            WorkspaceChecklistItem(text: "current", origin: .agent, agentTaskRef: currentRef),
+            WorkspaceChecklistItem(text: "other", origin: .agent, agentTaskRef: otherRef),
+        ]
+        let replacements = try #require(WorkspaceAgentChecklistSync().replacement(
+            existing: existing,
+            agentTasks: [],
+            workstreamId: "current"
+        ))
+        #expect(replacements.map(\.text) == ["other"])
+    }
+
+    @Test("dispatch metadata survives Codable round trip")
+    func dispatchMetadataRoundTrips() throws {
+        let item = WorkspaceChecklistItem(
+            text: "Run tests",
+            dispatchTarget: WorkspaceTaskDispatchTarget(
+                workingDirectory: "/tmp/project",
+                agentCommand: "claude --continue",
+                agentName: "claude"
+            ),
+            boundWorkspaceID: UUID(),
+            boundAgent: "claude",
+            lastActivityAt: Date(timeIntervalSince1970: 7)
+        )
+        let data = try JSONEncoder().encode(item)
+        let decoded = try JSONDecoder().decode(WorkspaceChecklistItem.self, from: data)
+        #expect(decoded.dispatchTarget == item.dispatchTarget)
+        #expect(decoded.boundWorkspaceID == item.boundWorkspaceID)
+        #expect(decoded.boundAgent == "claude")
+        #expect(decoded.lastActivityAt == item.lastActivityAt)
+    }
+}

--- a/Sources/Feed/FeedCoordinator+AgentTodos.swift
+++ b/Sources/Feed/FeedCoordinator+AgentTodos.swift
@@ -1,0 +1,130 @@
+import CMUXAgentLaunch
+import CmuxWorkspaces
+import Foundation
+
+/// Bridges agent task-tool payloads into the owning workspace checklist.
+/// `WorkspaceTodoState` remains the sole mutable task store; Feed only maps
+/// wire values and invokes the shared `Workspace.replaceChecklist` entry point.
+extension FeedCoordinator {
+    @MainActor
+    func recoverAgentTodosIfNeeded(for event: WorkstreamEvent) {
+        let isTaskEvent = event.hookEventName == .todoWrite
+            || event.toolName.flatMap(WorkstreamTaskTool.init(rawValue:)) != nil
+        guard isTaskEvent, let store, store.ownedTaskIds(forWorkstream: event.sessionId).isEmpty else {
+            return
+        }
+        // An accumulator can be empty after restart while persisted rows still
+        // carry exact workstream/task ownership. Seed from every live workspace
+        // before applying a status-only delta.
+        let candidates = AppDelegate.shared?.allWorkspacesForAgentTodoRetirement ?? []
+        var restored: [WorkstreamTaskTodo] = []
+        var seen = Set<String>()
+        for workspace in candidates {
+            for item in workspace.todoState.checklist {
+                guard let ref = item.agentTaskRef,
+                      ref.workstreamId == event.sessionId,
+                      seen.insert(ref.taskId).inserted else { continue }
+                restored.append(WorkstreamTaskTodo(
+                    id: ref.taskId,
+                    content: item.text,
+                    state: taskState(for: item.state)
+                ))
+            }
+        }
+        if !restored.isEmpty {
+            store.seedTaskTodos(forWorkstream: event.sessionId, todos: restored)
+        }
+    }
+
+    @MainActor
+    func applyAgentTodos(from item: WorkstreamItem, event: WorkstreamEvent) {
+        guard case .todos(let todos) = item.payload,
+              let workspace = resolveTodoWorkspace(for: event) else { return }
+        reconcileDispatchedItems(
+            in: workspace,
+            tasks: todos
+        )
+        retireAgentTodos(for: item.workstreamId, excluding: workspace.id)
+        let tasks = todos.map { todo in
+            WorkspaceAgentChecklistTask(
+                id: todo.stableChecklistItemId(workstreamId: item.workstreamId),
+                ref: WorkspaceAgentTaskRef(workstreamId: item.workstreamId, taskId: todo.id),
+                text: todo.content,
+                state: checklistState(for: todo.state),
+                lastActivityAt: event.receivedAt,
+                agentName: event.source
+            )
+        }
+        guard let replacements = WorkspaceAgentChecklistSync().replacement(
+            existing: workspace.todoState.checklist,
+            agentTasks: tasks,
+            workstreamId: item.workstreamId
+        ) else { return }
+        _ = workspace.replaceChecklist(with: replacements)
+        WorkspaceTodoFeature.markUsed()
+    }
+
+    @MainActor
+    private func retireAgentTodos(for workstreamId: String, excluding workspaceID: UUID) {
+        if lastTodoWorkspaceByWorkstream[workstreamId] == workspaceID { return }
+        defer { lastTodoWorkspaceByWorkstream[workstreamId] = workspaceID }
+        for workspace in AppDelegate.shared?.allWorkspacesForAgentTodoRetirement ?? [] where workspace.id != workspaceID {
+            guard workspace.todoState.checklist.contains(where: {
+                $0.agentTaskRef?.workstreamId == workstreamId
+            }) else { continue }
+            guard let replacements = WorkspaceAgentChecklistSync().replacement(
+                existing: workspace.todoState.checklist,
+                agentTasks: [],
+                workstreamId: workstreamId
+            ) else { continue }
+            _ = workspace.replaceChecklist(with: replacements)
+        }
+    }
+
+    /// A dispatched user row has no agent task id until its new workspace
+    /// emits hooks. Match the durable target workspace and normalized text so
+    /// completion can flow back through the same checklist state mutation
+    /// path without introducing a second task store.
+    @MainActor
+    private func reconcileDispatchedItems(
+        in agentWorkspace: Workspace,
+        tasks: [WorkstreamTaskTodo]
+    ) {
+        guard let app = AppDelegate.shared else { return }
+        let completedText = Set(tasks.filter { $0.state == .completed }.map {
+            WorkspaceChecklistItem.normalizedText($0.content) ?? $0.content
+        })
+        guard !completedText.isEmpty else { return }
+        for workspace in app.allWorkspacesForAgentTodoRetirement {
+            for checklistItem in workspace.todoState.checklist where
+                checklistItem.boundWorkspaceID == agentWorkspace.id &&
+                completedText.contains(WorkspaceChecklistItem.normalizedText(checklistItem.text) ?? checklistItem.text) {
+                _ = workspace.setChecklistItemState(id: checklistItem.id, state: .completed)
+            }
+        }
+    }
+
+    @MainActor
+    private func resolveTodoWorkspace(for event: WorkstreamEvent) -> Workspace? {
+        guard let raw = event.workspaceId?.trimmingCharacters(in: .whitespacesAndNewlines),
+              let workspaceID = UUID(uuidString: raw),
+              let manager = AppDelegate.shared?.tabManagerFor(tabId: workspaceID) else { return nil }
+        return manager.tabs.first { $0.id == workspaceID }
+    }
+
+    private func checklistState(for state: WorkstreamTaskTodo.State) -> WorkspaceChecklistItem.State {
+        switch state {
+        case .pending: .pending
+        case .inProgress: .inProgress
+        case .completed: .completed
+        }
+    }
+
+    private func taskState(for state: WorkspaceChecklistItem.State) -> WorkstreamTaskTodo.State {
+        switch state {
+        case .pending: .pending
+        case .inProgress: .inProgress
+        case .completed: .completed
+        }
+    }
+}

--- a/Sources/Feed/FeedCoordinator.swift
+++ b/Sources/Feed/FeedCoordinator.swift
@@ -29,6 +29,9 @@ final class FeedCoordinator: @unchecked Sendable {
     // The store runs on the main actor. The coordinator is not isolated,
     // so it hops to main explicitly when touching the store.
     @MainActor private(set) var store: WorkstreamStore!
+    /// Last workspace that each workstream updated. This is a fast path for
+    /// task re-homing; persisted row ownership remains the correctness source.
+    @MainActor var lastTodoWorkspaceByWorkstream: [String: UUID] = [:]
     @MainActor private var userNotificationCenter: (any UserNotificationCenterServing)?
 
     /// The bounded notification-center boundary. `install(store:)` injects it;
@@ -148,7 +151,11 @@ final class FeedCoordinator: @unchecked Sendable {
     @MainActor
     func ingestRevalidatedOnMainActor(_ event: WorkstreamEvent) -> UUID? {
         guard let store else { return nil }
+        recoverAgentTodosIfNeeded(for: event)
         store.ingest(event)
+        if let item = store.items.last {
+            applyAgentTodos(from: item, event: event)
+        }
         if let ppid = event.ppid, ppid > 0 {
             armPidWatcher(ppid: ppid)
         }

--- a/Sources/Feed/WorkstreamEvent+FeedIngress.swift
+++ b/Sources/Feed/WorkstreamEvent+FeedIngress.swift
@@ -15,7 +15,15 @@ extension WorkstreamEvent {
             // These establish authoritative session phase or needs-input state that cannot be
             // reconstructed from a later high-volume tool telemetry event.
             return .sessionCritical
-        case .preToolUse, .postToolUse, .postToolUseFailure, .todoWrite,
+        case .todoWrite:
+            // Whole-list snapshots must not be dropped: an empty snapshot is
+            // the only signal that the agent cleared its final task.
+            return .sessionCritical
+        case .preToolUse, .postToolUse
+            where event.toolName.flatMap(WorkstreamTaskTool.init(rawValue:)) != nil:
+            // Task deltas cannot be reconstructed from later tool traffic.
+            return .sessionCritical
+        case .preToolUse, .postToolUse,
              .subagentStart, .subagentStop, .preCompact, .postCompact:
             // Tool traffic is best-effort; prompt submission establishes working
             // state, while compaction/subagent events preserve the parent state.

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1163,6 +1163,7 @@
 		FEED0A00000000000000F007 /* feed-tui in Resources */ = {isa = PBXBuildFile; fileRef = FEED0A00000000000000F006 /* feed-tui */; };
 		9466A07A0000000000000001 /* FeedAttentionTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9466A07A0000000000000002 /* FeedAttentionTarget.swift */; };
 		FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */; };
+		A8E100000000000000000002 /* FeedCoordinator+AgentTodos.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8E100000000000000000001 /* FeedCoordinator+AgentTodos.swift */; };
 		8672D0018672D0018672D001 /* FeedCoordinator+DeliveryTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8672D0028672D0028672D002 /* FeedCoordinator+DeliveryTarget.swift */; };
 		B7F100090000000000000001 /* FeedCoordinator+NotificationDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7F100090000000000000002 /* FeedCoordinator+NotificationDelivery.swift */; };
 		FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEED0000000000000000F001 /* FeedCoordinator.swift */; };
@@ -4165,6 +4166,7 @@
 		FEED0A00000000000000F006 /* feed-tui */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = folder; path = "feed-tui"; sourceTree = "<group>"; };
 		9466A07A0000000000000002 /* FeedAttentionTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedAttentionTarget.swift; sourceTree = "<group>"; };
 		FEED0000000000000000F00C /* FeedButtonStyleDebugWindowController.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedButtonStyleDebugWindowController.swift; sourceTree = "<group>"; };
+		A8E100000000000000000001 /* FeedCoordinator+AgentTodos.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedCoordinator+AgentTodos.swift"; sourceTree = "<group>"; };
 		8672D0028672D0028672D002 /* FeedCoordinator+DeliveryTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedCoordinator+DeliveryTarget.swift"; sourceTree = "<group>"; };
 		B7F100090000000000000002 /* FeedCoordinator+NotificationDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FeedCoordinator+NotificationDelivery.swift"; sourceTree = "<group>"; };
 		FEED0000000000000000F001 /* FeedCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FeedCoordinator.swift; sourceTree = "<group>"; };
@@ -9139,6 +9141,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			isa = PBXGroup;
 			children = (
 				FEED0000000000000000F001 /* FeedCoordinator.swift */,
+				A8E100000000000000000001 /* FeedCoordinator+AgentTodos.swift */,
 				8672D0028672D0028672D002 /* FeedCoordinator+DeliveryTarget.swift */,
 				B7F100090000000000000002 /* FeedCoordinator+NotificationDelivery.swift */,
 				B7F1000A0000000000000002 /* FeedJumpResolver.swift */,
@@ -10289,6 +10292,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C0DEA7710000000000000007 /* FeatureFlags.swift in Sources */,
 				9466A07A0000000000000001 /* FeedAttentionTarget.swift in Sources */,
 				FEED0000000000000000F00D /* FeedButtonStyleDebugWindowController.swift in Sources */,
+				A8E100000000000000000002 /* FeedCoordinator+AgentTodos.swift in Sources */,
 				8672D0018672D0018672D001 /* FeedCoordinator+DeliveryTarget.swift in Sources */,
 				B7F100090000000000000001 /* FeedCoordinator+NotificationDelivery.swift in Sources */,
 				FEED0000000000000000F002 /* FeedCoordinator.swift in Sources */,


### PR DESCRIPTION
Fixes #8960

This is the ingestion-only slice of #11510. It adds Claude Code TaskCreate, TaskUpdate, TaskGet, and TaskList hook ingestion into workspace todos, including provisional identity reconciliation and checklist projection. It intentionally excludes the cross-workspace Task Queue UI, CLI, dispatch, and queue-only tests.

Checks: Swift frontend parse for all changed Swift files; package policy; workspace package groups; pbxproj validation; test wiring lint; diff check; merge-tree check. No Xcode or Rust tests run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11574"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790920204&installation_model_id=21920&pr_number=11574&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11574&signature=5cbb0cb833755ff9c7d9d07a3fcd6265d2992972d2b2d8ec94eebd2f9c242b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8960 by ingesting Claude Code's TaskCreate, TaskUpdate, TaskGet, and TaskList hook events into the workspace checklist. Previously only TodoWrite snapshots were reflected; now one-task deltas are accumulated per workstream and projected into the checklist.

- Task tool events are now session-critical so they aren't dropped from the feed.
- Provisional IDs from pre-tool events are reconciled with post-tool responses.
- Restart recovery seeds the accumulator from persisted checklist rows before applying status-only updates.
- Checklist sync replaces only rows owned by the reporting workstream; user and other-agent rows are preserved.
- The cross-workspace Task Queue UI, CLI, and dispatch are intentionally excluded; no Xcode or Rust tests were run.

<sup>Written for commit 1fb6bbe2b411fc0555aa03a148222cc3bcc3652d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11574?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

