### PR TITLE
test: replace fallback watcher sleep with readiness signal

### DIFF
--- a/web/tests/vm-cmux-tui.test.ts
+++ b/web/tests/vm-cmux-tui.test.ts
@@ -688,7 +688,7 @@ describe("cmux-tui install and daemon commands", () => {
     writeExecutable("mountpoint", [
       "#!/bin/sh",
       "path=\"$2\"",
-      "if [ \"$path\" = \"$CMUX_TEST_BACKING\" ]; then [ ! -e \"$CMUX_TEST_STATE/backing-unmounted\" ]; exit $?; fi",
+      "if [ \"$path\" = \"$CMUX_TEST_BACKING\" ]; then if [ -e \"$CMUX_TEST_STATE/daemon-ready\" ]; then : > \"$CMUX_TEST_STATE/fallback-watch-ready\"; fi; [ ! -e \"$CMUX_TEST_STATE/backing-unmounted\" ]; exit $?; fi",
       "exit 1",
       "",
     ].join("\n"));
@@ -721,7 +721,11 @@ describe("cmux-tui install and daemon commands", () => {
         await new Promise((resolve) => setTimeout(resolve, 10));
       }
       expect(existsSync(join(state, "daemon-ready"))).toBe(true);
-      await new Promise((resolve) => setTimeout(resolve, 100));
+      const watcherDeadline = Date.now() + 2_000;
+      while (!existsSync(join(state, "fallback-watch-ready")) && Date.now() < watcherDeadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      expect(existsSync(join(state, "fallback-watch-ready"))).toBe(true);
       // Missing findmnt must select a bounded direct mount check, not signal the
       // supervisor before the daemon has a chance to serve the mounted home.
       expect(child.exitCode).toBeNull();


### PR DESCRIPTION
Replace the fixed 100ms delay in the no-findmnt fallback liveness test with a deterministic readiness marker emitted by the fake mountpoint after daemon startup.

The test now waits up to 2 seconds for the fallback watcher to perform its first post-ready check, then asserts the supervisor remains alive.

Checks: `bun test ./web/tests/vm-cmux-tui.test.ts` (20 passed). Full TypeScript check is blocked by baseline missing dependency errors in this checkout.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11579"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790921014&installation_model_id=21920&pr_number=11579&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11579&signature=f0652da01795a3597074208496b10bf34d866b517f51b53cb2da72c4cd6ff82b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the fixed 100ms sleep in the no-findmnt fallback liveness test with a deterministic readiness signal so the test no longer depends on timing and reliably covers the liveness guard from issue-11566.

- The fake mountpoint now writes a `fallback-watch-ready` marker after the daemon signals `daemon-ready`.
- The test waits up to 2 seconds for that marker before asserting the supervisor stays alive.

<sup>Written for commit 72d40ddaab55ddd1df5d6e2f140c51bd510a595f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Improved test synchronization by waiting for an explicit readiness signal instead of relying on a fixed delay.
  - Added a deadline-based check to verify the fallback monitoring process is ready before assertions run.
  - Increased reliability when validating behavior with an active backing mount and no `findmnt` utility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->