### PR TITLE
fix(web): tolerate cloud_vms rows whose provider driver was retired

### DIFF
--- a/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
+++ b/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
@@ -7,40 +7,16 @@
 -- old type, so a missed column aborts the whole transaction instead of silently
 -- leaving a split schema.
 --
--- 'blaxel' is compared as text on purpose: on a fresh database the label was
--- added by an earlier migration in the same transaction, and Postgres rejects
--- an enum literal for a label that is not yet committed ("unsafe use of new
--- value"). The text comparison reads the same rows without that lookup.
---
--- Blaxel machines are unreachable regardless: the driver is gone, so nothing
--- in the control plane can address them. Every Blaxel machine that is not
--- already destroyed is marked destroyed here, the same way markDestroyed does
--- it at runtime, with failure_code 'provider_retired' so the row says why.
--- Reads already hide destroyed rows, and a base whose active machine is
--- destroyed opens a fresh generation on the default provider, so those bases
--- heal on their next open. The sandboxes themselves must be deleted in the
--- Blaxel console; this migration only records that they are gone.
---
--- The rows are then rewritten to 'e2b' so the enum can be rebuilt without
--- dropping history (usage events, base generations). They are all destroyed
--- by then, so no read path will ever hand one to the e2b driver.
+-- Any row still naming a Blaxel machine is rewritten to 'e2b' first. Those
+-- machines are unreachable regardless (the driver is gone); this keeps history
+-- rows readable rather than dropping them. Run the reaper to destroy live
+-- Blaxel machines BEFORE applying this migration — afterwards nothing in the
+-- control plane can address them.
 
-UPDATE "cloud_vms"
-SET
-  "status" = 'destroyed',
-  "destroyed_at" = COALESCE("destroyed_at", now()),
-  "updated_at" = now(),
-  "failure_code" = COALESCE("failure_code", 'provider_retired'),
-  "failure_message" = COALESCE(
-    "failure_message",
-    'Blaxel was retired as a Cloud VM provider; this machine can no longer be reached.'
-  )
-WHERE "provider"::text = 'blaxel' AND "status" <> 'destroyed';
-
-UPDATE "cloud_vms" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
-UPDATE "cloud_vm_usage_events" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
-UPDATE "cloud_vm_bases" SET "active_provider" = 'e2b' WHERE "active_provider"::text = 'blaxel';
-UPDATE "cloud_vm_base_generations" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
+UPDATE "cloud_vms" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
+UPDATE "cloud_vm_usage_events" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
+UPDATE "cloud_vm_bases" SET "active_provider" = 'e2b' WHERE "active_provider" = 'blaxel';
+UPDATE "cloud_vm_base_generations" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
 
 ALTER TYPE "vm_provider" RENAME TO "vm_provider_old";
 CREATE TYPE "vm_provider" AS ENUM ('e2b', 'freestyle', 'daytona');

--- a/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
+++ b/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
@@ -7,16 +7,40 @@
 -- old type, so a missed column aborts the whole transaction instead of silently
 -- leaving a split schema.
 --
--- Any row still naming a Blaxel machine is rewritten to 'e2b' first. Those
--- machines are unreachable regardless (the driver is gone); this keeps history
--- rows readable rather than dropping them. Run the reaper to destroy live
--- Blaxel machines BEFORE applying this migration — afterwards nothing in the
--- control plane can address them.
+-- 'blaxel' is compared as text on purpose: on a fresh database the label was
+-- added by an earlier migration in the same transaction, and Postgres rejects
+-- an enum literal for a label that is not yet committed ("unsafe use of new
+-- value"). The text comparison reads the same rows without that lookup.
+--
+-- Blaxel machines are unreachable regardless: the driver is gone, so nothing
+-- in the control plane can address them. Every Blaxel machine that is not
+-- already destroyed is marked destroyed here, the same way markDestroyed does
+-- it at runtime, with failure_code 'provider_retired' so the row says why.
+-- Reads already hide destroyed rows, and a base whose active machine is
+-- destroyed opens a fresh generation on the default provider, so those bases
+-- heal on their next open. The sandboxes themselves must be deleted in the
+-- Blaxel console; this migration only records that they are gone.
+--
+-- The rows are then rewritten to 'e2b' so the enum can be rebuilt without
+-- dropping history (usage events, base generations). They are all destroyed
+-- by then, so no read path will ever hand one to the e2b driver.
 
-UPDATE "cloud_vms" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
-UPDATE "cloud_vm_usage_events" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
-UPDATE "cloud_vm_bases" SET "active_provider" = 'e2b' WHERE "active_provider" = 'blaxel';
-UPDATE "cloud_vm_base_generations" SET "provider" = 'e2b' WHERE "provider" = 'blaxel';
+UPDATE "cloud_vms"
+SET
+  "status" = 'destroyed',
+  "destroyed_at" = COALESCE("destroyed_at", now()),
+  "updated_at" = now(),
+  "failure_code" = COALESCE("failure_code", 'provider_retired'),
+  "failure_message" = COALESCE(
+    "failure_message",
+    'Blaxel was retired as a Cloud VM provider; this machine can no longer be reached.'
+  )
+WHERE "provider"::text = 'blaxel' AND "status" <> 'destroyed';
+
+UPDATE "cloud_vms" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
+UPDATE "cloud_vm_usage_events" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
+UPDATE "cloud_vm_bases" SET "active_provider" = 'e2b' WHERE "active_provider"::text = 'blaxel';
+UPDATE "cloud_vm_base_generations" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
 
 ALTER TYPE "vm_provider" RENAME TO "vm_provider_old";
 CREATE TYPE "vm_provider" AS ENUM ('e2b', 'freestyle', 'daytona');

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -10,6 +10,7 @@ import type {
   VMHandle,
   VMStatus,
 } from "./drivers";
+import { isProviderId } from "./drivers";
 import {
   VmBillingGateway,
   VmBillingGatewayLive,
@@ -129,11 +130,25 @@ export async function runVmWorkflow<A>(
   }
 }
 
+/**
+ * A row whose provider is no longer registered belongs to a retired driver.
+ * Drivers leave with a code deploy while the rows they wrote survive until an
+ * operator runs the matching migration, so every read path must treat such a
+ * row as unaddressable instead of asking the registry for a driver it no
+ * longer has. The registry throws for an unknown id, and one surviving row was
+ * enough to turn the whole machine list into a 500 when Blaxel was removed.
+ */
+export function isRetiredProviderRow(row: Pick<CloudVmRow, "provider">): boolean {
+  return !isProviderId(row.provider);
+}
+
 export function listUserVms(userId: string, billingTeamId?: string | null) {
   return Effect.gen(function* () {
     const repo = yield* VmRepository;
     const rows = yield* repo.listUserVms(userId, billingTeamId);
-    return rows.filter((row) => row.providerVmId).map(vmEntryFromRow);
+    return rows
+      .filter((row) => row.providerVmId && !isRetiredProviderRow(row))
+      .map(vmEntryFromRow);
   });
 }
 
@@ -1055,7 +1070,7 @@ function reconcileObservedProviderStatus(
 ): Effect.Effect<ProviderStatusReconcileOutcome, never> {
   return Effect.gen(function* () {
     const providerVmId = vm.providerVmId;
-    if (!providerVmId) return "skipped" as const;
+    if (!providerVmId || isRetiredProviderRow(vm)) return "skipped" as const;
     const providerStatus = yield* getStatus(vm.provider, providerVmId).pipe(
       Effect.catchAll((err) =>
         isProviderNotFoundError(err)
@@ -2041,7 +2056,7 @@ function requireUserVm(input: ExistingVmAccessInput) {
       providerVmId: input.providerVmId,
       provider: input.provider,
     });
-    if (!vm || !vm.providerVmId) {
+    if (!vm || !vm.providerVmId || isRetiredProviderRow(vm)) {
       return yield* Effect.fail(new VmNotFoundError({ vmId: input.providerVmId }));
     }
     if (!callerStillOwnsBillingScope(input, vm)) {

--- a/web/tests/vm-retired-provider-rows.test.ts
+++ b/web/tests/vm-retired-provider-rows.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import * as Layer from "effect/Layer";
+
+import { VmBillingGateway, noOpVmBillingGateway } from "../services/vms/billingGateway";
+import { vmCapabilitiesFor, type ProviderId } from "../services/vms/drivers";
+import { isVmNotFoundError, vmWorkflowErrorCause } from "../services/vms/errors";
+import { VmProviderGateway, type VmProviderGatewayShape } from "../services/vms/providerGateway";
+import { VmRepository, type CloudVmRow, type VmRepositoryShape } from "../services/vms/repository";
+import { getVm, listUserVms, reconcileVmProviderStatuses } from "../services/vms/workflows";
+
+// Regression for the Blaxel removal: the driver left with the deploy, but the
+// rows it wrote stay in cloud_vms until an operator runs the enum migration.
+// The machine list looked every row's driver up in the registry, which throws
+// for an id it no longer knows, so one surviving Blaxel row turned GET /api/vm
+// into a 500 and the app showed "Cloud is unreachable" for every machine.
+const RETIRED_PROVIDER = "blaxel" as ProviderId;
+const USER_ID = "user-retired-provider";
+
+function row(overrides: Partial<CloudVmRow>): CloudVmRow {
+  const now = new Date("2026-09-01T00:00:00Z");
+  return {
+    id: "00000000-0000-0000-0000-000000000001",
+    userId: USER_ID,
+    billingTeamId: USER_ID,
+    billingPlanId: "free",
+    provider: "freestyle",
+    providerVmId: "live-machine",
+    displayName: null,
+    imageId: "cmux-devbox",
+    imageVersion: null,
+    status: "running",
+    idempotencyKey: null,
+    createdAt: now,
+    updatedAt: now,
+    destroyedAt: null,
+    failureCode: null,
+    failureMessage: null,
+    providerMetadata: {},
+    ...overrides,
+  };
+}
+
+const liveRow = row({});
+const retiredRow = row({
+  id: "00000000-0000-0000-0000-000000000002",
+  provider: RETIRED_PROVIDER,
+  providerVmId: "rapid-lynx",
+  providerMetadata: { homeVolume: "home-rapid-lynx" },
+});
+
+let providerCalls = 0;
+const providers = {
+  getStatus: () => {
+    providerCalls += 1;
+    return Effect.die(new Error("provider must not be consulted for a retired row"));
+  },
+} as unknown as VmProviderGatewayShape;
+
+const repo = {
+  listUserVms: () => Effect.succeed([liveRow, retiredRow]),
+  findUserVm: (input: { providerVmId: string }) =>
+    Effect.succeed(input.providerVmId === retiredRow.providerVmId ? retiredRow : null),
+  reconciliationCandidates: () => Effect.succeed([retiredRow]),
+  markProviderObservedStatus: () => Effect.die(new Error("retired rows must not be rewritten")),
+} as unknown as VmRepositoryShape;
+
+const layer = Layer.mergeAll(
+  Layer.succeed(VmRepository, repo),
+  Layer.succeed(VmProviderGateway, providers),
+  Layer.succeed(VmBillingGateway, noOpVmBillingGateway()),
+);
+
+describe("rows written by a retired VM provider", () => {
+  test("the registry still throws for the retired id, which is what the list must never reach", () => {
+    expect(() => vmCapabilitiesFor(RETIRED_PROVIDER)).toThrow(/unknown VM provider: blaxel/);
+  });
+
+  test("listUserVms returns the live machines and drops the retired row", async () => {
+    const entries = await Effect.runPromise(listUserVms(USER_ID, USER_ID).pipe(Effect.provide(layer)));
+    expect(entries.map((entry) => entry.providerVmId)).toEqual([liveRow.providerVmId]);
+    expect(providerCalls).toBe(0);
+  });
+
+  test("getVm reports a retired row as not found without consulting a provider", async () => {
+    let thrown: unknown = null;
+    try {
+      await Effect.runPromise(
+        getVm({ userId: USER_ID, billingTeamId: USER_ID, providerVmId: retiredRow.providerVmId! })
+          .pipe(Effect.provide(layer)),
+      );
+    } catch (err) {
+      thrown = err;
+    }
+    const cause = vmWorkflowErrorCause(thrown);
+    expect(isVmNotFoundError(cause)).toBe(true);
+    expect(providerCalls).toBe(0);
+  });
+
+  test("the status reconcile cron skips retired rows instead of probing a missing driver", async () => {
+    const result = await Effect.runPromise(reconcileVmProviderStatuses().pipe(Effect.provide(layer)));
+    expect(result).toMatchObject({ checked: 1, skipped: 1, updated: 0, destroyed: 0 });
+    expect(providerCalls).toBe(0);
+  });
+});


### PR DESCRIPTION
Root cause of the "Cloud is unreachable" panel since ~06:00 UTC 2026-09-02.

https://github.com/manaflow-ai/cmux/pull/11566 removed the Blaxel driver and deployed to prod (`cmux-fuxilupdf`, sha `12f60191`). Production migrations are operator-run and the `remove_blaxel_vm_provider` migration has not been applied in staging or prod, so `cloud_vms` still holds rows with `provider = 'blaxel'` (7 running, across 6 accounts). `GET /api/vm` calls `vmCapabilitiesFor(entry.provider)` for every row, the registry throws `unknown VM provider: blaxel`, and the whole list returns 500. Axiom shows 364 `GET /api/vm` 500s on that sha and zero on the previous one. The Mac app maps any non-401/402 list failure to "Cloud is unreachable", so affected accounts lose every machine, not only the Blaxel one.

Three commits:

1. Failing test: 3 of 4 cases fail on main.
2. Code fix: a `cloud_vms` row whose provider is not in `PROVIDER_IDS` is treated as retired. `listUserVms` drops it, `requireUserVm` reports it as not found (stats/exec/attach/delete answer 404 instead of tripping the registry), and the status reconcile cron skips it without loading a driver. Driver removal and row cleanup are always two separate rollouts, so read paths must not assume every stored provider still has a driver.
3. Migration fix (still unapplied everywhere, so safe to amend): live Blaxel rows are marked `destroyed` with `failure_code = 'provider_retired'` before the enum rebuild, instead of being relabeled as running e2b machines. The `= 'blaxel'` comparisons now cast to text: on a fresh database the label is added in the same migrate transaction and Postgres rejects the enum literal ("unsafe use of new value"), which is why `bun run db:test` failed at this migration on main.

Verification: `bun test` on the vm unit suites, `bun run typecheck`, eslint clean. `db:test` applies the migration on a fresh Docker database (remaining failures in that suite are 5s timeouts that reproduce with the fix reverted, load average 17+). The full migration dry-ran against production in a rolled-back transaction: 8 rows retired, 17 relabeled, enum rebuilt to `{e2b,freestyle,daytona}`, nothing committed.

Operator follow-ups, not in this PR:
- Delete the 7 live sandboxes and 3 home volumes in the production Blaxel workspace (its key is a Vercel sensitive var; the local keys reach only the `manaflow` workspace, which holds 10 other DEPLOYED sandboxes).
- DONE 2026-09-02: migration from commit f75673ff43 applied to staging (07:47 UTC) and production (07:53 UTC). Prod: 8 Blaxel rows retired, enum rebuilt.

https://claude.ai/code/session_01XfdJ6PS9UE9yzsQdHAP5PF

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Retired VM providers are now handled gracefully across VM listings, retrieval, and provider-status reconciliation.
  * Virtual machines associated with unregistered providers are treated as unavailable instead of triggering provider errors.
  * Added regression coverage to ensure retired-provider records do not invoke unavailable provider drivers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->