### PR TITLE
fix(tui): bound detached request id input

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -26,6 +26,7 @@ use serde_json::{Value, json};
 const MAX_NATIVE_PAYLOAD_BYTES: u64 = 1024 * 1024;
 const MAX_MESSAGE_BYTES: usize = 4 * 1024 * 1024;
 const MAX_RESPONSE_BYTES: usize = 16 * 1024 * 1024;
+const MAX_REQUEST_ID_BYTES: usize = 128;
 const SOCKET_TIMEOUT: Duration = Duration::from_secs(4);
 /// Bound on the provider-facing wait for the child's "request written"
 /// signal. The child itself gives up at `SOCKET_TIMEOUT` and closes the pipe,
@@ -207,10 +208,7 @@ fn detached_child_from_stdin() -> anyhow::Result<()> {
         .map(PathBuf::from)
         .context("CMUX_TUI_SOCKET is required in detached mode")?;
     let mut reader = BufReader::new(io::stdin().lock());
-    let mut request_id = String::new();
-    reader.read_line(&mut request_id).context("read detached request id")?;
-    let request_id = request_id.trim_end_matches(['\r', '\n']).to_owned();
-    anyhow::ensure!(!request_id.is_empty(), "detached request id is empty");
+    let request_id = read_detached_request_id(&mut reader).context("read detached request id")?;
     let mut encoded = Vec::new();
     reader
         .take(MAX_MESSAGE_BYTES as u64 + 1)
@@ -218,6 +216,23 @@ fn detached_child_from_stdin() -> anyhow::Result<()> {
         .context("read detached request")?;
     anyhow::ensure!(encoded.len() <= MAX_MESSAGE_BYTES, "detached request exceeds 4 MiB");
     append_with_receipt(&socket, &request_id, &encoded, &confirm_handoff_on_stdout)
+}
+
+fn read_detached_request_id(reader: &mut impl BufRead) -> anyhow::Result<String> {
+    let mut request_id = String::new();
+    let bytes_read = reader
+        .take((MAX_REQUEST_ID_BYTES + 1) as u64)
+        .read_line(&mut request_id)
+        .context("read detached request id")?;
+    anyhow::ensure!(request_id.ends_with('\n'), "detached request id is missing its line delimiter");
+    anyhow::ensure!(
+        bytes_read <= MAX_REQUEST_ID_BYTES + 1
+            && request_id.trim_end_matches(['\r', '\n']).len() <= MAX_REQUEST_ID_BYTES,
+        "detached request id exceeds {MAX_REQUEST_ID_BYTES} bytes"
+    );
+    let request_id = request_id.trim_end_matches(['\r', '\n']).to_owned();
+    anyhow::ensure!(!request_id.is_empty(), "detached request id is empty");
+    Ok(request_id)
 }
 
 fn shadowed_by_grok(source: &str, grok_hook_event: Option<&std::ffi::OsStr>) -> bool {

--- a/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
+++ b/cmux-tui/crates/cmux-tui/src/bin/cmux-tui-hook.rs
@@ -832,4 +832,12 @@ mod tests {
 
         assert!(matches!(result, Err(AppendAttemptError::Fatal(_))));
     }
+
+    #[test]
+    fn detached_request_id_rejects_an_overlong_line() {
+        let input = format!("{}\n{{}}", "x".repeat(MAX_REQUEST_ID_BYTES + 1));
+        let mut reader = BufReader::new(input.as_bytes());
+        let error = read_detached_request_id(&mut reader).expect_err("oversized ID accepted");
+        assert!(error.to_string().contains("request id"));
+    }
 }


### PR DESCRIPTION
## Summary
- bound the hidden detached hook request-id line before reading
- reject missing delimiters and IDs over 128 bytes

## Regression commits
1. 1642ec8b1a adds the failing oversized-ID behavior test.
2. 2598eba39e adds the bounded reader fix.

## Verification
- No Cargo/Xcode tests run, per cmux-tui policy.
- git diff --check passed implicitly through clean commits.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounds the detached request ID read in the cmux-tui hook so oversized or malformed IDs are rejected instead of being read without a limit.

- Rejects IDs over 128 bytes and lines missing a newline delimiter.
- Adds a regression test for oversized IDs.

<sup>Written for commit 2598eba39eab64992f04a29215fd26c4790e91d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

