### PR TITLE
fix: preserve in-flight task deltas across snapshots

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
@@ -12,6 +12,9 @@ struct WorkstreamTaskToolTodos: Sendable {
     static let maxRetainedTodos = 50
     /// Bounds ownership metadata retained for deleted/evicted tasks.
     static let maxOwnedIds = 200
+    /// Bounds provisional subject-to-id bookkeeping independently of the
+    /// retained checklist rows.
+    private static let maxProvisionalIDs = 200
 
     private var todos: [WorkstreamTaskTodo] = []
     private var ownedIDsInOrder: [String] = []
@@ -263,8 +266,23 @@ struct WorkstreamTaskToolTodos: Sendable {
             return .ignored
         }
         if establishesCompleteness {
-            pendingPreOperations.removeAll(keepingCapacity: true)
-            pendingPostOperations.removeAll(keepingCapacity: true)
+            // A complete snapshot supersedes only an earlier snapshot with
+            // the same operation identity. Delta operations for other tool
+            // calls remain in flight and must still project over this base.
+            if let index = pendingOperationIndex(
+                tool: tool,
+                inputJSON: inputJSON,
+                requestID: requestID
+            ) {
+                pendingPreOperations.remove(at: index)
+            }
+            if let index = pendingPostIndex(
+                tool: tool,
+                inputJSON: inputJSON,
+                requestID: requestID
+            ) {
+                pendingPostOperations.remove(at: index)
+            }
             return applyPreMutation(
                 tool: tool,
                 inputJSON: inputJSON,
@@ -383,8 +401,25 @@ struct WorkstreamTaskToolTodos: Sendable {
 
         if tool == .todoWrite || tool == .taskList,
            case .success(let authoritativeResponse) = completion {
-            pendingPreOperations.removeAll(keepingCapacity: true)
-            pendingPostOperations.removeAll(keepingCapacity: true)
+            // Keep unrelated deltas in flight. They are projected after this
+            // authoritative snapshot and reconciled when their own post hook
+            // arrives.
+            if let index = pendingOperationIndex(
+                tool: tool,
+                inputJSON: inputJSON,
+                requestID: requestID
+            ) {
+                pendingPreOperations[index].completion = completion
+                reconcileReadyOperations()
+                return .list(projectedState().todos)
+            }
+            if let index = pendingPostIndex(
+                tool: tool,
+                inputJSON: inputJSON,
+                requestID: requestID
+            ) {
+                pendingPostOperations.remove(at: index)
+            }
             let outcome = applyPostMutation(
                 tool: tool,
                 inputJSON: inputJSON,
@@ -655,6 +690,19 @@ struct WorkstreamTaskToolTodos: Sendable {
         if id.hasPrefix("pending-"),
            let suffix = Int(id.dropFirst("pending-".count)) {
             nextProvisionalID = max(nextProvisionalID, suffix)
+        }
+        guard provisionalIDsInOrder.count > Self.maxProvisionalIDs else { return }
+        let evicted = Set(provisionalIDsInOrder.prefix(
+            provisionalIDsInOrder.count - Self.maxProvisionalIDs
+        ))
+        provisionalIDsInOrder.removeFirst(evicted.count)
+        for key in Array(provisionalIDsBySubject.keys) {
+            let retained = provisionalIDsBySubject[key, default: []].filter { !evicted.contains($0) }
+            if retained.isEmpty {
+                provisionalIDsBySubject.removeValue(forKey: key)
+            } else {
+                provisionalIDsBySubject[key] = retained
+            }
         }
     }
 

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -410,6 +410,33 @@ struct WorkstreamTaskToolTodoTests {
         #expect(latestTodos(store)?.map(\.id) == ["1", "2"])
     }
 
+    @Test("A complete snapshot preserves an unrelated in-flight delta")
+    func completeSnapshotPreservesInFlightDelta() {
+        var accumulator = WorkstreamTaskToolTodos()
+        _ = accumulator.applyPre(
+            tool: .taskCreate,
+            inputJSON: #"{"subject":"still running"}"#,
+            requestID: "create-1"
+        )
+
+        _ = accumulator.applyPre(
+            tool: .todoWrite,
+            inputJSON: #"{"todos":[]}"#,
+            requestID: "snapshot-1",
+            establishesCompleteness: true
+        )
+        _ = accumulator.applyPost(
+            tool: .todoWrite,
+            inputJSON: #"{"todos":[]}"#,
+            responseJSON: #"{"todos":[]}"#,
+            isError: false,
+            requestID: "snapshot-1"
+        )
+
+        #expect(accumulator.ownedIDList == ["pending-1"])
+        #expect(accumulator.isEmpty == false)
+    }
+
     @Test("A failed TaskUpdate restores the pre-tool checklist")
     func failedTaskUpdateRestoresPreToolState() {
         let store = WorkstreamStore(ringCapacity: 50)


### PR DESCRIPTION
Fixes the ingestion bug in PR #11510 where a complete TodoWrite or TaskList event cleared every pending operation for the workstream.

The accumulator now removes only the matching snapshot operation, preserving unrelated TaskCreate and TaskUpdate deltas for projection and later reconciliation. Provisional subject-to-ID bookkeeping is capped at 200 entries.

Behavior coverage: a complete snapshot keeps an unrelated in-flight TaskCreate provisional row.

Checks: Swift frontend parse, package policy, workspace package groups, pbxproj validation, test wiring lint, diff check. No local Xcode tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11576"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790920741&installation_model_id=21920&pr_number=11576&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11576&signature=5b0c87b166b4869b9981753560fcfb4f161034b1c1a3dafa5038b34da6157d4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ingestion bug where a complete TodoWrite or TaskList event cleared every pending operation for the workstream, dropping unrelated in-flight deltas.

The accumulator now supersedes only the matching snapshot operation, preserving TaskCreate and TaskUpdate deltas for projection and later reconciliation. Provisional subject-to-ID bookkeeping is capped at 200 entries, and a test covers that a complete snapshot keeps an unrelated in-flight TaskCreate provisional row.

<sup>Written for commit 6e0d8eb22b888bc9a0fb934d2d0df14b9fb5b66e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11576?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

