### PR TITLE
perf: use indexed workspace lookup for task retirement

### DIFF
--- a/Sources/AppDelegate+RecoverableMainWindowRoutes.swift
+++ b/Sources/AppDelegate+RecoverableMainWindowRoutes.swift
@@ -651,4 +651,13 @@ extension AppDelegate {
         }
         return result
     }
+
+    /// Returns one workspace by identity without enumerating every live tab.
+    /// Feed uses this after its ownership index narrows a task event to a
+    /// small candidate set.
+    @MainActor
+    func workspaceForAgentTodoRetirement(id: UUID) -> Workspace? {
+        guard let manager = tabManagerFor(tabId: id) else { return nil }
+        return manager.tabs.first { $0.id == id }
+    }
 }

--- a/Sources/Feed/FeedCoordinator+AgentTodos.swift
+++ b/Sources/Feed/FeedCoordinator+AgentTodos.swift
@@ -125,12 +125,8 @@ extension FeedCoordinator {
             canonicalWorkstreamID: workstreamId,
             source: source
         )
-        let workspacesByID = Dictionary(
-            app.allWorkspacesForAgentTodoRetirement.map { ($0.id, $0) },
-            uniquingKeysWith: { first, _ in first }
-        )
         for candidateID in candidateIDs where candidateID != workspaceID {
-            guard let workspace = workspacesByID[candidateID] else { continue }
+            guard let workspace = app.workspaceForAgentTodoRetirement(id: candidateID) else { continue }
             var matchingWorkstreamIDs = Set<String>()
             for checklistItem in workspace.todoState.checklist {
                 guard let rawWorkstreamID = checklistItem.agentTaskRef?.workstreamId,

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -12,6 +12,26 @@ import CmuxWorkspaces
 
 @Suite("Feed coordinator", .serialized)
 struct FeedCoordinatorTests {
+    @MainActor
+    @Test("Agent todo retirement looks up only the requested workspace")
+    func agentTodoRetirementUsesDirectWorkspaceLookup() {
+        let previousAppDelegate = AppDelegate.shared
+        let appDelegate = AppDelegate()
+        let manager = TabManager(autoWelcomeIfNeeded: false)
+        AppDelegate.shared = appDelegate
+        appDelegate.tabManager = manager
+        appDelegate.didAttemptStartupSessionRestore = true
+        let workspace = manager.addWorkspace(title: "Indexed owner", select: true)
+        defer {
+            manager.tabs.forEach { $0.teardownAllPanels() }
+            appDelegate.tabManager = nil
+            AppDelegate.shared = previousAppDelegate
+        }
+
+        #expect(appDelegate.workspaceForAgentTodoRetirement(id: workspace.id)?.id == workspace.id)
+        #expect(appDelegate.workspaceForAgentTodoRetirement(id: UUID()) == nil)
+    }
+
     @Test("Workspace-only blocking events retain their session surface")
     func workspaceOnlyAttentionUsesSessionSurface() {
         let workspaceID = UUID()


### PR DESCRIPTION
## Summary

Fixes the remaining O(workspaces) path in #11510 task retirement. The ownership index already narrows a task event to candidate workspace IDs, but retirement rebuilt a dictionary by enumerating every live workspace on each event. The new route resolves each candidate UUID directly through `tabManagerFor`.

## Regression coverage

The first commit adds a behavior test for direct workspace lookup. The second commit adds the route helper and switches retirement to use it.

## Verification

- `swiftc -frontend -parse -parse-as-library` for changed Swift files
- `git diff --check`
- No local Xcode tests or builds

Stacked on #11510.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches agent todo retirement from scanning every live workspace to resolving candidate workspace IDs directly, so task events no longer rebuild a dictionary of all workspaces. Adds a route helper for single-workspace lookup and a behavior test for existing and missing workspaces.

<sup>Written for commit 0fc77d3d2cea415344073f836067a654e844310e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11599?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

