### PR TITLE
Make the Blaxel-removal migration apply on a fresh database

### DIFF
--- a/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
+++ b/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
@@ -12,11 +12,16 @@
 -- rows readable rather than dropping them. Run the reaper to destroy live
 -- Blaxel machines BEFORE applying this migration — afterwards nothing in the
 -- control plane can address them.
+--
+-- The comparisons cast to text on purpose: on a fresh database every migration
+-- runs in one transaction, and Postgres refuses to use an enum value added
+-- earlier in that same transaction ("unsafe use of new value"). Comparing the
+-- text form sidesteps the enum lookup and works on fresh and existing databases.
 
-UPDATE "cloud_vms" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
-UPDATE "cloud_vm_usage_events" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
-UPDATE "cloud_vm_bases" SET "active_provider" = 'e2b' WHERE "active_provider" = 'blaxel';
-UPDATE "cloud_vm_base_generations" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
+UPDATE "cloud_vms" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
+UPDATE "cloud_vm_usage_events" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
+UPDATE "cloud_vm_bases" SET "active_provider" = 'e2b' WHERE "active_provider"::text = 'blaxel';
+UPDATE "cloud_vm_base_generations" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
 
 ALTER TYPE "vm_provider" RENAME TO "vm_provider_old";
 CREATE TYPE "vm_provider" AS ENUM ('e2b', 'freestyle', 'daytona');


### PR DESCRIPTION
Every fresh local dev database on `main` fails `bun dev` at migration time since https://github.com/manaflow-ai/cmux/pull/11566:

```
error: unsafe use of new value "blaxel" of enum type vm_provider
```

The removal migration's four `UPDATE ... WHERE provider = 'blaxel'` statements reference an enum value that an earlier migration adds in the same transaction, which Postgres forbids. Comparing `provider::text = 'blaxel'` sidesteps the enum lookup. Existing databases (staging, production) rewrite the same rows as before.

Found while dogfooding https://github.com/manaflow-ai/cmux/pull/11580 on a fresh worktree database.

https://claude.ai/code/session_01S7SVaoTDXVuXZKaN5QAwHc


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Blaxel-removal migration so it applies on a fresh database instead of failing with Postgres' "unsafe use of new value" error. The UPDATE statements now compare the enum columns as text, which sidesteps the enum lookup and rewrites the same rows on existing databases.

<sup>Written for commit d29d60f99547ddd895a2623a0a8e5102fe3e4b4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11582?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved database migrations so provider updates complete successfully on both fresh and existing databases.
  - Prevented migration failures caused by PostgreSQL enum value comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->