### PR TITLE
ci: pin CLA Assistant to the whitespace fix and admit comments by substring

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,14 +18,17 @@ permissions: {}
 jobs:
   CLAAssistant:
     name: "CLA Assistant"
+    # Comment admission is a coarse filter: GitHub appends CRLF to plain
+    # comments, so equality would drop real declarations. The action does the
+    # exact match itself and ignores anything else.
     if: >-
       github.event_name == 'pull_request_target' ||
       (
         github.event.issue.pull_request &&
         github.event.comment.user.type == 'User' &&
         (
-          github.event.comment.body == 'recheck' ||
-          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+          contains(github.event.comment.body, 'recheck') ||
+          contains(github.event.comment.body, 'I have read the CLA Document v2.2 and I hereby sign the CLA')
         )
       )
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
@@ -47,7 +50,7 @@ jobs:
     steps:
       - name: "CLA Assistant"
         id: cla
-        uses: manaflow-ai/cla-github-action@72bff98aa0f3824cb519baaeaa68d044c970c377
+        uses: manaflow-ai/cla-github-action@f567430d44e22bc0bb6ecd1e00d383ef22886025
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
GitHub appends CRLF to plain comments, so the equality test on the comment body dropped both signing declarations and recheck requests (theswerd's declaration on https://github.com/manaflow-ai/cmux/pull/11590 was never recorded). https://github.com/manaflow-ai/cla-github-action/pull/15 trims the declaration before its exact match; the workflow now admits comments by substring and lets the action do the exact match.

https://claude.ai/code/session_019AS5qLDrLFuaJo6zxaZbCk

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CLA Assistant workflow so signing declarations and recheck requests are no longer dropped when GitHub appends CRLF to plain comments.

The workflow previously matched the comment body exactly; it now admits comments by substring and pins the CLA Assistant action to a version that trims whitespace before its exact match.

<sup>Written for commit 9807eec5e3c3583125df1f466f3002e34ece11ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

