### PR TITLE
fix(cmux-tui): compact active screen index after parse filtering

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -684,6 +684,30 @@ mod tests {
         assert_eq!(pane.active_tab, 1);
     }
 
+    #[test]
+    fn parser_reindexes_active_screen_after_dropping_malformed_screens() {
+        let tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [
+                    {"active": false},
+                    {
+                        "id": 2,
+                        "active": true,
+                        "active_pane": 3,
+                        "layout": {"type": "leaf", "pane": 3},
+                        "panes": []
+                    }
+                ]
+            }]
+        }));
+
+        assert_eq!(tree.workspaces[0].screens.len(), 1);
+        assert_eq!(tree.workspaces[0].active_screen, 0);
+        assert_eq!(tree.active_screen().map(|screen| screen.id), Some(2));
+    }
+
     fn tree_with_tabs(active_tab: usize, surfaces: &[SurfaceId]) -> TreeView {
         let tabs = surfaces
             .iter()

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -621,11 +621,12 @@ pub(super) fn parse_tree_with_capabilities(
             active_screen: 0,
         };
         if let Some(screens) = ws.get("screens").and_then(|v| v.as_array()) {
-            for (s, screen) in screens.iter().enumerate() {
-                if screen.get("active").and_then(|v| v.as_bool()) == Some(true) {
-                    view.active_screen = s;
-                }
+            for screen in screens {
                 if let Some(parsed) = parse_screen(screen, capabilities) {
+                    let parsed_index = view.screens.len();
+                    if screen.get("active").and_then(|v| v.as_bool()) == Some(true) {
+                        view.active_screen = parsed_index;
+                    }
                     view.screens.push(parsed);
                 }
             }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -436,6 +436,8 @@ fn parse_layout(value: &Value) -> Option<Node> {
 }
 
 fn parse_pane(value: &Value) -> Option<PaneView> {
+    let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let mut active_tab = raw_active_tab;
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
         resource_id: value
@@ -444,15 +446,16 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
             .and_then(|value| PanePublicId::parse(value.to_string()).ok()),
         short_id: value.get("short_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
         name: value.get("name").and_then(|v| v.as_str()).map(|s| s.to_string()),
-        active_tab: value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
         focused_at: value.get("focused_at").and_then(|v| v.as_u64()).unwrap_or(0),
         tabs: value
             .get("tabs")
             .and_then(|v| v.as_array())
             .map(|tabs| {
+                let mut compact_index = 0;
                 tabs.iter()
-                    .filter_map(|tab| {
-                        Some(TabView {
+                    .enumerate()
+                    .filter_map(|(raw_index, tab)| {
+                        let parsed = Some(TabView {
                             surface: tab.get("surface")?.as_u64()?,
                             public_id: tab
                                 .get("tab_resource_id")
@@ -504,11 +507,17 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                                 .and_then(Value::as_bool)
                                 .unwrap_or(false),
                             notification: tab.get("notification").and_then(parse_notification),
-                        })
+                        })?;
+                        if raw_index == raw_active_tab {
+                            active_tab = compact_index;
+                        }
+                        compact_index += 1;
+                        Some(parsed)
                     })
                     .collect()
             })
             .unwrap_or_default(),
+        active_tab,
     })
 }
 

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -979,6 +979,23 @@ mod tests {
     }
 
     #[test]
+    fn pane_parser_reindexes_active_tab_after_dropping_malformed_tabs() {
+        let pane = parse_pane(&json!({
+            "id": 3,
+            "active_tab": 1,
+            "tabs": [
+                {"title": "malformed"},
+                {"surface": 5, "title": "active"}
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(pane.tabs.len(), 1);
+        assert_eq!(pane.active_tab, 0);
+        assert_eq!(pane.active_surface(), Some(5));
+    }
+
+    #[test]
     fn tree_parser_defaults_and_preserves_pane_revision() {
         assert_eq!(parse_tree(&json!({"workspaces": []})).pane_revision, None);
         assert_eq!(


### PR DESCRIPTION
## Summary
- preserve the active screen selection when malformed screens are skipped
- add a regression test covering a malformed screen before the active screen

## Verification
- `rustfmt --edition 2024 cmux-tui/crates/cmux-tui/src/session/tree.rs`
- `git diff --check`
- Cargo tests were not run locally per cmux-tui policy; hosted verification is required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps active screen and tab selections aligned after parsing drops malformed entries. Previously raw indices could point past valid entries; now they use compacted parsed positions.

- Adds regression coverage for malformed entries before the active screen and tab.

<sup>Written for commit fc55b32af82725db616409fd6c179f33829b485a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected active tab and screen tracking when malformed entries are omitted.
  * Prevented invalid focus restoration and access when no valid active tab exists.
  * Improved tab and screen navigation when active indices are stale or invalid.
  * Updated the tab bar to handle empty tabs and out-of-range active selections safely.

* **Tests**
  * Added coverage for reindexing, fail-closed behavior, and preservation of inactive-state indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->