### PR TITLE
Fix stale relay rotation and bound IRX provisioning

### DIFF
--- a/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxEndpoint.swift
+++ b/Packages/Shared/CmuxIrxTransport/Sources/CmuxIrxTransport/IrxEndpoint.swift
@@ -74,6 +74,9 @@ public actor IrxEndpointSupervisor {
 
     public var currentGeneration: Int { generation }
 
+    /// Lifecycle token for callers that must fence work across suspension.
+    public var currentLifecycleEpoch: UInt64 { lifecycleEpoch }
+
     public func identity() -> IrxIdentity { configuration.identity }
 
     /// Returns a bound, relay-online endpoint, binding one if needed.
@@ -146,10 +149,18 @@ public actor IrxEndpointSupervisor {
     /// the forked iroh authenticates a replacement relay connection before
     /// swapping routes, so live sessions continue. Never removeRelay for a
     /// URL being rotated - remove tears the active relay down instantly.
-    public func rotateCredentials(_ credentials: [IrxRelayCredential]) async {
-        guard !deactivated else { return }
+    public func rotateCredentials(
+        _ credentials: [IrxRelayCredential],
+        expectedLifecycleEpoch: UInt64? = nil
+    ) async {
+        guard !deactivated,
+              expectedLifecycleEpoch == nil || expectedLifecycleEpoch == lifecycleEpoch
+        else { return }
         guard let driver, !driver.isClosed() else { return }
         for credential in credentials {
+            guard !deactivated,
+                  expectedLifecycleEpoch == nil || expectedLifecycleEpoch == lifecycleEpoch
+            else { return }
             do {
                 try await driver.insertRelay(
                     config: RelayConfig(

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -41,7 +41,15 @@ public actor MobileIrxRuntimeComposition {
         case notSignedIn
         case unsupportedRoute
         case peerNotDiscovered
+        case provisioningExhausted(attempts: Int)
     }
+
+    /// Provisioning is retried only for a bounded launch window. Auth events
+    /// start a fresh window after a later sign-in or account refresh.
+    nonisolated static let provisioningMaxAttempts = 5
+    nonisolated static let provisioningRetryDelays: [Duration] = [
+        .seconds(1), .seconds(2), .seconds(4), .seconds(8), .seconds(16),
+    ]
 
     /// Dial-gate refusals from the device-list lease. Deliberately NOT
     /// ``IrxAdmissionDenied``: the peer engine treats these as ordinary
@@ -233,10 +241,17 @@ public actor MobileIrxRuntimeComposition {
         let epoch = lifecycleEpoch
         provisioningTask = Task { [weak self] in
             guard let self else { return }
-            _ = await self.provisionSignedInWithRetry(
-                sessionIdentity: sessionIdentity,
-                epoch: epoch
-            )
+            do {
+                _ = try await self.provisionSignedInWithRetry(
+                    sessionIdentity: sessionIdentity,
+                    epoch: epoch
+                )
+            } catch {
+                Self.journal.record(
+                    "client-runtime", "provisioning-terminal",
+                    ["error": String(describing: error)]
+                )
+            }
         }
     }
 
@@ -246,7 +261,7 @@ public actor MobileIrxRuntimeComposition {
     private func provisionSignedInWithRetry(
         sessionIdentity: AuthenticatedSessionIdentity,
         epoch: UInt64
-    ) async -> Bool {
+    ) async throws -> Bool {
         guard let auth else { return false }
         Self.journal.record("client-runtime", "auth-gate-snapshot-check")
         guard await auth.isAuthenticatedSessionIdentityCurrent(sessionIdentity) else {
@@ -254,8 +269,7 @@ public actor MobileIrxRuntimeComposition {
             return false
         }
         Self.journal.record("client-runtime", "auth-gate-signed-in")
-        var delay: Duration = .seconds(1)
-        while !Task.isCancelled {
+        for attempt in 1...Self.provisioningMaxAttempts {
             guard lifecycleEpoch == epoch,
                   await auth.isAuthenticatedSessionIdentityCurrent(sessionIdentity)
             else { return false }
@@ -263,8 +277,10 @@ public actor MobileIrxRuntimeComposition {
                 sessionIdentity: sessionIdentity,
                 epoch: epoch
             ) { return true }
-            try? await Task.sleep(for: delay)
-            delay = min(delay * 2, .seconds(30))
+            guard attempt < Self.provisioningMaxAttempts else {
+                throw CompositionError.provisioningExhausted(attempts: attempt)
+            }
+            try await Task.sleep(for: Self.provisioningRetryDelays[attempt - 1])
         }
         return false
     }
@@ -517,10 +533,17 @@ public actor MobileIrxRuntimeComposition {
     /// identity binding, monotonic freshness), then rotate make-before-break
     /// and reset the autopilot timer so push and fallback never double-mint.
     private func ingestPushedPasses(_ credentials: [IrxRelayCredential]) async -> Bool {
+        let epoch = lifecycleEpoch
         guard let broker, let endpointSupervisor, let autopilot else { return false }
+        guard isCurrent(epoch) else { return false }
         guard let accepted = await broker.acceptPushedRelayCredentials(credentials)
         else { return false }
+        // Sign-out or an account switch may have deactivated this endpoint
+        // while the broker actor accepted the push. Never rotate credentials
+        // into that stale endpoint generation or kick its autopilot.
+        guard isCurrent(epoch) else { return false }
         await endpointSupervisor.rotateCredentials(accepted)
+        guard isCurrent(epoch) else { return false }
         await autopilot.kick()
         return true
     }

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrxRuntimeComposition.swift
@@ -116,6 +116,7 @@ public actor MobileIrxRuntimeComposition {
     private var authObservationTask: Task<Void, Never>?
     private var activeAccountID: String?
     private var lifecycleEpoch: UInt64 = 0
+    private var lastProvisioningFailure: CompositionError?
     /// One reconnect owner per Mac endpoint (contract: the single dialer).
     private var enginesByPeer: [String: IrxPeerEngine] = [:]
     /// Route material per peer, refreshed on every transport request.
@@ -238,6 +239,7 @@ public actor MobileIrxRuntimeComposition {
 
     private func startProvisioning(for sessionIdentity: AuthenticatedSessionIdentity) {
         provisioningTask?.cancel()
+        lastProvisioningFailure = nil
         let epoch = lifecycleEpoch
         provisioningTask = Task { [weak self] in
             guard let self else { return }
@@ -247,6 +249,7 @@ public actor MobileIrxRuntimeComposition {
                     epoch: epoch
                 )
             } catch {
+                self.lastProvisioningFailure = error as? CompositionError
                 Self.journal.record(
                     "client-runtime", "provisioning-terminal",
                     ["error": String(describing: error)]
@@ -542,10 +545,21 @@ public actor MobileIrxRuntimeComposition {
         // while the broker actor accepted the push. Never rotate credentials
         // into that stale endpoint generation or kick its autopilot.
         guard isCurrent(epoch) else { return false }
-        await endpointSupervisor.rotateCredentials(accepted)
+        let endpointEpoch = await endpointSupervisor.currentLifecycleEpoch
+        guard isCurrent(epoch) else { return false }
+        await endpointSupervisor.rotateCredentials(
+            accepted,
+            expectedLifecycleEpoch: endpointEpoch
+        )
         guard isCurrent(epoch) else { return false }
         await autopilot.kick()
         return true
+    }
+
+    /// The last terminal provisioning failure, if the owner needs to present
+    /// recovery guidance or expose a retry action.
+    public func provisioningFailure() -> CompositionError? {
+        lastProvisioningFailure
     }
 
     /// The event-driven relay race: a pushed hint that disagrees with the
@@ -584,6 +598,7 @@ public actor MobileIrxRuntimeComposition {
         _ = session
         do {
             _ = try await provisionedBroker(epoch: epoch)
+            lastProvisioningFailure = nil
             Self.journal.record("client-runtime", "provisioned")
             return true
         } catch {

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -16,6 +16,12 @@ import Testing
 @Suite
 struct MobileIrohRuntimeCompositionTests {
     @Test
+    func provisioningRetryPolicyHasTerminalBound() {
+        #expect(MobileIrxRuntimeComposition.provisioningMaxAttempts == 5)
+        #expect(MobileIrxRuntimeComposition.provisioningRetryDelays.count == 5)
+    }
+
+    @Test
     @MainActor
     func foregroundRevalidatesAuthBeforeConnectionReadinessCompletes() async throws {
         let fixture = try await MobileIrohSignOutFixture.make()

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileIrohRuntimeCompositionTests.swift
@@ -22,6 +22,12 @@ struct MobileIrohRuntimeCompositionTests {
     }
 
     @Test
+    func provisioningFailureIsObservableByOwner() async throws {
+        let fixture = try await MobileIrohSignOutFixture.make()
+        #expect(await fixture.composition.provisioningFailure() == nil)
+    }
+
+    @Test
     @MainActor
     func foregroundRevalidatesAuthBeforeConnectionReadinessCompletes() async throws {
         let fixture = try await MobileIrohSignOutFixture.make()


### PR DESCRIPTION
Stacked on #11573.

Fixes two P1 lifecycle findings:
- Capture and recheck the auth lifecycle epoch around pushed relay credential acceptance and endpoint rotation, so sign-out/account replacement cannot rotate stale passes or kick the old autopilot.
- Replace unbounded provisioning backoff with five cancellation-aware attempts and an explicit terminal error.

Tests:
- Added a Swift Testing regression for the bounded retry policy.
- `swiftc -parse-as-library -parse` passed for changed Swift sources.
- Package test execution is blocked because the checkout lacks a built GhosttyKit.xcframework binary.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11577"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790920886&installation_model_id=21920&pr_number=11577&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11577&signature=131f2a3a7e33ee17829512f11fcfaf2ea967f6cf266d26f8bc4ddbcd0a1f24dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two P1 lifecycle findings in the iOS client runtime: stale relay credentials can no longer be rotated after sign-out or account replacement, and provisioning retries now stop after a bounded number of attempts with the final failure surfaced to the owner.

- Credential rotation is fenced by a lifecycle epoch captured before broker acceptance and rechecked before rotating the endpoint or kicking the autopilot.
- Each provisioning window allows five cancellation-aware attempts with backoff; the last `provisioningExhausted` error is queryable via `provisioningFailure()`.
- A later sign-in or account refresh starts a fresh provisioning window.
- Adds Swift Testing coverage for the retry bound and the exposed failure state.

<sup>Written for commit 7b2a5eef78029527f6540df0051f76fc24e01e44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11577?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

