### PR TITLE
fix: fail closed on duplicate TaskCreate subjects

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
@@ -416,8 +416,9 @@ struct WorkstreamTaskToolTodos: Sendable {
         }
 
         // A subject is only a fallback identity when it identifies one
-        // pending create. If duplicate creates are in flight, retain the
-        // completion until a request id or task id disambiguates it.
+        // pending create. If duplicate creates are in flight, keep each
+        // confirmed task under its stable id without claiming a provisional
+        // row. This avoids both assigning the wrong row and losing progress.
         if tool == .taskCreate,
            requestID?.isEmpty != false,
            let subject = content(in: object(from: inputJSON)),
@@ -425,15 +426,14 @@ struct WorkstreamTaskToolTodos: Sendable {
                operation.tool == .taskCreate
                    && content(in: object(from: operation.inputJSON)) == subject
            }).count > 1 {
-            appendPendingPost(PendingPostOperation(
+            let outcome = applyPostMutation(
                 tool: tool,
                 inputJSON: inputJSON,
                 responseJSON: responseJSON,
-                isError: false,
-                requestID: requestID
-            ))
+                isError: false
+            )
             hasCompleteTaskList = false
-            return .list(projectedState().todos)
+            return outcome.producedList ? outcome : .list(projectedState().todos)
         }
 
         switch completion {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
@@ -430,7 +430,7 @@ struct WorkstreamTaskToolTodos: Sendable {
                 tool: tool,
                 inputJSON: inputJSON,
                 responseJSON: responseJSON,
-                isError: false
+                isError: isError
             )
             hasCompleteTaskList = false
             return outcome.producedList ? outcome : .list(projectedState().todos)

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
@@ -117,7 +117,6 @@ struct WorkstreamTaskToolTodos: Sendable {
                     && content(in: object(from: operations[$0][keyPath: inputJSONKeyPath])) == subject
             }
             if matches.count == 1, let index = matches.first { return index }
-            if tool == .taskCreate, let first = matches.first { return first }
         }
         return nil
     }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
@@ -415,6 +415,27 @@ struct WorkstreamTaskToolTodos: Sendable {
             return .list(projectedState().todos)
         }
 
+        // A subject is only a fallback identity when it identifies one
+        // pending create. If duplicate creates are in flight, retain the
+        // completion until a request id or task id disambiguates it.
+        if tool == .taskCreate,
+           requestID?.isEmpty != false,
+           let subject = content(in: object(from: inputJSON)),
+           pendingPreOperations.filter({ operation in
+               operation.tool == .taskCreate
+                   && content(in: object(from: operation.inputJSON)) == subject
+           }).count > 1 {
+            appendPendingPost(PendingPostOperation(
+                tool: tool,
+                inputJSON: inputJSON,
+                responseJSON: responseJSON,
+                isError: false,
+                requestID: requestID
+            ))
+            hasCompleteTaskList = false
+            return .list(projectedState().todos)
+        }
+
         switch completion {
         case .failure:
             appendPendingPost(PendingPostOperation(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -431,7 +431,7 @@ struct WorkstreamTaskToolTodoTests {
             isError: false
         )
 
-        #expect(accumulator.ownedIDList == ["pending-1", "pending-2", "42"])
+        #expect(accumulator.ownedIDList == ["42", "pending-1", "pending-2"])
     }
 
     @Test("A failed TaskUpdate restores the pre-tool checklist")

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -410,6 +410,30 @@ struct WorkstreamTaskToolTodoTests {
         #expect(latestTodos(store)?.map(\.id) == ["1", "2"])
     }
 
+    @Test("Duplicate TaskCreate subjects do not guess the provisional row")
+    func duplicateTaskCreateSubjectsFailClosed() {
+        var accumulator = WorkstreamTaskToolTodos()
+        _ = accumulator.applyPre(
+            tool: .taskCreate,
+            inputJSON: #"{"subject":"same subject"}"#,
+            requestID: "create-1"
+        )
+        _ = accumulator.applyPre(
+            tool: .taskCreate,
+            inputJSON: #"{"subject":"same subject"}"#,
+            requestID: "create-2"
+        )
+
+        _ = accumulator.applyPost(
+            tool: .taskCreate,
+            inputJSON: #"{"subject":"same subject"}"#,
+            responseJSON: #"{"task":{"id":"42","subject":"same subject"}}"#,
+            isError: false
+        )
+
+        #expect(accumulator.ownedIDList == ["pending-1", "pending-2"])
+    }
+
     @Test("A failed TaskUpdate restores the pre-tool checklist")
     func failedTaskUpdateRestoresPreToolState() {
         let store = WorkstreamStore(ringCapacity: 50)

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -431,7 +431,7 @@ struct WorkstreamTaskToolTodoTests {
             isError: false
         )
 
-        #expect(accumulator.ownedIDList == ["pending-1", "pending-2"])
+        #expect(accumulator.ownedIDList == ["pending-1", "pending-2", "42"])
     }
 
     @Test("A failed TaskUpdate restores the pre-tool checklist")


### PR DESCRIPTION
Fixes the duplicate-subject ambiguity identified in #11510.

When two pending TaskCreate operations have the same subject and a completion lacks a stable request ID, matching now fails closed instead of assigning the authoritative ID to the first row. Unique request IDs and unique normalized inputs keep their existing behavior.

Regression commits are test-first: the first commit adds the failing behavior test, and the second removes the unsafe fallback.

Verification: swiftc frontend parse for changed source and test files; git diff --check. No local Xcode tests run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11575"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790920583&installation_model_id=21920&pr_number=11575&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11575&signature=2f751fa4bc524931c41cf78fbc809cfd8b9282030e371573846de325a5e6e8c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the duplicate-subject ambiguity from #11510. When two pending TaskCreate operations share a subject and a completion has no stable request ID, matching now fails closed: the confirmed task keeps its stable id and the provisional rows stay untouched instead of assigning the authoritative ID to the first pending row. Successful and failed completions both follow this behavior. Unique request IDs and unique normalized inputs keep their existing behavior.

<sup>Written for commit d2f44b53fd00bf33dab806c3ae3ad165f4808087. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11575?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

