### PR TITLE
fix(remote): retain closed-stream tombstones per lane

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -15,9 +15,8 @@ use crate::daemon::{DaemonError, ServerConnection};
 use crate::session::ReceivedFrame;
 
 const MAX_OPEN_STREAMS: usize = 256;
-// Covers the default aggregate replay window (4,096 frames on each of four
-// lanes), so a resumed slow lane cannot outlive the closed-stream memory.
-const MAX_CLOSED_STREAM_TOMBSTONES: usize = 16 * 1024;
+const REPLAY_FRAMES_PER_LANE: usize = 4_096;
+const DELIVERY_FRAMES_PER_LANE: usize = 64;
 const MAX_BUFFERED_STREAM_BYTES: usize = 32 * 1024 * 1024;
 const MAX_BUFFERED_NON_INTERACTIVE_BYTES: usize = 28 * 1024 * 1024;
 const MAX_BUFFERED_BULK_TUNNEL_BYTES: usize = 24 * 1024 * 1024;
@@ -131,21 +130,67 @@ pub struct ServiceMultiplexer {
     cleanup: Arc<TerminalCleanup>,
 }
 
-#[derive(Default)]
 struct ClosedStreams {
     ids: HashSet<u64>,
-    order: VecDeque<u64>,
+    lanes: HashMap<u64, u8>,
+    order: [VecDeque<u64>; 4],
+}
+
+impl Default for ClosedStreams {
+    fn default() -> Self {
+        Self {
+            ids: HashSet::new(),
+            lanes: HashMap::new(),
+            order: std::array::from_fn(|_| VecDeque::new()),
+        }
+    }
 }
 
 impl ClosedStreams {
     fn insert(&mut self, stream: u64) -> bool {
-        if !self.ids.insert(stream) {
+        self.insert_on(
+            stream,
+            LANE_INTERACTIVE_BIT | LANE_CONTROL_BIT | LANE_BULK_BIT | LANE_TUNNEL_BIT,
+        )
+    }
+
+    fn insert_on(&mut self, stream: u64, lane_mask: u8) -> bool {
+        if lane_mask == 0 {
             return false;
         }
-        self.order.push_back(stream);
-        while self.order.len() > MAX_CLOSED_STREAM_TOMBSTONES {
-            if let Some(expired) = self.order.pop_front() {
-                self.ids.remove(&expired);
+        let previous = match self.lanes.get(&stream) {
+            Some(previous) => *previous,
+            None => {
+                self.ids.insert(stream);
+                0
+            }
+        };
+        let new_lanes = lane_mask & !previous;
+        if new_lanes == 0 {
+            return false;
+        }
+        self.lanes.insert(stream, previous | new_lanes);
+        for lane in Lane::ALL {
+            let bit = lane_bit(lane);
+            if new_lanes & bit == 0 {
+                continue;
+            }
+            let queue = &mut self.order[lane as usize];
+            queue.push_back(stream);
+            let limit = if lane.replays_across_generations() {
+                REPLAY_FRAMES_PER_LANE
+            } else {
+                DELIVERY_FRAMES_PER_LANE
+            };
+            while queue.len() > limit {
+                let Some(expired) = queue.pop_front() else { break };
+                if let Some(mask) = self.lanes.get_mut(&expired) {
+                    *mask &= !bit;
+                    if *mask == 0 {
+                        self.lanes.remove(&expired);
+                        self.ids.remove(&expired);
+                    }
+                }
             }
         }
         true
@@ -2610,26 +2655,26 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delayed_frame_for_evicted_tombstone_is_fatal() {
+    async fn delayed_frame_survives_cross_lane_tombstone_churn() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
-        let stream = client.open(Service::WorkspaceRpc, BTreeMap::new()).await.unwrap();
+        let stream = client.open(Service::ProcessStream, BTreeMap::new()).await.unwrap();
         let stream_id = stream.id();
         stream.close().await.unwrap();
 
-        // Model a stalled lane whose frame is delayed while other lanes churn
-        // through the global ID-counted tombstone window.
+        // Model a stalled lane whose frame is delayed while another lane churns
+        // through its bounded tombstone window.
         let mut closed = client.closed.lock().await;
-        for id in 100_000..100_000 + MAX_CLOSED_STREAM_TOMBSTONES as u64 {
-            closed.insert(id * 2 + 1);
+        for id in 100_000..100_000 + REPLAY_FRAMES_PER_LANE as u64 {
+            closed.insert_on(id * 2 + 1, LANE_CONTROL_BIT);
         }
-        assert!(!closed.ids.contains(&stream_id));
+        assert!(closed.ids.contains(&stream_id));
         drop(closed);
 
         daemon_endpoint
             .send_frame(
                 None,
-                Lane::Control,
+                Lane::Interactive,
                 stream_id,
                 Bytes::from_static(b"delayed"),
                 FrameFlags::empty(),
@@ -2638,10 +2683,8 @@ mod tests {
             .unwrap();
 
         let mut fatal = client.subscribe_fatal();
-        tokio::time::timeout(Duration::from_secs(1), fatal.changed()).await.unwrap().unwrap();
-        assert!(
-            fatal.borrow().as_deref().is_some_and(|message| message.contains("unknown stream"))
-        );
+        assert!(tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.is_err());
+        assert!(fatal.borrow().is_none());
         client.shutdown().await;
     }
 

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -147,13 +147,6 @@ impl Default for ClosedStreams {
 }
 
 impl ClosedStreams {
-    fn insert(&mut self, stream: u64) -> bool {
-        self.insert_on(
-            stream,
-            LANE_INTERACTIVE_BIT | LANE_CONTROL_BIT | LANE_BULK_BIT | LANE_TUNNEL_BIT,
-        )
-    }
-
     fn insert_on(&mut self, stream: u64, lane_mask: u8) -> bool {
         if lane_mask == 0 {
             return false;

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2744,6 +2744,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropped_stream_tombstone_covers_its_default_lane() {
+        let (client_endpoint, daemon_endpoint) = endpoint_pair();
+        let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
+        let stream = client.open(Service::ProcessStream, BTreeMap::new()).await.unwrap();
+        let stream_id = stream.id();
+        drop(stream);
+        tokio::task::yield_now().await;
+
+        let mut fatal = client.subscribe_fatal();
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Interactive,
+                stream_id,
+                Bytes::from_static(b"late drop"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
+
+        assert!(tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.is_err());
+        assert!(fatal.borrow().is_none());
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn mux_payload_after_a_lane_fin_resets_before_the_aggregate_fin() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2610,6 +2610,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delayed_frame_for_evicted_tombstone_is_fatal() {
+        let (client_endpoint, daemon_endpoint) = endpoint_pair();
+        let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
+        let stream = client.open(Service::WorkspaceRpc, BTreeMap::new()).await.unwrap();
+        let stream_id = stream.id();
+        stream.close().await.unwrap();
+
+        // Model a stalled lane whose frame is delayed while other lanes churn
+        // through the global ID-counted tombstone window.
+        let mut closed = client.closed.lock().await;
+        for id in 100_000..100_000 + MAX_CLOSED_STREAM_TOMBSTONES as u64 {
+            closed.insert(id * 2 + 1);
+        }
+        assert!(!closed.ids.contains(&stream_id));
+        drop(closed);
+
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Control,
+                stream_id,
+                Bytes::from_static(b"delayed"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
+
+        let mut fatal = client.subscribe_fatal();
+        tokio::time::timeout(Duration::from_secs(1), fatal.changed()).await.unwrap().unwrap();
+        assert!(
+            fatal.borrow().as_deref().is_some_and(|message| message.contains("unknown stream"))
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn mux_payload_after_a_lane_fin_resets_before_the_aggregate_fin() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -147,6 +147,10 @@ impl Default for ClosedStreams {
 }
 
 impl ClosedStreams {
+    fn contains_on(&self, stream: u64, lane: Lane) -> bool {
+        self.lanes.get(&stream).is_some_and(|lane_mask| lane_mask & lane_bit(lane) != 0)
+    }
+
     fn insert_on(&mut self, stream: u64, lane_mask: u8) -> bool {
         if lane_mask == 0 {
             return false;
@@ -1097,7 +1101,7 @@ async fn reader_loop(reader: ReaderLoop) {
             if frame.flags.contains(FrameFlags::RESET) || frame.flags.contains(FrameFlags::FIN) {
                 continue;
             }
-            if closed.lock().await.ids.contains(&frame.stream) {
+            if closed.lock().await.contains_on(frame.stream, frame.lane) {
                 continue;
             }
             if frame.lane == Lane::Tunnel && frame.generation != *generation.borrow() {

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -593,7 +593,10 @@ impl PendingOpenGuard {
         }
         self.state.store(STREAM_LOCAL_FIN | STREAM_REMOTE_FIN | STREAM_RESET, Ordering::Release);
         self.failure.send_replace(Some(StreamFailure::Reset(reason.into())));
-        self.closed.lock().await.insert(self.id);
+        self.closed
+            .lock()
+            .await
+            .insert_on(self.id, tombstone_lane_mask(self.service, open_lane(self.service)));
         self.registrations.lock().await.remove(&self.id);
         self.cleanup.spawn(
             self.endpoint.clone(),
@@ -620,10 +623,11 @@ impl Drop for PendingOpenGuard {
         let cleanup = self.cleanup.clone();
         let generation = self.generation;
         let lane = open_lane(self.service);
+        let service = self.service;
         let id = self.id;
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                closed.lock().await.insert(id);
+                closed.lock().await.insert_on(id, tombstone_lane_mask(service, lane));
                 registrations.lock().await.remove(&id);
                 cleanup.spawn(endpoint, generation, lane, id, None);
             });
@@ -817,7 +821,8 @@ impl ServiceStream {
         };
         let previous = self.state.fetch_or(committed, Ordering::AcqRel);
         if self.service != Service::TcpTunnel || previous & STREAM_REMOTE_FIN != 0 {
-            self.closed.lock().await.insert(self.id);
+            let lane_mask = lanes.iter().fold(0, |mask, lane| mask | lane_bit(*lane));
+            self.closed.lock().await.insert_on(self.id, lane_mask);
             self.registrations.lock().await.remove(&self.id);
         }
         Ok(())
@@ -889,7 +894,7 @@ impl Drop for ServiceStream {
         let service = self.service;
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                closed.lock().await.insert(id);
+                closed.lock().await.insert_on(id, tombstone_lane_mask(service, lane));
                 registrations.lock().await.remove(&id);
                 if !complete {
                     cleanup.spawn(endpoint, generation, lane, id, Some((state, service)));
@@ -1004,7 +1009,10 @@ async fn reader_loop(reader: ReaderLoop) {
             let mut table = streams.lock().await;
             if table.len() >= MAX_OPEN_STREAMS {
                 drop(table);
-                closed.lock().await.insert(frame.stream);
+                closed
+                    .lock()
+                    .await
+                    .insert_on(frame.stream, tombstone_lane_mask(control.0, frame.lane));
                 cleanup.spawn(
                     endpoint.clone(),
                     stream_generation,
@@ -1059,7 +1067,10 @@ async fn reader_loop(reader: ReaderLoop) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Closed(_)) => break,
                 Err(mpsc::error::TrySendError::Full(incoming)) => {
-                    closed.lock().await.insert(frame.stream);
+                    closed
+                        .lock()
+                        .await
+                        .insert_on(frame.stream, tombstone_lane_mask(control.0, frame.lane));
                     if let Some(registration) = streams.lock().await.remove(&frame.stream) {
                         fail_registration(
                             registration,
@@ -1113,6 +1124,7 @@ async fn reader_loop(reader: ReaderLoop) {
                 &streams,
                 &closed,
                 frame.stream,
+                frame.lane,
                 "mux-control frame used the tunnel lane",
             )
             .await;
@@ -1131,6 +1143,7 @@ async fn reader_loop(reader: ReaderLoop) {
                 &streams,
                 &closed,
                 frame.stream,
+                frame.lane,
                 "peer sent a frame after FIN on the same lane",
             )
             .await;
@@ -1143,6 +1156,7 @@ async fn reader_loop(reader: ReaderLoop) {
                 &streams,
                 &closed,
                 frame.stream,
+                frame.lane,
                 "remote peer reset the stream",
             )
             .await;
@@ -1164,6 +1178,7 @@ async fn reader_loop(reader: ReaderLoop) {
                 &streams,
                 &closed,
                 frame.stream,
+                frame.lane,
                 "incoming frame length exceeded the stream budget representation",
             )
             .await;
@@ -1176,6 +1191,7 @@ async fn reader_loop(reader: ReaderLoop) {
                     &streams,
                     &closed,
                     frame.stream,
+                    frame.lane,
                     "incoming stream byte budget was exhausted",
                 )
                 .await;
@@ -1204,18 +1220,25 @@ async fn reader_loop(reader: ReaderLoop) {
                     || prior_state & STREAM_LOCAL_FIN != 0 =>
             {
                 streams.lock().await.remove(&frame.stream);
-                closed.lock().await.insert(frame.stream);
+                closed
+                    .lock()
+                    .await
+                    .insert_on(frame.stream, tombstone_lane_mask(service, frame.lane));
             }
             Ok(()) => {}
             Err(mpsc::error::TrySendError::Closed(_)) => {
                 streams.lock().await.remove(&frame.stream);
-                closed.lock().await.insert(frame.stream);
+                closed
+                    .lock()
+                    .await
+                    .insert_on(frame.stream, tombstone_lane_mask(service, frame.lane));
             }
             Err(mpsc::error::TrySendError::Full(_)) => {
                 reset_registered_stream(
                     &streams,
                     &closed,
                     frame.stream,
+                    frame.lane,
                     "incoming stream delivery queue was full",
                 )
                 .await;
@@ -1233,10 +1256,15 @@ async fn reset_registered_stream(
     streams: &Mutex<HashMap<u64, StreamRegistration>>,
     closed: &Mutex<ClosedStreams>,
     stream: u64,
+    lane: Lane,
     reason: &str,
 ) -> bool {
     let registration = streams.lock().await.remove(&stream);
-    closed.lock().await.insert(stream);
+    let lane_mask = registration
+        .as_ref()
+        .map(|registration| tombstone_lane_mask(registration.service, lane))
+        .unwrap_or_else(|| lane_bit(lane));
+    closed.lock().await.insert_on(stream, lane_mask);
     if let Some(registration) = registration {
         fail_registration(registration, StreamFailure::Reset(reason.into()));
         true
@@ -1424,6 +1452,10 @@ fn lane_bit(lane: Lane) -> u8 {
         Lane::Bulk => LANE_BULK_BIT,
         Lane::Tunnel => LANE_TUNNEL_BIT,
     }
+}
+
+fn tombstone_lane_mask(service: Service, lane: Lane) -> u8 {
+    if service == Service::MuxControl { MULTI_LANE_TERMINAL_MASK } else { lane_bit(lane) }
 }
 
 fn open_lane(service: Service) -> Lane {

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -590,10 +590,7 @@ impl PendingOpenGuard {
         }
         self.state.store(STREAM_LOCAL_FIN | STREAM_REMOTE_FIN | STREAM_RESET, Ordering::Release);
         self.failure.send_replace(Some(StreamFailure::Reset(reason.into())));
-        self.closed
-            .lock()
-            .await
-            .insert_on(self.id, tombstone_lane_mask(self.service, default_lane(self.service)));
+        self.closed.lock().await.insert_on(self.id, legal_tombstone_lane_mask(self.service));
         self.registrations.lock().await.remove(&self.id);
         self.cleanup.spawn(
             self.endpoint.clone(),
@@ -624,10 +621,7 @@ impl Drop for PendingOpenGuard {
         let id = self.id;
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                closed
-                    .lock()
-                    .await
-                    .insert_on(id, tombstone_lane_mask(service, default_lane(service)));
+                closed.lock().await.insert_on(id, legal_tombstone_lane_mask(service));
                 registrations.lock().await.remove(&id);
                 cleanup.spawn(endpoint, generation, lane, id, None);
             });
@@ -894,10 +888,7 @@ impl Drop for ServiceStream {
         let service = self.service;
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                closed
-                    .lock()
-                    .await
-                    .insert_on(id, tombstone_lane_mask(service, default_lane(service)));
+                closed.lock().await.insert_on(id, legal_tombstone_lane_mask(service));
                 registrations.lock().await.remove(&id);
                 if !complete {
                     cleanup.spawn(endpoint, generation, lane, id, Some((state, service)));
@@ -1459,6 +1450,10 @@ fn lane_bit(lane: Lane) -> u8 {
 
 fn tombstone_lane_mask(service: Service, lane: Lane) -> u8 {
     if service == Service::MuxControl { MULTI_LANE_TERMINAL_MASK } else { lane_bit(lane) }
+}
+
+fn legal_tombstone_lane_mask(service: Service) -> u8 {
+    if service == Service::TcpTunnel { lane_bit(Lane::Tunnel) } else { MULTI_LANE_TERMINAL_MASK }
 }
 
 fn open_lane(service: Service) -> Lane {

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -593,7 +593,7 @@ impl PendingOpenGuard {
         self.closed
             .lock()
             .await
-            .insert_on(self.id, tombstone_lane_mask(self.service, open_lane(self.service)));
+            .insert_on(self.id, tombstone_lane_mask(self.service, default_lane(self.service)));
         self.registrations.lock().await.remove(&self.id);
         self.cleanup.spawn(
             self.endpoint.clone(),
@@ -624,7 +624,10 @@ impl Drop for PendingOpenGuard {
         let id = self.id;
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                closed.lock().await.insert_on(id, tombstone_lane_mask(service, lane));
+                closed
+                    .lock()
+                    .await
+                    .insert_on(id, tombstone_lane_mask(service, default_lane(service)));
                 registrations.lock().await.remove(&id);
                 cleanup.spawn(endpoint, generation, lane, id, None);
             });
@@ -891,7 +894,10 @@ impl Drop for ServiceStream {
         let service = self.service;
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                closed.lock().await.insert_on(id, tombstone_lane_mask(service, lane));
+                closed
+                    .lock()
+                    .await
+                    .insert_on(id, tombstone_lane_mask(service, default_lane(service)));
                 registrations.lock().await.remove(&id);
                 if !complete {
                     cleanup.spawn(endpoint, generation, lane, id, Some((state, service)));

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2776,6 +2776,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn dropped_stream_tombstone_covers_non_default_legal_lane() {
+        let (client_endpoint, daemon_endpoint) = endpoint_pair();
+        let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
+        let stream = client.open(Service::WorkspaceRpc, BTreeMap::new()).await.unwrap();
+        let stream_id = stream.id();
+        drop(stream);
+        tokio::task::yield_now().await;
+
+        let mut fatal = client.subscribe_fatal();
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Bulk,
+                stream_id,
+                Bytes::from_static(b"late bulk drop"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
+
+        assert!(tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.is_err());
+        assert!(fatal.borrow().is_none());
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn mux_payload_after_a_lane_fin_resets_before_the_aggregate_fin() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2714,6 +2714,32 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn unknown_stream_tombstone_is_lane_specific() {
+        let (client_endpoint, daemon_endpoint) = endpoint_pair();
+        let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
+        let stream_id = 77;
+        client.closed.lock().await.insert_on(stream_id, LANE_INTERACTIVE_BIT);
+
+        let mut fatal = client.subscribe_fatal();
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Control,
+                stream_id,
+                Bytes::from_static(b"wrong lane"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
+
+        tokio::time::timeout(Duration::from_secs(1), fatal.changed()).await.unwrap().unwrap();
+        assert!(
+            fatal.borrow().as_deref().is_some_and(|message| message.contains("unknown stream"))
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn mux_payload_after_a_lane_fin_resets_before_the_aggregate_fin() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2841,6 +2841,16 @@ mod tests {
             )
             .await
             .unwrap();
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Interactive,
+                stream_id,
+                Bytes::from_static(b"late reset data"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
         assert!(tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.is_err());
         assert!(fatal.borrow().is_none());
         client.shutdown().await;
@@ -2853,7 +2863,7 @@ mod tests {
         reset_registered_stream(&streams, &closed, 1, Lane::Control, "queue full").await;
         let closed = closed.lock().await;
         assert!(closed.contains_on(1, Lane::Control));
-        assert!(!closed.contains_on(1, Lane::Interactive));
+        assert!(closed.contains_on(1, Lane::Interactive));
         assert!(!closed.contains_on(1, Lane::Bulk));
     }
 

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2877,6 +2877,16 @@ mod tests {
             )
             .await
             .unwrap();
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Interactive,
+                stream_id,
+                Bytes::from_static(b"late open-limit data"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
         assert!(tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.is_err());
         assert!(fatal.borrow().is_none());
         client.shutdown().await;

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2803,7 +2803,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reset_tombstone_covers_all_legal_lanes() {
+    async fn reset_tombstone_is_lane_specific() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
         let stream = client.open(Service::ProcessStream, BTreeMap::new()).await.unwrap();
@@ -2821,7 +2821,7 @@ mod tests {
         daemon_endpoint
             .send_frame(
                 None,
-                Lane::Interactive,
+                Lane::Control,
                 stream_id,
                 Bytes::from_static(b"late reset"),
                 FrameFlags::empty(),
@@ -2834,17 +2834,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn queue_full_tombstone_covers_all_legal_lanes() {
+    async fn queue_full_tombstone_is_lane_specific() {
         let streams = Mutex::new(HashMap::from([(1, test_registration(Service::ProcessStream))]));
         let closed = Mutex::new(ClosedStreams::default());
         reset_registered_stream(&streams, &closed, 1, Lane::Control, "queue full").await;
         let closed = closed.lock().await;
-        assert!(closed.contains_on(1, Lane::Interactive));
-        assert!(closed.contains_on(1, Lane::Bulk));
+        assert!(closed.contains_on(1, Lane::Control));
+        assert!(!closed.contains_on(1, Lane::Interactive));
+        assert!(!closed.contains_on(1, Lane::Bulk));
     }
 
     #[tokio::test]
-    async fn open_limit_tombstone_covers_all_legal_lanes() {
+    async fn open_limit_tombstone_is_lane_specific() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
         {
@@ -2869,7 +2870,7 @@ mod tests {
         daemon_endpoint
             .send_frame(
                 None,
-                Lane::Interactive,
+                Lane::Control,
                 stream_id,
                 Bytes::from_static(b"late open-limit"),
                 FrameFlags::empty(),
@@ -2908,7 +2909,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn dropped_stream_tombstone_covers_non_default_legal_lane() {
+    async fn dropped_stream_tombstone_is_lane_specific() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
         let stream = client.open(Service::WorkspaceRpc, BTreeMap::new()).await.unwrap();
@@ -2920,9 +2921,9 @@ mod tests {
         daemon_endpoint
             .send_frame(
                 None,
-                Lane::Bulk,
+                Lane::Control,
                 stream_id,
-                Bytes::from_static(b"late bulk drop"),
+                Bytes::from_static(b"late control drop"),
                 FrameFlags::empty(),
             )
             .await

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2072,7 +2072,7 @@ mod tests {
         let multiplexer = ServiceMultiplexer::new(endpoint.clone(), EndpointRole::Client);
         let open = tokio::spawn({
             let multiplexer = multiplexer.clone();
-            async move { multiplexer.open(Service::MuxControl, BTreeMap::new()).await }
+            async move { multiplexer.open(Service::ProcessStream, BTreeMap::new()).await }
         });
         endpoint.wait_for(&endpoint.open_active, true).await;
 
@@ -2095,6 +2095,9 @@ mod tests {
         })
         .await
         .unwrap();
+        let closed = multiplexer.closed.lock().await;
+        assert!(closed.contains_on(1, Lane::Control));
+        assert!(closed.contains_on(1, Lane::Interactive));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2744,6 +2744,98 @@ mod tests {
         client.shutdown().await;
     }
 
+    fn test_registration(service: Service) -> StreamRegistration {
+        let (chunks, _receiver) = mpsc::channel(1);
+        let (failure, _failure_changed) = watch::channel(None);
+        StreamRegistration {
+            service,
+            generation: generation_for_service(service, 0),
+            chunks,
+            failure,
+            state: Arc::new(AtomicU8::new(0)),
+            terminal: LaneTerminalState::new(service),
+        }
+    }
+
+    #[tokio::test]
+    async fn reset_tombstone_covers_all_legal_lanes() {
+        let (client_endpoint, daemon_endpoint) = endpoint_pair();
+        let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
+        let stream = client.open(Service::ProcessStream, BTreeMap::new()).await.unwrap();
+        let stream_id = stream.id();
+        let _peer = daemon_endpoint.receive_frame().await.unwrap().expect("open frame");
+        daemon_endpoint
+            .send_frame(None, Lane::Control, stream_id, Bytes::new(), FrameFlags::RESET)
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_secs(1), stream.wait_for_failure())
+            .await
+            .expect("reset was not delivered");
+
+        let mut fatal = client.subscribe_fatal();
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Interactive,
+                stream_id,
+                Bytes::from_static(b"late reset"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
+        assert!(tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.is_err());
+        assert!(fatal.borrow().is_none());
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
+    async fn queue_full_tombstone_covers_all_legal_lanes() {
+        let streams = Mutex::new(HashMap::from([(1, test_registration(Service::ProcessStream))]));
+        let closed = Mutex::new(ClosedStreams::default());
+        reset_registered_stream(&streams, &closed, 1, Lane::Control, "queue full").await;
+        let closed = closed.lock().await;
+        assert!(closed.contains_on(1, Lane::Interactive));
+        assert!(closed.contains_on(1, Lane::Bulk));
+    }
+
+    #[tokio::test]
+    async fn open_limit_tombstone_covers_all_legal_lanes() {
+        let (client_endpoint, daemon_endpoint) = endpoint_pair();
+        let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
+        {
+            let mut streams = client.streams.lock().await;
+            for id in 1..=MAX_OPEN_STREAMS as u64 {
+                streams.insert(id * 2, test_registration(Service::ProcessStream));
+            }
+        }
+        let stream_id = 2 * (MAX_OPEN_STREAMS as u64 + 1);
+        let payload = serde_json::to_vec(&ServiceControl::Open {
+            service: Service::ProcessStream,
+            metadata: BTreeMap::new(),
+        })
+        .unwrap();
+        daemon_endpoint
+            .send_frame(None, Lane::Control, stream_id, Bytes::from(payload), FrameFlags::OPEN)
+            .await
+            .unwrap();
+        tokio::task::yield_now().await;
+
+        let mut fatal = client.subscribe_fatal();
+        daemon_endpoint
+            .send_frame(
+                None,
+                Lane::Interactive,
+                stream_id,
+                Bytes::from_static(b"late open-limit"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
+        assert!(tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.is_err());
+        assert!(fatal.borrow().is_none());
+        client.shutdown().await;
+    }
+
     #[tokio::test]
     async fn dropped_stream_tombstone_covers_its_default_lane() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -1260,7 +1260,7 @@ async fn reset_registered_stream(
     let registration = streams.lock().await.remove(&stream);
     let lane_mask = registration
         .as_ref()
-        .map(|registration| tombstone_lane_mask(registration.service, lane))
+        .map(|registration| rejected_open_tombstone_lane_mask(registration.service, lane))
         .unwrap_or_else(|| lane_bit(lane));
     closed.lock().await.insert_on(stream, lane_mask);
     if let Some(registration) = registration {

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -1447,7 +1447,7 @@ fn lane_bit(lane: Lane) -> u8 {
 }
 
 fn tombstone_lane_mask(service: Service, lane: Lane) -> u8 {
-    if service == Service::TcpTunnel { lane_bit(lane) } else { MULTI_LANE_TERMINAL_MASK }
+    if service == Service::MuxControl { MULTI_LANE_TERMINAL_MASK } else { lane_bit(lane) }
 }
 
 fn legal_tombstone_lane_mask(service: Service) -> u8 {

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2719,6 +2719,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn delayed_tunnel_frame_survives_delivery_tombstone_churn() {
+        let (client_endpoint, daemon_endpoint) = endpoint_pair();
+        let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
+        let daemon = ServiceMultiplexer::new(daemon_endpoint.clone(), EndpointRole::Daemon);
+        let client_stream = client.open(Service::TcpTunnel, BTreeMap::new()).await.unwrap();
+        let stream_id = client_stream.id();
+        let daemon_stream = daemon.accept().await.unwrap().unwrap().stream;
+
+        client_stream.close().await.unwrap();
+        assert!(daemon_stream.receive().await.unwrap().unwrap().finished);
+        daemon_stream.close().await.unwrap();
+        assert!(client_stream.receive().await.unwrap().unwrap().finished);
+        assert!(client_stream.receive().await.unwrap().is_none());
+
+        let mut closed = client.closed.lock().await;
+        for id in 100_000..100_000 + DELIVERY_FRAMES_PER_LANE as u64 + 1 {
+            closed.insert_on(id * 2 + 1, LANE_TUNNEL_BIT);
+        }
+        assert!(!closed.contains_on(stream_id, Lane::Tunnel));
+        drop(closed);
+
+        let mut fatal = client.subscribe_fatal();
+        daemon_endpoint
+            .send_frame(
+                Some(0),
+                Lane::Tunnel,
+                stream_id,
+                Bytes::from_static(b"delayed tunnel"),
+                FrameFlags::empty(),
+            )
+            .await
+            .unwrap();
+        tokio::time::timeout(Duration::from_millis(25), fatal.changed()).await.unwrap().unwrap();
+        assert!(
+            fatal.borrow().as_deref().is_some_and(|message| message.contains("unknown stream"))
+        );
+        client.shutdown().await;
+    }
+
+    #[tokio::test]
     async fn unknown_stream_tombstone_is_lane_specific() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -17,6 +17,10 @@ use crate::session::ReceivedFrame;
 const MAX_OPEN_STREAMS: usize = 256;
 const REPLAY_FRAMES_PER_LANE: usize = 4_096;
 const DELIVERY_FRAMES_PER_LANE: usize = 64;
+// Tombstones track stream IDs, not queued frames. Keep one ID per replay
+// budget on every lane, including generation-scoped Tunnel, preserving the
+// protocol's bounded aggregate replay window while allowing delayed frames.
+const TOMBSTONES_PER_LANE: usize = REPLAY_FRAMES_PER_LANE;
 const MAX_BUFFERED_STREAM_BYTES: usize = 32 * 1024 * 1024;
 const MAX_BUFFERED_NON_INTERACTIVE_BYTES: usize = 28 * 1024 * 1024;
 const MAX_BUFFERED_BULK_TUNNEL_BYTES: usize = 24 * 1024 * 1024;
@@ -174,12 +178,7 @@ impl ClosedStreams {
             }
             let queue = &mut self.order[lane as usize];
             queue.push_back(stream);
-            let limit = if lane.replays_across_generations() {
-                REPLAY_FRAMES_PER_LANE
-            } else {
-                DELIVERY_FRAMES_PER_LANE
-            };
-            while queue.len() > limit {
+            while queue.len() > TOMBSTONES_PER_LANE {
                 let Some(expired) = queue.pop_front() else { break };
                 if let Some(mask) = self.lanes.get_mut(&expired) {
                     *mask &= !bit;

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -1449,11 +1449,11 @@ fn lane_bit(lane: Lane) -> u8 {
 }
 
 fn tombstone_lane_mask(service: Service, lane: Lane) -> u8 {
-    if service == Service::MuxControl { MULTI_LANE_TERMINAL_MASK } else { lane_bit(lane) }
+    if service == Service::TcpTunnel { lane_bit(lane) } else { MULTI_LANE_TERMINAL_MASK }
 }
 
 fn legal_tombstone_lane_mask(service: Service) -> u8 {
-    if service == Service::TcpTunnel { lane_bit(Lane::Tunnel) } else { MULTI_LANE_TERMINAL_MASK }
+    tombstone_lane_mask(service, default_lane(service))
 }
 
 fn open_lane(service: Service) -> Lane {

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -2683,21 +2683,28 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delayed_frame_survives_cross_lane_tombstone_churn() {
+    async fn delayed_frame_survives_cross_lane_real_close_churn() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
-        let stream = client.open(Service::ProcessStream, BTreeMap::new()).await.unwrap();
-        let stream_id = stream.id();
-        stream.close().await.unwrap();
+        let daemon = ServiceMultiplexer::new(daemon_endpoint.clone(), EndpointRole::Daemon);
+        let client_stream = client.open(Service::ProcessStream, BTreeMap::new()).await.unwrap();
+        let stream_id = client_stream.id();
+        let daemon_stream = daemon.accept().await.unwrap().unwrap().stream;
+        daemon_stream.close().await.unwrap();
+        assert!(client_stream.receive().await.unwrap().unwrap().finished);
+        assert!(client_stream.receive().await.unwrap().is_none());
 
-        // Model a stalled lane whose frame is delayed while another lane churns
-        // through its bounded tombstone window.
-        let mut closed = client.closed.lock().await;
-        for id in 100_000..100_000 + REPLAY_FRAMES_PER_LANE as u64 {
-            closed.insert_on(id * 2 + 1, LANE_CONTROL_BIT);
+        // Churn real remote closes on Control while the Interactive tombstone
+        // waits for a delayed frame.
+        for _ in 0..TOMBSTONES_PER_LANE {
+            let churn_client = client.open(Service::WorkspaceRpc, BTreeMap::new()).await.unwrap();
+            let churn_daemon = daemon.accept().await.unwrap().unwrap().stream;
+            churn_daemon.close().await.unwrap();
+            assert!(churn_client.receive().await.unwrap().unwrap().finished);
+            assert!(churn_client.receive().await.unwrap().is_none());
         }
-        assert!(closed.ids.contains(&stream_id));
-        drop(closed);
+
+        assert!(client.closed.lock().await.contains_on(stream_id, Lane::Interactive));
 
         daemon_endpoint
             .send_frame(

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -588,7 +588,10 @@ impl PendingOpenGuard {
         }
         self.state.store(STREAM_LOCAL_FIN | STREAM_REMOTE_FIN | STREAM_RESET, Ordering::Release);
         self.failure.send_replace(Some(StreamFailure::Reset(reason.into())));
-        self.closed.lock().await.insert_on(self.id, legal_tombstone_lane_mask(self.service));
+        self.closed.lock().await.insert_on(
+            self.id,
+            rejected_open_tombstone_lane_mask(self.service, open_lane(self.service)),
+        );
         self.registrations.lock().await.remove(&self.id);
         self.cleanup.spawn(
             self.endpoint.clone(),
@@ -619,7 +622,10 @@ impl Drop for PendingOpenGuard {
         let id = self.id;
         if let Ok(runtime) = tokio::runtime::Handle::try_current() {
             runtime.spawn(async move {
-                closed.lock().await.insert_on(id, legal_tombstone_lane_mask(service));
+                closed
+                    .lock()
+                    .await
+                    .insert_on(id, rejected_open_tombstone_lane_mask(service, open_lane(service)));
                 registrations.lock().await.remove(&id);
                 cleanup.spawn(endpoint, generation, lane, id, None);
             });

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -1001,10 +1001,10 @@ async fn reader_loop(reader: ReaderLoop) {
             let mut table = streams.lock().await;
             if table.len() >= MAX_OPEN_STREAMS {
                 drop(table);
-                closed
-                    .lock()
-                    .await
-                    .insert_on(frame.stream, tombstone_lane_mask(control.0, frame.lane));
+                closed.lock().await.insert_on(
+                    frame.stream,
+                    rejected_open_tombstone_lane_mask(control.0, frame.lane),
+                );
                 cleanup.spawn(
                     endpoint.clone(),
                     stream_generation,
@@ -1059,10 +1059,10 @@ async fn reader_loop(reader: ReaderLoop) {
                 Ok(()) => {}
                 Err(mpsc::error::TrySendError::Closed(_)) => break,
                 Err(mpsc::error::TrySendError::Full(incoming)) => {
-                    closed
-                        .lock()
-                        .await
-                        .insert_on(frame.stream, tombstone_lane_mask(control.0, frame.lane));
+                    closed.lock().await.insert_on(
+                        frame.stream,
+                        rejected_open_tombstone_lane_mask(control.0, frame.lane),
+                    );
                     if let Some(registration) = streams.lock().await.remove(&frame.stream) {
                         fail_registration(
                             registration,
@@ -1452,6 +1452,10 @@ fn tombstone_lane_mask(service: Service, lane: Lane) -> u8 {
 
 fn legal_tombstone_lane_mask(service: Service) -> u8 {
     tombstone_lane_mask(service, default_lane(service))
+}
+
+fn rejected_open_tombstone_lane_mask(service: Service, open_lane: Lane) -> u8 {
+    tombstone_lane_mask(service, open_lane) | legal_tombstone_lane_mask(service)
 }
 
 fn open_lane(service: Service) -> Lane {

--- a/cmux-tui/crates/cmux-remote/src/service.rs
+++ b/cmux-tui/crates/cmux-remote/src/service.rs
@@ -16,7 +16,6 @@ use crate::session::ReceivedFrame;
 
 const MAX_OPEN_STREAMS: usize = 256;
 const REPLAY_FRAMES_PER_LANE: usize = 4_096;
-const DELIVERY_FRAMES_PER_LANE: usize = 64;
 // Tombstones track stream IDs, not queued frames. Keep one ID per replay
 // budget on every lane, including generation-scoped Tunnel, preserving the
 // protocol's bounded aggregate replay window while allowing delayed frames.
@@ -2718,7 +2717,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn delayed_tunnel_frame_survives_delivery_tombstone_churn() {
+    async fn delayed_tunnel_frame_survives_tombstone_churn() {
         let (client_endpoint, daemon_endpoint) = endpoint_pair();
         let client = ServiceMultiplexer::new(client_endpoint, EndpointRole::Client);
         let daemon = ServiceMultiplexer::new(daemon_endpoint.clone(), EndpointRole::Daemon);
@@ -2733,7 +2732,7 @@ mod tests {
         assert!(client_stream.receive().await.unwrap().is_none());
 
         let mut closed = client.closed.lock().await;
-        for id in 100_000..100_000 + DELIVERY_FRAMES_PER_LANE as u64 + 1 {
+        for id in 100_000..100_000 + TOMBSTONES_PER_LANE as u64 + 1 {
             closed.insert_on(id * 2 + 1, LANE_TUNNEL_BIT);
         }
         assert!(!closed.contains_on(stream_id, Lane::Tunnel));


### PR DESCRIPTION
## Summary

- reproduce cross-lane replay tombstone eviction with a deterministic service test
- retain closed-stream tombstones in bounded per-lane windows, so churn on one lane cannot evict a stalled lane tombstone
- match tombstone suppression to the incoming lane, while duplicate OPEN handling remains global
- retain default-lane tombstones for dropped streams

## Verification

- rustfmt --edition 2024 cmux-tui/crates/cmux-remote/src/service.rs
- git diff --check

Rust tests were not run locally because repository rules prohibit local Cargo builds. Test-first commits are 3de6a379e0, 0446922e1e, and c421aa687e; fixes follow each test commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved stream recovery and replay handling across multiple connection lanes.
  - Prevented delayed or stale frames from being incorrectly processed after a stream is reset, closed, rejected, or cleaned up.
  - Improved behavior when replay history exceeds its available window, reducing interference between connection lanes.
  - Enhanced cleanup reliability for control and tunneled connections.
  - Improved handling of delayed frames during replay-window changes and stream lifecycle transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->