### PR TITLE
cmux-tui: bound detached hook request ID reads

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -24,6 +24,7 @@ use cmux_tui_core::platform::transport;
 use serde_json::{Value, json};
 
 const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
+const MAX_REQUEST_ID_BYTES: usize = 128;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
@@ -207,10 +208,7 @@ fn detached_child_from_stdin() -> anyhow::Result<()> {
         .map(PathBuf::from)
         .context("CMUX_TUI_SOCKET is required in detached mode")?;
     let mut reader = BufReader::new(io::stdin().lock());
-    let mut request_id = String::new();
-    reader.read_line(&mut request_id).context("read detached request id")?;
-    let request_id = request_id.trim_end_matches(['\r', '\n']).to_owned();
-    anyhow::ensure!(!request_id.is_empty(), "detached request id is empty");
+    let request_id = read_detached_request_id(&mut reader)?;
     let mut encoded = Vec::new();
     reader
         .take(MAX_MESSAGE_BYTES as u64 + 1)
@@ -218,6 +216,35 @@ fn detached_child_from_stdin() -> anyhow::Result<()> {
         .context("read detached request")?;
     anyhow::ensure!(encoded.len() <= MAX_MESSAGE_BYTES, "detached request exceeds 4 MiB");
     append_with_receipt(&socket, &request_id, &encoded, &confirm_handoff_on_stdout)
+}
+
+/// Read the detached request id without allowing a missing delimiter to grow
+/// the destination string indefinitely. `read_line` otherwise keeps reading
+/// until a newline or EOF, so the `Take` limit is part of the framing contract.
+fn read_detached_request_id(reader: &mut impl BufRead) -> anyhow::Result<String> {
+    // Allow an optional carriage return before the required newline. The
+    // delimiter itself is not part of the request id byte limit.
+    let line_limit =
+        MAX_REQUEST_ID_BYTES.checked_add(2).expect("detached request id limit fits usize");
+    let mut line = String::new();
+    let bytes_read =
+        reader.take(line_limit as u64).read_line(&mut line).context("read detached request id")?;
+    if bytes_read == 0 {
+        bail!("detached request id is empty");
+    }
+    if !line.ends_with('\n') {
+        if bytes_read >= line_limit {
+            bail!("detached request id exceeds {MAX_REQUEST_ID_BYTES} bytes");
+        }
+        bail!("detached request id is missing newline delimiter");
+    }
+    let request_id = line.trim_end_matches(['\r', '\n']);
+    anyhow::ensure!(!request_id.is_empty(), "detached request id is empty");
+    anyhow::ensure!(
+        request_id.len() <= MAX_REQUEST_ID_BYTES,
+        "detached request id exceeds {MAX_REQUEST_ID_BYTES} bytes"
+    );
+    Ok(request_id.to_owned())
 }
 
 fn shadowed_by_grok(source: &str, grok_hook_event: Option<&std::ffi::OsStr>) -> bool {
@@ -806,6 +833,43 @@ mod tests {
     fn invalid_utf8_is_retained_as_base64() {
         let native = read_native_payload(&[0xff, 0x00][..]).unwrap();
         assert_eq!(native, json!({"encoding":"base64","data":"/wA="}));
+    }
+
+    #[test]
+    fn bounded_detached_request_id_preserves_uuid_and_payload() {
+        use std::io::Cursor;
+
+        let request_id = "550e8400-e29b-41d4-a716-446655440000";
+        let mut reader =
+            BufReader::new(Cursor::new(format!("{request_id}\n{{\"event\":\"Stop\"}}")));
+        assert_eq!(read_detached_request_id(&mut reader).unwrap(), request_id);
+
+        let mut payload = Vec::new();
+        reader.read_to_end(&mut payload).unwrap();
+        assert_eq!(payload, br#"{"event":"Stop"}"#);
+    }
+
+    #[test]
+    fn bounded_detached_request_id_rejects_an_unterminated_line() {
+        use std::io::Cursor;
+
+        let mut reader = BufReader::new(Cursor::new(b"550e8400-e29b-41d4-a716-446655440000"));
+        let error = read_detached_request_id(&mut reader).unwrap_err();
+        assert_eq!(error.to_string(), "detached request id is missing newline delimiter");
+    }
+
+    #[test]
+    fn bounded_detached_request_id_rejects_an_oversized_line() {
+        use std::io::Cursor;
+
+        let mut input = vec![b'x'; MAX_REQUEST_ID_BYTES + 1];
+        input.push(b'\n');
+        let mut reader = BufReader::new(Cursor::new(input));
+        let error = read_detached_request_id(&mut reader).unwrap_err();
+        assert_eq!(
+            error.to_string(),
+            format!("detached request id exceeds {MAX_REQUEST_ID_BYTES} bytes")
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -850,6 +850,21 @@ mod tests {
     }
 
     #[test]
+    fn bounded_detached_request_id_accepts_maximum_length_with_crlf() {
+        use std::io::Cursor;
+
+        let request_id = "x".repeat(MAX_REQUEST_ID_BYTES);
+        let mut input = request_id.as_bytes().to_vec();
+        input.extend_from_slice(b"\r\n{}");
+        let mut reader = BufReader::new(Cursor::new(input));
+        assert_eq!(read_detached_request_id(&mut reader).unwrap(), request_id);
+
+        let mut payload = Vec::new();
+        reader.read_to_end(&mut payload).unwrap();
+        assert_eq!(payload, b"{}");
+    }
+
+    #[test]
     fn bounded_detached_request_id_rejects_an_unterminated_line() {
         use std::io::Cursor;
 

--- a/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
+++ b/cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs
@@ -118,3 +118,22 @@ fn detached_hook_without_a_listener_fails_immediately() {
     assert!(!output.status.success(), "{output:?}");
     assert!(started.elapsed() < Duration::from_secs(2));
 }
+
+#[test]
+fn detached_child_rejects_a_newline_free_request_id_before_reading_payload() {
+    let socket = socket_path("missing-id-delimiter");
+    let mut child = Command::new(env!("CARGO_BIN_EXE_cmux-tui-hook"))
+        .args(["__detached-append"])
+        .env("CMUX_TUI_SOCKET", &socket)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child.stdin.take().unwrap().write_all(b"550e8400-e29b-41d4-a716-446655440000{}").unwrap();
+    let output = child.wait_with_output().unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("detached request id is missing newline delimiter"), "{stderr}");
+}


### PR DESCRIPTION
## Summary
- add a regression test for a detached request ID without a newline delimiter
- bound detached request ID framing to 128 bytes plus CRLF
- preserve UUID IDs and leave the encoded payload aligned in the buffered reader

`BufRead::read_line` reads until newline or EOF and can grow its destination indefinitely. The bounded `Take` framing follows the Rust standard library guidance: <https://doc.rust-lang.org/stable/std/io/trait.BufRead.html#method.read_line>.

## Verification
- `rustfmt --check --edition 2021 cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs cmux-tui/crates/cmux-tui/tests/journal_hook_detach.rs`
- `git diff --check`
- Cargo and Xcode tests were not run, per task scope.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detached `cmux-tui` request ID reads now require a newline-delimited ID of at most 128 bytes instead of accepting unterminated or unbounded input, preventing unbounded memory growth when reading the ID.

- LF and CRLF are accepted without counting the delimiter toward the limit.
- Missing delimiters and oversized IDs fail before payload reading; valid IDs and the buffered payload stay aligned.
- Adds unit and integration coverage for missing delimiters, oversized IDs, maximum-length CRLF IDs, and payload handling.

<sup>Written for commit f12ea61eea05bf1c27622dd7d069ca8a6eed0c2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11591?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Detached request IDs now require a newline delimiter and must be within the maximum supported length.
  * Invalid, oversized, or improperly terminated request IDs are rejected before payload processing, providing safer and more predictable handling of detached operations.

* **Tests**
  * Added coverage for request ID length limits, bounded reading, and newline-delimiter validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->