### PR TITLE
fix: roll back failed explicit-ID TaskCreate rows

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
@@ -391,6 +391,15 @@ public final class WorkstreamStore {
         case .preToolUse:
             let toolName = event.toolName ?? ""
             if let taskTool = WorkstreamTaskTool(rawValue: toolName) {
+                // A failed pre-hook can still include the attempted input. Do
+                // not project that input into the checklist, or a failed
+                // explicit-ID TaskCreate becomes a phantom row.
+                if event.isError == true {
+                    return (
+                        .toolResult,
+                        .toolResult(toolName: toolName, resultJSON: toolInput, isError: true)
+                    )
+                }
                 var accumulator = taskToolTodosByWorkstream[workstreamID] ?? WorkstreamTaskToolTodos()
                 let outcome: WorkstreamTaskToolOutcome
                 if event.toolResponseJSON != nil {

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamStore.swift
@@ -395,6 +395,13 @@ public final class WorkstreamStore {
                 // not project that input into the checklist, or a failed
                 // explicit-ID TaskCreate becomes a phantom row.
                 if event.isError == true {
+                    var accumulator = taskToolTodosByWorkstream[workstreamID]
+                        ?? WorkstreamTaskToolTodos()
+                    accumulator.invalidateCompleteness()
+                    taskToolTodosByWorkstream[workstreamID] = accumulator
+                    taskToolListCompletenessByWorkstream[workstreamID] = false
+                    touchTaskToolWorkstream(workstreamID)
+                    trimTaskToolWorkstreams()
                     return (
                         .toolResult,
                         .toolResult(toolName: toolName, resultJSON: toolInput, isError: true)

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -158,6 +158,47 @@ struct WorkstreamTaskToolTodoTests {
         #expect(store.ownedTaskIds(forWorkstream: "s1").isEmpty)
     }
 
+    @Test("A failed explicit-ID create retires its checklist row")
+    func failedExplicitIDCreateRemovesRow() {
+        let store = WorkstreamStore(ringCapacity: 50)
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TaskCreate",
+            input: #"{"id":"explicit-1","subject":"will fail"}"#,
+            requestId: "create-explicit"
+        ))
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            hook: .postToolUseFailure,
+            tool: "TaskCreate",
+            input: #"{"id":"explicit-1","subject":"will fail"}"#,
+            requestId: "create-explicit"
+        ))
+
+        #expect(latestTodos(store)?.isEmpty == true)
+        #expect(store.ownedTaskIds(forWorkstream: "s1").isEmpty)
+    }
+
+    @Test("An explicit-ID create marked failed on PreToolUse does not publish a row")
+    func failedExplicitIDPreToolUseDoesNotPublishRow() {
+        let store = WorkstreamStore(ringCapacity: 50)
+        store.ingest(toolEvent(
+            sessionId: "s1",
+            tool: "TaskCreate",
+            input: #"{"id":"explicit-pre-failure","subject":"must not appear"}"#,
+            requestId: "create-explicit-pre-failure",
+            isError: true
+        ))
+
+        #expect(latestTodos(store) == nil)
+        #expect(store.ownedTaskIds(forWorkstream: "s1").isEmpty)
+        guard case .toolResult(_, _, let isError) = store.items.last?.payload else {
+            Issue.record("failed PreToolUse must remain error telemetry")
+            return
+        }
+        #expect(isError)
+    }
+
     @Test("Late PreToolUse does not duplicate an authoritative create")
     func postThenPreCreateIsDeduplicated() {
         let store = WorkstreamStore(ringCapacity: 50)

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -184,14 +184,23 @@ struct WorkstreamTaskToolTodoTests {
         let store = WorkstreamStore(ringCapacity: 50)
         store.ingest(toolEvent(
             sessionId: "s1",
+            hook: .todoWrite,
+            tool: "TodoWrite",
+            input: #"{"todos":[]}"#
+        ))
+        #expect(store.isTaskListComplete(forWorkstream: "s1"))
+
+        store.ingest(toolEvent(
+            sessionId: "s1",
             tool: "TaskCreate",
             input: #"{"id":"explicit-pre-failure","subject":"must not appear"}"#,
             requestId: "create-explicit-pre-failure",
             isError: true
         ))
 
-        #expect(latestTodos(store) == nil)
+        #expect(latestTodos(store)?.isEmpty == true)
         #expect(store.ownedTaskIds(forWorkstream: "s1").isEmpty)
+        #expect(store.isTaskListComplete(forWorkstream: "s1") == false)
         guard case .toolResult(_, _, let isError) = store.items.last?.payload else {
             Issue.record("failed PreToolUse must remain error telemetry")
             return


### PR DESCRIPTION
Fixes the failed explicit-ID TaskCreate phantom row on the #11510 task-ingestion branch.

A failed PreToolUse frame can include valid TaskCreate input and an explicit ID. The task accumulator previously projected that input as a checklist row despite the error flag. Keep failed pre-hooks as error telemetry and do not mutate or publish task rows.

Regression coverage is in the first commit; the guard is in the second commit.

Verification:
- swift test --package-path Packages/macOS/CMUXAgentLaunch --filter WorkstreamTaskToolTodoTests/failedExplicitID --disable-automatic-resolution
- swiftc -frontend -parse -parse-as-library for changed Swift files
- git diff --check
- local isolated autoreview completed without reported findings

No local xcodebuild tests were run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11578"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790920927&installation_model_id=21920&pr_number=11578&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11578&signature=c608d3ab039d5efde79be1433634786eacc2f1712d4581ddc5153f0be3731f8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes failed explicit-ID TaskCreate calls leaving a phantom checklist row, and now marks the task list incomplete when the failed pre-hook occurs.

- Failed pre-hooks stay as error telemetry and no longer mutate or publish task rows; they also invalidate task completeness.
- Adds regression tests for failed explicit-ID creates on PreToolUse and PostToolUseFailure, including completeness invalidation.

<sup>Written for commit a13894279707375d3d54d1070ecb0a6534d07028. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11578?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

