### PR TITLE
security: migrate CLA Assistant to guarded v3 (superseded by #11608)

### DIFF
--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -1,0 +1,1108 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+# The job-level expression is the first gate. Repeat it here so a
+# future edit to that expression cannot turn this token into a
+# general-purpose workflow rerunner.
+[[ "${EVENT_NAME}" == "issue_comment" ]] || fail "Unexpected event for CLA rerun"
+[[ "${ISSUE_NUMBER}" =~ ^[1-9][0-9]*$ ]] || fail "Invalid issue number"
+[[ "${PR_NUMBER}" == "${ISSUE_NUMBER}" ]] || fail "Issue and pull request numbers differ"
+[[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]] || fail "Comment is not an accepted CLA trigger"
+[[ "${COMMENT_CREATED_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || fail "Invalid comment timestamp"
+[[ "${COMMENT_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment ID is invalid"
+[[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment author ID is invalid"
+[[ -n "${COMMENT_AUTHOR_LOGIN}" ]] || fail "Comment author is missing"
+[[ "${COMMENT_AUTHOR_TYPE}" == "User" ]] || fail "Comment author is not a human user"
+case "${COMMENT_AUTHOR_LOGIN,,}" in
+  *"[bot]") fail "Bot comments cannot trigger a CLA rerun" ;;
+esac
+case "${COMMENT_AUTHOR_ASSOCIATION}" in
+  OWNER|MEMBER|COLLABORATOR|CONTRIBUTOR|FIRST_TIME_CONTRIBUTOR|FIRST_TIMER|NONE) ;;
+  *) fail "Comment author association is invalid" ;;
+esac
+case "${SIGNATURE_RECORDED}" in
+  true|false|'') ;;
+  *) fail "The CLA action did not provide a valid signature result" ;;
+esac
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" &&
+      "${SIGNATURE_RECORDED}" != "true" ]]; then
+  fail "The signing comment did not result in a persisted signature"
+fi
+[[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{7,40}$ ]] || fail "Invalid CLA generation marker"
+
+# These values are part of the trusted workflow contract. They are deliberately
+# constants, not event or comment input, so a contributor cannot redirect this
+# check to a different ledger.
+readonly SIGNATURES_BRANCH='cla-signatures'
+readonly SIGNATURES_PATH='signatures/version2/cla.json'
+readonly MAX_RUN_PAGES=10
+readonly MAX_LEDGER_BYTES=1000000
+readonly MAX_LEDGER_SIGNATURES=10000
+# GitHub wraps Contents API Base64 responses with newlines. Allow that
+# transport overhead while bounding the raw field before normalization.
+readonly MAX_LEDGER_RAW_BYTES=2000000
+
+validate_triggering_signature_record() {
+  local ledger_response ledger_content ledger_content_compact ledger_json ledger_raw_bytes ledger_encoded_bytes ledger_decoded_bytes
+  ledger_response="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field ref="${SIGNATURES_BRANCH}" \
+    "repos/${GH_REPO}/contents/${SIGNATURES_PATH}" 2>/dev/null)" || fail "Could not query the trusted CLA signature ledger"
+  jq -e '.type == "file" and .encoding == "base64" and (.content | type == "string") and (.content | length > 0)' <<<"${ledger_response}" >/dev/null || fail "The trusted CLA signature ledger response is malformed"
+  ledger_content="$(jq -r '.content' <<<"${ledger_response}")"
+  ledger_raw_bytes="$(printf '%s' "${ledger_content}" | wc -c | tr -d '[:space:]')"
+  [[ "${ledger_raw_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the trusted CLA signature ledger"
+  (( ledger_raw_bytes <= MAX_LEDGER_RAW_BYTES )) || fail "The trusted CLA signature ledger response is too large"
+  # The Contents API inserts line breaks into Base64 content. Remove only
+  # transport whitespace before applying the encoded-size limit; otherwise a
+  # valid near-limit ledger is rejected solely because it is wrapped.
+  ledger_content_compact="$(printf '%s' "${ledger_content}" | LC_ALL=C tr -d '[:space:]')"
+  [[ "${ledger_content_compact}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]] || fail "The trusted CLA signature ledger is not valid base64"
+  ledger_encoded_bytes="$(printf '%s' "${ledger_content_compact}" | wc -c | tr -d '[:space:]')"
+  [[ "${ledger_encoded_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the trusted CLA signature ledger"
+  (( ledger_encoded_bytes % 4 == 0 )) || fail "The trusted CLA signature ledger is not valid base64"
+  # The maintained action rejects ledgers larger than 1 MB. Enforce the same
+  # bound before decoding, so a malformed Contents response cannot make this
+  # privileged job retain an unbounded payload.
+  (( ledger_encoded_bytes <= ((MAX_LEDGER_BYTES + 2) * 4 / 3 + 4) )) || fail "The trusted CLA signature ledger exceeds the 1 MB limit; ask an administrator to compact or migrate it before signing"
+  if ! ledger_json="$(
+    if base64 --decode >/dev/null 2>&1 <<<''; then
+      printf '%s' "${ledger_content_compact}" | base64 --decode
+    else
+      printf '%s' "${ledger_content_compact}" | base64 -D
+    fi
+  )"; then
+    fail "The trusted CLA signature ledger is not valid base64"
+  fi
+  ledger_decoded_bytes="$(printf '%s' "${ledger_json}" | wc -c | tr -d ' ')"
+  [[ "${ledger_decoded_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the decoded CLA signature ledger"
+  (( ledger_decoded_bytes <= MAX_LEDGER_BYTES )) || fail "The trusted CLA signature ledger exceeds the 1 MB limit; ask an administrator to compact or migrate it before signing"
+  jq -e \
+    --arg login "${COMMENT_AUTHOR_LOGIN}" \
+    --argjson id "${COMMENT_AUTHOR_ID}" \
+    --argjson comment_id "${COMMENT_ID}" \
+    --arg created_at "${COMMENT_CREATED_AT}" \
+    --argjson repo_id "${repo_id}" \
+    --argjson pr_number "${PR_NUMBER}" \
+    --argjson max_signatures "${MAX_LEDGER_SIGNATURES}" \
+    'type == "object" and
+     (.signedContributors | type == "array") and
+     (.signedContributors | length <= $max_signatures) and
+     any(.signedContributors[]?;
+       (.name | type == "string") and .name == $login and
+       (.id | type == "number") and .id == $id and
+       (.comment_id | type == "number") and .comment_id == $comment_id and
+       (.created_at | type == "string") and .created_at == $created_at and
+       (.repoId | type == "number") and .repoId == $repo_id and
+       (.pullRequestNo | type == "number") and .pullRequestNo == $pr_number
+     )' <<<"${ledger_json}" >/dev/null || fail "The signing comment was not the signature persisted by the CLA action"
+}
+
+issue_json="$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
+issue_state="$(jq -r '.state // empty' <<<"${issue_json}")"
+issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
+[[ "${issue_state}" == "open" ]] || fail "The issue is not an open pull request"
+[[ "${issue_pr_url}" == "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" ]] || fail "The issue is not the exact repository pull request"
+
+pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
+jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
+  .number == $number and
+  .state == "open" and
+  .base.ref == $base and
+  (.base.repo.id | type == "number") and
+  .base.repo.full_name == $repo and
+  (.head.sha | type == "string") and
+  (.head.sha | test("^[0-9a-f]{40}$")) and
+  (.head.repo.id | type == "number") and
+  (.head.repo.full_name | type == "string") and
+  (.user.login | type == "string") and
+  (.user.id | type == "number")
+' <<<"${pr_json}" >/dev/null || fail "The live pull request is not valid"
+head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
+head_ref="$(jq -r '.head.ref // empty' <<<"${pr_json}")"
+head_repo="$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")"
+head_repo_id="$(jq -r '.head.repo.id // empty' <<<"${pr_json}")"
+repo_id="$(jq -r '.base.repo.id // empty' <<<"${pr_json}")"
+pr_author_login="$(jq -r '.user.login // empty' <<<"${pr_json}")"
+pr_author_id="$(jq -r '.user.id // empty' <<<"${pr_json}")"
+[[ "${head_ref}" != "" && "${head_repo}" != "" ]] || fail "The pull request head repository is missing"
+[[ "${head_repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request head repository ID is missing"
+[[ "${repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request base repository ID is missing"
+[[ "${pr_author_login}" != "" ]] || fail "The pull request author is missing"
+[[ "${pr_author_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request author ID is missing"
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+  validate_triggering_signature_record
+fi
+# A contributor may recheck their own pull request. A different
+# commenter must be a trusted repository participant, which limits
+# unauthenticated users to the harmless no-op path.
+if [[ "${COMMENT_BODY}" == "recheck" && "${COMMENT_AUTHOR_ID}" != "${pr_author_id}" ]]; then
+  case "${COMMENT_AUTHOR_ASSOCIATION}" in
+    OWNER|MEMBER|COLLABORATOR) ;;
+    *) fail "Only the pull request author or a trusted repository participant may request a CLA rerun" ;;
+  esac
+fi
+
+# The workflow-run list can omit pull_requests for pull_request_target runs.
+# The exact live PR plus the run head_repository/head_branch binding below is
+# used for populated source-head runs. Empty associations are accepted only
+# when the run execution SHA equals the live PR head SHA; a base or merge SHA
+# is not sufficient evidence for a privileged rerun.
+# GitHub may return a not-found or validation response when the source commit
+# exists only in a fork. Treat only that documented missing-commit response as
+# an empty association list; every other API failure remains fatal.
+commit_prs_json=""
+commit_association_error=""
+commit_association_stderr_file="$(mktemp)"
+cleanup_commit_association_stderr() {
+  rm -f -- "${commit_association_stderr_file}"
+}
+trap cleanup_commit_association_stderr EXIT
+if commit_prs_json="$(gh api \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>"${commit_association_stderr_file}")"; then
+  :
+else
+  commit_association_error="${commit_prs_json}"$'\n'"$(cat "${commit_association_stderr_file}")"
+  if jq -e '
+    ((.status == 404 or .status == "404") and
+      (.message == "Not Found" or .message == "Resource not found")) or
+    ((.status == 422 or .status == "422") and
+      (.message | type == "string" and startswith("No commit found for SHA: ")))
+  ' <<<"${commit_prs_json}" >/dev/null 2>&1 ||
+     { grep -Eq 'HTTP 404' <<<"${commit_association_error}" &&
+       grep -Eq 'Not Found|Resource not found' <<<"${commit_association_error}"; } ||
+     { grep -Eq 'HTTP 422' <<<"${commit_association_error}" &&
+       grep -Eq 'No commit found for SHA: [0-9a-f]{40}' <<<"${commit_association_error}"; }; then
+    commit_prs_json='[]'
+  else
+    fail "Could not query pull request associations"
+  fi
+fi
+cleanup_commit_association_stderr
+trap - EXIT
+jq -e 'type == "array"' <<<"${commit_prs_json}" >/dev/null || fail "Could not validate pull request associations"
+association_count="$(jq -r 'length' <<<"${commit_prs_json}")"
+[[ "${association_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations"
+(( association_count <= 100 )) || fail "The pull request association page is oversized"
+if (( association_count == 100 )); then
+  commit_prs_page2="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=2 \
+    "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>/dev/null)" || fail "Could not query pull request associations page 2"
+  jq -e 'type == "array"' <<<"${commit_prs_page2}" >/dev/null || fail "Could not validate pull request associations page 2"
+  commit_prs_page2_count="$(jq -r 'length' <<<"${commit_prs_page2}")"
+  [[ "${commit_prs_page2_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations page 2"
+  (( commit_prs_page2_count <= 100 )) || fail "The pull request association page is oversized"
+  commit_prs_json="$(jq -c --argjson page2 "${commit_prs_page2}" '. + $page2' <<<"${commit_prs_json}")"
+  association_count=$((association_count + commit_prs_page2_count))
+  (( commit_prs_page2_count < 100 )) || fail "Too many pull request associations for this head after two pages; ask an administrator to resolve the association before requesting a rerun"
+fi
+if (( association_count > 0 )); then
+  jq -e \
+    --arg repo "${GH_REPO}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg sha "${head_sha}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --argjson head_repo_id "${head_repo_id}" '
+      any(.[]?;
+        (.number | tostring) == $pr and
+        .base.ref == $base and
+        .base.repo.full_name == $repo and
+        .head.ref == $head_ref and
+        .head.sha == $sha and
+        (.head.repo.id | type == "number") and
+        .head.repo.id == $head_repo_id
+      )
+    ' <<<"${commit_prs_json}" >/dev/null || fail "The current head is not associated with this pull request"
+elif [[ "${head_repo}" == "${GH_REPO}" ]]; then
+  fail "The base-repository head has no pull request association"
+fi
+
+# A fork-only commit can be absent from the commit association API.
+# Resolve it through the live open-PR list instead. The head filter
+# is owner:ref, so the result must contain exactly one PR with the
+# exact number, SHA, head repository, and base repository. This
+# rejects duplicate or cross-PR matches before a run is selected,
+# and the helper is called again immediately before the POST.
+validate_live_open_head_association() {
+  local head_owner head_name open_prs_page open_pr_count open_prs_json matching_open_prs_json open_association_count
+  [[ "${head_repo}" == */* && "${head_repo}" != */*/* ]] || fail "The pull request head repository name is invalid"
+  head_owner="${head_repo%%/*}"
+  head_name="${head_repo#*/}"
+  [[ -n "${head_owner}" && -n "${head_name}" ]] || fail "The pull request head repository name is invalid"
+  open_prs_page="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field state=open \
+    --raw-field base="${TARGET_BASE_REF}" \
+    --raw-field head="${head_owner}:${head_ref}" \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/pulls" 2>/dev/null)" || fail "Could not query live open pull requests for this head"
+  jq -e 'type == "array"' <<<"${open_prs_page}" >/dev/null || fail "Could not validate live open pull requests"
+  open_pr_count="$(jq -r 'length' <<<"${open_prs_page}")"
+  [[ "${open_pr_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests"
+  (( open_pr_count <= 100 )) || fail "The live open pull request page is oversized"
+  if (( open_pr_count == 100 )); then
+    open_prs_page2="$(gh api \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field state=open \
+      --raw-field base="${TARGET_BASE_REF}" \
+      --raw-field head="${head_owner}:${head_ref}" \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/pulls" 2>/dev/null)" || fail "Could not query live open pull requests page 2"
+    jq -e 'type == "array"' <<<"${open_prs_page2}" >/dev/null || fail "Could not validate live open pull requests page 2"
+    open_pr_count2="$(jq -r 'length' <<<"${open_prs_page2}")"
+    [[ "${open_pr_count2}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests page 2"
+    (( open_pr_count2 <= 100 )) || fail "The live open pull request page is oversized"
+    open_prs_page="$(jq -c --argjson page2 "${open_prs_page2}" '. + $page2' <<<"${open_prs_page}")"
+    open_pr_count=$((open_pr_count + open_pr_count2))
+    (( open_pr_count2 < 100 )) || fail "Too many open pull requests share this head after two pages; push a new head or ask an administrator to resolve the association before requesting a rerun"
+  fi
+  open_prs_json="$(jq -c '[.]' <<<"${open_prs_page}")"
+  if ! matching_open_prs_json="$(jq -c \
+      --arg repo "${GH_REPO}" \
+      --arg sha "${head_sha}" \
+      --arg base "${TARGET_BASE_REF}" \
+      --arg head_ref "${head_ref}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" \
+      --argjson repo_id "${repo_id}" '
+        [ .[] | .[]?
+          | select(
+              (.number | type == "number") and
+              .state == "open" and
+              .base.ref == $base and
+              .base.repo.full_name == $repo and
+              (.base.repo.id | type == "number") and
+              .base.repo.id == $repo_id and
+              .head.ref == $head_ref and
+              .head.sha == $sha and
+              .head.repo.full_name == $head_repo and
+              (.head.repo.id | type == "number") and
+              .head.repo.id == $head_repo_id
+            )
+        ]
+        | sort_by(.number)
+      ' <<<"${open_prs_json}")"; then
+    fail "Could not validate live open pull request data"
+  fi
+  open_association_count="$(jq -r 'length' <<<"${matching_open_prs_json}")"
+  [[ "${open_association_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull request associations"
+  [[ "${open_association_count}" == "1" ]] || fail "Expected exactly one open pull request for this head"
+  jq -e --argjson number "${PR_NUMBER}" '.[0].number == $number' <<<"${matching_open_prs_json}" >/dev/null || fail "The live head is associated with a different pull request"
+}
+validate_live_open_head_association
+
+workflow_page="$(gh api \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/actions/workflows" 2>/dev/null)" || fail "Could not query repository workflows"
+jq -e 'type == "object" and (.workflows | type == "array")' <<<"${workflow_page}" >/dev/null || fail "Could not validate repository workflows"
+workflow_count="$(jq -r '.workflows | length' <<<"${workflow_page}")"
+[[ "${workflow_count}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows"
+(( workflow_count <= 100 )) || fail "The repository workflow page is oversized"
+if (( workflow_count == 100 )); then
+  workflow_page2="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=2 \
+    "repos/${GH_REPO}/actions/workflows" 2>/dev/null)" || fail "Could not query repository workflows page 2"
+  jq -e 'type == "object" and (.workflows | type == "array")' <<<"${workflow_page2}" >/dev/null || fail "Could not validate repository workflows page 2"
+  workflow_count2="$(jq -r '.workflows | length' <<<"${workflow_page2}")"
+  [[ "${workflow_count2}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows page 2"
+  (( workflow_count2 <= 100 )) || fail "The repository workflow page is oversized"
+  workflow_page="$(jq -c --argjson page2 "${workflow_page2}" '.workflows += $page2.workflows' <<<"${workflow_page}")"
+  workflow_count=$((workflow_count + workflow_count2))
+  (( workflow_count2 < 100 )) || fail "Too many active repository workflows after two pages; ask an administrator to reduce the workflow list before requesting a rerun"
+fi
+workflow_json="$(jq -c '[.]' <<<"${workflow_page}")"
+workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | select(.path == $path and .state == "active") | .id] | if length == 1 then .[0] else empty end' <<<"${workflow_json}")"
+[[ "${workflow_id}" =~ ^[1-9][0-9]*$ ]] || fail "The expected CLA workflow is not active"
+
+# Search a bounded first page, then choose the newest completed
+# failure created no later than this comment. Edited, reopened, and
+# synchronize events can leave several eligible failures for one
+# exact head, so sort by creation time and run ID and select the
+# newest one. Every candidate is tied to the exact workflow path,
+# event, and PR association. When GitHub includes pull_requests on a
+# run, bind the candidate to the exact PR object, including its
+# source head SHA.
+# GitHub can return an empty array for fork pull_request_target runs,
+# so those candidates are retained only when the run's execution SHA equals
+# the live PR source SHA. Populated pull_requests records may bind a different
+# execution SHA to the exact source PR object.
+runs_page="$(gh api \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field event="${TARGET_EVENT}" \
+  --raw-field branch="${head_ref}" \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs"
+jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${runs_page}" >/dev/null || fail "Could not validate CLA workflow runs"
+run_count="$(jq -r '.workflow_runs | length' <<<"${runs_page}")"
+[[ "${run_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs"
+(( run_count <= 100 )) || fail "The CLA workflow run page is oversized"
+runs_json="$(jq -c '[.]' <<<"${runs_page}")"
+
+# The API returns newest runs first. Probe additional bounded pages when the
+# first page is full, so normal workflow history growth does not strand a
+# failed check. GitHub documents a 1,000-result cap for filtered workflow-run
+# queries, so ten 100-item pages cover the complete API result window. Search
+# the complete bounded window before deciding whether it is full: a valid
+# candidate on page ten is still actionable. If the window is full and no
+# candidate matches, fail with an actionable message instead of pretending page
+# 11 can reveal an unreported run. `runs_json` stays an array of response
+# objects; the candidate query below flattens each `.workflow_runs` array
+# explicitly.
+page_count="${run_count}"
+page_number=2
+while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
+  next_runs_page="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field event="${TARGET_EVENT}" \
+    --raw-field branch="${head_ref}" \
+    --raw-field per_page=100 \
+    --raw-field page="${page_number}" \
+    "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs page ${page_number}"
+  jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${next_runs_page}" >/dev/null || fail "Could not validate CLA workflow runs page ${page_number}"
+  page_count="$(jq -r '.workflow_runs | length' <<<"${next_runs_page}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs page ${page_number}"
+  (( page_count <= 100 )) || fail "The CLA workflow returned an oversized run page"
+  runs_json="$(jq -c --argjson next_page "${next_runs_page}" '. + [$next_page]' <<<"${runs_json}")"
+  (( page_number++ ))
+done
+run_window_full=false
+(( page_count == 100 )) && run_window_full=true
+
+# `pull_requests` is optional for fork runs, but when GitHub sends it, the
+# field must keep its documented array shape. Treat a changed or malformed
+# response as an infrastructure error. Silently treating it as an unmatched
+# run could strand a required failed check with no recovery path.
+if ! jq -e '
+  all(.[] | .workflow_runs[]?;
+    (type == "object") and
+    (.pull_requests == null or (.pull_requests | type == "array"))
+  )
+' <<<"${runs_json}" >/dev/null; then
+  fail "The CLA workflow returned malformed pull request associations"
+fi
+
+if ! candidate_list_json="$(jq -c \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --arg before "${COMMENT_CREATED_AT}" '
+      def run_binds_to_pr:
+        (.pull_requests) as $raw_prs
+        | (if $raw_prs == null then []
+           elif ($raw_prs | type) == "array" then $raw_prs
+           else null end) as $prs
+        | if $prs == null then false
+          elif ($prs | length) == 0 then
+            .head_sha == $sha and
+            .head_branch == $head_ref and
+            (
+              ((.head_repository | type) == "object" and
+               .head_repository.full_name == $head_repo and
+               (.head_repository.id | type == "number") and
+               .head_repository.id == $head_repo_id) or
+              (.head_repository == null and
+               $head_repo == $repo and
+               $head_repo_id == $repo_id)
+            )
+            # Empty associations are eligible only for the exact current
+            # source SHA. A base or merge SHA must never shadow an older
+            # eligible run for this pull request.
+          else any($prs[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            .base.ref == $base and
+            ((.base.repo.full_name // "") == "" or
+             .base.repo.full_name == $repo) and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            ((.head.repo.full_name // "") == "" or
+             .head.repo.full_name == $head_repo)
+          )
+          end;
+      [ .[] | .workflow_runs[]?
+        | select(
+            (.path == $path or
+            ((.path | startswith($path + "@")) and
+             ((.path | length) > (($path | length) + 1)))) and
+            .event == $event and
+            (.workflow_id | type == "number") and
+            .workflow_id == ($workflow_id | tonumber) and
+            (.head_sha | type == "string") and
+            (.head_sha | test("^[0-9a-f]{40}$")) and
+            (.id | type == "number") and
+            .id > 0 and
+            .status == "completed" and
+            .conclusion == "failure" and
+            (.created_at | type == "string") and
+            .created_at <= $before and
+            run_binds_to_pr
+          )
+      ]
+      | sort_by([.created_at, .id])
+    ' <<<"${runs_json}")"; then
+  fail "Could not validate CLA workflow run data"
+fi
+candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
+[[ "${candidate_count}" =~ ^[0-9]+$ ]] || fail "Could not count matching CLA workflow runs"
+if [[ "${candidate_count}" == "0" ]]; then
+  if [[ "${run_window_full}" == true ]]; then
+    fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
+  fi
+  # Do not silently treat a failed run with an empty association and a
+  # different execution SHA as a successful no-op. It is not eligible for a
+  # rerun, but it still needs an explicit fail-closed migration/error path.
+  # Runs with the exact source SHA are handled by the candidate query above;
+  # this count therefore only catches mismatched runs that would otherwise be
+  # indistinguishable from an absent check.
+  empty_execution_mismatch_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg head_ref "${head_ref}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    '[ .[] | .workflow_runs[]?
+      | select(
+          (.path == $path or
+           ((.path | startswith($path + "@")) and
+            ((.path | length) > (($path | length) + 1)))) and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          .head_sha != $sha and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          .created_at <= $before and
+          .head_branch == $head_ref and
+          (.pull_requests == null or
+           ((.pull_requests | type) == "array" and
+            (.pull_requests | length) == 0)) and
+          (
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             (.head_repository.id | type == "number") and
+             .head_repository.id == $head_repo_id) or
+            (.head_repository == null and
+             $head_repo == $repo and
+             $head_repo_id == $repo_id)
+          )
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
+  if (( empty_execution_mismatch_count > 0 )); then
+    fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+  fi
+  # A run from before this workflow generation cannot be safely
+  # rerun: GitHub reruns the old workflow revision, which could
+  # execute the archived action or an obsolete policy. Distinguish
+  # that migration case from a normal no-op after a successful CLA
+  # check so contributors receive an actionable recovery path.
+  stale_run_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    'def run_binds_to_pr:
+       (.pull_requests) as $raw_prs
+       | (if $raw_prs == null then []
+          elif ($raw_prs | type) == "array" then $raw_prs
+          else null end) as $prs
+       | if $prs == null then false
+         elif ($prs | length) == 0 then
+           .head_sha == $sha and
+           .head_branch == $head_ref and
+           (
+             ((.head_repository | type) == "object" and
+              .head_repository.full_name == $head_repo and
+              (.head_repository.id | type == "number") and
+              .head_repository.id == $head_repo_id) or
+             (.head_repository == null and
+              $head_repo == $repo and
+              $head_repo_id == $repo_id)
+           )
+         else any($prs[]?;
+           (.number | type == "number") and
+           (.number | tostring) == $pr and
+           .base.ref == $base and
+           ((.base.repo.full_name // "") == "" or
+            .base.repo.full_name == $repo) and
+           (.base.repo.id | type == "number") and
+           .base.repo.id == $repo_id and
+           .head.ref == $head_ref and
+           .head.sha == $sha and
+           (.head.repo.id | type == "number") and
+           .head.repo.id == $head_repo_id and
+           ((.head.repo.full_name // "") == "" or
+            .head.repo.full_name == $head_repo)
+         )
+         end;
+     [ .[] | .workflow_runs[]?
+      | select(
+          (.path == $path or
+          ((.path | startswith($path + "@")) and
+            ((.path | length) > (($path | length) + 1)))) and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          .created_at <= $before and
+          run_binds_to_pr
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${stale_run_count}" =~ ^[0-9]+$ ]] || fail "Could not count stale CLA workflow runs"
+  if (( stale_run_count > 0 )); then
+    fail "The failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  fi
+  # A valid signature can arrive after the check already passed.
+  # Preserve the action's historical no-op behavior in that case.
+  echo "No failed CLA run exists for this pull request head"
+  exit 0
+fi
+# candidate_list_json is sorted oldest-first above. The selected run
+# is fully fetched and validated below before any state-changing API
+# call, so multiple historical failures do not create ambiguity.
+candidate_json="$(jq -c '.[-1]' <<<"${candidate_list_json}")"
+run_id="$(jq -r '.id // empty' <<<"${candidate_json}")"
+[[ "${run_id}" =~ ^[1-9][0-9]*$ ]] || fail "The selected CLA run ID is invalid"
+run_execution_sha="$(jq -r '.head_sha // empty' <<<"${candidate_json}")"
+[[ "${run_execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The selected CLA run execution SHA is invalid"
+run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
+[[ -n "${run_head_branch}" && "${run_head_branch}" != *$'\n'* && "${run_head_branch}" != *$'\r'* ]] || fail "The selected CLA run head branch is invalid"
+
+# A run with a populated pull_requests array already carries an
+# authenticated source-PR association. Some GitHub API responses
+# omit that array, so prove a differing execution SHA through the
+# commit association endpoint before allowing the fallback. A bare
+# branch/repository match is not enough because a branch can be
+# reused after a push.
+validate_run_source_binding() {
+  local run_payload="$1"
+  local execution_sha pull_requests_type pull_request_count
+  execution_sha="$(jq -r '.head_sha // empty' <<<"${run_payload}")"
+  [[ "${execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The workflow run execution SHA is invalid"
+  pull_requests_type="$(jq -r 'if .pull_requests == null then "null" else (.pull_requests | type) end' <<<"${run_payload}")"
+  case "${pull_requests_type}" in
+    null) pull_request_count=0 ;;
+    array) pull_request_count="$(jq -r '.pull_requests | length' <<<"${run_payload}")" ;;
+    *) fail "The workflow run pull request association is malformed" ;;
+  esac
+  [[ "${pull_request_count}" =~ ^[0-9]+$ ]] || fail "The workflow run pull request association count is invalid"
+  if (( pull_request_count == 0 )); then
+    # GitHub may omit pull_requests on a pull_request_target run. Without an
+    # authenticated PR object, accept only the source-head form. A base or
+    # merge execution SHA cannot be proved to belong to this PR, so fail
+    # closed instead of querying commit associations that may describe an
+    # ancestor or another pull request.
+    [[ "${execution_sha}" == "${head_sha}" ]] || fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+  fi
+}
+
+# Re-read the individual run. The list response is only a discovery
+# result, not authorization to rerun it.
+run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
+jq -e \
+  --arg run_id "${run_id}" \
+  --arg path "${WORKFLOW_PATH}" \
+  --arg event "${TARGET_EVENT}" \
+  --arg sha "${head_sha}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg run_head_branch "${run_head_branch}" \
+  --arg pr "${PR_NUMBER}" \
+  --arg repo "${GH_REPO}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" \
+  --argjson repo_id "${repo_id}" \
+  --arg head_ref "${head_ref}" \
+  --arg workflow_id "${workflow_id}" \
+  --arg base "${TARGET_BASE_REF}" \
+  --arg before "${COMMENT_CREATED_AT}" '
+    def run_binds_to_pr:
+      (.pull_requests) as $raw_prs
+      | (if $raw_prs == null then []
+         elif ($raw_prs | type) == "array" then $raw_prs
+         else null end) as $prs
+      | if $prs == null then false
+        elif ($prs | length) == 0 then
+          .head_branch == $head_ref and
+          (
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             (.head_repository.id | type == "number") and
+             .head_repository.id == $head_repo_id) or
+            (.head_repository == null and
+             $head_repo == $repo and
+             $head_repo_id == $repo_id)
+          )
+        else any($prs[]?;
+          (.number | type == "number") and
+          (.number | tostring) == $pr and
+          .base.ref == $base and
+          ((.base.repo.full_name // "") == "" or
+           .base.repo.full_name == $repo) and
+          (.base.repo.id | type == "number") and
+          .base.repo.id == $repo_id and
+          .head.ref == $head_ref and
+          .head.sha == $sha and
+          (.head.repo.id | type == "number") and
+          .head.repo.id == $head_repo_id and
+          ((.head.repo.full_name // "") == "" or
+           .head.repo.full_name == $head_repo)
+        )
+        end;
+    .id == ($run_id | tonumber) and
+    .workflow_id == ($workflow_id | tonumber) and
+    (.path == $path or
+     ((.path | startswith($path + "@")) and
+      ((.path | length) > (($path | length) + 1)))) and
+    .event == $event and
+    .status == "completed" and
+    .conclusion == "failure" and
+    .head_sha == $run_sha and
+    .head_branch == $run_head_branch and
+    (.created_at | type == "string") and
+    .created_at <= $before and
+    run_binds_to_pr
+  ' <<<"${run_json}" >/dev/null || fail "The selected run no longer matches the exact failed CLA check"
+validate_run_source_binding "${run_json}"
+
+# Close the main TOCTOU window. A push, close, or another rerun can
+# happen while the API calls above run. Never rerun a stale head.
+latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
+jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
+  .number == $number and
+  .state == "open" and
+  .base.ref == $base and
+  .base.repo.full_name == $repo and
+  .base.repo.id == $base_repo_id and
+  .head.sha == $sha and
+  .head.ref == $head_ref and
+  .head.repo.full_name == $head_repo and
+  .head.repo.id == $head_repo_id and
+  .user.login == $opener
+' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA run"
+
+# Ensure another queued invocation did not already rerun this run.
+final_run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
+jq -e \
+  --arg path "${WORKFLOW_PATH}" \
+  --arg event "${TARGET_EVENT}" \
+  --arg sha "${head_sha}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg run_head_branch "${run_head_branch}" \
+  --arg pr "${PR_NUMBER}" \
+  --arg repo "${GH_REPO}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" \
+  --argjson repo_id "${repo_id}" \
+  --arg head_ref "${head_ref}" \
+  --arg workflow_id "${workflow_id}" \
+  --arg run_id "${run_id}" \
+  --arg base "${TARGET_BASE_REF}" \
+  --arg before "${COMMENT_CREATED_AT}" '
+    def run_binds_to_pr:
+      (.pull_requests) as $raw_prs
+      | (if $raw_prs == null then []
+         elif ($raw_prs | type) == "array" then $raw_prs
+         else null end) as $prs
+      | if $prs == null then false
+        elif ($prs | length) == 0 then
+          .head_branch == $head_ref and
+          (
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             (.head_repository.id | type == "number") and
+             .head_repository.id == $head_repo_id) or
+            (.head_repository == null and
+             $head_repo == $repo and
+             $head_repo_id == $repo_id)
+          )
+        else any($prs[]?;
+          (.number | type == "number") and
+          (.number | tostring) == $pr and
+          .base.ref == $base and
+          ((.base.repo.full_name // "") == "" or
+           .base.repo.full_name == $repo) and
+          (.base.repo.id | type == "number") and
+          .base.repo.id == $repo_id and
+          .head.ref == $head_ref and
+          .head.sha == $sha and
+          (.head.repo.id | type == "number") and
+          .head.repo.id == $head_repo_id and
+          ((.head.repo.full_name // "") == "" or
+           .head.repo.full_name == $head_repo)
+        )
+        end;
+    .id == ($run_id | tonumber) and
+    .workflow_id == ($workflow_id | tonumber) and
+    (.path == $path or
+     ((.path | startswith($path + "@")) and
+      ((.path | length) > (($path | length) + 1)))) and
+    .event == $event and
+    .status == "completed" and
+    .conclusion == "failure" and
+    .head_sha == $run_sha and
+    .head_branch == $run_head_branch and
+    (.created_at | type == "string") and
+    .created_at <= $before and
+    run_binds_to_pr
+' <<<"${final_run_json}" >/dev/null || fail "The exact failed CLA run is no longer eligible"
+validate_run_source_binding "${final_run_json}"
+
+# Fetch the complete bounded job set for one exact run. The rerun endpoint
+# requires actions:write, so discovery must fail closed if pagination or shape
+# checks cannot prove that every failed job belongs to this CLA workflow.
+# The workflow-run response is authoritative for workflow name, head branch,
+# and source repository. GitHub's jobs endpoint does not document those fields
+# and omits them in production, so job validation uses only its documented
+# identity fields, plus optional source metadata when GitHub supplies it.
+fetch_jobs_for_run() {
+  local target_run_id="$1"
+  local page_json page_count page2_json page2_count
+  page_json="$(gh api \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+  jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page_json}" >/dev/null || return 1
+  page_count="$(jq -r '.jobs | length' <<<"${page_json}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2_json="$(gh api \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+    jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page2_json}" >/dev/null || return 1
+    page2_count="$(jq -r '.jobs | length' <<<"${page2_json}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    page_json="$(jq -c --argjson page2 "${page2_json}" '.jobs += $page2.jobs' <<<"${page_json}")"
+    (( page2_count < 100 )) || return 1
+  fi
+  jq -c '[.]' <<<"${page_json}"
+}
+
+jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and validate jobs for the selected CLA run"
+
+# Validate every failed job before granting the state-changing API call. The
+# old compatibility check is an intentional dependent of the v2 job. When it
+# is also failed, use the failed-jobs endpoint so GitHub refreshes both
+# head-bound check contexts. Any extra failure, cancellation, malformed job,
+# or stale source identity aborts the request.
+validate_failed_job_set() {
+  local payload="$1"
+  local all_jobs_json failed_jobs_json failed_count nonfailure_count
+  local unexpected_count v2_count v2_valid_count compatibility_count compatibility_valid_count
+  if ! all_jobs_json="$(jq -c '[.[] | .jobs[]?]' <<<"${payload}")"; then
+    fail "Could not flatten jobs for the selected CLA run"
+  fi
+  jq -e \
+    --arg run_id "${run_id}" \
+    'type == "array" and all(.[];
+      (.id | type == "number") and
+      .id > 0 and
+      (.run_id | type == "number") and
+      .run_id == ($run_id | tonumber) and
+      (.name | type == "string") and
+      (.status == "completed") and
+      (.conclusion | type == "string")
+    )' <<<"${all_jobs_json}" >/dev/null || fail "The selected CLA run contains a malformed or incomplete job"
+
+  failed_jobs_json="$(jq -c '[.[] | select(.conclusion != "success" and .conclusion != "skipped")]' <<<"${all_jobs_json}")"
+  failed_count="$(jq -r 'length' <<<"${failed_jobs_json}")"
+  [[ "${failed_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed jobs for the selected CLA run"
+  nonfailure_count="$(jq -r '[.[] | select(.conclusion != "failure")] | length' <<<"${failed_jobs_json}")"
+  (( nonfailure_count == 0 )) || fail "The selected CLA run contains a cancelled or non-failure job; refusing to rerun it"
+  unexpected_count="$(jq -r '[.[] | select(.name != "CLA Assistant v2" and .name != "CLA Assistant")] | length' <<<"${failed_jobs_json}")"
+  (( unexpected_count == 0 )) || fail "The selected CLA run contains an unexpected failed job; refusing to rerun it"
+
+  if ! v2_count="$(jq -r '[.[] | select(.name == "CLA Assistant v2")] | length' <<<"${failed_jobs_json}")" ||
+     ! v2_valid_count="$(jq -r \
+       --arg run_id "${run_id}" \
+       --arg run_sha "${run_execution_sha}" \
+       --arg head_repo "${head_repo}" \
+       --argjson head_repo_id "${head_repo_id}" \
+       --arg cla_generation "${CLA_GENERATION}" \
+       '[.[] | select(
+          .name == "CLA Assistant v2" and
+          .run_id == ($run_id | tonumber) and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          ((has("head_repository") | not) or
+           (.head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id))) and
+          any(.steps[]?;
+            .name == ("CLA generation " + $cla_generation) and
+            .status == "completed" and
+            .conclusion == "success"
+          )
+       )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA Assistant v2 jobs"
+  fi
+  [[ "${v2_count}" =~ ^[0-9]+$ && "${v2_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA Assistant v2 jobs"
+  (( v2_count == 1 )) || fail "Expected exactly one failed CLA Assistant v2 job"
+  (( v2_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+
+  compatibility_count="$(jq -r '[.[] | select(.name == "CLA Assistant")] | length' <<<"${failed_jobs_json}")"
+  if ! compatibility_valid_count="$(jq -r \
+      --arg run_id "${run_id}" \
+      --arg run_sha "${run_execution_sha}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" \
+      '[.[] | select(
+         .name == "CLA Assistant" and
+         .run_id == ($run_id | tonumber) and
+         (.head_sha | type == "string") and
+         .head_sha == $run_sha and
+         ((has("head_repository") | not) or
+          (.head_repository == null or
+           ((.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            .head_repository.id == $head_repo_id)))
+      )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA compatibility jobs"
+  fi
+  [[ "${compatibility_count}" =~ ^[0-9]+$ && "${compatibility_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA compatibility jobs"
+  (( compatibility_count <= 1 )) || fail "The selected CLA run contains multiple failed compatibility jobs"
+  (( compatibility_valid_count == compatibility_count )) || fail "The failed CLA compatibility job is malformed or bound to a different source"
+  if (( compatibility_count == 1 )); then
+    RERUN_FAILED_JOBS=true
+  else
+    RERUN_FAILED_JOBS=false
+  fi
+}
+validate_failed_job_set "${jobs_json}"
+if ! cla_job_json="$(jq -c \
+    --arg run_id "${run_id}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg cla_generation "${CLA_GENERATION}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    '[.[] | .jobs[]?
+      | select(
+          (.run_id | tostring) == $run_id and
+          .name == "CLA Assistant v2" and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          (
+            .head_repository == null or
+            (.head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)
+          ) and
+          any(.steps[]?;
+            .name == ("CLA generation " + $cla_generation) and
+            .status == "completed" and
+            .conclusion == "success"
+          )
+        )
+    ]
+    | if length == 1 then .[0] else empty end
+  ' <<<"${jobs_json}")"; then
+  fail "Could not validate CLA job data"
+fi
+if [[ -z "${cla_job_json}" ]]; then
+  # The run matched the current PR and failed, but no job carried
+  # this workflow generation marker. It is an old or malformed
+  # generation and must not be replayed with the privileged token.
+  fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+fi
+job_id="$(jq -r '.id // empty' <<<"${cla_job_json}")"
+[[ "${job_id}" =~ ^[1-9][0-9]*$ ]] || fail "The selected CLA job ID is invalid"
+
+# Re-read the individual job. The jobs list is discovery only, just
+# like the workflow-run list above.
+job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA job"
+jq -e \
+  --arg job_id "${job_id}" \
+  --arg run_id "${run_id}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg cla_generation "${CLA_GENERATION}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" '
+    .id == ($job_id | tonumber) and
+    .run_id == ($run_id | tonumber) and
+    .name == "CLA Assistant v2" and
+    .status == "completed" and
+    .conclusion == "failure" and
+    (.head_sha | type == "string") and
+    .head_sha == $run_sha and
+    (
+      (has("head_repository") | not) or
+      .head_repository == null or
+      ((.head_repository | type) == "object" and
+       .head_repository.full_name == $head_repo and
+       .head_repository.id == $head_repo_id)
+    ) and
+    any(.steps[]?;
+      .name == ("CLA generation " + $cla_generation) and
+      .status == "completed" and
+      .conclusion == "success"
+    )
+  ' <<<"${job_json}" >/dev/null || fail "The selected CLA job no longer matches the failed job in this run"
+
+# Recheck both resources immediately before the state-changing call.
+# This prevents a push or a concurrent rerun from making the job
+# stale while the preceding API requests were in flight.
+latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
+  .number == $number and
+  .state == "open" and
+  .base.ref == $base and
+  .base.repo.full_name == $repo and
+  .base.repo.id == $base_repo_id and
+  .head.sha == $sha and
+  .head.ref == $head_ref and
+  .head.repo.full_name == $head_repo and
+  .head.repo.id == $head_repo_id and
+  .user.login == $opener
+' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA job"
+final_job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
+jq -e \
+  --arg job_id "${job_id}" \
+  --arg run_id "${run_id}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg cla_generation "${CLA_GENERATION}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" '
+    .id == ($job_id | tonumber) and
+    .run_id == ($run_id | tonumber) and
+    .name == "CLA Assistant v2" and
+    .status == "completed" and
+    .conclusion == "failure" and
+    (.head_sha | type == "string") and
+    .head_sha == $run_sha and
+    (
+      (has("head_repository") | not) or
+      .head_repository == null or
+      ((.head_repository | type) == "object" and
+       .head_repository.full_name == $head_repo and
+       .head_repository.id == $head_repo_id)
+    ) and
+    any(.steps[]?;
+      .name == ("CLA generation " + $cla_generation) and
+      .status == "completed" and
+      .conclusion == "success"
+    )
+' <<<"${final_job_json}" >/dev/null || fail "The exact failed CLA job is no longer eligible"
+
+# Re-fetch the whole job set immediately before the state-changing call. This
+# catches a newly cancelled or unrelated failed job that could otherwise be
+# pulled into a failed-jobs rerun after the first validation.
+final_jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not recheck and validate jobs for the selected CLA run"
+validate_failed_job_set "${final_jobs_json}"
+final_job_id="$(jq -r \
+  --arg run_id "${run_id}" \
+  --arg run_sha "${run_execution_sha}" \
+  --arg head_repo "${head_repo}" \
+  --argjson head_repo_id "${head_repo_id}" \
+  --arg cla_generation "${CLA_GENERATION}" \
+  '[.[] | .jobs[]? | select(
+      .run_id == ($run_id | tonumber) and
+      .name == "CLA Assistant v2" and
+      .status == "completed" and
+      .conclusion == "failure" and
+      (.head_sha | type == "string") and
+      .head_sha == $run_sha and
+      ((has("head_repository") | not) or
+       (.head_repository == null or
+        ((.head_repository | type) == "object" and
+         .head_repository.full_name == $head_repo and
+         .head_repository.id == $head_repo_id))) and
+      any(.steps[]?;
+        .name == ("CLA generation " + $cla_generation) and
+        .status == "completed" and
+        .conclusion == "success"
+      )
+    )]
+    | if length == 1 then .[0].id else empty end' <<<"${final_jobs_json}")"
+[[ "${final_job_id}" == "${job_id}" ]] || fail "The selected CLA job changed while preparing the rerun"
+
+# Repeat the positive live-PR association check after all discovery
+# calls. A second open PR for the same fork ref and SHA must stop the
+# rerun even if it appeared while the earlier checks were running.
+validate_live_open_head_association
+
+if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
+  rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"
+  rerun_description="failed CLA jobs (v2 and compatibility)"
+else
+  rerun_endpoint="repos/${GH_REPO}/actions/jobs/${job_id}/rerun"
+  rerun_description="CLA job ${job_id}"
+fi
+if ! gh api \
+  --method POST \
+  --header 'Accept: application/vnd.github+json' \
+  --header 'X-GitHub-Api-Version: 2022-11-28' \
+  "${rerun_endpoint}" >/dev/null 2>&1; then
+  fail "Could not rerun the exact failed CLA job set"
+fi
+echo "Requested rerun for ${rerun_description} in workflow run ${run_id} at execution ${run_execution_sha} for PR head ${head_sha}"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -17,6 +17,7 @@ fail() {
 [[ "${COMMENT_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment ID is invalid"
 [[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment author ID is invalid"
 [[ -n "${COMMENT_AUTHOR_LOGIN}" ]] || fail "Comment author is missing"
+[[ "${COMMENT_AUTHOR_LOGIN}" != *$'\n'* && "${COMMENT_AUTHOR_LOGIN}" != *$'\r'* ]] || fail "Comment author is malformed"
 [[ "${COMMENT_AUTHOR_TYPE}" == "User" ]] || fail "Comment author is not a human user"
 case "${COMMENT_AUTHOR_LOGIN,,}" in
   *"[bot]") fail "Bot comments cannot trigger a CLA rerun" ;;
@@ -33,7 +34,8 @@ if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign 
       "${SIGNATURE_RECORDED}" != "true" ]]; then
   fail "The signing comment did not result in a persisted signature"
 fi
-[[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{7,40}$ ]] || fail "Invalid CLA generation marker"
+readonly EXPECTED_CLA_GENERATION='v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af'
+[[ "${CLA_GENERATION}" == "${EXPECTED_CLA_GENERATION}" ]] || fail "Unexpected CLA generation marker"
 [[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
 checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
 [[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"
@@ -46,6 +48,7 @@ checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify th
 readonly SIGNATURES_BRANCH='cla-signatures'
 readonly SIGNATURES_PATH='signatures/version2/cla.json'
 readonly MAX_RUN_PAGES=10
+readonly MAX_CHECK_PAGES=2
 # Keep every GitHub JSON response below a fixed byte budget before it enters a
 # shell variable. GitHub's pagination limits bound item counts, not the size of
 # individual fields, so a response-size guard is still required.
@@ -64,6 +67,9 @@ readonly MAX_LEDGER_RAW_BYTES=2000000
 readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
 readonly CLA_WRITER_JOB='CLA ledger writer'
 readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
+readonly CLA_COMPATIBILITY_STEP='Mirror CLA Assistant compatibility result'
+readonly CLA_WORKFLOW_NAME='CLA Assistant v3'
+readonly CLA_ACTION_APP_ID=15368
 
 # Capture one byte past the limit in a temporary file. This keeps an oversized
 # response out of shell memory and bounds disk use before command substitution
@@ -208,6 +214,8 @@ repo_id="$(jq -r '.base.repo.id // empty' <<<"${pr_json}")"
 pr_author_login="$(jq -r '.user.login // empty' <<<"${pr_json}")"
 pr_author_id="$(jq -r '.user.id // empty' <<<"${pr_json}")"
 [[ "${head_ref}" != "" && "${head_repo}" != "" ]] || fail "The pull request head repository is missing"
+[[ "${head_ref}" != *$'\n'* && "${head_ref}" != *$'\r'* ]] || fail "The pull request head branch is malformed"
+[[ "${head_repo}" != *$'\n'* && "${head_repo}" != *$'\r'* ]] || fail "The pull request head repository is malformed"
 [[ "${head_repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request head repository ID is missing"
 [[ "${base_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The pull request base SHA is missing"
 [[ "${repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request base repository ID is missing"
@@ -292,6 +300,7 @@ assert_exact_pr_association() {
     --arg pr "${PR_NUMBER}" \
     --arg sha "${expected_sha}" \
     --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
     --arg head_ref "${head_ref}" \
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" \
@@ -303,6 +312,8 @@ assert_exact_pr_association() {
         .base.repo.full_name == $repo and
         (.base.repo.id | type == "number") and
         .base.repo.id == $repo_id and
+        (.base.sha | type == "string") and
+        .base.sha == $base_sha and
         .head.ref == $head_ref and
         .head.sha == $sha and
         .head.repo.full_name == $head_repo and
@@ -468,11 +479,11 @@ workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | selec
 # exact head, so sort by creation time and run ID and select the
 # newest one. Every candidate is tied to the exact workflow path and event.
 # When GitHub includes pull_requests on a run, bind the candidate to the exact
-# PR object, including its source head SHA. GitHub can return an empty array for
-# pull_request_target runs. Those candidates are retained when their branch and
-# repository identity matches the live PR, then independently bound below by
-# the live base SHA or an exact failed check on the source head. Populated
-# records may bind a different execution SHA directly.
+# PR object, including its source head and live base SHAs. GitHub can return an
+# empty array for pull_request_target runs. Those candidates are accepted only
+# when the run has complete source-repository metadata and its execution SHA is
+# the live PR base SHA. Missing metadata cannot identify which fork produced a
+# branch, so it is always rejected before any check is rerun.
 runs_page="$(gh_api_bounded \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
@@ -525,7 +536,9 @@ run_window_full=false
 if ! jq -e '
   all(.[] | .workflow_runs[]?;
     (type == "object") and
-    (.pull_requests == null or (.pull_requests | type == "array"))
+    (.pull_requests == null or
+     ((.pull_requests | type) == "array" and
+      (.pull_requests | length <= 100)))
   )
 ' <<<"${runs_json}" >/dev/null; then
   fail "The CLA workflow returned malformed pull request associations"
@@ -544,6 +557,7 @@ if ! candidate_list_json="$(jq -c \
     --argjson repo_id "${repo_id}" \
     --arg base "${TARGET_BASE_REF}" \
     --arg head_ref "${head_ref}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
     --arg before "${COMMENT_CREATED_AT}" '
       def run_binds_to_pr:
         (.pull_requests) as $raw_prs
@@ -551,23 +565,21 @@ if ! candidate_list_json="$(jq -c \
            elif ($raw_prs | type) == "array" then $raw_prs
            else null end) as $prs
         | if $prs == null then false
+          elif ($prs | length > 100) then false
           elif ($prs | length) == 0 then
+            .head_sha == $base_sha and
             .head_branch == $head_ref and
-            (
-              ((.head_repository | type) == "object" and
-               .head_repository.full_name == $head_repo and
-               (.head_repository.id | type == "number") and
-               .head_repository.id == $head_repo_id) or
-              .head_repository == null
-            )
-            # Empty associations are discovery candidates only. Source and
-            # repository binding is proved after the exact run and job are
-            # re-read; the sort rank keeps an exact source run ahead of an
-            # unrelated execution while preserving the base-SHA preference.
+            (.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            (.head_repository.id | type == "number") and
+            .head_repository.id == $head_repo_id
           else any($prs[]?;
             (.number | type == "number") and
             (.number | tostring) == $pr and
             .base.ref == $base and
+            (.base.sha | type == "string") and
+            (.base.sha | test("^[0-9a-f]{40}$")) and
+            .base.sha == $base_sha and
             ((.base.repo.full_name // "") == "" or
              .base.repo.full_name == $repo) and
             (.base.repo.id | type == "number") and
@@ -582,19 +594,24 @@ if ! candidate_list_json="$(jq -c \
           end;
       [ .[] | .workflow_runs[]?
         | select(
-            (.path == $path or
-            ((.path | startswith($path + "@")) and
-             ((.path | length) > (($path | length) + 1)))) and
+            .path == $path and
             .event == $event and
             (.workflow_id | type == "number") and
             .workflow_id == ($workflow_id | tonumber) and
+            (.name | type == "string") and
+            .name == $workflow_name and
             (.head_sha | type == "string") and
             (.head_sha | test("^[0-9a-f]{40}$")) and
+            (.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            (.head_repository.id | type == "number") and
+            .head_repository.id == $head_repo_id and
             (.id | type == "number") and
             .id > 0 and
             .status == "completed" and
             .conclusion == "failure" and
             (.created_at | type == "string") and
+            (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
             .created_at <= $before and
             run_binds_to_pr
           )
@@ -616,6 +633,121 @@ if [[ "${candidate_count}" == "0" ]]; then
   if [[ "${run_window_full}" == true ]]; then
     fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
   fi
+  # Do not silently treat a failed run with an empty association and incomplete
+  # source metadata as a successful no-op. A branch name or a null repository
+  # can describe another fork, so every such run gets an explicit fail-closed
+  # error before the helper can return.
+  empty_execution_mismatch_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --arg head_ref "${head_ref}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    '[ .[] | .workflow_runs[]?
+      | select(
+          .path == $path and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.name | type == "string") and
+          .name == $workflow_name and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          (
+            .head_sha != $sha or
+            (.head_repository | type) != "object" or
+            .head_repository.full_name != $head_repo or
+            (.head_repository.id | type) != "number" or
+            .head_repository.id != $head_repo_id
+          ) and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+          .created_at <= $before and
+          .head_branch == $head_ref and
+          (.pull_requests == null or
+           ((.pull_requests | type) == "array" and
+            (.pull_requests | length) == 0))
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
+  if (( empty_execution_mismatch_count > 0 )); then
+    fail "The workflow run has no pull request association with complete source metadata and an exact execution SHA"
+  fi
+
+  # A populated association with an old base SHA is not an absent check. It is
+  # a stale failed run that must fail closed, otherwise a later rerun could
+  # execute policy against a different target revision. Count only an exact
+  # PR/source identity and treat a missing or malformed association base SHA as
+  # stale as well.
+  stale_base_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    '[ .[] | .workflow_runs[]?
+      | select(
+          .path == $path and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.name | type == "string") and
+          .name == $workflow_name and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          (.head_repository | type) == "object" and
+          .head_repository.full_name == $head_repo and
+          (.head_repository.id | type == "number") and
+          .head_repository.id == $head_repo_id and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+          .created_at <= $before and
+          (.pull_requests | type) == "array" and
+          (.pull_requests | length > 0) and
+          any(.pull_requests[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            .base.ref == $base and
+            .base.repo.full_name == $repo and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            .head.repo.full_name == $head_repo and
+            (if (.base.sha | type) == "string"
+             then ((.base.sha | test("^[0-9a-f]{40}$") | not) or .base.sha != $base_sha)
+             else true
+             end)
+          )
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${stale_base_count}" =~ ^[0-9]+$ ]] || fail "Could not count stale CLA workflow base associations"
+  if (( stale_base_count > 0 )); then
+    fail "The failed CLA check is bound to an outdated or malformed pull request base SHA; push a new commit before requesting a rerun"
+  fi
   # A run from before this workflow generation cannot be safely
   # rerun: GitHub reruns the old workflow revision, which could
   # execute the archived action or an obsolete policy. Distinguish
@@ -633,6 +765,8 @@ if [[ "${candidate_count}" == "0" ]]; then
     --argjson head_repo_id "${head_repo_id}" \
     --argjson repo_id "${repo_id}" \
     --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
     --arg before "${COMMENT_CREATED_AT}" \
     'def run_binds_to_pr:
        (.pull_requests) as $raw_prs
@@ -640,20 +774,21 @@ if [[ "${candidate_count}" == "0" ]]; then
           elif ($raw_prs | type) == "array" then $raw_prs
           else null end) as $prs
        | if $prs == null then false
+         elif ($prs | length > 100) then false
          elif ($prs | length) == 0 then
            .head_sha == $sha and
            .head_branch == $head_ref and
-           (
-             ((.head_repository | type) == "object" and
-              .head_repository.full_name == $head_repo and
-              (.head_repository.id | type == "number") and
-              .head_repository.id == $head_repo_id) or
-             .head_repository == null
-           )
+           (.head_repository | type) == "object" and
+           .head_repository.full_name == $head_repo and
+           (.head_repository.id | type == "number") and
+           .head_repository.id == $head_repo_id
          else any($prs[]?;
            (.number | type == "number") and
            (.number | tostring) == $pr and
            .base.ref == $base and
+           (.base.sha | type == "string") and
+           (.base.sha | test("^[0-9a-f]{40}$")) and
+           .base.sha == $base_sha and
            ((.base.repo.full_name // "") == "" or
             .base.repo.full_name == $repo) and
            (.base.repo.id | type == "number") and
@@ -668,12 +803,12 @@ if [[ "${candidate_count}" == "0" ]]; then
          end;
      [ .[] | .workflow_runs[]?
       | select(
-          (.path == $path or
-          ((.path | startswith($path + "@")) and
-            ((.path | length) > (($path | length) + 1)))) and
+          .path == $path and
           .event == $event and
           (.workflow_id | type == "number") and
           .workflow_id == ($workflow_id | tonumber) and
+          (.name | type == "string") and
+          .name == $workflow_name and
           (.head_sha | type == "string") and
           (.head_sha | test("^[0-9a-f]{40}$")) and
           (.id | type == "number") and
@@ -681,6 +816,7 @@ if [[ "${candidate_count}" == "0" ]]; then
           .status == "completed" and
           .conclusion == "failure" and
           (.created_at | type == "string") and
+          (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
           .created_at <= $before and
           run_binds_to_pr
         )
@@ -689,8 +825,8 @@ if [[ "${candidate_count}" == "0" ]]; then
   if (( stale_run_count > 0 )); then
     fail "The failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
   fi
-  # A valid signature can arrive after the check already passed.
-  # Preserve the action's historical no-op behavior in that case.
+  # A valid signature can arrive after the check already passed. Keep this
+  # path read-only and report the absence of a failed current-head run.
   echo "No failed CLA run exists for this pull request head"
   exit 0
 fi
@@ -705,43 +841,57 @@ run_execution_sha="$(jq -r '.head_sha // empty' <<<"${candidate_json}")"
 run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
 [[ -n "${run_head_branch}" && "${run_head_branch}" != *$'\n'* && "${run_head_branch}" != *$'\r'* ]] || fail "The selected CLA run head branch is invalid"
 
-# A run with a populated pull_requests array already carries an
-# authenticated source-PR association. Some GitHub API responses omit that
-# array. For the fallback, the run must match the live PR source branch and
-# either use the live base SHA or carry a failed check on the exact source head
-# whose details URL names this run and job. A bare branch/repository match is
-# not enough because a branch can be reused after a push.
-RUN_REQUIRES_CHECK_BINDING=false
+# A run with a populated pull_requests array carries a source-PR association,
+# but that association is still only discovery data. For pull_request_target,
+# GitHub records the Actions check on the workflow execution SHA (normally the
+# live PR base SHA), not on the untrusted source head. Empty associations need
+# one extra branch: when GitHub omits or cannot prove the source repository and
+# base execution SHA, require a failed check on the exact source head instead.
+# The selected check always names the exact run and job in its details URL.
 
-fetch_check_runs_for_head() {
+# These values are set by validate_run_source_binding before each check lookup.
+# Keeping the lookup SHA separate from the PR source SHA avoids silently using
+# the wrong commit when GitHub returns pull_request_target metadata.
+CHECK_LOOKUP_SHA=""
+CHECK_EXPECTED_SHA=""
+CHECK_BINDING_MODE=""
+
+fetch_check_runs_for_sha() {
   local commit_sha="$1"
-  local response page_count page2 page2_count
+  local check_name="$2"
+  local response page_count page2 page2_count page=1
   response="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
+    --raw-field check_name="${check_name}" \
+    --raw-field app_id="${CLA_ACTION_APP_ID}" \
     --raw-field filter=all \
     --raw-field per_page=100 \
-    --raw-field page=1 \
+    --raw-field page="${page}" \
     "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
   jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${response}" >/dev/null || return 1
   page_count="$(jq -r '.check_runs | length' <<<"${response}")"
   [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
   (( page_count <= 100 )) || return 1
-  if (( page_count == 100 )); then
+  while (( page_count == 100 && page < MAX_CHECK_PAGES )); do
+    (( page++ ))
     page2="$(gh_api_bounded \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
+      --raw-field check_name="${check_name}" \
+      --raw-field app_id="${CLA_ACTION_APP_ID}" \
       --raw-field filter=all \
       --raw-field per_page=100 \
-      --raw-field page=2 \
+      --raw-field page="${page}" \
       "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
     jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${page2}" >/dev/null || return 1
     page2_count="$(jq -r '.check_runs | length' <<<"${page2}")"
     [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
     (( page2_count <= 100 )) || return 1
     response="$(jq -c --argjson page2 "${page2}" '.check_runs += $page2.check_runs' <<<"${response}")"
-    (( page2_count < 100 )) || return 1
-  fi
+    page_count="${page2_count}"
+  done
+  (( page_count < 100 )) || return 1
   printf '%s\n' "${response}"
 }
 
@@ -749,41 +899,65 @@ assert_failed_check_binding() {
   local checks="$1"
   local expected_run_id="$2"
   local expected_job_id="$3"
+  local expected_check_sha="$4"
+  local expected_check_name="$5"
   local details_url="https://github.com/${GH_REPO}/actions/runs/${expected_run_id}/job/${expected_job_id}"
-  jq -e \
-    --arg job "${CLA_ASSISTANT_JOB}" \
-    --arg sha "${head_sha}" \
-    --arg url "${details_url}" '
-      any(.check_runs[]?;
+  local matching_count
+  [[ "${expected_check_sha}" =~ ^[0-9a-f]{40}$ ]] || return 1
+  matching_count="$(jq -r \
+    --arg job "${expected_check_name}" \
+    --arg sha "${expected_check_sha}" \
+    --arg url "${details_url}" \
+    --argjson app_id "${CLA_ACTION_APP_ID}" '
+      [ .check_runs[]?
+        | select(
+        (.id | type == "number") and
+        .id > 0 and
         .name == $job and
         .status == "completed" and
         .conclusion == "failure" and
         (.head_sha | type == "string") and
         .head_sha == $sha and
-        (.app.slug? == "github-actions") and
+        (.app | type == "object") and
+        (.app.id | type == "number") and
+        .app.id == $app_id and
+        .app.slug == "github-actions" and
         (.details_url | type == "string") and
         (.details_url == $url or
          (.details_url | startswith($url + "?") or startswith($url + "#")))
-      )
-    ' <<<"${checks}" >/dev/null
+        )
+      ] | length
+    ' <<<"${checks}")"
+  [[ "${matching_count}" =~ ^[0-9]+$ && "${matching_count}" == 1 ]]
 }
 
 validate_failed_check_binding() {
   local expected_run_id="$1"
   local expected_job_id="$2"
+  local expected_check_name="$3"
+  local check_sha="${CHECK_LOOKUP_SHA}"
+  local expected_check_sha="${CHECK_EXPECTED_SHA}"
   local checks
-  checks="$(fetch_check_runs_for_head "${head_sha}")" ||
-    fail "Could not query checks for the exact pull request head"
-  assert_failed_check_binding "${checks}" "${expected_run_id}" "${expected_job_id}" ||
-    fail "No failed CLA check is bound to the exact pull request head and selected job"
+  [[ "${check_sha}" =~ ^[0-9a-f]{40}$ && "${expected_check_sha}" =~ ^[0-9a-f]{40}$ ]] ||
+    fail "The selected CLA run has no valid check binding context"
+  checks="$(fetch_check_runs_for_sha "${check_sha}" "${expected_check_name}")" ||
+    fail "Could not query checks for the selected CLA execution"
+  assert_failed_check_binding "${checks}" "${expected_run_id}" "${expected_job_id}" "${expected_check_sha}" "${expected_check_name}" ||
+    if [[ "${CHECK_BINDING_MODE}" == source-fallback ]]; then
+      fail "No failed CLA check is bound to the exact pull request source head and selected job"
+    else
+      fail "No failed CLA check is bound to the workflow execution SHA and selected job"
+    fi
 }
 
 validate_run_source_binding() {
   local run_payload="$1"
   local execution_sha pull_requests_type pull_request_count head_repository_type
-  RUN_REQUIRES_CHECK_BINDING=false
   execution_sha="$(jq -r '.head_sha // empty' <<<"${run_payload}")"
   [[ "${execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The workflow run execution SHA is invalid"
+  CHECK_LOOKUP_SHA="${execution_sha}"
+  CHECK_EXPECTED_SHA="${execution_sha}"
+  CHECK_BINDING_MODE=execution
   pull_requests_type="$(jq -r 'if .pull_requests == null then "null" else (.pull_requests | type) end' <<<"${run_payload}")"
   case "${pull_requests_type}" in
     null) pull_request_count=0 ;;
@@ -792,21 +966,38 @@ validate_run_source_binding() {
   esac
   [[ "${pull_request_count}" =~ ^[0-9]+$ ]] || fail "The workflow run pull request association count is invalid"
   if (( pull_request_count == 0 )); then
-    # GitHub may omit pull_requests on a pull_request_target run. Its documented
-    # execution SHA is the last commit on the base branch, so accept the empty
-    # association form without a check only when the repository identity is
-    # complete and that SHA equals the live PR base SHA. A source SHA, a null
-    # repository, or any other execution SHA needs an exact failed check on the
-    # source head after the job ID is known.
+    # GitHub may omit pull_requests on a pull_request_target run. A complete
+    # source repository plus the live PR base SHA binds the run directly. A
+    # null source repository cannot identify which fork produced the branch,
+    # so it is never eligible for the source-head fallback.
     head_repository_type="$(jq -r 'if .head_repository == null then "null" else (.head_repository | type) end' <<<"${run_payload}")"
-    if [[ "${execution_sha}" == "${base_sha}" && "${head_repository_type}" == object ]]; then
-      validate_live_open_head_association
-      return 0
-    fi
-    RUN_REQUIRES_CHECK_BINDING=true
-    # The check binding is validated after the exact job ID is selected.
-    # Keep the live source check here so the run cannot pass on a stale branch.
+    case "${head_repository_type}" in
+      null) fail "The workflow run source repository metadata is missing" ;;
+      object)
+        jq -e \
+          --arg head_repo "${head_repo}" \
+          --argjson head_repo_id "${head_repo_id}" \
+          '.head_repository.full_name == $head_repo and
+           (.head_repository.id | type == "number") and
+           .head_repository.id == $head_repo_id' <<<"${run_payload}" >/dev/null ||
+          fail "The workflow run source repository does not match the pull request"
+        ;;
+      *) fail "The workflow run source repository metadata is malformed" ;;
+    esac
     validate_live_open_head_association
+    if [[ "${execution_sha}" == "${base_sha}" ]]; then
+      CHECK_LOOKUP_SHA="${execution_sha}"
+      CHECK_EXPECTED_SHA="${execution_sha}"
+      CHECK_BINDING_MODE=execution
+    else
+      # Some pull_request_target API responses expose a non-base execution
+      # SHA. Bind those runs to the immutable live source head and its exact
+      # job URL only after the complete repository metadata and live PR
+      # association above have been verified.
+      CHECK_LOOKUP_SHA="${head_sha}"
+      CHECK_EXPECTED_SHA="${head_sha}"
+      CHECK_BINDING_MODE=source-fallback
+    fi
   fi
 }
 
@@ -828,7 +1019,9 @@ validate_exact_run_payload() {
     --argjson repo_id "${repo_id}" \
     --arg head_ref "${head_ref}" \
     --arg workflow_id "${workflow_id}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
     --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
     --arg before "${COMMENT_CREATED_AT}" '
       def run_binds_to_pr:
         (.pull_requests) as $raw_prs
@@ -837,18 +1030,19 @@ validate_exact_run_payload() {
            else null end) as $prs
         | if $prs == null then false
           elif ($prs | length) == 0 then
+            .head_sha == $base_sha and
             .head_branch == $head_ref and
-            (
-              ((.head_repository | type) == "object" and
-               .head_repository.full_name == $head_repo and
-               (.head_repository.id | type == "number") and
-               .head_repository.id == $head_repo_id) or
-              .head_repository == null
-            )
+            (.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            (.head_repository.id | type == "number") and
+            .head_repository.id == $head_repo_id
           else any($prs[]?;
             (.number | type == "number") and
             (.number | tostring) == $pr and
             .base.ref == $base and
+            (.base.sha | type == "string") and
+            (.base.sha | test("^[0-9a-f]{40}$")) and
+            .base.sha == $base_sha and
             ((.base.repo.full_name // "") == "" or
              .base.repo.full_name == $repo) and
             (.base.repo.id | type == "number") and
@@ -865,16 +1059,21 @@ validate_exact_run_payload() {
       .id == ($run_id | tonumber) and
       (.workflow_id | type == "number") and
       .workflow_id == ($workflow_id | tonumber) and
+      (.name | type == "string") and
+      .name == $workflow_name and
       (.path | type == "string") and
-      (.path == $path or
-       ((.path | startswith($path + "@")) and
-        ((.path | length) > (($path | length) + 1)))) and
+      .path == $path and
       .event == $event and
       .status == "completed" and
       .conclusion == "failure" and
       .head_sha == $run_sha and
       .head_branch == $run_head_branch and
+      (.head_repository | type) == "object" and
+      .head_repository.full_name == $head_repo and
+      (.head_repository.id | type == "number") and
+      .head_repository.id == $head_repo_id and
       (.created_at | type == "string") and
+      (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
       .created_at <= $before and
       run_binds_to_pr
     ' <<<"${payload}" >/dev/null
@@ -933,6 +1132,8 @@ fetch_jobs_for_run() {
 }
 
 jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and validate jobs for the selected CLA run"
+RERUN_TARGET_JOB_NAME=""
+RERUN_FAILED_JOBS=false
 
 # Validate every failed job before granting the state-changing API call. The
 # v3 writer, required result, and migration compatibility jobs are the only
@@ -943,7 +1144,8 @@ jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and valid
 validate_failed_job_set() {
   local payload="$1"
   local all_jobs_json failed_jobs_json failed_count nonfailure_count
-  local unexpected_count assistant_count assistant_valid_count writer_count writer_valid_count
+  local unexpected_count assistant_count assistant_valid_count assistant_failed_count assistant_success_count
+  local writer_count writer_valid_count
   local compatibility_count compatibility_valid_count
   if ! all_jobs_json="$(jq -c '[.[] | .jobs[]?]' <<<"${payload}")"; then
     fail "Could not flatten jobs for the selected CLA run"
@@ -957,7 +1159,21 @@ validate_failed_job_set() {
       .run_id == ($run_id | tonumber) and
       (.name | type == "string") and
       (.status == "completed") and
-      (.conclusion | type == "string")
+      (.conclusion | type == "string") and
+      (.head_sha | type == "string") and
+      (.head_sha | test("^[0-9a-f]{40}$")) and
+      (.steps | type == "array") and
+      (.steps | length <= 100) and
+      all(.steps[]?; type == "object") and
+      ((has("head_repository") | not) or
+       .head_repository == null or
+       ((.head_repository | type) == "object" and
+        (.head_repository.full_name | type) == "string" and
+        (.head_repository.id | type == "number"))) and
+      ((has("workflow_name") | not) or
+       (.workflow_name | type) == "string") and
+      ((has("workflow_id") | not) or
+       (.workflow_id | type == "number"))
     )' <<<"${all_jobs_json}" >/dev/null || fail "The selected CLA run contains a malformed or incomplete job"
 
   failed_jobs_json="$(jq -c '[.[] | select(.conclusion != "success" and .conclusion != "skipped")]' <<<"${all_jobs_json}")"
@@ -973,18 +1189,35 @@ validate_failed_job_set() {
     <<<"${failed_jobs_json}")"
   (( unexpected_count == 0 )) || fail "The selected CLA run contains an unexpected failed job; refusing to rerun it"
 
+  # The v3 job is the generation anchor even when only the compatibility
+  # mirror failed. Validate exactly one current-generation v3 job across the
+  # whole run, then select a failed v3 or compatibility job below.
   if ! assistant_count="$(jq -r \
       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
-      '[.[] | select(.name == $assistant_job)] | length' <<<"${failed_jobs_json}")" ||
+      '[.[] | select(.name == $assistant_job)] | length' <<<"${all_jobs_json}")" ||
+     ! assistant_failed_count="$(jq -r \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       '[.[] | select(.name == $assistant_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! assistant_success_count="$(jq -r \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       '[.[] | select(.name == $assistant_job and .conclusion == "success")] | length' <<<"${all_jobs_json}")" ||
      ! assistant_valid_count="$(jq -r \
        --arg run_id "${run_id}" \
        --arg run_sha "${run_execution_sha}" \
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
        --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+       --arg workflow_id "${workflow_id}" \
        --arg generation_step "CLA generation ${CLA_GENERATION}" \
        '[.[] | select(
           .name == $assistant_job and
+          ((has("workflow_name") | not) or
+           ((.workflow_name | type) == "string" and
+            .workflow_name == $workflow_name)) and
+          ((has("workflow_id") | not) or
+           ((.workflow_id | type) == "number" and
+            .workflow_id == ($workflow_id | tonumber))) and
           .run_id == ($run_id | tonumber) and
           (.head_sha | type == "string") and
           .head_sha == $run_sha and
@@ -997,12 +1230,18 @@ validate_failed_job_set() {
             .name == $generation_step and
             .status == "completed"
           )
-       )] | length' <<<"${failed_jobs_json}")"; then
-    fail "Could not validate failed CLA Assistant v3 jobs"
+       )] | length' <<<"${all_jobs_json}")"; then
+    fail "Could not validate CLA Assistant v3 generation anchor"
   fi
-  [[ "${assistant_count}" =~ ^[0-9]+$ && "${assistant_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA Assistant v3 jobs"
-  (( assistant_count == 1 )) || fail "Expected exactly one failed CLA Assistant v3 job"
+  [[ "${assistant_count}" =~ ^[0-9]+$ && "${assistant_failed_count}" =~ ^[0-9]+$ &&
+     "${assistant_success_count}" =~ ^[0-9]+$ && "${assistant_valid_count}" =~ ^[0-9]+$ ]] ||
+    fail "Could not count CLA Assistant v3 jobs"
+  (( assistant_count == 1 )) || fail "Expected exactly one CLA Assistant v3 generation anchor"
   (( assistant_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  (( assistant_failed_count <= 1 )) || fail "The selected CLA run contains multiple failed CLA Assistant v3 jobs"
+  if (( assistant_failed_count == 0 && assistant_success_count != 1 )); then
+    fail "The CLA Assistant v3 generation anchor did not complete successfully"
+  fi
 
   if ! writer_count="$(jq -r \
       --arg writer_job "${CLA_WRITER_JOB}" \
@@ -1013,8 +1252,16 @@ validate_failed_job_set() {
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
        --arg writer_job "${CLA_WRITER_JOB}" \
+       --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+       --arg workflow_id "${workflow_id}" \
        '[.[] | select(
           .name == $writer_job and
+          ((has("workflow_name") | not) or
+           ((.workflow_name | type) == "string" and
+            .workflow_name == $workflow_name)) and
+          ((has("workflow_id") | not) or
+           ((.workflow_id | type) == "number" and
+            .workflow_id == ($workflow_id | tonumber))) and
           .run_id == ($run_id | tonumber) and
           (.head_sha | type == "string") and
           .head_sha == $run_sha and
@@ -1037,8 +1284,17 @@ validate_failed_job_set() {
       --arg head_repo "${head_repo}" \
       --argjson head_repo_id "${head_repo_id}" \
       --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+      --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+      --arg workflow_id "${workflow_id}" \
+      --arg compatibility_step "${CLA_COMPATIBILITY_STEP}" \
       '[.[] | select(
          .name == $compatibility_job and
+         ((has("workflow_name") | not) or
+          ((.workflow_name | type) == "string" and
+           .workflow_name == $workflow_name)) and
+         ((has("workflow_id") | not) or
+          ((.workflow_id | type) == "number" and
+           .workflow_id == ($workflow_id | tonumber))) and
          .run_id == ($run_id | tonumber) and
          (.head_sha | type == "string") and
          .head_sha == $run_sha and
@@ -1047,12 +1303,26 @@ validate_failed_job_set() {
            ((.head_repository | type) == "object" and
             .head_repository.full_name == $head_repo and
             .head_repository.id == $head_repo_id)))
-      )] | length' <<<"${failed_jobs_json}")"; then
+          and any(.steps[]?;
+            .name == $compatibility_step and
+            .status == "completed"
+          )
+       )] | length' <<<"${failed_jobs_json}")"; then
     fail "Could not validate failed CLA compatibility jobs"
   fi
   [[ "${compatibility_count}" =~ ^[0-9]+$ && "${compatibility_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA compatibility jobs"
   (( compatibility_count <= 1 )) || fail "The selected CLA run contains multiple failed compatibility jobs"
   (( compatibility_valid_count == compatibility_count )) || fail "The failed CLA compatibility job is malformed or bound to a different source"
+  if (( assistant_failed_count == 1 )); then
+    RERUN_TARGET_JOB_NAME="${CLA_ASSISTANT_JOB}"
+  elif (( compatibility_count == 1 && writer_count == 0 )); then
+    # A transient compatibility-mirror failure can block a repository that
+    # still requires the legacy context during migration. The successful v3
+    # job above remains the independently validated generation anchor.
+    RERUN_TARGET_JOB_NAME="${CLA_COMPATIBILITY_JOB}"
+  else
+    fail "The selected CLA run has no eligible failed result job"
+  fi
   if (( writer_count == 1 || compatibility_count == 1 )); then
     RERUN_FAILED_JOBS=true
   else
@@ -1060,20 +1330,33 @@ validate_failed_job_set() {
   fi
 }
 validate_failed_job_set "${jobs_json}"
-# Select the sole current-generation assistant job from a validated job set.
-select_cla_job() {
+# Select the sole failed result job from a validated job set. The v3 job
+# carries the generation marker. A compatibility-only failure uses the
+# separately validated successful v3 job as its generation anchor.
+select_rerun_job() {
   local payload="$1"
   jq -c \
     --arg run_id "${run_id}" \
     --arg run_sha "${run_execution_sha}" \
+    --arg target_job "${RERUN_TARGET_JOB_NAME}" \
     --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg workflow_id "${workflow_id}" \
     --arg generation_step "CLA generation ${CLA_GENERATION}" \
+    --arg compatibility_step "${CLA_COMPATIBILITY_STEP}" \
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" \
     '[.[] | .jobs[]?
       | select(
           (.run_id | tostring) == $run_id and
-          .name == $assistant_job and
+          .name == $target_job and
+          ((has("workflow_name") | not) or
+           ((.workflow_name | type) == "string" and
+            .workflow_name == $workflow_name)) and
+          ((has("workflow_id") | not) or
+           ((.workflow_id | type) == "number" and
+            .workflow_id == ($workflow_id | tonumber))) and
           .status == "completed" and
           .conclusion == "failure" and
           (.head_sha | type == "string") and
@@ -1083,32 +1366,49 @@ select_cla_job() {
             (.head_repository.full_name == $head_repo and
              .head_repository.id == $head_repo_id)
           ) and
-          any(.steps[]?;
-            .name == $generation_step and
-            .status == "completed"
-          )
+          (($target_job == $assistant_job and
+            any(.steps[]?;
+              .name == $generation_step and
+              .status == "completed"
+            )) or
+           ($target_job == $compatibility_job and
+            any(.steps[]?;
+              .name == $compatibility_step and
+              .status == "completed"
+            )))
         )
     ]
     | if length == 1 then .[0] else empty end
   ' <<<"${payload}"
 }
 
-# Validate one exact assistant job for every discovery and final re-read.
+# Validate the exact failed result job for every discovery and final re-read.
 validate_exact_job_payload() {
   local payload="$1"
   jq -e \
     --arg job_id "${job_id}" \
     --arg run_id "${run_id}" \
     --arg run_sha "${run_execution_sha}" \
+    --arg target_job "${RERUN_TARGET_JOB_NAME}" \
     --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg workflow_id "${workflow_id}" \
     --arg generation_step "CLA generation ${CLA_GENERATION}" \
+    --arg compatibility_step "${CLA_COMPATIBILITY_STEP}" \
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" '
       (.id | type == "number") and
       .id == ($job_id | tonumber) and
       (.run_id | type == "number") and
       .run_id == ($run_id | tonumber) and
-      .name == $assistant_job and
+      .name == $target_job and
+      ((has("workflow_name") | not) or
+       ((.workflow_name | type) == "string" and
+        .workflow_name == $workflow_name)) and
+      ((has("workflow_id") | not) or
+       ((.workflow_id | type) == "number" and
+        .workflow_id == ($workflow_id | tonumber))) and
       .status == "completed" and
       .conclusion == "failure" and
       (.head_sha | type == "string") and
@@ -1120,32 +1420,35 @@ validate_exact_job_payload() {
          .head_repository.full_name == $head_repo and
          .head_repository.id == $head_repo_id)
       ) and
-      any(.steps[]?;
-        .name == $generation_step and
-        .status == "completed"
-      )
+      (($target_job == $assistant_job and
+        any(.steps[]?;
+          .name == $generation_step and
+          .status == "completed"
+        )) or
+       ($target_job == $compatibility_job and
+        any(.steps[]?;
+          .name == $compatibility_step and
+          .status == "completed"
+        )))
     ' <<<"${payload}" >/dev/null
 }
 
-if ! cla_job_json="$(select_cla_job "${jobs_json}")"; then
-  fail "Could not validate CLA Assistant v3 job data"
+target_job_name="${RERUN_TARGET_JOB_NAME}"
+[[ -n "${target_job_name}" ]] || fail "The selected CLA run has no eligible failed result job"
+if ! cla_job_json="$(select_rerun_job "${jobs_json}")"; then
+  fail "Could not validate the selected CLA result job"
 fi
 if [[ -z "${cla_job_json}" ]]; then
-  # The run matched the current PR and failed, but no job carried
-  # this workflow generation marker. It is an old or malformed
-  # generation and must not be replayed with the privileged token.
-  fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  fail "The selected failed CLA result job is malformed or bound to an older workflow generation"
 fi
 job_id="$(jq -r '.id // empty' <<<"${cla_job_json}")"
 [[ "${job_id}" =~ ^[1-9][0-9]*$ ]] || fail "The selected CLA job ID is invalid"
-if [[ "${RUN_REQUIRES_CHECK_BINDING}" == true ]]; then
-  validate_failed_check_binding "${run_id}" "${job_id}"
-fi
+validate_failed_check_binding "${run_id}" "${job_id}" "${target_job_name}"
 
 # Re-read the individual job. The jobs list is discovery only, just
 # like the workflow-run list above.
-job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA Assistant v3 job"
-validate_exact_job_payload "${job_json}" || fail "The selected CLA Assistant v3 job no longer matches the failed job in this run"
+job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA result job"
+validate_exact_job_payload "${job_json}" || fail "The selected CLA result job no longer matches the failed job in this run"
 
 # Recheck both resources immediately before the state-changing call.
 # This prevents a push or a concurrent rerun from making the job
@@ -1153,16 +1456,15 @@ validate_exact_job_payload "${job_json}" || fail "The selected CLA Assistant v3 
 latest_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
 validate_exact_pr_snapshot "${latest_pr_json}" || fail "The pull request changed while selecting the CLA job"
 final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
-validate_exact_job_payload "${final_job_json}" || fail "The exact failed CLA Assistant v3 job is no longer eligible"
+validate_exact_job_payload "${final_job_json}" || fail "The exact failed CLA result job is no longer eligible"
 
 # Re-fetch the whole job set immediately before the state-changing call. This
 # catches a newly cancelled or unrelated failed job that could otherwise be
 # pulled into a failed-jobs rerun after the first validation.
 final_jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not recheck and validate jobs for the selected CLA run"
 validate_failed_job_set "${final_jobs_json}"
-if ! final_cla_job_json="$(select_cla_job "${final_jobs_json}")"; then
-  fail "Could not validate the final CLA Assistant v3 job data"
-fi
+[[ "${RERUN_TARGET_JOB_NAME}" == "${target_job_name}" ]] || fail "The failed CLA result job changed while preparing the rerun"
+final_cla_job_json="$(select_rerun_job "${final_jobs_json}")" || fail "Could not select the final CLA result job"
 final_job_id="$(jq -r '.id // empty' <<<"${final_cla_job_json}")"
 [[ "${final_job_id}" == "${job_id}" ]] || fail "The selected CLA job changed while preparing the rerun"
 
@@ -1172,21 +1474,16 @@ final_job_id="$(jq -r '.id // empty' <<<"${final_cla_job_json}")"
 # check is fetched last and must bind both the exact source SHA and this job.
 final_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
 validate_exact_pr_snapshot "${final_pr_json}" || fail "The pull request changed before rerun"
-# The individual PR response does not enumerate duplicate fork references.
-# Recheck the filtered open-PR association at the same final boundary.
-validate_live_open_head_association
 final_run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run before rerun"
 validate_exact_run_payload "${final_run_json}" || fail "The selected CLA run changed before rerun"
 validate_run_source_binding "${final_run_json}"
 final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job before rerun"
 validate_exact_job_payload "${final_job_json}" || fail "The selected CLA job changed before rerun"
-if [[ "${RUN_REQUIRES_CHECK_BINDING}" == true ]]; then
-  validate_failed_check_binding "${run_id}" "${job_id}"
-fi
+validate_failed_check_binding "${run_id}" "${job_id}" "${target_job_name}"
 
 if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
   rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"
-  rerun_description="failed CLA v3 jobs (writer, assistant, and compatibility)"
+  rerun_description="failed CLA result jobs (writer, v3, and compatibility)"
 else
   rerun_endpoint="repos/${GH_REPO}/actions/jobs/${job_id}/rerun"
   rerun_description="CLA job ${job_id}"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -34,6 +34,11 @@ if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign 
   fail "The signing comment did not result in a persisted signature"
 fi
 [[ "${CLA_GENERATION}" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{7,40}$ ]] || fail "Invalid CLA generation marker"
+[[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
+checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
+[[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"
+[[ "${WORKFLOW_PATH}" == ".github/workflows/cla.yml" ]] || fail "Unexpected CLA workflow path"
+[[ -f .github/scripts/rerun-failed-cla.sh ]] || fail "The trusted CLA rerun helper is missing"
 
 # These values are part of the trusted workflow contract. They are deliberately
 # constants, not event or comment input, so a contributor cannot redirect this
@@ -41,15 +46,62 @@ fi
 readonly SIGNATURES_BRANCH='cla-signatures'
 readonly SIGNATURES_PATH='signatures/version2/cla.json'
 readonly MAX_RUN_PAGES=10
+# Keep every GitHub JSON response below a fixed byte budget before it enters a
+# shell variable. GitHub's pagination limits bound item counts, not the size of
+# individual fields, so a response-size guard is still required.
+readonly MAX_API_RESPONSE_BYTES=2000000
+readonly MAX_API_ERROR_BYTES=65536
 readonly MAX_LEDGER_BYTES=1000000
 readonly MAX_LEDGER_SIGNATURES=10000
 # GitHub wraps Contents API Base64 responses with newlines. Allow that
 # transport overhead while bounding the raw field before normalization.
 readonly MAX_LEDGER_RAW_BYTES=2000000
+# These rendered job names are part of the v3 workflow contract. Keep them
+# fixed here so a workflow edit cannot make this actions:write helper rerun an
+# arbitrary failed job. The writer and compatibility jobs are optional failed
+# members because a recheck can target a result-only failure; when either is
+# failed, rerun-failed-jobs refreshes every failed v3 context together.
+readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
+readonly CLA_WRITER_JOB='CLA ledger writer'
+readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
+
+# Capture one byte past the limit in a temporary file. This keeps an oversized
+# response out of shell memory and bounds disk use before command substitution
+# can expose the response to jq. Bound stderr separately because GitHub can
+# include response text in gh diagnostics.
+gh_api_bounded() {
+  local temp_dir body_file response_bytes gh_status head_status cat_status
+  local -a pipeline_status
+  temp_dir="$(mktemp -d)" || return 1
+  body_file="${temp_dir}/body"
+  set +e
+  gh api "$@" 2> >(head -c "${MAX_API_ERROR_BYTES}" >&2) |
+    head -c "$((MAX_API_RESPONSE_BYTES + 1))" >"${body_file}"
+  pipeline_status=("${PIPESTATUS[@]}")
+  set -e
+  gh_status="${pipeline_status[0]:-1}"
+  head_status="${pipeline_status[1]:-1}"
+  response_bytes="$(LC_ALL=C wc -c <"${body_file}" | tr -d '[:space:]')"
+  if [[ ! "${response_bytes}" =~ ^[0-9]+$ ]] || (( response_bytes > MAX_API_RESPONSE_BYTES )); then
+    rm -rf -- "${temp_dir}"
+    return 2
+  fi
+  if (( head_status != 0 )); then
+    rm -rf -- "${temp_dir}"
+    return 1
+  fi
+  cat "${body_file}"
+  cat_status=$?
+  rm -rf -- "${temp_dir}"
+  if (( gh_status != 0 )); then
+    return "${gh_status}"
+  fi
+  return "${cat_status}"
+}
 
 validate_triggering_signature_record() {
   local ledger_response ledger_content ledger_content_compact ledger_json ledger_raw_bytes ledger_encoded_bytes ledger_decoded_bytes
-  ledger_response="$(gh api \
+  ledger_response="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field ref="${SIGNATURES_BRANCH}" \
@@ -104,19 +156,42 @@ validate_triggering_signature_record() {
      )' <<<"${ledger_json}" >/dev/null || fail "The signing comment was not the signature persisted by the CLA action"
 }
 
-issue_json="$(gh api "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
+issue_json="$(gh_api_bounded "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
 issue_state="$(jq -r '.state // empty' <<<"${issue_json}")"
 issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
 [[ "${issue_state}" == "open" ]] || fail "The issue is not an open pull request"
 [[ "${issue_pr_url}" == "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" ]] || fail "The issue is not the exact repository pull request"
 
-pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
+# Re-fetch the triggering comment immediately before using its ledger entry.
+# A comment can be edited or deleted after the writer records a signature; a
+# stale event payload must never authorize a rerun of the failed check.
+comment_json="$(gh_api_bounded "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" 2>/dev/null)" || fail "Could not query the triggering comment"
+jq -e \
+  --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+  --arg body "${COMMENT_BODY}" \
+  --arg author_id "${COMMENT_AUTHOR_ID}" \
+  --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
+  --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+  --arg created_at "${COMMENT_CREATED_AT}" \
+  '.issue_url == $issue_url and
+   .body == $body and
+   (.user | type == "object") and
+   (.user.id | type == "number") and
+   (.user.id | tostring) == $author_id and
+   .user.login == $author_login and
+   .user.type == $author_type and
+   .created_at == $created_at and
+   .updated_at == $created_at' <<<"${comment_json}" >/dev/null || fail "The triggering CLA comment was edited, deleted, or moved"
+
+pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
 jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
   .number == $number and
   .state == "open" and
   .base.ref == $base and
   (.base.repo.id | type == "number") and
   .base.repo.full_name == $repo and
+  (.base.sha | type == "string") and
+  (.base.sha | test("^[0-9a-f]{40}$")) and
   (.head.sha | type == "string") and
   (.head.sha | test("^[0-9a-f]{40}$")) and
   (.head.repo.id | type == "number") and
@@ -128,11 +203,13 @@ head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
 head_ref="$(jq -r '.head.ref // empty' <<<"${pr_json}")"
 head_repo="$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")"
 head_repo_id="$(jq -r '.head.repo.id // empty' <<<"${pr_json}")"
+base_sha="$(jq -r '.base.sha // empty' <<<"${pr_json}")"
 repo_id="$(jq -r '.base.repo.id // empty' <<<"${pr_json}")"
 pr_author_login="$(jq -r '.user.login // empty' <<<"${pr_json}")"
 pr_author_id="$(jq -r '.user.id // empty' <<<"${pr_json}")"
 [[ "${head_ref}" != "" && "${head_repo}" != "" ]] || fail "The pull request head repository is missing"
 [[ "${head_repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request head repository ID is missing"
+[[ "${base_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The pull request base SHA is missing"
 [[ "${repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request base repository ID is missing"
 [[ "${pr_author_login}" != "" ]] || fail "The pull request author is missing"
 [[ "${pr_author_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request author ID is missing"
@@ -150,83 +227,96 @@ if [[ "${COMMENT_BODY}" == "recheck" && "${COMMENT_AUTHOR_ID}" != "${pr_author_i
 fi
 
 # The workflow-run list can omit pull_requests for pull_request_target runs.
-# The exact live PR plus the run head_repository/head_branch binding below is
-# used for populated source-head runs. Empty associations are accepted only
-# when the run execution SHA equals the live PR head SHA; a base or merge SHA
-# is not sufficient evidence for a privileged rerun.
-# GitHub may return a not-found or validation response when the source commit
-# exists only in a fork. Treat only that documented missing-commit response as
-# an empty association list; every other API failure remains fatal.
-commit_prs_json=""
-commit_association_error=""
-commit_association_stderr_file="$(mktemp)"
-cleanup_commit_association_stderr() {
-  rm -f -- "${commit_association_stderr_file}"
-}
-trap cleanup_commit_association_stderr EXIT
-if commit_prs_json="$(gh api \
-  --method GET \
-  --header 'Accept: application/vnd.github+json' \
-  --raw-field per_page=100 \
-  --raw-field page=1 \
-  "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>"${commit_association_stderr_file}")"; then
-  :
-else
-  commit_association_error="${commit_prs_json}"$'\n'"$(cat "${commit_association_stderr_file}")"
-  if jq -e '
-    ((.status == 404 or .status == "404") and
-      (.message == "Not Found" or .message == "Resource not found")) or
-    ((.status == 422 or .status == "422") and
-      (.message | type == "string" and startswith("No commit found for SHA: ")))
-  ' <<<"${commit_prs_json}" >/dev/null 2>&1 ||
-     { grep -Eq 'HTTP 404' <<<"${commit_association_error}" &&
-       grep -Eq 'Not Found|Resource not found' <<<"${commit_association_error}"; } ||
-     { grep -Eq 'HTTP 422' <<<"${commit_association_error}" &&
-       grep -Eq 'No commit found for SHA: [0-9a-f]{40}' <<<"${commit_association_error}"; }; then
-    commit_prs_json='[]'
-  else
-    fail "Could not query pull request associations"
-  fi
-fi
-cleanup_commit_association_stderr
-trap - EXIT
-jq -e 'type == "array"' <<<"${commit_prs_json}" >/dev/null || fail "Could not validate pull request associations"
-association_count="$(jq -r 'length' <<<"${commit_prs_json}")"
-[[ "${association_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations"
-(( association_count <= 100 )) || fail "The pull request association page is oversized"
-if (( association_count == 100 )); then
-  commit_prs_page2="$(gh api \
+# Fetch the source-head associations once, allowing only GitHub's documented
+# fork-only missing-commit response to fall through to the live PR check.
+fetch_commit_associations() {
+  local commit_sha="$1"
+  local allow_missing="$2"
+  local response error_text stderr_file page_count page2_count page2
+  stderr_file="$(mktemp)" || return 1
+  if response="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
-    --raw-field page=2 \
-    "repos/${GH_REPO}/commits/${head_sha}/pulls" 2>/dev/null)" || fail "Could not query pull request associations page 2"
-  jq -e 'type == "array"' <<<"${commit_prs_page2}" >/dev/null || fail "Could not validate pull request associations page 2"
-  commit_prs_page2_count="$(jq -r 'length' <<<"${commit_prs_page2}")"
-  [[ "${commit_prs_page2_count}" =~ ^[0-9]+$ ]] || fail "Could not count pull request associations page 2"
-  (( commit_prs_page2_count <= 100 )) || fail "The pull request association page is oversized"
-  commit_prs_json="$(jq -c --argjson page2 "${commit_prs_page2}" '. + $page2' <<<"${commit_prs_json}")"
-  association_count=$((association_count + commit_prs_page2_count))
-  (( commit_prs_page2_count < 100 )) || fail "Too many pull request associations for this head after two pages; ask an administrator to resolve the association before requesting a rerun"
-fi
-if (( association_count > 0 )); then
+    --raw-field page=1 \
+    "repos/${GH_REPO}/commits/${commit_sha}/pulls" 2>"${stderr_file}")"; then
+    :
+  else
+    error_text="${response}"$'\n'"$(head -c "${MAX_API_ERROR_BYTES}" "${stderr_file}" 2>/dev/null || true)"
+    if [[ "${allow_missing}" == true ]] && (jq -e '
+      ((.status == 404 or .status == "404") and
+        (.message == "Not Found" or .message == "Resource not found")) or
+      ((.status == 422 or .status == "422") and
+        (.message | type == "string" and startswith("No commit found for SHA: ")))
+    ' <<<"${response}" >/dev/null 2>&1 ||
+      { grep -Eq 'HTTP 404' <<<"${error_text}" &&
+        grep -Eq 'Not Found|Resource not found' <<<"${error_text}"; } ||
+      { grep -Eq 'HTTP 422' <<<"${error_text}" &&
+        grep -Eq 'No commit found for SHA: [0-9a-f]{40}' <<<"${error_text}"; }); then
+      response='[]'
+    else
+      rm -f -- "${stderr_file}"
+      return 1
+    fi
+  fi
+  rm -f -- "${stderr_file}"
+  jq -e 'type == "array"' <<<"${response}" >/dev/null || return 1
+  page_count="$(jq -r 'length' <<<"${response}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/commits/${commit_sha}/pulls" 2>/dev/null)" || return 1
+    jq -e 'type == "array"' <<<"${page2}" >/dev/null || return 1
+    page2_count="$(jq -r 'length' <<<"${page2}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    response="$(jq -c --argjson page2 "${page2}" '. + $page2' <<<"${response}")"
+    if (( page2_count == 100 )); then
+      echo "::error::Too many pull request associations for this head after two pages" >&2
+      return 1
+    fi
+  fi
+  printf '%s\n' "${response}"
+}
+
+assert_exact_pr_association() {
+  local associations="$1"
+  local expected_sha="$2"
   jq -e \
     --arg repo "${GH_REPO}" \
     --arg pr "${PR_NUMBER}" \
-    --arg sha "${head_sha}" \
+    --arg sha "${expected_sha}" \
     --arg base "${TARGET_BASE_REF}" \
     --arg head_ref "${head_ref}" \
-    --argjson head_repo_id "${head_repo_id}" '
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" '
       any(.[]?;
+        (.number | type == "number") and
         (.number | tostring) == $pr and
         .base.ref == $base and
         .base.repo.full_name == $repo and
+        (.base.repo.id | type == "number") and
+        .base.repo.id == $repo_id and
         .head.ref == $head_ref and
         .head.sha == $sha and
+        .head.repo.full_name == $head_repo and
         (.head.repo.id | type == "number") and
         .head.repo.id == $head_repo_id
       )
-    ' <<<"${commit_prs_json}" >/dev/null || fail "The current head is not associated with this pull request"
+    ' <<<"${associations}" >/dev/null
+}
+
+if ! commit_prs_json="$(fetch_commit_associations "${head_sha}" true)"; then
+  fail "Could not query pull request associations"
+fi
+if [[ "$(jq -r 'length' <<<"${commit_prs_json}")" != 0 ]]; then
+  assert_exact_pr_association "${commit_prs_json}" "${head_sha}" || fail "The current head is not associated with this pull request"
 elif [[ "${head_repo}" == "${GH_REPO}" ]]; then
   fail "The base-repository head has no pull request association"
 fi
@@ -243,7 +333,7 @@ validate_live_open_head_association() {
   head_owner="${head_repo%%/*}"
   head_name="${head_repo#*/}"
   [[ -n "${head_owner}" && -n "${head_name}" ]] || fail "The pull request head repository name is invalid"
-  open_prs_page="$(gh api \
+  open_prs_page="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field state=open \
@@ -257,7 +347,7 @@ validate_live_open_head_association() {
   [[ "${open_pr_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests"
   (( open_pr_count <= 100 )) || fail "The live open pull request page is oversized"
   if (( open_pr_count == 100 )); then
-    open_prs_page2="$(gh api \
+    open_prs_page2="$(gh_api_bounded \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
       --raw-field state=open \
@@ -278,6 +368,7 @@ validate_live_open_head_association() {
   if ! matching_open_prs_json="$(jq -c \
       --arg repo "${GH_REPO}" \
       --arg sha "${head_sha}" \
+      --arg base_sha "${base_sha}" \
       --arg base "${TARGET_BASE_REF}" \
       --arg head_ref "${head_ref}" \
       --arg head_repo "${head_repo}" \
@@ -291,6 +382,8 @@ validate_live_open_head_association() {
               .base.repo.full_name == $repo and
               (.base.repo.id | type == "number") and
               .base.repo.id == $repo_id and
+              (.base.sha | type == "string") and
+              .base.sha == $base_sha and
               .head.ref == $head_ref and
               .head.sha == $sha and
               .head.repo.full_name == $head_repo and
@@ -309,7 +402,38 @@ validate_live_open_head_association() {
 }
 validate_live_open_head_association
 
-workflow_page="$(gh api \
+# Use one immutable PR predicate for each re-read. Keeping base and source
+# identity in one helper prevents a late check from validating fewer fields
+# than the initial snapshot.
+validate_exact_pr_snapshot() {
+  local payload="$1"
+  jq -e \
+    --arg repo "${GH_REPO}" \
+    --argjson number "${PR_NUMBER}" \
+    --arg sha "${head_sha}" \
+    --arg base_sha "${base_sha}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson base_repo_id "${repo_id}" \
+    --arg opener "${pr_author_login}" '
+      .number == $number and
+      .state == "open" and
+      .base.ref == $base and
+      .base.repo.full_name == $repo and
+      .base.repo.id == $base_repo_id and
+      (.base.sha | type == "string") and
+      .base.sha == $base_sha and
+      .head.sha == $sha and
+      .head.ref == $head_ref and
+      .head.repo.full_name == $head_repo and
+      .head.repo.id == $head_repo_id and
+      .user.login == $opener
+    ' <<<"${payload}" >/dev/null
+}
+
+workflow_page="$(gh_api_bounded \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
   --raw-field per_page=100 \
@@ -320,7 +444,7 @@ workflow_count="$(jq -r '.workflows | length' <<<"${workflow_page}")"
 [[ "${workflow_count}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows"
 (( workflow_count <= 100 )) || fail "The repository workflow page is oversized"
 if (( workflow_count == 100 )); then
-  workflow_page2="$(gh api \
+  workflow_page2="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
@@ -342,15 +466,14 @@ workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | selec
 # failure created no later than this comment. Edited, reopened, and
 # synchronize events can leave several eligible failures for one
 # exact head, so sort by creation time and run ID and select the
-# newest one. Every candidate is tied to the exact workflow path,
-# event, and PR association. When GitHub includes pull_requests on a
-# run, bind the candidate to the exact PR object, including its
-# source head SHA.
-# GitHub can return an empty array for fork pull_request_target runs,
-# so those candidates are retained only when the run's execution SHA equals
-# the live PR source SHA. Populated pull_requests records may bind a different
-# execution SHA to the exact source PR object.
-runs_page="$(gh api \
+# newest one. Every candidate is tied to the exact workflow path and event.
+# When GitHub includes pull_requests on a run, bind the candidate to the exact
+# PR object, including its source head SHA. GitHub can return an empty array for
+# pull_request_target runs. Those candidates are retained when their branch and
+# repository identity matches the live PR, then independently bound below by
+# the live base SHA or an exact failed check on the source head. Populated
+# records may bind a different execution SHA directly.
+runs_page="$(gh_api_bounded \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
   --raw-field event="${TARGET_EVENT}" \
@@ -377,7 +500,7 @@ runs_json="$(jq -c '[.]' <<<"${runs_page}")"
 page_count="${run_count}"
 page_number=2
 while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
-  next_runs_page="$(gh api \
+  next_runs_page="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field event="${TARGET_EVENT}" \
@@ -412,6 +535,7 @@ if ! candidate_list_json="$(jq -c \
     --arg path "${WORKFLOW_PATH}" \
     --arg event "${TARGET_EVENT}" \
     --arg sha "${head_sha}" \
+    --arg base_sha "${base_sha}" \
     --arg workflow_id "${workflow_id}" \
     --arg pr "${PR_NUMBER}" \
     --arg repo "${GH_REPO}" \
@@ -428,20 +552,18 @@ if ! candidate_list_json="$(jq -c \
            else null end) as $prs
         | if $prs == null then false
           elif ($prs | length) == 0 then
-            .head_sha == $sha and
             .head_branch == $head_ref and
             (
               ((.head_repository | type) == "object" and
                .head_repository.full_name == $head_repo and
                (.head_repository.id | type == "number") and
                .head_repository.id == $head_repo_id) or
-              (.head_repository == null and
-               $head_repo == $repo and
-               $head_repo_id == $repo_id)
+              .head_repository == null
             )
-            # Empty associations are eligible only for the exact current
-            # source SHA. A base or merge SHA must never shadow an older
-            # eligible run for this pull request.
+            # Empty associations are discovery candidates only. Source and
+            # repository binding is proved after the exact run and job are
+            # re-read; the sort rank keeps an exact source run ahead of an
+            # unrelated execution while preserving the base-SHA preference.
           else any($prs[]?;
             (.number | type == "number") and
             (.number | tostring) == $pr and
@@ -477,7 +599,14 @@ if ! candidate_list_json="$(jq -c \
             run_binds_to_pr
           )
       ]
-      | sort_by([.created_at, .id])
+      | sort_by([
+          if ((.pull_requests | type) == "array" and (.pull_requests | length) > 0) then 3
+          elif (.head_repository | type) == "object" and .head_sha == $base_sha then 2
+          elif .head_sha == $sha then 1
+          else 0 end,
+          .created_at,
+          .id
+        ])
     ' <<<"${runs_json}")"; then
   fail "Could not validate CLA workflow run data"
 fi
@@ -486,59 +615,6 @@ candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
 if [[ "${candidate_count}" == "0" ]]; then
   if [[ "${run_window_full}" == true ]]; then
     fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
-  fi
-  # Do not silently treat a failed run with an empty association and a
-  # different execution SHA as a successful no-op. It is not eligible for a
-  # rerun, but it still needs an explicit fail-closed migration/error path.
-  # Runs with the exact source SHA are handled by the candidate query above;
-  # this count therefore only catches mismatched runs that would otherwise be
-  # indistinguishable from an absent check.
-  empty_execution_mismatch_count="$(jq -r \
-    --arg path "${WORKFLOW_PATH}" \
-    --arg event "${TARGET_EVENT}" \
-    --arg sha "${head_sha}" \
-    --arg workflow_id "${workflow_id}" \
-    --arg repo "${GH_REPO}" \
-    --arg head_repo "${head_repo}" \
-    --argjson head_repo_id "${head_repo_id}" \
-    --argjson repo_id "${repo_id}" \
-    --arg head_ref "${head_ref}" \
-    --arg before "${COMMENT_CREATED_AT}" \
-    '[ .[] | .workflow_runs[]?
-      | select(
-          (.path == $path or
-           ((.path | startswith($path + "@")) and
-            ((.path | length) > (($path | length) + 1)))) and
-          .event == $event and
-          (.workflow_id | type == "number") and
-          .workflow_id == ($workflow_id | tonumber) and
-          (.head_sha | type == "string") and
-          (.head_sha | test("^[0-9a-f]{40}$")) and
-          .head_sha != $sha and
-          (.id | type == "number") and
-          .id > 0 and
-          .status == "completed" and
-          .conclusion == "failure" and
-          (.created_at | type == "string") and
-          .created_at <= $before and
-          .head_branch == $head_ref and
-          (.pull_requests == null or
-           ((.pull_requests | type) == "array" and
-            (.pull_requests | length) == 0)) and
-          (
-            ((.head_repository | type) == "object" and
-             .head_repository.full_name == $head_repo and
-             (.head_repository.id | type == "number") and
-             .head_repository.id == $head_repo_id) or
-            (.head_repository == null and
-             $head_repo == $repo and
-             $head_repo_id == $repo_id)
-          )
-        )
-    ] | length' <<<"${runs_json}")"
-  [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
-  if (( empty_execution_mismatch_count > 0 )); then
-    fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
   fi
   # A run from before this workflow generation cannot be safely
   # rerun: GitHub reruns the old workflow revision, which could
@@ -572,9 +648,7 @@ if [[ "${candidate_count}" == "0" ]]; then
               .head_repository.full_name == $head_repo and
               (.head_repository.id | type == "number") and
               .head_repository.id == $head_repo_id) or
-             (.head_repository == null and
-              $head_repo == $repo and
-              $head_repo_id == $repo_id)
+             .head_repository == null
            )
          else any($prs[]?;
            (.number | type == "number") and
@@ -632,14 +706,82 @@ run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
 [[ -n "${run_head_branch}" && "${run_head_branch}" != *$'\n'* && "${run_head_branch}" != *$'\r'* ]] || fail "The selected CLA run head branch is invalid"
 
 # A run with a populated pull_requests array already carries an
-# authenticated source-PR association. Some GitHub API responses
-# omit that array, so prove a differing execution SHA through the
-# commit association endpoint before allowing the fallback. A bare
-# branch/repository match is not enough because a branch can be
-# reused after a push.
+# authenticated source-PR association. Some GitHub API responses omit that
+# array. For the fallback, the run must match the live PR source branch and
+# either use the live base SHA or carry a failed check on the exact source head
+# whose details URL names this run and job. A bare branch/repository match is
+# not enough because a branch can be reused after a push.
+RUN_REQUIRES_CHECK_BINDING=false
+
+fetch_check_runs_for_head() {
+  local commit_sha="$1"
+  local response page_count page2 page2_count
+  response="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field filter=all \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
+  jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${response}" >/dev/null || return 1
+  page_count="$(jq -r '.check_runs | length' <<<"${response}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field filter=all \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
+    jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${page2}" >/dev/null || return 1
+    page2_count="$(jq -r '.check_runs | length' <<<"${page2}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    response="$(jq -c --argjson page2 "${page2}" '.check_runs += $page2.check_runs' <<<"${response}")"
+    (( page2_count < 100 )) || return 1
+  fi
+  printf '%s\n' "${response}"
+}
+
+assert_failed_check_binding() {
+  local checks="$1"
+  local expected_run_id="$2"
+  local expected_job_id="$3"
+  local details_url="https://github.com/${GH_REPO}/actions/runs/${expected_run_id}/job/${expected_job_id}"
+  jq -e \
+    --arg job "${CLA_ASSISTANT_JOB}" \
+    --arg sha "${head_sha}" \
+    --arg url "${details_url}" '
+      any(.check_runs[]?;
+        .name == $job and
+        .status == "completed" and
+        .conclusion == "failure" and
+        (.head_sha | type == "string") and
+        .head_sha == $sha and
+        (.app.slug? == "github-actions") and
+        (.details_url | type == "string") and
+        (.details_url == $url or
+         (.details_url | startswith($url + "?") or startswith($url + "#")))
+      )
+    ' <<<"${checks}" >/dev/null
+}
+
+validate_failed_check_binding() {
+  local expected_run_id="$1"
+  local expected_job_id="$2"
+  local checks
+  checks="$(fetch_check_runs_for_head "${head_sha}")" ||
+    fail "Could not query checks for the exact pull request head"
+  assert_failed_check_binding "${checks}" "${expected_run_id}" "${expected_job_id}" ||
+    fail "No failed CLA check is bound to the exact pull request head and selected job"
+}
+
 validate_run_source_binding() {
   local run_payload="$1"
-  local execution_sha pull_requests_type pull_request_count
+  local execution_sha pull_requests_type pull_request_count head_repository_type
+  RUN_REQUIRES_CHECK_BINDING=false
   execution_sha="$(jq -r '.head_sha // empty' <<<"${run_payload}")"
   [[ "${execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The workflow run execution SHA is invalid"
   pull_requests_type="$(jq -r 'if .pull_requests == null then "null" else (.pull_requests | type) end' <<<"${run_payload}")"
@@ -650,164 +792,107 @@ validate_run_source_binding() {
   esac
   [[ "${pull_request_count}" =~ ^[0-9]+$ ]] || fail "The workflow run pull request association count is invalid"
   if (( pull_request_count == 0 )); then
-    # GitHub may omit pull_requests on a pull_request_target run. Without an
-    # authenticated PR object, accept only the source-head form. A base or
-    # merge execution SHA cannot be proved to belong to this PR, so fail
-    # closed instead of querying commit associations that may describe an
-    # ancestor or another pull request.
-    [[ "${execution_sha}" == "${head_sha}" ]] || fail "The workflow run has no pull request association and its execution SHA does not match the current pull request head"
+    # GitHub may omit pull_requests on a pull_request_target run. Its documented
+    # execution SHA is the last commit on the base branch, so accept the empty
+    # association form without a check only when the repository identity is
+    # complete and that SHA equals the live PR base SHA. A source SHA, a null
+    # repository, or any other execution SHA needs an exact failed check on the
+    # source head after the job ID is known.
+    head_repository_type="$(jq -r 'if .head_repository == null then "null" else (.head_repository | type) end' <<<"${run_payload}")"
+    if [[ "${execution_sha}" == "${base_sha}" && "${head_repository_type}" == object ]]; then
+      validate_live_open_head_association
+      return 0
+    fi
+    RUN_REQUIRES_CHECK_BINDING=true
+    # The check binding is validated after the exact job ID is selected.
+    # Keep the live source check here so the run cannot pass on a stale branch.
+    validate_live_open_head_association
   fi
 }
 
-# Re-read the individual run. The list response is only a discovery
-# result, not authorization to rerun it.
-run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
-jq -e \
-  --arg run_id "${run_id}" \
-  --arg path "${WORKFLOW_PATH}" \
-  --arg event "${TARGET_EVENT}" \
-  --arg sha "${head_sha}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg run_head_branch "${run_head_branch}" \
-  --arg pr "${PR_NUMBER}" \
-  --arg repo "${GH_REPO}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" \
-  --argjson repo_id "${repo_id}" \
-  --arg head_ref "${head_ref}" \
-  --arg workflow_id "${workflow_id}" \
-  --arg base "${TARGET_BASE_REF}" \
-  --arg before "${COMMENT_CREATED_AT}" '
-    def run_binds_to_pr:
-      (.pull_requests) as $raw_prs
-      | (if $raw_prs == null then []
-         elif ($raw_prs | type) == "array" then $raw_prs
-         else null end) as $prs
-      | if $prs == null then false
-        elif ($prs | length) == 0 then
-          .head_branch == $head_ref and
-          (
-            ((.head_repository | type) == "object" and
-             .head_repository.full_name == $head_repo and
-             (.head_repository.id | type == "number") and
-             .head_repository.id == $head_repo_id) or
-            (.head_repository == null and
-             $head_repo == $repo and
-             $head_repo_id == $repo_id)
+# Keep one exact run predicate for discovery rechecks and the final TOCTOU
+# re-read. The list response is discovery only, never authorization.
+validate_exact_run_payload() {
+  local payload="$1"
+  jq -e \
+    --arg run_id "${run_id}" \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg run_head_branch "${run_head_branch}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg head_ref "${head_ref}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg before "${COMMENT_CREATED_AT}" '
+      def run_binds_to_pr:
+        (.pull_requests) as $raw_prs
+        | (if $raw_prs == null then []
+           elif ($raw_prs | type) == "array" then $raw_prs
+           else null end) as $prs
+        | if $prs == null then false
+          elif ($prs | length) == 0 then
+            .head_branch == $head_ref and
+            (
+              ((.head_repository | type) == "object" and
+               .head_repository.full_name == $head_repo and
+               (.head_repository.id | type == "number") and
+               .head_repository.id == $head_repo_id) or
+              .head_repository == null
+            )
+          else any($prs[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            .base.ref == $base and
+            ((.base.repo.full_name // "") == "" or
+             .base.repo.full_name == $repo) and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            ((.head.repo.full_name // "") == "" or
+             .head.repo.full_name == $head_repo)
           )
-        else any($prs[]?;
-          (.number | type == "number") and
-          (.number | tostring) == $pr and
-          .base.ref == $base and
-          ((.base.repo.full_name // "") == "" or
-           .base.repo.full_name == $repo) and
-          (.base.repo.id | type == "number") and
-          .base.repo.id == $repo_id and
-          .head.ref == $head_ref and
-          .head.sha == $sha and
-          (.head.repo.id | type == "number") and
-          .head.repo.id == $head_repo_id and
-          ((.head.repo.full_name // "") == "" or
-           .head.repo.full_name == $head_repo)
-        )
-        end;
-    .id == ($run_id | tonumber) and
-    .workflow_id == ($workflow_id | tonumber) and
-    (.path == $path or
-     ((.path | startswith($path + "@")) and
-      ((.path | length) > (($path | length) + 1)))) and
-    .event == $event and
-    .status == "completed" and
-    .conclusion == "failure" and
-    .head_sha == $run_sha and
-    .head_branch == $run_head_branch and
-    (.created_at | type == "string") and
-    .created_at <= $before and
-    run_binds_to_pr
-  ' <<<"${run_json}" >/dev/null || fail "The selected run no longer matches the exact failed CLA check"
+          end;
+      (.id | type == "number") and
+      .id == ($run_id | tonumber) and
+      (.workflow_id | type == "number") and
+      .workflow_id == ($workflow_id | tonumber) and
+      (.path | type == "string") and
+      (.path == $path or
+       ((.path | startswith($path + "@")) and
+        ((.path | length) > (($path | length) + 1)))) and
+      .event == $event and
+      .status == "completed" and
+      .conclusion == "failure" and
+      .head_sha == $run_sha and
+      .head_branch == $run_head_branch and
+      (.created_at | type == "string") and
+      .created_at <= $before and
+      run_binds_to_pr
+    ' <<<"${payload}" >/dev/null
+}
+
+# Re-read the individual run. The list response is only a discovery result.
+run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
+validate_exact_run_payload "${run_json}" || fail "The selected run no longer matches the exact failed CLA check"
 validate_run_source_binding "${run_json}"
 
 # Close the main TOCTOU window. A push, close, or another rerun can
 # happen while the API calls above run. Never rerun a stale head.
-latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
-jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
-  .number == $number and
-  .state == "open" and
-  .base.ref == $base and
-  .base.repo.full_name == $repo and
-  .base.repo.id == $base_repo_id and
-  .head.sha == $sha and
-  .head.ref == $head_ref and
-  .head.repo.full_name == $head_repo and
-  .head.repo.id == $head_repo_id and
-  .user.login == $opener
-' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA run"
+latest_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
+validate_exact_pr_snapshot "${latest_pr_json}" || fail "The pull request changed while selecting the CLA run"
 
 # Ensure another queued invocation did not already rerun this run.
-final_run_json="$(gh api "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
-jq -e \
-  --arg path "${WORKFLOW_PATH}" \
-  --arg event "${TARGET_EVENT}" \
-  --arg sha "${head_sha}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg run_head_branch "${run_head_branch}" \
-  --arg pr "${PR_NUMBER}" \
-  --arg repo "${GH_REPO}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" \
-  --argjson repo_id "${repo_id}" \
-  --arg head_ref "${head_ref}" \
-  --arg workflow_id "${workflow_id}" \
-  --arg run_id "${run_id}" \
-  --arg base "${TARGET_BASE_REF}" \
-  --arg before "${COMMENT_CREATED_AT}" '
-    def run_binds_to_pr:
-      (.pull_requests) as $raw_prs
-      | (if $raw_prs == null then []
-         elif ($raw_prs | type) == "array" then $raw_prs
-         else null end) as $prs
-      | if $prs == null then false
-        elif ($prs | length) == 0 then
-          .head_branch == $head_ref and
-          (
-            ((.head_repository | type) == "object" and
-             .head_repository.full_name == $head_repo and
-             (.head_repository.id | type == "number") and
-             .head_repository.id == $head_repo_id) or
-            (.head_repository == null and
-             $head_repo == $repo and
-             $head_repo_id == $repo_id)
-          )
-        else any($prs[]?;
-          (.number | type == "number") and
-          (.number | tostring) == $pr and
-          .base.ref == $base and
-          ((.base.repo.full_name // "") == "" or
-           .base.repo.full_name == $repo) and
-          (.base.repo.id | type == "number") and
-          .base.repo.id == $repo_id and
-          .head.ref == $head_ref and
-          .head.sha == $sha and
-          (.head.repo.id | type == "number") and
-          .head.repo.id == $head_repo_id and
-          ((.head.repo.full_name // "") == "" or
-           .head.repo.full_name == $head_repo)
-        )
-        end;
-    .id == ($run_id | tonumber) and
-    .workflow_id == ($workflow_id | tonumber) and
-    (.path == $path or
-     ((.path | startswith($path + "@")) and
-      ((.path | length) > (($path | length) + 1)))) and
-    .event == $event and
-    .status == "completed" and
-    .conclusion == "failure" and
-    .head_sha == $run_sha and
-    .head_branch == $run_head_branch and
-    (.created_at | type == "string") and
-    .created_at <= $before and
-    run_binds_to_pr
-' <<<"${final_run_json}" >/dev/null || fail "The exact failed CLA run is no longer eligible"
+final_run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
+validate_exact_run_payload "${final_run_json}" || fail "The exact failed CLA run is no longer eligible"
 validate_run_source_binding "${final_run_json}"
 
 # Fetch the complete bounded job set for one exact run. The rerun endpoint
@@ -820,7 +905,7 @@ validate_run_source_binding "${final_run_json}"
 fetch_jobs_for_run() {
   local target_run_id="$1"
   local page_json page_count page2_json page2_count
-  page_json="$(gh api \
+  page_json="$(gh_api_bounded \
     --method GET \
     --header 'Accept: application/vnd.github+json' \
     --raw-field per_page=100 \
@@ -831,7 +916,7 @@ fetch_jobs_for_run() {
   [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
   (( page_count <= 100 )) || return 1
   if (( page_count == 100 )); then
-    page2_json="$(gh api \
+    page2_json="$(gh_api_bounded \
       --method GET \
       --header 'Accept: application/vnd.github+json' \
       --raw-field per_page=100 \
@@ -850,14 +935,16 @@ fetch_jobs_for_run() {
 jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and validate jobs for the selected CLA run"
 
 # Validate every failed job before granting the state-changing API call. The
-# old compatibility check is an intentional dependent of the v2 job. When it
-# is also failed, use the failed-jobs endpoint so GitHub refreshes both
-# head-bound check contexts. Any extra failure, cancellation, malformed job,
-# or stale source identity aborts the request.
+# v3 writer, required result, and migration compatibility jobs are the only
+# failures this helper may replay. If the writer or compatibility job failed,
+# use the failed-jobs endpoint so GitHub refreshes every head-bound context;
+# otherwise replay only the required result job. Any extra failure,
+# cancellation, malformed job, or stale source identity aborts the request.
 validate_failed_job_set() {
   local payload="$1"
   local all_jobs_json failed_jobs_json failed_count nonfailure_count
-  local unexpected_count v2_count v2_valid_count compatibility_count compatibility_valid_count
+  local unexpected_count assistant_count assistant_valid_count writer_count writer_valid_count
+  local compatibility_count compatibility_valid_count
   if ! all_jobs_json="$(jq -c '[.[] | .jobs[]?]' <<<"${payload}")"; then
     fail "Could not flatten jobs for the selected CLA run"
   fi
@@ -878,18 +965,26 @@ validate_failed_job_set() {
   [[ "${failed_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed jobs for the selected CLA run"
   nonfailure_count="$(jq -r '[.[] | select(.conclusion != "failure")] | length' <<<"${failed_jobs_json}")"
   (( nonfailure_count == 0 )) || fail "The selected CLA run contains a cancelled or non-failure job; refusing to rerun it"
-  unexpected_count="$(jq -r '[.[] | select(.name != "CLA Assistant v2" and .name != "CLA Assistant")] | length' <<<"${failed_jobs_json}")"
+  unexpected_count="$(jq -r \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg writer_job "${CLA_WRITER_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    '[.[] | select(.name != $assistant_job and .name != $writer_job and .name != $compatibility_job)] | length' \
+    <<<"${failed_jobs_json}")"
   (( unexpected_count == 0 )) || fail "The selected CLA run contains an unexpected failed job; refusing to rerun it"
 
-  if ! v2_count="$(jq -r '[.[] | select(.name == "CLA Assistant v2")] | length' <<<"${failed_jobs_json}")" ||
-     ! v2_valid_count="$(jq -r \
+  if ! assistant_count="$(jq -r \
+      --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+      '[.[] | select(.name == $assistant_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! assistant_valid_count="$(jq -r \
        --arg run_id "${run_id}" \
        --arg run_sha "${run_execution_sha}" \
        --arg head_repo "${head_repo}" \
        --argjson head_repo_id "${head_repo_id}" \
-       --arg cla_generation "${CLA_GENERATION}" \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       --arg generation_step "CLA generation ${CLA_GENERATION}" \
        '[.[] | select(
-          .name == "CLA Assistant v2" and
+          .name == $assistant_job and
           .run_id == ($run_id | tonumber) and
           (.head_sha | type == "string") and
           .head_sha == $run_sha and
@@ -899,25 +994,51 @@ validate_failed_job_set() {
              .head_repository.full_name == $head_repo and
              .head_repository.id == $head_repo_id))) and
           any(.steps[]?;
-            .name == ("CLA generation " + $cla_generation) and
-            .status == "completed" and
-            .conclusion == "success"
+            .name == $generation_step and
+            .status == "completed"
           )
        )] | length' <<<"${failed_jobs_json}")"; then
-    fail "Could not validate failed CLA Assistant v2 jobs"
+    fail "Could not validate failed CLA Assistant v3 jobs"
   fi
-  [[ "${v2_count}" =~ ^[0-9]+$ && "${v2_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA Assistant v2 jobs"
-  (( v2_count == 1 )) || fail "Expected exactly one failed CLA Assistant v2 job"
-  (( v2_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  [[ "${assistant_count}" =~ ^[0-9]+$ && "${assistant_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA Assistant v3 jobs"
+  (( assistant_count == 1 )) || fail "Expected exactly one failed CLA Assistant v3 job"
+  (( assistant_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
 
-  compatibility_count="$(jq -r '[.[] | select(.name == "CLA Assistant")] | length' <<<"${failed_jobs_json}")"
+  if ! writer_count="$(jq -r \
+      --arg writer_job "${CLA_WRITER_JOB}" \
+      '[.[] | select(.name == $writer_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! writer_valid_count="$(jq -r \
+       --arg run_id "${run_id}" \
+       --arg run_sha "${run_execution_sha}" \
+       --arg head_repo "${head_repo}" \
+       --argjson head_repo_id "${head_repo_id}" \
+       --arg writer_job "${CLA_WRITER_JOB}" \
+       '[.[] | select(
+          .name == $writer_job and
+          .run_id == ($run_id | tonumber) and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          ((has("head_repository") | not) or
+           (.head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)))
+       )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA ledger writer jobs"
+  fi
+  [[ "${writer_count}" =~ ^[0-9]+$ && "${writer_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA ledger writer jobs"
+  (( writer_count <= 1 )) || fail "The selected CLA run contains multiple failed CLA ledger writer jobs"
+  (( writer_valid_count == writer_count )) || fail "The failed CLA ledger writer job is malformed or bound to a different source"
+
+  compatibility_count="$(jq -r --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" '[.[] | select(.name == $compatibility_job)] | length' <<<"${failed_jobs_json}")"
   if ! compatibility_valid_count="$(jq -r \
       --arg run_id "${run_id}" \
       --arg run_sha "${run_execution_sha}" \
       --arg head_repo "${head_repo}" \
       --argjson head_repo_id "${head_repo_id}" \
+      --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
       '[.[] | select(
-         .name == "CLA Assistant" and
+         .name == $compatibility_job and
          .run_id == ($run_id | tonumber) and
          (.head_sha | type == "string") and
          .head_sha == $run_sha and
@@ -932,23 +1053,27 @@ validate_failed_job_set() {
   [[ "${compatibility_count}" =~ ^[0-9]+$ && "${compatibility_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA compatibility jobs"
   (( compatibility_count <= 1 )) || fail "The selected CLA run contains multiple failed compatibility jobs"
   (( compatibility_valid_count == compatibility_count )) || fail "The failed CLA compatibility job is malformed or bound to a different source"
-  if (( compatibility_count == 1 )); then
+  if (( writer_count == 1 || compatibility_count == 1 )); then
     RERUN_FAILED_JOBS=true
   else
     RERUN_FAILED_JOBS=false
   fi
 }
 validate_failed_job_set "${jobs_json}"
-if ! cla_job_json="$(jq -c \
+# Select the sole current-generation assistant job from a validated job set.
+select_cla_job() {
+  local payload="$1"
+  jq -c \
     --arg run_id "${run_id}" \
     --arg run_sha "${run_execution_sha}" \
-    --arg cla_generation "${CLA_GENERATION}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg generation_step "CLA generation ${CLA_GENERATION}" \
     --arg head_repo "${head_repo}" \
     --argjson head_repo_id "${head_repo_id}" \
     '[.[] | .jobs[]?
       | select(
           (.run_id | tostring) == $run_id and
-          .name == "CLA Assistant v2" and
+          .name == $assistant_job and
           .status == "completed" and
           .conclusion == "failure" and
           (.head_sha | type == "string") and
@@ -959,15 +1084,51 @@ if ! cla_job_json="$(jq -c \
              .head_repository.id == $head_repo_id)
           ) and
           any(.steps[]?;
-            .name == ("CLA generation " + $cla_generation) and
-            .status == "completed" and
-            .conclusion == "success"
+            .name == $generation_step and
+            .status == "completed"
           )
         )
     ]
     | if length == 1 then .[0] else empty end
-  ' <<<"${jobs_json}")"; then
-  fail "Could not validate CLA job data"
+  ' <<<"${payload}"
+}
+
+# Validate one exact assistant job for every discovery and final re-read.
+validate_exact_job_payload() {
+  local payload="$1"
+  jq -e \
+    --arg job_id "${job_id}" \
+    --arg run_id "${run_id}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg generation_step "CLA generation ${CLA_GENERATION}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" '
+      (.id | type == "number") and
+      .id == ($job_id | tonumber) and
+      (.run_id | type == "number") and
+      .run_id == ($run_id | tonumber) and
+      .name == $assistant_job and
+      .status == "completed" and
+      .conclusion == "failure" and
+      (.head_sha | type == "string") and
+      .head_sha == $run_sha and
+      (
+        (has("head_repository") | not) or
+        .head_repository == null or
+        ((.head_repository | type) == "object" and
+         .head_repository.full_name == $head_repo and
+         .head_repository.id == $head_repo_id)
+      ) and
+      any(.steps[]?;
+        .name == $generation_step and
+        .status == "completed"
+      )
+    ' <<<"${payload}" >/dev/null
+}
+
+if ! cla_job_json="$(select_cla_job "${jobs_json}")"; then
+  fail "Could not validate CLA Assistant v3 job data"
 fi
 if [[ -z "${cla_job_json}" ]]; then
   # The run matched the current PR and failed, but no job carried
@@ -977,123 +1138,55 @@ if [[ -z "${cla_job_json}" ]]; then
 fi
 job_id="$(jq -r '.id // empty' <<<"${cla_job_json}")"
 [[ "${job_id}" =~ ^[1-9][0-9]*$ ]] || fail "The selected CLA job ID is invalid"
+if [[ "${RUN_REQUIRES_CHECK_BINDING}" == true ]]; then
+  validate_failed_check_binding "${run_id}" "${job_id}"
+fi
 
 # Re-read the individual job. The jobs list is discovery only, just
 # like the workflow-run list above.
-job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA job"
-jq -e \
-  --arg job_id "${job_id}" \
-  --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg cla_generation "${CLA_GENERATION}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" '
-    .id == ($job_id | tonumber) and
-    .run_id == ($run_id | tonumber) and
-    .name == "CLA Assistant v2" and
-    .status == "completed" and
-    .conclusion == "failure" and
-    (.head_sha | type == "string") and
-    .head_sha == $run_sha and
-    (
-      (has("head_repository") | not) or
-      .head_repository == null or
-      ((.head_repository | type) == "object" and
-       .head_repository.full_name == $head_repo and
-       .head_repository.id == $head_repo_id)
-    ) and
-    any(.steps[]?;
-      .name == ("CLA generation " + $cla_generation) and
-      .status == "completed" and
-      .conclusion == "success"
-    )
-  ' <<<"${job_json}" >/dev/null || fail "The selected CLA job no longer matches the failed job in this run"
+job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA Assistant v3 job"
+validate_exact_job_payload "${job_json}" || fail "The selected CLA Assistant v3 job no longer matches the failed job in this run"
 
 # Recheck both resources immediately before the state-changing call.
 # This prevents a push or a concurrent rerun from making the job
 # stale while the preceding API requests were in flight.
-latest_pr_json="$(gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
-jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg sha "${head_sha}" --arg base "${TARGET_BASE_REF}" --arg head_ref "${head_ref}" --arg head_repo "${head_repo}" --argjson head_repo_id "${head_repo_id}" --argjson base_repo_id "${repo_id}" --arg opener "${pr_author_login}" '
-  .number == $number and
-  .state == "open" and
-  .base.ref == $base and
-  .base.repo.full_name == $repo and
-  .base.repo.id == $base_repo_id and
-  .head.sha == $sha and
-  .head.ref == $head_ref and
-  .head.repo.full_name == $head_repo and
-  .head.repo.id == $head_repo_id and
-  .user.login == $opener
-' <<<"${latest_pr_json}" >/dev/null || fail "The pull request changed while selecting the CLA job"
-final_job_json="$(gh api "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
-jq -e \
-  --arg job_id "${job_id}" \
-  --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg cla_generation "${CLA_GENERATION}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" '
-    .id == ($job_id | tonumber) and
-    .run_id == ($run_id | tonumber) and
-    .name == "CLA Assistant v2" and
-    .status == "completed" and
-    .conclusion == "failure" and
-    (.head_sha | type == "string") and
-    .head_sha == $run_sha and
-    (
-      (has("head_repository") | not) or
-      .head_repository == null or
-      ((.head_repository | type) == "object" and
-       .head_repository.full_name == $head_repo and
-       .head_repository.id == $head_repo_id)
-    ) and
-    any(.steps[]?;
-      .name == ("CLA generation " + $cla_generation) and
-      .status == "completed" and
-      .conclusion == "success"
-    )
-' <<<"${final_job_json}" >/dev/null || fail "The exact failed CLA job is no longer eligible"
+latest_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+validate_exact_pr_snapshot "${latest_pr_json}" || fail "The pull request changed while selecting the CLA job"
+final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
+validate_exact_job_payload "${final_job_json}" || fail "The exact failed CLA Assistant v3 job is no longer eligible"
 
 # Re-fetch the whole job set immediately before the state-changing call. This
 # catches a newly cancelled or unrelated failed job that could otherwise be
 # pulled into a failed-jobs rerun after the first validation.
 final_jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not recheck and validate jobs for the selected CLA run"
 validate_failed_job_set "${final_jobs_json}"
-final_job_id="$(jq -r \
-  --arg run_id "${run_id}" \
-  --arg run_sha "${run_execution_sha}" \
-  --arg head_repo "${head_repo}" \
-  --argjson head_repo_id "${head_repo_id}" \
-  --arg cla_generation "${CLA_GENERATION}" \
-  '[.[] | .jobs[]? | select(
-      .run_id == ($run_id | tonumber) and
-      .name == "CLA Assistant v2" and
-      .status == "completed" and
-      .conclusion == "failure" and
-      (.head_sha | type == "string") and
-      .head_sha == $run_sha and
-      ((has("head_repository") | not) or
-       (.head_repository == null or
-        ((.head_repository | type) == "object" and
-         .head_repository.full_name == $head_repo and
-         .head_repository.id == $head_repo_id))) and
-      any(.steps[]?;
-        .name == ("CLA generation " + $cla_generation) and
-        .status == "completed" and
-        .conclusion == "success"
-      )
-    )]
-    | if length == 1 then .[0].id else empty end' <<<"${final_jobs_json}")"
+if ! final_cla_job_json="$(select_cla_job "${final_jobs_json}")"; then
+  fail "Could not validate the final CLA Assistant v3 job data"
+fi
+final_job_id="$(jq -r '.id // empty' <<<"${final_cla_job_json}")"
 [[ "${final_job_id}" == "${job_id}" ]] || fail "The selected CLA job changed while preparing the rerun"
 
-# Repeat the positive live-PR association check after all discovery
-# calls. A second open PR for the same fork ref and SHA must stop the
-# rerun even if it appeared while the earlier checks were running.
+# Re-read the live PR, run, and job as one final authorization set. A source
+# push, branch retarget, job replacement, or concurrent rerun must invalidate
+# the request before the state-changing call. For fallback runs, the failed
+# check is fetched last and must bind both the exact source SHA and this job.
+final_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+validate_exact_pr_snapshot "${final_pr_json}" || fail "The pull request changed before rerun"
+# The individual PR response does not enumerate duplicate fork references.
+# Recheck the filtered open-PR association at the same final boundary.
 validate_live_open_head_association
+final_run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run before rerun"
+validate_exact_run_payload "${final_run_json}" || fail "The selected CLA run changed before rerun"
+validate_run_source_binding "${final_run_json}"
+final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job before rerun"
+validate_exact_job_payload "${final_job_json}" || fail "The selected CLA job changed before rerun"
+if [[ "${RUN_REQUIRES_CHECK_BINDING}" == true ]]; then
+  validate_failed_check_binding "${run_id}" "${job_id}"
+fi
 
 if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
   rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"
-  rerun_description="failed CLA jobs (v2 and compatibility)"
+  rerun_description="failed CLA v3 jobs (writer, assistant, and compatibility)"
 else
   rerun_endpoint="repos/${GH_REPO}/actions/jobs/${job_id}/rerun"
   rerun_description="CLA job ${job_id}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ on:
       - scripts/ghosttykit-checksums.txt
       - tests/test_ci_ghosttykit_release_check.sh
       - tests/test_ci_change_areas.py
+      - .github/workflows/cla.yml
       - .github/workflows/ci.yml
+      - .github/scripts/rerun-failed-cla.sh
+      - tests/test_cla_rerun_workflow.sh
+      - tests/test_cla_lock_workflow.sh
+      - tests/test_cla_trigger_gate.sh
   workflow_dispatch:
 
 permissions:
@@ -185,6 +190,18 @@ jobs:
 
       - name: Install workflow guard Python dependencies
         run: python3 -m pip install --disable-pip-version-check --no-input PyYAML==6.0.3 bashlex==0.18
+
+      # These fixtures run only in this unprivileged pull_request job. They
+      # exercise the candidate workflow for developer feedback, never serve as
+      # the security boundary, and never run from pull_request_target.
+      - name: Validate CLA trigger admission behavior
+        run: ./tests/test_cla_trigger_gate.sh
+
+      - name: Validate CLA rerun authorization behavior
+        run: ./tests/test_cla_rerun_workflow.sh
+
+      - name: Validate merged pull request lock behavior
+        run: ./tests/test_cla_lock_workflow.sh
 
       - name: Validate Blacksmith Testbox broker trust boundary
         run: python3 tests/test_ci_testbox_broker_guard.py

--- a/.github/workflows/cla-policy-guard.yml
+++ b/.github/workflows/cla-policy-guard.yml
@@ -1,0 +1,66 @@
+name: CLA policy guard
+
+on:
+  # This workflow is evaluated from the base branch. It never checks out or
+  # executes the pull-request revision, so a contributor cannot edit the guard
+  # and the policy it protects in the same pull request.
+  pull_request_target:
+    branches: [main]
+    types: [opened,edited,reopened,synchronize]
+permissions: {}
+
+jobs:
+  validate:
+    name: CLA policy guard
+    # This control-plane workflow parses attacker-controlled YAML and shell
+    # bytes. Use a GitHub-hosted ephemeral runner; a repository variable must
+    # not be able to redirect it to a persistent or contributor-controlled
+    # machine.
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Checkout immutable guard revision
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.workflow_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+          sparse-checkout: scripts/ci/validate-cla-policy.rb
+          sparse-checkout-cone-mode: false
+
+      - name: Verify trusted checkout
+        env:
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$(git rev-parse HEAD)" == "$WORKFLOW_SHA" ]]
+          [[ -f scripts/ci/validate-cla-policy.rb ]]
+
+      - name: Run trusted CLA regression matrix and validate policy as data
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          candidate_dir="$(mktemp -d "$RUNNER_TEMP/cla-policy.XXXXXX")"
+          trap 'rm -rf "$candidate_dir"' EXIT
+          CANDIDATE_DIR="$candidate_dir" ruby scripts/ci/validate-cla-policy.rb
+          if [[ -f "$candidate_dir/rerun-failed-cla.sh" ]]; then
+            shellcheck --shell=bash "$candidate_dir/rerun-failed-cla.sh"
+          fi
+          if [[ -f "$candidate_dir/cla.yml" ]]; then
+            archive="$RUNNER_TEMP/actionlint.tar.gz"
+            curl -fsSL -o "$archive" \
+              "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz"
+            echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  $archive" | sha256sum --check --strict
+            tar -xzf "$archive" -C "$RUNNER_TEMP" actionlint
+            "$RUNNER_TEMP/actionlint" "$candidate_dir/cla.yml"
+          fi

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,86 +1,486 @@
-name: "CLA Assistant"
+name: "CLA Assistant v3"
 
-# Contributor License Agreement check. The action lives in our fork,
-# manaflow-ai/cla-github-action, and is pinned to a commit. Signers are the
-# pull request opener plus every primary commit author GitHub maps to an
-# account. Co-authored-by trailers (pairing partners, AI agents) and the git
-# committer field never need to sign, and a signature is reused in every
-# later pull request. Maintainer accounts in allowlist-ids never sign.
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     branches: [main]
-    types: [opened, closed, reopened, synchronize]
+    types: [opened,closed,edited,reopened,synchronize,ready_for_review]
 
 permissions: {}
 
+# This marker changes only when the policy or maintained action changes. It
+# gives the rerun worker a stable generation that is independent of unrelated
+# commits on main.
+env:
+  CLA_GENERATION: "v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+
 jobs:
-  CLAAssistant:
-    name: "CLA Assistant"
-    # Comment admission is a coarse filter: GitHub appends CRLF to plain
-    # comments, so equality would drop real declarations. The action does the
-    # exact match itself and ignores anything else.
+  # This job has read-only permissions. It performs the exact event check and
+  # authenticates a new signing comment before any write-capable job starts.
+  CLACommentGate:
+    name: "Validate CLA trigger"
     if: >-
-      github.event_name == 'pull_request_target' ||
       (
+        github.event_name == 'pull_request_target' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'edited' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize' ||
+          github.event.action == 'ready_for_review'
+        )
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.action == 'created' &&
+        github.event.issue.state == 'open' &&
         github.event.issue.pull_request &&
         github.event.comment.user.type == 'User' &&
         (
-          contains(github.event.comment.body, 'recheck') ||
-          contains(github.event.comment.body, 'I have read the CLA Document v2.2 and I hereby sign the CLA')
+          (
+            github.event.comment.body == 'recheck' &&
+            (
+              github.event.comment.user.id == github.event.issue.user.id ||
+              github.event.comment.author_association == 'OWNER' ||
+              github.event.comment.author_association == 'MEMBER' ||
+              github.event.comment.author_association == 'COLLABORATOR'
+            )
+          ) ||
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
         )
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
     timeout-minutes: 10
-    # One run at a time per pull request so two signature events cannot write
-    # the ledger from different snapshots. Independent pull requests proceed.
     concurrency:
-      group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.run_id }}
       cancel-in-progress: false
     permissions:
-      # Signature ledger commits on the cla-signatures branch.
-      contents: write
-      # Bot comment on the pull request. issues:write is needed for reactions
-      # and comments on fork pull requests.
-      issues: write
-      pull-requests: write
-      # Re-run the pull_request_target check after a signature comment.
-      actions: write
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      admitted: ${{ steps.admission.outputs.admitted }}
+      signer_authorized: ${{ steps.signer_preflight.outputs.signer_authorized }}
+      head_sha: ${{ steps.signer_preflight.outputs.head_sha }}
+      base_sha: ${{ steps.signer_preflight.outputs.base_sha }}
+      comment_id: ${{ steps.signer_preflight.outputs.comment_id }}
+      comment_created_at: ${{ steps.signer_preflight.outputs.comment_created_at }}
+      comment_author_id: ${{ steps.signer_preflight.outputs.comment_author_id }}
     steps:
-      - name: "CLA Assistant"
-        id: cla
-        uses: manaflow-ai/cla-github-action@f567430d44e22bc0bb6ecd1e00d383ef22886025
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Validate exact CLA trigger"
+        id: admission
+        if: runner.environment == 'github-hosted'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id || '' }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login || '' }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || '' }}
+          PR_AUTHOR_ID: ${{ github.event.issue.user.id || '' }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || '' }}
+        run: |
+          set -euo pipefail
+          fail() {
+            echo "::error::$1"
+            exit 1
+          }
+          emit() {
+            [[ -n "${GITHUB_OUTPUT+x}" && -n "${GITHUB_OUTPUT}" ]] || fail "GITHUB_OUTPUT is unavailable"
+            printf 'admitted=%s\n' "$1" >>"${GITHUB_OUTPUT}"
+          }
+          [[ -n "${EVENT_NAME:-}" && -n "${EVENT_ACTION:-}" ]] || fail "Event metadata is incomplete"
+          if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
+            [[ "${EVENT_ACTION}" == "created" ]] || fail "Issue-comment event action is unsupported"
+            [[ "${COMMENT_AUTHOR_TYPE}" == "User" && -n "${COMMENT_AUTHOR_LOGIN}" ]] || fail "Comment author is not a human user"
+            [[ "${COMMENT_AUTHOR_LOGIN,,}" != *"[bot]" ]] || fail "Bot comments cannot trigger the CLA action"
+            [[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ && "${PR_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment identity is malformed"
+            [[ -n "${COMMENT_AUTHOR_ASSOCIATION}" && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\n'* && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\r'* ]] || fail "Comment association is malformed"
+            if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+              printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
+            elif [[ "${COMMENT_BODY}" == "recheck" ]]; then
+              if [[ "${COMMENT_AUTHOR_ID}" == "${PR_AUTHOR_ID}" ]]; then
+                emit true
+              else
+                case "${COMMENT_AUTHOR_ASSOCIATION}" in
+                  OWNER|MEMBER|COLLABORATOR) emit true ;;
+                  *) emit false ;;
+                esac
+              fi
+            else
+              emit false
+            fi
+          elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+            case "${EVENT_ACTION}" in
+              opened|edited|reopened|synchronize|ready_for_review) emit true ;;
+              *) fail "Pull-request event action is unsupported" ;;
+            esac
+          else
+            fail "Event is not an accepted CLA trigger"
+          fi
+
+      - name: "Authenticate exact CLA signer"
+        id: signer_preflight
+        if: >-
+          runner.environment == 'github-hosted' &&
+          success() &&
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version2/cla.json'
-          path-to-document: 'https://github.com/manaflow-ai/cmux/blob/main/CLA.md'
-          # Signatures live on an unprotected branch so main's checks never
-          # block the bot's ledger commits.
-          branch: 'cla-signatures'
-          required-base-ref: 'main'
-          custom-pr-sign-comment: 'I have read the CLA Document v2.2 and I hereby sign the CLA'
-          lock-pullrequest-aftermerge: 'false'
-          # Numeric GitHub IDs of maintainers who never sign, as opener or as
-          # commit author: @lawrencecchen, @austinywang, @azooz2003-bit.
-          allowlist-ids: '54008264,38676809,67667005'
+          mode: "signer-preflight"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          require-opener-as-author: "true"
+          allowlist-ids: "38676809,67667005"
 
-      # A signature comment runs this workflow from main, so its check run
-      # attaches to main, not to the pull request head. Re-run the failed
-      # pull_request_target run for the head so the pull request turns green
-      # without another push.
-      - name: "Refresh the pull request check after a new signature"
-        if: github.event_name == 'issue_comment' && steps.cla.outputs.signature_recorded == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+  # This is the only job with ledger and comment write permissions. It has no
+  # shell step, so policy text cannot execute with its token. The action repeats
+  # live PR/comment validation and binds a signing write to the exact head SHA
+  # observed by the read-only gate.
+  CLALedgerWriter:
+    name: "CLA ledger writer"
+    needs: CLACommentGate
+    if: >-
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize' ||
+            github.event.action == 'ready_for_review'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
+          (
+            (
+              github.event.comment.body == 'recheck' &&
+              (
+                github.event.comment.user.id == github.event.issue.user.id ||
+                github.event.comment.author_association == 'OWNER' ||
+                github.event.comment.author_association == 'MEMBER' ||
+                github.event.comment.author_association == 'COLLABORATOR'
+              )
+            ) ||
+              (
+                github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+                needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+                needs.CLACommentGate.outputs.head_sha != '' &&
+                needs.CLACommentGate.outputs.base_sha != ''
+            )
+          )
+        )
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 15
+    concurrency:
+      group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
+      cla_passed: ${{ steps.cla_action.outputs.cla_passed }}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
         run: |
           set -euo pipefail
-          head="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)"
-          run_id="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow cla.yml --event pull_request_target --commit "$head" --status failure --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
-          if [[ -z "$run_id" ]]; then
-            echo "No failed CLA run for $head; nothing to refresh."
-            exit 0
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Write CLA result"
+        id: cla_action
+        if: runner.environment == 'github-hosted'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          path-to-signatures: "signatures/version2/cla.json"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "false"
+          expected-head-sha: "${{ needs.CLACommentGate.outputs.head_sha }}"
+          expected-base-sha: "${{ needs.CLACommentGate.outputs.base_sha }}"
+          expected-comment-id: "${{ needs.CLACommentGate.outputs.comment_id }}"
+          expected-comment-created-at: "${{ needs.CLACommentGate.outputs.comment_created_at }}"
+          expected-comment-author-id: "${{ needs.CLACommentGate.outputs.comment_author_id }}"
+
+  # This no-permission job owns the required v3 check context. A gate or writer
+  # failure is visible as a failed check instead of being hidden as a skipped
+  # privileged job.
+  CLAAssistant:
+    name: "CLA Assistant v3"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+    if: >-
+      always() &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize' ||
+            github.event.action == 'ready_for_review'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.action == 'created' &&
+          github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
+          (
+            (
+              github.event.comment.body == 'recheck' &&
+              needs.CLACommentGate.result == 'success' &&
+              needs.CLACommentGate.outputs.admitted == 'true' &&
+              (
+                github.event.comment.user.id == github.event.issue.user.id ||
+                github.event.comment.author_association == 'OWNER' ||
+                github.event.comment.author_association == 'MEMBER' ||
+                github.event.comment.author_association == 'COLLABORATOR'
+              )
+            ) ||
+            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+          )
+        )
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      # Keep the generation marker on the required check's only step. The
+      # marker must remain visible when this result fails because the writer
+      # failed in the original pull_request_target run. The immutable rerun
+      # helper uses the rendered step name to reject older workflow runs.
+      - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+        if: runner.environment == 'github-hosted'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          GATE_RESULT: ${{ needs.CLACommentGate.result }}
+          ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
+          SIGNER_AUTHORIZED: ${{ needs.CLACommentGate.outputs.signer_authorized || '' }}
+          WRITER_RESULT: ${{ needs.CLALedgerWriter.result }}
+          CLA_PASSED: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
+        run: |
+          set -euo pipefail
+          echo "CLA generation ${CLA_GENERATION}"
+          if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
+            echo "::error::CLA trigger admission failed"
+            exit 1
           fi
-          gh run rerun "$run_id" --failed --repo "$GITHUB_REPOSITORY"
+          if [[ "${EVENT_NAME}" == "issue_comment" &&
+                "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" &&
+                "${SIGNER_AUTHORIZED}" != "true" ]]; then
+            echo "::error::CLA signer preflight failed"
+            exit 1
+          fi
+          if [[ "${WRITER_RESULT}" != "success" ]]; then
+            echo "::error::CLA ledger writer failed"
+            exit 1
+          fi
+          if [[ "${CLA_PASSED}" != "true" ]]; then
+            echo "::error::CLA action did not confirm that all contributors have signed"
+            exit 1
+          fi
+
+  # Keep the old context during migration. It has no token and is not the
+  # required context after the v3 ruleset migration.
+  CLACompatibility:
+    name: "CLA Assistant"
+    needs:
+      - CLACommentGate
+      - CLAAssistant
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'edited' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'ready_for_review'
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Mirror CLA Assistant compatibility result"
+        if: runner.environment == 'github-hosted'
+        env:
+          RESULT: ${{ needs.CLAAssistant.result }}
+        run: |
+          set -euo pipefail
+          [[ "${RESULT}" == "success" ]] || {
+            echo "::error::CLA Assistant v3 did not pass"
+            exit 1
+          }
+
+  # This job can refresh a failed check only through the immutable helper from
+  # the base workflow revision. It receives actions:write, never contents or
+  # comment write access, and its shell command and environment are fixed by
+  # the base-controlled policy validator.
+  RerunFailedCLA:
+    name: "Rerun failed CLA check"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+      - CLAAssistant
+    if: >-
+      always() &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      needs.CLAAssistant.result != 'skipped' &&
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
+      (
+        (
+          github.event.comment.body == 'recheck' &&
+          (
+            github.event.comment.user.id == github.event.issue.user.id ||
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          ) &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.cla_passed == 'true'
+        ) ||
+        (
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+          needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.cla_passed == 'true' &&
+          needs.CLALedgerWriter.outputs.signature_recorded == 'true'
+        )
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 15
+    concurrency:
+      group: cla-rerun-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      actions: write
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Checkout trusted CLA rerun helper"
+        if: runner.environment == 'github-hosted'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/rerun-failed-cla.sh
+          sparse-checkout-cone-mode: false
+      - name: "Rerun exact failed pull_request_target run"
+        if: runner.environment == 'github-hosted'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          WORKFLOW_PATH: ".github/workflows/cla.yml"
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          CLA_GENERATION: ${{ env.CLA_GENERATION }}
+          TARGET_EVENT: "pull_request_target"
+          TARGET_BASE_REF: "main"
+          SIGNATURE_RECORDED: ${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}
+        run: bash .github/scripts/rerun-failed-cla.sh
+
+  LockMergedPullRequest:
+    name: "Lock merged pull request"
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 10
+    concurrency:
+      group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Lock merged pull request"
+        if: runner.environment == 'github-hosted'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "sign"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "true"

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -1,0 +1,2379 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# This file is executed only from the immutable base revision by
+# cla-policy-guard.yml. It treats pull-request files as data: no file fetched
+# from the PR is sourced, loaded as Ruby, or executed.
+
+require "base64"
+require "digest"
+require "fileutils"
+require "json"
+require "open3"
+require "tempfile"
+require "time"
+require "yaml"
+
+class PolicyError < StandardError; end
+
+SHA = /\A[0-9a-f]{40}\z/
+REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
+MAX_FILE_BYTES = 300_000
+MAX_YAML_NODES = 10_000
+MAX_YAML_DEPTH = 64
+CLA_ACTION = "manaflow-ai/cla-github-action@b4d3c4fab86d21e7775c63522d4b39b3724ea4bf"
+# CLA policy jobs handle repository trust decisions and must stay on an
+# ephemeral GitHub-hosted runner. A repository variable could redirect this
+# privileged work to an untrusted self-hosted machine, so the label is an
+# immutable contract.
+CLA_RUNNER = "ubuntu-24.04".freeze
+CLA_HOSTED_RUNNER_GUARD_NAME = "Require GitHub-hosted runner".freeze
+CLA_HOSTED_RUNNER_GUARD_IF = "runner.environment != 'github-hosted'".freeze
+CLA_HOSTED_RUNNER_STEP_IF = "runner.environment == 'github-hosted'".freeze
+CLA_HOSTED_RUNNER_GUARD_RUN = <<~'SH'.strip.freeze
+  set -euo pipefail
+  echo "::error::CLA policy requires a GitHub-hosted runner"
+  exit 1
+SH
+CLA_DOCUMENT_PATH = "CLA.md".freeze
+CLA_DOCUMENT_VERSION = "v2.2".freeze
+CLA_SIGNATURES_PATH = "signatures/version2/cla.json".freeze
+CLA_SIGNATURES_PATH_PATTERN = %r{\Asignatures/version[0-9]+(?:\.[0-9]+)?/cla\.json\z}
+# The maintained action does not accept a document digest. The workflow URL
+# therefore binds every action read to github.workflow_sha, while a document
+# change must rotate the visible version, generation marker, and ledger path.
+# The privileged workflow is an explicit reviewed policy, not an extensible
+# script. Its candidate structure is checked as data, and every policy change
+# requires trusted review without a fragile follow-up hash bump.
+EXPECTED_GUARD_WORKFLOW_DIGEST = "01b3eed13d54db27ed195781dc0f6926a04cb9557de81f50762b532ea14e4440"
+# The guard workflow remains pinned to its reviewed immutable bytes. The CLA
+# policy itself is validated structurally, then authorized by an exact-head
+# trusted review.
+EXPECTED_GUARD_SCRIPT_DIGEST = "fcd6013a41913c94b82585fafbc98475c173478b1ca3524125fcb37b19fb591a"
+# Migration marker for the base v2 guard validator. That validator requires
+# the literal EXPECTED_WORKFLOW_DIGEST while it checks this candidate. The v3
+# validator does not use this inert marker for policy authorization.
+# The first v3 migration is allowed only from these exact, base-controlled v2
+# bytes. This is a one-step compatibility bridge for the live main branch,
+# not a second policy vocabulary. The migration still needs trusted review,
+# and the candidate must pass every v3 check below.
+LEGACY_CLA_WORKFLOW_DIGEST = "22f4f8c4b7fb879514a5b072505877843fd94dc32b279f2aceb8fc216adde65f"
+LEGACY_CLA_RERUN_DIGEST = "f4f1fa51bb05b062ebf3f60cc949d8d5b4b501e7849cb065e9a07d7a34030840"
+# Current organization administrators who may approve a trusted control-plane
+# update. IDs are used instead of names, and the review must target the exact
+# PR head. This is the human path for intentional policy maintenance.
+TRUSTED_REVIEWER_IDS = %w[54008264 38676809 67667005].freeze
+TRUSTED_REVIEW_STATES = %w[APPROVED COMMENTED CHANGES_REQUESTED DISMISSED PENDING].freeze
+TRUSTED_REVIEW_DECISION_STATES = %w[APPROVED CHANGES_REQUESTED DISMISSED].freeze
+MAX_REVIEW_PAGES = 3
+MAX_REVIEWS_PER_PAGE = 100
+MAX_REVIEW_ID = (1 << 63) - 1
+GITHUB_TOKEN_EXPRESSION = "${{ secrets.GITHUB_TOKEN }}"
+ALLOWED_SECRET_PATHS = [
+  %w[jobs CLACommentGate steps] + [2] + %w[env GITHUB_TOKEN],
+  %w[jobs CLALedgerWriter steps] + [1] + %w[env GITHUB_TOKEN],
+  %w[jobs RerunFailedCLA steps] + [2] + %w[env GH_TOKEN],
+  %w[jobs LockMergedPullRequest steps] + [1] + %w[env GITHUB_TOKEN]
+].freeze
+GUARD_ALLOWED_SECRET_PATHS = [
+  %w[jobs validate steps] + [2] + %w[env GH_TOKEN]
+].freeze
+GUARD_HOSTED_ALLOWED_SECRET_PATHS = [
+  %w[jobs validate steps] + [3] + %w[env GH_TOKEN]
+].freeze
+
+ADMISSION_ENV = {
+  "EVENT_NAME" => "${{ github.event_name }}",
+  "EVENT_ACTION" => "${{ github.event.action }}",
+  "COMMENT_BODY" => "${{ github.event.comment.body || '' }}",
+  "COMMENT_AUTHOR_ID" => "${{ github.event.comment.user.id || '' }}",
+  "COMMENT_AUTHOR_LOGIN" => "${{ github.event.comment.user.login || '' }}",
+  "COMMENT_AUTHOR_TYPE" => "${{ github.event.comment.user.type || '' }}",
+  "PR_AUTHOR_ID" => "${{ github.event.issue.user.id || '' }}",
+  "COMMENT_AUTHOR_ASSOCIATION" => "${{ github.event.comment.author_association || '' }}"
+}.freeze
+RESULT_ENV = {
+  "EVENT_NAME" => "${{ github.event_name }}",
+  "COMMENT_BODY" => "${{ github.event.comment.body || '' }}",
+  "GATE_RESULT" => "${{ needs.CLACommentGate.result }}",
+  "ADMITTED" => "${{ needs.CLACommentGate.outputs.admitted || '' }}",
+  "SIGNER_AUTHORIZED" => "${{ needs.CLACommentGate.outputs.signer_authorized || '' }}",
+  "WRITER_RESULT" => "${{ needs.CLALedgerWriter.result }}"
+}.freeze
+CLA_COMMENT_BINDING_OUTPUTS = {
+  "comment_id" => "${{ steps.signer_preflight.outputs.comment_id }}",
+  "comment_created_at" => "${{ steps.signer_preflight.outputs.comment_created_at }}",
+  "comment_author_id" => "${{ steps.signer_preflight.outputs.comment_author_id }}"
+}.freeze
+CLA_COMMENT_BINDING_INPUTS = {
+  "expected-comment-id" => "${{ needs.CLACommentGate.outputs.comment_id }}",
+  "expected-comment-created-at" => "${{ needs.CLACommentGate.outputs.comment_created_at }}",
+  "expected-comment-author-id" => "${{ needs.CLACommentGate.outputs.comment_author_id }}"
+}.freeze
+COMPATIBILITY_ENV = {
+  "RESULT" => "${{ needs.CLAAssistant.result }}"
+}.freeze
+RERUN_ENV = {
+  "GH_TOKEN" => GITHUB_TOKEN_EXPRESSION,
+  "GH_REPO" => "${{ github.repository }}",
+  "EVENT_NAME" => "${{ github.event_name }}",
+  "ISSUE_NUMBER" => "${{ github.event.issue.number }}",
+  "PR_NUMBER" => "${{ github.event.issue.number }}",
+  "COMMENT_ID" => "${{ github.event.comment.id }}",
+  "COMMENT_BODY" => "${{ github.event.comment.body }}",
+  "COMMENT_CREATED_AT" => "${{ github.event.comment.created_at }}",
+  "COMMENT_AUTHOR_ID" => "${{ github.event.comment.user.id }}",
+  "COMMENT_AUTHOR_LOGIN" => "${{ github.event.comment.user.login }}",
+  "COMMENT_AUTHOR_TYPE" => "${{ github.event.comment.user.type }}",
+  "COMMENT_AUTHOR_ASSOCIATION" => "${{ github.event.comment.author_association }}",
+  "WORKFLOW_PATH" => ".github/workflows/cla.yml",
+  "WORKFLOW_SHA" => "${{ github.workflow_sha }}",
+  "CLA_GENERATION" => "${{ env.CLA_GENERATION }}",
+  "TARGET_EVENT" => "pull_request_target",
+  "TARGET_BASE_REF" => "main",
+  "SIGNATURE_RECORDED" => "${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}"
+}.freeze
+# Run blocks are shell text, not an expression surface. Reject every GitHub
+# expression here, including bracket notation and nested format/toJSON calls
+# that a token-specific regular expression cannot parse safely.
+GITHUB_CONTEXT_IN_RUN = /\$\{\{/m
+TOKEN_ENV_IN_RUN = /(?:\A|[^A-Za-z0-9_])(?:GITHUB_TOKEN|GH_TOKEN|ACTIONS_RUNTIME_TOKEN|ACTIONS_ID_TOKEN_REQUEST_TOKEN|RUNNER_TOKEN)(?:\z|[^A-Za-z0-9_])/i
+EXPRESSION_MARKER = /\$\{\{/m
+GITHUB_CONTEXT_EXPRESSION = /\bgithub\b/i
+GITHUB_TOKEN_EXPRESSION_PATTERN = /\bgithub\b.*\btoken\b|\btoJSON\s*\(\s*github\b/i
+ALLOWED_EXPRESSION_PATHS = [
+  /\Aenv\.[^.]+\z/,
+  /\Ajobs\.[^.]+\.if\z/,
+  /\Ajobs\.[^.]+\.concurrency\.group\z/,
+  /\Ajobs\.[^.]+\.outputs\.[^.]+\z/,
+  /\Ajobs\.[^.]+\.steps\.\d+\.env\.[^.]+\z/,
+  /\Ajobs\.[^.]+\.steps\.\d+\.with\.[^.]+\z/
+].freeze
+
+# The guard workflow is itself a privileged control-plane input. Keep its
+# checkout, environment, and shell contracts as immutable data. Whitespace is
+# normalized only at line boundaries so a YAML block scalar cannot gain an
+# extra command, redirection, or interpolation while retaining the reviewed
+# command sequence.
+GUARD_CHECKOUT_WITH = {
+  "repository" => "${{ github.repository }}",
+  "ref" => "${{ github.workflow_sha }}",
+  "fetch-depth" => 1,
+  "persist-credentials" => false,
+  "sparse-checkout" => "scripts/ci/validate-cla-policy.rb",
+  "sparse-checkout-cone-mode" => false
+}.freeze
+GUARD_TRIGGER_KEYS = %w[pull_request_target].freeze
+GUARD_TRIGGER = {
+  "branches" => ["main"],
+  "types" => %w[opened edited reopened synchronize]
+}.freeze
+GUARD_HOSTED_TRIGGER = {
+  "branches" => ["main"],
+  "types" => %w[opened edited reopened synchronize ready_for_review]
+}.freeze
+GUARD_WORKFLOW_NAME = "CLA policy guard"
+GUARD_TIMEOUT_MINUTES = 10
+GUARD_VERIFY_ENV = {
+  "WORKFLOW_SHA" => "${{ github.workflow_sha }}"
+}.freeze
+GUARD_VALIDATE_ENV = {
+  "GH_TOKEN" => GITHUB_TOKEN_EXPRESSION,
+  "GH_REPO" => "${{ github.repository }}",
+  "PR_NUMBER" => "${{ github.event.pull_request.number }}",
+  "BASE_SHA" => "${{ github.event.pull_request.base.sha }}",
+  "HEAD_SHA" => "${{ github.event.pull_request.head.sha }}"
+}.freeze
+GUARD_VERIFY_RUN = <<~'SH'.strip.freeze
+  set -euo pipefail
+  [[ "$WORKFLOW_SHA" =~ ^[0-9a-f]{40}$ ]]
+  [[ "$(git rev-parse HEAD)" == "$WORKFLOW_SHA" ]]
+  [[ -f scripts/ci/validate-cla-policy.rb ]]
+SH
+GUARD_VALIDATE_RUN = <<~'SH'.strip.freeze
+  set -euo pipefail
+  candidate_dir="$(mktemp -d "$RUNNER_TEMP/cla-policy.XXXXXX")"
+  trap 'rm -rf "$candidate_dir"' EXIT
+  CANDIDATE_DIR="$candidate_dir" ruby scripts/ci/validate-cla-policy.rb
+  if [[ -f "$candidate_dir/rerun-failed-cla.sh" ]]; then
+    shellcheck --shell=bash "$candidate_dir/rerun-failed-cla.sh"
+  fi
+  if [[ -f "$candidate_dir/cla.yml" ]]; then
+    archive="$RUNNER_TEMP/actionlint.tar.gz"
+    curl -fsSL -o "$archive" \
+      "https://github.com/rhysd/actionlint/releases/download/v1.7.7/actionlint_1.7.7_linux_amd64.tar.gz"
+    echo "023070a287cd8cccd71515fedc843f1985bf96c436b7effaecce67290e7e0757  $archive" | sha256sum --check --strict
+    tar -xzf "$archive" -C "$RUNNER_TEMP" actionlint
+    "$RUNNER_TEMP/actionlint" "$candidate_dir/cla.yml"
+  fi
+SH
+# These hashes make the reviewed command contracts auditable without relying
+# on YAML formatting. They are recomputed from normalize_run_text below when
+# this policy file changes intentionally.
+GUARD_VERIFY_RUN_HASH = "708659eb2df9c50e070dab49190c2c3712a1485a5292eadb86eb4ae3fb01cbb5"
+GUARD_VALIDATE_RUN_HASH = "759f3978ae0a2e0620eb2630cd4c1ec2cbff8f9bcc9a37f76b330b845091bda8"
+
+# Keep the admission contract in one small, executable specification. The
+# pull-request workflow is still checked as data below, but its shell cannot be
+# run by this privileged workflow because it comes from an untrusted revision.
+CLA_SIGN_PHRASE = "I have read the CLA Document #{CLA_DOCUMENT_VERSION} and I hereby sign the CLA"
+CLA_RECHECK_PHRASE = "recheck"
+CLA_DOCUMENT_INPUT = "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/#{CLA_DOCUMENT_PATH}"
+CLA_LIFECYCLE_ACTIONS = %w[opened edited reopened synchronize ready_for_review].freeze
+CLA_TRUSTED_ASSOCIATIONS = %w[OWNER MEMBER COLLABORATOR].freeze
+POSITIVE_ID = /\A[1-9][0-9]*\z/
+CLA_WRITER_CONDITION = <<~EXPRESSION.gsub(/\s+/, " ").strip.freeze
+  needs.CLACommentGate.result == 'success' &&
+  needs.CLACommentGate.outputs.admitted == 'true' &&
+  (
+    (
+      github.event_name == 'pull_request_target' &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'edited' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'ready_for_review'
+      )
+    ) ||
+    (
+      github.event_name == 'issue_comment' &&
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
+      (
+        (
+          github.event.comment.body == 'recheck' &&
+          (
+            github.event.comment.user.id == github.event.issue.user.id ||
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          )
+        ) ||
+        (
+          github.event.comment.body == '#{CLA_SIGN_PHRASE}' &&
+          needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+          needs.CLACommentGate.outputs.head_sha != '' &&
+          needs.CLACommentGate.outputs.base_sha != ''
+        )
+      )
+    )
+  )
+EXPRESSION
+
+# The guard validates a deliberately closed workflow vocabulary. A policy
+# change may alter messages and implementation details inside the listed
+# steps, but it may not add a job, permission, action, runner feature, or
+# workflow-level control that this validator does not understand.
+WORKFLOW_KEYS = %w[name on permissions env jobs].freeze
+WORKFLOW_JOB_NAMES = %w[
+  CLACommentGate
+  CLAAssistant
+  CLALedgerWriter
+  CLACompatibility
+  RerunFailedCLA
+  LockMergedPullRequest
+].freeze
+ALLOWED_ACTIONS = [
+  CLA_ACTION,
+  "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+].freeze
+
+class BoundedYamlTreeBuilder < Psych::TreeBuilder
+  def initialize
+    super
+    @node_count = 0
+    @container_depth = 0
+  end
+
+  def start_mapping(*args)
+    count_node!
+    enter_container!
+    super
+  end
+
+  def start_document(version, tag_directives, implicit)
+    has_version = version.respond_to?(:empty?) ? !version.empty? : !version.nil?
+    has_tags = tag_directives.respond_to?(:empty?) ? !tag_directives.empty? : !tag_directives.nil?
+    fail!("CLA workflow YAML directives are not allowed") if has_version || has_tags
+    super
+  end
+
+  def end_mapping(*args)
+    @container_depth -= 1
+    super
+  end
+
+  def start_sequence(*args)
+    count_node!
+    enter_container!
+    super
+  end
+
+  def end_sequence(*args)
+    @container_depth -= 1
+    super
+  end
+
+  def scalar(*args)
+    count_node!
+    super
+  end
+
+  def alias(*_args)
+    fail!("YAML aliases are not allowed")
+  end
+
+  private
+
+  def count_node!
+    @node_count += 1
+    fail!("CLA workflow YAML has too many nodes") if @node_count > MAX_YAML_NODES
+  end
+
+  def enter_container!
+    @container_depth += 1
+    fail!("CLA workflow YAML is nested too deeply") if @container_depth > MAX_YAML_DEPTH
+  end
+end
+
+YAML_KEY_SCANNER = Psych::ScalarScanner.new(Psych::ClassLoader::Restricted.new([], [])).freeze
+
+def fail!(message)
+  raise PolicyError, message
+end
+
+def required_env(name, pattern = nil)
+  value = ENV[name].to_s
+  fail!("#{name} is missing") if value.empty?
+  fail!("#{name} is malformed") if pattern && value !~ pattern
+  value
+end
+
+def api_failure_status(stdout, stderr)
+  [stderr, stdout].each do |text|
+    if (match = text.to_s.match(/\bHTTP(?:\/\d(?:\.\d+)?)?\s+([1-5]\d{2})\b/i))
+      return match[1].to_i
+    end
+  end
+  begin
+    payload = JSON.parse(stdout)
+    value = payload.is_a?(Hash) ? payload["status"] : nil
+    return value.to_i if value.to_s.match?(/\A[1-5]\d{2}\z/)
+  rescue JSON::ParserError
+    # The caller reports the original API failure below.
+  end
+  nil
+end
+
+def api_json(repository, endpoint, allow_missing: false)
+  stdout, stderr, status = Open3.capture3(
+    "gh", "api", "--header", "Accept: application/vnd.github+json", endpoint
+  )
+  unless status.success?
+    response_status = api_failure_status(stdout, stderr)
+    return nil if allow_missing && response_status == 404
+
+    fail!("GitHub API request failed for #{endpoint}: #{stderr.strip}")
+  end
+  JSON.parse(stdout)
+rescue JSON::ParserError
+  fail!("GitHub API returned malformed JSON for #{endpoint}")
+end
+
+def review_sort_key(review)
+  timestamp = review["submitted_at"]
+  fail!("trusted review timestamp is malformed") unless timestamp.is_a?(String)
+  fail!("trusted review timestamp is malformed") unless timestamp.match?(
+    /\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?Z\z/
+  )
+  review_id = review["id"]
+  fail!("pull-request review ID is malformed") unless
+    review_id.is_a?(Integer) && review_id.positive? && review_id <= MAX_REVIEW_ID
+  [Time.iso8601(timestamp).to_r, review_id]
+rescue ArgumentError
+  fail!("trusted review timestamp is malformed")
+end
+
+def collect_latest_trusted_review!(latest, seen_review_ids, review)
+  fail!("pull-request review entry is malformed") unless review.is_a?(Hash)
+  review_id = review["id"]
+  fail!("pull-request review ID is malformed") unless
+    review_id.is_a?(Integer) && review_id.positive? && review_id <= MAX_REVIEW_ID
+  fail!("pull-request review pagination repeated an entry") if seen_review_ids.key?(review_id)
+
+  seen_review_ids[review_id] = true
+  # Deleted users are represented by a null user object. They cannot match a
+  # trusted reviewer ID, so ignore them before enforcing the strict shape used
+  # for trusted control-plane approvals. Untrusted reviewers are likewise
+  # irrelevant to this gate and must not be able to DoS a policy update with a
+  # malformed historical review.
+  user = review["user"]
+  return unless user.is_a?(Hash)
+  user_id = user["id"]
+  return unless user_id.is_a?(Integer) && user_id.positive?
+  reviewer_id = user_id.to_s
+  return unless TRUSTED_REVIEWER_IDS.include?(reviewer_id)
+
+  state = review["state"]
+  fail!("pull-request review state is malformed") unless TRUSTED_REVIEW_STATES.include?(state)
+  # COMMENTED and PENDING reviews do not change GitHub's approval decision.
+  # In particular, a later comment must not erase a valid approval.
+  return unless TRUSTED_REVIEW_DECISION_STATES.include?(state)
+  fail!("pull-request review commit is malformed") unless review["commit_id"].is_a?(String) && review["commit_id"].match?(SHA)
+  fail!("pull-request review user is not a human") unless user["type"] == "User"
+
+  order = review_sort_key(review)
+  previous = latest[reviewer_id]
+  latest[reviewer_id] = [order, review] if previous.nil? || (order <=> previous[0]).positive?
+end
+
+def require_trusted_review!(repository, pr_number, head_sha)
+  fail!("pull-request head SHA is malformed") unless head_sha.is_a?(String) && head_sha.match?(SHA)
+  latest = {}
+  seen_review_ids = {}
+  1.upto(MAX_REVIEW_PAGES) do |page|
+    reviews = api_json(
+      repository,
+      "repos/#{repository}/pulls/#{pr_number}/reviews?per_page=#{MAX_REVIEWS_PER_PAGE}&page=#{page}"
+    )
+    fail!("pull-request review response is malformed") unless reviews.is_a?(Array)
+    fail!("pull-request review page is too large") if reviews.length > MAX_REVIEWS_PER_PAGE
+
+    reviews.each { |review| collect_latest_trusted_review!(latest, seen_review_ids, review) }
+
+    break if reviews.length < MAX_REVIEWS_PER_PAGE
+    fail!("pull-request review history is too large") if page == MAX_REVIEW_PAGES
+  end
+  approved = latest.values.any? do |_order, review|
+    review["state"] == "APPROVED" &&
+      review["commit_id"] == head_sha &&
+      review.fetch("dismissed_at", nil).nil?
+  end
+  fail!("trusted approval for this control-plane update is required") unless approved
+end
+
+def fetch_file(repository, sha, path, allow_missing: false)
+  payload = api_json(repository, "repos/#{repository}/contents/#{path}?ref=#{sha}", allow_missing: allow_missing)
+  return nil if payload.nil?
+  fail!("#{path} is not a regular file") unless payload["type"] == "file"
+  fail!("#{path} is not base64 encoded") unless payload["encoding"] == "base64"
+
+  encoded = payload["content"].to_s.delete("\r\n")
+  fail!("#{path} has malformed base64") unless encoded.match?(/\A(?:[A-Za-z0-9+\/]{4})*(?:[A-Za-z0-9+\/]{2}==|[A-Za-z0-9+\/]{3}=)?\z/)
+  bytes = Base64.strict_decode64(encoded)
+  fail!("#{path} is too large") if bytes.bytesize > MAX_FILE_BYTES
+  bytes
+rescue ArgumentError
+  fail!("#{path} has malformed base64")
+end
+
+def walk(value, &block)
+  case value
+  when Hash
+    value.each do |key, child|
+      block.call(key, child)
+      walk(child, &block)
+    end
+  when Array
+    value.each { |child| walk(child, &block) }
+  end
+end
+
+def reject_yaml_node_features!(node)
+  fail!("CLA workflow YAML tags are not allowed") if node.respond_to?(:tag) && node.tag
+  fail!("CLA workflow YAML anchors are not allowed") if node.respond_to?(:anchor) && node.anchor
+end
+
+def plain_yaml_key_is_string?(value)
+  YAML_KEY_SCANNER.tokenize(value).is_a?(String)
+rescue Psych::Exception
+  false
+end
+
+def validate_yaml_tree!(stream)
+  fail!("CLA workflow YAML stream is malformed") unless stream.is_a?(Psych::Nodes::Stream)
+  fail!("CLA workflow must contain exactly one YAML document") unless stream.children.length == 1
+  fail!("CLA workflow YAML document is malformed") unless stream.children.first.is_a?(Psych::Nodes::Document)
+  stack = [[stream.children.first, 0]]
+  until stack.empty?
+    node, depth = stack.pop
+    fail!("CLA workflow YAML is malformed") unless node.is_a?(Psych::Nodes::Node)
+    reject_yaml_node_features!(node)
+    fail!("CLA workflow YAML is nested too deeply") if depth > MAX_YAML_DEPTH
+
+    case node
+    when Psych::Nodes::Stream, Psych::Nodes::Document
+      stack.concat(node.children.reverse_each.map { |child| [child, depth] })
+    when Psych::Nodes::Mapping
+      children = node.children
+      fail!("CLA workflow YAML mapping has an odd number of entries") unless children.length.even?
+      pairs = children.each_slice(2).to_a
+      seen_keys = {}
+      pairs.each do |key_node, _value_node|
+        fail!("CLA workflow has a non-scalar mapping key") unless key_node.is_a?(Psych::Nodes::Scalar)
+        reject_yaml_node_features!(key_node)
+        if key_node.style == Psych::Nodes::Scalar::PLAIN &&
+            !plain_yaml_key_is_string?(key_node.value) && !(depth.zero? && key_node.value == "on")
+          fail!("CLA workflow YAML mapping keys must be strings")
+        end
+        fail!("CLA workflow YAML merge keys are not allowed") if key_node.value == "<<"
+        fail!("CLA workflow YAML has duplicate mapping keys") if seen_keys.key?(key_node.value)
+
+        seen_keys[key_node.value] = true
+      end
+      stack.concat(pairs.reverse_each.map { |_key_node, value_node| [value_node, depth + 1] })
+    when Psych::Nodes::Sequence
+      stack.concat(node.children.reverse_each.map { |child| [child, depth + 1] })
+    when Psych::Nodes::Scalar
+      # Scalar anchors and tags were checked above. Their lexical values are
+      # intentionally left unchanged for the GitHub-specific `on` check.
+    when Psych::Nodes::Alias
+      fail!("CLA workflow YAML aliases are not allowed")
+    else
+      fail!("CLA workflow YAML contains an unsupported node")
+    end
+  end
+end
+
+def parse_workflow(raw)
+  builder = BoundedYamlTreeBuilder.new
+  Psych::Parser.new(builder).parse(raw)
+  stream = builder.root
+  validate_yaml_tree!(stream)
+  root = stream.children.first.root
+  fail!("CLA workflow is not a YAML mapping") unless root.is_a?(Psych::Nodes::Mapping)
+  keys = root.children.each_slice(2).map do |key_node, _value_node|
+    fail!("CLA workflow has a non-scalar top-level key") unless key_node.is_a?(Psych::Nodes::Scalar)
+
+    key_node.value
+  end
+  # Psych applies YAML 1.1 boolean coercion to an unquoted `on` key. GitHub
+  # uses the literal key, so accepting `true` here would validate a workflow
+  # that GitHub does not trigger. Keep the lexical key check before loading.
+  fail!("CLA workflow must contain the literal on trigger key") unless keys.include?("on")
+  fail!("CLA workflow must not use a boolean trigger key") if keys.include?("true")
+
+  document = YAML.safe_load(raw, aliases: false)
+  fail!("CLA workflow is not a YAML mapping") unless document.is_a?(Hash)
+  document
+rescue Psych::Exception => error
+  fail!("CLA workflow YAML is invalid: #{error.message.lines.first.to_s.strip}")
+end
+
+def workflow_digest(raw)
+  # Hash the exact bytes after validating the YAML lexical structure. A parsed
+  # digest can hide duplicate keys or YAML 1.1/GitHub parser differences.
+  parse_workflow(raw)
+  Digest::SHA256.hexdigest(raw)
+end
+
+def expect_policy_error(name)
+  raised = false
+  begin
+    yield
+  rescue PolicyError
+    raised = true
+  end
+  fail!("YAML regression case #{name} unexpectedly passed") unless raised
+end
+
+def run_yaml_regression_matrix!
+  valid = <<~YAML
+    name: test
+    on: {}
+    permissions: {}
+    env: {}
+    jobs: {}
+  YAML
+  parse_workflow(valid)
+  cases = {
+    "duplicate nested key" => <<~YAML,
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        duplicate: one
+        duplicate: two
+    YAML
+    "merge key" => <<~YAML,
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        merged:
+          <<: {}
+    YAML
+    "alias" => <<~YAML,
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        base: &anchor {}
+        copied: *anchor
+    YAML
+    "explicit tag" => <<~YAML,
+      name: !!str test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs: {}
+    YAML
+    "multiple documents" => "---\nname: test\non: {}\n---\nname: second\non: {}\n",
+    "boolean trigger key" => <<~YAML,
+      name: test
+      true: {}
+      permissions: {}
+      env: {}
+      jobs: {}
+    YAML
+    "boolean key collision" => <<~YAML,
+      name: test
+      on: {}
+      yes: {}
+      permissions: {}
+      env: {}
+      jobs: {}
+    YAML
+    "numeric nested key" => <<~YAML
+      name: test
+      on: {}
+      permissions: {}
+      env: {}
+      jobs:
+        1: value
+    YAML
+  }
+  deep = +"name: test\non: {}\npermissions: {}\nenv: {}\njobs:\n"
+  MAX_YAML_DEPTH.times { |index| deep << "  " * (index + 1) << "k#{index}:\n" }
+  deep << "  " * (MAX_YAML_DEPTH + 1) << "value\n"
+  cases["excessive nesting"] = deep
+  cases["YAML directive"] = "%YAML 1.1\n---\nname: test\non: {}\npermissions: {}\nenv: {}\njobs: {}\n"
+  many = +"name: test\non: {}\npermissions: {}\nenv: {}\njobs:\n"
+  (MAX_YAML_NODES / 2).times { |index| many << "  k#{index}: value\n" }
+  cases["excessive nodes"] = many
+
+  cases.each { |name, raw| expect_policy_error(name) { parse_workflow(raw) } }
+  puts "PASS: bounded YAML regression matrix (#{cases.length + 1} cases)"
+end
+
+def legacy_v2_base?(base_workflow_digest:, base_script_digest:)
+  base_workflow_digest == LEGACY_CLA_WORKFLOW_DIGEST &&
+    base_script_digest == LEGACY_CLA_RERUN_DIGEST
+end
+
+def guard_script_digest(raw)
+  normalized = raw.sub(
+    /EXPECTED_GUARD_SCRIPT_DIGEST = "[0-9a-f]{64}"/,
+    'EXPECTED_GUARD_SCRIPT_DIGEST = "<self-digest>"'
+  )
+  Digest::SHA256.hexdigest(normalized)
+end
+
+def cla_document_version(raw, name)
+  first_line = raw.to_s.lines.first.to_s.strip
+  match = first_line.match(/\A# Individual Contributor License Agreement \("Agreement"\) (v[0-9]+\.[0-9]+)\z/)
+  fail!("#{name} must declare a version in its heading") unless match
+
+  match[1]
+end
+
+def workflow_document_contract(raw, name)
+  document = parse_workflow(raw)
+  contract = {
+    generation: document.dig("env", "CLA_GENERATION"),
+    signature_paths: [],
+    sign_phrases: [],
+    document_inputs: []
+  }
+  walk_paths(document) do |path, value|
+    next unless value.is_a?(String)
+
+    case path.last.to_s
+    when "path-to-signatures"
+      contract[:signature_paths] << value
+    when "custom-pr-sign-comment"
+      contract[:sign_phrases] << value
+    when "path-to-document"
+      contract[:document_inputs] << value
+    end
+  end
+  contract[:signature_paths] = contract[:signature_paths].uniq.sort
+  contract[:sign_phrases] = contract[:sign_phrases].uniq.sort
+  contract[:document_inputs] = contract[:document_inputs].uniq.sort
+  fail!("#{name} is missing its signature ledger path") if contract[:signature_paths].empty?
+  fail!("#{name} is missing its signing phrase") if contract[:sign_phrases].empty?
+  fail!("#{name} is missing its document URL") if contract[:document_inputs].empty?
+  contract
+end
+
+def document_major(version)
+  match = version.to_s.match(/\Av([0-9]+)/)
+  fail!("CLA document version is malformed") unless match
+
+  match[1]
+end
+
+def expected_signature_path(version)
+  "signatures/version#{document_major(version)}/cla.json"
+end
+
+def assert_script_document_binding(raw, phrase, signature_path, name)
+  source = raw.to_s
+  quoted_phrase = ["\"#{phrase}\"", "'#{phrase}'"]
+  fail!("#{name} does not contain the reviewed signing phrase") unless
+    quoted_phrase.any? { |value| source.include?(value) }
+  fail!("#{name} does not bind the reviewed signature ledger path") unless
+    source.match?(/SIGNATURES_PATH\s*=\s*['\"]#{Regexp.escape(signature_path)}['\"]/)
+end
+
+def assert_cla_document_change_contract(base_cla:, head_cla:, base_workflow:, head_workflow:, base_script:, head_script:)
+  # A workflow SHA URL is the action's immutable document binding. Keep the
+  # ledger namespace and human-readable version in lockstep so old signatures
+  # cannot authorize a changed legal document.
+  base_digest = Digest::SHA256.hexdigest(base_cla)
+  head_digest = Digest::SHA256.hexdigest(head_cla)
+  return false if base_digest == head_digest
+
+  fail!("CLA.md changes require a CLA policy workflow change") if base_workflow == head_workflow
+  base_version = cla_document_version(base_cla, "base CLA.md")
+  head_version = cla_document_version(head_cla, "proposed CLA.md")
+  base_major = document_major(base_version)
+  head_major = document_major(head_version)
+  base_contract = workflow_document_contract(base_workflow, "base CLA workflow")
+  head_contract = workflow_document_contract(head_workflow, "proposed CLA workflow")
+  fail!("CLA.md changes must rotate the rerun helper") unless
+    base_script.is_a?(String) && head_script.is_a?(String) && base_script != head_script
+
+  fail!("CLA.md changes must rotate the document version") if base_version == head_version
+  fail!("CLA document major version must increase") unless head_major.to_i > base_major.to_i
+  fail!("CLA.md changes must rotate CLA_GENERATION") if base_contract[:generation] == head_contract[:generation]
+  fail!("base CLA workflow uses an unexpected signature ledger path") unless
+    base_contract[:signature_paths] == [expected_signature_path(base_version)]
+  fail!("CLA.md changes must rotate the signature ledger path") unless
+    head_contract[:signature_paths] == [expected_signature_path(head_version)]
+
+  expected_phrase = "I have read the CLA Document #{head_version} and I hereby sign the CLA"
+  fail!("proposed CLA workflow uses the wrong document version phrase") unless
+    head_contract[:sign_phrases] == [expected_phrase]
+  fail!("proposed CLA workflow must bind the document URL to github.workflow_sha") unless
+    head_contract[:document_inputs] == [CLA_DOCUMENT_INPUT]
+  fail!("proposed CLA generation is not bound to the document version") unless
+    head_contract[:generation].to_s.start_with?("#{head_version}-action-")
+
+  base_phrase = "I have read the CLA Document #{base_version} and I hereby sign the CLA"
+  assert_script_document_binding(base_script, base_phrase, expected_signature_path(base_version), "base CLA rerun helper")
+  assert_script_document_binding(head_script, expected_phrase, expected_signature_path(head_version), "proposed CLA rerun helper")
+  fail!("proposed CLA rerun helper still accepts the old document phrase") if
+    head_script.include?(base_phrase)
+  fail!("proposed CLA rerun helper still reads the old signature ledger") if
+    head_script.include?(expected_signature_path(base_version)) &&
+    expected_signature_path(base_version) != expected_signature_path(head_version)
+
+  true
+end
+
+def job(document, name)
+  jobs = document["jobs"]
+  fail!("jobs is not a mapping") unless jobs.is_a?(Hash)
+  value = jobs[name]
+  fail!("required job #{name} is missing") unless value.is_a?(Hash)
+  value
+end
+
+def steps(job_value, name)
+  value = job_value["steps"]
+  fail!("#{name}.steps is not a list") unless value.is_a?(Array)
+  value
+end
+
+def step_using(job_value, action, name)
+  found = steps(job_value, name).find { |step| step.is_a?(Hash) && step["uses"] == action }
+  fail!("#{name} does not use #{action}") unless found
+  found
+end
+
+def step_using_with(job_value, action, input, expected, name)
+  found = steps(job_value, name).find do |step|
+    step.is_a?(Hash) &&
+      step["uses"] == action &&
+      step["with"].is_a?(Hash) &&
+      step["with"][input].to_s == expected
+  end
+  fail!("#{name} does not use #{action} with #{input}=#{expected}") unless found
+  found
+end
+
+def dependencies(job_value, name)
+  value = job_value["needs"]
+  result = value.is_a?(Array) ? value : [value]
+  fail!("#{name}.needs is malformed") unless result.all? { |item| item.is_a?(String) && !item.empty? }
+  result
+end
+
+def assert_text(text, fragment)
+  fail!("CLA workflow is missing #{fragment.inspect}") unless text.include?(fragment)
+end
+
+def assert_permission(job_value, name, permission, expected)
+  permissions = job_value["permissions"]
+  fail!("#{name}.permissions is not a mapping") unless permissions.is_a?(Hash)
+  fail!("#{name}.permissions.#{permission} must be #{expected}") unless permissions[permission] == expected
+end
+
+def assert_exact_keys(value, expected, name)
+  fail!("#{name} is not a mapping") unless value.is_a?(Hash)
+  actual = value.keys.map(&:to_s)
+  expected = expected.map(&:to_s)
+  unknown = actual - expected
+  missing = expected - actual
+  fail!("#{name} has unsupported keys: #{unknown.join(', ')}") unless unknown.empty?
+  fail!("#{name} is missing keys: #{missing.join(', ')}") unless missing.empty?
+end
+
+def assert_no_keys(value, forbidden, name)
+  return unless value.is_a?(Hash)
+
+  found = value.keys.map(&:to_s) & forbidden
+  fail!("#{name} contains forbidden keys: #{found.join(', ')}") unless found.empty?
+end
+
+def assert_positive_integer(value, name)
+  fail!("#{name} must be a positive integer") unless value.is_a?(Integer) && value.positive?
+end
+
+def assert_string(value, name)
+  fail!("#{name} must be a string") unless value.is_a?(String)
+  value
+end
+
+def assert_cla_runner(value, name)
+  fail!("#{name} must use the reviewed CLA runner") unless value == CLA_RUNNER
+end
+
+def assert_hosted_runner_guard_step(step, name)
+  assert_step_keys(step, "#{name} runner guard", %w[name if run])
+  fail!("#{name} runner guard has an unexpected name") unless step["name"] == CLA_HOSTED_RUNNER_GUARD_NAME
+  fail!("#{name} runner guard has an unsafe condition") unless step["if"] == CLA_HOSTED_RUNNER_GUARD_IF
+  fail!("#{name} runner guard has an unsafe shell") unless
+    normalize_run_text(step["run"]) == normalize_run_text(CLA_HOSTED_RUNNER_GUARD_RUN)
+end
+
+def assert_hosted_runner_step(step, name)
+  condition = step.is_a?(Hash) ? step["if"].to_s.gsub(/\s+/, " ").strip : ""
+  # The hosted identity must be an AND term. A substring check would accept
+  # `runner.environment == 'github-hosted' || true`, which would execute a
+  # privileged action on a self-hosted runner.
+  terms = condition.split(/\s*&&\s*/)
+  fail!("#{name} is not restricted to a GitHub-hosted runner") unless
+    !condition.include?("||") && terms.any? { |term| term == CLA_HOSTED_RUNNER_STEP_IF }
+end
+
+def assert_hosted_runner_job_steps(job_value, name)
+  job_steps = steps(job_value, name)
+  fail!("#{name} must have a runner identity guard") if job_steps.empty?
+  assert_hosted_runner_guard_step(job_steps.first, name)
+  job_steps.drop(1).each_with_index do |step, index|
+    assert_hosted_runner_step(step, "#{name} step #{index + 2}")
+  end
+end
+
+def guard_step_layout(target, step_count)
+  case target
+  when GUARD_TRIGGER
+    fail!("guard workflow steps are malformed") unless step_count == 3
+    {
+      verification_index: 1,
+      validation_index: 2,
+      hosted: false,
+      allowed_secret_paths: GUARD_ALLOWED_SECRET_PATHS
+    }
+  when GUARD_HOSTED_TRIGGER
+    fail!("hosted guard workflow steps are malformed") unless step_count == 4
+    {
+      verification_index: 2,
+      validation_index: 3,
+      hosted: true,
+      allowed_secret_paths: GUARD_HOSTED_ALLOWED_SECRET_PATHS
+    }
+  else
+    fail!("guard workflow has an unsupported trigger or step layout")
+  end
+end
+
+def assert_comment_binding_contract(gate_outputs, writer_inputs)
+  CLA_COMMENT_BINDING_OUTPUTS.each do |name, expected|
+    fail!("CLA gate must expose the signer comment #{name} output") unless
+      gate_outputs.is_a?(Hash) && gate_outputs[name] == expected
+  end
+  CLA_COMMENT_BINDING_INPUTS.each do |name, expected|
+    fail!("CLA writer must bind the signer comment #{name} input") unless
+      writer_inputs.is_a?(Hash) && writer_inputs[name] == expected
+  end
+end
+
+def assert_lifecycle_admission_contract(expressions, admission_run)
+  CLA_LIFECYCLE_ACTIONS.each do |action|
+    fragment = "github.event.action == '#{action}'"
+    expressions.each_with_index do |expression, index|
+      fail!("CLA lifecycle job #{index + 1} is missing #{action}") unless
+        expression.is_a?(String) && expression.include?(fragment)
+    end
+  end
+
+  normalized_run = admission_run.to_s.gsub(/\s+/, " ").strip
+  expected_emit = "emit() { [[ -n \"${GITHUB_OUTPUT+x}\" && -n \"${GITHUB_OUTPUT}\" ]] || fail \"GITHUB_OUTPUT is unavailable\" printf 'admitted=%s\\n' \"$1\" >>\"${GITHUB_OUTPUT}\" }"
+  fail!("CLA admission shell must define the reviewed output helper") unless
+    normalized_run.include?(expected_emit)
+  expected_case = "case \"${EVENT_ACTION}\" in #{CLA_LIFECYCLE_ACTIONS.join("|")}) emit true ;;"
+  fail!("CLA admission shell is missing the complete pull-request lifecycle case") unless
+    normalized_run.include?(expected_case)
+end
+
+def assert_action_reference(reference, name)
+  fail!("#{name} must be a pinned action reference") unless reference.is_a?(String)
+  fail!("#{name} uses an unapproved action") unless ALLOWED_ACTIONS.include?(reference)
+end
+
+def assert_action_inputs(step, expected, name)
+  inputs = step["with"]
+  assert_exact_keys(inputs, expected.keys, "#{name}.with")
+  expected.each do |key, value|
+    fail!("#{name}.with.#{key} is unsafe") unless inputs[key].to_s == value.to_s
+  end
+end
+
+def assert_exact_typed_inputs(step, expected, name)
+  inputs = step["with"]
+  assert_exact_keys(inputs, expected.keys, "#{name}.with")
+  expected.each do |key, value|
+    fail!("#{name}.with.#{key} has the wrong YAML type or value") unless inputs[key].eql?(value)
+  end
+end
+
+def assert_exact_environment(step, expected, name)
+  environment = step["env"]
+  assert_exact_keys(environment, expected.keys, "#{name}.env")
+  expected.each do |key, value|
+    fail!("#{name}.env.#{key} is unsafe") unless environment[key] == value
+  end
+end
+
+def walk_paths(value, path = [], &block)
+  block.call(path, value)
+  case value
+  when Hash
+    value.each { |key, child| walk_paths(child, path + [key.to_s], &block) }
+  when Array
+    value.each_with_index { |child, index| walk_paths(child, path + [index], &block) }
+  end
+end
+
+def assert_exact_secret_paths(document, allowed_paths: ALLOWED_SECRET_PATHS)
+  expected = {}
+  allowed_paths.each { |path| expected[path] = GITHUB_TOKEN_EXPRESSION }
+  actual = {}
+  walk_paths(document) do |path, value|
+    next unless value.is_a?(String) && value.match?(
+      /\bsecrets\b|\bgithub\b.*\btoken\b|\btoJSON\s*\(\s*github\b/i
+    )
+
+    actual[path] = value
+  end
+  fail!("workflow token references are not the reviewed contract") unless actual == expected
+end
+
+def assert_safe_expression_fields(document, name, allowed_secret_paths: ALLOWED_SECRET_PATHS)
+  walk_paths(document) do |path, value|
+    next unless value.is_a?(String) && value.match?(EXPRESSION_MARKER)
+
+    joined_path = path.map(&:to_s).join(".")
+    fail!("#{name} has an expression in an unreviewed field") unless
+      ALLOWED_EXPRESSION_PATHS.any? { |pattern| joined_path.match?(pattern) }
+    if value.match?(GITHUB_CONTEXT_EXPRESSION) && value.match?(GITHUB_TOKEN_EXPRESSION_PATTERN)
+      fail!("#{name} may not reference the GitHub token or serialized context")
+    end
+    if value.match?(/\bsecrets\b/i)
+      fail!("#{name} has an unapproved secret expression") unless
+        allowed_secret_paths.include?(path) && value == GITHUB_TOKEN_EXPRESSION
+    end
+  end
+end
+
+def assert_safe_run_text(run, name)
+  fail!("#{name} must be a shell string") unless run.is_a?(String)
+  fail!("#{name} may not interpolate GitHub expressions") if run.match?(GITHUB_CONTEXT_IN_RUN)
+  fail!("#{name} may not access a token environment variable") if run.match?(TOKEN_ENV_IN_RUN)
+  fail!("#{name} may not contain trailing whitespace") if run.lines.any? { |line| line.chomp.end_with?(" ", "\t") }
+end
+
+def normalize_run_text(run)
+  normalized = run.to_s.gsub("\r\n", "\n").gsub("\r", "\n")
+  normalized.end_with?("\n") ? normalized[0...-1] : normalized
+end
+
+def assert_exact_normalized_run(run, expected, expected_digest, name)
+  assert_safe_run_text(run, name)
+  normalized = normalize_run_text(run)
+  fail!("#{name} is not the reviewed shell contract") unless
+    normalized == normalize_run_text(expected) && Digest::SHA256.hexdigest(normalized) == expected_digest
+end
+
+def run_guard_contract_regression_matrix!
+  checks = 0
+  expect_failure = lambda do |name, &block|
+    failed = false
+    begin
+      block.call
+    rescue PolicyError
+      failed = true
+    end
+    fail!("#{name} guard contract regression failed") unless failed
+    checks += 1
+  end
+
+  checkout = { "with" => GUARD_CHECKOUT_WITH.dup }
+  assert_exact_typed_inputs(checkout, GUARD_CHECKOUT_WITH, "regression guard checkout")
+  checks += 1
+  expect_failure.call("changed checkout ref") do
+    changed = Marshal.load(Marshal.dump(checkout))
+    changed["with"]["ref"] = "${{ github.event.pull_request.head.sha }}"
+    assert_exact_typed_inputs(changed, GUARD_CHECKOUT_WITH, "regression guard checkout")
+  end
+  expect_failure.call("changed checkout input type") do
+    changed = Marshal.load(Marshal.dump(checkout))
+    changed["with"]["fetch-depth"] = "1"
+    assert_exact_typed_inputs(changed, GUARD_CHECKOUT_WITH, "regression guard checkout")
+  end
+
+  runner_guard = {
+    "name" => CLA_HOSTED_RUNNER_GUARD_NAME,
+    "if" => CLA_HOSTED_RUNNER_GUARD_IF,
+    "run" => CLA_HOSTED_RUNNER_GUARD_RUN
+  }
+  assert_hosted_runner_guard_step(runner_guard, "regression guard")
+  checks += 1
+  expect_failure.call("guard runner can be self-hosted") do
+    assert_hosted_runner_guard_step(
+      runner_guard.merge("if" => "runner.environment == 'github-hosted'"),
+      "regression guard"
+    )
+  end
+
+  current_layout = guard_step_layout(GUARD_TRIGGER, 3)
+  fail!("current guard layout regression failed") unless
+    current_layout == {
+      verification_index: 1,
+      validation_index: 2,
+      hosted: false,
+      allowed_secret_paths: GUARD_ALLOWED_SECRET_PATHS
+    }
+  checks += 1
+  hosted_layout = guard_step_layout(GUARD_HOSTED_TRIGGER, 4)
+  fail!("future hosted guard layout regression failed") unless
+    hosted_layout == {
+      verification_index: 2,
+      validation_index: 3,
+      hosted: true,
+      allowed_secret_paths: GUARD_HOSTED_ALLOWED_SECRET_PATHS
+    }
+  checks += 1
+  expect_failure.call("hosted trigger without runner guard") do
+    guard_step_layout(GUARD_HOSTED_TRIGGER, 3)
+  end
+  expect_failure.call("runner guard without ready trigger") do
+    guard_step_layout(GUARD_TRIGGER, 4)
+  end
+
+  verification = { "env" => GUARD_VERIFY_ENV.dup, "run" => GUARD_VERIFY_RUN }
+  assert_exact_environment(verification, GUARD_VERIFY_ENV, "regression guard verification")
+  assert_exact_normalized_run(
+    verification["run"], GUARD_VERIFY_RUN, GUARD_VERIFY_RUN_HASH, "regression guard verification run"
+  )
+  checks += 2
+  expect_failure.call("added verification token env") do
+    changed = Marshal.load(Marshal.dump(verification))
+    changed["env"]["GH_TOKEN"] = GITHUB_TOKEN_EXPRESSION
+    assert_exact_environment(changed, GUARD_VERIFY_ENV, "regression guard verification")
+  end
+  expect_failure.call("changed verification shell") do
+    assert_exact_normalized_run(
+      "#{verification["run"]}\nprintf 'unexpected\\n'",
+      GUARD_VERIFY_RUN,
+      GUARD_VERIFY_RUN_HASH,
+      "regression guard verification run"
+    )
+  end
+  expect_failure.call("trailing shell whitespace") do
+    assert_exact_normalized_run(
+      verification["run"].sub("set -euo pipefail", "set -euo pipefail "),
+      GUARD_VERIFY_RUN,
+      GUARD_VERIFY_RUN_HASH,
+      "regression guard verification run"
+    )
+  end
+
+  validation = { "env" => GUARD_VALIDATE_ENV.dup, "run" => GUARD_VALIDATE_RUN }
+  assert_exact_environment(validation, GUARD_VALIDATE_ENV, "regression guard validation")
+  assert_exact_normalized_run(
+    validation["run"], GUARD_VALIDATE_RUN, GUARD_VALIDATE_RUN_HASH, "regression guard validation run"
+  )
+  checks += 2
+  expect_failure.call("added validation secret env") do
+    changed = Marshal.load(Marshal.dump(validation))
+    changed["env"]["EXTRA_TOKEN"] = "${{ secrets.OTHER_TOKEN }}"
+    assert_exact_environment(changed, GUARD_VALIDATE_ENV, "regression guard validation")
+  end
+  expect_failure.call("GitHub context in validation shell") do
+    assert_exact_normalized_run(
+      "#{validation["run"]}\nprintf '%s\\n' '${{ github['token'] }}'",
+      GUARD_VALIDATE_RUN,
+      GUARD_VALIDATE_RUN_HASH,
+      "regression guard validation run"
+    )
+  end
+  puts "PASS: guard workflow contract regression matrix (#{checks} cases)"
+end
+
+def assert_safe_run_values(document)
+  walk(document) do |key, value|
+    assert_safe_run_text(value, "workflow run step") if key == "run"
+  end
+end
+
+def assert_safe_job_common(job_value, name)
+  # These keys are the complete job-level surface used by the reviewed policy.
+  # In particular, environment, containers, services, defaults, and
+  # continue-on-error are intentionally absent. They can change where a
+  # token-bearing step runs or whether a failed guard is ignored.
+  assert_no_keys(
+    job_value,
+    %w[environment container services defaults strategy continue-on-error concurrency-group],
+    name
+  )
+  assert_string(job_value["runs-on"], "#{name}.runs-on")
+  assert_positive_integer(job_value["timeout-minutes"], "#{name}.timeout-minutes")
+  fail!("#{name}.runs-on may not be PR-controlled") if job_value["runs-on"].include?("github.event")
+end
+
+def assert_step_keys(step, name, allowed)
+  assert_exact_keys(step, allowed, name)
+  fail!("#{name} must be a mapping") unless step.is_a?(Hash)
+end
+
+# Return the observable result of the exact admission contract. `:ordinary`
+# means a valid human discussion comment that must not reach the signer. The
+# `:malformed` result represents a fail-closed event or metadata shape error.
+# This is deliberately independent of the candidate workflow text. The
+# structural checks in `validate_workflow` bind the candidate to the same
+# contract, while this matrix catches accidental drift in the trusted policy
+# specification itself.
+def cla_admission_outcome(event)
+  return :malformed unless event.is_a?(Hash)
+
+  event_name = event[:event_name]
+  event_action = event[:action]
+  if event_name == "pull_request_target"
+    return :admitted if CLA_LIFECYCLE_ACTIONS.include?(event_action)
+
+    return :malformed
+  end
+  return :malformed unless event_name == "issue_comment" && event_action == "created"
+
+  required = %i[
+    issue_state
+    issue_pull_request
+    comment_body
+    comment_author_type
+    comment_author_id
+    comment_author_login
+    pr_author_id
+    comment_author_association
+  ]
+  return :malformed unless required.all? { |key| event.key?(key) }
+  return :malformed unless event[:issue_state] == "open" && event[:issue_pull_request] == true
+
+  author_type = event[:comment_author_type]
+  author_id = event[:comment_author_id]
+  author_login = event[:comment_author_login]
+  pr_author_id = event[:pr_author_id]
+  association = event[:comment_author_association]
+  return :malformed unless author_type == "User" && author_login.is_a?(String) && !author_login.empty?
+  return :malformed if author_login.downcase.end_with?("[bot]")
+  return :malformed unless author_id.is_a?(String) && author_id.match?(POSITIVE_ID)
+  return :malformed unless pr_author_id.is_a?(String) && pr_author_id.match?(POSITIVE_ID)
+  return :malformed unless association.is_a?(String) && !association.empty? && !association.match?(/[\r\n]/)
+
+  if event[:comment_body] == CLA_SIGN_PHRASE
+    # The maintained action's signer-preflight is the single source of truth
+    # for commit authorship and co-authorship. The base-controlled matrix only
+    # admits an authenticated exact declaration to that read-only check; an
+    # arbitrary commenter cannot reach the writer unless preflight authorizes
+    # the same live identity.
+    return :admitted
+  end
+  if event[:comment_body] == CLA_RECHECK_PHRASE
+    return :admitted if author_id == pr_author_id || CLA_TRUSTED_ASSOCIATIONS.include?(association)
+
+    return :ordinary
+  end
+
+  :ordinary
+end
+
+def run_trusted_cla_regression_matrix!
+  base = {
+    event_name: "issue_comment",
+    action: "created",
+    issue_state: "open",
+    issue_pull_request: true,
+    comment_body: CLA_RECHECK_PHRASE,
+    comment_author_type: "User",
+    comment_author_id: "300",
+    comment_author_login: "contributor",
+    pr_author_id: "300",
+    comment_author_association: "NONE"
+  }
+  cases = []
+  add = lambda do |name, changes, expected|
+    cases << [name, base.merge(changes), expected]
+  end
+
+  add.call("author-recheck", {}, :admitted)
+  add.call("exact-sign", { comment_body: CLA_SIGN_PHRASE }, :admitted)
+  add.call("other-contributor-sign", {
+    comment_body: CLA_SIGN_PHRASE,
+    comment_author_id: "301",
+    comment_author_login: "reviewer",
+    comment_author_association: "MEMBER"
+  }, :admitted)
+  add.call("legacy-sign", { comment_body: "I have read the CLA Document and I hereby sign the CLA" }, :ordinary)
+  add.call("uppercase-recheck", { comment_body: "RECHECK" }, :ordinary)
+  add.call("padded-sign", { comment_body: " #{CLA_SIGN_PHRASE} " }, :ordinary)
+  add.call("wrapped-sign", { comment_body: "Please sign: #{CLA_SIGN_PHRASE}" }, :ordinary)
+  add.call("ordinary-comment", { comment_body: "Thanks for the review!" }, :ordinary)
+  CLA_TRUSTED_ASSOCIATIONS.each do |association|
+    add.call("#{association.downcase}-recheck", {
+      comment_author_id: "301",
+      comment_author_login: "maintainer",
+      comment_author_association: association
+    }, :admitted)
+  end
+  add.call("untrusted-recheck", { comment_author_id: "301" }, :ordinary)
+  add.call("bot-type", { comment_author_type: "Bot" }, :malformed)
+  add.call("bot-login", { comment_author_login: "github-actions[bot]" }, :malformed)
+  add.call("missing-author-id", { comment_author_id: nil }, :malformed)
+  add.call("malformed-association", { comment_author_association: "MEMBER\nOWNER" }, :malformed)
+  add.call("closed-issue", { issue_state: "closed" }, :malformed)
+  add.call("non-pull-request", { issue_pull_request: false }, :malformed)
+  add.call("wrong-comment-action", { action: "edited" }, :malformed)
+  CLA_LIFECYCLE_ACTIONS.each do |action|
+    add.call("pull-request-#{action}", {
+      event_name: "pull_request_target",
+      action: action
+    }, :admitted)
+  end
+  add.call("pull-request-closed", { event_name: "pull_request_target", action: "closed" }, :malformed)
+  add.call("unsupported-event", { event_name: "push", action: "" }, :malformed)
+  cases << ["nil-event", nil, :malformed]
+
+  failures = []
+  cases.each do |name, event, expected|
+    actual = cla_admission_outcome(event)
+    failures << "#{name}: expected #{expected}, got #{actual}" unless actual == expected
+  end
+  fail!("trusted CLA regression matrix failed: #{failures.join('; ')}") unless failures.empty?
+  puts "PASS: trusted CLA regression matrix (#{cases.length} cases)"
+
+  migration_cases = [
+    ["exact legacy v2 bridge", LEGACY_CLA_WORKFLOW_DIGEST, LEGACY_CLA_RERUN_DIGEST, true],
+    ["different legacy workflow", "0" * 64, LEGACY_CLA_RERUN_DIGEST, false],
+    ["different legacy helper", LEGACY_CLA_WORKFLOW_DIGEST, "0" * 64, false]
+  ]
+  migration_failures = migration_cases.each_with_object([]) do |(name, workflow_digest, script_digest, expected), failures|
+    actual = legacy_v2_base?(
+      base_workflow_digest: workflow_digest,
+      base_script_digest: script_digest
+    )
+    failures << "#{name}: expected #{expected}, got #{actual}" unless actual == expected
+  end
+  fail!("CLA migration regression matrix failed: #{migration_failures.join('; ')}") unless migration_failures.empty?
+  puts "PASS: CLA migration regression matrix (#{migration_cases.length} cases)"
+end
+
+def run_environment_regression_matrix!
+  checks = 0
+  assert_exact_environment({ "env" => ADMISSION_ENV.dup }, ADMISSION_ENV, "regression admission")
+  checks += 1
+
+  expect_failure = lambda do |name, &block|
+    failed = false
+    begin
+      block.call
+    rescue PolicyError
+      failed = true
+    end
+    fail!("#{name} environment regression failed") unless failed
+    checks += 1
+  end
+
+  expect_failure.call("added variable") do
+    assert_exact_environment(
+      { "env" => ADMISSION_ENV.merge("EXTRA" => "value") },
+      ADMISSION_ENV,
+      "regression admission"
+    )
+  end
+  expect_failure.call("missing variable") do
+    assert_exact_environment(
+      { "env" => ADMISSION_ENV.reject { |key, _value| key == "EVENT_NAME" } },
+      ADMISSION_ENV,
+      "regression admission"
+    )
+  end
+  expect_failure.call("changed expression") do
+    assert_exact_environment(
+      { "env" => ADMISSION_ENV.merge("EVENT_NAME" => "${{ secrets.OTHER_TOKEN }}") },
+      ADMISSION_ENV,
+      "regression admission"
+    )
+  end
+
+  secret_document = {
+    "jobs" => {
+      "CLACommentGate" => { "steps" => [{}, {}, { "env" => { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] },
+      "CLALedgerWriter" => { "steps" => [{}, { "env" => { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] },
+      "RerunFailedCLA" => { "steps" => [{}, {}, { "env" => { "GH_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] },
+      "LockMergedPullRequest" => { "steps" => [{}, { "env" => { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION } }] }
+    }
+  }
+  assert_exact_secret_paths(secret_document)
+  checks += 1
+
+  expect_failure.call("extra secret path") do
+    changed = Marshal.load(Marshal.dump(secret_document))
+    changed["jobs"]["CLAAssistant"] = {
+      "steps" => [{ "env" => { "LEAK" => "${{ secrets.OTHER_TOKEN }}" } }]
+    }
+    assert_exact_secret_paths(changed)
+  end
+  expect_failure.call("github token alias") do
+    changed = Marshal.load(Marshal.dump(secret_document))
+    changed["jobs"]["CLAAssistant"] = {
+      "steps" => [{ "run" => "echo '${{ github.token }}'" }]
+    }
+    assert_exact_secret_paths(changed)
+  end
+  expect_failure.call("changed allowed token") do
+    changed = Marshal.load(Marshal.dump(secret_document))
+    changed.dig("jobs", "CLACommentGate", "steps", 2, "env")["GITHUB_TOKEN"] =
+      "${{ secrets.OTHER_TOKEN }}"
+    assert_exact_secret_paths(changed)
+  end
+  expect_failure.call("bracket GitHub context") do
+    assert_safe_run_text("echo '${{ github['token'] }}'", "regression run")
+  end
+  expect_failure.call("serialized GitHub context") do
+    assert_safe_run_text("echo '${{ toJSON(github) }}'", "regression run")
+  end
+  expect_failure.call("nested expression") do
+    assert_safe_run_text("echo '${{ format('{0}', 'value') }}'", "regression run")
+  end
+  expect_failure.call("token environment variable") do
+    assert_safe_run_text("echo \"$ACTIONS_RUNTIME_TOKEN\"", "regression run")
+  end
+
+  safe_expression_document = {
+    "jobs" => {
+      "example" => {
+        "if" => "${{ github.event_name == 'issue_comment' }}",
+        "concurrency" => { "group" => "cla-${{ github.run_id }}" },
+        "outputs" => { "result" => "${{ steps.result.outputs.value }}" },
+        "steps" => [
+          {
+            "env" => { "EVENT" => "${{ github.event_name }}" },
+            "with" => { "repository" => "${{ github.repository }}" }
+          }
+        ]
+      }
+    }
+  }
+  assert_safe_expression_fields(safe_expression_document, "regression expressions")
+  checks += 1
+  expect_failure.call("expression in metadata") do
+    changed = Marshal.load(Marshal.dump(safe_expression_document))
+    changed["jobs"]["example"]["name"] = "${{ github['token'] }}"
+    assert_safe_expression_fields(changed, "regression expressions")
+  end
+  expect_failure.call("serialized context in metadata") do
+    changed = Marshal.load(Marshal.dump(safe_expression_document))
+    changed["jobs"]["example"]["name"] = "${{ toJSON(github) }}"
+    assert_safe_expression_fields(changed, "regression expressions")
+  end
+  expect_failure.call("indexed secret expression") do
+    changed = Marshal.load(Marshal.dump(safe_expression_document))
+    changed["jobs"]["example"]["steps"][0]["env"]["EVENT"] = "${{ secrets['OTHER_TOKEN'] }}"
+    assert_safe_expression_fields(changed, "regression expressions")
+  end
+
+  puts "PASS: CLA environment regression matrix (#{checks} cases)"
+end
+
+def run_runner_regression_matrix!
+  expected_runner = "ubuntu-24.04"
+  cla_jobs = %w[
+    CLACommentGate
+    CLAAssistant
+    CLALedgerWriter
+    CLACompatibility
+    RerunFailedCLA
+    LockMergedPullRequest
+  ]
+  cla_jobs.each do |job_name|
+    assert_cla_runner(expected_runner, "#{job_name}.runs-on")
+  end
+
+  rejected_runners = {
+    "configured repository variable" => "${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+    "alternate repository variable" => "${{ vars.OTHER_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}",
+    "event-controlled runner" => "${{ github.event.repository.default_branch }}",
+    "self-hosted runner" => "self-hosted",
+    "floating GitHub runner" => "ubuntu-latest"
+  }
+  rejected_runners.each do |name, runner|
+    expect_policy_error(name) { assert_cla_runner(runner, "CLACommentGate.runs-on") }
+  end
+  guard_step = {
+    "name" => CLA_HOSTED_RUNNER_GUARD_NAME,
+    "if" => CLA_HOSTED_RUNNER_GUARD_IF,
+    "run" => CLA_HOSTED_RUNNER_GUARD_RUN
+  }
+  assert_hosted_runner_guard_step(guard_step, "regression CLA job")
+  expect_policy_error("runner guard condition") do
+    assert_hosted_runner_guard_step(guard_step.merge("if" => "runner.environment == 'github-hosted'"), "regression CLA job")
+  end
+  expect_policy_error("runner guard shell") do
+    assert_hosted_runner_guard_step(guard_step.merge("run" => "exit 0"), "regression CLA job")
+  end
+  expect_policy_error("missing hosted action condition") do
+    assert_hosted_runner_step({ "run" => "echo ok" }, "regression CLA action")
+  end
+  expect_policy_error("runner condition bypass") do
+    assert_hosted_runner_step(
+      { "if" => "runner.environment == 'github-hosted' || always()" },
+      "regression CLA action"
+    )
+  end
+  puts "PASS: CLA runner contract regression matrix (#{cla_jobs.length + rejected_runners.length + 4} cases)"
+end
+
+def run_comment_binding_regression_matrix!
+  gate_outputs = {
+    "admitted" => "${{ steps.admission.outputs.admitted }}",
+    "signer_authorized" => "${{ steps.signer_preflight.outputs.signer_authorized }}",
+    "head_sha" => "${{ steps.signer_preflight.outputs.head_sha }}",
+    "base_sha" => "${{ steps.signer_preflight.outputs.base_sha }}"
+  }.merge(CLA_COMMENT_BINDING_OUTPUTS)
+  writer_inputs = {
+    "path-to-document" => CLA_DOCUMENT_INPUT,
+    "path-to-signatures" => CLA_SIGNATURES_PATH,
+    "branch" => "cla-signatures",
+    "required-base-ref" => "main",
+    "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
+    "allowlist-ids" => "38676809,67667005",
+    "require-opener-as-author" => "true",
+    "lock-pullrequest-aftermerge" => "false",
+    "expected-head-sha" => "${{ needs.CLACommentGate.outputs.head_sha }}",
+    "expected-base-sha" => "${{ needs.CLACommentGate.outputs.base_sha }}"
+  }.merge(CLA_COMMENT_BINDING_INPUTS)
+  assert_comment_binding_contract(gate_outputs, writer_inputs)
+  checks = 1
+
+  CLA_COMMENT_BINDING_OUTPUTS.each_key do |key|
+    expect_policy_error("missing #{key} signer output") do
+      assert_comment_binding_contract(gate_outputs.reject { |name, _| name == key }, writer_inputs)
+    end
+    checks += 1
+  end
+  CLA_COMMENT_BINDING_INPUTS.each_key do |key|
+    expect_policy_error("missing #{key} writer input") do
+      assert_comment_binding_contract(gate_outputs, writer_inputs.reject { |name, _| name == key })
+    end
+    checks += 1
+  end
+  puts "PASS: CLA signer comment binding regression matrix (#{checks} cases)"
+end
+
+def run_lifecycle_regression_matrix!
+  fragments = CLA_LIFECYCLE_ACTIONS.map { |action| "github.event.action == '#{action}'" }
+  expressions = Array.new(4) { fragments.join(" || ") }
+  admission_helper = <<~'SH'
+    emit() {
+      [[ -n "${GITHUB_OUTPUT+x}" && -n "${GITHUB_OUTPUT}" ]] || fail "GITHUB_OUTPUT is unavailable"
+      printf 'admitted=%s\n' "$1" >>"${GITHUB_OUTPUT}"
+    }
+  SH
+  admission_run = admission_helper + <<~'SH'
+    case "${EVENT_ACTION}" in
+      opened|edited|reopened|synchronize|ready_for_review) emit true ;;
+      *) fail "Pull-request event action is unsupported" ;;
+    esac
+  SH
+  assert_lifecycle_admission_contract(expressions, admission_run)
+  checks = 1
+
+  CLA_LIFECYCLE_ACTIONS.each do |action|
+    expect_policy_error("missing #{action} lifecycle expression") do
+      changed = expressions.dup
+      changed[0] = changed[0].sub("github.event.action == '#{action}'", "")
+      assert_lifecycle_admission_contract(changed, admission_run)
+    end
+    checks += 1
+  end
+  expect_policy_error("missing lifecycle admission shell case") do
+    assert_lifecycle_admission_contract(expressions, admission_run.sub("ready_for_review", ""))
+  end
+  checks += 1
+  expect_policy_error("missing lifecycle admission output helper") do
+    assert_lifecycle_admission_contract(expressions, admission_run.sub("emit() {", "helper() {"))
+  end
+  checks += 1
+  puts "PASS: CLA lifecycle path regression matrix (#{checks} cases)"
+end
+
+def run_document_contract_regression_matrix!
+  workflow = lambda do |version, generation, ledger_path, phrase = nil, document_url = CLA_DOCUMENT_INPUT|
+    phrase ||= "I have read the CLA Document #{version} and I hereby sign the CLA"
+    <<~YAML
+      name: test
+      on: {}
+      permissions: {}
+      env:
+        CLA_GENERATION: #{generation}
+      jobs:
+        writer:
+          steps:
+            - with:
+                path-to-document: '#{document_url}'
+                path-to-signatures: '#{ledger_path}'
+                custom-pr-sign-comment: '#{phrase}'
+    YAML
+  end
+  document = lambda do |version, body = "terms"|
+    "# Individual Contributor License Agreement (\"Agreement\") #{version}\n#{body}\n"
+  end
+  helper = lambda do |version, ledger_path|
+    phrase = "I have read the CLA Document #{version} and I hereby sign the CLA"
+    <<~SH
+      #!/usr/bin/env bash
+      [[ "${COMMENT_BODY}" == "#{phrase}" ]] || exit 1
+      readonly SIGNATURES_PATH='#{ledger_path}'
+      [[ -n "${SIGNATURES_PATH}" ]]
+    SH
+  end
+  base_cla = document.call("v2.2")
+  changed_cla = document.call("v3.0", "revised terms")
+  base_script = helper.call("v2.2", "signatures/version2/cla.json")
+  rotated_script = helper.call("v3.0", "signatures/version3/cla.json")
+  base_workflow = workflow.call(
+    "v2.2", "v2.2-action-#{'a' * 40}", "signatures/version2/cla.json"
+  )
+  unchanged = assert_cla_document_change_contract(
+    base_cla: base_cla,
+    head_cla: base_cla,
+    base_workflow: base_workflow,
+    head_workflow: base_workflow,
+    base_script: base_script,
+    head_script: base_script
+  )
+  fail!("unchanged CLA document contract was reported as changed") unless unchanged == false
+  checks = 1
+
+  expect_policy_error("document-only change") do
+    assert_cla_document_change_contract(
+      base_cla: base_cla,
+      head_cla: changed_cla,
+      base_workflow: base_workflow,
+      head_workflow: base_workflow,
+      base_script: base_script,
+      head_script: base_script
+    )
+  end
+  checks += 1
+
+  rotated_workflow = workflow.call(
+    "v3.0", "v3.0-action-#{'b' * 40}", "signatures/version3/cla.json"
+  )
+  assert_cla_document_change_contract(
+    base_cla: base_cla,
+    head_cla: changed_cla,
+    base_workflow: base_workflow,
+    head_workflow: rotated_workflow,
+    base_script: base_script,
+    head_script: rotated_script
+  )
+  checks += 1
+
+  {
+    "same document version" => workflow.call(
+      "v2.2", "v3.0-action-#{'b' * 40}", "signatures/version3/cla.json"
+    ),
+    "same generation" => workflow.call(
+      "v3.0", "v2.2-action-#{'a' * 40}", "signatures/version3/cla.json"
+    ),
+    "same ledger path" => workflow.call(
+      "v3.0", "v3.0-action-#{'b' * 40}", "signatures/version2/cla.json"
+    ),
+    "old ledger namespace" => workflow.call(
+      "v3.0", "v3.0-action-#{'b' * 40}", "signatures/version1/cla.json"
+    ),
+    "minor ledger namespace" => workflow.call(
+      "v3.0", "v3.0-action-#{'b' * 40}", "signatures/version3.0/cla.json"
+    ),
+    "mutable document URL" => workflow.call(
+      "v3.0", "v3.0-action-#{'b' * 40}", "signatures/version3/cla.json", nil,
+      "https://github.com/${{ github.repository }}/blob/main/CLA.md"
+    ),
+    "wrong document phrase" => workflow.call(
+      "v3.0", "v3.0-action-#{'b' * 40}", "signatures/version3/cla.json",
+      "I have read the CLA Document v2.2 and I hereby sign the CLA"
+    )
+  }.each do |name, candidate|
+    expect_policy_error(name) do
+      assert_cla_document_change_contract(
+        base_cla: base_cla,
+        head_cla: changed_cla,
+        base_workflow: base_workflow,
+        head_workflow: candidate,
+        base_script: base_script,
+        head_script: rotated_script
+      )
+    end
+    checks += 1
+  end
+  expect_policy_error("stale rerun helper") do
+    assert_cla_document_change_contract(
+      base_cla: base_cla,
+      head_cla: changed_cla,
+      base_workflow: base_workflow,
+      head_workflow: rotated_workflow,
+      base_script: base_script,
+      head_script: base_script
+    )
+  end
+  checks += 1
+  expect_policy_error("decreasing document major") do
+    older_cla = document.call("v1.0", "reverted terms")
+    older_workflow = workflow.call("v1.0", "v1.0-action-#{'c' * 40}", "signatures/version1/cla.json")
+    older_script = helper.call("v1.0", "signatures/version1/cla.json")
+    assert_cla_document_change_contract(
+      base_cla: base_cla,
+      head_cla: older_cla,
+      base_workflow: base_workflow,
+      head_workflow: older_workflow,
+      base_script: base_script,
+      head_script: older_script
+    )
+  end
+  checks += 1
+  puts "PASS: CLA document contract regression matrix (#{checks} cases)"
+end
+
+def run_trusted_review_regression_matrix!
+  head = "a" * 40
+  review = lambda do |id, state, at, commit = head, user = 54008264, dismissed = nil|
+    {
+      "id" => id,
+      "user" => { "id" => user, "type" => "User" },
+      "state" => state,
+      "commit_id" => commit,
+      "submitted_at" => at,
+      "dismissed_at" => dismissed
+    }
+  end
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(2, "COMMENTED", "2026-01-02T00:00:00Z"))
+  collect_latest_trusted_review!(latest, seen, review.call(1, "APPROVED", "2026-01-01T00:00:00Z"))
+  fail!("trusted review ordering regression failed") unless latest.fetch("54008264")[1]["state"] == "APPROVED"
+
+  latest = {}
+  seen = {}
+  timestamp = "2026-01-03T00:00:00Z"
+  collect_latest_trusted_review!(latest, seen, review.call(4, "COMMENTED", timestamp))
+  collect_latest_trusted_review!(latest, seen, review.call(3, "APPROVED", timestamp))
+  fail!("trusted review ID tie-break regression failed") unless latest.fetch("54008264")[1]["id"] == 3
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(5, "APPROVED", "2026-01-04T00:00:00Z", head, 38676809))
+  collect_latest_trusted_review!(latest, seen, review.call(6, "DISMISSED", "2026-01-05T00:00:00Z", head, 38676809))
+  fail!("trusted review dismissal regression failed") unless latest.fetch("38676809")[1]["state"] == "DISMISSED"
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(10, "APPROVED", "2026-01-05T00:00:00Z", head, 67667005))
+  fail!("Aziz trusted review regression failed") unless latest.fetch("67667005")[1]["state"] == "APPROVED"
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, review.call(7, "APPROVED", "2026-01-06T00:00:00Z", head, 12345))
+  fail!("untrusted review was treated as trusted") unless latest.empty?
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, { "id" => 8, "state" => "PENDING" })
+  fail!("pending review changed trusted state") unless latest.empty?
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, { "id" => 11, "user" => nil, "state" => "APPROVED" })
+  fail!("deleted reviewer changed trusted state") unless latest.empty?
+
+  latest = {}
+  seen = {}
+  collect_latest_trusted_review!(latest, seen, { "id" => 12, "user" => { "id" => 12345 }, "state" => "invalid" })
+  fail!("malformed untrusted review changed trusted state") unless latest.empty?
+
+  duplicate_failed = false
+  begin
+    collect_latest_trusted_review!(latest, seen, review.call(9, "APPROVED", "2026-01-06T00:00:00Z"))
+    collect_latest_trusted_review!(latest, seen, review.call(9, "APPROVED", "2026-01-06T00:00:01Z"))
+  rescue PolicyError
+    duplicate_failed = true
+  end
+  fail!("duplicate review regression failed") unless duplicate_failed
+  puts "PASS: trusted review state regression matrix (9 cases)"
+end
+
+def validate_workflow(raw)
+  document = parse_workflow(raw)
+
+  # Keep the policy surface closed. YAML keys that are harmless in an
+  # ordinary workflow, such as `defaults`, `services`, or `concurrency` at the
+  # top level, can silently change the trust boundary here. A maintainer must
+  # update this validator in a separate control-plane PR before introducing a
+  # new surface.
+  top_level_keys = document.keys.map { |key| key == true ? "on" : key.to_s }
+  fail!("CLA workflow has unsupported top-level keys") unless
+    top_level_keys.uniq.sort == WORKFLOW_KEYS.sort
+  fail!("CLA workflow name is not the reviewed context") unless document["name"] == "CLA Assistant v3"
+
+  triggers = document["on"] || document[true]
+  fail!("CLA workflow has no mapping of triggers") unless triggers.is_a?(Hash)
+  fail!("CLA workflow must not use pull_request") if triggers.key?("pull_request")
+  fail!("issue_comment must trigger only on created") unless triggers["issue_comment"] == { "types" => ["created"] }
+  target = triggers["pull_request_target"]
+  fail!("pull_request_target is malformed") unless target.is_a?(Hash)
+  fail!("pull_request_target must target main only") unless target["branches"] == ["main"]
+  expected_types = %w[opened closed edited reopened synchronize ready_for_review]
+  fail!("pull_request_target event set is unsafe") unless target["types"] == expected_types
+  fail!("top-level permissions must be empty") unless document["permissions"] == {}
+
+  env = document["env"]
+  assert_exact_keys(env, ["CLA_GENERATION"], "CLA workflow env")
+  generation = env["CLA_GENERATION"]
+  fail!("CLA_GENERATION is missing or malformed") unless
+    generation.is_a?(String) && generation.match?(/\Av[0-9]+\.[0-9]+-action-[0-9a-f]{40}\z/)
+  action_sha = CLA_ACTION.split("@", 2).last
+  fail!("CLA_GENERATION is not bound to the maintained action") unless
+    generation.match?(/\A v[0-9]+\.[0-9]+-action-#{Regexp.escape(action_sha)} \z/x)
+
+  gate = job(document, "CLACommentGate")
+  assistant = job(document, "CLAAssistant")
+  writer = job(document, "CLALedgerWriter")
+  compatibility = job(document, "CLACompatibility")
+  rerun = job(document, "RerunFailedCLA")
+  lock = job(document, "LockMergedPullRequest")
+  jobs = document["jobs"]
+  fail!("CLA workflow has unsupported jobs") unless jobs.keys.map(&:to_s).sort == WORKFLOW_JOB_NAMES.sort
+  job_keys = {
+    "CLACommentGate" => %w[name if runs-on timeout-minutes concurrency permissions outputs steps],
+    "CLAAssistant" => %w[name needs if runs-on timeout-minutes permissions steps],
+    "CLALedgerWriter" => %w[name needs if runs-on timeout-minutes concurrency permissions outputs steps],
+    "CLACompatibility" => %w[name needs if runs-on timeout-minutes permissions steps],
+    "RerunFailedCLA" => %w[name needs if runs-on timeout-minutes permissions steps],
+    "LockMergedPullRequest" => %w[name if runs-on timeout-minutes concurrency permissions steps]
+  }
+  [gate, assistant, writer, compatibility, rerun, lock].each_with_index do |value, index|
+    names = %w[CLACommentGate CLAAssistant CLALedgerWriter CLACompatibility RerunFailedCLA LockMergedPullRequest]
+    fail!("#{names[index]} has no runner") unless value.key?("runs-on")
+    assert_exact_keys(value, job_keys.fetch(names[index]), names[index])
+    assert_safe_job_common(value, names[index])
+    assert_cla_runner(value["runs-on"], names[index])
+    assert_hosted_runner_job_steps(value, names[index])
+  end
+
+  fail!("CLACommentGate must use read-only permissions") unless
+    gate["permissions"] == { "contents" => "read", "issues" => "read", "pull-requests" => "read" }
+  fail!("CLACompatibility must have no permissions") unless compatibility["permissions"] == {}
+  fail!("CLA Assistant result must have no permissions") unless assistant["permissions"] == {}
+  fail!("CLACommentGate outputs are not the reviewed contract") unless
+    gate["outputs"] == {
+      "admitted" => "${{ steps.admission.outputs.admitted }}",
+      "signer_authorized" => "${{ steps.signer_preflight.outputs.signer_authorized }}",
+      "head_sha" => "${{ steps.signer_preflight.outputs.head_sha }}",
+      "base_sha" => "${{ steps.signer_preflight.outputs.base_sha }}"
+    }.merge(CLA_COMMENT_BINDING_OUTPUTS)
+  fail!("CLALedgerWriter outputs are not the reviewed contract") unless
+    writer["outputs"] == {
+      "signature_recorded" => "${{ steps.cla_action.outputs.signature_recorded }}"
+    }
+  fail!("CLA ledger writer must depend on the admission gate") unless dependencies(writer, "CLALedgerWriter").include?("CLACommentGate")
+  fail!("CLA ledger writer must not run with always()") if writer["if"].to_s.include?("always()")
+  writer_condition = writer["if"].to_s.gsub(/\s+/, " ").strip
+  fail!("CLA ledger writer condition is not the reviewed admission contract") unless
+    writer_condition == CLA_WRITER_CONDITION
+  fail!("CLA Assistant result must depend on the ledger writer") unless dependencies(assistant, "CLAAssistant").include?("CLALedgerWriter")
+  fail!("CLA Assistant result must always report the writer outcome") unless assistant["if"].to_s.include?("always()")
+  fail!("CLA compatibility must depend on the v2 result") unless dependencies(compatibility, "CLACompatibility").include?("CLAAssistant")
+
+  # A write-capable job is intentionally one pinned action invocation. An
+  # extra `run` step would execute contributor-controlled policy text with the
+  # ledger token in its environment. The no-permission result and compatibility
+  # jobs may run shell diagnostics, but they cannot introduce actions or
+  # service/container settings.
+  writer_steps = steps(writer, "CLALedgerWriter")
+  fail!("CLALedgerWriter must contain a runner guard and one action step") unless writer_steps.length == 2
+  writer_step = writer_steps[1]
+  assert_step_keys(writer_step, "CLALedgerWriter step", %w[name id if uses env with])
+  assert_hosted_runner_step(writer_step, "CLALedgerWriter action")
+  fail!("CLALedgerWriter step must have id cla_action") unless writer_step["id"] == "cla_action"
+  assert_action_reference(writer_step["uses"], "CLALedgerWriter step uses")
+  fail!("CLALedgerWriter must invoke only the maintained CLA action") unless writer_step["uses"] == CLA_ACTION
+  assert_exact_environment(
+    writer_step,
+    { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION },
+    "CLALedgerWriter step"
+  )
+
+  gate_steps = steps(gate, "CLACommentGate")
+  fail!("CLACommentGate must contain a runner guard, admission, and preflight") unless gate_steps.length == 3
+  admission_step_shape = gate_steps[1]
+  assert_step_keys(admission_step_shape, "CLACommentGate admission step", %w[name id if env run])
+  assert_hosted_runner_step(admission_step_shape, "CLACommentGate admission")
+  fail!("CLACommentGate admission step must have id admission") unless admission_step_shape["id"] == "admission"
+  assert_exact_environment(admission_step_shape, ADMISSION_ENV, "CLACommentGate admission step")
+  fail!("CLACommentGate admission step must not access a token or network") if
+    admission_step_shape["run"].to_s.match?(/\b(gh|curl|wget|git|ssh|sudo|eval|source)\b|\bsecrets\b|\bgithub\.token\b|GITHUB_TOKEN/i)
+  preflight_step_shape = gate_steps[2]
+  assert_step_keys(preflight_step_shape, "CLACommentGate preflight step", %w[name id if uses env with])
+  assert_hosted_runner_step(preflight_step_shape, "CLACommentGate preflight")
+  assert_action_reference(preflight_step_shape["uses"], "CLACommentGate preflight uses")
+  fail!("CLACommentGate preflight must invoke only the maintained CLA action") unless preflight_step_shape["uses"] == CLA_ACTION
+  fail!("CLACommentGate preflight step must have id signer_preflight") unless preflight_step_shape["id"] == "signer_preflight"
+  assert_exact_environment(
+    preflight_step_shape,
+    { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION },
+    "CLACommentGate preflight step"
+  )
+
+  result_steps = steps(assistant, "CLAAssistant")
+  fail!("CLAAssistant must contain a runner guard and one result step") unless result_steps.length == 2
+  assert_step_keys(result_steps[1], "CLAAssistant result step", %w[name if env run])
+  assert_hosted_runner_step(result_steps[1], "CLAAssistant result")
+  assert_exact_environment(result_steps[1], RESULT_ENV, "CLAAssistant result step")
+  compatibility_steps = steps(compatibility, "CLACompatibility")
+  fail!("CLACompatibility must contain a runner guard and one result step") unless compatibility_steps.length == 2
+  assert_step_keys(compatibility_steps[1], "CLACompatibility result step", %w[name if env run])
+  assert_hosted_runner_step(compatibility_steps[1], "CLACompatibility result")
+  assert_exact_environment(compatibility_steps[1], COMPATIBILITY_ENV, "CLACompatibility result step")
+
+  rerun_steps = steps(rerun, "RerunFailedCLA")
+  fail!("RerunFailedCLA must contain a runner guard, checkout, and guard step") unless rerun_steps.length == 3
+  assert_step_keys(rerun_steps[1], "RerunFailedCLA checkout step", %w[name if uses with])
+  assert_hosted_runner_step(rerun_steps[1], "RerunFailedCLA checkout")
+  assert_step_keys(rerun_steps[2], "RerunFailedCLA guard step", %w[name if env run])
+  assert_hosted_runner_step(rerun_steps[2], "RerunFailedCLA helper")
+  assert_action_reference(rerun_steps[1]["uses"], "RerunFailedCLA checkout uses")
+  fail!("RerunFailedCLA may not invoke the CLA action") if rerun_steps.any? { |step| step["uses"] == CLA_ACTION }
+  fail!("RerunFailedCLA guard step must invoke the immutable helper exactly") unless
+    rerun_steps[2]["run"] == "bash .github/scripts/rerun-failed-cla.sh"
+  assert_exact_environment(rerun_steps[2], RERUN_ENV, "RerunFailedCLA guard step")
+
+  lock_steps = steps(lock, "LockMergedPullRequest")
+  fail!("LockMergedPullRequest must contain a runner guard and one action step") unless lock_steps.length == 2
+  assert_step_keys(lock_steps[1], "LockMergedPullRequest step", %w[name if uses env with])
+  assert_hosted_runner_step(lock_steps[1], "LockMergedPullRequest action")
+  assert_action_reference(lock_steps[1]["uses"], "LockMergedPullRequest uses")
+  fail!("LockMergedPullRequest must invoke only the maintained CLA action") unless lock_steps[1]["uses"] == CLA_ACTION
+  assert_exact_environment(
+    lock_steps[1],
+    { "GITHUB_TOKEN" => GITHUB_TOKEN_EXPRESSION },
+    "LockMergedPullRequest step"
+  )
+  assert_action_inputs(
+    lock_steps[1],
+    {
+      "mode" => "sign",
+      "path-to-signatures" => CLA_SIGNATURES_PATH,
+      "path-to-document" => CLA_DOCUMENT_INPUT,
+      "branch" => "cla-signatures",
+      "required-base-ref" => "main",
+      "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
+      "allowlist-ids" => "38676809,67667005",
+      "require-opener-as-author" => "true",
+      "lock-pullrequest-aftermerge" => "true"
+    },
+    "LockMergedPullRequest action"
+  )
+
+  [assistant, compatibility, rerun, lock].each do |job_value|
+    steps(job_value, job_value.equal?(assistant) ? "CLAAssistant" : job_value.equal?(compatibility) ? "CLACompatibility" : job_value.equal?(rerun) ? "RerunFailedCLA" : "LockMergedPullRequest").each do |step|
+      fail!("policy jobs may not mix run and uses in one step") if step.is_a?(Hash) && step.key?("run") && step.key?("uses")
+    end
+  end
+
+  admission_step = steps(gate, "CLACommentGate").find { |step| step.is_a?(Hash) && step["id"] == "admission" }
+  admission_run = admission_step && admission_step["run"]
+  fail!("CLACommentGate admission implementation is missing") unless admission_run.is_a?(String)
+  assert_lifecycle_admission_contract(
+    [gate["if"], assistant["if"], compatibility["if"], writer_condition],
+    admission_run
+  )
+  sign_branch = admission_run[/if \[\[ "\$\{COMMENT_BODY\}" == "#{Regexp.escape(CLA_SIGN_PHRASE)}" \]\]; then(.*?)(?:\n\s*fi)/m]
+  fail!("CLA signing admission implementation is missing") unless sign_branch&.include?("printf 'admitted=true\\n'")
+  fail!("CLA signing admission must not duplicate commit identity mapping") if sign_branch.match?(/COMMENT_AUTHOR_ID|PR_AUTHOR_ID/)
+  preflight = step_using_with(gate, CLA_ACTION, "mode", "signer-preflight", "CLACommentGate")
+  preflight_with = preflight["with"]
+  fail!("CLA signer preflight inputs are missing") unless preflight_with.is_a?(Hash)
+  {
+    "mode" => "signer-preflight",
+    "path-to-signatures" => CLA_SIGNATURES_PATH,
+    "path-to-document" => CLA_DOCUMENT_INPUT,
+    "required-base-ref" => "main",
+    "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
+    "require-opener-as-author" => "true",
+    "allowlist-ids" => "38676809,67667005",
+    "branch" => "cla-signatures"
+  }.then { |expected| assert_action_inputs(preflight, expected, "CLACommentGate preflight") }
+  fail!("CLA signer preflight must be conditional on the exact signing phrase") unless preflight["if"].to_s.include?(CLA_SIGN_PHRASE)
+  fail!("CLA gate must expose the signer preflight result") unless gate.dig("outputs", "signer_authorized").to_s.include?("signer_preflight")
+  fail!("CLALedgerWriter permissions are not least-privilege") unless
+    writer["permissions"] == { "contents" => "write", "issues" => "write", "pull-requests" => "write" }
+  fail!("RerunFailedCLA permissions are not least-privilege") unless
+    rerun["permissions"] == { "actions" => "write", "contents" => "read", "issues" => "read", "pull-requests" => "read" }
+  fail!("LockMergedPullRequest permissions are not least-privilege") unless
+    lock["permissions"] == { "issues" => "write", "pull-requests" => "read" }
+
+  action_step = step_using(writer, CLA_ACTION, "CLALedgerWriter")
+  with_values = action_step["with"]
+  fail!("CLA action inputs are missing") unless with_values.is_a?(Hash)
+  writer_inputs = {
+    "path-to-document" => CLA_DOCUMENT_INPUT,
+    "path-to-signatures" => CLA_SIGNATURES_PATH,
+    "branch" => "cla-signatures",
+    "required-base-ref" => "main",
+    "custom-pr-sign-comment" => CLA_SIGN_PHRASE,
+    "allowlist-ids" => "38676809,67667005",
+    "require-opener-as-author" => "true",
+    "lock-pullrequest-aftermerge" => "false",
+    "expected-head-sha" => "${{ needs.CLACommentGate.outputs.head_sha }}",
+    "expected-base-sha" => "${{ needs.CLACommentGate.outputs.base_sha }}"
+  }.merge(CLA_COMMENT_BINDING_INPUTS)
+  assert_action_inputs(action_step, writer_inputs, "CLALedgerWriter action")
+  assert_comment_binding_contract(gate["outputs"], writer_inputs)
+
+  checkout = step_using(rerun, "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd", "RerunFailedCLA")
+  assert_action_inputs(
+    checkout,
+    {
+      "repository" => "${{ github.repository }}",
+      "ref" => "${{ github.workflow_sha }}",
+      "persist-credentials" => false,
+      "sparse-checkout" => ".github/scripts/rerun-failed-cla.sh",
+      "sparse-checkout-cone-mode" => false
+    },
+    "RerunFailedCLA checkout"
+  )
+  rerun_runs = steps(rerun, "RerunFailedCLA").each_with_object([]) do |step, runs|
+    runs << step["run"] if step.is_a?(Hash) && step["run"].is_a?(String)
+  end
+  fail!("rerun job does not invoke the trusted guard") unless rerun_runs.any? { |run| run.include?("bash .github/scripts/rerun-failed-cla.sh") }
+
+  # These are the high-value admission and identity invariants. The local
+  # fixture harnesses exercise their full event matrix; this base-controlled
+  # check ensures a PR cannot remove the invariants from that harness's input.
+  [
+    "github.event.comment.body == '#{CLA_RECHECK_PHRASE}'",
+    "github.event.comment.body == '#{CLA_SIGN_PHRASE}'",
+    "github.event.comment.user.type == 'User'",
+    "github.event.comment.user.id == github.event.issue.user.id",
+    "github.event.action == 'created'",
+    "id: admission",
+    "admitted: ${{ steps.admission.outputs.admitted }}",
+    "issues: write"
+  ].each { |fragment| assert_text(raw, fragment) }
+  # YAML block scalars normalize the expression at runtime. Check the parsed
+  # signer step instead of matching raw source, so an explicit runner guard
+  # may precede the success() term without creating a source-shape bypass.
+  fail!("CLA workflow is missing a successful-step guard") unless
+    preflight_step_shape["if"].to_s.gsub(/\s+/, " ").include?("success()")
+  [gate["if"], assistant["if"]].each do |expression|
+    fail!("CLA signing trigger is missing from a signer job") unless expression.is_a?(String) && expression.include?(CLA_SIGN_PHRASE)
+  end
+  sign_author_guard = Regexp.new(
+    "github\\.event\\.comment\\.body\\s*==\\s*'#{Regexp.escape(CLA_SIGN_PHRASE)}'\\s*&&\\s*" \
+    "github\\.event\\.comment\\.user\\.id\\s*==\\s*github\\.event\\.issue\\.user\\.id"
+  )
+  fail!("CLA signing trigger must admit authenticated contributors") if [gate["if"], assistant["if"], rerun["if"]].any? { |expression| expression.to_s.match?(sign_author_guard) }
+  fail!("CLA workflow may not checkout a pull-request ref") if raw.match?(/ref:\s*\$\{\{\s*github\.event\.pull_request/)
+
+  uses = []
+  walk(document) { |key, value| uses << value if key == "uses" && value.is_a?(String) }
+  uses.each do |reference|
+    assert_action_reference(reference, "CLA workflow action")
+  end
+  assert_exact_secret_paths(document)
+  assert_safe_expression_fields(document, "CLA workflow")
+  assert_safe_run_values(document)
+
+  raw
+rescue Psych::Exception => error
+  fail!("CLA workflow YAML is invalid: #{error.message.lines.first.to_s.strip}")
+end
+
+def validate_script(raw)
+  fail!("CLA rerun script is missing a shell shebang") unless raw.start_with?("#!/usr/bin/env bash")
+  Tempfile.create(["cla-rerun", ".sh"]) do |file|
+    file.write(raw)
+    file.close
+    _stdout, stderr, status = Open3.capture3("bash", "-n", file.path)
+    fail!("CLA rerun script has invalid shell syntax: #{stderr.strip}") unless status.success?
+  end
+end
+
+def validate_guard_workflow(raw, authorize: true)
+  document = parse_workflow(raw)
+  digest = workflow_digest(raw)
+  fail!("guard workflow name is not the reviewed context") unless document["name"] == GUARD_WORKFLOW_NAME
+  triggers = document["on"] || document[true]
+  fail!("guard workflow has no mapping of triggers") unless triggers.is_a?(Hash)
+  fail!("guard workflow has unsupported triggers") unless triggers.keys.map(&:to_s).sort == GUARD_TRIGGER_KEYS.sort
+  target = triggers["pull_request_target"]
+  fail!("guard workflow pull_request_target trigger is malformed") unless target.is_a?(Hash)
+  assert_exact_keys(target, GUARD_TRIGGER.keys, "guard workflow pull_request_target trigger")
+  fail!("guard workflow must have empty top-level permissions") unless document["permissions"] == {}
+  guard_top_level_keys = document.keys.map { |key| key == true ? "on" : key.to_s }
+  fail!("guard workflow has unsupported top-level keys") unless
+    guard_top_level_keys.uniq.sort == %w[name on permissions jobs].sort
+  jobs = document["jobs"]
+  fail!("guard workflow jobs are malformed") unless jobs.is_a?(Hash)
+  fail!("guard workflow has an unexpected job") unless jobs.keys == ["validate"]
+  guard_job = document.dig("jobs", "validate")
+  fail!("guard workflow validate job is missing") unless guard_job.is_a?(Hash)
+  assert_exact_keys(guard_job, %w[name runs-on timeout-minutes permissions steps], "guard workflow validate job")
+  assert_string(guard_job["name"], "guard workflow validate job name")
+  assert_positive_integer(guard_job["timeout-minutes"], "guard workflow validate timeout")
+  fail!("guard workflow validate timeout is not the reviewed value") unless
+    guard_job["timeout-minutes"] == GUARD_TIMEOUT_MINUTES
+  fail!("guard workflow must use an ephemeral GitHub-hosted runner") unless guard_job["runs-on"] == "ubuntu-24.04"
+  fail!("guard workflow must use read-only permissions") unless
+    guard_job["permissions"] == { "contents" => "read", "pull-requests" => "read" }
+  guard_steps = guard_job["steps"]
+  fail!("guard workflow steps are malformed") unless guard_steps.is_a?(Array)
+  layout = guard_step_layout(target, guard_steps.length)
+  assert_step_keys(guard_steps[0], "guard checkout step", %w[name uses with])
+  assert_hosted_runner_guard_step(guard_steps[1], "guard workflow") if layout[:hosted]
+  verification_step = guard_steps.fetch(layout[:verification_index])
+  validation_step = guard_steps.fetch(layout[:validation_index])
+  assert_step_keys(verification_step, "guard checkout verification step", %w[name env run])
+  assert_step_keys(validation_step, "guard validation step", %w[name env run])
+  fail!("guard workflow checkout step is not the immutable checkout") unless
+    guard_steps[0]["uses"] == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+  assert_exact_typed_inputs(guard_steps[0], GUARD_CHECKOUT_WITH, "guard checkout step")
+  fail!("guard checkout step has an unexpected name") unless guard_steps[0]["name"] == "Checkout immutable guard revision"
+  fail!("guard checkout step must pin the trusted repository") unless
+    guard_steps[0].dig("with", "repository") == "${{ github.repository }}"
+  fail!("guard verification step has an unexpected name") unless verification_step["name"] == "Verify trusted checkout"
+  assert_exact_environment(verification_step, GUARD_VERIFY_ENV, "guard checkout verification step")
+  assert_exact_normalized_run(
+    verification_step["run"],
+    GUARD_VERIFY_RUN,
+    GUARD_VERIFY_RUN_HASH,
+    "guard checkout verification step run"
+  )
+  fail!("guard validation step has an unexpected name") unless
+    validation_step["name"] == "Run trusted CLA regression matrix and validate policy as data"
+  assert_exact_environment(validation_step, GUARD_VALIDATE_ENV, "guard validation step")
+  assert_exact_normalized_run(
+    validation_step["run"],
+    GUARD_VALIDATE_RUN,
+    GUARD_VALIDATE_RUN_HASH,
+    "guard validation step run"
+  )
+  assert_exact_secret_paths(document, allowed_paths: layout[:allowed_secret_paths])
+  assert_safe_expression_fields(document, "guard workflow", allowed_secret_paths: layout[:allowed_secret_paths])
+  assert_safe_run_values(document)
+  uses = []
+  walk(document) { |key, value| uses << value if key == "uses" && value.is_a?(String) }
+  uses.each do |reference|
+    fail!("guard workflow may not use repository-local actions") if reference.start_with?("./")
+    fail!("guard workflow uses an unapproved action") unless reference == "actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd"
+  end
+  if authorize && digest != EXPECTED_GUARD_WORKFLOW_DIGEST
+    require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
+  end
+rescue Psych::Exception
+  fail!("guard workflow YAML is invalid")
+end
+
+def validate_guard_script(raw)
+  fail!("guard script is missing a Ruby shebang") unless raw.start_with?("#!/usr/bin/env ruby")
+  if guard_script_digest(raw) != EXPECTED_GUARD_SCRIPT_DIGEST
+    require_trusted_review!(ENV.fetch("GH_REPO"), ENV.fetch("PR_NUMBER"), ENV.fetch("HEAD_SHA"))
+  end
+  [
+    "def parse_workflow",
+    "class BoundedYamlTreeBuilder",
+    "Psych::Parser.new",
+    "MAX_YAML_NODES",
+    "MAX_YAML_DEPTH",
+    "duplicate mapping keys",
+    "merge keys",
+    "mapping keys must be strings",
+    "run_yaml_regression_matrix!",
+    "run_environment_regression_matrix!",
+    "run_runner_regression_matrix!",
+    "run_comment_binding_regression_matrix!",
+    "run_lifecycle_regression_matrix!",
+    "run_document_contract_regression_matrix!",
+    "run_trusted_review_regression_matrix!",
+    "CLA_LIFECYCLE_ACTIONS",
+    "ready_for_review",
+    "collect_latest_trusted_review!",
+    "def workflow_digest",
+    "Digest::SHA256.hexdigest(raw)",
+    "literal on trigger key",
+    "def legacy_v2_base?",
+    "EXPECTED_WORKFLOW_DIGEST",
+    "assert_exact_environment",
+    "assert_exact_typed_inputs",
+    "assert_exact_secret_paths",
+    "assert_safe_expression_fields",
+    "assert_cla_runner",
+    "CLA_RUNNER",
+    "assert_hosted_runner_guard_step",
+    "assert_hosted_runner_step",
+    "assert_hosted_runner_job_steps",
+    "CLA_HOSTED_RUNNER_GUARD_NAME",
+    "CLA_HOSTED_RUNNER_GUARD_RUN",
+    "CLA_HOSTED_RUNNER_GUARD_IF",
+    "CLA_HOSTED_RUNNER_STEP_IF",
+    "assert_comment_binding_contract",
+    "CLA_COMMENT_BINDING_OUTPUTS",
+    "CLA_COMMENT_BINDING_INPUTS",
+    "assert_lifecycle_admission_contract",
+    "GITHUB_OUTPUT+x",
+    "admitted=%s",
+    "CLA_DOCUMENT_PATH",
+    "CLA_DOCUMENT_VERSION",
+    "CLA_SIGNATURES_PATH",
+    "CLA_SIGNATURES_PATH_PATTERN",
+    "document_major",
+    "expected_signature_path",
+    "assert_script_document_binding",
+    "assert_cla_document_change_contract",
+    "workflow_document_contract",
+    "cla_document_version",
+    "CLA_DOCUMENT_INPUT",
+    "CLA.md changes require a CLA policy workflow change",
+    "CLA.md changes must rotate the document version",
+    "CLA.md changes must rotate CLA_GENERATION",
+    "CLA.md changes must rotate the signature ledger path",
+    "CLA.md changes must rotate the rerun helper",
+    "base CLA workflow uses an unexpected signature ledger path",
+    "proposed CLA rerun helper still accepts the old document phrase",
+    "proposed CLA rerun helper still reads the old signature ledger",
+    "assert_safe_run_text",
+    "assert_exact_normalized_run",
+    "run_guard_contract_regression_matrix!",
+    "GUARD_CHECKOUT_WITH",
+    "GUARD_TRIGGER_KEYS",
+    "GUARD_TRIGGER",
+    "GUARD_HOSTED_TRIGGER",
+    "guard_step_layout",
+    "GUARD_WORKFLOW_NAME",
+    "GUARD_TIMEOUT_MINUTES",
+    "GUARD_VERIFY_ENV",
+    "GUARD_VALIDATE_ENV",
+    "GUARD_VERIFY_RUN_HASH",
+    "GUARD_VALIDATE_RUN_HASH",
+    "GUARD_ALLOWED_SECRET_PATHS",
+    "GUARD_HOSTED_ALLOWED_SECRET_PATHS",
+    "GITHUB_CONTEXT_IN_RUN",
+    "TOKEN_ENV_IN_RUN",
+    "TRUSTED_REVIEW_STATES",
+    "base_workflow_digest",
+    "validate_workflow(head_workflow)",
+    "require_trusted_review!(repository, pr_number, head_sha) if policy_changed",
+    "def validate_workflow",
+    "signer-preflight",
+    "CLALedgerWriter",
+    "base_sha",
+    "expected-base-sha",
+    "base_workflow != head_workflow",
+    "guard_changed && policy_changed",
+    "pull-request revision deletes the rerun helper",
+    "CLA policy validation rejected the proposed policy"
+  ].each do |fragment|
+    fail!("guard script is missing a required safety check") unless raw.include?(fragment)
+  end
+  Tempfile.create(["cla-policy-guard", ".rb"]) do |file|
+    file.write(raw)
+    file.close
+    _stdout, _stderr, status = Open3.capture3("ruby", "-c", file.path)
+    fail!("guard script has invalid Ruby syntax") unless status.success?
+  end
+end
+
+begin
+  run_yaml_regression_matrix!
+  run_guard_contract_regression_matrix!
+  run_trusted_cla_regression_matrix!
+  run_environment_regression_matrix!
+  run_runner_regression_matrix!
+  run_comment_binding_regression_matrix!
+  run_lifecycle_regression_matrix!
+  run_document_contract_regression_matrix!
+  run_trusted_review_regression_matrix!
+  repository = required_env("GH_REPO", REPOSITORY)
+  pr_number = required_env("PR_NUMBER", /\A[1-9][0-9]*\z/)
+  base_sha = required_env("BASE_SHA", SHA)
+  head_sha = required_env("HEAD_SHA", SHA)
+  fail!("base and head revisions are identical") if base_sha == head_sha
+
+  repository_metadata = api_json(repository, "repos/#{repository}")
+  repository_id = repository_metadata.is_a?(Hash) ? repository_metadata["id"] : nil
+  assert_positive_integer(repository_id, "base repository ID")
+  live_pr = api_json(repository, "repos/#{repository}/pulls/#{pr_number}")
+  fail!("pull request metadata is malformed") unless live_pr.is_a?(Hash)
+  live_base = live_pr["base"]
+  live_head = live_pr["head"]
+  live_base_repo = live_base.is_a?(Hash) ? live_base["repo"] : nil
+  live_head_repo = live_head.is_a?(Hash) ? live_head["repo"] : nil
+  fail!("pull request metadata changed while validating") unless
+    live_pr["number"].to_s == pr_number &&
+    live_pr["state"] == "open" &&
+    live_base.is_a?(Hash) &&
+    live_base["ref"] == "main" &&
+    live_base["sha"] == base_sha &&
+    live_base_repo.is_a?(Hash) &&
+    live_base_repo["full_name"].to_s.downcase == repository.downcase &&
+    live_base_repo["id"] == repository_id &&
+    live_head.is_a?(Hash) &&
+    live_head["sha"] == head_sha &&
+    live_head["ref"].is_a?(String) &&
+    !live_head["ref"].empty? &&
+    live_head_repo.is_a?(Hash) &&
+    live_head_repo["full_name"].is_a?(String) &&
+    !live_head_repo["full_name"].empty? &&
+    live_head_repo["id"].is_a?(Integer) &&
+    live_head_repo["id"].positive?
+
+  base_workflow = fetch_file(repository, base_sha, ".github/workflows/cla.yml")
+  head_workflow = fetch_file(repository, head_sha, ".github/workflows/cla.yml")
+  fail!("CLA workflow is missing from the pull-request revision") if head_workflow.nil?
+  base_guard_workflow = fetch_file(repository, base_sha, ".github/workflows/cla-policy-guard.yml", allow_missing: true)
+  head_guard_workflow = fetch_file(repository, head_sha, ".github/workflows/cla-policy-guard.yml", allow_missing: true)
+  base_guard_script = fetch_file(repository, base_sha, "scripts/ci/validate-cla-policy.rb", allow_missing: true)
+  head_guard_script = fetch_file(repository, head_sha, "scripts/ci/validate-cla-policy.rb", allow_missing: true)
+  guard_changed = base_guard_workflow != head_guard_workflow || base_guard_script != head_guard_script
+
+  base_cla = fetch_file(repository, base_sha, CLA_DOCUMENT_PATH)
+  head_cla = fetch_file(repository, head_sha, CLA_DOCUMENT_PATH)
+  base_script = fetch_file(repository, base_sha, ".github/scripts/rerun-failed-cla.sh", allow_missing: true)
+  head_script = fetch_file(repository, head_sha, ".github/scripts/rerun-failed-cla.sh", allow_missing: true)
+  policy_changed = base_workflow != head_workflow || base_script != head_script
+  document_changed = Digest::SHA256.hexdigest(base_cla) != Digest::SHA256.hexdigest(head_cla)
+  if policy_changed
+    fail!("CLA workflow must use the reviewed document version") unless
+      cla_document_version(head_cla, "proposed CLA.md") == CLA_DOCUMENT_VERSION
+  end
+  if document_changed
+    fail!("CLA.md changes are not allowed in a guard-only pull request") if guard_changed
+    assert_cla_document_change_contract(
+      base_cla: base_cla,
+      head_cla: head_cla,
+      base_workflow: base_workflow,
+      head_workflow: head_workflow,
+      base_script: base_script,
+      head_script: head_script
+    )
+  end
+  # A policy PR cannot also weaken the validator that reviews it. A guard-only
+  # PR remains possible for normal maintenance, with CODEOWNERS providing the
+  # human review gate for this trusted control plane.
+  fail!("guard and CLA policy files must change in separate pull requests") if guard_changed && policy_changed
+
+  if guard_changed
+    fail!("guard workflow cannot be deleted") if head_guard_workflow.nil?
+    fail!("guard validator cannot be deleted") if head_guard_script.nil?
+    validate_guard_workflow(head_guard_workflow)
+    validate_guard_script(head_guard_script)
+  end
+
+  if base_workflow == head_workflow && base_script == head_script
+    puts "PASS: CLA policy files are unchanged"
+    exit 0
+  end
+
+  if base_script && head_script.nil?
+    fail!("the pull-request revision deletes the rerun helper used by the base workflow")
+  end
+  if base_workflow == head_workflow && base_script != head_script &&
+      Digest::SHA256.hexdigest(base_workflow.to_s) == LEGACY_CLA_WORKFLOW_DIGEST &&
+      Digest::SHA256.hexdigest(base_script.to_s) == LEGACY_CLA_RERUN_DIGEST
+    fail!("the legacy v2 CLA workflow must migrate to v3 before its helper changes")
+  end
+  if base_workflow == head_workflow &&
+      !legacy_v2_base?(
+        base_workflow_digest: Digest::SHA256.hexdigest(base_workflow),
+        base_script_digest: Digest::SHA256.hexdigest(base_script.to_s)
+      )
+    # A guard-only change still has to prove that the policy already running
+    # on main is a reviewed v3 policy. The exact legacy v2 pair is the one
+    # intentional bridge: it is immutable base state and is allowed only
+    # until the separate v3 migration PR lands.
+    validate_workflow(head_workflow)
+  end
+  if base_workflow != head_workflow
+    fail!("CLA rerun helper is missing from the changed workflow revision") if head_script.nil?
+    base_document = parse_workflow(base_workflow)
+    base_workflow_digest = Digest::SHA256.hexdigest(base_workflow)
+    base_script_digest = Digest::SHA256.hexdigest(base_script.to_s)
+    if base_document["name"] == "CLA Assistant v2" && !legacy_v2_base?(
+      base_workflow_digest: base_workflow_digest,
+      base_script_digest: base_script_digest
+    )
+      fail!("the legacy v2 CLA base is not the exact reviewed transition state")
+    end
+    validate_workflow(head_workflow)
+  end
+  validate_script(head_script) unless head_script.nil?
+  # Policy changes always need a current, exact-head trusted approval. The
+  # legacy digest bridge only identifies the permitted v2 base bytes. It never
+  # skips this review or any strict v3 candidate validation.
+  require_trusted_review!(repository, pr_number, head_sha) if policy_changed
+
+  candidate_dir = ENV["CANDIDATE_DIR"].to_s
+  unless candidate_dir.empty?
+    FileUtils.mkdir_p(candidate_dir)
+    File.binwrite(File.join(candidate_dir, "cla.yml"), head_workflow) if head_workflow
+    File.binwrite(File.join(candidate_dir, "rerun-failed-cla.sh"), head_script) if head_script
+  end
+  puts "PASS: base-controlled CLA policy validation for #{head_sha}"
+rescue PolicyError
+  # Candidate-controlled API, YAML, and shell diagnostics must not be copied
+  # into a public check annotation. Keep the check deterministic and generic;
+  # maintainers can reproduce the exact revision locally from the PR URL.
+  warn "::error::CLA policy validation rejected the proposed policy"
+  exit 1
+rescue StandardError
+  warn "::error::CLA policy validation could not complete"
+  exit 1
+end

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -21,7 +21,7 @@ REPOSITORY = /\A[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+\z/
 MAX_FILE_BYTES = 300_000
 MAX_YAML_NODES = 10_000
 MAX_YAML_DEPTH = 64
-CLA_ACTION = "manaflow-ai/cla-github-action@b4d3c4fab86d21e7775c63522d4b39b3724ea4bf"
+CLA_ACTION = "manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af"
 # CLA policy jobs handle repository trust decisions and must stay on an
 # ephemeral GitHub-hosted runner. A repository variable could redirect this
 # privileged work to an untrusted self-hosted machine, so the label is an
@@ -98,7 +98,8 @@ RESULT_ENV = {
   "GATE_RESULT" => "${{ needs.CLACommentGate.result }}",
   "ADMITTED" => "${{ needs.CLACommentGate.outputs.admitted || '' }}",
   "SIGNER_AUTHORIZED" => "${{ needs.CLACommentGate.outputs.signer_authorized || '' }}",
-  "WRITER_RESULT" => "${{ needs.CLALedgerWriter.result }}"
+  "WRITER_RESULT" => "${{ needs.CLALedgerWriter.result }}",
+  "CLA_PASSED" => "${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}"
 }.freeze
 CLA_COMMENT_BINDING_OUTPUTS = {
   "comment_id" => "${{ steps.signer_preflight.outputs.comment_id }}",
@@ -1796,7 +1797,7 @@ def validate_workflow(raw)
     "CLAAssistant" => %w[name needs if runs-on timeout-minutes permissions steps],
     "CLALedgerWriter" => %w[name needs if runs-on timeout-minutes concurrency permissions outputs steps],
     "CLACompatibility" => %w[name needs if runs-on timeout-minutes permissions steps],
-    "RerunFailedCLA" => %w[name needs if runs-on timeout-minutes permissions steps],
+    "RerunFailedCLA" => %w[name needs if runs-on timeout-minutes concurrency permissions steps],
     "LockMergedPullRequest" => %w[name if runs-on timeout-minutes concurrency permissions steps]
   }
   [gate, assistant, writer, compatibility, rerun, lock].each_with_index do |value, index|
@@ -1821,7 +1822,8 @@ def validate_workflow(raw)
     }.merge(CLA_COMMENT_BINDING_OUTPUTS)
   fail!("CLALedgerWriter outputs are not the reviewed contract") unless
     writer["outputs"] == {
-      "signature_recorded" => "${{ steps.cla_action.outputs.signature_recorded }}"
+      "signature_recorded" => "${{ steps.cla_action.outputs.signature_recorded }}",
+      "cla_passed" => "${{ steps.cla_action.outputs.cla_passed }}"
     }
   fail!("CLA ledger writer must depend on the admission gate") unless dependencies(writer, "CLALedgerWriter").include?("CLACommentGate")
   fail!("CLA ledger writer must not run with always()") if writer["if"].to_s.include?("always()")
@@ -1935,7 +1937,10 @@ def validate_workflow(raw)
     [gate["if"], assistant["if"], compatibility["if"], writer_condition],
     admission_run
   )
-  sign_branch = admission_run[/if \[\[ "\$\{COMMENT_BODY\}" == "#{Regexp.escape(CLA_SIGN_PHRASE)}" \]\]; then(.*?)(?:\n\s*fi)/m]
+  # Stop at the first sibling branch. A non-signing recheck branch may need
+  # opener identity fields, but those fields must not be duplicated inside the
+  # exact signing declaration branch itself.
+  sign_branch = admission_run[/if \[\[ "\$\{COMMENT_BODY\}" == "#{Regexp.escape(CLA_SIGN_PHRASE)}" \]\]; then(.*?)(?=\n\s*(?:elif|fi))/m]
   fail!("CLA signing admission implementation is missing") unless sign_branch&.include?("printf 'admitted=true\\n'")
   fail!("CLA signing admission must not duplicate commit identity mapping") if sign_branch.match?(/COMMENT_AUTHOR_ID|PR_AUTHOR_ID/)
   preflight = step_using_with(gate, CLA_ACTION, "mode", "signer-preflight", "CLACommentGate")
@@ -1956,9 +1961,9 @@ def validate_workflow(raw)
   fail!("CLALedgerWriter permissions are not least-privilege") unless
     writer["permissions"] == { "contents" => "write", "issues" => "write", "pull-requests" => "write" }
   fail!("RerunFailedCLA permissions are not least-privilege") unless
-    rerun["permissions"] == { "actions" => "write", "contents" => "read", "issues" => "read", "pull-requests" => "read" }
+    rerun["permissions"] == { "actions" => "write", "checks" => "read", "contents" => "read", "issues" => "read", "pull-requests" => "read" }
   fail!("LockMergedPullRequest permissions are not least-privilege") unless
-    lock["permissions"] == { "issues" => "write", "pull-requests" => "read" }
+    lock["permissions"] == { "issues" => "write", "pull-requests" => "write" }
 
   action_step = step_using(writer, CLA_ACTION, "CLALedgerWriter")
   with_values = action_step["with"]

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -15,6 +15,22 @@ COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 E2E_FILE="$ROOT_DIR/.github/workflows/test-e2e.yml"
 TMUX_CORPUS_FILE="$ROOT_DIR/.github/workflows/tmux-corpus.yml"
 IOS_FILE="$ROOT_DIR/.github/workflows/test-ios.yml"
+CLA_GUARD_FILE="$ROOT_DIR/.github/workflows/cla-policy-guard.yml"
+
+check_cla_guard_runner() {
+  if ! grep -Fqx '    runs-on: ubuntu-24.04' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must use the fixed GitHub-hosted ubuntu-24.04 runner"
+    exit 1
+  fi
+
+  if grep -Eq '^    runs-on:.*(vars\.LINUX_RUNNER|blacksmith-|self-hosted)' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must not allow a variable or self-hosted runner override"
+    exit 1
+  fi
+
+  echo "PASS: CLA policy guard uses the fixed GitHub-hosted runner"
+}
+
 check_macos_runner() {
   local file="$1" job="$2"
   if ! awk -v job="$job" '
@@ -1109,11 +1125,14 @@ check_no_bare_github_hosted_runners() {
   # MACOS_RUNNER_*) so the Blacksmith<->Warp / Blacksmith<->macos-26 overflow
   # switch is a single repo-variable flip with no PR. A bare GitHub-hosted
   # label (ubuntu-*, macos-NN) cannot be redirected, so it is forbidden.
+  # The CLA policy guard is a separate immutable control-plane job and is
+  # intentionally exempted below because it must never honor a repository
+  # variable or self-hosted runner override.
   # Bare paid-provider labels (blacksmith-*, warp-*, depot-*) stay allowed for
   # deliberate single-runner pins such as the testmanagerd-wedged
   # `app-host-unit-tests` job.
   local hits
-  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)([[:space:]]*$|[[:space:]]+#)" "$ROOT_DIR/.github/workflows" | grep -v "github-hosted-required" || true)"
+  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)([[:space:]]*$|[[:space:]]+#)" "$ROOT_DIR/.github/workflows" | grep -v "github-hosted-required" | grep -v '/.github/workflows/cla-policy-guard.yml:' || true)"
   if [[ -n "$hits" ]]; then
     echo "FAIL: these jobs use a bare GitHub-hosted runner; route them through vars.LINUX_RUNNER / vars.MACOS_RUNNER_IOS so Blacksmith<->overflow stays a repo-variable flip:"
     echo "$hits"
@@ -1237,6 +1256,7 @@ check_no_self_hosted_fleet_runners() {
 }
 
 # ci.yml jobs
+check_cla_guard_runner
 check_no_bare_github_hosted_runners
 check_no_self_hosted_fleet_runners
 check_macos_runner "$CI_FILE" "app-host-unit-tests"

--- a/tests/test_cla_lock_workflow.sh
+++ b/tests/test_cla_lock_workflow.sh
@@ -1,0 +1,235 @@
+#!/usr/bin/env bash
+# Exercise the merged-PR lock shell block against deterministic API fixtures.
+# This verifies the live identity recheck, rather than only checking YAML text.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
+test -f "$WORKFLOW"
+command -v jq >/dev/null
+grep -Fq "group: cla-lock-\${{ github.repository }}-\${{ github.event.pull_request.number }}" "$WORKFLOW"
+grep -Fq '      issues: write' "$WORKFLOW"
+grep -Fq '      pull-requests: read' "$WORKFLOW"
+
+# The merge-lock queue must remain independent from the signature queue. A
+# later sign/comment event must not replace a pending merge lock.
+lock_block="$(awk '
+  /^  LockMergedPullRequest:/ { in_job=1; next }
+  in_job && /^  [A-Za-z0-9_]+:/ { exit }
+  in_job { print }
+' "$WORKFLOW")"
+expected_lock_group="group: cla-lock-\${{ github.repository }}-\${{ github.event.pull_request.number }}"
+[[ "$lock_block" == *"$expected_lock_group"* ]]
+[[ "$lock_block" != *'group: cla-signatures-'* ]]
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+lock_script="$work/lock.sh"
+
+awk '
+  /^  LockMergedPullRequest:/ { in_job=1; next }
+  in_job && /^        run: \|$/ { in_run=1; next }
+  in_run { sub(/^          /, ""); print }
+' "$WORKFLOW" >"$lock_script"
+bash -n "$lock_script"
+
+export GH_REPO=manaflow-ai/cmux
+export PR_NUMBER=123
+export EVENT_BASE_REF=main
+export EVENT_BASE_REPO=manaflow-ai/cmux
+export EVENT_BASE_REPO_ID=100
+export EVENT_HEAD_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+export EVENT_HEAD_REF=feature/review
+export EVENT_HEAD_REPO=contributor/cmux
+export EVENT_HEAD_REPO_ID=200
+export EVENT_OPENER_ID=42
+export EVENT_OPENER_LOGIN=contributor
+
+gh() {
+  local endpoint=""
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == repos/* ]]; then
+      endpoint="$arg"
+      break
+    fi
+  done
+  [[ -n "$endpoint" ]] || {
+    echo "missing API endpoint" >&2
+    return 1
+  }
+
+  if [[ "${FAKE_MODE:-}" == api-failure && "$endpoint" == repos/*/pulls/123 ]]; then
+    return 1
+  fi
+  if [[ "${FAKE_MODE:-}" == already-locked-read-failure &&
+        "$endpoint" == repos/*/pulls/123 &&
+        -f "${FAKE_LOCK_FILE}.recheck" ]]; then
+    return 1
+  fi
+
+  case "$endpoint" in
+    repos/manaflow-ai/cmux/pulls/123)
+      if [[ "${FAKE_MODE:-}" == already-locked-reopen-after-final-read ]]; then
+        local pull_read_count=0
+        [[ -f "${FAKE_LOCK_FILE}.pull-reads" ]] && pull_read_count="$(<"${FAKE_LOCK_FILE}.pull-reads")"
+        pull_read_count=$((pull_read_count + 1))
+        printf '%s\n' "$pull_read_count" >"${FAKE_LOCK_FILE}.pull-reads"
+      fi
+      local state=closed
+      local merged=true
+      local base_ref=main
+      local head_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      local head_repo=contributor/cmux
+      local head_repo_id=200
+      local opener_id=42
+      local opener_login=contributor
+      case "${FAKE_MODE:-}" in
+        reopened) state=open; merged=false ;;
+        already-locked-reopen-after-read)
+          if [[ -f "${FAKE_LOCK_FILE}.recheck" ]]; then
+            state=open
+            merged=false
+          fi
+          ;;
+        already-locked-reopen-after-final-read)
+          if [[ -f "${FAKE_LOCK_FILE}.recheck" &&
+                -f "${FAKE_LOCK_FILE}.pull-reads" &&
+                "$(<"${FAKE_LOCK_FILE}.pull-reads")" -ge 3 ]]; then
+            state=open
+            merged=false
+          fi
+          ;;
+        reopen-after-lock)
+          if [[ -f "${FAKE_LOCK_FILE}" ]] && [[ "$(<"${FAKE_LOCK_FILE}")" == true ]]; then
+            state=open
+            merged=false
+          fi
+          ;;
+        retargeted) base_ref=release ;;
+        changed-head) head_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
+        changed-head-repo) head_repo=attacker/cmux; head_repo_id=201 ;;
+        changed-opener) opener_id=43; opener_login=attacker ;;
+        malformed-head) head_repo=""; head_repo_id=0 ;;
+        deleted-fork) head_repo=""; head_repo_id=0 ;;
+      esac
+      if [[ "${FAKE_MODE:-}" == deleted-fork ]]; then
+        jq -nc \
+          --arg state "$state" \
+          --argjson merged "$merged" \
+          --arg base_ref "$base_ref" \
+          --arg head_sha "$head_sha" \
+          --arg head_ref "$EVENT_HEAD_REF" \
+          --argjson opener_id "$opener_id" \
+          --arg opener_login "$opener_login" \
+          '{number:123,state:$state,merged:$merged,base:{ref:$base_ref,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{sha:$head_sha,ref:$head_ref,repo:null},user:{id:$opener_id,login:$opener_login}}'
+      else
+        jq -nc \
+          --arg state "$state" \
+          --argjson merged "$merged" \
+          --arg base_ref "$base_ref" \
+          --arg head_sha "$head_sha" \
+          --arg head_ref "$EVENT_HEAD_REF" \
+          --arg head_repo "$head_repo" \
+          --argjson head_repo_id "$head_repo_id" \
+          --argjson opener_id "$opener_id" \
+          --arg opener_login "$opener_login" \
+          '{number:123,state:$state,merged:$merged,base:{ref:$base_ref,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{sha:$head_sha,ref:$head_ref,repo:{id:$head_repo_id,full_name:$head_repo}},user:{id:$opener_id,login:$opener_login}}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/issues/123)
+      local locked=false
+      [[ -f "${FAKE_LOCK_FILE}" ]] && locked="$(<"${FAKE_LOCK_FILE}")"
+      if [[ " $* " == *" --jq .locked "* ]]; then
+  if [[ "${FAKE_MODE:-}" == already-locked-reopen-after-read ||
+              "${FAKE_MODE:-}" == already-locked-read-failure ||
+              "${FAKE_MODE:-}" == already-locked-reopen-after-final-read ]]; then
+          printf 'seen\n' >"${FAKE_LOCK_FILE}.recheck"
+        fi
+        printf '%s\n' "$locked"
+      else
+        jq -nc --argjson locked "$locked" '{locked:$locked}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/issues/123/lock)
+      if [[ " $* " == *" --method PUT "* ]]; then
+        printf '%s\n' "$endpoint" >>"${FAKE_POST_FILE}"
+        if [[ "${FAKE_MODE:-}" == lock-failure ]]; then return 1; fi
+        printf 'true\n' >"${FAKE_LOCK_FILE}"
+      elif [[ " $* " == *" --method DELETE "* ]]; then
+        printf '%s\n' "$endpoint" >>"${FAKE_POST_FILE}"
+        printf 'false\n' >"${FAKE_LOCK_FILE}"
+      fi
+      ;;
+    *)
+      echo "unexpected API endpoint: $endpoint" >&2
+      return 1
+      ;;
+  esac
+}
+export -f gh
+
+run_case() {
+  local mode="$1"
+  local expected_status="$2"
+  local expected_text="$3"
+  local expected_posts="$4"
+  local output status posts
+  local event_head_repo="$EVENT_HEAD_REPO"
+  local event_head_repo_id="$EVENT_HEAD_REPO_ID"
+  : >"$work/posts-$mode"
+  : >"$work/lock-$mode"
+  if [[ "$mode" == already-locked || "$mode" == already-locked-reopen-after-read ||
+        "$mode" == already-locked-read-failure ||
+        "$mode" == already-locked-reopen-after-final-read ]]; then
+    printf 'true\n' >"$work/lock-$mode"
+  fi
+  if [[ "$mode" == deleted-fork || "$mode" == deleted-fork-metadata-mismatch ]]; then
+    event_head_repo=""
+    event_head_repo_id=""
+  fi
+  set +e
+  output="$(
+    FAKE_MODE="$mode" \
+    FAKE_POST_FILE="$work/posts-$mode" \
+    FAKE_LOCK_FILE="$work/lock-$mode" \
+    EVENT_HEAD_REPO="$event_head_repo" \
+    EVENT_HEAD_REPO_ID="$event_head_repo_id" \
+    bash "$lock_script" 2>&1
+  )"
+  status=$?
+  set -e
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: $mode exited $status, expected $expected_status" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected_text"* ]]; then
+    echo "FAIL: $mode did not report '$expected_text'" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  posts="$(wc -l <"$work/posts-$mode" | tr -d ' ')"
+  if [[ "$posts" != "$expected_posts" ]]; then
+    echo "FAIL: $mode made $posts lock calls, expected $expected_posts" >&2
+    exit 1
+  fi
+  echo "PASS: $mode"
+}
+
+run_case valid 0 "Pull request 123 is locked" 1
+run_case already-locked 0 "already locked" 0
+run_case reopened 1 "live pull request no longer matches" 0
+run_case retargeted 1 "live pull request no longer matches" 0
+run_case changed-head 0 "Pull request 123 is locked" 1
+run_case changed-head-repo 0 "Pull request 123 is locked" 1
+run_case changed-opener 1 "live pull request no longer matches" 0
+run_case malformed-head 1 "live pull request no longer matches" 0
+run_case deleted-fork 0 "Pull request 123 is locked" 1
+run_case deleted-fork-metadata-mismatch 0 "Pull request 123 is locked" 1
+run_case api-failure 1 "Could not query the merged pull request" 0
+run_case lock-failure 1 "Could not lock the merged pull request" 1
+run_case reopen-after-lock 1 "changed after locking; the stale lock was removed" 2
+run_case already-locked-reopen-after-read 1 "already-locked pull request changed; the stale lock was removed" 1
+run_case already-locked-read-failure 1 "Could not verify the already-locked pull request" 0
+run_case already-locked-reopen-after-final-read 1 "already-locked pull request changed; the stale lock was removed" 1

--- a/tests/test_cla_lock_workflow.sh
+++ b/tests/test_cla_lock_workflow.sh
@@ -1,235 +1,56 @@
 #!/usr/bin/env bash
-# Exercise the merged-PR lock shell block against deterministic API fixtures.
-# This verifies the live identity recheck, rather than only checking YAML text.
+# Verify the merged-PR lock job as a workflow artifact. The maintained action
+# owns the API behavior and has its own tests; this check proves that the
+# privileged cmux workflow invokes it only for a merged pull request with the
+# narrow lock contract.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
 test -f "$WORKFLOW"
-command -v jq >/dev/null
-grep -Fq "group: cla-lock-\${{ github.repository }}-\${{ github.event.pull_request.number }}" "$WORKFLOW"
-grep -Fq '      issues: write' "$WORKFLOW"
-grep -Fq '      pull-requests: read' "$WORKFLOW"
+command -v ruby >/dev/null
 
-# The merge-lock queue must remain independent from the signature queue. A
-# later sign/comment event must not replace a pending merge lock.
-lock_block="$(awk '
-  /^  LockMergedPullRequest:/ { in_job=1; next }
-  in_job && /^  [A-Za-z0-9_]+:/ { exit }
-  in_job { print }
-' "$WORKFLOW")"
-expected_lock_group="group: cla-lock-\${{ github.repository }}-\${{ github.event.pull_request.number }}"
-[[ "$lock_block" == *"$expected_lock_group"* ]]
-[[ "$lock_block" != *'group: cla-signatures-'* ]]
+WORKFLOW="$WORKFLOW" ruby <<'RUBY'
+require "yaml"
 
-work="$(mktemp -d)"
-trap 'rm -rf "$work"' EXIT
-lock_script="$work/lock.sh"
+workflow = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+jobs = workflow.fetch("jobs")
+lock = jobs.fetch("LockMergedPullRequest")
 
-awk '
-  /^  LockMergedPullRequest:/ { in_job=1; next }
-  in_job && /^        run: \|$/ { in_run=1; next }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$lock_script"
-bash -n "$lock_script"
-
-export GH_REPO=manaflow-ai/cmux
-export PR_NUMBER=123
-export EVENT_BASE_REF=main
-export EVENT_BASE_REPO=manaflow-ai/cmux
-export EVENT_BASE_REPO_ID=100
-export EVENT_HEAD_SHA=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-export EVENT_HEAD_REF=feature/review
-export EVENT_HEAD_REPO=contributor/cmux
-export EVENT_HEAD_REPO_ID=200
-export EVENT_OPENER_ID=42
-export EVENT_OPENER_LOGIN=contributor
-
-gh() {
-  local endpoint=""
-  local arg
-  for arg in "$@"; do
-    if [[ "$arg" == repos/* ]]; then
-      endpoint="$arg"
-      break
-    fi
-  done
-  [[ -n "$endpoint" ]] || {
-    echo "missing API endpoint" >&2
-    return 1
-  }
-
-  if [[ "${FAKE_MODE:-}" == api-failure && "$endpoint" == repos/*/pulls/123 ]]; then
-    return 1
-  fi
-  if [[ "${FAKE_MODE:-}" == already-locked-read-failure &&
-        "$endpoint" == repos/*/pulls/123 &&
-        -f "${FAKE_LOCK_FILE}.recheck" ]]; then
-    return 1
-  fi
-
-  case "$endpoint" in
-    repos/manaflow-ai/cmux/pulls/123)
-      if [[ "${FAKE_MODE:-}" == already-locked-reopen-after-final-read ]]; then
-        local pull_read_count=0
-        [[ -f "${FAKE_LOCK_FILE}.pull-reads" ]] && pull_read_count="$(<"${FAKE_LOCK_FILE}.pull-reads")"
-        pull_read_count=$((pull_read_count + 1))
-        printf '%s\n' "$pull_read_count" >"${FAKE_LOCK_FILE}.pull-reads"
-      fi
-      local state=closed
-      local merged=true
-      local base_ref=main
-      local head_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
-      local head_repo=contributor/cmux
-      local head_repo_id=200
-      local opener_id=42
-      local opener_login=contributor
-      case "${FAKE_MODE:-}" in
-        reopened) state=open; merged=false ;;
-        already-locked-reopen-after-read)
-          if [[ -f "${FAKE_LOCK_FILE}.recheck" ]]; then
-            state=open
-            merged=false
-          fi
-          ;;
-        already-locked-reopen-after-final-read)
-          if [[ -f "${FAKE_LOCK_FILE}.recheck" &&
-                -f "${FAKE_LOCK_FILE}.pull-reads" &&
-                "$(<"${FAKE_LOCK_FILE}.pull-reads")" -ge 3 ]]; then
-            state=open
-            merged=false
-          fi
-          ;;
-        reopen-after-lock)
-          if [[ -f "${FAKE_LOCK_FILE}" ]] && [[ "$(<"${FAKE_LOCK_FILE}")" == true ]]; then
-            state=open
-            merged=false
-          fi
-          ;;
-        retargeted) base_ref=release ;;
-        changed-head) head_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
-        changed-head-repo) head_repo=attacker/cmux; head_repo_id=201 ;;
-        changed-opener) opener_id=43; opener_login=attacker ;;
-        malformed-head) head_repo=""; head_repo_id=0 ;;
-        deleted-fork) head_repo=""; head_repo_id=0 ;;
-      esac
-      if [[ "${FAKE_MODE:-}" == deleted-fork ]]; then
-        jq -nc \
-          --arg state "$state" \
-          --argjson merged "$merged" \
-          --arg base_ref "$base_ref" \
-          --arg head_sha "$head_sha" \
-          --arg head_ref "$EVENT_HEAD_REF" \
-          --argjson opener_id "$opener_id" \
-          --arg opener_login "$opener_login" \
-          '{number:123,state:$state,merged:$merged,base:{ref:$base_ref,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{sha:$head_sha,ref:$head_ref,repo:null},user:{id:$opener_id,login:$opener_login}}'
-      else
-        jq -nc \
-          --arg state "$state" \
-          --argjson merged "$merged" \
-          --arg base_ref "$base_ref" \
-          --arg head_sha "$head_sha" \
-          --arg head_ref "$EVENT_HEAD_REF" \
-          --arg head_repo "$head_repo" \
-          --argjson head_repo_id "$head_repo_id" \
-          --argjson opener_id "$opener_id" \
-          --arg opener_login "$opener_login" \
-          '{number:123,state:$state,merged:$merged,base:{ref:$base_ref,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{sha:$head_sha,ref:$head_ref,repo:{id:$head_repo_id,full_name:$head_repo}},user:{id:$opener_id,login:$opener_login}}'
-      fi
-      ;;
-    repos/manaflow-ai/cmux/issues/123)
-      local locked=false
-      [[ -f "${FAKE_LOCK_FILE}" ]] && locked="$(<"${FAKE_LOCK_FILE}")"
-      if [[ " $* " == *" --jq .locked "* ]]; then
-  if [[ "${FAKE_MODE:-}" == already-locked-reopen-after-read ||
-              "${FAKE_MODE:-}" == already-locked-read-failure ||
-              "${FAKE_MODE:-}" == already-locked-reopen-after-final-read ]]; then
-          printf 'seen\n' >"${FAKE_LOCK_FILE}.recheck"
-        fi
-        printf '%s\n' "$locked"
-      else
-        jq -nc --argjson locked "$locked" '{locked:$locked}'
-      fi
-      ;;
-    repos/manaflow-ai/cmux/issues/123/lock)
-      if [[ " $* " == *" --method PUT "* ]]; then
-        printf '%s\n' "$endpoint" >>"${FAKE_POST_FILE}"
-        if [[ "${FAKE_MODE:-}" == lock-failure ]]; then return 1; fi
-        printf 'true\n' >"${FAKE_LOCK_FILE}"
-      elif [[ " $* " == *" --method DELETE "* ]]; then
-        printf '%s\n' "$endpoint" >>"${FAKE_POST_FILE}"
-        printf 'false\n' >"${FAKE_LOCK_FILE}"
-      fi
-      ;;
-    *)
-      echo "unexpected API endpoint: $endpoint" >&2
-      return 1
-      ;;
-  esac
+abort "lock job has unexpected permissions" unless lock.fetch("permissions") == {
+  "issues" => "write",
+  "pull-requests" => "write"
 }
-export -f gh
+abort "lock job must run only for merged pull requests" unless lock.fetch("if").include?("github.event.action == 'closed'") && lock.fetch("if").include?("github.event.pull_request.merged == true")
+abort "lock queue is not per pull request" unless lock.fetch("concurrency").fetch("group") == "cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}"
+abort "lock queue must not cancel an earlier lock" unless lock.fetch("concurrency").fetch("cancel-in-progress") == false
 
-run_case() {
-  local mode="$1"
-  local expected_status="$2"
-  local expected_text="$3"
-  local expected_posts="$4"
-  local output status posts
-  local event_head_repo="$EVENT_HEAD_REPO"
-  local event_head_repo_id="$EVENT_HEAD_REPO_ID"
-  : >"$work/posts-$mode"
-  : >"$work/lock-$mode"
-  if [[ "$mode" == already-locked || "$mode" == already-locked-reopen-after-read ||
-        "$mode" == already-locked-read-failure ||
-        "$mode" == already-locked-reopen-after-final-read ]]; then
-    printf 'true\n' >"$work/lock-$mode"
-  fi
-  if [[ "$mode" == deleted-fork || "$mode" == deleted-fork-metadata-mismatch ]]; then
-    event_head_repo=""
-    event_head_repo_id=""
-  fi
-  set +e
-  output="$(
-    FAKE_MODE="$mode" \
-    FAKE_POST_FILE="$work/posts-$mode" \
-    FAKE_LOCK_FILE="$work/lock-$mode" \
-    EVENT_HEAD_REPO="$event_head_repo" \
-    EVENT_HEAD_REPO_ID="$event_head_repo_id" \
-    bash "$lock_script" 2>&1
-  )"
-  status=$?
-  set -e
-  if [[ "$status" != "$expected_status" ]]; then
-    echo "FAIL: $mode exited $status, expected $expected_status" >&2
-    echo "$output" >&2
-    exit 1
-  fi
-  if [[ "$output" != *"$expected_text"* ]]; then
-    echo "FAIL: $mode did not report '$expected_text'" >&2
-    echo "$output" >&2
-    exit 1
-  fi
-  posts="$(wc -l <"$work/posts-$mode" | tr -d ' ')"
-  if [[ "$posts" != "$expected_posts" ]]; then
-    echo "FAIL: $mode made $posts lock calls, expected $expected_posts" >&2
-    exit 1
-  fi
-  echo "PASS: $mode"
+steps = lock.fetch("steps")
+abort "lock job must contain a runner guard and one action step" unless steps.length == 2
+runner_guard = steps.fetch(0)
+abort "lock runner guard is not fail-closed" unless runner_guard == {
+  "name" => "Require GitHub-hosted runner",
+  "if" => "runner.environment != 'github-hosted'",
+  "run" => "set -euo pipefail\necho \"::error::CLA policy requires a GitHub-hosted runner\"\nexit 1\n"
 }
-
-run_case valid 0 "Pull request 123 is locked" 1
-run_case already-locked 0 "already locked" 0
-run_case reopened 1 "live pull request no longer matches" 0
-run_case retargeted 1 "live pull request no longer matches" 0
-run_case changed-head 0 "Pull request 123 is locked" 1
-run_case changed-head-repo 0 "Pull request 123 is locked" 1
-run_case changed-opener 1 "live pull request no longer matches" 0
-run_case malformed-head 1 "live pull request no longer matches" 0
-run_case deleted-fork 0 "Pull request 123 is locked" 1
-run_case deleted-fork-metadata-mismatch 0 "Pull request 123 is locked" 1
-run_case api-failure 1 "Could not query the merged pull request" 0
-run_case lock-failure 1 "Could not lock the merged pull request" 1
-run_case reopen-after-lock 1 "changed after locking; the stale lock was removed" 2
-run_case already-locked-reopen-after-read 1 "already-locked pull request changed; the stale lock was removed" 1
-run_case already-locked-read-failure 1 "Could not verify the already-locked pull request" 0
-run_case already-locked-reopen-after-final-read 1 "already-locked pull request changed; the stale lock was removed" 1
+step = steps.fetch(1)
+abort "lock action is not restricted to a hosted runner" unless step.fetch("if") == "runner.environment == 'github-hosted'"
+abort "lock job may not execute workflow shell text" if step.key?("run")
+uses = step.fetch("uses")
+abort "lock action is not pinned to the maintained release" unless
+  uses == "manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af"
+abort "lock action token is not the workflow token" unless step.fetch("env") == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+expected = {
+  "mode" => "sign",
+  "path-to-signatures" => "signatures/version2/cla.json",
+  "path-to-document" => "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md",
+  "branch" => "cla-signatures",
+  "required-base-ref" => "main",
+  "custom-pr-sign-comment" => "I have read the CLA Document v2.2 and I hereby sign the CLA",
+  "allowlist-ids" => "38676809,67667005",
+  "require-opener-as-author" => "true",
+  "lock-pullrequest-aftermerge" => "true"
+}
+abort "lock action inputs changed" unless step.fetch("with") == expected
+puts "PASS: merged-PR lock workflow contract"
+RUBY

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -1,0 +1,461 @@
+#!/usr/bin/env bash
+# Exercise the trusted CLA rerun script against deterministic GitHub API
+# fixtures. This runs the workflow code itself, rather than checking text
+# shape, so stale generations and fork associations stay covered.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
+test -f "$WORKFLOW"
+command -v jq >/dev/null
+
+# The pull_request CI workflow executes this harness against PR-controlled
+# workflow text. It must never receive Actions write authority. Only the
+# isolated CLA rerun job may have that permission. Use awk here because this
+# check runs before CI installs its optional Python dependencies.
+if awk '
+  /^permissions:[[:space:]]*$/ { in_permissions=1; next }
+  in_permissions && /^[^[:space:]]/ { in_permissions=0 }
+  in_permissions && /^[[:space:]]+actions:[[:space:]]*write([[:space:]]*#.*)?$/ { found=1 }
+  END { exit found ? 0 : 1 }
+' "$ROOT_DIR/.github/workflows/ci.yml"; then
+  echo "CI must not grant top-level actions: write to pull_request jobs" >&2
+  exit 1
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+rerun_script="$ROOT_DIR/.github/scripts/rerun-failed-cla.sh"
+test -f "$rerun_script"
+bash -n "$rerun_script"
+
+# The privileged job checks out only the immutable workflow revision and
+# launches the checked-in guard. Keep the launcher below the Actions step-size
+# limit, and reject any future attempt to execute the pull-request head.
+grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2' "$WORKFLOW"
+grep -Fq "repository: \${{ github.repository }}" "$WORKFLOW"
+grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
+grep -Fq 'sparse-checkout: .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
+grep -Fq 'bash .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
+grep -Fq "COMMENT_ID: \${{ github.event.comment.id }}" "$WORKFLOW"
+grep -Fq '      - .github/scripts/rerun-failed-cla.sh' "$ROOT_DIR/.github/workflows/ci.yml"
+if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
+  echo 'FAIL: CLA rerun checkout must never use a pull-request ref' >&2
+  exit 1
+fi
+launcher_bytes="$(awk '
+  /^  RerunFailedCLA:/ { in_job=1; next }
+  in_job && /^  LockMergedPullRequest:/ { exit }
+  in_job && /^        run: \|$/ { in_run=1; next }
+  in_run { sub(/^          /, ""); print }
+' "$WORKFLOW" | wc -c | tr -d ' ')"
+[[ "$launcher_bytes" =~ ^[0-9]+$ && "$launcher_bytes" -lt 21000 ]] || {
+  echo "FAIL: CLA rerun launcher is too large (${launcher_bytes} bytes)" >&2
+  exit 1
+}
+
+export GH_REPO=manaflow-ai/cmux
+export EVENT_NAME=issue_comment
+export ISSUE_NUMBER=123
+export PR_NUMBER=123
+export COMMENT_ID=900
+export COMMENT_BODY=recheck
+export COMMENT_CREATED_AT=2026-08-31T08:00:00Z
+export COMMENT_AUTHOR_ID=300
+export COMMENT_AUTHOR_LOGIN=contributor
+export COMMENT_AUTHOR_TYPE=User
+export COMMENT_AUTHOR_ASSOCIATION=NONE
+export WORKFLOW_PATH=.github/workflows/cla.yml
+export CLA_GENERATION=v2.2-action-bc206ed9b52ad0b0cbe85244ce522e5e9b65c10e
+export TARGET_EVENT=pull_request_target
+export TARGET_BASE_REF=main
+export SIGNATURE_RECORDED=false
+
+# This stub models the API fields used by the rerun guard. In particular, a
+# fork-only commit has no result from /commits/:sha/pulls, while the workflow
+# run still carries head_repository identity. GitHub may report the source PR
+# SHA or a different execution SHA on a pull_request_target run, so this fixture
+# keeps the live PR head at `aaaa...` and, for the populated-association case,
+# the selected run/job execution SHA at `bbbb...`. A populated pull_requests
+# object binds that differing execution to the source PR. An empty association
+# must use the exact live PR head SHA or fail closed.
+gh() {
+  local endpoint=""
+  local api_page=1
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == page=* ]]; then
+      api_page="${arg#page=}"
+    fi
+    if [[ "$arg" == repos/* ]]; then
+      endpoint="$arg"
+    fi
+  done
+  [[ -n "$endpoint" ]] || {
+    echo "missing API endpoint" >&2
+    return 1
+  }
+  if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/pulls &&
+        " $* " != *" --method GET "* ]]; then
+    echo "commit association lookup must use GET" >&2
+    return 1
+  fi
+  local live_state=open
+  local live_base=main
+  local live_head_repo=contributor/cmux
+  local live_head_repo_id=200
+  local run_head_repo=contributor/cmux
+  local run_head_repo_id=200
+  local run_head_repository_null=false
+  local omit_job_head_repository=false
+  local run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  local marker="CLA generation ${CLA_GENERATION}"
+  local run_path=.github/workflows/cla.yml
+  local run_prs='[{"number":123,"base":{"ref":"main","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]'
+  local ledger_id=400
+  local ledger_login=coauthor
+  local ledger_comment_id=900
+
+  case "${FAKE_MODE}" in
+    stale-marker) marker="CLA generation v2.2-action-0000000000000000000000000000000000000000" ;;
+    unrelated-main-commit) marker="CLA generation ${CLA_GENERATION}" ;;
+    wrong-head-repo) run_head_repo=attacker/cmux; run_head_repo_id=201; run_prs='[]' ;;
+    association-overflow) run_prs='[]' ;;
+    fork-current|empty-run-association) run_prs='[]'; run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ;;
+    empty-different-execution-associated) run_prs='[]' ;;
+    same-repo-empty)
+      run_prs='[]'
+      run_head_repo=manaflow-ai/cmux
+      run_head_repo_id=100
+      run_head_repository_null=true
+      run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      live_head_repo=manaflow-ai/cmux
+      live_head_repo_id=100
+      ;;
+    stale-empty-execution) run_prs='[]'; run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
+    empty-mismatched-newer) run_prs='[]' ;;
+    unbound-signer) ledger_id=401; ledger_login=other-signer; ledger_comment_id=901 ;;
+    minimal-run-association) run_prs='[{"number":123,"base":{"ref":"main","repo":{"id":100}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200}}}]' ;;
+    wrong-run-association) run_prs='[{"number":124,"base":{"ref":"main","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]' ;;
+    malformed-run-association) run_prs='{}' ;;
+    invalid-run-association) run_prs='false' ;;
+    closed-pr) live_state=closed ;;
+    retargeted-pr) live_base=release ;;
+    suffixed-path) run_path=.github/workflows/cla.yml@main ;;
+    job-missing-head-repository) omit_job_head_repository=true ;;
+  esac
+
+  if [[ " $* " == *" --method POST "* ]]; then
+    printf '%s\n' "$endpoint" >>"$FAKE_POST_FILE"
+    return 0
+  fi
+
+  case "$endpoint" in
+    repos/manaflow-ai/cmux/issues/123)
+      jq -nc --arg state "$live_state" '{state:$state,pull_request:{url:"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"}}'
+      ;;
+    repos/manaflow-ai/cmux/pulls/123)
+      jq -nc --arg state "$live_state" --arg base "$live_base" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" \
+        '{number:123,state:$state,user:{id:300,login:"contributor"},base:{ref:$base,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}'
+      ;;
+    repos/manaflow-ai/cmux/commits/*/pulls)
+      if [[ "${FAKE_MODE}" == association-not-found ]]; then
+        printf '{"message":"Not Found","status":404}\n'
+        return 1
+      elif [[ "${FAKE_MODE}" == association-validation-error ]]; then
+        printf '{"message":"No commit found for SHA: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"422"}\n'
+        return 1
+      elif [[ "${FAKE_MODE}" == association-stderr-not-found ]]; then
+        printf 'gh: Not Found (HTTP 404)\n' >&2
+        return 1
+      elif [[ "${FAKE_MODE}" == association-stderr-validation-error ]]; then
+        printf 'gh: No commit found for SHA: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (HTTP 422)\n' >&2
+        return 1
+      elif [[ "${FAKE_MODE}" == association-api-failure ]]; then
+        printf '{"message":"API unavailable","status":503}\n'
+        return 1
+      elif [[ "${FAKE_MODE}" == association-overflow ]]; then
+        jq -nc '[range(0; 100) | {number:(1000 + .),base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 1 ]]; then
+        jq -nc '[range(0; 100) | {number:(1000 + .),base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 2 ]]; then
+        jq -nc '[{number:123,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == same-repo-empty ]]; then
+        jq -nc '[{number:123,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:100,full_name:"manaflow-ai/cmux"}}}]'
+      else
+        printf '[]\n'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/contents/signatures/version2/cla.json)
+      ledger_content="{\"signedContributors\":[{\"name\":\"${ledger_login}\",\"id\":${ledger_id},\"comment_id\":${ledger_comment_id},\"created_at\":\"2026-08-31T08:00:00Z\",\"repoId\":100,\"pullRequestNo\":123}]}"
+      if [[ "${FAKE_MODE}" == wrapped-ledger || "${FAKE_MODE}" == oversized-ledger ]]; then
+        local target_bytes=1000000
+        [[ "${FAKE_MODE}" == oversized-ledger ]] && target_bytes=1000001
+        local padding=$((target_bytes - ${#ledger_content} - 13))
+        local padding_text
+        (( padding > 0 )) || {
+          echo "ledger fixture core unexpectedly exceeds target size" >&2
+          return 1
+        }
+        padding_text="$(printf '%*s' "$padding" '' | tr ' ' 'A')"
+        ledger_content="${ledger_content%?},\"padding\":\"${padding_text}\"}"
+      fi
+      if [[ "${FAKE_MODE}" == malformed-ledger ]]; then
+        encoded_ledger='not-valid-base64'
+      elif [[ "${FAKE_MODE}" == wrapped-ledger || "${FAKE_MODE}" == oversized-ledger ]]; then
+        encoded_ledger="$(printf '%s' "$ledger_content" | base64)"
+      else
+        encoded_ledger="$(printf '%s' "$ledger_content" | base64 | tr -d '\n')"
+      fi
+      # Stream the potentially near-limit fixture through jq instead of
+      # passing it as an argv value, which exceeds macOS ARG_MAX.
+      printf '{"type":"file","encoding":"base64","content":'
+      printf '%s' "$encoded_ledger" | jq -Rs .
+      printf '}\n'
+      ;;
+    repos/manaflow-ai/cmux/pulls)
+      local association_call=1
+      if [[ -n "${FAKE_ASSOC_CALL_FILE:-}" ]]; then
+        if [[ -s "${FAKE_ASSOC_CALL_FILE}" ]]; then
+          read -r association_call <"${FAKE_ASSOC_CALL_FILE}"
+          association_call=$((association_call + 1))
+        fi
+        printf '%s\n' "$association_call" >"${FAKE_ASSOC_CALL_FILE}"
+      fi
+      if [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 1 ]]; then
+        jq -nc '[range(0; 100) | {number:(1000 + .),state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 2 ]]; then
+        jq -nc '[{number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == ambiguous-association || ( "${FAKE_MODE}" == late-ambiguous && "$association_call" -gt 1 ) ]]; then
+        jq -nc '[
+          {number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}},
+          {number:124,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}
+        ]'
+      else
+        jq -nc --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" '[{number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}]'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/workflows)
+      if [[ "${FAKE_MODE}" == paginated-workflows && "${api_page}" == 1 ]]; then
+        jq -nc '{workflows:[range(0; 100) | {id:(1000 + .),path:(".github/workflows/other-" + (.|tostring) + ".yml"),state:"active"}]}'
+      else
+        printf '{"workflows":[{"id":300,"path":".github/workflows/cla.yml","state":"active"}]}\n'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/workflows/300/runs)
+      if [[ "${FAKE_MODE}" == full-run-window ]]; then
+        if [[ "${api_page}" == 10 ]]; then
+          jq -nc --arg path "$run_path" --arg run_sha "$run_sha" --argjson run_prs "$run_prs" \
+            '{workflow_runs:([range(0; 99) | {id:(1000 + .),workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}] + [{id:400,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}])}'
+        else
+          jq -nc '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+        fi
+      elif [[ "${FAKE_MODE}" == full-run-window-no-match ]]; then
+        jq -nc '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+      elif [[ "${FAKE_MODE}" == paginated-runs && "${api_page}" == 1 ]]; then
+        jq -nc '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+      elif [[ "${FAKE_MODE}" == empty-mismatched-newer ]]; then
+        jq -nc '{workflow_runs:[
+          {id:400,workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:00:00Z"},
+          {id:401,workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
+        ]}'
+      elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
+        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --argjson run_prs "$run_prs" \
+          '{workflow_runs:[
+            {id:400,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"},
+            {id:401,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:30:00Z"}
+          ]}'
+      else
+        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --argjson run_prs "$run_prs" \
+          '{workflow_runs:[{id:400,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}]}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/runs/400|repos/manaflow-ai/cmux/actions/runs/401)
+      local run_id=400
+      local created_at=2026-08-31T07:00:00Z
+      if [[ "$endpoint" == repos/manaflow-ai/cmux/actions/runs/401 ]]; then
+        run_id=401
+        created_at=2026-08-31T07:30:00Z
+      fi
+      local detail_sha="$run_sha"
+      if [[ "${FAKE_MODE}" == empty-mismatched-newer ]]; then
+        if [[ "$run_id" == 400 ]]; then detail_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; else detail_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; fi
+      fi
+      jq -nc --argjson run_id "$run_id" --arg created_at "$created_at" --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$detail_sha" --arg path "$run_path" --argjson run_prs "$run_prs" \
+        '{id:$run_id,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:$created_at}'
+      ;;
+    repos/manaflow-ai/cmux/actions/runs/400/jobs|repos/manaflow-ai/cmux/actions/runs/401/jobs)
+      local run_id=400
+      local job_id=500
+      if [[ "$endpoint" == repos/manaflow-ai/cmux/actions/runs/401/jobs ]]; then
+        run_id=401
+        job_id=501
+      fi
+      local jobs_sha="$run_sha"
+      if [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 400 ]]; then
+        jobs_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      fi
+      if [[ "${FAKE_MODE}" == paginated-jobs && "${api_page}" == 1 ]]; then
+        jq -nc --argjson run_id "$run_id" --arg run_sha "$jobs_sha" '{jobs:[range(0; 100) | {id:(1000 + .),run_id:$run_id,name:"unrelated",status:"completed",conclusion:"success",head_sha:$run_sha,steps:[]}]}'
+      elif [[ "${FAKE_MODE}" == compatibility-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
+            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == unexpected-failure ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
+            {id:503,run_id:$run_id,name:"Unexpected privileged job",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == cancelled-job ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
+            {id:504,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"cancelled",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      else
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$jobs_sha" --argjson omit "$omit_job_head_repository" \
+          '{jobs:[({id:$job_id,run_id:$run_id,name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"success"}]} + (if $omit then {} else {head_repository:null} end))]}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/jobs/500|repos/manaflow-ai/cmux/actions/jobs/501)
+      local job_id=500
+      local run_id=400
+      if [[ "$endpoint" == repos/manaflow-ai/cmux/actions/jobs/501 ]]; then
+        job_id=501
+        run_id=401
+      fi
+      local job_sha="$run_sha"
+      if [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 400 ]]; then
+        job_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      fi
+      jq -nc --argjson job_id "$job_id" --argjson run_id "$run_id" --arg marker "$marker" --arg run_sha "$job_sha" --argjson omit "$omit_job_head_repository" \
+        '({id:$job_id,run_id:$run_id,name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"success"}]} + (if $omit then {} else {head_repository:null} end))'
+      ;;
+    *)
+      echo "unexpected API endpoint: $endpoint" >&2
+      return 1
+      ;;
+  esac
+}
+export -f gh
+
+run_case() {
+  local mode="$1"
+  local expected_status="$2"
+  local expected_text="$3"
+  local expected_posts="$4"
+  local expected_post="${5:-}"
+  local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false
+  if [[ "$mode" == untrusted-recheck ]]; then
+    comment_author=untrusted-user
+    comment_author_id=301
+  elif [[ "$mode" == recheck-unset-output ]]; then
+    signature_recorded=''
+  elif [[ "$mode" == external-signer ]]; then
+    comment_author=coauthor
+    comment_author_id=400
+    comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
+    signature_recorded=true
+  elif [[ "$mode" == unrecorded-signer || "$mode" == unbound-signer ]]; then
+    comment_author=coauthor
+    comment_author_id=400
+    comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
+    if [[ "$mode" == unbound-signer ]]; then
+      signature_recorded=true
+    fi
+  elif [[ "$mode" == wrapped-ledger || "$mode" == oversized-ledger || "$mode" == malformed-ledger ]]; then
+    comment_author=coauthor
+    comment_author_id=400
+    comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
+    signature_recorded=true
+  fi
+  : >"$work/posts-$mode"
+  printf '0\n' >"$work/association-$mode"
+  set +e
+  output="$(
+    FAKE_MODE="$mode" \
+    FAKE_POST_FILE="$work/posts-$mode" \
+    FAKE_ASSOC_CALL_FILE="$work/association-$mode" \
+    COMMENT_BODY="$comment_body" \
+    COMMENT_AUTHOR_ID="$comment_author_id" \
+    COMMENT_AUTHOR_LOGIN="$comment_author" \
+    COMMENT_AUTHOR_TYPE="$comment_type" \
+    COMMENT_AUTHOR_ASSOCIATION="$comment_association" \
+    SIGNATURE_RECORDED="$signature_recorded" \
+    bash "$rerun_script" 2>&1
+  )"
+  status=$?
+  set -e
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: $mode exited $status, expected $expected_status" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected_text"* ]]; then
+    echo "FAIL: $mode did not report '$expected_text'" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  posts="$(wc -l <"$work/posts-$mode" | tr -d ' ')"
+  if [[ "$posts" != "$expected_posts" ]]; then
+    echo "FAIL: $mode made $posts rerun calls, expected $expected_posts" >&2
+    exit 1
+  fi
+  if [[ -n "$expected_post" ]] && ! grep -Fxq "$expected_post" "$work/posts-$mode"; then
+    echo "FAIL: $mode did not rerun the expected endpoint '$expected_post'" >&2
+    cat "$work/posts-$mode" >&2
+    exit 1
+  fi
+  echo "PASS: $mode"
+}
+
+run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case minimal-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case fork-current 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-stderr-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-stderr-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-api-failure 1 "Could not query pull request associations" 0
+run_case empty-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case same-repo-empty 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-overflow 1 "Too many pull request associations" 0
+run_case paginated-associations 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-open-prs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-workflows 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-runs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case full-run-window 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case full-run-window-no-match 1 "workflow-run result window is full" 0
+run_case paginated-jobs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case empty-different-execution-associated 1 "no pull request association and its execution SHA does not match" 0
+run_case stale-empty-execution 1 "no pull request association and its execution SHA does not match" 0
+run_case empty-mismatched-newer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case wrong-run-association 0 "No failed CLA run exists for this pull request head" 0
+run_case malformed-run-association 1 "malformed pull request associations" 0
+run_case invalid-run-association 1 "malformed pull request associations" 0
+run_case stale-marker 1 "older workflow generation" 0
+run_case unrelated-main-commit 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case wrong-head-repo 0 "No failed CLA run exists for this pull request head" 0
+run_case closed-pr 1 "The issue is not an open pull request" 0
+run_case retargeted-pr 1 "The live pull request is not valid" 0
+run_case ambiguous-association 1 "Expected exactly one open pull request for this head" 0
+run_case untrusted-recheck 1 "Only the pull request author or a trusted repository participant" 0
+run_case recheck-unset-output 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case suffixed-path 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case late-ambiguous 1 "Expected exactly one open pull request for this head" 0
+run_case external-signer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case unrecorded-signer 1 "did not result in a persisted signature" 0
+run_case unbound-signer 1 "signing comment was not the signature persisted" 0
+run_case duplicate-runs 0 "Requested rerun for CLA job 501 in workflow run 401" 1 \
+  "repos/manaflow-ai/cmux/actions/jobs/501/rerun"
+run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case wrapped-ledger 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case oversized-ledger 1 "exceeds the 1 MB limit" 0
+run_case malformed-ledger 1 "not valid base64" 0
+run_case compatibility-failed 0 "Requested rerun for failed CLA jobs (v2 and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case unexpected-failure 1 "unexpected failed job" 0
+run_case cancelled-job 1 "cancelled or non-failure job" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -634,7 +634,7 @@ run_case wrong-workflow-name 0 "No failed CLA run exists for this pull request h
 run_case stale-base-association 1 "outdated or malformed pull request base SHA" 0
 run_case alternate-generation 1 "Unexpected CLA generation marker" 0
 run_case malformed-comment-login 1 "Comment author is malformed" 0
-run_case late-ambiguous 1 "Expected exactly one open pull request for this head" 0
+run_case late-ambiguous 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case external-signer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case unrecorded-signer 1 "did not result in a persisted signature" 0
 run_case unbound-signer 1 "signing comment was not the signature persisted" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -501,6 +501,9 @@ run_case() {
   local expected_post="${5:-}"
   local expected_checks="${6:-}"
   local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false generation="${CLA_GENERATION}"
+  if [[ -n "${ONLY_MODE:-}" && "${ONLY_MODE}" != "${mode}" ]]; then
+    return 0
+  fi
   if [[ "$mode" == untrusted-recheck ]]; then
     comment_author=untrusted-user
     comment_author_id=301
@@ -583,15 +586,15 @@ run_case() {
 
 run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case oversized-api-response 1 "Could not query the issue" 0
-run_case minimal-run-association 1 "outdated or malformed pull request base SHA" 0
-run_case fork-current 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case minimal-run-association 0 "No failed CLA run exists for this pull request head" 0
+run_case fork-current 1 "older workflow generation" 0
 run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-stderr-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-stderr-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-api-failure 1 "Could not query pull request associations" 0
-run_case empty-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case same-repo-empty 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case empty-run-association 1 "older workflow generation" 0
+run_case same-repo-empty 1 "no pull request association with complete source metadata" 0
 run_case association-overflow 1 "Too many pull request associations" 0
 run_case paginated-associations 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case paginated-open-prs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
@@ -600,34 +603,34 @@ run_case paginated-runs 0 "Requested rerun for CLA job 500 in workflow run 400" 
 run_case full-run-window 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case full-run-window-no-match 1 "workflow-run result window is full" 0
 run_case paginated-jobs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case empty-different-execution-associated 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
-run_case empty-different-execution-source-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 0
-run_case empty-different-execution-source-mismatch 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
-run_case empty-different-execution-check-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
-run_case empty-different-execution-check-mismatch 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
-run_case fork-null-head-check-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
-run_case fork-null-head-no-check 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
-run_case check-wrong-app 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case empty-different-execution-associated 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-source-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
+run_case empty-different-execution-source-mismatch 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-check-bound 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-check-mismatch 1 "no pull request association with complete source metadata" 0
+run_case fork-null-head-check-bound 1 "no pull request association with complete source metadata" 0
+run_case fork-null-head-no-check 1 "no pull request association with complete source metadata" 0
+run_case check-wrong-app 1 "No failed CLA check is bound" 0 "" 1
 run_case check-wrong-app-id 1 "No failed CLA check is bound" 0 "" 1
-run_case check-wrong-sha 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
-run_case check-wrong-job 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
-run_case check-missing-final 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 2
-run_case oversized-check-response 1 "Could not query checks for the exact pull request head" 0 "" 1
-run_case stale-empty-execution 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
-run_case empty-mismatched-newer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case check-wrong-sha 1 "No failed CLA check is bound" 0 "" 1
+run_case check-wrong-job 1 "No failed CLA check is bound" 0 "" 1
+run_case check-missing-final 1 "No failed CLA check is bound" 0 "" 2
+run_case oversized-check-response 1 "Could not query checks for the selected CLA execution" 0 "" 1
+run_case stale-empty-execution 1 "no pull request association with complete source metadata" 0
+run_case empty-mismatched-newer 1 "no pull request association with complete source metadata" 0
 run_case wrong-run-association 0 "No failed CLA run exists for this pull request head" 0
 run_case malformed-run-association 1 "malformed pull request associations" 0
 run_case invalid-run-association 1 "malformed pull request associations" 0
 run_case stale-marker 1 "older workflow generation" 0
 run_case unrelated-main-commit 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case wrong-head-repo 0 "No failed CLA run exists for this pull request head" 0
+run_case wrong-head-repo 1 "no pull request association with complete source metadata" 0
 run_case closed-pr 1 "The issue is not an open pull request" 0
 run_case retargeted-pr 1 "The live pull request is not valid" 0
 run_case ambiguous-association 1 "Expected exactly one open pull request for this head" 0
 run_case untrusted-recheck 1 "Only the pull request author or a trusted repository participant" 0
 run_case recheck-unset-output 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case suffixed-path 1 "No failed CLA run exists for this pull request head" 0
-run_case wrong-workflow-name 1 "No failed CLA run exists for this pull request head" 0
+run_case suffixed-path 0 "No failed CLA run exists for this pull request head" 0
+run_case wrong-workflow-name 0 "No failed CLA run exists for this pull request head" 0
 run_case stale-base-association 1 "outdated or malformed pull request base SHA" 0
 run_case alternate-generation 1 "Unexpected CLA generation marker" 0
 run_case malformed-comment-login 1 "Comment author is malformed" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -644,11 +644,11 @@ run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workf
 run_case wrapped-ledger 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case oversized-ledger 1 "exceeds the 1 MB limit" 0
 run_case malformed-ledger 1 "not valid base64" 0
-run_case compatibility-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
+run_case compatibility-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
-run_case writer-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
+run_case writer-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
-run_case writer-only-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
+run_case writer-only-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
 run_case unexpected-failure 1 "unexpected failed job" 0
 run_case cancelled-job 1 "cancelled or non-failure job" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -95,14 +95,15 @@ export SIGNATURE_RECORDED=false
 # run still carries head_repository identity. GitHub may report the source PR
 # SHA or a different execution SHA on a pull_request_target run, so this fixture
 # keeps the live PR head at `aaaa...` and the selected run/job execution SHA at
-# `bbbb...`. The production-shaped fallback has an empty pull_requests array;
-# it is accepted without another check only when the run uses the live PR base
-# SHA. A source-SHA, null-repository, or mismatched-base run must carry a failed
-# GitHub Actions check whose URL binds the selected run and job to `aaaa...`.
+# `bbbb...`. A production-shaped empty association is accepted only when the
+# run has complete source metadata and uses the live PR base SHA. A source-SHA,
+# null-repository, stale-base, or mismatched metadata run must fail closed.
 gh() {
   local endpoint=""
   local api_page=1
   local api_filter=""
+  local api_check_name=""
+  local api_app_id=""
   local arg
   for arg in "$@"; do
     if [[ "$arg" == page=* ]]; then
@@ -110,6 +111,12 @@ gh() {
     fi
     if [[ "$arg" == filter=* ]]; then
       api_filter="${arg#filter=}"
+    fi
+    if [[ "$arg" == check_name=* ]]; then
+      api_check_name="${arg#check_name=}"
+    fi
+    if [[ "$arg" == app_id=* ]]; then
+      api_app_id="${arg#app_id=}"
     fi
     if [[ "$arg" == repos/* ]]; then
       endpoint="$arg"
@@ -122,6 +129,12 @@ gh() {
   if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/check-runs &&
         "$api_filter" != all ]]; then
     echo "check-runs lookup must request filter=all" >&2
+    return 1
+  fi
+  if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/check-runs &&
+        ( "$api_check_name" != "CLA Assistant v3" && "$api_check_name" != "CLA Assistant" ||
+          "$api_app_id" != 15368 ) ]]; then
+    echo "check-runs lookup must bind the expected CLA check and app" >&2
     return 1
   fi
   if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/pulls &&
@@ -141,7 +154,9 @@ gh() {
   local run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
   local marker="CLA generation ${CLA_GENERATION}"
   local run_path=.github/workflows/cla.yml
-  local run_prs='[{"number":123,"base":{"ref":"main","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]'
+  local run_name='CLA Assistant v3'
+  local check_app_id=15368
+  local run_prs='[{"number":123,"base":{"ref":"main","sha":"cccccccccccccccccccccccccccccccccccccccc","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]'
   local ledger_id=400
   local ledger_login=coauthor
   local ledger_comment_id=900
@@ -150,6 +165,9 @@ gh() {
     stale-marker) marker="CLA generation v2.2-action-0000000000000000000000000000000000000000" ;;
     unrelated-main-commit) marker="CLA generation ${CLA_GENERATION}" ;;
     wrong-head-repo) run_head_repo=attacker/cmux; run_head_repo_id=201; run_prs='[]' ;;
+    stale-base-association)
+      run_prs='[{"number":123,"base":{"ref":"main","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]'
+      ;;
     association-overflow) run_prs='[]' ;;
     fork-current|empty-run-association) run_prs='[]'; run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ;;
     empty-different-execution-associated|empty-different-execution-source-mismatch|empty-different-execution-check-bound|empty-different-execution-check-mismatch)
@@ -161,10 +179,12 @@ gh() {
       run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       ;;
-    check-wrong-app|check-wrong-sha|check-wrong-job|check-missing-final|oversized-check-response)
+    check-wrong-app|check-wrong-app-id|check-wrong-sha|check-wrong-job|check-missing-final|oversized-check-response)
       run_prs='[]'
       run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       ;;
+    wrong-workflow-name) run_name='Untrusted workflow' ;;
     fork-null-head-check-bound|fork-null-head-no-check)
       run_prs='[]'
       run_head_repository_null=true
@@ -242,21 +262,21 @@ gh() {
         commit_sha="${commit_sha%/pulls}"
         if [[ "${FAKE_MODE}" == empty-different-execution-source-bound &&
               "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
-          jq -nc '[{number:123,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+          jq -nc --arg base_sha "$live_base_sha" '[{number:123,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
         elif [[ "${FAKE_MODE}" == empty-different-execution-source-mismatch &&
                 "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
-          jq -nc '[{number:124,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+          jq -nc --arg base_sha "$live_base_sha" '[{number:124,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
         else
           printf '[]\n'
         fi
       elif [[ "${FAKE_MODE}" == association-overflow ]]; then
-        jq -nc '[range(0; 100) | {number:(1000 + .),base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 1 ]]; then
-        jq -nc '[range(0; 100) | {number:(1000 + .),base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 2 ]]; then
-        jq -nc '[{number:123,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+          jq -nc --arg base_sha "$live_base_sha" '[{number:123,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == same-repo-empty ]]; then
-        jq -nc '[{number:123,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:100,full_name:"manaflow-ai/cmux"}}}]'
+        jq -nc --arg base_sha "$live_base_sha" '[{number:123,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:100,full_name:"manaflow-ai/cmux"}}}]'
       else
         printf '[]\n'
       fi
@@ -312,6 +332,14 @@ gh() {
       ;;
     repos/manaflow-ai/cmux/commits/*/check-runs)
       local check_call=1
+      local check_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      local check_app_slug=github-actions
+      local check_id=9000
+      local check_name="CLA Assistant v3"
+      local check_details="https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"
+      local check_prefix=repos/manaflow-ai/cmux/commits/
+      check_sha="${endpoint#"${check_prefix}"}"
+      check_sha="${check_sha%/check-runs}"
       if [[ -n "${FAKE_CHECK_CALL_FILE:-}" ]]; then
         if [[ -s "${FAKE_CHECK_CALL_FILE}" ]]; then
           read -r check_call <"${FAKE_CHECK_CALL_FILE}"
@@ -327,19 +355,22 @@ gh() {
             "${FAKE_MODE}" == check-missing-final && "${check_call}" -gt 1 ]]; then
         printf '%s\n' '{"check_runs":[]}'
       elif [[ "${FAKE_MODE}" == oversized-check-response ]]; then
-        printf '%s' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500","padding":"'
+        printf '%s' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500","padding":"'
         head -c 2100000 /dev/zero | tr '\0' 'A'
         printf '%s\n' '"}]}'
       elif [[ "${FAKE_MODE}" == check-wrong-app ]]; then
-        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"untrusted-app"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"untrusted-app"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-app-id ]]; then
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":999,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
       elif [[ "${FAKE_MODE}" == check-wrong-sha ]]; then
-        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
       elif [[ "${FAKE_MODE}" == check-wrong-job ]]; then
-        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/999"}]}'
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/999"}]}'
       elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
-        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"}]}'
+        printf '%s\n' '{"id":9000,"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"}]}'
       else
-        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+        jq -nc --arg sha "$check_sha" --arg slug "$check_app_slug" --argjson app_id "$check_app_id" --argjson id "$check_id" --arg name "$check_name" --arg details "$check_details" \
+          '{check_runs:[{id:$id,name:$name,status:"completed",conclusion:"failure",head_sha:$sha,app:{id:$app_id,slug:$slug},details_url:$details}]}'
       fi
       ;;
     repos/manaflow-ai/cmux/actions/workflows)
@@ -352,29 +383,29 @@ gh() {
     repos/manaflow-ai/cmux/actions/workflows/300/runs)
       if [[ "${FAKE_MODE}" == full-run-window ]]; then
         if [[ "${api_page}" == 10 ]]; then
-          jq -nc --arg path "$run_path" --arg run_sha "$run_sha" --argjson run_prs "$run_prs" \
-            '{workflow_runs:([range(0; 99) | {id:(1000 + .),workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}] + [{id:400,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}])}'
+          jq -nc --arg path "$run_path" --arg name "$run_name" --arg run_sha "$run_sha" --argjson run_prs "$run_prs" \
+            '{workflow_runs:([range(0; 99) | {id:(1000 + .),workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}] + [{id:400,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}])}'
         else
-          jq -nc '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+          jq -nc --arg name "$run_name" '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
         fi
       elif [[ "${FAKE_MODE}" == full-run-window-no-match ]]; then
-        jq -nc '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+        jq -nc --arg name "$run_name" '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
       elif [[ "${FAKE_MODE}" == paginated-runs && "${api_page}" == 1 ]]; then
-        jq -nc '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+        jq -nc --arg name "$run_name" '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
       elif [[ "${FAKE_MODE}" == empty-mismatched-newer ]]; then
-        jq -nc '{workflow_runs:[
-          {id:400,workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:00:00Z"},
-          {id:401,workflow_id:300,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
+        jq -nc --arg name "$run_name" '{workflow_runs:[
+          {id:400,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:00:00Z"},
+          {id:401,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
         ]}'
       elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
-        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --argjson run_prs "$run_prs" \
+        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
           '{workflow_runs:[
-            {id:400,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"},
-            {id:401,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:30:00Z"}
+            {id:400,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"},
+            {id:401,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:30:00Z"}
           ]}'
       else
-        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --argjson run_prs "$run_prs" \
-          '{workflow_runs:[{id:400,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}]}'
+        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
+          '{workflow_runs:[{id:400,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}]}'
       fi
       ;;
     repos/manaflow-ai/cmux/actions/runs/400|repos/manaflow-ai/cmux/actions/runs/401)
@@ -388,8 +419,8 @@ gh() {
       if [[ "${FAKE_MODE}" == empty-mismatched-newer ]]; then
         if [[ "$run_id" == 400 ]]; then detail_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; else detail_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; fi
       fi
-      jq -nc --argjson run_id "$run_id" --arg created_at "$created_at" --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$detail_sha" --arg path "$run_path" --argjson run_prs "$run_prs" \
-        '{id:$run_id,workflow_id:300,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:$created_at}'
+      jq -nc --argjson run_id "$run_id" --arg created_at "$created_at" --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$detail_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
+        '{id:$run_id,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:$created_at}'
       ;;
     repos/manaflow-ai/cmux/actions/runs/400/jobs|repos/manaflow-ai/cmux/actions/runs/401/jobs)
       local run_id=400
@@ -408,14 +439,14 @@ gh() {
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
             {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
-            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:"Mirror CLA Assistant compatibility result",status:"completed",conclusion:"failure"}]}
           ]}'
       elif [[ "${FAKE_MODE}" == writer-failed ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
             {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
             {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
-            {id:506,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:506,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:"Mirror CLA Assistant compatibility result",status:"completed",conclusion:"failure"}]}
           ]}'
       elif [[ "${FAKE_MODE}" == writer-only-failed ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
@@ -469,7 +500,7 @@ run_case() {
   local expected_posts="$4"
   local expected_post="${5:-}"
   local expected_checks="${6:-}"
-  local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false
+  local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false generation="${CLA_GENERATION}"
   if [[ "$mode" == untrusted-recheck ]]; then
     comment_author=untrusted-user
     comment_author_id=301
@@ -492,6 +523,10 @@ run_case() {
     comment_author_id=400
     comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
     signature_recorded=true
+  elif [[ "$mode" == alternate-generation ]]; then
+    generation=v2.2-action-deadbeef
+  elif [[ "$mode" == malformed-comment-login ]]; then
+    comment_author=$'contributor\nattacker'
   fi
   : >"$work/posts-$mode"
   printf '0\n' >"$work/association-$mode"
@@ -508,6 +543,7 @@ run_case() {
     COMMENT_AUTHOR_TYPE="$comment_type" \
     COMMENT_AUTHOR_ASSOCIATION="$comment_association" \
     SIGNATURE_RECORDED="$signature_recorded" \
+    CLA_GENERATION="$generation" \
     bash "$rerun_script" 2>&1
   )"
   status=$?
@@ -547,7 +583,7 @@ run_case() {
 
 run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case oversized-api-response 1 "Could not query the issue" 0
-run_case minimal-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case minimal-run-association 1 "outdated or malformed pull request base SHA" 0
 run_case fork-current 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
@@ -572,6 +608,7 @@ run_case empty-different-execution-check-mismatch 1 "No failed CLA check is boun
 run_case fork-null-head-check-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
 run_case fork-null-head-no-check 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
 run_case check-wrong-app 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-wrong-app-id 1 "No failed CLA check is bound" 0 "" 1
 run_case check-wrong-sha 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
 run_case check-wrong-job 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
 run_case check-missing-final 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 2
@@ -589,7 +626,11 @@ run_case retargeted-pr 1 "The live pull request is not valid" 0
 run_case ambiguous-association 1 "Expected exactly one open pull request for this head" 0
 run_case untrusted-recheck 1 "Only the pull request author or a trusted repository participant" 0
 run_case recheck-unset-output 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case suffixed-path 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case suffixed-path 1 "No failed CLA run exists for this pull request head" 0
+run_case wrong-workflow-name 1 "No failed CLA run exists for this pull request head" 0
+run_case stale-base-association 1 "outdated or malformed pull request base SHA" 0
+run_case alternate-generation 1 "Unexpected CLA generation marker" 0
+run_case malformed-comment-login 1 "Comment author is malformed" 0
 run_case late-ambiguous 1 "Expected exactly one open pull request for this head" 0
 run_case external-signer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case unrecorded-signer 1 "did not result in a persisted signature" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -32,7 +32,7 @@ bash -n "$rerun_script"
 # The privileged job checks out only the immutable workflow revision and
 # launches the checked-in guard. Keep the launcher below the Actions step-size
 # limit, and reject any future attempt to execute the pull-request head.
-grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2' "$WORKFLOW"
+grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' "$WORKFLOW"
 grep -Fq "repository: \${{ github.repository }}" "$WORKFLOW"
 grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
 grep -Fq 'sparse-checkout: .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
@@ -43,6 +43,23 @@ if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
   echo 'FAIL: CLA rerun checkout must never use a pull-request ref' >&2
   exit 1
 fi
+WORKFLOW="$WORKFLOW" ruby -ryaml <<'RUBY'
+workflow = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+rerun = workflow.fetch("jobs").fetch("RerunFailedCLA")
+expected_group = "cla-rerun-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+abort "CLA rerun queue is not serialized per pull request" unless
+  rerun.fetch("concurrency") == {
+    "group" => expected_group,
+    "cancel-in-progress" => false
+  }
+abort "CLA rerun job cannot read check runs" unless rerun.fetch("permissions") == {
+  "actions" => "write",
+  "checks" => "read",
+  "contents" => "read",
+  "issues" => "read",
+  "pull-requests" => "read"
+}
+RUBY
 launcher_bytes="$(awk '
   /^  RerunFailedCLA:/ { in_job=1; next }
   in_job && /^  LockMergedPullRequest:/ { exit }
@@ -66,7 +83,9 @@ export COMMENT_AUTHOR_LOGIN=contributor
 export COMMENT_AUTHOR_TYPE=User
 export COMMENT_AUTHOR_ASSOCIATION=NONE
 export WORKFLOW_PATH=.github/workflows/cla.yml
-export CLA_GENERATION=v2.2-action-bc206ed9b52ad0b0cbe85244ce522e5e9b65c10e
+WORKFLOW_SHA="$(git rev-parse HEAD)"
+export WORKFLOW_SHA
+export CLA_GENERATION=v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af
 export TARGET_EVENT=pull_request_target
 export TARGET_BASE_REF=main
 export SIGNATURE_RECORDED=false
@@ -75,17 +94,22 @@ export SIGNATURE_RECORDED=false
 # fork-only commit has no result from /commits/:sha/pulls, while the workflow
 # run still carries head_repository identity. GitHub may report the source PR
 # SHA or a different execution SHA on a pull_request_target run, so this fixture
-# keeps the live PR head at `aaaa...` and, for the populated-association case,
-# the selected run/job execution SHA at `bbbb...`. A populated pull_requests
-# object binds that differing execution to the source PR. An empty association
-# must use the exact live PR head SHA or fail closed.
+# keeps the live PR head at `aaaa...` and the selected run/job execution SHA at
+# `bbbb...`. The production-shaped fallback has an empty pull_requests array;
+# it is accepted without another check only when the run uses the live PR base
+# SHA. A source-SHA, null-repository, or mismatched-base run must carry a failed
+# GitHub Actions check whose URL binds the selected run and job to `aaaa...`.
 gh() {
   local endpoint=""
   local api_page=1
+  local api_filter=""
   local arg
   for arg in "$@"; do
     if [[ "$arg" == page=* ]]; then
       api_page="${arg#page=}"
+    fi
+    if [[ "$arg" == filter=* ]]; then
+      api_filter="${arg#filter=}"
     fi
     if [[ "$arg" == repos/* ]]; then
       endpoint="$arg"
@@ -95,6 +119,11 @@ gh() {
     echo "missing API endpoint" >&2
     return 1
   }
+  if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/check-runs &&
+        "$api_filter" != all ]]; then
+    echo "check-runs lookup must request filter=all" >&2
+    return 1
+  fi
   if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/pulls &&
         " $* " != *" --method GET "* ]]; then
     echo "commit association lookup must use GET" >&2
@@ -102,6 +131,7 @@ gh() {
   fi
   local live_state=open
   local live_base=main
+  local live_base_sha=cccccccccccccccccccccccccccccccccccccccc
   local live_head_repo=contributor/cmux
   local live_head_repo_id=200
   local run_head_repo=contributor/cmux
@@ -122,7 +152,24 @@ gh() {
     wrong-head-repo) run_head_repo=attacker/cmux; run_head_repo_id=201; run_prs='[]' ;;
     association-overflow) run_prs='[]' ;;
     fork-current|empty-run-association) run_prs='[]'; run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ;;
-    empty-different-execution-associated) run_prs='[]' ;;
+    empty-different-execution-associated|empty-different-execution-source-mismatch|empty-different-execution-check-bound|empty-different-execution-check-mismatch)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    empty-different-execution-source-bound)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    check-wrong-app|check-wrong-sha|check-wrong-job|check-missing-final|oversized-check-response)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    fork-null-head-check-bound|fork-null-head-no-check)
+      run_prs='[]'
+      run_head_repository_null=true
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
     same-repo-empty)
       run_prs='[]'
       run_head_repo=manaflow-ai/cmux
@@ -152,11 +199,26 @@ gh() {
 
   case "$endpoint" in
     repos/manaflow-ai/cmux/issues/123)
-      jq -nc --arg state "$live_state" '{state:$state,pull_request:{url:"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"}}'
+      if [[ "${FAKE_MODE}" == oversized-api-response ]]; then
+        printf '%s' '{"state":"open","pull_request":{"url":"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"},"padding":"'
+        head -c 2100000 /dev/zero | tr '\0' 'A'
+        printf '%s\n' '"}'
+      else
+        jq -nc --arg state "$live_state" '{state:$state,pull_request:{url:"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"}}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/issues/comments/900)
+      jq -nc \
+        --arg body "${COMMENT_BODY}" \
+        --argjson author_id "${COMMENT_AUTHOR_ID}" \
+        --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
+        --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+        --arg created_at "${COMMENT_CREATED_AT}" \
+        '{issue_url:"https://api.github.com/repos/manaflow-ai/cmux/issues/123",body:$body,user:{id:$author_id,login:$author_login,type:$author_type},created_at:$created_at,updated_at:$created_at}'
       ;;
     repos/manaflow-ai/cmux/pulls/123)
-      jq -nc --arg state "$live_state" --arg base "$live_base" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" \
-        '{number:123,state:$state,user:{id:300,login:"contributor"},base:{ref:$base,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}'
+      jq -nc --arg state "$live_state" --arg base "$live_base" --arg base_sha "$live_base_sha" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" \
+        '{number:123,state:$state,user:{id:300,login:"contributor"},base:{ref:$base,sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}'
       ;;
     repos/manaflow-ai/cmux/commits/*/pulls)
       if [[ "${FAKE_MODE}" == association-not-found ]]; then
@@ -174,6 +236,19 @@ gh() {
       elif [[ "${FAKE_MODE}" == association-api-failure ]]; then
         printf '{"message":"API unavailable","status":503}\n'
         return 1
+      elif [[ "${FAKE_MODE}" == empty-different-execution-source-bound ||
+              "${FAKE_MODE}" == empty-different-execution-source-mismatch ]]; then
+        local commit_sha="${endpoint#repos/manaflow-ai/cmux/commits/}"
+        commit_sha="${commit_sha%/pulls}"
+        if [[ "${FAKE_MODE}" == empty-different-execution-source-bound &&
+              "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
+          jq -nc '[{number:123,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        elif [[ "${FAKE_MODE}" == empty-different-execution-source-mismatch &&
+                "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
+          jq -nc '[{number:124,base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        else
+          printf '[]\n'
+        fi
       elif [[ "${FAKE_MODE}" == association-overflow ]]; then
         jq -nc '[range(0; 100) | {number:(1000 + .),base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 1 ]]; then
@@ -223,16 +298,48 @@ gh() {
         printf '%s\n' "$association_call" >"${FAKE_ASSOC_CALL_FILE}"
       fi
       if [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 1 ]]; then
-        jq -nc '[range(0; 100) | {number:(1000 + .),state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 2 ]]; then
-        jq -nc '[{number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        jq -nc --arg base_sha "$live_base_sha" '[{number:123,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == ambiguous-association || ( "${FAKE_MODE}" == late-ambiguous && "$association_call" -gt 1 ) ]]; then
         jq -nc '[
-          {number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}},
-          {number:124,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}
+          {number:123,state:"open",base:{ref:"main",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}},
+          {number:124,state:"open",base:{ref:"main",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}
         ]'
       else
-        jq -nc --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" '[{number:123,state:"open",base:{ref:"main",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}]'
+        jq -nc --arg base_sha "$live_base_sha" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" '[{number:123,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}]'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/commits/*/check-runs)
+      local check_call=1
+      if [[ -n "${FAKE_CHECK_CALL_FILE:-}" ]]; then
+        if [[ -s "${FAKE_CHECK_CALL_FILE}" ]]; then
+          read -r check_call <"${FAKE_CHECK_CALL_FILE}"
+          check_call=$((check_call + 1))
+        fi
+        printf '%s\n' "$check_call" >"${FAKE_CHECK_CALL_FILE}"
+      fi
+      if [[ "${FAKE_MODE}" == fork-null-head-no-check ||
+            "${FAKE_MODE}" == empty-different-execution-check-mismatch ||
+            "${FAKE_MODE}" == empty-different-execution-associated ||
+            "${FAKE_MODE}" == empty-different-execution-source-mismatch ||
+            "${FAKE_MODE}" == stale-empty-execution ||
+            "${FAKE_MODE}" == check-missing-final && "${check_call}" -gt 1 ]]; then
+        printf '%s\n' '{"check_runs":[]}'
+      elif [[ "${FAKE_MODE}" == oversized-check-response ]]; then
+        printf '%s' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500","padding":"'
+        head -c 2100000 /dev/zero | tr '\0' 'A'
+        printf '%s\n' '"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-app ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"untrusted-app"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-sha ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-job ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/999"}]}'
+      elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"}]}'
+      else
+        printf '%s\n' '{"check_runs":[{"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
       fi
       ;;
     repos/manaflow-ai/cmux/actions/workflows)
@@ -300,24 +407,37 @@ gh() {
       elif [[ "${FAKE_MODE}" == compatibility-failed ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
-            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
-            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == writer-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:506,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == writer-only-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]}
           ]}'
       elif [[ "${FAKE_MODE}" == unexpected-failure ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
-            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
-            {id:503,run_id:$run_id,name:"Unexpected privileged job",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:503,run_id:$run_id,name:"Unexpected privileged job",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
           ]}'
       elif [[ "${FAKE_MODE}" == cancelled-job ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
-            {id:$job_id,run_id:$run_id,name:"CLA Assistant v2",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"success"}]},
-            {id:504,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v2",status:"completed",conclusion:"cancelled",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:504,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"cancelled",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
           ]}'
       else
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$jobs_sha" --argjson omit "$omit_job_head_repository" \
-          '{jobs:[({id:$job_id,run_id:$run_id,name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"success"}]} + (if $omit then {} else {head_repository:null} end))]}'
+          '{jobs:[({id:$job_id,run_id:$run_id,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"failure"}]} + (if $omit then {} else {head_repository:null} end))]}'
       fi
       ;;
     repos/manaflow-ai/cmux/actions/jobs/500|repos/manaflow-ai/cmux/actions/jobs/501)
@@ -332,7 +452,7 @@ gh() {
         job_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
       fi
       jq -nc --argjson job_id "$job_id" --argjson run_id "$run_id" --arg marker "$marker" --arg run_sha "$job_sha" --argjson omit "$omit_job_head_repository" \
-        '({id:$job_id,run_id:$run_id,name:"CLA Assistant v2",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"success"}]} + (if $omit then {} else {head_repository:null} end))'
+        '({id:$job_id,run_id:$run_id,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"failure"}]} + (if $omit then {} else {head_repository:null} end))'
       ;;
     *)
       echo "unexpected API endpoint: $endpoint" >&2
@@ -348,6 +468,7 @@ run_case() {
   local expected_text="$3"
   local expected_posts="$4"
   local expected_post="${5:-}"
+  local expected_checks="${6:-}"
   local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false
   if [[ "$mode" == untrusted-recheck ]]; then
     comment_author=untrusted-user
@@ -374,11 +495,13 @@ run_case() {
   fi
   : >"$work/posts-$mode"
   printf '0\n' >"$work/association-$mode"
+  printf '0\n' >"$work/check-$mode"
   set +e
   output="$(
     FAKE_MODE="$mode" \
     FAKE_POST_FILE="$work/posts-$mode" \
     FAKE_ASSOC_CALL_FILE="$work/association-$mode" \
+    FAKE_CHECK_CALL_FILE="$work/check-$mode" \
     COMMENT_BODY="$comment_body" \
     COMMENT_AUTHOR_ID="$comment_author_id" \
     COMMENT_AUTHOR_LOGIN="$comment_author" \
@@ -409,10 +532,21 @@ run_case() {
     cat "$work/posts-$mode" >&2
     exit 1
   fi
+  if [[ -n "$expected_checks" ]]; then
+    local checks=0
+    if [[ -s "$work/check-$mode" ]]; then
+      read -r checks <"$work/check-$mode"
+    fi
+    if [[ "$checks" != "$expected_checks" ]]; then
+      echo "FAIL: $mode made $checks check lookups, expected $expected_checks" >&2
+      exit 1
+    fi
+  fi
   echo "PASS: $mode"
 }
 
 run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case oversized-api-response 1 "Could not query the issue" 0
 run_case minimal-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case fork-current 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
@@ -430,8 +564,19 @@ run_case paginated-runs 0 "Requested rerun for CLA job 500 in workflow run 400" 
 run_case full-run-window 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case full-run-window-no-match 1 "workflow-run result window is full" 0
 run_case paginated-jobs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case empty-different-execution-associated 1 "no pull request association and its execution SHA does not match" 0
-run_case stale-empty-execution 1 "no pull request association and its execution SHA does not match" 0
+run_case empty-different-execution-associated 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case empty-different-execution-source-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 0
+run_case empty-different-execution-source-mismatch 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case empty-different-execution-check-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
+run_case empty-different-execution-check-mismatch 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case fork-null-head-check-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
+run_case fork-null-head-no-check 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-wrong-app 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-wrong-sha 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-wrong-job 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
+run_case check-missing-final 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 2
+run_case oversized-check-response 1 "Could not query checks for the exact pull request head" 0 "" 1
+run_case stale-empty-execution 1 "No failed CLA check is bound to the exact pull request head and selected job" 0 "" 1
 run_case empty-mismatched-newer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case wrong-run-association 0 "No failed CLA run exists for this pull request head" 0
 run_case malformed-run-association 1 "malformed pull request associations" 0
@@ -455,7 +600,11 @@ run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workf
 run_case wrapped-ledger 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case oversized-ledger 1 "exceeds the 1 MB limit" 0
 run_case malformed-ledger 1 "not valid base64" 0
-run_case compatibility-failed 0 "Requested rerun for failed CLA jobs (v2 and compatibility) in workflow run 400" 1 \
+run_case compatibility-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case writer-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case writer-only-failed 0 "Requested rerun for failed CLA v3 jobs (writer, assistant, and compatibility) in workflow run 400" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
 run_case unexpected-failure 1 "unexpected failed job" 0
 run_case cancelled-job 1 "cancelled or non-failure job" 0

--- a/tests/test_cla_trigger_gate.sh
+++ b/tests/test_cla_trigger_gate.sh
@@ -1,0 +1,299 @@
+#!/usr/bin/env bash
+# Exercise the unprivileged CLA trigger admission gate. The shell gate emits a
+# true/false admission result, rejects malformed metadata, and keeps ordinary
+# human comments out of the privileged signer queue.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
+test -f "$WORKFLOW"
+
+grep -Fq 'types: [opened,closed,edited,reopened,synchronize]' "$WORKFLOW"
+if rg -n 'changes\.base' "$WORKFLOW" >/dev/null; then
+  echo 'FAIL: edited pull-request events must not require a base-change payload' >&2
+  exit 1
+fi
+
+# The protected ruleset must be migrated to the versioned check context before
+# enforcement. The admission queue is bounded per pull request. Its known
+# case-insensitive replacement behavior is an availability residual; the
+# exact shell check still prevents an invalid comment from reaching signing.
+grep -Fq 'name: "CLA Assistant v2"' "$WORKFLOW"
+grep -Fq 'name: "CLA Assistant"' "$WORKFLOW"
+grep -Fq 'github.event.comment.body == '\''recheck'\''' "$WORKFLOW"
+grep -Fq 'github.event.comment.body == '\''I have read the CLA Document v2.2 and I hereby sign the CLA'\''' "$WORKFLOW"
+grep -Fq 'github.event.comment.user.id == github.event.issue.user.id' "$WORKFLOW"
+grep -Fq "github.event.action == 'created'" "$WORKFLOW"
+grep -Fq 'id: admission' "$WORKFLOW"
+grep -Fq "admitted: \${{ steps.admission.outputs.admitted }}" "$WORKFLOW"
+grep -Fq "allowlist-ids: '38676809,67667005'" "$WORKFLOW"
+grep -Fq 'always() &&' "$WORKFLOW"
+grep -Fq 'cancel-in-progress: false' "$WORKFLOW"
+grep -Fq "group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}" "$WORKFLOW"
+for job in CLACommentGate CLAAssistant CLACompatibility RerunFailedCLA LockMergedPullRequest; do
+  job_block="$(awk -v job="$job" '$0 == "  " job ":" { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
+  if [[ "$job_block" != *"    runs-on: \${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"* ]]; then
+    echo "FAIL: $job must use the configured Linux runner" >&2
+    exit 1
+  fi
+done
+assistant_block="$(awk '/^  CLAAssistant:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
+if [[ "$assistant_block" != *$'    if: >-\n      always() &&'* ||
+      "$assistant_block" != *"needs.CLACommentGate.result == 'failure'"* ||
+      "$assistant_block" != *"needs.CLACommentGate.outputs.admitted == 'true'"* ||
+      "$assistant_block" != *'      - name: "Require CLA admission"'* ||
+      "$assistant_block" != *'        if: always()'* ||
+      "$assistant_block" != *"          ADMITTED: \${{ needs.CLACommentGate.outputs.admitted }}"* ]]; then
+  echo 'FAIL: CLA assistant must expose a failed check when admission fails' >&2
+  exit 1
+fi
+success_guard_count="$(grep -Fc '        if: success()' <<<"$assistant_block")"
+if [[ "$success_guard_count" -lt 4 ]]; then
+  echo 'FAIL: privileged CLA steps must require successful admission' >&2
+  exit 1
+fi
+echo "PASS: signer admission failure is visible and privileged steps are guarded"
+gate_group_block="$(awk '/^  CLACommentGate:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
+if [[ "$gate_group_block" != *$'\n    concurrency:'* ||
+      "$gate_group_block" != *"group: cla-admission-\${{ github.repository }}-\${{ github.event_name }}-\${{ github.event.issue.number || github.event.pull_request.number }}"* ||
+      "$gate_group_block" != *$'cancel-in-progress: false'* ]]; then
+  echo 'FAIL: CLA admission gate must use a bounded per-PR non-canceling queue' >&2
+  exit 1
+fi
+if [[ "$gate_group_block" != *"github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'"* ||
+      "$gate_group_block" != *"github.event.comment.body == 'recheck'"* ]]; then
+  echo 'FAIL: the job-level gate must keep ordinary comments out of the admission queue' >&2
+  exit 1
+fi
+assistant_group_block="$(awk '/^  CLAAssistant:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
+if [[ "$assistant_group_block" != *"group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}"* ]]; then
+  echo 'FAIL: signer concurrency must serialize all events for one pull request' >&2
+  exit 1
+fi
+if rg -n -- '--paginate|--slurp' "$WORKFLOW" >/dev/null; then
+  echo 'FAIL: CLA rerun queries must use explicit bounded pages' >&2
+  exit 1
+fi
+grep -Fq "path-to-signatures: 'signatures/version2/cla.json'" "$WORKFLOW"
+grep -Fq "github.event.comment.body == 'recheck'" "$WORKFLOW"
+grep -Fq "github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'" "$WORKFLOW"
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+gate_script="$work/gate.sh"
+
+awk '
+  /^  CLACommentGate:/ { in_job=1; next }
+  in_job && /^  [A-Za-z0-9_]+:/ { exit }
+  in_job && /^        run: \|$/ { in_run=1; next }
+  in_run { sub(/^          /, ""); print }
+' "$WORKFLOW" >"$gate_script"
+bash -n "$gate_script"
+
+admission_script="$work/admission.sh"
+awk '
+  /^      - name: "Require CLA admission"/ { found=1; next }
+  found && /^        run: \|$/ { in_run=1; next }
+  found && in_run && /^      - name:/ { exit }
+  in_run { sub(/^          /, ""); print }
+' "$WORKFLOW" >"$admission_script"
+bash -n "$admission_script"
+for gate_result in success failure skipped; do
+  admitted=true
+  [[ "$gate_result" == success ]] || admitted=false
+  set +e
+  output="$(GATE_RESULT="$gate_result" ADMITTED="$admitted" bash "$admission_script" 2>&1)"
+  status=$?
+  set -e
+  if [[ "$gate_result" == success && "$status" -ne 0 ]]; then
+    echo "FAIL: admission guard rejected successful gate result" >&2
+    exit 1
+  elif [[ "$gate_result" != success && "$status" -eq 0 ]]; then
+    echo "FAIL: admission guard accepted gate result '$gate_result'" >&2
+    exit 1
+  fi
+done
+set +e
+output="$(GATE_RESULT=success ADMITTED=false bash "$admission_script" 2>&1)"
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"admitted: false"* ]]; then
+  echo 'FAIL: admission guard accepted a false admission output' >&2
+  exit 1
+fi
+echo "PASS: admission result guard"
+
+run_case() {
+  local mode="$1"
+  local expected_status="$2"
+  local expected_text="$3"
+  local expected_admitted="$4"
+  local event_name=issue_comment
+  local event_action=created
+  local comment_body=recheck
+  local comment_author_id=300
+  local comment_author_login=contributor
+  local pr_author_id=300
+  local comment_author_type=User
+  local comment_author_association=NONE
+  local output status output_file actual_admitted
+  output_file="$work/output-$mode"
+  rm -f "$output_file"
+  case "$mode" in
+    exact-sign) comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA' ;;
+    non-author-sign) comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'; comment_author_id=301; comment_author_login=reviewer; comment_author_association=MEMBER ;;
+    legacy-sign) comment_body='I have read the CLA Document and I hereby sign the CLA' ;;
+    uppercase-recheck) comment_body=RECHECK ;;
+    padded-sign) comment_body=' I have read the CLA Document v2.2 and I hereby sign the CLA ' ;;
+    wrapped-sign) comment_body='Please sign: I have read the CLA Document v2.2 and I hereby sign the CLA' ;;
+    ordinary-comment) comment_body='Thanks for the review!' ;;
+    untrusted-recheck) comment_author_id=301 ;;
+    trusted-recheck) comment_author_id=301; comment_author_association=MEMBER ;;
+    bot-comment) comment_author_login='github-actions[bot]'; comment_author_type=Bot ;;
+    pull-opened) event_name=pull_request_target; event_action=opened; comment_body='' ;;
+    pull-edited) event_name=pull_request_target; event_action=edited; comment_body='' ;;
+    pull-reopened) event_name=pull_request_target; event_action=reopened; comment_body='' ;;
+    pull-synchronize) event_name=pull_request_target; event_action=synchronize; comment_body='' ;;
+    pull-closed) event_name=pull_request_target; event_action=closed; comment_body='' ;;
+    wrong-event) event_name=push; event_action=; comment_body='' ;;
+  esac
+  set +e
+  output="$(
+    GITHUB_OUTPUT="$output_file" \
+    EVENT_NAME="$event_name" \
+    EVENT_ACTION="$event_action" \
+    COMMENT_BODY="$comment_body" \
+    COMMENT_AUTHOR_ID="$comment_author_id" \
+    COMMENT_AUTHOR_LOGIN="$comment_author_login" \
+    PR_AUTHOR_ID="$pr_author_id" \
+    COMMENT_AUTHOR_TYPE="$comment_author_type" \
+    COMMENT_AUTHOR_ASSOCIATION="$comment_author_association" \
+    bash "$gate_script" 2>&1
+  )"
+  status=$?
+  set -e
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: $mode exited $status, expected $expected_status" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ -n "$expected_text" && "$output" != *"$expected_text"* ]]; then
+    echo "FAIL: $mode did not report '$expected_text'" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ "$expected_admitted" == none ]]; then
+    if [[ -s "$output_file" ]]; then
+      echo "FAIL: $mode unexpectedly wrote an admission result" >&2
+      cat "$output_file" >&2
+      exit 1
+    fi
+  else
+    if [[ ! -s "$output_file" ]]; then
+      echo "FAIL: $mode did not write admitted=$expected_admitted" >&2
+      exit 1
+    fi
+    actual_admitted="$(<"$output_file")"
+    if [[ "$actual_admitted" != "admitted=$expected_admitted" ]]; then
+      echo "FAIL: $mode wrote '$actual_admitted', expected admitted=$expected_admitted" >&2
+      exit 1
+    fi
+  fi
+  echo "PASS: $mode"
+}
+
+run_case exact-recheck 0 "" true
+run_case exact-sign 0 "" true
+run_case non-author-sign 0 "" false
+run_case legacy-sign 0 "" false
+run_case uppercase-recheck 0 "" false
+run_case untrusted-recheck 0 "" false
+run_case trusted-recheck 0 "" true
+run_case bot-comment 1 "Bot" none
+run_case padded-sign 0 "" false
+run_case wrapped-sign 0 "" false
+run_case ordinary-comment 0 "" false
+run_case pull-opened 0 "" true
+run_case pull-edited 0 "" true
+run_case pull-reopened 0 "" true
+run_case pull-synchronize 0 "" true
+run_case pull-closed 1 "accepted CLA trigger" none
+run_case wrong-event 1 "accepted CLA trigger" none
+
+# Missing runner metadata is an infrastructure/malformed-event failure, not a
+# false admission. The gate must fail closed before a privileged dependency.
+set +e
+output="$(
+  GITHUB_OUTPUT="$work/output-missing-author" \
+  EVENT_NAME=issue_comment EVENT_ACTION=created COMMENT_BODY='ordinary' \
+  COMMENT_AUTHOR_LOGIN=contributor PR_AUTHOR_ID=300 COMMENT_AUTHOR_TYPE=User \
+  COMMENT_AUTHOR_ASSOCIATION=NONE bash -u "$gate_script" 2>&1
+)"
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"metadata is incomplete"* ]]; then
+  echo 'FAIL: missing comment metadata did not fail closed' >&2
+  echo "$output" >&2
+  exit 1
+fi
+set +e
+output="$(
+  env -u GITHUB_OUTPUT \
+  EVENT_NAME=issue_comment EVENT_ACTION=created COMMENT_BODY=ordinary \
+  COMMENT_AUTHOR_ID=300 COMMENT_AUTHOR_LOGIN=contributor PR_AUTHOR_ID=300 \
+  COMMENT_AUTHOR_TYPE=User COMMENT_AUTHOR_ASSOCIATION=NONE bash -u "$gate_script" 2>&1
+)"
+status=$?
+set -e
+if [[ "$status" -eq 0 || "$output" != *"GITHUB_OUTPUT is unavailable"* ]]; then
+  echo 'FAIL: missing GITHUB_OUTPUT did not fail closed' >&2
+  echo "$output" >&2
+  exit 1
+fi
+echo "PASS: malformed and infrastructure admission failures"
+
+# The compatibility check must fail closed when the v2 action fails or is
+# skipped. A skipped dependency must never become a successful old required
+# context during migration.
+compat_script="$work/compatibility.sh"
+awk '
+  /^  CLACompatibility:/ { in_job=1; next }
+  in_job && /^  [A-Za-z0-9_]+:/ { exit }
+  in_job && /^        run: \|$/ { in_run=1; next }
+  in_run { sub(/^          /, ""); print }
+' "$WORKFLOW" >"$compat_script"
+bash -n "$compat_script"
+for gate_result in success failure skipped; do
+  for result in success failure skipped; do
+  set +e
+  GATE_RESULT="$gate_result" V2_RESULT="$result" bash "$compat_script" >/dev/null 2>&1
+  status=$?
+  set -e
+  if [[ "$gate_result" == success && "$result" == success && "$status" -ne 0 ]]; then
+    echo "FAIL: compatibility check rejected successful gate and v2 result" >&2
+    exit 1
+  elif [[ ( "$gate_result" != success || "$result" != success ) && "$status" -eq 0 ]]; then
+    echo "FAIL: compatibility check accepted gate '$gate_result' and v2 result '$result'" >&2
+    exit 1
+  fi
+  done
+done
+echo "PASS: compatibility result mirror"
+
+compat_block="$(awk '/^  CLACompatibility:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
+if [[ "$compat_block" == *"github.event_name == 'issue_comment'"* ]]; then
+  echo 'FAIL: compatibility context must not pretend issue-comment checks are PR-head checks' >&2
+  exit 1
+fi
+echo "PASS: compatibility event scope"
+
+# Edited events must reach the signer and compatibility jobs as well as the
+# admission shell. This prevents a skipped old required context after a title
+# or body edit. Keep the assertion narrow to the event clauses, not comments.
+for job in CLAAssistant CLACompatibility; do
+  job_block="$(awk -v job="$job" '$0 == "  " job ":" { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
+  if [[ "$job_block" != *"github.event.action == 'edited'"* ]]; then
+    echo "FAIL: $job does not run for edited pull-request events" >&2
+    exit 1
+  fi
+done
+echo "PASS: edited event job routing"

--- a/tests/test_cla_trigger_gate.sh
+++ b/tests/test_cla_trigger_gate.sh
@@ -20,7 +20,7 @@ grep -Fq "echo \"CLA generation \${CLA_GENERATION}\"" "$WORKFLOW"
 grep -Fq 'name: "CLA ledger writer"' "$WORKFLOW"
 grep -Fq '      issues: write' "$WORKFLOW"
 grep -Fq 'allowlist-ids: "38676809,67667005"' "$WORKFLOW"
-grep -Fq 'cla_passed: ${{ steps.cla_action.outputs.cla_passed }}' "$WORKFLOW"
+grep -Fq "cla_passed: \${{ steps.cla_action.outputs.cla_passed }}" "$WORKFLOW"
 grep -Fq 'CLA_PASSED:' "$WORKFLOW"
 # shellcheck disable=SC2016
 WORKFLOW="$WORKFLOW" ruby -ryaml -e '

--- a/tests/test_cla_trigger_gate.sh
+++ b/tests/test_cla_trigger_gate.sh
@@ -1,299 +1,191 @@
 #!/usr/bin/env bash
-# Exercise the unprivileged CLA trigger admission gate. The shell gate emits a
-# true/false admission result, rejects malformed metadata, and keeps ordinary
-# human comments out of the privileged signer queue.
+# Run the executable admission and result guards from the v3 workflow. These
+# checks cover the event boundary and the failed-check path without granting a
+# test process a GitHub token or pretending that YAML text alone proves it.
 set -euo pipefail
 
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
 test -f "$WORKFLOW"
 
-grep -Fq 'types: [opened,closed,edited,reopened,synchronize]' "$WORKFLOW"
-if rg -n 'changes\.base' "$WORKFLOW" >/dev/null; then
-  echo 'FAIL: edited pull-request events must not require a base-change payload' >&2
+grep -Fq 'name: "CLA Assistant v3"' "$WORKFLOW"
+if grep -Fq 'name: "CLA Assistant v2"' "$WORKFLOW"; then
+  echo 'FAIL: the retired v2 check name remains in the workflow' >&2
+  exit 1
+fi
+generation="$(WORKFLOW="$WORKFLOW" ruby -ryaml -e 'puts YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false).fetch("env").fetch("CLA_GENERATION")')"
+[[ "$generation" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{40}$ ]]
+grep -Fq "name: \"CLA generation $generation\"" "$WORKFLOW"
+grep -Fq "echo \"CLA generation \${CLA_GENERATION}\"" "$WORKFLOW"
+grep -Fq 'name: "CLA ledger writer"' "$WORKFLOW"
+grep -Fq '      issues: write' "$WORKFLOW"
+grep -Fq 'allowlist-ids: "38676809,67667005"' "$WORKFLOW"
+grep -Fq 'cla_passed: ${{ steps.cla_action.outputs.cla_passed }}' "$WORKFLOW"
+grep -Fq 'CLA_PASSED:' "$WORKFLOW"
+# shellcheck disable=SC2016
+WORKFLOW="$WORKFLOW" ruby -ryaml -e '
+  document = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+  expected = "ubuntu-24.04"
+  jobs = %w[CLACommentGate CLALedgerWriter CLAAssistant CLACompatibility RerunFailedCLA LockMergedPullRequest]
+  actual = jobs.to_h { |name| [name, document.fetch("jobs").fetch(name).fetch("runs-on")] }
+  abort "CLA jobs do not use the fixed GitHub-hosted runner" unless actual.values.all? { |runner| runner == expected }
+  gate_group = document.fetch("jobs").fetch("CLACommentGate").fetch("concurrency").fetch("group")
+  expected_gate_group = "cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.run_id }}"
+  abort "CLA admission queue is not event-unique" unless gate_group == expected_gate_group
+  recheck_guard_terms = [
+    "github.event.comment.body == \x27recheck\x27",
+    "github.event.comment.user.id == github.event.issue.user.id",
+    "github.event.comment.author_association == \x27OWNER\x27",
+    "github.event.comment.author_association == \x27MEMBER\x27",
+    "github.event.comment.author_association == \x27COLLABORATOR\x27"
+  ]
+  %w[CLACommentGate CLAAssistant].each do |name|
+    condition = document.fetch("jobs").fetch(name).fetch("if").gsub(/\s+/, " ")
+    abort "#{name} admits untrusted recheck comments" unless
+      recheck_guard_terms.all? { |term| condition.include?(term) }
+  end
+  action_ref = "manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af"
+  action_refs = []
+  walk = lambda do |value|
+    case value
+    when Hash
+      value.each { |key, child| action_refs << child if key == "uses" && child.is_a?(String) && child.start_with?("manaflow-ai/cla-github-action@"); walk.call(child) }
+    when Array
+      value.each { |child| walk.call(child) }
+    end
+  end
+  walk.call(document)
+  abort "CLA workflow uses an unexpected action reference" unless action_refs == [action_ref, action_ref, action_ref]
+'
+grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' "$WORKFLOW"
+grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
+if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
+  echo 'FAIL: the rerun helper may not check out a pull-request revision' >&2
   exit 1
 fi
 
-# The protected ruleset must be migrated to the versioned check context before
-# enforcement. The admission queue is bounded per pull request. Its known
-# case-insensitive replacement behavior is an availability residual; the
-# exact shell check still prevents an invalid comment from reaching signing.
-grep -Fq 'name: "CLA Assistant v2"' "$WORKFLOW"
-grep -Fq 'name: "CLA Assistant"' "$WORKFLOW"
-grep -Fq 'github.event.comment.body == '\''recheck'\''' "$WORKFLOW"
-grep -Fq 'github.event.comment.body == '\''I have read the CLA Document v2.2 and I hereby sign the CLA'\''' "$WORKFLOW"
-grep -Fq 'github.event.comment.user.id == github.event.issue.user.id' "$WORKFLOW"
-grep -Fq "github.event.action == 'created'" "$WORKFLOW"
-grep -Fq 'id: admission' "$WORKFLOW"
-grep -Fq "admitted: \${{ steps.admission.outputs.admitted }}" "$WORKFLOW"
-grep -Fq "allowlist-ids: '38676809,67667005'" "$WORKFLOW"
-grep -Fq 'always() &&' "$WORKFLOW"
-grep -Fq 'cancel-in-progress: false' "$WORKFLOW"
-grep -Fq "group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}" "$WORKFLOW"
-for job in CLACommentGate CLAAssistant CLACompatibility RerunFailedCLA LockMergedPullRequest; do
-  job_block="$(awk -v job="$job" '$0 == "  " job ":" { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-  if [[ "$job_block" != *"    runs-on: \${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}"* ]]; then
-    echo "FAIL: $job must use the configured Linux runner" >&2
-    exit 1
-  fi
-done
-assistant_block="$(awk '/^  CLAAssistant:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$assistant_block" != *$'    if: >-\n      always() &&'* ||
-      "$assistant_block" != *"needs.CLACommentGate.result == 'failure'"* ||
-      "$assistant_block" != *"needs.CLACommentGate.outputs.admitted == 'true'"* ||
-      "$assistant_block" != *'      - name: "Require CLA admission"'* ||
-      "$assistant_block" != *'        if: always()'* ||
-      "$assistant_block" != *"          ADMITTED: \${{ needs.CLACommentGate.outputs.admitted }}"* ]]; then
-  echo 'FAIL: CLA assistant must expose a failed check when admission fails' >&2
-  exit 1
-fi
-success_guard_count="$(grep -Fc '        if: success()' <<<"$assistant_block")"
-if [[ "$success_guard_count" -lt 4 ]]; then
-  echo 'FAIL: privileged CLA steps must require successful admission' >&2
-  exit 1
-fi
-echo "PASS: signer admission failure is visible and privileged steps are guarded"
-gate_group_block="$(awk '/^  CLACommentGate:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$gate_group_block" != *$'\n    concurrency:'* ||
-      "$gate_group_block" != *"group: cla-admission-\${{ github.repository }}-\${{ github.event_name }}-\${{ github.event.issue.number || github.event.pull_request.number }}"* ||
-      "$gate_group_block" != *$'cancel-in-progress: false'* ]]; then
-  echo 'FAIL: CLA admission gate must use a bounded per-PR non-canceling queue' >&2
-  exit 1
-fi
-if [[ "$gate_group_block" != *"github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'"* ||
-      "$gate_group_block" != *"github.event.comment.body == 'recheck'"* ]]; then
-  echo 'FAIL: the job-level gate must keep ordinary comments out of the admission queue' >&2
-  exit 1
-fi
-assistant_group_block="$(awk '/^  CLAAssistant:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$assistant_group_block" != *"group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}"* ]]; then
-  echo 'FAIL: signer concurrency must serialize all events for one pull request' >&2
-  exit 1
-fi
-if rg -n -- '--paginate|--slurp' "$WORKFLOW" >/dev/null; then
-  echo 'FAIL: CLA rerun queries must use explicit bounded pages' >&2
-  exit 1
-fi
-grep -Fq "path-to-signatures: 'signatures/version2/cla.json'" "$WORKFLOW"
+workflow_types='types: [opened,closed,edited,reopened,synchronize,ready_for_review]'
+grep -Fq "$workflow_types" "$WORKFLOW"
 grep -Fq "github.event.comment.body == 'recheck'" "$WORKFLOW"
 grep -Fq "github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'" "$WORKFLOW"
+grep -Fq "group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}" "$WORKFLOW"
+
 work="$(mktemp -d)"
 trap 'rm -rf "$work"' EXIT
-gate_script="$work/gate.sh"
 
-awk '
-  /^  CLACommentGate:/ { in_job=1; next }
-  in_job && /^  [A-Za-z0-9_]+:/ { exit }
-  in_job && /^        run: \|$/ { in_run=1; next }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$gate_script"
-bash -n "$gate_script"
+extract_run() {
+  local job="$1" marker="$2" output="$3"
+  awk -v job="$job" -v marker="$marker" '
+    $0 == "  " job ":" { in_job=1; next }
+    in_job && /^  [A-Za-z0-9_]+:/ { exit }
+    in_job && index($0, marker) { target_step=1; next }
+    in_run && /^      - name:/ { exit }
+    target_step && /^        run: \|$/ { in_run=1; next }
+    in_run { sub(/^          /, ""); print }
+  ' "$WORKFLOW" >"$output"
+  test -s "$output"
+  bash -n "$output"
+}
 
-admission_script="$work/admission.sh"
-awk '
-  /^      - name: "Require CLA admission"/ { found=1; next }
-  found && /^        run: \|$/ { in_run=1; next }
-  found && in_run && /^      - name:/ { exit }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$admission_script"
-bash -n "$admission_script"
-for gate_result in success failure skipped; do
-  admitted=true
-  [[ "$gate_result" == success ]] || admitted=false
-  set +e
-  output="$(GATE_RESULT="$gate_result" ADMITTED="$admitted" bash "$admission_script" 2>&1)"
-  status=$?
-  set -e
-  if [[ "$gate_result" == success && "$status" -ne 0 ]]; then
-    echo "FAIL: admission guard rejected successful gate result" >&2
-    exit 1
-  elif [[ "$gate_result" != success && "$status" -eq 0 ]]; then
-    echo "FAIL: admission guard accepted gate result '$gate_result'" >&2
-    exit 1
-  fi
-done
-set +e
-output="$(GATE_RESULT=success ADMITTED=false bash "$admission_script" 2>&1)"
-status=$?
-set -e
-if [[ "$status" -eq 0 || "$output" != *"admitted: false"* ]]; then
-  echo 'FAIL: admission guard accepted a false admission output' >&2
-  exit 1
-fi
-echo "PASS: admission result guard"
+extract_run CLACommentGate 'id: admission' "$work/admission.sh"
 
-run_case() {
-  local mode="$1"
-  local expected_status="$2"
-  local expected_text="$3"
-  local expected_admitted="$4"
-  local event_name=issue_comment
-  local event_action=created
-  local comment_body=recheck
-  local comment_author_id=300
-  local comment_author_login=contributor
-  local pr_author_id=300
-  local comment_author_type=User
-  local comment_author_association=NONE
-  local output status output_file actual_admitted
-  output_file="$work/output-$mode"
+run_gate() {
+  local name="$1" expected_status="$2" expected_output="$3"
+  shift 3
+  local output_file="$work/gate-$name.out" output status
   rm -f "$output_file"
-  case "$mode" in
-    exact-sign) comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA' ;;
-    non-author-sign) comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'; comment_author_id=301; comment_author_login=reviewer; comment_author_association=MEMBER ;;
-    legacy-sign) comment_body='I have read the CLA Document and I hereby sign the CLA' ;;
-    uppercase-recheck) comment_body=RECHECK ;;
-    padded-sign) comment_body=' I have read the CLA Document v2.2 and I hereby sign the CLA ' ;;
-    wrapped-sign) comment_body='Please sign: I have read the CLA Document v2.2 and I hereby sign the CLA' ;;
-    ordinary-comment) comment_body='Thanks for the review!' ;;
-    untrusted-recheck) comment_author_id=301 ;;
-    trusted-recheck) comment_author_id=301; comment_author_association=MEMBER ;;
-    bot-comment) comment_author_login='github-actions[bot]'; comment_author_type=Bot ;;
-    pull-opened) event_name=pull_request_target; event_action=opened; comment_body='' ;;
-    pull-edited) event_name=pull_request_target; event_action=edited; comment_body='' ;;
-    pull-reopened) event_name=pull_request_target; event_action=reopened; comment_body='' ;;
-    pull-synchronize) event_name=pull_request_target; event_action=synchronize; comment_body='' ;;
-    pull-closed) event_name=pull_request_target; event_action=closed; comment_body='' ;;
-    wrong-event) event_name=push; event_action=; comment_body='' ;;
-  esac
   set +e
   output="$(
     GITHUB_OUTPUT="$output_file" \
-    EVENT_NAME="$event_name" \
-    EVENT_ACTION="$event_action" \
-    COMMENT_BODY="$comment_body" \
-    COMMENT_AUTHOR_ID="$comment_author_id" \
-    COMMENT_AUTHOR_LOGIN="$comment_author_login" \
-    PR_AUTHOR_ID="$pr_author_id" \
-    COMMENT_AUTHOR_TYPE="$comment_author_type" \
-    COMMENT_AUTHOR_ASSOCIATION="$comment_author_association" \
-    bash "$gate_script" 2>&1
+    EVENT_NAME=issue_comment EVENT_ACTION=created \
+    COMMENT_BODY='recheck' COMMENT_AUTHOR_ID=300 COMMENT_AUTHOR_LOGIN=contributor \
+    COMMENT_AUTHOR_TYPE=User PR_AUTHOR_ID=300 COMMENT_AUTHOR_ASSOCIATION=NONE \
+    "$@" bash "$work/admission.sh" 2>&1
   )"
   status=$?
   set -e
   if [[ "$status" != "$expected_status" ]]; then
-    echo "FAIL: $mode exited $status, expected $expected_status" >&2
+    echo "FAIL: gate $name exited $status, expected $expected_status" >&2
     echo "$output" >&2
     exit 1
   fi
-  if [[ -n "$expected_text" && "$output" != *"$expected_text"* ]]; then
-    echo "FAIL: $mode did not report '$expected_text'" >&2
-    echo "$output" >&2
-    exit 1
-  fi
-  if [[ "$expected_admitted" == none ]]; then
-    if [[ -s "$output_file" ]]; then
-      echo "FAIL: $mode unexpectedly wrote an admission result" >&2
+  if [[ "$expected_output" == none ]]; then
+    [[ ! -s "$output_file" ]] || {
+      echo "FAIL: gate $name emitted an admission result" >&2
+      exit 1
+    }
+  else
+    [[ "$(<"$output_file")" == "admitted=$expected_output" ]] || {
+      echo "FAIL: gate $name emitted an unexpected admission result" >&2
       cat "$output_file" >&2
       exit 1
-    fi
-  else
-    if [[ ! -s "$output_file" ]]; then
-      echo "FAIL: $mode did not write admitted=$expected_admitted" >&2
-      exit 1
-    fi
-    actual_admitted="$(<"$output_file")"
-    if [[ "$actual_admitted" != "admitted=$expected_admitted" ]]; then
-      echo "FAIL: $mode wrote '$actual_admitted', expected admitted=$expected_admitted" >&2
-      exit 1
-    fi
+    }
   fi
-  echo "PASS: $mode"
+  echo "PASS: gate $name"
 }
 
-run_case exact-recheck 0 "" true
-run_case exact-sign 0 "" true
-run_case non-author-sign 0 "" false
-run_case legacy-sign 0 "" false
-run_case uppercase-recheck 0 "" false
-run_case untrusted-recheck 0 "" false
-run_case trusted-recheck 0 "" true
-run_case bot-comment 1 "Bot" none
-run_case padded-sign 0 "" false
-run_case wrapped-sign 0 "" false
-run_case ordinary-comment 0 "" false
-run_case pull-opened 0 "" true
-run_case pull-edited 0 "" true
-run_case pull-reopened 0 "" true
-run_case pull-synchronize 0 "" true
-run_case pull-closed 1 "accepted CLA trigger" none
-run_case wrong-event 1 "accepted CLA trigger" none
+# The gate admits a syntactically valid declaration before the maintained
+# action authenticates the signer. This keeps the write-capable job from
+# duplicating identity policy while still exposing unauthorized signers as a
+# failed preflight result.
+run_gate exact-recheck 0 true
+run_gate unauthorized-recheck 0 false env COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=reviewer COMMENT_AUTHOR_ASSOCIATION=NONE
+run_gate member-recheck 0 true env COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=maintainer COMMENT_AUTHOR_ASSOCIATION=MEMBER
+run_gate exact-sign 0 true env COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA'
+run_gate non-author-sign 0 true env COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA' COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=reviewer COMMENT_AUTHOR_ASSOCIATION=MEMBER
+run_gate ordinary-comment 0 false env COMMENT_BODY='Thanks for the review!'
+run_gate padded-comment 0 false env COMMENT_BODY=' recheck'
+run_gate uppercase-comment 0 false env COMMENT_BODY=RECHECK
+run_gate bot-comment 1 none env COMMENT_AUTHOR_TYPE=Bot COMMENT_AUTHOR_LOGIN='github-actions[bot]'
 
-# Missing runner metadata is an infrastructure/malformed-event failure, not a
-# false admission. The gate must fail closed before a privileged dependency.
-set +e
-output="$(
-  GITHUB_OUTPUT="$work/output-missing-author" \
-  EVENT_NAME=issue_comment EVENT_ACTION=created COMMENT_BODY='ordinary' \
-  COMMENT_AUTHOR_LOGIN=contributor PR_AUTHOR_ID=300 COMMENT_AUTHOR_TYPE=User \
-  COMMENT_AUTHOR_ASSOCIATION=NONE bash -u "$gate_script" 2>&1
-)"
-status=$?
-set -e
-if [[ "$status" -eq 0 || "$output" != *"metadata is incomplete"* ]]; then
-  echo 'FAIL: missing comment metadata did not fail closed' >&2
-  echo "$output" >&2
-  exit 1
-fi
-set +e
-output="$(
-  env -u GITHUB_OUTPUT \
-  EVENT_NAME=issue_comment EVENT_ACTION=created COMMENT_BODY=ordinary \
-  COMMENT_AUTHOR_ID=300 COMMENT_AUTHOR_LOGIN=contributor PR_AUTHOR_ID=300 \
-  COMMENT_AUTHOR_TYPE=User COMMENT_AUTHOR_ASSOCIATION=NONE bash -u "$gate_script" 2>&1
-)"
-status=$?
-set -e
-if [[ "$status" -eq 0 || "$output" != *"GITHUB_OUTPUT is unavailable"* ]]; then
-  echo 'FAIL: missing GITHUB_OUTPUT did not fail closed' >&2
-  echo "$output" >&2
-  exit 1
-fi
-echo "PASS: malformed and infrastructure admission failures"
+for action in opened edited reopened synchronize ready_for_review; do
+  run_gate "pull-$action" 0 true env EVENT_NAME=pull_request_target EVENT_ACTION="$action" COMMENT_BODY=''
+done
+run_gate pull-closed 1 none env EVENT_NAME=pull_request_target EVENT_ACTION=closed COMMENT_BODY=''
 
-# The compatibility check must fail closed when the v2 action fails or is
-# skipped. A skipped dependency must never become a successful old required
-# context during migration.
-compat_script="$work/compatibility.sh"
-awk '
-  /^  CLACompatibility:/ { in_job=1; next }
-  in_job && /^  [A-Za-z0-9_]+:/ { exit }
-  in_job && /^        run: \|$/ { in_run=1; next }
-  in_run { sub(/^          /, ""); print }
-' "$WORKFLOW" >"$compat_script"
-bash -n "$compat_script"
-for gate_result in success failure skipped; do
-  for result in success failure skipped; do
+extract_run CLAAssistant "CLA generation $generation" "$work/assistant.sh"
+CLA_GENERATION="$generation"
+export CLA_GENERATION
+run_result() {
+  local name="$1" expected_status="$2" event_name="$3" comment_body="$4" gate_result="$5" admitted="$6" signer="$7" writer="$8" cla_passed="$9"
+  local output status
   set +e
-  GATE_RESULT="$gate_result" V2_RESULT="$result" bash "$compat_script" >/dev/null 2>&1
+  output="$(
+    EVENT_NAME="$event_name" COMMENT_BODY="$comment_body" GATE_RESULT="$gate_result" \
+    ADMITTED="$admitted" SIGNER_AUTHORIZED="$signer" WRITER_RESULT="$writer" \
+    CLA_PASSED="$cla_passed" \
+    CLA_GENERATION="$CLA_GENERATION" bash "$work/assistant.sh" 2>&1
+  )"
   status=$?
   set -e
-  if [[ "$gate_result" == success && "$result" == success && "$status" -ne 0 ]]; then
-    echo "FAIL: compatibility check rejected successful gate and v2 result" >&2
-    exit 1
-  elif [[ ( "$gate_result" != success || "$result" != success ) && "$status" -eq 0 ]]; then
-    echo "FAIL: compatibility check accepted gate '$gate_result' and v2 result '$result'" >&2
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: assistant $name exited $status, expected $expected_status" >&2
+    echo "$output" >&2
     exit 1
   fi
-  done
-done
-echo "PASS: compatibility result mirror"
+  echo "PASS: assistant $name"
+}
+run_result lifecycle-success 0 pull_request_target '' success true false success true
+run_result recheck-success 0 issue_comment recheck success true false success true
+run_result signing-success 0 issue_comment 'I have read the CLA Document v2.2 and I hereby sign the CLA' success true true success true
+run_result policy-failure 1 issue_comment recheck success true false success false
+run_result missing-policy-result 1 issue_comment recheck success true false success ''
+run_result unauthorized-sign 1 issue_comment 'I have read the CLA Document v2.2 and I hereby sign the CLA' success true false success false
+run_result writer-failure 1 issue_comment recheck success true false failure false
+run_result gate-failure 1 issue_comment recheck failure false false skipped false
 
-compat_block="$(awk '/^  CLACompatibility:/ { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-if [[ "$compat_block" == *"github.event_name == 'issue_comment'"* ]]; then
-  echo 'FAIL: compatibility context must not pretend issue-comment checks are PR-head checks' >&2
-  exit 1
-fi
-echo "PASS: compatibility event scope"
-
-# Edited events must reach the signer and compatibility jobs as well as the
-# admission shell. This prevents a skipped old required context after a title
-# or body edit. Keep the assertion narrow to the event clauses, not comments.
-for job in CLAAssistant CLACompatibility; do
-  job_block="$(awk -v job="$job" '$0 == "  " job ":" { in_job=1; next } in_job && /^  [A-Za-z0-9_]+:/ { exit } in_job { print }' "$WORKFLOW")"
-  if [[ "$job_block" != *"github.event.action == 'edited'"* ]]; then
-    echo "FAIL: $job does not run for edited pull-request events" >&2
+extract_run CLACompatibility 'Mirror CLA Assistant compatibility result' "$work/compatibility.sh"
+for result in success failure skipped; do
+  set +e
+  RESULT="$result" bash "$work/compatibility.sh" >/dev/null 2>&1
+  status=$?
+  set -e
+  if [[ "$result" == success && "$status" -ne 0 ]] ||
+     [[ "$result" != success && "$status" -eq 0 ]]; then
+    echo "FAIL: compatibility mirror returned $status for $result" >&2
     exit 1
   fi
 done
-echo "PASS: edited event job routing"
+echo 'PASS: compatibility result mirror'
+
+echo 'PASS: CLA v3 trigger and result guards'


### PR DESCRIPTION
Superseded by [#11608](https://github.com/manaflow-ai/cmux/pull/11608). The policy guard and privileged policy must land in separate pull requests so the base-controlled guard can protect the policy change. This PR is retained only for traceability and will be closed after the replacement is ready.