### PR TITLE
ci: activate guarded CLA v3 workflow

### DIFF
--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -34,6 +34,11 @@ if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign 
   fail "The signing comment did not result in a persisted signature"
 fi
 [[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{7,40}$ ]] || fail "Invalid CLA generation marker"
+[[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
+checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
+[[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"
+[[ "${WORKFLOW_PATH}" == ".github/workflows/cla.yml" ]] || fail "Unexpected CLA workflow path"
+[[ -f .github/scripts/rerun-failed-cla.sh ]] || fail "The trusted CLA rerun helper is missing"
 
 # These values are part of the trusted workflow contract. They are deliberately
 # constants, not event or comment input, so a contributor cannot redirect this
@@ -41,15 +46,62 @@ fi
 readonly SIGNATURES_BRANCH='cla-signatures'
 readonly SIGNATURES_PATH='signatures/version2/cla.json'
 readonly MAX_RUN_PAGES=10
+# Keep every GitHub JSON response below a fixed byte budget before it enters a
+# shell variable. GitHub's pagination limits bound item counts, not the size of
+# individual fields, so a response-size guard is still required.
+readonly MAX_API_RESPONSE_BYTES=2000000
+readonly MAX_API_ERROR_BYTES=65536
 readonly MAX_LEDGER_BYTES=1000000
 readonly MAX_LEDGER_SIGNATURES=10000
 # GitHub wraps Contents API Base64 responses with newlines. Allow that
 # transport overhead while bounding the raw field before normalization.
 readonly MAX_LEDGER_RAW_BYTES=2000000
+# These rendered job names are part of the v3 workflow contract. Keep them
+# fixed here so a workflow edit cannot make this actions:write helper rerun an
+# arbitrary failed job. The writer and compatibility jobs are optional failed
+# members because a recheck can target a result-only failure; when either is
+# failed, rerun-failed-jobs refreshes every failed v3 context together.
+readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
+readonly CLA_WRITER_JOB='CLA ledger writer'
+readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
+
+# Capture one byte past the limit in a temporary file. This keeps an oversized
+# response out of shell memory and bounds disk use before command substitution
+# can expose the response to jq. Bound stderr separately because GitHub can
+# include response text in gh diagnostics.
+gh_api_bounded() {
+  local temp_dir body_file response_bytes gh_status head_status cat_status
+  local -a pipeline_status
+  temp_dir="$(mktemp -d)" || return 1
+  body_file="${temp_dir}/body"
+  set +e
+  gh api "$@" 2> >(head -c "${MAX_API_ERROR_BYTES}" >&2) |
+    head -c "$((MAX_API_RESPONSE_BYTES + 1))" >"${body_file}"
+  pipeline_status=("${PIPESTATUS[@]}")
+  set -e
+  gh_status="${pipeline_status[0]:-1}"
+  head_status="${pipeline_status[1]:-1}"
+  response_bytes="$(LC_ALL=C wc -c <"${body_file}" | tr -d '[:space:]')"
+  if [[ ! "${response_bytes}" =~ ^[0-9]+$ ]] || (( response_bytes > MAX_API_RESPONSE_BYTES )); then
+    rm -rf -- "${temp_dir}"
+    return 2
+  fi
+  if (( head_status != 0 )); then
+    rm -rf -- "${temp_dir}"
+    return 1
+  fi
+  cat "${body_file}"
+  cat_status=$?
+  rm -rf -- "${temp_dir}"
+  if (( gh_status != 0 )); then
+    return "${gh_status}"
+  fi
+  return "${cat_status}"
+}
 
 validate_triggering_signature_record() {
   local ledger_response ledger_content ledger_content_compact ledger_json ledger_raw_bytes ledger_encoded_bytes ledger_decoded_bytes
-  ledger_response="$(gh api \
+  ledger_response="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field ref="${SIGNATURES_BRANCH}" \
@@ -104,19 +156,42 @@ validate_triggering_signature_record() {
      )' <<<"${ledger_json}" >/dev/null || fail "The signing comment was not the signature persisted by the CLA action"
 }
 
-issue_json="$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
+issue_json="$(gh_api_bounded "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
 issue_state="$(jq -r '.state // empty' <<<"${issue_json}")"
 issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
 [[ "${issue_state}" == "open" ]] || fail "The issue is not an open pull request"
 [[ "${issue_pr_url}" == "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" ]] || fail "The issue is not the exact repository pull request"
 
-pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
+# Re-fetch the triggering comment immediately before using its ledger entry.
+# A comment can be edited or deleted after the writer records a signature; a
+# stale event payload must never authorize a rerun of the failed check.
+comment_json="$(gh_api_bounded "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" 2>/dev/null)" || fail "Could not query the triggering comment"
+jq -e \
+  --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+  --arg body "${COMMENT_BODY}" \
+  --arg author_id "${COMMENT_AUTHOR_ID}" \
+  --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
+  --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+  --arg created_at "${COMMENT_CREATED_AT}" \
+  '.issue_url == $issue_url and
+   .body == $body and
+   (.user | type == "object") and
+   (.user.id | type == "number") and
+   (.user.id | tostring) == $author_id and
+   .user.login == $author_login and
+   .user.type == $author_type and
+   .created_at == $created_at and
+   .updated_at == $created_at' <<<"${comment_json}" >/dev/null || fail "The triggering CLA comment was edited, deleted, or moved"
+
+pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
 jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
   .number == $number and
   .state == "open" and
   .base.ref == $base and
   (.base.repo.id | type == "number") and
   .base.repo.full_name == $repo and
+  (.base.sha | type == "string") and
+  (.base.sha | test("^[0-9a-f]{40}$")) and
   (.head.sha | type == "string") and
   (.head.sha | test("^[0-9a-f]{40}$")) and
   (.head.repo.id | type == "number") and
@@ -128,11 +203,13 @@ head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
 head_ref="$(jq -r '.head.ref // empty' <<<"${pr_json}")"
 head_repo="$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")"
 head_repo_id="$(jq -r '.head.repo.id // empty' <<<"${pr_json}")"
+base_sha="$(jq -r '.base.sha // empty' <<<"${pr_json}")"
 repo_id="$(jq -r '.base.repo.id // empty' <<<"${pr_json}")"
 pr_author_login="$(jq -r '.user.login // empty' <<<"${pr_json}")"
 pr_author_id="$(jq -r '.user.id // empty' <<<"${pr_json}")"
 [[ "${head_ref}" != "" && "${head_repo}" != "" ]] || fail "The pull request head repository is missing"
 [[ "${head_repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request head repository ID is missing"
+[[ "${base_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The pull request base SHA is missing"
 [[ "${repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request base repository ID is missing"
 [[ "${pr_author_login}" != "" ]] || fail "The pull request author is missing"
 [[ "${pr_author_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request author ID is missing"
@@ -150,83 +227,96 @@ if [[ "${COMMENT_BODY}" == "recheck" && "${COMMENT_AUTHOR_ID}" != "${pr_author_i
 fi
 
 # The workflow-run list can omit pull_requests for pull_request_target runs.
-# The exact live PR plus the run head_repository/head_branch binding below is
-# used for populated source-head runs. Empty associations are accepted only
-# when the run execution SHA equals the live PR head SHA; a base or merge SHA
-# is not sufficient evidence for a privileged rerun.
-# GitHub may return a not-found or validation response when the source commit
-# exists only in a fork. Treat only that documented missing-commit response as
-# an empty association list; every other API failure remains fatal.
-commit_prs_json=""
-commit_association_error=""
-commit_association_stderr_file="$(mktemp)"
-cleanup_commit_association_stderr() {
-  rm -f -- "${commit_association_stderr_file}"
-}
-trap cleanup_commit_association_stderr EXIT
-if commit_prs_json="$(gh api \
-  --method GET \
-  --header 'Accept: application/vnd.github+json' \
-  --raw-field per_page=100 \
-  --raw-field page=1 \
-  "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>"${commit_association_stderr_file}")"; then
-  :
-else
-  commit_association_error="${commit_prs_json}"$'\n'"$(cat "${commit_association_stderr_file}")"
-  if jq -e '
-    ((.status == 404 or .status == "404") and
-      (.message == "Not Found" or .message == "Resource not found")) or
-    ((.status == 422 or .status == "422") and
-      (.message | type == "string" and startswith("No commit found for SHA: ")))
-  ' <<<"${commit_prs_json}" >/dev/null 2>&1 ||
-     { grep -Eq 'HTTP 404' <<<"${commit_association_error}" &&
-       grep -Eq 'Not Found|Resource not found' <<<"${commit_association_error}"; } ||
-     { grep -Eq 'HTTP 422' <<<"${commit_association_error}" &&
-       grep -Eq 'No commit found for SHA: [0-9a-f]{40}' <<<"${commit_association_error}"; }; then
-    commit_prs_json='[]'
-  else
-    fail "Could not query pull request associations"
-  fi
-fi
-cleanup_commit_association_stderr
-trap - EXIT
-jq -e 'type == "array"' <<<"${commit_prs_json}" >/dev/null || fail "Could not validate pull request associations"
-association_count="$(jq -r 'length' <<<"${commit_prs_json}")"
-[[ "${association_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations"
-(( association_count <= 100 )) || fail "The pull request association page is oversized"
-if (( association_count == 100 )); then
-  commit_prs_page2="$(gh api \
+# Fetch the source-head associations once, allowing only GitHub's documented
+# fork-only missing-commit response to fall through to the live PR check.
+fetch_commit_associations() {
+  local commit_sha="$1"
+  local allow_missing="$2"
+  local response error_text stderr_file page_count page2_count page2
+  stderr_file="$(mktemp)" || return 1
+  if response="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
-    --raw-field page=2 \
-    "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>/dev/null)" || fail "Could not query pull request associations page 2"
-  jq -e 'type == "array"' <<<"${commit_prs_page2}" >/dev/null || fail "Could not validate pull request associations page 2"
-  commit_prs_page2_count="$(jq -r 'length' <<<"${commit_prs_page2}")"
-  [[ "${commit_prs_page2_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations page 2"
-  (( commit_prs_page2_count <= 100 )) || fail "The pull request association page is oversized"
-  commit_prs_json="$(jq -c --argjson page2 "${commit_prs_page2}" '. + $page2' <<<"${commit_prs_json}")"
-  association_count=$((association_count + commit_prs_page2_count))
-  (( commit_prs_page2_count < 100 )) || fail "Too many pull request associations for this head after two pages; ask an administrator to resolve the association before requesting a rerun"
-fi
-if (( association_count > 0 )); then
+    --raw-field page=1 \
+    "repos/${GH_REPO}/commits/${commit_sha}/pulls" 2>"${stderr_file}")"; then
+    :
+  else
+    error_text="${response}"$'\n'"$(head -c "${MAX_API_ERROR_BYTES}" "${stderr_file}" 2>/dev/null || true)"
+    if [[ "${allow_missing}" == true ]] && (jq -e '
+      ((.status == 404 or .status == "404") and
+        (.message == "Not Found" or .message == "Resource not found")) or
+      ((.status == 422 or .status == "422") and
+        (.message | type == "string" and startswith("No commit found for SHA: ")))
+    ' <<<"${response}" >/dev/null 2>&1 ||
+      { grep -Eq 'HTTP 404' <<<"${error_text}" &&
+        grep -Eq 'Not Found|Resource not found' <<<"${error_text}"; } ||
+      { grep -Eq 'HTTP 422' <<<"${error_text}" &&
+        grep -Eq 'No commit found for SHA: [0-9a-f]{40}' <<<"${error_text}"; }); then
+      response='[]'
+    else
+      rm -f -- "${stderr_file}"
+      return 1
+    fi
+  fi
+  rm -f -- "${stderr_file}"
+  jq -e 'type == "array"' <<<"${response}" >/dev/null || return 1
+  page_count="$(jq -r 'length' <<<"${response}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/commits/${commit_sha}/pulls" 2>/dev/null)" || return 1
+    jq -e 'type == "array"' <<<"${page2}" >/dev/null || return 1
+    page2_count="$(jq -r 'length' <<<"${page2}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    response="$(jq -c --argjson page2 "${page2}" '. + $page2' <<<"${response}")"
+    if (( page2_count == 100 )); then
+      echo "::error::Too many pull request associations for this head after two pages" >&2
+      return 1
+    fi
+  fi
+  printf '%s\n' "${response}"
+}
+
+assert_exact_pr_association() {
+  local associations="$1"
+  local expected_sha="$2"
   jq -e \
     --arg repo "${GH_REPO}" \
     --arg pr "${PR_NUMBER}" \
-    --arg sha "${head_sha}" \
+    --arg sha "${expected_sha}" \
     --arg base "${TARGET_BASE_REF}" \
     --arg head_ref "${head_ref}" \
-    --argjson head_repo_id "${head_repo_id}" '
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" '
       any(.[]?;
+        (.number | type == "number") and
         (.number | tostring) == $pr and
         .base.ref == $base and
         .base.repo.full_name == $repo and
+        (.base.repo.id | type == "number") and
+        .base.repo.id == $repo_id and
         .head.ref == $head_ref and
         .head.sha == $sha and
+        .head.repo.full_name == $head_repo and
         (.head.repo.id | type == "number") and
         .head.repo.id == $head_repo_id
       )
-    ' <<<"${commit_prs_json}" >/dev/null || fail "The current head is not associated with this pull request"
+    ' <<<"${associations}" >/dev/null
+}
+
+if ! commit_prs_json="$(fetch_commit_associations "${head_sha}" true)"; then
+  fail "Could not query pull request associations"
+fi
+if [[ "$(jq -r 'length' <<<"${commit_prs_json}")" != 0 ]]; then
+  assert_exact_pr_association "${commit_prs_json}" "${head_sha}" || fail "The current head is not associated with this pull request"
 elif [[ "${head_repo}" == "${GH_REPO}" ]]; then
   fail "The base-repository head has no pull request association"
 fi
@@ -243,7 +333,7 @@ validate_live_open_head_association() {
   head_owner="${head_repo%%/*}"
   head_name="${head_repo#*/}"
   [[ -n "${head_owner}" && -n "${head_name}" ]] || fail "The pull request head repository name is invalid"
-  open_prs_page="$(gh api \
+  open_prs_page="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field state=open \
@@ -257,7 +347,7 @@ validate_live_open_head_association() {
   [[ "${open_pr_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests"
   (( open_pr_count <= 100 )) || fail "The live open pull request page is oversized"
   if (( open_pr_count == 100 )); then
-    open_prs_page2="$(gh api \
+    open_prs_page2="$(gh_api_bounded \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
       --raw-field state=open \
@@ -278,6 +368,7 @@ validate_live_open_head_association() {
   if ! matching_open_prs_json="$(jq -c \
       --arg repo "${GH_REPO}" \
       --arg sha "${head_sha}" \
+      --arg base_sha "${base_sha}" \
       --arg base "${TARGET_BASE_REF}" \
       --arg head_ref "${head_ref}" \
       --arg head_repo "${head_repo}" \
@@ -291,6 +382,8 @@ validate_live_open_head_association() {
               .base.repo.full_name == $repo and
               (.base.repo.id | type == "number") and
               .base.repo.id == $repo_id and
+              (.base.sha | type == "string") and
+              .base.sha == $base_sha and
               .head.ref == $head_ref and
               .head.sha == $sha and
               .head.repo.full_name == $head_repo and
@@ -309,7 +402,38 @@ validate_live_open_head_association() {
 }
 validate_live_open_head_association
 
-workflow_page="$(gh api \
+# Use one immutable PR predicate for each re-read. Keeping base and source
+# identity in one helper prevents a late check from validating fewer fields
+# than the initial snapshot.
+validate_exact_pr_snapshot() {
+  local payload="$1"
+  jq -e \
+    --arg repo "${GH_REPO}" \
+    --argjson number "${PR_NUMBER}" \
+    --arg sha "${head_sha}" \
+    --arg base_sha "${base_sha}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson base_repo_id "${repo_id}" \
+    --arg opener "${pr_author_login}" '
+      .number == $number and
+      .state == "open" and
+      .base.ref == $base and
+      .base.repo.full_name == $repo and
+      .base.repo.id == $base_repo_id and
+      (.base.sha | type == "string") and
+      .base.sha == $base_sha and
+      .head.sha == $sha and
+      .head.ref == $head_ref and
+      .head.repo.full_name == $head_repo and
+      .head.repo.id == $head_repo_id and
+      .user.login == $opener
+    ' <<<"${payload}" >/dev/null
+}
+
+workflow_page="$(gh_api_bounded \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
   --raw-field per_page=100 \
@@ -320,7 +444,7 @@ workflow_count="$(jq -r '.workflows | length' <<<"${workflow_page}")"
 [[ "${workflow_count}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows"
 (( workflow_count <= 100 )) || fail "The repository workflow page is oversized"
 if (( workflow_count == 100 )); then
-  workflow_page2="$(gh api \
+  workflow_page2="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
@@ -342,15 +466,14 @@ workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | selec
 # failure created no later than this comment. Edited, reopened, and
 # synchronize events can leave several eligible failures for one
 # exact head, so sort by creation time and run ID and select the
-# newest one. Every candidate is tied to the exact workflow path,
-# event, and PR association. When GitHub includes pull_requests on a
-# run, bind the candidate to the exact PR object, including its
-# source head SHA.
-# GitHub can return an empty array for fork pull_request_target runs,
-# so those candidates are retained only when the run's execution SHA equals
-# the live PR source SHA. Populated pull_requests records may bind a different
-# execution SHA to the exact source PR object.
-runs_page="$(gh api \
+# newest one. Every candidate is tied to the exact workflow path and event.
+# When GitHub includes pull_requests on a run, bind the candidate to the exact
+# PR object, including its source head SHA. GitHub can return an empty array for
+# pull_request_target runs. Those candidates are retained when their branch and
+# repository identity matches the live PR, then independently bound below by
+# the live base SHA or an exact failed check on the source head. Populated
+# records may bind a different execution SHA directly.
+runs_page="$(gh_api_bounded \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
   --raw-field event="${TARGET_EVENT}" \
@@ -377,7 +500,7 @@ runs_json="$(jq -c '[.]' <<<"${runs_page}")"
 page_count="${run_count}"
 page_number=2
 while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
-  next_runs_page="$(gh api \
+  next_runs_page="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field event="${TARGET_EVENT}" \
@@ -412,6 +535,7 @@ if ! candidate_list_json="$(jq -c \
     --arg path "${WORKFLOW_PATH}" \
     --arg event "${TARGET_EVENT}" \
     --arg sha "${head_sha}" \
+    --arg base_sha "${base_sha}" \
     --arg workflow_id "${workflow_id}" \
     --arg pr "${PR_NUMBER}" \
     --arg repo "${GH_REPO}" \
@@ -428,20 +552,18 @@ if ! candidate_list_json="$(jq -c \
            else null end) as $prs
         | if $prs == null then false
           elif ($prs | length) == 0 then
-            .head_sha == $sha and
             .head_branch == $head_ref and
             (
               ((.head_repository | type) == "object" and
                .head_repository.full_name == $head_repo and
                (.head_repository.id | type == "number") and
                .head_repository.id == $head_repo_id) or
-              (.head_repository == null and
-               $head_repo == $repo and
-               $head_repo_id == $repo_id)
+              .head_repository == null
             )
-            # Empty associations are eligible only for the exact current
-            # source SHA. A base or merge SHA must never shadow an older
-            # eligible run for this pull request.
+            # Empty associations are discovery candidates only. Source and
+            # repository binding is proved after the exact run and job are
+            # re-read; the sort rank keeps an exact source run ahead of an
+            # unrelated execution while preserving the base-SHA preference.
           else any($prs[]?;
             (.number | type == "number") and
             (.number | tostring) == $pr and
@@ -477,7 +599,14 @@ if ! candidate_list_json="$(jq -c \
             run_binds_to_pr
           )
       ]
-      | sort_by([.created_at, .id])
+      | sort_by([
+          if ((.pull_requests | type) == "array" and (.pull_requests | length) > 0) then 3
+          elif (.head_repository | type) == "object" and .head_sha == $base_sha then 2
+          elif .head_sha == $sha then 1
+          else 0 end,
+          .created_at,
+          .id
+        ])
     ' <<<"${runs_json}")"; then
   fail "Could not validate CLA workflow run data"
 fi
@@ -486,59 +615,6 @@ candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
 if [[ "${candidate_count}" == "0" ]]; then
   if [[ "${run_window_full}" == true ]]; then
     fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
-  fi
-  # Do not silently treat a failed run with an empty association and a
-  # different execution SHA as a successful no-op. It is not eligible for a
-  # rerun, but it still needs an explicit fail-closed migration/error path.
-  # Runs with the exact source SHA are handled by the candidate query above;
-  # this count therefore only catches mismatched runs that would otherwise be
-  # indistinguishable from an absent check.
-  empty_execution_mismatch_count="$(jq -r \
-    --arg path "${WORKFLOW_PATH}" \
-    --arg event "${TARGET_EVENT}" \
-    --arg sha "${head_sha}" \
-    --arg workflow_id "${workflow_id}" \
-    --arg repo "${GH_REPO}" \
-    --arg head_repo "${head_repo}" \
-    --argjson head_repo_id "${head_repo_id}" \
-    --argjson repo_id "${repo_id}" \
-    --arg head_ref "${head_ref}" \
-    --arg before "${COMMENT_CREATED_AT}" \
-    '[ .[] | .workflow_runs[]?
-      | select(
-          (.path == $path or
-           ((.path | startswith($path + "@")) and
-            ((.path | length) > (($path | length) + 1)))) and
-          .event == $event and
-          (.workflow_id | type == "number") and
-          .workflow_id == ($workflow_id | tonumber) and
-          (.head_sha | type == "string") and
-          (.head_sha | test("^[0-9a-f]{40}$")) and
-          .head_sha != $sha and
-          (.id | type == "number") and
-          .id > 0 and
-          .status == "completed" and
-          .conclusion == "failure" and
-          (.created_at | type == "string") and
-          .created_at <= $before and
-          .head_branch == $head_ref and
-          (.pull_requests == null or
-           ((.pull_requests | type) == "array" and
-            (.pull_requests | length) == 0)) and
-          (
-            ((.head_repository | type) == "object" and
-             .head_repository.full_name == $head_repo and
-             (.head_repository.id | type == "number") and
-             .head_repository.id == $head_repo_id) or
-            (.head_repository == null and
-             $head_repo == $repo and
-             $head_repo_id == $repo_id)
-          )
-        )
-    ] | length' <<<"${runs_json}")"
-  [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
-  if (( empty_execution_mismatch_count > 0 )); then
-    fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
   fi
   # A run from before this workflow generation cannot be safely
   # rerun: GitHub reruns the old workflow revision, which could
@@ -572,9 +648,7 @@ if [[ "${candidate_count}" == "0" ]]; then
               .head_repository.full_name == $head_repo and
               (.head_repository.id | type == "number") and
               .head_repository.id == $head_repo_id) or
-             (.head_repository == null and
-              $head_repo == $repo and
-              $head_repo_id == $repo_id)
+             .head_repository == null
            )
          else any($prs[]?;
            (.number | type == "number") and
@@ -632,14 +706,82 @@ run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
 [[ -n "${run_head_branch}" && "${run_head_branch}" != *$'\n'* && "${run_head_branch}" != *$'\r'* ]] || fail "The selected CLA run head branch is invalid"
 
 # A run with a populated pull_requests array already carries an
-# authenticated source-PR association. Some GitHub API responses
-# omit that array, so prove a differing execution SHA through the
-# commit association endpoint before allowing the fallback. A bare
-# branch/repository match is not enough because a branch can be
-# reused after a push.
+# authenticated source-PR association. Some GitHub API responses omit that
+# array. For the fallback, the run must match the live PR source branch and
+# either use the live base SHA or carry a failed check on the exact source head
+# whose details URL names this run and job. A bare branch/repository match is
+# not enough because a branch can be reused after a push.
+RUN_REQUIRES_CHECK_BINDING=false
+
+fetch_check_runs_for_head() {
+  local commit_sha="$1"
+  local response page_count page2 page2_count
+  response="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field filter=all \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
+  jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${response}" >/dev/null || return 1
+  page_count="$(jq -r '.check_runs | length' <<<"${response}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field filter=all \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
+    jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${page2}" >/dev/null || return 1
+    page2_count="$(jq -r '.check_runs | length' <<<"${page2}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    response="$(jq -c --argjson page2 "${page2}" '.check_runs += $page2.check_runs' <<<"${response}")"
+    (( page2_count < 100 )) || return 1
+  fi
+  printf '%s\n' "${response}"
+}
+
+assert_failed_check_binding() {
+  local checks="$1"
+  local expected_run_id="$2"
+  local expected_job_id="$3"
+  local details_url="https://github.com/${GH_REPO}/actions/runs/${expected_run_id}/job/${expected_job_id}"
+  jq -e \
+    --arg job "${CLA_ASSISTANT_JOB}" \
+    --arg sha "${head_sha}" \
+    --arg url "${details_url}" '
+      any(.check_runs[]?;
+        .name == $job and
+        .status == "completed" and
+        .conclusion == "failure" and
+        (.head_sha | type == "string") and
+        .head_sha == $sha and
+        (.app.slug? == "github-actions") and
+        (.details_url | type == "string") and
+        (.details_url == $url or
+         (.details_url | startswith($url + "?") or startswith($url + "#")))
+      )
+    ' <<<"${checks}" >/dev/null
+}
+
+validate_failed_check_binding() {
+  local expected_run_id="$1"
+  local expected_job_id="$2"
+  local checks
+  checks="$(fetch_check_runs_for_head "${head_sha}")" ||
+    fail "Could not query checks for the exact pull request head"
+  assert_failed_check_binding "${checks}" "${expected_run_id}" "${expected_job_id}" ||
+    fail "No failed CLA check is bound to the exact pull request head and selected job"
+}
+
 validate_run_source_binding() {
   local run_payload="$1"
-  local execution_sha pull_requests_type pull_request_count
+  local execution_sha pull_requests_type pull_request_count head_repository_type
+  RUN_REQUIRES_CHECK_BINDING=false
   execution_sha="$(jq -r '.head_sha // empty' <<<"${run_payload}")"
   [[ "${execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The workflow run execution SHA is invalid"
   pull_requests_type="$(jq -r 'if .pull_requests == null then "null" else (.pull_requests | type) end' <<<"${run_payload}")"
@@ -650,164 +792,107 @@ validate_run_source_binding() {
   esac
   [[ "${pull_request_count}" =~ ^[0-9]+$ ]] || fail "The workflow run pull request association count is invalid"
   if (( pull_request_count == 0 )); then
-    # GitHub may omit pull_requests on a pull_request_target run. Without an
-    # authenticated PR object, accept only the source-head form. A base or
-    # merge execution SHA cannot be proved to belong to this PR, so fail
-    # closed instead of querying commit associations that may describe an
-    # ancestor or another pull request.
-    [[ "${execution_sha}" == "${head_sha}" ]] || fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+    # GitHub may omit pull_requests on a pull_request_target run. Its documented
+    # execution SHA is the last commit on the base branch, so accept the empty
+    # association form without a check only when the repository identity is
+    # complete and that SHA equals the live PR base SHA. A source SHA, a null
+    # repository, or any other execution SHA needs an exact failed check on the
+    # source head after the job ID is known.
+    head_repository_type="$(jq -r 'if .head_repository == null then "null" else (.head_repository | type) end' <<<"${run_payload}")"
+    if [[ "${execution_sha}" == "${base_sha}" && "${head_repository_type}" == object ]]; then
+      validate_live_open_head_association
+      return 0
+    fi
+    RUN_REQUIRES_CHECK_BINDING=true
+    # The check binding is validated after the exact job ID is selected.
+    # Keep the live source check here so the run cannot pass on a stale branch.
+    validate_live_open_head_association
   fi
 }
 
-# Re-read the individual run. The list response is only a discovery
-# result, not authorization to rerun it.
-run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
-jq -e \
-  --arg run_id "${run_id}" \
-  --arg path "${WORKFLOW_PATH}" \
-  --arg event "${TARGET_EVENT}" \
-  --arg sha "${head_sha}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg run_head_branch "${run_head_branch}" \
-  --arg pr "${PR_NUMBER}" \
-  --arg repo "${GH_REPO}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" \
-  --argjson repo_id "${repo_id}" \
-  --arg head_ref "${head_ref}" \
-  --arg workflow_id "${workflow_id}" \
-  --arg base "${TARGET_BASE_REF}" \
-  --arg before "${COMMENT_CREATED_AT}" '
-    def run_binds_to_pr:
-      (.pull_requests) as $raw_prs
-      | (if $raw_prs == null then []
-         elif ($raw_prs | type) == "array" then $raw_prs
-         else null end) as $prs
-      | if $prs == null then false
-        elif ($prs | length) == 0 then
-          .head_branch == $head_ref and
-          (
-            ((.head_repository | type) == "object" and
-             .head_repository.full_name == $head_repo and
-             (.head_repository.id | type == "number") and
-             .head_repository.id == $head_repo_id) or
-            (.head_repository == null and
-             $head_repo == $repo and
-             $head_repo_id == $repo_id)
+# Keep one exact run predicate for discovery rechecks and the final TOCTOU
+# re-read. The list response is discovery only, never authorization.
+validate_exact_run_payload() {
+  local payload="$1"
+  jq -e \
+    --arg run_id "${run_id}" \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg run_head_branch "${run_head_branch}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg head_ref "${head_ref}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg before "${COMMENT_CREATED_AT}" '
+      def run_binds_to_pr:
+        (.pull_requests) as $raw_prs
+        | (if $raw_prs == null then []
+           elif ($raw_prs | type) == "array" then $raw_prs
+           else null end) as $prs
+        | if $prs == null then false
+          elif ($prs | length) == 0 then
+            .head_branch == $head_ref and
+            (
+              ((.head_repository | type) == "object" and
+               .head_repository.full_name == $head_repo and
+               (.head_repository.id | type == "number") and
+               .head_repository.id == $head_repo_id) or
+              .head_repository == null
+            )
+          else any($prs[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            .base.ref == $base and
+            ((.base.repo.full_name // "") == "" or
+             .base.repo.full_name == $repo) and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            ((.head.repo.full_name // "") == "" or
+             .head.repo.full_name == $head_repo)
           )
-        else any($prs[]?;
-          (.number | type == "number") and
-          (.number | tostring) == $pr and
-          .base.ref == $base and
-          ((.base.repo.full_name // "") == "" or
-           .base.repo.full_name == $repo) and
-          (.base.repo.id | type == "number") and
-          .base.repo.id == $repo_id and
-          .head.ref == $head_ref and
-          .head.sha == $sha and
-          (.head.repo.id | type == "number") and
-          .head.repo.id == $head_repo_id and
-          ((.head.repo.full_name // "") == "" or
-           .head.repo.full_name == $head_repo)
-        )
-        end;
-    .id == ($run_id | tonumber) and
-    .workflow_id == ($workflow_id | tonumber) and
-    (.path == $path or
-     ((.path | startswith($path + "@")) and
-      ((.path | length) > (($path | length) + 1)))) and
-    .event == $event and
-    .status == "completed" and
-    .conclusion == "failure" and
-    .head_sha == $run_sha and
-    .head_branch == $run_head_branch and
-    (.created_at | type == "string") and
-    .created_at <= $before and
-    run_binds_to_pr
-  ' <<<"${run_json}" >/dev/null || fail "The selected run no longer matches the exact failed CLA check"
+          end;
+      (.id | type == "number") and
+      .id == ($run_id | tonumber) and
+      (.workflow_id | type == "number") and
+      .workflow_id == ($workflow_id | tonumber) and
+      (.path | type == "string") and
+      (.path == $path or
+       ((.path | startswith($path + "@")) and
+        ((.path | length) > (($path | length) + 1)))) and
+      .event == $event and
+      .status == "completed" and
+      .conclusion == "failure" and
+      .head_sha == $run_sha and
+      .head_branch == $run_head_branch and
+      (.created_at | type == "string") and
+      .created_at <= $before and
+      run_binds_to_pr
+    ' <<<"${payload}" >/dev/null
+}
+
+# Re-read the individual run. The list response is only a discovery result.
+run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
+validate_exact_run_payload "${run_json}" || fail "The selected run no longer matches the exact failed CLA check"
 validate_run_source_binding "${run_json}"
 
 # Close the main TOCTOU window. A push, close, or another rerun can
 # happen while the API calls above run. Never rerun a stale head.
-latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
-jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
-  .number == $number and
-  .state == "open" and
-  .base.ref == $base and
-  .base.repo.full_name == $repo and
-  .base.repo.id == $base_repo_id and
-  .head.sha == $sha and
-  .head.ref == $head_ref and
-  .head.repo.full_name == $head_repo and
-  .head.repo.id == $head_repo_id and
-  .user.login == $opener
-' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA run"
+latest_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
+validate_exact_pr_snapshot "${latest_pr_json}" || fail "The pull request changed while selecting the CLA run"
 
 # Ensure another queued invocation did not already rerun this run.
-final_run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
-jq -e \
-  --arg path "${WORKFLOW_PATH}" \
-  --arg event "${TARGET_EVENT}" \
-  --arg sha "${head_sha}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg run_head_branch "${run_head_branch}" \
-  --arg pr "${PR_NUMBER}" \
-  --arg repo "${GH_REPO}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" \
-  --argjson repo_id "${repo_id}" \
-  --arg head_ref "${head_ref}" \
-  --arg workflow_id "${workflow_id}" \
-  --arg run_id "${run_id}" \
-  --arg base "${TARGET_BASE_REF}" \
-  --arg before "${COMMENT_CREATED_AT}" '
-    def run_binds_to_pr:
-      (.pull_requests) as $raw_prs
-      | (if $raw_prs == null then []
-         elif ($raw_prs | type) == "array" then $raw_prs
-         else null end) as $prs
-      | if $prs == null then false
-        elif ($prs | length) == 0 then
-          .head_branch == $head_ref and
-          (
-            ((.head_repository | type) == "object" and
-             .head_repository.full_name == $head_repo and
-             (.head_repository.id | type == "number") and
-             .head_repository.id == $head_repo_id) or
-            (.head_repository == null and
-             $head_repo == $repo and
-             $head_repo_id == $repo_id)
-          )
-        else any($prs[]?;
-          (.number | type == "number") and
-          (.number | tostring) == $pr and
-          .base.ref == $base and
-          ((.base.repo.full_name // "") == "" or
-           .base.repo.full_name == $repo) and
-          (.base.repo.id | type == "number") and
-          .base.repo.id == $repo_id and
-          .head.ref == $head_ref and
-          .head.sha == $sha and
-          (.head.repo.id | type == "number") and
-          .head.repo.id == $head_repo_id and
-          ((.head.repo.full_name // "") == "" or
-           .head.repo.full_name == $head_repo)
-        )
-        end;
-    .id == ($run_id | tonumber) and
-    .workflow_id == ($workflow_id | tonumber) and
-    (.path == $path or
-     ((.path | startswith($path + "@")) and
-      ((.path | length) > (($path | length) + 1)))) and
-    .event == $event and
-    .status == "completed" and
-    .conclusion == "failure" and
-    .head_sha == $run_sha and
-    .head_branch == $run_head_branch and
-    (.created_at | type == "string") and
-    .created_at <= $before and
-    run_binds_to_pr
-' <<<"${final_run_json}" >/dev/null || fail "The exact failed CLA run is no longer eligible"
+final_run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
+validate_exact_run_payload "${final_run_json}" || fail "The exact failed CLA run is no longer eligible"
 validate_run_source_binding "${final_run_json}"
 
 # Fetch the complete bounded job set for one exact run. The rerun endpoint
@@ -820,7 +905,7 @@ validate_run_source_binding "${final_run_json}"
 fetch_jobs_for_run() {
   local target_run_id="$1"
   local page_json page_count page2_json page2_count
-  page_json="$(gh api \
+  page_json="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
@@ -831,7 +916,7 @@ fetch_jobs_for_run() {
   [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
   (( page_count <= 100 )) || return 1
   if (( page_count == 100 )); then
-    page2_json="$(gh api \
+    page2_json="$(gh_api_bounded \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
       --raw-field per_page=100 \
@@ -850,14 +935,16 @@ fetch_jobs_for_run() {
 jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and validate jobs for the selected CLA run"
 
 # Validate every failed job before granting the state-changing API call. The
-# old compatibility check is an intentional dependent of the v2 job. When it
-# is also failed, use the failed-jobs endpoint so GitHub refreshes both
-# head-bound check contexts. Any extra failure, cancellation, malformed job,
-# or stale source identity aborts the request.
+# v3 writer, required result, and migration compatibility jobs are the only
+# failures this helper may replay. If the writer or compatibility job failed,
+# use the failed-jobs endpoint so GitHub refreshes every head-bound context;
+# otherwise replay only the required result job. Any extra failure,
+# cancellation, malformed job, or stale source identity aborts the request.
 validate_failed_job_set() {
   local payload="$1"
   local all_jobs_json failed_jobs_json failed_count nonfailure_count
-  local unexpected_count v2_count v2_valid_count compatibility_count compatibility_valid_count
+  local unexpected_count assistant_count assistant_valid_count writer_count writer_valid_count
+  local compatibility_count compatibility_valid_count
   if ! all_jobs_json="$(jq -c '[.[] | .jobs[]?]' <<<"${payload}")"; then
     fail "Could not flatten jobs for the selected CLA run"
   fi
@@ -878,18 +965,26 @@ validate_failed_job_set() {
   [[ "${failed_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed jobs for the selected CLA run"
   nonfailure_count="$(jq -r '[.[] | select(.conclusion != "failure")] | length' <<<"${failed_jobs_json}")"
   (( nonfailure_count == 0 )) || fail "The selected CLA run contains a cancelled or non-failure job; refusing to rerun it"
-  unexpected_count="$(jq -r '[.[] | select(.name != "CLA Assistant v2" and .name != "CLA Assistant")] | length' <<<"${failed_jobs_json}")"
+  unexpected_count="$(jq -r \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg writer_job "${CLA_WRITER_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    '[.[] | select(.name != $assistant_job and .name != $writer_job and .name != $compatibility_job)] | length' \
+    <<<"${failed_jobs_json}")"
   (( unexpected_count == 0 )) || fail "The selected CLA run contains an unexpected failed job; refusing to rerun it"
 
-  if ! v2_count="$(jq -r '[.[] | select(.name == "CLA Assistant v2")] | length' <<<"${failed_jobs_json}")" ||
-     ! v2_valid_count="$(jq -r \
+  if ! assistant_count="$(jq -r \
+      --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+      '[.[] | select(.name == $assistant_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! assistant_valid_count="$(jq -r \
        --arg run_id "${run_id}" \
        --arg run_sha "${run_execution_sha}" \
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
-       --arg cla_generation "${CLA_GENERATION}" \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       --arg generation_step "CLA generation ${CLA_GENERATION}" \
        '[.[] | select(
-          .name == "CLA Assistant v2" and
+          .name == $assistant_job and
           .run_id == ($run_id | tonumber) and
           (.head_sha | type == "string") and
           .head_sha == $run_sha and
@@ -899,25 +994,51 @@ validate_failed_job_set() {
              .head_repository.full_name == $head_repo and
              .head_repository.id == $head_repo_id))) and
           any(.steps[]?;
-            .name == ("CLA generation " + $cla_generation) and
-            .status == "completed" and
-            .conclusion == "success"
+            .name == $generation_step and
+            .status == "completed"
           )
        )] | length' <<<"${failed_jobs_json}")"; then
-    fail "Could not validate failed CLA Assistant v2 jobs"
+    fail "Could not validate failed CLA Assistant v3 jobs"
   fi
-  [[ "${v2_count}" =~ ^[0-9]+$ && "${v2_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA Assistant v2 jobs"
-  (( v2_count == 1 )) || fail "Expected exactly one failed CLA Assistant v2 job"
-  (( v2_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  [[ "${assistant_count}" =~ ^[0-9]+$ && "${assistant_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA Assistant v3 jobs"
+  (( assistant_count == 1 )) || fail "Expected exactly one failed CLA Assistant v3 job"
+  (( assistant_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
 
-  compatibility_count="$(jq -r '[.[] | select(.name == "CLA Assistant")] | length' <<<"${failed_jobs_json}")"
+  if ! writer_count="$(jq -r \
+      --arg writer_job "${CLA_WRITER_JOB}" \
+      '[.[] | select(.name == $writer_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! writer_valid_count="$(jq -r \
+       --arg run_id "${run_id}" \
+       --arg run_sha "${run_execution_sha}" \
+       --arg head_repo "${head_repo}" \
+       --argjson head_repo_id "${head_repo_id}" \
+       --arg writer_job "${CLA_WRITER_JOB}" \
+       '[.[] | select(
+          .name == $writer_job and
+          .run_id == ($run_id | tonumber) and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          ((has("head_repository") | not) or
+           (.head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)))
+       )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA ledger writer jobs"
+  fi
+  [[ "${writer_count}" =~ ^[0-9]+$ && "${writer_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA ledger writer jobs"
+  (( writer_count <= 1 )) || fail "The selected CLA run contains multiple failed CLA ledger writer jobs"
+  (( writer_valid_count == writer_count )) || fail "The failed CLA ledger writer job is malformed or bound to a different source"
+
+  compatibility_count="$(jq -r --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" '[.[] | select(.name == $compatibility_job)] | length' <<<"${failed_jobs_json}")"
   if ! compatibility_valid_count="$(jq -r \
       --arg run_id "${run_id}" \
       --arg run_sha "${run_execution_sha}" \
       --arg head_repo "${head_repo}" \
       --argjson head_repo_id "${head_repo_id}" \
+      --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
       '[.[] | select(
-         .name == "CLA Assistant" and
+         .name == $compatibility_job and
          .run_id == ($run_id | tonumber) and
          (.head_sha | type == "string") and
          .head_sha == $run_sha and
@@ -932,23 +1053,27 @@ validate_failed_job_set() {
   [[ "${compatibility_count}" =~ ^[0-9]+$ && "${compatibility_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA compatibility jobs"
   (( compatibility_count <= 1 )) || fail "The selected CLA run contains multiple failed compatibility jobs"
   (( compatibility_valid_count == compatibility_count )) || fail "The failed CLA compatibility job is malformed or bound to a different source"
-  if (( compatibility_count == 1 )); then
+  if (( writer_count == 1 || compatibility_count == 1 )); then
     RERUN_FAILED_JOBS=true
   else
     RERUN_FAILED_JOBS=false
   fi
 }
 validate_failed_job_set "${jobs_json}"
-if ! cla_job_json="$(jq -c \
+# Select the sole current-generation assistant job from a validated job set.
+select_cla_job() {
+  local payload="$1"
+  jq -c \
     --arg run_id "${run_id}" \
     --arg run_sha "${run_execution_sha}" \
-    --arg cla_generation "${CLA_GENERATION}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg generation_step "CLA generation ${CLA_GENERATION}" \
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" \
     '[.[] | .jobs[]?
       | select(
           (.run_id | tostring) == $run_id and
-          .name == "CLA Assistant v2" and
+          .name == $assistant_job and
           .status == "completed" and
           .conclusion == "failure" and
           (.head_sha | type == "string") and
@@ -959,15 +1084,51 @@ if ! cla_job_json="$(jq -c \
              .head_repository.id == $head_repo_id)
           ) and
           any(.steps[]?;
-            .name == ("CLA generation " + $cla_generation) and
-            .status == "completed" and
-            .conclusion == "success"
+            .name == $generation_step and
+            .status == "completed"
           )
         )
     ]
     | if length == 1 then .[0] else empty end
-  ' <<<"${jobs_json}")"; then
-  fail "Could not validate CLA job data"
+  ' <<<"${payload}"
+}
+
+# Validate one exact assistant job for every discovery and final re-read.
+validate_exact_job_payload() {
+  local payload="$1"
+  jq -e \
+    --arg job_id "${job_id}" \
+    --arg run_id "${run_id}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg generation_step "CLA generation ${CLA_GENERATION}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" '
+      (.id | type == "number") and
+      .id == ($job_id | tonumber) and
+      (.run_id | type == "number") and
+      .run_id == ($run_id | tonumber) and
+      .name == $assistant_job and
+      .status == "completed" and
+      .conclusion == "failure" and
+      (.head_sha | type == "string") and
+      .head_sha == $run_sha and
+      (
+        (has("head_repository") | not) or
+        .head_repository == null or
+        ((.head_repository | type) == "object" and
+         .head_repository.full_name == $head_repo and
+         .head_repository.id == $head_repo_id)
+      ) and
+      any(.steps[]?;
+        .name == $generation_step and
+        .status == "completed"
+      )
+    ' <<<"${payload}" >/dev/null
+}
+
+if ! cla_job_json="$(select_cla_job "${jobs_json}")"; then
+  fail "Could not validate CLA Assistant v3 job data"
 fi
 if [[ -z "${cla_job_json}" ]]; then
   # The run matched the current PR and failed, but no job carried
@@ -977,123 +1138,55 @@ if [[ -z "${cla_job_json}" ]]; then
 fi
 job_id="$(jq -r '.id // empty' <<<"${cla_job_json}")"
 [[ "${job_id}" =~ ^[1-9][0-9]*$ ]] || fail "The selected CLA job ID is invalid"
+if [[ "${RUN_REQUIRES_CHECK_BINDING}" == true ]]; then
+  validate_failed_check_binding "${run_id}" "${job_id}"
+fi
 
 # Re-read the individual job. The jobs list is discovery only, just
 # like the workflow-run list above.
-job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA job"
-jq -e \
-  --arg job_id "${job_id}" \
-  --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg cla_generation "${CLA_GENERATION}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" '
-    .id == ($job_id | tonumber) and
-    .run_id == ($run_id | tonumber) and
-    .name == "CLA Assistant v2" and
-    .status == "completed" and
-    .conclusion == "failure" and
-    (.head_sha | type == "string") and
-    .head_sha == $run_sha and
-    (
-      (has("head_repository") | not) or
-      .head_repository == null or
-      ((.head_repository | type) == "object" and
-       .head_repository.full_name == $head_repo and
-       .head_repository.id == $head_repo_id)
-    ) and
-    any(.steps[]?;
-      .name == ("CLA generation " + $cla_generation) and
-      .status == "completed" and
-      .conclusion == "success"
-    )
-  ' <<<"${job_json}" >/dev/null || fail "The selected CLA job no longer matches the failed job in this run"
+job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA Assistant v3 job"
+validate_exact_job_payload "${job_json}" || fail "The selected CLA Assistant v3 job no longer matches the failed job in this run"
 
 # Recheck both resources immediately before the state-changing call.
 # This prevents a push or a concurrent rerun from making the job
 # stale while the preceding API requests were in flight.
-latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
-jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
-  .number == $number and
-  .state == "open" and
-  .base.ref == $base and
-  .base.repo.full_name == $repo and
-  .base.repo.id == $base_repo_id and
-  .head.sha == $sha and
-  .head.ref == $head_ref and
-  .head.repo.full_name == $head_repo and
-  .head.repo.id == $head_repo_id and
-  .user.login == $opener
-' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA job"
-final_job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
-jq -e \
-  --arg job_id "${job_id}" \
-  --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg cla_generation "${CLA_GENERATION}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" '
-    .id == ($job_id | tonumber) and
-    .run_id == ($run_id | tonumber) and
-    .name == "CLA Assistant v2" and
-    .status == "completed" and
-    .conclusion == "failure" and
-    (.head_sha | type == "string") and
-    .head_sha == $run_sha and
-    (
-      (has("head_repository") | not) or
-      .head_repository == null or
-      ((.head_repository | type) == "object" and
-       .head_repository.full_name == $head_repo and
-       .head_repository.id == $head_repo_id)
-    ) and
-    any(.steps[]?;
-      .name == ("CLA generation " + $cla_generation) and
-      .status == "completed" and
-      .conclusion == "success"
-    )
-' <<<"${final_job_json}" >/dev/null || fail "The exact failed CLA job is no longer eligible"
+latest_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+validate_exact_pr_snapshot "${latest_pr_json}" || fail "The pull request changed while selecting the CLA job"
+final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
+validate_exact_job_payload "${final_job_json}" || fail "The exact failed CLA Assistant v3 job is no longer eligible"
 
 # Re-fetch the whole job set immediately before the state-changing call. This
 # catches a newly cancelled or unrelated failed job that could otherwise be
 # pulled into a failed-jobs rerun after the first validation.
 final_jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not recheck and validate jobs for the selected CLA run"
 validate_failed_job_set "${final_jobs_json}"
-final_job_id="$(jq -r \
-  --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" \
-  --arg cla_generation "${CLA_GENERATION}" \
-  '[.[] | .jobs[]? | select(
-      .run_id == ($run_id | tonumber) and
-      .name == "CLA Assistant v2" and
-      .status == "completed" and
-      .conclusion == "failure" and
-      (.head_sha | type == "string") and
-      .head_sha == $run_sha and
-      ((has("head_repository") | not) or
-       (.head_repository == null or
-        ((.head_repository | type) == "object" and
-         .head_repository.full_name == $head_repo and
-         .head_repository.id == $head_repo_id))) and
-      any(.steps[]?;
-        .name == ("CLA generation " + $cla_generation) and
-        .status == "completed" and
-        .conclusion == "success"
-      )
-    )]
-    | if length == 1 then .[0].id else empty end' <<<"${final_jobs_json}")"
+if ! final_cla_job_json="$(select_cla_job "${final_jobs_json}")"; then
+  fail "Could not validate the final CLA Assistant v3 job data"
+fi
+final_job_id="$(jq -r '.id // empty' <<<"${final_cla_job_json}")"
 [[ "${final_job_id}" == "${job_id}" ]] || fail "The selected CLA job changed while preparing the rerun"
 
-# Repeat the positive live-PR association check after all discovery
-# calls. A second open PR for the same fork ref and SHA must stop the
-# rerun even if it appeared while the earlier checks were running.
+# Re-read the live PR, run, and job as one final authorization set. A source
+# push, branch retarget, job replacement, or concurrent rerun must invalidate
+# the request before the state-changing call. For fallback runs, the failed
+# check is fetched last and must bind both the exact source SHA and this job.
+final_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+validate_exact_pr_snapshot "${final_pr_json}" || fail "The pull request changed before rerun"
+# The individual PR response does not enumerate duplicate fork references.
+# Recheck the filtered open-PR association at the same final boundary.
 validate_live_open_head_association
+final_run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run before rerun"
+validate_exact_run_payload "${final_run_json}" || fail "The selected CLA run changed before rerun"
+validate_run_source_binding "${final_run_json}"
+final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job before rerun"
+validate_exact_job_payload "${final_job_json}" || fail "The selected CLA job changed before rerun"
+if [[ "${RUN_REQUIRES_CHECK_BINDING}" == true ]]; then
+  validate_failed_check_binding "${run_id}" "${job_id}"
+fi
 
 if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
   rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"
-  rerun_description="failed CLA jobs (v2 and compatibility)"
+  rerun_description="failed CLA v3 jobs (writer, assistant, and compatibility)"
 else
   rerun_endpoint="repos/${GH_REPO}/actions/jobs/${job_id}/rerun"
   rerun_description="CLA job ${job_id}"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,31 +1,25 @@
-name: "CLA Assistant v2"
+name: "CLA Assistant v3"
+
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     branches: [main]
-    # Re-run full CLA validation for every non-closed edit. Do not narrow
-    # edited events to a base-change payload, because title/body edits also
-    # need to refresh required check contexts.
-    types: [opened,closed,edited,reopened,synchronize]
+    types: [opened,closed,edited,reopened,synchronize,ready_for_review]
 
-# Jobs declare only the permissions they need.
 permissions: {}
 
-# Bump this value when the CLA workflow policy or maintained action pin
-# changes. Do not derive the rerun marker from `github.workflow_sha`: that SHA
-# changes for every unrelated commit on main and would strand valid failed
-# checks on open pull requests.
+# This marker changes only when the policy or maintained action changes. It
+# gives the rerun worker a stable generation that is independent of unrelated
+# commits on main.
 env:
-  CLA_GENERATION: 'v2.2-action-fc608ba7106e7029d981d487d7bad28a64325956'
+  CLA_GENERATION: "v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
 
 jobs:
+  # This job has read-only permissions. It performs the exact event check and
+  # authenticates a new signing comment before any write-capable job starts.
   CLACommentGate:
     name: "Validate CLA trigger"
-    # This job is intentionally unprivileged. The job-level expression is a
-    # coarse admission filter, and the shell step below is the exact,
-    # case-sensitive check. GitHub expressions compare strings without case,
-    # so the shell remains the authority for the declaration itself.
     if: >-
       (
         github.event_name == 'pull_request_target' &&
@@ -33,7 +27,8 @@ jobs:
           github.event.action == 'opened' ||
           github.event.action == 'edited' ||
           github.event.action == 'reopened' ||
-          github.event.action == 'synchronize'
+          github.event.action == 'synchronize' ||
+          github.event.action == 'ready_for_review'
         )
       ) ||
       (
@@ -44,10 +39,6 @@ jobs:
         github.event.comment.user.type == 'User' &&
         (
           (
-            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-            github.event.comment.user.id == github.event.issue.user.id
-          ) ||
-          (
             github.event.comment.body == 'recheck' &&
             (
               github.event.comment.user.id == github.event.issue.user.id ||
@@ -55,144 +46,116 @@ jobs:
               github.event.comment.author_association == 'MEMBER' ||
               github.event.comment.author_association == 'COLLABORATOR'
             )
-          )
+          ) ||
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
         )
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 5
-    # Bound issue-comment fanout to one running and one pending admission per
-    # pull request. GitHub expression equality is case-insensitive, so a
-    # rejected case variant can replace a valid pending comment in this queue;
-    # the shell remains the exact-byte authority and the signer queue runs only
-    # after this gate succeeds. This is an availability tradeoff, not an
-    # authorization bypass.
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 10
     concurrency:
-      group: cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}
+      group: cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.run_id }}
       cancel-in-progress: false
-    permissions: {}
+    permissions:
+      contents: read
+      issues: read
+      pull-requests: read
     outputs:
       admitted: ${{ steps.admission.outputs.admitted }}
+      signer_authorized: ${{ steps.signer_preflight.outputs.signer_authorized }}
+      head_sha: ${{ steps.signer_preflight.outputs.head_sha }}
+      base_sha: ${{ steps.signer_preflight.outputs.base_sha }}
+      comment_id: ${{ steps.signer_preflight.outputs.comment_id }}
+      comment_created_at: ${{ steps.signer_preflight.outputs.comment_created_at }}
+      comment_author_id: ${{ steps.signer_preflight.outputs.comment_author_id }}
     steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
       - name: "Validate exact CLA trigger"
         id: admission
+        if: runner.environment == 'github-hosted'
         env:
           EVENT_NAME: ${{ github.event_name }}
           EVENT_ACTION: ${{ github.event.action }}
-          COMMENT_BODY: ${{ github.event.comment.body }}
-          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id }}
-          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
-          PR_AUTHOR_ID: ${{ github.event.issue.user.id }}
-          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
-          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id || '' }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login || '' }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || '' }}
+          PR_AUTHOR_ID: ${{ github.event.issue.user.id || '' }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || '' }}
         run: |
           set -euo pipefail
-
           fail() {
             echo "::error::$1"
             exit 1
           }
-
-          # Actions supplies GITHUB_OUTPUT. A missing output file is a runner
-          # protocol failure, so do not let a dependent privileged job run
-          # without an explicit admission result.
-          [[ -n "${GITHUB_OUTPUT+x}" && -n "${GITHUB_OUTPUT}" ]] || fail "GITHUB_OUTPUT is unavailable"
-          [[ -n "${EVENT_NAME+x}" && -n "${EVENT_ACTION+x}" ]] || fail "The event metadata is incomplete"
-
+          emit() {
+            [[ -n "${GITHUB_OUTPUT+x}" && -n "${GITHUB_OUTPUT}" ]] || fail "GITHUB_OUTPUT is unavailable"
+            printf 'admitted=%s\n' "$1" >>"${GITHUB_OUTPUT}"
+          }
+          [[ -n "${EVENT_NAME:-}" && -n "${EVENT_ACTION:-}" ]] || fail "Event metadata is incomplete"
           if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
-            [[ "${EVENT_ACTION}" == "created" ]] || fail "The issue-comment event action is not supported"
-            [[ -n "${COMMENT_BODY+x}" &&
-               -n "${COMMENT_AUTHOR_TYPE+x}" &&
-               -n "${COMMENT_AUTHOR_ID+x}" &&
-               -n "${COMMENT_AUTHOR_LOGIN+x}" &&
-               -n "${PR_AUTHOR_ID+x}" &&
-               -n "${COMMENT_AUTHOR_ASSOCIATION+x}" ]] || fail "The issue-comment metadata is incomplete"
-            [[ "${COMMENT_AUTHOR_TYPE}" == "User" && -n "${COMMENT_AUTHOR_LOGIN}" ]] ||
-              fail "Bot and malformed comments cannot trigger the CLA action"
-            case "${COMMENT_AUTHOR_LOGIN,,}" in
-              *"[bot]")
-                fail "Bot comments cannot trigger the CLA action"
-                ;;
-            esac
-            [[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The issue-comment author ID is malformed"
-            [[ "${PR_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request author ID is malformed"
-            [[ -n "${COMMENT_AUTHOR_ASSOCIATION}" &&
-               "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\n'* &&
-               "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\r'* ]] ||
-              fail "The issue-comment author association is malformed"
-
+            [[ "${EVENT_ACTION}" == "created" ]] || fail "Issue-comment event action is unsupported"
+            [[ "${COMMENT_AUTHOR_TYPE}" == "User" && -n "${COMMENT_AUTHOR_LOGIN}" ]] || fail "Comment author is not a human user"
+            [[ "${COMMENT_AUTHOR_LOGIN,,}" != *"[bot]" ]] || fail "Bot comments cannot trigger the CLA action"
+            [[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ && "${PR_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment identity is malformed"
+            [[ -n "${COMMENT_AUTHOR_ASSOCIATION}" && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\n'* && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\r'* ]] || fail "Comment association is malformed"
             if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
-              if [[ "${COMMENT_AUTHOR_ID}" != "${PR_AUTHOR_ID}" ]]; then
-                printf 'admitted=false\n' >>"${GITHUB_OUTPUT}"
-                exit 0
-              fi
               printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-              exit 0
-            fi
-            if [[ "${COMMENT_BODY}" == "recheck" ]]; then
+            elif [[ "${COMMENT_BODY}" == "recheck" ]]; then
               if [[ "${COMMENT_AUTHOR_ID}" == "${PR_AUTHOR_ID}" ]]; then
-                printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-                exit 0
-              fi
-              if [[ "${COMMENT_AUTHOR_ID}" != "${PR_AUTHOR_ID}" ]]; then
+                emit true
+              else
                 case "${COMMENT_AUTHOR_ASSOCIATION}" in
-                  OWNER|MEMBER|COLLABORATOR)
-                    printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-                    exit 0
-                    ;;
-                  *)
-                    # A well-formed but unauthorized recheck is ordinary
-                    # discussion and must not reach the privileged signer.
-                    printf 'admitted=false\n' >>"${GITHUB_OUTPUT}"
-                    exit 0
-                    ;;
+                  OWNER|MEMBER|COLLABORATOR) emit true ;;
+                  *) emit false ;;
                 esac
               fi
+            else
+              emit false
             fi
-            # All other well-formed human comments are ordinary discussion.
-            printf 'admitted=false\n' >>"${GITHUB_OUTPUT}"
-            exit 0
           elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
             case "${EVENT_ACTION}" in
-              opened|edited|reopened|synchronize)
-                printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
-                exit 0
-                ;;
-              *)
-                fail "The pull request event is not an accepted CLA trigger"
-                ;;
+              opened|edited|reopened|synchronize|ready_for_review) emit true ;;
+              *) fail "Pull-request event action is unsupported" ;;
             esac
           else
-            fail "The event is not an accepted CLA trigger"
+            fail "Event is not an accepted CLA trigger"
           fi
 
-  CLAAssistant:
-    # This versioned context is deliberate. The old "CLA Assistant" check
-    # could remain successful on an unchanged PR after this workflow changed.
-    # Update the main ruleset to require this context only after the migration
-    # smoke test and open-PR sweep complete.
-    name: "CLA Assistant v2"
+      - name: "Authenticate exact CLA signer"
+        id: signer_preflight
+        if: >-
+          runner.environment == 'github-hosted' &&
+          success() &&
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "signer-preflight"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          require-opener-as-author: "true"
+          allowlist-ids: "38676809,67667005"
+
+  # This is the only job with ledger and comment write permissions. It has no
+  # shell step, so policy text cannot execute with its token. The action repeats
+  # live PR/comment validation and binds a signing write to the exact head SHA
+  # observed by the read-only gate.
+  CLALedgerWriter:
+    name: "CLA ledger writer"
     needs: CLACommentGate
-    outputs:
-      # The rerun worker may use this only as proof that this exact action run
-      # persisted a new signature. A comment by itself is not authorization
-      # for a job with actions:write.
-      signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
-    timeout-minutes: 15
-    # Filter before concurrency admission. Untrusted recheck comments cannot
-    # consume the signature queue or invoke the write-capable action. Keep
-    # `always()` here so a gate failure produces a visible failed signer check
-    # instead of a skipped result; the first shell step enforces the gate
-    # result before any privileged step can run.
     if: >-
-      always() &&
-      (
-        needs.CLACommentGate.result == 'failure' ||
-        (
-          needs.CLACommentGate.result == 'success' &&
-          needs.CLACommentGate.outputs.admitted == 'true'
-        )
-      ) &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
       (
         (
           github.event_name == 'pull_request_target' &&
@@ -200,7 +163,8 @@ jobs:
             github.event.action == 'opened' ||
             github.event.action == 'edited' ||
             github.event.action == 'reopened' ||
-            github.event.action == 'synchronize'
+            github.event.action == 'synchronize' ||
+            github.event.action == 'ready_for_review'
           )
         ) ||
         (
@@ -210,10 +174,6 @@ jobs:
           github.event.comment.user.type == 'User' &&
           (
             (
-              github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-              github.event.comment.user.id == github.event.issue.user.id
-            ) ||
-            (
               github.event.comment.body == 'recheck' &&
               (
                 github.event.comment.user.id == github.event.issue.user.id ||
@@ -221,176 +181,147 @@ jobs:
                 github.event.comment.author_association == 'MEMBER' ||
                 github.event.comment.author_association == 'COLLABORATOR'
               )
+            ) ||
+              (
+                github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+                needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+                needs.CLACommentGate.outputs.head_sha != '' &&
+                needs.CLACommentGate.outputs.base_sha != ''
             )
           )
         )
       )
-    # Serialize every signer event for one PR, but let independent PRs proceed.
-    # A signing comment and a lifecycle event must not compute competing
-    # ledger/status plans from different snapshots.
-    # The maintained action at fc608ba7106e7029d981d487d7bad28a64325956 uses
-    # Contents-API SHA compare-and-swap writes. On HTTP 409 it rereads and
-    # merges the current ledger, with three bounded attempts; its persistence
-    # unit test covers a concurrent update. This is the ledger writer lock.
-    # A global Actions lock would retain only one pending run and could drop
-    # valid signatures from unrelated PRs, so it is not safe for this intake.
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 15
     concurrency:
       group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
       cancel-in-progress: false
     permissions:
       contents: write
       issues: write
-      # The maintained action does not call the commit-status API. GitHub
-      # creates the job check run itself and keys it to the pull request head
-      # for pull_request_target runs, so statuses:write would add an unused
-      # write capability without changing the displayed CLA result. The
-      # production check-run API confirms this head binding; do not replace it
-      # with a manually posted status.
-      # GitHub's pull_request_target token denied issue comments for fork PRs
-      # with this set to read, despite the endpoint documentation allowing
-      # issues:write. Keep write until that live behavior changes.
       pull-requests: write
+    outputs:
+      signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
+      cla_passed: ${{ steps.cla_action.outputs.cla_passed }}
     steps:
-      - name: "Require CLA admission"
-        if: always()
-        env:
-          GATE_RESULT: ${{ needs.CLACommentGate.result }}
-          ADMITTED: ${{ needs.CLACommentGate.outputs.admitted }}
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
         run: |
           set -euo pipefail
-          if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
-            echo "::error::CLA trigger admission did not pass (gate: ${GATE_RESULT}, admitted: ${ADMITTED})"
-            exit 1
-          fi
-
-      # Stable generation marker. It changes only when the policy or action
-      # pin changes, unlike github.workflow_sha, which follows every main
-      # commit.
-      - name: "CLA generation ${{ env.CLA_GENERATION }}"
-        if: success()
-        run: echo "CLA generation ${{ env.CLA_GENERATION }}"
-
-      - name: "Validate CLA comment declaration"
-        if: success() && github.event_name == 'issue_comment'
-        env:
-          EVENT_COMMENT_BODY: ${{ github.event.comment.body }}
-        run: |
-          set -euo pipefail
-          # GitHub Actions string equality is case-insensitive, and the
-          # archived action also accepts broad regular-expression matches.
-          # Check the complete body in a shell before the action can record a
-          # signature. `recheck` is the only other accepted trigger.
-          if [[ "${EVENT_COMMENT_BODY}" != "recheck" &&
-                "${EVENT_COMMENT_BODY}" != "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
-            echo "::error::The comment is not an exact CLA declaration or recheck command"
-            exit 1
-          fi
-
-      - name: "Validate CLA pull request"
-        id: cla-preflight
-        if: success()
-        # The maintained action bounds its commit-identity pagination at 1,000
-        # commits. Keep the same fail-closed limit here so the preflight and
-        # action operate on the same contribution envelope.
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number || github.event.issue.number }}
-          EVENT_NAME: ${{ github.event_name }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-        run: |
-          set -euo pipefail
-          if ! [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]]; then
-            echo "::error::Invalid pull request number"
-            exit 1
-          fi
-          if ! pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-            echo "::error::Could not query the pull request"
-            exit 1
-          fi
-          if ! jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" '
-            .number == $number and
-            .state == "open" and
-            .base.ref == "main" and
-            .base.repo.full_name == $repo and
-            (.head.sha | type == "string") and
-            (.head.sha | test("^[0-9a-f]{40}$")) and
-            (.commits | type == "number")
-          ' <<<"${pr_json}" >/dev/null; then
-            echo "::error::The pull request is not an open pull request targeting main"
-            exit 1
-          fi
-          live_head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
-          if [[ "${EVENT_NAME}" == "pull_request_target" ]] && {
-            [[ "${EVENT_HEAD_SHA}" != "${live_head_sha}" ]] ||
-            [[ "${EVENT_BASE_REF}" != "main" ]] ||
-            [[ "${EVENT_BASE_REPO}" != "${GH_REPO}" ]]
-          }; then
-            echo "::error::The pull request changed while the CLA workflow was starting"
-            exit 1
-          fi
-          commit_count="$(jq -r '.commits' <<<"${pr_json}")"
-          if ! [[ "${commit_count}" =~ ^[0-9]+$ ]]; then
-            echo "::error::Could not determine the pull request commit count"
-            exit 1
-          fi
-          if (( commit_count > 1000 )); then
-            echo "::error title=Pull request commit limit::This pull request has ${commit_count} commits. Split it into 1,000 or fewer commits before requesting a CLA check."
-            exit 1
-          fi
-
-      - name: "CLA Assistant v2"
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Write CLA result"
         id: cla_action
-        if: success()
-        # Use the reviewed in-organization action fork. Pin the runtime commit
-        # so a branch move cannot change the code executed by this workflow.
-        # The fork's default branch must be protected before this check is made
-        # required in repository rulesets.
-        uses: manaflow-ai/cla-github-action@fc608ba7106e7029d981d487d7bad28a64325956 # v0.0.1
+        if: runner.environment == 'github-hosted'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          # Version 2 has a separate ledger. Existing version-1 signatures were
-          # collected under earlier CLA terms and must not silently accept this
-          # revised document.
-          path-to-signatures: 'signatures/version2/cla.json'
-          path-to-document: 'https://github.com/manaflow-ai/cmux/blob/${{ github.workflow_sha }}/CLA.md'
-          # Merged pull requests use the explicit lock step below, which
-          # supplies a valid lock reason and fails on API errors.
-          lock-pullrequest-aftermerge: 'false'
-          # signatures live on the unprotected cla-signatures branch so required checks on main don't block the bot's signature commits
-          branch: 'cla-signatures'
-          # Pin the policy branch explicitly.
-          required-base-ref: 'main'
-          # Require the exact phrase below. Raw-name allowlists are disabled;
-          # commit metadata is not authenticated identity evidence.
-          custom-pr-sign-comment: 'I have read the CLA Document v2.2 and I hereby sign the CLA'
-          # These reviewed numeric IDs exempt only authenticated pull-request
-          # openers: @austinywang (Austin Wang, 38676809) and
-          # @azooz2003-bit (Abdulaziz Albahar, 67667005). Names, commit
-          # authors, commenters, and later collaborators do not receive an
-          # exemption. Other bot-opened PRs remain fail-closed.
-          allowlist-ids: '38676809,67667005'
-          require-opener-as-author: 'true'
-          # Pre-merge administrator action: before making "CLA Assistant v2" a
-          # required check, verify that the `cla-signatures` branch contains
-          # `signatures/version2/cla.json` with a read-only Contents API query.
-          # If it is absent, run the maintained action's reviewed bootstrap once
-          # under administrator control. Never create or edit this data branch
-          # from a pull-request workflow.
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          path-to-signatures: "signatures/version2/cla.json"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "false"
+          expected-head-sha: "${{ needs.CLACommentGate.outputs.head_sha }}"
+          expected-base-sha: "${{ needs.CLACommentGate.outputs.base_sha }}"
+          expected-comment-id: "${{ needs.CLACommentGate.outputs.comment_id }}"
+          expected-comment-created-at: "${{ needs.CLACommentGate.outputs.comment_created_at }}"
+          expected-comment-author-id: "${{ needs.CLACommentGate.outputs.comment_author_id }}"
 
-  # Compatibility check for the current ruleset. It mirrors the v2 action
-  # result under the old context while administrators migrate the required
-  # check to "CLA Assistant v2". It runs for every non-closed pull-request
-  # lifecycle event, including edited events, because issue_comment checks
-  # attach to the default branch SHA, not the pull request head, and cannot
-  # safely refresh the old required context by themselves. On a signing
-  # comment, RerunFailedCLA validates both failed contexts in the exact prior
-  # target run and uses the failed-jobs endpoint to refresh them together.
-  # `always()` is required so a failed v2 action cannot turn this old required
-  # context into a skipped-success check.
+  # This no-permission job owns the required v3 check context. A gate or writer
+  # failure is visible as a failed check instead of being hidden as a skipped
+  # privileged job.
+  CLAAssistant:
+    name: "CLA Assistant v3"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+    if: >-
+      always() &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize' ||
+            github.event.action == 'ready_for_review'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.action == 'created' &&
+          github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
+          (
+            (
+              github.event.comment.body == 'recheck' &&
+              needs.CLACommentGate.result == 'success' &&
+              needs.CLACommentGate.outputs.admitted == 'true' &&
+              (
+                github.event.comment.user.id == github.event.issue.user.id ||
+                github.event.comment.author_association == 'OWNER' ||
+                github.event.comment.author_association == 'MEMBER' ||
+                github.event.comment.author_association == 'COLLABORATOR'
+              )
+            ) ||
+            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+          )
+        )
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      # Keep the generation marker on the required check's only step. The
+      # marker must remain visible when this result fails because the writer
+      # failed in the original pull_request_target run. The immutable rerun
+      # helper uses the rendered step name to reject older workflow runs.
+      - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+        if: runner.environment == 'github-hosted'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          GATE_RESULT: ${{ needs.CLACommentGate.result }}
+          ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
+          SIGNER_AUTHORIZED: ${{ needs.CLACommentGate.outputs.signer_authorized || '' }}
+          WRITER_RESULT: ${{ needs.CLALedgerWriter.result }}
+          CLA_PASSED: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
+        run: |
+          set -euo pipefail
+          echo "CLA generation ${CLA_GENERATION}"
+          if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
+            echo "::error::CLA trigger admission failed"
+            exit 1
+          fi
+          if [[ "${EVENT_NAME}" == "issue_comment" &&
+                "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" &&
+                "${SIGNER_AUTHORIZED}" != "true" ]]; then
+            echo "::error::CLA signer preflight failed"
+            exit 1
+          fi
+          if [[ "${WRITER_RESULT}" != "success" ]]; then
+            echo "::error::CLA ledger writer failed"
+            exit 1
+          fi
+          if [[ "${CLA_PASSED}" != "true" ]]; then
+            echo "::error::CLA action did not confirm that all contributors have signed"
+            exit 1
+          fi
+
+  # Keep the old context during migration. It has no token and is not the
+  # required context after the v3 ruleset migration.
   CLACompatibility:
     name: "CLA Assistant"
     needs:
@@ -403,92 +334,99 @@ jobs:
         github.event.action == 'opened' ||
         github.event.action == 'edited' ||
         github.event.action == 'reopened' ||
-        github.event.action == 'synchronize'
+        github.event.action == 'synchronize' ||
+        github.event.action == 'ready_for_review'
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
     timeout-minutes: 5
     permissions: {}
     steps:
-      - name: "Require CLA Assistant v2 success"
-        env:
-          GATE_RESULT: ${{ needs.CLACommentGate.result }}
-          V2_RESULT: ${{ needs.CLAAssistant.result }}
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
         run: |
           set -euo pipefail
-          if [[ "${GATE_RESULT}" != "success" || "${V2_RESULT}" != "success" ]]; then
-            echo "::error::CLA Assistant v2 did not pass (gate: ${GATE_RESULT}, action: ${V2_RESULT})"
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Mirror CLA Assistant compatibility result"
+        if: runner.environment == 'github-hosted'
+        env:
+          RESULT: ${{ needs.CLAAssistant.result }}
+        run: |
+          set -euo pipefail
+          [[ "${RESULT}" == "success" ]] || {
+            echo "::error::CLA Assistant v3 did not pass"
             exit 1
-          fi
+          }
 
+  # This job can refresh a failed check only through the immutable helper from
+  # the base workflow revision. It receives actions:write, never contents or
+  # comment write access, and its shell command and environment are fixed by
+  # the base-controlled policy validator.
   RerunFailedCLA:
     name: "Rerun failed CLA check"
-    needs: CLAAssistant
-    # Keep the workflow-rerun token out of the signature-writing job. This
-    # isolated fixed shell is the only job that can rerun a failed check, and
-    # it runs only after the exact accepted issue-comment path reaches the
-    # assistant. A signing declaration may authorize a rerun only when the
-    # action output proves that this run persisted a new signature. `recheck`
-    # remains available to the PR author or a trusted repository participant
-    # for a normal failed-check refresh.
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+      - CLAAssistant
     if: >-
       always() &&
-      (
-        needs.CLAAssistant.result == 'success' ||
-        needs.CLAAssistant.result == 'failure'
-      ) &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      needs.CLAAssistant.result != 'skipped' &&
       github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
       github.event.issue.state == 'open' &&
       github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
       (
         (
           github.event.comment.body == 'recheck' &&
-          github.event.comment.user.type == 'User' &&
           (
             github.event.comment.user.id == github.event.issue.user.id ||
             github.event.comment.author_association == 'OWNER' ||
             github.event.comment.author_association == 'MEMBER' ||
             github.event.comment.author_association == 'COLLABORATOR'
-          )
+          ) &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.cla_passed == 'true'
         ) ||
         (
           github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
-          github.event.comment.user.type == 'User' &&
-          github.event.comment.user.id == github.event.issue.user.id &&
-          needs.CLAAssistant.outputs.signature_recorded == 'true'
+          needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.cla_passed == 'true' &&
+          needs.CLALedgerWriter.outputs.signature_recorded == 'true'
         )
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
     timeout-minutes: 15
-    # A contributor can submit more than one valid comment while the signing
-    # job is running. Serialize reruns per PR so two comments cannot race the
-    # same workflow run. The default Actions policy keeps one pending rerun
-    # and replaces older pending requests. The script rechecks the run state
-    # before POSTing.
     concurrency:
-      group: cla-rerun-${{ github.event.issue.number }}
+      group: cla-rerun-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
-      # The job checks out only the fixed script at the immutable workflow
-      # revision below. actions:write is required by the rerun endpoint;
-      # contents:read is limited to that trusted sparse checkout.
       actions: write
+      checks: read
       contents: read
       issues: read
       pull-requests: read
     steps:
-      # Check out only the immutable workflow revision. Never use the PR head
-      # ref, and never execute files supplied by the pull request.
-      - name: "Checkout trusted CLA guard"
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Checkout trusted CLA rerun helper"
+        if: runner.environment == 'github-hosted'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.workflow_sha }}
-          fetch-depth: 1
           persist-credentials: false
           sparse-checkout: .github/scripts/rerun-failed-cla.sh
           sparse-checkout-cone-mode: false
-
       - name: "Rerun exact failed pull_request_target run"
+        if: runner.environment == 'github-hosted'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
@@ -502,218 +440,47 @@ jobs:
           COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
           COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
           COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
-          WORKFLOW_PATH: '.github/workflows/cla.yml'
+          WORKFLOW_PATH: ".github/workflows/cla.yml"
           WORKFLOW_SHA: ${{ github.workflow_sha }}
           CLA_GENERATION: ${{ env.CLA_GENERATION }}
-          TARGET_EVENT: 'pull_request_target'
-          TARGET_BASE_REF: 'main'
-          SIGNATURE_RECORDED: ${{ needs.CLAAssistant.outputs.signature_recorded }}
-        run: |
-          set -euo pipefail
-          [[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || {
-            echo "::error::The trusted workflow revision is invalid"
-            exit 1
-          }
-          checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || {
-            echo "::error::Could not verify the trusted workflow checkout"
-            exit 1
-          }
-          [[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || {
-            echo "::error::The checkout is not the immutable workflow revision"
-            exit 1
-          }
-          [[ -f .github/scripts/rerun-failed-cla.sh ]] || {
-            echo "::error::The trusted CLA guard script is missing"
-            exit 1
-          }
-          bash .github/scripts/rerun-failed-cla.sh
+          TARGET_EVENT: "pull_request_target"
+          TARGET_BASE_REF: "main"
+          SIGNATURE_RECORDED: ${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}
+        run: bash .github/scripts/rerun-failed-cla.sh
+
   LockMergedPullRequest:
     name: "Lock merged pull request"
     if: >-
       github.event_name == 'pull_request_target' &&
       github.event.action == 'closed' &&
       github.event.pull_request.merged == true
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
     timeout-minutes: 10
-    # Keep merge locks in a stable per-PR queue that is separate from the
-    # signer's signature queue. A later sign/comment event must not replace a
-    # pending lock event, and a close event must not replace a pending ledger
-    # write. The default Actions policy keeps one pending event in each queue;
-    # the live merged-PR check below prevents stale events from locking a
-    # reopened or retargeted pull request.
     concurrency:
       group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
       issues: write
-      pull-requests: read
+      pull-requests: write
     steps:
-      - name: "Lock merged pull request"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          EVENT_BASE_REF: ${{ github.event.pull_request.base.ref }}
-          EVENT_BASE_REPO: ${{ github.event.pull_request.base.repo.full_name }}
-          EVENT_BASE_REPO_ID: ${{ github.event.pull_request.base.repo.id }}
-          EVENT_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          EVENT_HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          # GitHub can redact a deleted fork from a merged pull-request
-          # payload. Validate the event shape, but do not treat source-head
-          # fields as immutable. GitHub permits a source branch to advance or
-          # be deleted after merge while the issue still needs locking.
-          EVENT_HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name || '' }}
-          EVENT_HEAD_REPO_ID: ${{ github.event.pull_request.head.repo.id || '' }}
-          EVENT_OPENER_ID: ${{ github.event.pull_request.user.id }}
-          EVENT_OPENER_LOGIN: ${{ github.event.pull_request.user.login }}
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
         run: |
           set -euo pipefail
-
-          fail() {
-            echo "::error::$1"
-            exit 1
-          }
-
-          [[ "${PR_NUMBER}" =~ ^[1-9][0-9]*$ ]] || fail "Invalid pull request number"
-          [[ "${EVENT_BASE_REF}" == "main" ]] || fail "The merge event targets an unexpected base branch"
-          [[ "${EVENT_BASE_REPO}" == "${GH_REPO}" ]] || fail "The merge event targets an unexpected base repository"
-          [[ "${EVENT_BASE_REPO_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The merge event has no valid base repository ID"
-          [[ "${EVENT_HEAD_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "The merge event has no valid head SHA"
-          [[ -n "${EVENT_HEAD_REF}" && "${EVENT_HEAD_REF}" != *$'\n'* && "${EVENT_HEAD_REF}" != *$'\r'* ]] || fail "The merge event has no valid head ref"
-          if [[ -z "${EVENT_HEAD_REPO}" || -z "${EVENT_HEAD_REPO_ID}" ]]; then
-            [[ -z "${EVENT_HEAD_REPO}" && -z "${EVENT_HEAD_REPO_ID}" ]] || fail "The merge event has incomplete head repository metadata"
-          else
-            [[ "${EVENT_HEAD_REPO}" == */* && "${EVENT_HEAD_REPO}" != */*/* ]] || fail "The merge event has no valid head repository"
-            [[ "${EVENT_HEAD_REPO_ID}" =~ ^[1-9][0-9]*$ ]] || fail "The merge event has no valid head repository ID"
-          fi
-          [[ "${EVENT_OPENER_ID}" =~ ^[1-9][0-9]*$ && -n "${EVENT_OPENER_LOGIN}" ]] || fail "The merge event has no valid pull request opener"
-
-          validate_live_merged_pr() {
-            local live_pr_json="$1"
-            jq -e \
-              --arg repo "${GH_REPO}" \
-              --argjson number "${PR_NUMBER}" \
-              --arg base_ref "${EVENT_BASE_REF}" \
-              --arg base_repo "${EVENT_BASE_REPO}" \
-              --argjson base_repo_id "${EVENT_BASE_REPO_ID}" \
-              --argjson opener_id "${EVENT_OPENER_ID}" \
-              --arg opener_login "${EVENT_OPENER_LOGIN}" '
-                .number == $number and
-                .state == "closed" and
-                .merged == true and
-                .base.ref == $base_ref and
-                .base.repo.full_name == $base_repo and
-                .base.repo.full_name == $repo and
-                .base.repo.id == $base_repo_id and
-                (.head.sha | type == "string") and
-                (.head.ref | type == "string") and
-                (
-                  if .head.repo == null then
-                    true
-                  else
-                    (.head.repo.full_name | type == "string") and
-                    (.head.repo.id | type == "number") and
-                    .head.repo.id > 0
-                  end
-                ) and
-                .user.id == $opener_id and
-                (.user.login | type == "string") and
-                (.user.login | length > 0)
-              ' <<<"${live_pr_json}" >/dev/null || return 1
-          }
-
-          live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the merged pull request"
-          validate_live_merged_pr "${live_pr_json}" || fail "The live pull request no longer matches the merged event"
-
-          issue_endpoint="repos/${GH_REPO}/issues/${PR_NUMBER}"
-          lock_endpoint="${issue_endpoint}/lock"
-
-          unlock_after_state_change() {
-            if ! gh api --method DELETE \
-              --header 'Accept: application/vnd.github+json' \
-              --header 'X-GitHub-Api-Version: 2022-11-28' \
-              "${lock_endpoint}" \
-              >/dev/null 2>&1; then
-              echo "::error::The pull request changed after locking and the stale lock could not be removed"
-              exit 1
-            fi
-            if ! unlocked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-              echo "::error::The stale pull request lock was removed, but its state could not be verified"
-              exit 1
-            fi
-            [[ "${unlocked}" == "false" ]] || {
-              echo "::error::The stale pull request lock could not be removed"
-              exit 1
-            }
-          }
-
-          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-            echo "::error::Could not query the pull request lock state"
-            exit 1
-          fi
-          if [[ "${locked}" == "true" ]]; then
-            # An existing lock may have been left behind by an earlier close
-            # event. Recheck the live state before treating it as valid, and
-            # remove it if the pull request was reopened or retargeted.
-            if ! live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-              fail "Could not verify the already-locked pull request"
-            fi
-            if ! validate_live_merged_pr "${live_pr_json}"; then
-              unlock_after_state_change
-              fail "The already-locked pull request changed; the stale lock was removed"
-            fi
-            # A lock may change state immediately after the first validation.
-            # Re-read before returning success so a concurrent reopen or
-            # retarget does not leave a stale lock with no later close event
-            # available to clean it up. Only a successful read that proves a
-            # stale state permits unlocking; an API error preserves the lock.
-            if ! final_live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-              fail "Could not verify the already-locked pull request before success"
-            fi
-            if ! validate_live_merged_pr "${final_live_pr_json}"; then
-              unlock_after_state_change
-              fail "The already-locked pull request changed; the stale lock was removed"
-            fi
-            echo "Pull request ${PR_NUMBER} is already locked"
-            exit 0
-          fi
-
-          # Re-fetch immediately before the state-changing call. A queued lock
-          # job must not lock a pull request that was reopened or retargeted
-          # after the closed event was delivered.
-          live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the merged pull request before locking"
-          validate_live_merged_pr "${live_pr_json}" || fail "The pull request changed before locking"
-
-          if ! gh api --method PUT \
-            --header 'Accept: application/vnd.github+json' \
-            --header 'X-GitHub-Api-Version: 2022-11-28' \
-            "${lock_endpoint}" \
-            --field lock_reason=resolved >/dev/null 2>&1; then
-            echo "::error::Could not lock the merged pull request"
-            exit 1
-          fi
-
-          if ! locked="$(gh api "${issue_endpoint}" --jq '.locked' 2>/dev/null)"; then
-            echo "::error::Could not verify the pull request lock state"
-            unlock_after_state_change
-            exit 1
-          fi
-          if [[ "${locked}" != "true" ]]; then
-            echo "::error::The merged pull request is not locked"
-            unlock_after_state_change
-            exit 1
-          fi
-
-          # There is no conditional lock endpoint. Re-read the live pull
-          # request after the PUT and remove the lock if an administrator
-          # reopened or retargeted it during the request. The final read is
-          # the recovery boundary for the API's unavoidable TOCTOU window.
-          if ! live_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)"; then
-            unlock_after_state_change
-            fail "Could not verify the merged pull request after locking"
-          fi
-          if ! validate_live_merged_pr "${live_pr_json}"; then
-            unlock_after_state_change
-            fail "The pull request changed after locking; the stale lock was removed"
-          fi
-          echo "Pull request ${PR_NUMBER} is locked"
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Lock merged pull request"
+        if: runner.environment == 'github-hosted'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "sign"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "true"

--- a/tests/test_cla_lock_workflow.sh
+++ b/tests/test_cla_lock_workflow.sh
@@ -1,235 +1,56 @@
 #!/usr/bin/env bash
-# Exercise the merged-PR lock shell block against deterministic API fixtures.
-# This verifies the live identity recheck, rather than only checking YAML text.
+# Verify the merged-PR lock job as a workflow artifact. The maintained action
+# owns the API behavior and has its own tests; this check proves that the
+# privileged cmux workflow invokes it only for a merged pull request with the
+# narrow lock contract.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
 test -f "$WORKFLOW"
-command -v jq >/dev/null
-grep -Fq "group: cla-lock-\${{ github.repository }}-\${{ github.event.pull_request.number }}" "$WORKFLOW"
-grep -Fq '      issues: write' "$WORKFLOW"
-grep -Fq '      pull-requests: read' "$WORKFLOW"
+command -v ruby >/dev/null
 
-# The merge-lock queue must remain independent from the signature queue. A
-# later sign/comment event must not replace a pending merge lock.
-lock_block="$(awk '
-  /^  LockMergedPullRequest:/ { in_job=1; next }
-  in_job && /^  [A-Za-z0-9_]+:/ { exit }
-  in_job { print }
-' "$WORKFLOW")"
-expected_lock_group="group: cla-lock-\${{ github.repository }}-\${{ github.event.pull_request.number }}"
-[[ "$lock_block" == *"$expected_lock_group"* ]]
-[[ "$lock_block" != *'group: cla-signatures-'* ]]
+WORKFLOW="$WORKFLOW" ruby <<'RUBY'
+require "yaml"
 
-work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT
-lock_script="$work/lock.sh"
+workflow = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+jobs = workflow.fetch("jobs")
+lock = jobs.fetch("LockMergedPullRequest")
 
-awk '
-  /^  LockMergedPullRequest:/ { in_job=1; next }
-  in_job && /^        run: \|$/ { in_run=1; next }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$lock_script"
-bash -n "$lock_script"
-
-export GH_REPO=manaflow-ai/cmux
-export PR_NUMBER=123
-export EVENT_BASE_REF=main
-export EVENT_BASE_REPO=manaflow-ai/cmux
-export EVENT_BASE_REPO_ID=100
-export EVENT_HEAD_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-export EVENT_HEAD_REF=feature/review
-export EVENT_HEAD_REPO=contributor/cmux
-export EVENT_HEAD_REPO_ID=200
-export EVENT_OPENER_ID=42
-export EVENT_OPENER_LOGIN=contributor
-
-gh() {
-  local endpoint=""
-  local arg
-  for arg in "$@"; do
-    if [[ "$arg" == repos/* ]]; then
-      endpoint="$arg"
-      break
-    fi
-  done
-  [[ -n "$endpoint" ]] || {
-    echo "missing API endpoint" >&2
-    return 1
-  }
-
-  if [[ "${FAKE_MODE:-}" == api-failure && "$endpoint" == repos/*/pulls/123 ]]; then
-    return 1
-  fi
-  if [[ "${FAKE_MODE:-}" == already-locked-read-failure &&
-        "$endpoint" == repos/*/pulls/123 &&
-        -f "${FAKE_LOCK_FILE}.recheck" ]]; then
-    return 1
-  fi
-
-  case "$endpoint" in
-    repos/manaflow-ai/cmux/pulls/123)
-      if [[ "${FAKE_MODE:-}" == already-locked-reopen-after-final-read ]]; then
-        local pull_read_count=0
-        [[ -f "${FAKE_LOCK_FILE}.pull-reads" ]] && pull_read_count="$(<"${FAKE_LOCK_FILE}.pull-reads")"
-        pull_read_count=$((pull_read_count + 1))
-        printf '%s\n' "$pull_read_count" >"${FAKE_LOCK_FILE}.pull-reads"
-      fi
-      local state=closed
-      local merged=true
-      local base_ref=main
-      local head_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      local head_repo=contributor/cmux
-      local head_repo_id=200
-      local opener_id=42
-      local opener_login=contributor
-      case "${FAKE_MODE:-}" in
-        reopened) state=open; merged=false ;;
-        already-locked-reopen-after-read)
-          if [[ -f "${FAKE_LOCK_FILE}.recheck" ]]; then
-            state=open
-            merged=false
-          fi
-          ;;
-        already-locked-reopen-after-final-read)
-          if [[ -f "${FAKE_LOCK_FILE}.recheck" &&
-                -f "${FAKE_LOCK_FILE}.pull-reads" &&
-                "$(<"${FAKE_LOCK_FILE}.pull-reads")" -ge 3 ]]; then
-            state=open
-            merged=false
-          fi
-          ;;
-        reopen-after-lock)
-          if [[ -f "${FAKE_LOCK_FILE}" ]] && [[ "$(<"${FAKE_LOCK_FILE}")" == true ]]; then
-            state=open
-            merged=false
-          fi
-          ;;
-        retargeted) base_ref=release ;;
-        changed-head) head_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
-        changed-head-repo) head_repo=attacker/cmux; head_repo_id=201 ;;
-        changed-opener) opener_id=43; opener_login=attacker ;;
-        malformed-head) head_repo=""; head_repo_id=0 ;;
-        deleted-fork) head_repo=""; head_repo_id=0 ;;
-      esac
-      if [[ "${FAKE_MODE:-}" == deleted-fork ]]; then
-        jq -nc \
-          --arg state "$state" \
-          --argjson merged "$merged" \
-          --arg base_ref "$base_ref" \
-          --arg head_sha "$head_sha" \
-          --arg head_ref "$EVENT_HEAD_REF" \
-          --argjson opener_id "$opener_id" \
-          --arg opener_login "$opener_login" \
-          '{number:123,state:$state,merged:$merged,base:{ref:$base_ref,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{sha:$head_sha,ref:$head_ref,repo:null},user:{id:$opener_id,login:$opener_login}}'
-      else
-        jq -nc \
-          --arg state "$state" \
-          --argjson merged "$merged" \
-          --arg base_ref "$base_ref" \
-          --arg head_sha "$head_sha" \
-          --arg head_ref "$EVENT_HEAD_REF" \
-          --arg head_repo "$head_repo" \
-          --argjson head_repo_id "$head_repo_id" \
-          --argjson opener_id "$opener_id" \
-          --arg opener_login "$opener_login" \
-          '{number:123,state:$state,merged:$merged,base:{ref:$base_ref,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{sha:$head_sha,ref:$head_ref,repo:{id:$head_repo_id,full_name:$head_repo}},user:{id:$opener_id,login:$opener_login}}'
-      fi
-      ;;
-    repos/manaflow-ai/cmux/issues/123)
-      local locked=false
-      [[ -f "${FAKE_LOCK_FILE}" ]] && locked="$(<"${FAKE_LOCK_FILE}")"
-      if [[ " $* " == *" --jq .locked "* ]]; then
-  if [[ "${FAKE_MODE:-}" == already-locked-reopen-after-read ||
-              "${FAKE_MODE:-}" == already-locked-read-failure ||
-              "${FAKE_MODE:-}" == already-locked-reopen-after-final-read ]]; then
-          printf 'seen\n' >"${FAKE_LOCK_FILE}.recheck"
-        fi
-        printf '%s\n' "$locked"
-      else
-        jq -nc --argjson locked "$locked" '{locked:$locked}'
-      fi
-      ;;
-    repos/manaflow-ai/cmux/issues/123/lock)
-      if [[ " $* " == *" --method PUT "* ]]; then
-        printf '%s\n' "$endpoint" >>"${FAKE_POST_FILE}"
-        if [[ "${FAKE_MODE:-}" == lock-failure ]]; then return 1; fi
-        printf 'true\n' >"${FAKE_LOCK_FILE}"
-      elif [[ " $* " == *" --method DELETE "* ]]; then
-        printf '%s\n' "$endpoint" >>"${FAKE_POST_FILE}"
-        printf 'false\n' >"${FAKE_LOCK_FILE}"
-      fi
-      ;;
-    *)
-      echo "unexpected API endpoint: $endpoint" >&2
-      return 1
-      ;;
-  esac
+abort "lock job has unexpected permissions" unless lock.fetch("permissions") == {
+  "issues" => "write",
+  "pull-requests" => "write"
 }
-export -f gh
+abort "lock job must run only for merged pull requests" unless lock.fetch("if").include?("github.event.action == 'closed'") && lock.fetch("if").include?("github.event.pull_request.merged == true")
+abort "lock queue is not per pull request" unless lock.fetch("concurrency").fetch("group") == "cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}"
+abort "lock queue must not cancel an earlier lock" unless lock.fetch("concurrency").fetch("cancel-in-progress") == false
 
-run_case() {
-  local mode="$1"
-  local expected_status="$2"
-  local expected_text="$3"
-  local expected_posts="$4"
-  local output status posts
-  local event_head_repo="$EVENT_HEAD_REPO"
-  local event_head_repo_id="$EVENT_HEAD_REPO_ID"
-  : >"$work/posts-$mode"
-  : >"$work/lock-$mode"
-  if [[ "$mode" == already-locked || "$mode" == already-locked-reopen-after-read ||
-        "$mode" == already-locked-read-failure ||
-        "$mode" == already-locked-reopen-after-final-read ]]; then
-    printf 'true\n' >"$work/lock-$mode"
-  fi
-  if [[ "$mode" == deleted-fork || "$mode" == deleted-fork-metadata-mismatch ]]; then
-    event_head_repo=""
-    event_head_repo_id=""
-  fi
-  set +e
-  output="$(
-    FAKE_MODE="$mode" \
-    FAKE_POST_FILE="$work/posts-$mode" \
-    FAKE_LOCK_FILE="$work/lock-$mode" \
-    EVENT_HEAD_REPO="$event_head_repo" \
-    EVENT_HEAD_REPO_ID="$event_head_repo_id" \
-    bash "$lock_script" 2>&1
-  )"
-  status=$?
-  set -e
-  if [[ "$status" != "$expected_status" ]]; then
-    echo "FAIL: $mode exited $status, expected $expected_status" >&2
-    echo "$output" >&2
-    exit 1
-  fi
-  if [[ "$output" != *"$expected_text"* ]]; then
-    echo "FAIL: $mode did not report '$expected_text'" >&2
-    echo "$output" >&2
-    exit 1
-  fi
-  posts="$(wc -l <"$work/posts-$mode" | tr -d ' ')"
-  if [[ "$posts" != "$expected_posts" ]]; then
-    echo "FAIL: $mode made $posts lock calls, expected $expected_posts" >&2
-    exit 1
-  fi
-  echo "PASS: $mode"
+steps = lock.fetch("steps")
+abort "lock job must contain a runner guard and one action step" unless steps.length == 2
+runner_guard = steps.fetch(0)
+abort "lock runner guard is not fail-closed" unless runner_guard == {
+  "name" => "Require GitHub-hosted runner",
+  "if" => "runner.environment != 'github-hosted'",
+  "run" => "set -euo pipefail\necho \"::error::CLA policy requires a GitHub-hosted runner\"\nexit 1\n"
 }
-
-run_case valid 0 "Pull request 123 is locked" 1
-run_case already-locked 0 "already locked" 0
-run_case reopened 1 "live pull request no longer matches" 0
-run_case retargeted 1 "live pull request no longer matches" 0
-run_case changed-head 0 "Pull request 123 is locked" 1
-run_case changed-head-repo 0 "Pull request 123 is locked" 1
-run_case changed-opener 1 "live pull request no longer matches" 0
-run_case malformed-head 1 "live pull request no longer matches" 0
-run_case deleted-fork 0 "Pull request 123 is locked" 1
-run_case deleted-fork-metadata-mismatch 0 "Pull request 123 is locked" 1
-run_case api-failure 1 "Could not query the merged pull request" 0
-run_case lock-failure 1 "Could not lock the merged pull request" 1
-run_case reopen-after-lock 1 "changed after locking; the stale lock was removed" 2
-run_case already-locked-reopen-after-read 1 "already-locked pull request changed; the stale lock was removed" 1
-run_case already-locked-read-failure 1 "Could not verify the already-locked pull request" 0
-run_case already-locked-reopen-after-final-read 1 "already-locked pull request changed; the stale lock was removed" 1
+step = steps.fetch(1)
+abort "lock action is not restricted to a hosted runner" unless step.fetch("if") == "runner.environment == 'github-hosted'"
+abort "lock job may not execute workflow shell text" if step.key?("run")
+uses = step.fetch("uses")
+abort "lock action is not pinned to the maintained release" unless
+  uses == "manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af"
+abort "lock action token is not the workflow token" unless step.fetch("env") == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+expected = {
+  "mode" => "sign",
+  "path-to-signatures" => "signatures/version2/cla.json",
+  "path-to-document" => "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md",
+  "branch" => "cla-signatures",
+  "required-base-ref" => "main",
+  "custom-pr-sign-comment" => "I have read the CLA Document v2.2 and I hereby sign the CLA",
+  "allowlist-ids" => "38676809,67667005",
+  "require-opener-as-author" => "true",
+  "lock-pullrequest-aftermerge" => "true"
+}
+abort "lock action inputs changed" unless step.fetch("with") == expected
+puts "PASS: merged-PR lock workflow contract"
+RUBY

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -32,7 +32,7 @@ bash -n "$rerun_script"
 # The privileged job checks out only the immutable workflow revision and
 # launches the checked-in guard. Keep the launcher below the Actions step-size
 # limit, and reject any future attempt to execute the pull-request head.
-grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2' "$WORKFLOW"
+grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' "$WORKFLOW"
 grep -Fq "repository: \${{ github.repository }}" "$WORKFLOW"
 grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
 grep -Fq 'sparse-checkout: .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
@@ -43,6 +43,23 @@ if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
   echo 'FAIL: CLA rerun checkout must never use a pull-request ref' >&2
   exit 1
 fi
+WORKFLOW="$WORKFLOW" ruby -ryaml <<'RUBY'
+workflow = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+rerun = workflow.fetch("jobs").fetch("RerunFailedCLA")
+expected_group = "cla-rerun-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+abort "CLA rerun queue is not serialized per pull request" unless
+  rerun.fetch("concurrency") == {
+    "group" => expected_group,
+    "cancel-in-progress" => false
+  }
+abort "CLA rerun job cannot read check runs" unless rerun.fetch("permissions") == {
+  "actions" => "write",
+  "checks" => "read",
+  "contents" => "read",
+  "issues" => "read",
+  "pull-requests" => "read"
+}
+RUBY
 launcher_bytes="$(awk '
   /^  RerunFailedCLA:/ { in_job=1; next }
   in_job && /^  LockMergedPullRequest:/ { exit }
@@ -66,7 +83,9 @@ export COMMENT_AUTHOR_LOGIN=contributor
 export COMMENT_AUTHOR_TYPE=User
 export COMMENT_AUTHOR_ASSOCIATION=NONE
 export WORKFLOW_PATH=.github/workflows/cla.yml
-export CLA_GENERATION=v2.2-action-bc206ed9b52ad0b0cbe85244ce522e5e9b65c10e
+WORKFLOW_SHA="$(git rev-parse HEAD)"
+export WORKFLOW_SHA
+export CLA_GENERATION=v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af
 export TARGET_EVENT=pull_request_target
 export TARGET_BASE_REF=main
 export SIGNATURE_RECORDED=false
@@ -75,17 +94,22 @@ export SIGNATURE_RECORDED=false
 # fork-only commit has no result from /commits/:sha/pulls, while the workflow
 # run still carries head_repository identity. GitHub may report the source PR
 # SHA or a different execution SHA on a pull_request_target run, so this fixture
-# keeps the live PR head at `aaaa...` and, for the populated-association case,
-# the selected run/job execution SHA at `bbbb...`. A populated pull_requests
-# object binds that differing execution to the source PR. An empty association
-# must use the exact live PR head SHA or fail closed.
+# keeps the live PR head at `aaaa...` and the selected run/job execution SHA at
+# `bbbb...`. The production-shaped fallback has an empty pull_requests array;
+# it is accepted without another check only when the run uses the live PR base
+# SHA. A source-SHA, null-repository, or mismatched-base run must carry a failed
+# GitHub Actions check whose URL binds the selected run and job to `aaaa...`.
 gh() {
   local endpoint=""
   local api_page=1
+  local api_filter=""
   local arg
   for arg in "$@"; do
     if [[ "$arg" == page=* ]]; then
       api_page="${arg#page=}"
+    fi
+    if [[ "$arg" == filter=* ]]; then
+      api_filter="${arg#filter=}"
     fi
     if [[ "$arg" == repos/* ]]; then
       endpoint="$arg"
@@ -95,6 +119,11 @@ gh() {
     echo "missing API endpoint" >&2
     return 1
   }
+  if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/check-runs &&
+        "$api_filter" != all ]]; then
+    echo "check-runs lookup must request filter=all" >&2
+    return 1
+  fi
   if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/pulls &&
         " $* " != *" --method GET "* ]]; then
     echo "commit association lookup must use GET" >&2
@@ -102,6 +131,7 @@ gh() {
   fi
   local live_state=open
   local live_base=main
+  local live_base_sha=cccccccccccccccccccccccccccccccccccccccc
   local live_head_repo=contributor/cmux
   local live_head_repo_id=200
   local run_head_repo=contributor/cmux
@@ -122,7 +152,24 @@ gh() {
     wrong-head-repo) run_head_repo=attacker/cmux; run_head_repo_id=201; run_prs='[]' ;;
     association-overflow) run_prs='[]' ;;
     fork-current|empty-run-association) run_prs='[]'; run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ;;
-    empty-different-execution-associated) run_prs='[]' ;;
+    empty-different-execution-associated|empty-different-execution-source-mismatch|empty-different-execution-check-bound|empty-different-execution-check-mismatch)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    empty-different-execution-source-bound)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    check-wrong-app|check-wrong-sha|check-wrong-job|check-missing-final|oversized-check-response)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    fork-null-head-check-bound|fork-null-head-no-check)
+      run_prs='[]'
+      run_head_repository_null=true
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
     same-repo-empty)
       run_prs='[]'
       run_head_repo=manaflow-ai/cmux
@@ -152,11 +199,26 @@ gh() {
 
   case "$endpoint" in
     repos/manaflow-ai/cmux/issues/123)
-      jq -nc --arg state "$live_state" '{state:$state,pull_request:{url:"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"}}'
+      if [[ "${FAKE_MODE}" == oversized-api-response ]]; then
+        printf '%s' '{"state":"open","pull_request":{"url":"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"},"padding":"'
+        head -c 2100000 /dev/zero | tr '\0' 'A'
+        printf '%s\n' '"}'
+      else
+        jq -nc --arg state "$live_state" '{state:$state,pull_request:{url:"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"}}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/issues/comments/900)
+      jq -nc \
+        --arg body "${COMMENT_BODY}" \
+        --argjson author_id "${COMMENT_AUTHOR_ID}" \
+        --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
+        --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+        --arg created_at "${COMMENT_CREATED_AT}" \
+        '{issue_url:"https://api.github.com/repos/manaflow-ai/cmux/issues/123",body:$body,user:{id:$author_id,login:$author_login,type:$author_type},created_at:$created_at,updated_at:$created_at}'
       ;;
     repos/manaflow-ai/cmux/pulls/123)
-      jq -nc --arg state "$live_state" --arg base "$live_base" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" \
-        '{number:123,state:$state,user:{id:300,login:"contributor"},base:{ref:$base,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}'
+      jq -nc --arg state "$live_state" --arg base "$live_base" --arg base_sha "$live_base_sha" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" \
+        '{number:123,state:$state,user:{id:300,login:"contributor"},base:{ref:$base,sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}'
       ;;
     repos/manaflow-ai/cmux/commits/*/pulls)
       if [[ "${FAKE_MODE}" == association-not-found ]]; then
@@ -174,6 +236,19 @@ gh() {
       elif [[ "${FAKE_MODE}" == association-api-failure ]]; then
         printf '{"message":"API unavailable","status":503}\n'
         return 1
+      elif [[ "${FAKE_MODE}" == empty-different-execution-source-bound ||
+              "${FAKE_MODE}" == empty-different-execution-source-mismatch ]]; then
+        local commit_sha="${endpoint#repos/manaflow-ai/cmux/commits/}"
+        commit_sha="${commit_sha%/pulls}"
+        if [[ "${FAKE_MODE}" == empty-different-execution-source-bound &&
+              "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
+          jq -nc '[{number:123,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        elif [[ "${FAKE_MODE}" == empty-different-execution-source-mismatch &&
+                "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
+          jq -nc '[{number:124,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        else
+          printf '[]\n'
+        fi
       elif [[ "${FAKE_MODE}" == association-overflow ]]; then
         jq -nc '[range(0; 100) | {number:(1000 + .),base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 1 ]]; then
@@ -223,16 +298,48 @@ gh() {
         printf '%s\n' "$association_call" >"${FAKE_ASSOC_CALL_FILE}"
       fi
       if [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 1 ]]; then
-        jq -nc '[range(0; 100) | {number:(1000 + .),state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 2 ]]; then
-        jq -nc '[{number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        jq -nc --arg base_sha "$live_base_sha" '[{number:123,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == ambiguous-association || ( "${FAKE_MODE}" == late-ambiguous && "$association_call" -gt 1 ) ]]; then
         jq -nc '[
-          {number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}},
-          {number:124,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}
+          {number:123,state:"open",base:{ref:"main",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}},
+          {number:124,state:"open",base:{ref:"main",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}
         ]'
       else
-        jq -nc --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" '[{number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}]'
+        jq -nc --arg base_sha "$live_base_sha" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" '[{number:123,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}]'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/commits/*/check-runs)
+      local check_call=1
+      if [[ -n "${FAKE_CHECK_CALL_FILE:-}" ]]; then
+        if [[ -s "${FAKE_CHECK_CALL_FILE}" ]]; then
+          read -r check_call <"${FAKE_CHECK_CALL_FILE}"
+          check_call=$((check_call + 1))
+        fi
+        printf '%s\n' "$check_call" >"${FAKE_CHECK_CALL_FILE}"
+      fi
+      if [[ "${FAKE_MODE}" == fork-null-head-no-check ||
+            "${FAKE_MODE}" == empty-different-execution-check-mismatch ||
+            "${FAKE_MODE}" == empty-different-execution-associated ||
+            "${FAKE_MODE}" == empty-different-execution-source-mismatch ||
+            "${FAKE_MODE}" == stale-empty-execution ||
+            "${FAKE_MODE}" == check-missing-final && "${check_call}" -gt 1 ]]; then
+        printf '%s\n' '{"check_runs":[]}'
+      elif [[ "${FAKE_MODE}" == oversized-check-response ]]; then
+        printf '%s' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500","padding":"'
+        head -c 2100000 /dev/zero | tr '\0' 'A'
+        printf '%s\n' '"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-app ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"untrusted-app"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-sha ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-job ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/999"}]}'
+      elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"}]}'
+      else
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
       fi
       ;;
     repos/manaflow-ai/cmux/actions/workflows)
@@ -300,24 +407,37 @@ gh() {
       elif [[ "${FAKE_MODE}" == compatibility-failed ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
-            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
-            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == writer-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:506,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == writer-only-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]}
           ]}'
       elif [[ "${FAKE_MODE}" == unexpected-failure ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
-            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
-            {id:503,run_id:$run_id,name:"Unexpected privileged job",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:503,run_id:$run_id,name:"Unexpected privileged job",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
           ]}'
       elif [[ "${FAKE_MODE}" == cancelled-job ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
-            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
-            {id:504,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"cancelled",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:504,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"cancelled",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
           ]}'
       else
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$jobs_sha" --argjson omit "$omit_job_head_repository" \
-          '{jobs:[({id:$job_id,run_id:$run_id,name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"success"}]} + (if $omit then {} else {head_repository:null} end))]}'
+          '{jobs:[({id:$job_id,run_id:$run_id,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"failure"}]} + (if $omit then {} else {head_repository:null} end))]}'
       fi
       ;;
     repos/manaflow-ai/cmux/actions/jobs/500|repos/manaflow-ai/cmux/actions/jobs/501)
@@ -332,7 +452,7 @@ gh() {
         job_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       fi
       jq -nc --argjson job_id "$job_id" --argjson run_id "$run_id" --arg marker "$marker" --arg run_sha "$job_sha" --argjson omit "$omit_job_head_repository" \
-        '({id:$job_id,run_id:$run_id,name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"success"}]} + (if $omit then {} else {head_repository:null} end))'
+        '({id:$job_id,run_id:$run_id,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"failure"}]} + (if $omit then {} else {head_repository:null} end))'
       ;;
     *)
       echo "unexpected API endpoint: $endpoint" >&2
@@ -348,6 +468,7 @@ run_case() {
   local expected_text="$3"
   local expected_posts="$4"
   local expected_post="${5:-}"
+  local expected_checks="${6:-}"
   local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false
   if [[ "$mode" == untrusted-recheck ]]; then
     comment_author=untrusted-user
@@ -374,11 +495,13 @@ run_case() {
   fi
   : >"$work/posts-$mode"
   printf '0\n' >"$work/association-$mode"
+  printf '0\n' >"$work/check-$mode"
   set +e
   output="$(
     FAKE_MODE="$mode" \
     FAKE_POST_FILE="$work/posts-$mode" \
     FAKE_ASSOC_CALL_FILE="$work/association-$mode" \
+    FAKE_CHECK_CALL_FILE="$work/check-$mode" \
     COMMENT_BODY="$comment_body" \
     COMMENT_AUTHOR_ID="$comment_author_id" \
     COMMENT_AUTHOR_LOGIN="$comment_author" \
@@ -409,10 +532,21 @@ run_case() {
     cat "$work/posts-$mode" >&2
     exit 1
   fi
+  if [[ -n "$expected_checks" ]]; then
+    local checks=0
+    if [[ -s "$work/check-$mode" ]]; then
+      read -r checks <"$work/check-$mode"
+    fi
+    if [[ "$checks" != "$expected_checks" ]]; then
+      echo "FAIL: $mode made $checks check lookups, expected $expected_checks" >&2
+      exit 1
+    fi
+  fi
   echo "PASS: $mode"
 }
 
 run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case oversized-api-response 1 "Could not query the issue" 0
 run_case minimal-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case fork-current 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
@@ -430,8 +564,19 @@ run_case paginated-runs 0 "Requested rerun for CLA job 500 in workflow run 400" 
 run_case full-run-window 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case full-run-window-no-match 1 "workflow-run result window is full" 0
 run_case paginated-jobs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case empty-different-execution-associated 1 "no pull request association and its execution SHA does not match" 0
-run_case stale-empty-execution 1 "no pull request association and its execution SHA does not match" 0
+run_case empty-different-execution-associated 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case empty-different-execution-source-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 0
+run_case empty-different-execution-source-mismatch 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case empty-different-execution-check-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
+run_case empty-different-execution-check-mismatch 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case fork-null-head-check-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
+run_case fork-null-head-no-check 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-wrong-app 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-wrong-sha 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-wrong-job 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-missing-final 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 2
+run_case oversized-check-response 1 "Could not query checks for the exact pull request head" 0 "" 1
+run_case stale-empty-execution 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
 run_case empty-mismatched-newer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case wrong-run-association 0 "No failed CLA run exists for this pull request head" 0
 run_case malformed-run-association 1 "malformed pull request associations" 0
@@ -455,7 +600,11 @@ run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workf
 run_case wrapped-ledger 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case oversized-ledger 1 "exceeds the 1 MB limit" 0
 run_case malformed-ledger 1 "not valid base64" 0
-run_case compatibility-failed 0 "Requested rerun for failed CLA jobs (v2 and compatibility) in workflow run 400" 1 \
+run_case compatibility-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case writer-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case writer-only-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
 run_case unexpected-failure 1 "unexpected failed job" 0
 run_case cancelled-job 1 "cancelled or non-failure job" 0

--- a/tests/test_cla_trigger_gate.sh
+++ b/tests/test_cla_trigger_gate.sh
@@ -1,299 +1,191 @@
 #!/usr/bin/env bash
-# Exercise the unprivileged CLA trigger admission gate. The shell gate emits a
-# true/false admission result, rejects malformed metadata, and keeps ordinary
-# human comments out of the privileged signer queue.
+# Run the executable admission and result guards from the v3 workflow. These
+# checks cover the event boundary and the failed-check path without granting a
+# test process a GitHub token or pretending that YAML text alone proves it.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
 test -f "$WORKFLOW"
 
-grep -Fq 'types: [opened,closed,edited,reopened,synchronize]' "$WORKFLOW"
-if rg -n 'changes\.base' "$WORKFLOW" >/dev/null; then
-  echo 'FAIL: edited pull-request events must not require a base-change payload' >&2
+grep -Fq 'name: "CLA Assistant v3"' "$WORKFLOW"
+if grep -Fq 'name: "CLA Assistant v2"' "$WORKFLOW"; then
+  echo 'FAIL: the retired v2 check name remains in the workflow' >&2
+  exit 1
+fi
+generation="$(WORKFLOW="$WORKFLOW" ruby -ryaml -e 'puts YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false).fetch("env").fetch("CLA_GENERATION")')"
+[[ "$generation" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{40}$ ]]
+grep -Fq "name: \"CLA generation $generation\"" "$WORKFLOW"
+grep -Fq "echo \"CLA generation \${CLA_GENERATION}\"" "$WORKFLOW"
+grep -Fq 'name: "CLA ledger writer"' "$WORKFLOW"
+grep -Fq '      issues: write' "$WORKFLOW"
+grep -Fq 'allowlist-ids: "38676809,67667005"' "$WORKFLOW"
+grep -Fq 'cla_passed: ${{ steps.cla_action.outputs.cla_passed }}' "$WORKFLOW"
+grep -Fq 'CLA_PASSED:' "$WORKFLOW"
+# shellcheck disable=SC2016
+WORKFLOW="$WORKFLOW" ruby -ryaml -e '
+  document = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+  expected = "ubuntu-24.04"
+  jobs = %w[CLACommentGate CLALedgerWriter CLAAssistant CLACompatibility RerunFailedCLA LockMergedPullRequest]
+  actual = jobs.to_h { |name| [name, document.fetch("jobs").fetch(name).fetch("runs-on")] }
+  abort "CLA jobs do not use the fixed GitHub-hosted runner" unless actual.values.all? { |runner| runner == expected }
+  gate_group = document.fetch("jobs").fetch("CLACommentGate").fetch("concurrency").fetch("group")
+  expected_gate_group = "cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.run_id }}"
+  abort "CLA admission queue is not event-unique" unless gate_group == expected_gate_group
+  recheck_guard_terms = [
+    "github.event.comment.body == \x27recheck\x27",
+    "github.event.comment.user.id == github.event.issue.user.id",
+    "github.event.comment.author_association == \x27OWNER\x27",
+    "github.event.comment.author_association == \x27MEMBER\x27",
+    "github.event.comment.author_association == \x27COLLABORATOR\x27"
+  ]
+  %w[CLACommentGate CLAAssistant].each do |name|
+    condition = document.fetch("jobs").fetch(name).fetch("if").gsub(/\s+/, " ")
+    abort "#{name} admits untrusted recheck comments" unless
+      recheck_guard_terms.all? { |term| condition.include?(term) }
+  end
+  action_ref = "manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af"
+  action_refs = []
+  walk = lambda do |value|
+    case value
+    when Hash
+      value.each { |key, child| action_refs << child if key == "uses" && child.is_a?(String) && child.start_with?("manaflow-ai/cla-github-action@"); walk.call(child) }
+    when Array
+      value.each { |child| walk.call(child) }
+    end
+  end
+  walk.call(document)
+  abort "CLA workflow uses an unexpected action reference" unless action_refs == [action_ref, action_ref, action_ref]
+'
+grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' "$WORKFLOW"
+grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
+if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
+  echo 'FAIL: the rerun helper may not check out a pull-request revision' >&2
   exit 1
 fi
 
-# The protected ruleset must be migrated to the versioned check context before
-# enforcement. The admission queue is bounded per pull request. Its known
-# case-insensitive replacement behavior is an availability residual; the
-# exact shell check still prevents an invalid comment from reaching signing.
-grep -Fq 'name: "CLA Assistant v2"' "$WORKFLOW"
-grep -Fq 'name: "CLA Assistant"' "$WORKFLOW"
-grep -Fq 'github.event.comment.body == '\''recheck'\''' "$WORKFLOW"
-grep -Fq 'github.event.comment.body == '\''I have read the CLA Document v2.2 and I hereby sign the CLA'\''' "$WORKFLOW"
-grep -Fq 'github.event.comment.user.id == github.event.issue.user.id' "$WORKFLOW"
-grep -Fq "github.event.action == 'created'" "$WORKFLOW"
-grep -Fq 'id: admission' "$WORKFLOW"
-grep -Fq "admitted: \${{ steps.admission.outputs.admitted }}" "$WORKFLOW"
-grep -Fq "allowlist-ids: '38676809,67667005'" "$WORKFLOW"
-grep -Fq 'always() &&' "$WORKFLOW"
-grep -Fq 'cancel-in-progress: false' "$WORKFLOW"
-grep -Fq "group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}" "$WORKFLOW"
-for job in CLACommentGate CLAAssistant CLACompatibility RerunFailedCLA LockMergedPullRequest; do
-  job_block="$(awk -v job="$job" '$0 == "  " job ":" { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-  if [[ "$job_block" != *"    runs-on: \${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"* ]]; then
-    echo "FAIL: $job must use the configured Linux runner" >&2
-    exit 1
-  fi
-done
-assistant_block="$(awk '/^  CLAAssistant:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$assistant_block" != *$'    if: >-\n      always() &&'* ||
-      "$assistant_block" != *"needs.CLACommentGate.result == 'failure'"* ||
-      "$assistant_block" != *"needs.CLACommentGate.outputs.admitted == 'true'"* ||
-      "$assistant_block" != *'      - name: "Require CLA admission"'* ||
-      "$assistant_block" != *'        if: always()'* ||
-      "$assistant_block" != *"          ADMITTED: \${{ needs.CLACommentGate.outputs.admitted }}"* ]]; then
-  echo 'FAIL: CLA assistant must expose a failed check when admission fails' >&2
-  exit 1
-fi
-success_guard_count="$(grep -Fc '        if: success()' <<<"$assistant_block")"
-if [[ "$success_guard_count" -lt 4 ]]; then
-  echo 'FAIL: privileged CLA steps must require successful admission' >&2
-  exit 1
-fi
-echo "PASS: signer admission failure is visible and privileged steps are guarded"
-gate_group_block="$(awk '/^  CLACommentGate:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$gate_group_block" != *$'\n    concurrency:'* ||
-      "$gate_group_block" != *"group: cla-admission-\${{ github.repository }}-\${{ github.event_name }}-\${{ github.event.issue.number || github.event.pull_request.number }}"* ||
-      "$gate_group_block" != *$'cancel-in-progress: false'* ]]; then
-  echo 'FAIL: CLA admission gate must use a bounded per-PR non-canceling queue' >&2
-  exit 1
-fi
-if [[ "$gate_group_block" != *"github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'"* ||
-      "$gate_group_block" != *"github.event.comment.body == 'recheck'"* ]]; then
-  echo 'FAIL: the job-level gate must keep ordinary comments out of the admission queue' >&2
-  exit 1
-fi
-assistant_group_block="$(awk '/^  CLAAssistant:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$assistant_group_block" != *"group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}"* ]]; then
-  echo 'FAIL: signer concurrency must serialize all events for one pull request' >&2
-  exit 1
-fi
-if rg -n -- '--paginate|--slurp' "$WORKFLOW" >/dev/null; then
-  echo 'FAIL: CLA rerun queries must use explicit bounded pages' >&2
-  exit 1
-fi
-grep -Fq "path-to-signatures: 'signatures/version2/cla.json'" "$WORKFLOW"
+workflow_types='types: [opened,closed,edited,reopened,synchronize,ready_for_review]'
+grep -Fq "$workflow_types" "$WORKFLOW"
 grep -Fq "github.event.comment.body == 'recheck'" "$WORKFLOW"
 grep -Fq "github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'" "$WORKFLOW"
+grep -Fq "group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}" "$WORKFLOW"
+
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
-gate_script="$work/gate.sh"
 
-awk '
-  /^  CLACommentGate:/ { in_job=1; next }
-  in_job && /^  [A-Za-z0-9_]+:/ { exit }
-  in_job && /^        run: \|$/ { in_run=1; next }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$gate_script"
-bash -n "$gate_script"
+extract_run() {
+  local job="$1" marker="$2" output="$3"
+  awk -v job="$job" -v marker="$marker" '
+    $0 == "  " job ":" { in_job=1; next }
+    in_job && /^  [A-Za-z0-9_]+:/ { exit }
+    in_job && index($0, marker) { target_step=1; next }
+    in_run && /^      - name:/ { exit }
+    target_step && /^        run: \|$/ { in_run=1; next }
+    in_run { sub(/^          /, ""); print }
+  ' "$WORKFLOW" >"$output"
+  test -s "$output"
+  bash -n "$output"
+}
 
-admission_script="$work/admission.sh"
-awk '
-  /^      - name: "Require CLA admission"/ { found=1; next }
-  found && /^        run: \|$/ { in_run=1; next }
-  found && in_run && /^      - name:/ { exit }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$admission_script"
-bash -n "$admission_script"
-for gate_result in success failure skipped; do
-  admitted=true
-  [[ "$gate_result" == success ]] || admitted=false
-  set +e
-  output="$(GATE_RESULT="$gate_result" ADMITTED="$admitted" bash "$admission_script" 2>&1)"
-  status=$?
-  set -e
-  if [[ "$gate_result" == success && "$status" -ne 0 ]]; then
-    echo "FAIL: admission guard rejected successful gate result" >&2
-    exit 1
-  elif [[ "$gate_result" != success && "$status" -eq 0 ]]; then
-    echo "FAIL: admission guard accepted gate result '$gate_result'" >&2
-    exit 1
-  fi
-done
-set +e
-output="$(GATE_RESULT=success ADMITTED=false bash "$admission_script" 2>&1)"
-status=$?
-set -e
-if [[ "$status" -eq 0 || "$output" != *"admitted: false"* ]]; then
-  echo 'FAIL: admission guard accepted a false admission output' >&2
-  exit 1
-fi
-echo "PASS: admission result guard"
+extract_run CLACommentGate 'id: admission' "$work/admission.sh"
 
-run_case() {
-  local mode="$1"
-  local expected_status="$2"
-  local expected_text="$3"
-  local expected_admitted="$4"
-  local event_name=issue_comment
-  local event_action=created
-  local comment_body=recheck
-  local comment_author_id=300
-  local comment_author_login=contributor
-  local pr_author_id=300
-  local comment_author_type=User
-  local comment_author_association=NONE
-  local output status output_file actual_admitted
-  output_file="$work/output-$mode"
+run_gate() {
+  local name="$1" expected_status="$2" expected_output="$3"
+  shift 3
+  local output_file="$work/gate-$name.out" output status
   rm -f "$output_file"
-  case "$mode" in
-    exact-sign) comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA' ;;
-    non-author-sign) comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'; comment_author_id=301; comment_author_login=reviewer; comment_author_association=MEMBER ;;
-    legacy-sign) comment_body='I have read the CLA Document and I hereby sign the CLA' ;;
-    uppercase-recheck) comment_body=RECHECK ;;
-    padded-sign) comment_body=' I have read the CLA Document v2.2 and I hereby sign the CLA ' ;;
-    wrapped-sign) comment_body='Please sign: I have read the CLA Document v2.2 and I hereby sign the CLA' ;;
-    ordinary-comment) comment_body='Thanks for the review!' ;;
-    untrusted-recheck) comment_author_id=301 ;;
-    trusted-recheck) comment_author_id=301; comment_author_association=MEMBER ;;
-    bot-comment) comment_author_login='github-actions[bot]'; comment_author_type=Bot ;;
-    pull-opened) event_name=pull_request_target; event_action=opened; comment_body='' ;;
-    pull-edited) event_name=pull_request_target; event_action=edited; comment_body='' ;;
-    pull-reopened) event_name=pull_request_target; event_action=reopened; comment_body='' ;;
-    pull-synchronize) event_name=pull_request_target; event_action=synchronize; comment_body='' ;;
-    pull-closed) event_name=pull_request_target; event_action=closed; comment_body='' ;;
-    wrong-event) event_name=push; event_action=; comment_body='' ;;
-  esac
   set +e
   output="$(
     GITHUB_OUTPUT="$output_file" \
-    EVENT_NAME="$event_name" \
-    EVENT_ACTION="$event_action" \
-    COMMENT_BODY="$comment_body" \
-    COMMENT_AUTHOR_ID="$comment_author_id" \
-    COMMENT_AUTHOR_LOGIN="$comment_author_login" \
-    PR_AUTHOR_ID="$pr_author_id" \
-    COMMENT_AUTHOR_TYPE="$comment_author_type" \
-    COMMENT_AUTHOR_ASSOCIATION="$comment_author_association" \
-    bash "$gate_script" 2>&1
+    EVENT_NAME=issue_comment EVENT_ACTION=created \
+    COMMENT_BODY='recheck' COMMENT_AUTHOR_ID=300 COMMENT_AUTHOR_LOGIN=contributor \
+    COMMENT_AUTHOR_TYPE=User PR_AUTHOR_ID=300 COMMENT_AUTHOR_ASSOCIATION=NONE \
+    "$@" bash "$work/admission.sh" 2>&1
   )"
   status=$?
   set -e
   if [[ "$status" != "$expected_status" ]]; then
-    echo "FAIL: $mode exited $status, expected $expected_status" >&2
+    echo "FAIL: gate $name exited $status, expected $expected_status" >&2
     echo "$output" >&2
     exit 1
   fi
-  if [[ -n "$expected_text" && "$output" != *"$expected_text"* ]]; then
-    echo "FAIL: $mode did not report '$expected_text'" >&2
-    echo "$output" >&2
-    exit 1
-  fi
-  if [[ "$expected_admitted" == none ]]; then
-    if [[ -s "$output_file" ]]; then
-      echo "FAIL: $mode unexpectedly wrote an admission result" >&2
+  if [[ "$expected_output" == none ]]; then
+    [[ ! -s "$output_file" ]] || {
+      echo "FAIL: gate $name emitted an admission result" >&2
+      exit 1
+    }
+  else
+    [[ "$(<"$output_file")" == "admitted=$expected_output" ]] || {
+      echo "FAIL: gate $name emitted an unexpected admission result" >&2
       cat "$output_file" >&2
       exit 1
-    fi
-  else
-    if [[ ! -s "$output_file" ]]; then
-      echo "FAIL: $mode did not write admitted=$expected_admitted" >&2
-      exit 1
-    fi
-    actual_admitted="$(<"$output_file")"
-    if [[ "$actual_admitted" != "admitted=$expected_admitted" ]]; then
-      echo "FAIL: $mode wrote '$actual_admitted', expected admitted=$expected_admitted" >&2
-      exit 1
-    fi
+    }
   fi
-  echo "PASS: $mode"
+  echo "PASS: gate $name"
 }
 
-run_case exact-recheck 0 "" true
-run_case exact-sign 0 "" true
-run_case non-author-sign 0 "" false
-run_case legacy-sign 0 "" false
-run_case uppercase-recheck 0 "" false
-run_case untrusted-recheck 0 "" false
-run_case trusted-recheck 0 "" true
-run_case bot-comment 1 "Bot" none
-run_case padded-sign 0 "" false
-run_case wrapped-sign 0 "" false
-run_case ordinary-comment 0 "" false
-run_case pull-opened 0 "" true
-run_case pull-edited 0 "" true
-run_case pull-reopened 0 "" true
-run_case pull-synchronize 0 "" true
-run_case pull-closed 1 "accepted CLA trigger" none
-run_case wrong-event 1 "accepted CLA trigger" none
+# The gate admits a syntactically valid declaration before the maintained
+# action authenticates the signer. This keeps the write-capable job from
+# duplicating identity policy while still exposing unauthorized signers as a
+# failed preflight result.
+run_gate exact-recheck 0 true
+run_gate unauthorized-recheck 0 false env COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=reviewer COMMENT_AUTHOR_ASSOCIATION=NONE
+run_gate member-recheck 0 true env COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=maintainer COMMENT_AUTHOR_ASSOCIATION=MEMBER
+run_gate exact-sign 0 true env COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA'
+run_gate non-author-sign 0 true env COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA' COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=reviewer COMMENT_AUTHOR_ASSOCIATION=MEMBER
+run_gate ordinary-comment 0 false env COMMENT_BODY='Thanks for the review!'
+run_gate padded-comment 0 false env COMMENT_BODY=' recheck'
+run_gate uppercase-comment 0 false env COMMENT_BODY=RECHECK
+run_gate bot-comment 1 none env COMMENT_AUTHOR_TYPE=Bot COMMENT_AUTHOR_LOGIN='github-actions[bot]'
 
-# Missing runner metadata is an infrastructure/malformed-event failure, not a
-# false admission. The gate must fail closed before a privileged dependency.
-set +e
-output="$(
-  GITHUB_OUTPUT="$work/output-missing-author" \
-  EVENT_NAME=issue_comment EVENT_ACTION=created COMMENT_BODY='ordinary' \
-  COMMENT_AUTHOR_LOGIN=contributor PR_AUTHOR_ID=300 COMMENT_AUTHOR_TYPE=User \
-  COMMENT_AUTHOR_ASSOCIATION=NONE bash -u "$gate_script" 2>&1
-)"
-status=$?
-set -e
-if [[ "$status" -eq 0 || "$output" != *"metadata is incomplete"* ]]; then
-  echo 'FAIL: missing comment metadata did not fail closed' >&2
-  echo "$output" >&2
-  exit 1
-fi
-set +e
-output="$(
-  env -u GITHUB_OUTPUT \
-  EVENT_NAME=issue_comment EVENT_ACTION=created COMMENT_BODY=ordinary \
-  COMMENT_AUTHOR_ID=300 COMMENT_AUTHOR_LOGIN=contributor PR_AUTHOR_ID=300 \
-  COMMENT_AUTHOR_TYPE=User COMMENT_AUTHOR_ASSOCIATION=NONE bash -u "$gate_script" 2>&1
-)"
-status=$?
-set -e
-if [[ "$status" -eq 0 || "$output" != *"GITHUB_OUTPUT is unavailable"* ]]; then
-  echo 'FAIL: missing GITHUB_OUTPUT did not fail closed' >&2
-  echo "$output" >&2
-  exit 1
-fi
-echo "PASS: malformed and infrastructure admission failures"
+for action in opened edited reopened synchronize ready_for_review; do
+  run_gate "pull-$action" 0 true env EVENT_NAME=pull_request_target EVENT_ACTION="$action" COMMENT_BODY=''
+done
+run_gate pull-closed 1 none env EVENT_NAME=pull_request_target EVENT_ACTION=closed COMMENT_BODY=''
 
-# The compatibility check must fail closed when the v2 action fails or is
-# skipped. A skipped dependency must never become a successful old required
-# context during migration.
-compat_script="$work/compatibility.sh"
-awk '
-  /^  CLACompatibility:/ { in_job=1; next }
-  in_job && /^  [A-Za-z0-9_]+:/ { exit }
-  in_job && /^        run: \|$/ { in_run=1; next }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$compat_script"
-bash -n "$compat_script"
-for gate_result in success failure skipped; do
-  for result in success failure skipped; do
+extract_run CLAAssistant "CLA generation $generation" "$work/assistant.sh"
+CLA_GENERATION="$generation"
+export CLA_GENERATION
+run_result() {
+  local name="$1" expected_status="$2" event_name="$3" comment_body="$4" gate_result="$5" admitted="$6" signer="$7" writer="$8" cla_passed="$9"
+  local output status
   set +e
-  GATE_RESULT="$gate_result" V2_RESULT="$result" bash "$compat_script" >/dev/null 2>&1
+  output="$(
+    EVENT_NAME="$event_name" COMMENT_BODY="$comment_body" GATE_RESULT="$gate_result" \
+    ADMITTED="$admitted" SIGNER_AUTHORIZED="$signer" WRITER_RESULT="$writer" \
+    CLA_PASSED="$cla_passed" \
+    CLA_GENERATION="$CLA_GENERATION" bash "$work/assistant.sh" 2>&1
+  )"
   status=$?
   set -e
-  if [[ "$gate_result" == success && "$result" == success && "$status" -ne 0 ]]; then
-    echo "FAIL: compatibility check rejected successful gate and v2 result" >&2
-    exit 1
-  elif [[ ( "$gate_result" != success || "$result" != success ) && "$status" -eq 0 ]]; then
-    echo "FAIL: compatibility check accepted gate '$gate_result' and v2 result '$result'" >&2
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: assistant $name exited $status, expected $expected_status" >&2
+    echo "$output" >&2
     exit 1
   fi
-  done
-done
-echo "PASS: compatibility result mirror"
+  echo "PASS: assistant $name"
+}
+run_result lifecycle-success 0 pull_request_target '' success true false success true
+run_result recheck-success 0 issue_comment recheck success true false success true
+run_result signing-success 0 issue_comment 'I have read the CLA Document v2.2 and I hereby sign the CLA' success true true success true
+run_result policy-failure 1 issue_comment recheck success true false success false
+run_result missing-policy-result 1 issue_comment recheck success true false success ''
+run_result unauthorized-sign 1 issue_comment 'I have read the CLA Document v2.2 and I hereby sign the CLA' success true false success false
+run_result writer-failure 1 issue_comment recheck success true false failure false
+run_result gate-failure 1 issue_comment recheck failure false false skipped false
 
-compat_block="$(awk '/^  CLACompatibility:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$compat_block" == *"github.event_name == 'issue_comment'"* ]]; then
-  echo 'FAIL: compatibility context must not pretend issue-comment checks are PR-head checks' >&2
-  exit 1
-fi
-echo "PASS: compatibility event scope"
-
-# Edited events must reach the signer and compatibility jobs as well as the
-# admission shell. This prevents a skipped old required context after a title
-# or body edit. Keep the assertion narrow to the event clauses, not comments.
-for job in CLAAssistant CLACompatibility; do
-  job_block="$(awk -v job="$job" '$0 == "  " job ":" { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-  if [[ "$job_block" != *"github.event.action == 'edited'"* ]]; then
-    echo "FAIL: $job does not run for edited pull-request events" >&2
+extract_run CLACompatibility 'Mirror CLA Assistant compatibility result' "$work/compatibility.sh"
+for result in success failure skipped; do
+  set +e
+  RESULT="$result" bash "$work/compatibility.sh" >/dev/null 2>&1
+  status=$?
+  set -e
+  if [[ "$result" == success && "$status" -ne 0 ]] ||
+     [[ "$result" != success && "$status" -eq 0 ]]; then
+    echo "FAIL: compatibility mirror returned $status for $result" >&2
     exit 1
   fi
 done
-echo "PASS: edited event job routing"
+echo 'PASS: compatibility result mirror'
+
+echo 'PASS: CLA v3 trigger and result guards'


### PR DESCRIPTION
## Summary

Replace the stale CLA workflow and rerun helper with the tested CLA Assistant v3 contract.

- Pin every maintained action use to `manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af`.
- Keep signing, issue comments, and lock writes on fixed GitHub-hosted runners with explicit runner-environment guards.
- Keep the immutable workflow checkout, exact pull request and comment rechecks, bounded API parsing, and stable generation marker.
- Keep `issues: write` for explanatory signer comments and the Austin/Aziz opener allowlist only (`38676809,67667005`).
- Emit the stable required check name `CLA Assistant v3`, while retaining the compatibility context during migration.

The branch keeps the required two-commit regression sequence. The first commit adds behavior tests that fail against the previous workflow. The second commit activates the implementation and makes those tests pass.

The base validator pin is intentionally handled by its separate compatibility PR before this workflow is merged.

## Verification

- `bash tests/test_cla_trigger_gate.sh`
- `bash tests/test_cla_lock_workflow.sh`
- `bash tests/test_cla_rerun_workflow.sh`
- `bash -n .github/scripts/rerun-failed-cla.sh`
- `shellcheck --shell=bash .github/scripts/rerun-failed-cla.sh`
- `actionlint .github/workflows/cla.yml`
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the stale CLA Assistant v2 workflow with the guarded v3 contract, pinning the maintained action to a fixed revision and adding regression tests. The required check name changes to `CLA Assistant v3`, so branch protection must be updated accordingly.

**Migration**
- Update branch protection to require `CLA Assistant v3` instead of `CLA Assistant v2`.
- The base validator pin lands in a separate compatibility PR before this merge.

**Refactors**
- The first commit adds tests that fail against the old workflow; the second activates the implementation and makes them pass.
- Runner guards keep signing, issue comments, and lock writes on fixed GitHub-hosted runners.

<sup>Written for commit 884677428a495e154f9b7e652d54202294884664. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11581?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

