### PR TITLE
ci: pin CLA Assistant to the stale-base-SHA fix

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         id: cla
-        uses: manaflow-ai/cla-github-action@0a9c9e3d32ae5cc8adef9c93f303924ee77492e4
+        uses: manaflow-ai/cla-github-action@72bff98aa0f3824cb519baaeaa68d044c970c377
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
The action rejected every reopened pull request with "payload does not match the live Pull Request identity" because the event payload carried a base SHA older than the live one. https://github.com/manaflow-ai/cla-github-action/pull/14 drops that comparison. Pin bump only.

https://claude.ai/code/session_019AS5qLDrLFuaJo6zxaZbCk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins the CLA Assistant action to the stale-base-SHA fix so reopened pull requests are no longer rejected.

The action previously rejected every reopened pull request with "payload does not match the live Pull Request identity" because the event payload carried a base SHA older than the live one. `manaflow-ai/cla-github-action#14` drops that comparison.

<sup>Written for commit de4ebcfe56064b9a798b5ef5105c7c57f4059a02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

