### PR TITLE
Bound managed enrollment file reads

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -28,6 +28,8 @@ use crate::config::{Config, ManagedEvents, ManagedIdentity};
 pub const MANAGED_CLIENT: &str = "cmux-relay-managed-v1";
 const ALLOWED_BACKENDS: [&str; 2] = ["https://api.chatmux.dev", "https://api-staging.chatmux.dev"];
 const E2E_BACKEND_ENV: &str = "CHATMUX_RELAY_E2E_BACKEND";
+/// Enrollment JSON is carried through the relay's bounded frame protocol.
+const MAX_ENROLLMENT_BYTES: usize = 4 << 20;
 
 #[cfg(unix)]
 static NEXT_CLEANUP_ID: AtomicU64 = AtomicU64::new(0);
@@ -413,6 +415,19 @@ mod tests {
         assert_eq!(managed.provider, "daytona");
         assert!(loaded.events.is_none());
         assert!(!Path::new(&path).exists(), "file must be shredded after the read");
+    }
+
+    #[test]
+    fn oversized_regular_enrollment_is_rejected_and_deleted() {
+        let path = fixture(&enrollment(), 0o600, "oversized");
+        let current_len = std::fs::metadata(&path).unwrap().len() as usize;
+        let padding = vec![b' '; MAX_ENROLLMENT_BYTES + 1 - current_len];
+        let mut file = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        file.write_all(&padding).unwrap();
+
+        let error = load_managed_enrollment_file(&path, NOW).expect_err("oversized enrollment");
+        assert_eq!(error.0, "Managed enrollment file is invalid.");
+        assert!(!Path::new(&path).exists(), "oversized file must be shredded after refusal");
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -91,8 +91,16 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
         }
     }
 
-    let mut contents = Vec::new();
-    let read_result = file.read_to_end(&mut contents);
+    let mut contents =
+        Vec::with_capacity(metadata.len().min((MAX_ENROLLMENT_BYTES as u64) + 1) as usize);
+    // `Take` bounds every read from the file. Read one byte past the accepted
+    // size so an exact-limit enrollment remains valid and an oversized one is
+    // detected without reading the rest of the file.
+    let read_result = {
+        let mut limited = Read::by_ref(&mut file).take((MAX_ENROLLMENT_BYTES as u64) + 1);
+        limited.read_to_end(&mut contents).map(|_| ())
+    };
+    let oversized = contents.len() > MAX_ENROLLMENT_BYTES;
 
     // Reopen for writing only after validation and reading. The second open
     // is still O_NOFOLLOW and must resolve to the descriptor's inode before it
@@ -114,7 +122,10 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
         // Best-effort overwrite through the already-open descriptor. This
         // keeps shredding tied to the inode that was validated above.
         let _ = write_file.seek(SeekFrom::Start(0));
-        let mut remaining = metadata.len();
+        // Truncation removes all logical contents. Limit the best-effort
+        // physical overwrite so a large sparse file cannot force unbounded
+        // cleanup I/O or temporary disk allocation.
+        let mut remaining = metadata.len().min((MAX_ENROLLMENT_BYTES as u64) + 1);
         let zeros = [0_u8; 4096];
         while remaining > 0 {
             let chunk = remaining.min(zeros.len() as u64) as usize;
@@ -135,6 +146,9 @@ fn read_and_shred(path: &Path) -> Result<String, ManagedEnrollmentError> {
         return Err(validation_error);
     }
     read_result.map_err(|_| error("Managed enrollment file is unavailable."))?;
+    if oversized {
+        return Err(error("Managed enrollment file is invalid."));
+    }
     String::from_utf8(contents).map_err(|_| error("Managed enrollment file is unavailable."))
 }
 
@@ -417,6 +431,7 @@ mod tests {
         assert!(!Path::new(&path).exists(), "file must be shredded after the read");
     }
 
+    #[cfg(unix)]
     #[test]
     fn oversized_regular_enrollment_is_rejected_and_deleted() {
         let path = fixture(&enrollment(), 0o600, "oversized");


### PR DESCRIPTION
Managed enrollment loading now applies the relay's 4 MiB frame limit plus one-byte overflow detection. Oversized regular 0600 files are rejected after the existing shred-and-unlink cleanup.

Regression coverage uses a valid enrollment padded beyond the cap, which would previously parse successfully.

Checks: git diff --check; rustfmt check reports pre-existing formatting differences in this file. Cargo and Xcode tests were not run per task scope.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11588"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790924598&installation_model_id=21920&pr_number=11588&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11588&signature=ac98589739382c3e47edc5a4acbfede35360bfbd0ae7c3caa9e4d4c3b40c4dc6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Managed enrollment files are now read with a 4 MiB bound, so oversized enrollments are rejected instead of being parsed. The existing shred-and-unlink cleanup still runs for rejected files.

- Reads one byte past the limit so exact-limit files stay valid and overflow is detected.
- Caps the cleanup overwrite to avoid unbounded I/O on large sparse files.
- Adds regression coverage for an oversized regular 0600 enrollment.

<sup>Written for commit d8db146f7797da280eae94b0c3a862de764b3bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11588?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Managed enrollment files are now limited to 4 MiB.
  - Oversized or invalid enrollment files are rejected and securely shredded.
  - Enrollment reading now handles interrupted read operations more reliably.
  - Files exceeding the size limit are no longer processed, helping prevent invalid enrollment attempts and preserving expected enrollment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->