### PR TITLE
Plus menu: one New Cloud VM item that opens the New Machine sheet

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -65711,23 +65711,6 @@
         }
       }
     },
-    "command.cloudVM.advanced.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Advanced"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "詳細"
-          }
-        }
-      }
-    },
     "command.cloudVM.current.missing.message": {
       "extractionState": "manual",
       "localizations": {
@@ -65996,6 +65979,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "エージェントハンドオフ"
+          }
+        }
+      }
+    },
+    "command.cloudVM.new.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Cloud VM"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しい Cloud VM"
           }
         }
       }

--- a/Sources/Update/TitlebarCloudVMButton.swift
+++ b/Sources/Update/TitlebarCloudVMButton.swift
@@ -386,26 +386,11 @@ struct TitlebarCloudVMButton: View {
     @MainActor
     static func appendCloudVMMenuItems(to menu: NSMenu) {
         menu.addItem(mouseDownMenuItem(
-            title: String(localized: "command.cloudVM.open.title", defaultValue: "Open Base"),
+            title: String(localized: "command.cloudVM.new.title", defaultValue: "New Cloud VM"),
             action: {
-                CloudVMMenuTarget.shared.open()
+                CloudVMMenuTarget.shared.newMachine()
             }
         ))
-        menu.addItem(NSMenuItem.separator())
-        menu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.fork.title", defaultValue: "Fork Cloud VM"),
-            action: #selector(CloudVMMenuTarget.fork)
-        ))
-        menu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.snapshot.title", defaultValue: "Checkpoint Cloud VM"),
-            action: #selector(CloudVMMenuTarget.snapshot)
-        ))
-        menu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.restore.title", defaultValue: "Restore Checkpoint..."),
-            action: #selector(CloudVMMenuTarget.restore)
-        ))
-        menu.addItem(NSMenuItem.separator())
-        menu.addItem(advancedMenuItem())
     }
 
     private static func menuItem(title: String, action: Selector) -> NSMenuItem {
@@ -415,40 +400,8 @@ struct TitlebarCloudVMButton: View {
     }
 
     private static func mouseDownMenuItem(title: String, action: @escaping () -> Void) -> NSMenuItem {
-        let item = menuItem(title: title, action: #selector(CloudVMMenuTarget.open))
+        let item = menuItem(title: title, action: #selector(CloudVMMenuTarget.newMachine))
         item.view = MouseDownMenuItemView(title: title, action: action)
-        return item
-    }
-
-    private static func advancedMenuItem() -> NSMenuItem {
-        let item = NSMenuItem(
-            title: String(localized: "command.cloudVM.advanced.title", defaultValue: "Advanced"),
-            action: nil,
-            keyEquivalent: ""
-        )
-        let submenu = NSMenu()
-        submenu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.status.title", defaultValue: "Status"),
-            action: #selector(CloudVMMenuTarget.status)
-        ))
-        submenu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.ports.title", defaultValue: "Ports"),
-            action: #selector(CloudVMMenuTarget.ports)
-        ))
-        submenu.addItem(NSMenuItem.separator())
-        submenu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.promoteTemplate.title", defaultValue: "Promote to Template"),
-            action: #selector(CloudVMMenuTarget.promoteTemplate)
-        ))
-        submenu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.tools.title", defaultValue: "Inspect Tools"),
-            action: #selector(CloudVMMenuTarget.tools)
-        ))
-        submenu.addItem(menuItem(
-            title: String(localized: "command.cloudVM.handoff.title", defaultValue: "Agent Handoff"),
-            action: #selector(CloudVMMenuTarget.handoff)
-        ))
-        item.submenu = submenu
         return item
     }
 }
@@ -457,39 +410,11 @@ struct TitlebarCloudVMButton: View {
 private final class CloudVMMenuTarget: NSObject {
     static let shared = CloudVMMenuTarget()
 
-    @objc func open() {
-        _ = AppDelegate.shared?.performCloudVMAction(debugSource: "titlebar.cloudVM.menu.open")
-    }
-
-    @objc func fork() {
-        _ = AppDelegate.shared?.performCurrentCloudVMCommand(.fork, debugSource: "titlebar.cloudVM.menu.fork")
-    }
-
-    @objc func snapshot() {
-        _ = AppDelegate.shared?.performCurrentCloudVMCommand(.snapshot, debugSource: "titlebar.cloudVM.menu.snapshot")
-    }
-
-    @objc func restore() {
-        _ = AppDelegate.shared?.performCloudVMRestoreCommand(debugSource: "titlebar.cloudVM.menu.restore")
-    }
-
-    @objc func promoteTemplate() {
-        _ = AppDelegate.shared?.performCurrentCloudVMCommand(.promoteTemplate, debugSource: "titlebar.cloudVM.menu.promoteTemplate")
-    }
-
-    @objc func status() {
-        _ = AppDelegate.shared?.performCurrentCloudVMCommand(.status, debugSource: "titlebar.cloudVM.menu.status")
-    }
-
-    @objc func ports() {
-        _ = AppDelegate.shared?.performCurrentCloudVMCommand(.ports, debugSource: "titlebar.cloudVM.menu.ports")
-    }
-
-    @objc func tools() {
-        _ = AppDelegate.shared?.performCurrentCloudVMCommand(.tools, debugSource: "titlebar.cloudVM.menu.tools")
-    }
-
-    @objc func handoff() {
-        _ = AppDelegate.shared?.performCurrentCloudVMCommand(.handoff, debugSource: "titlebar.cloudVM.menu.handoff")
+    /// Same path as the Machines panel ＋ button and the command palette: the
+    /// New Machine sheet, with the plan meter read from the fleet page first.
+    @objc func newMachine() {
+        NewMachineSheetPresenter.shared.presentNewMachineFetchingPlan(
+            preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow
+        )
     }
 }

--- a/cmuxTests/CmuxConfigNewWorkspaceMenuTests.swift
+++ b/cmuxTests/CmuxConfigNewWorkspaceMenuTests.swift
@@ -167,7 +167,7 @@ struct CmuxConfigNewWorkspaceMenuTests {
             ))
             #expect(!store.newWorkspaceContextMenuIsConfigured)
             #expect(store.newWorkspaceMenuSectionOrder == .cloudFirst)
-            let cloudOpenTitle = String(localized: "command.cloudVM.open.title", defaultValue: "Open Base")
+            let cloudOpenTitle = String(localized: "command.cloudVM.new.title", defaultValue: "New Cloud VM")
             let cloudOpenIndex = try #require(menu.items.firstIndex { item in
                 !item.isSeparatorItem && item.title == cloudOpenTitle
             })


### PR DESCRIPTION
The ＋ dropdown (and the cloud button right-click menu, which shares the same builder) listed Open Cloud VM, Fork, Checkpoint, Restore, and an Advanced submenu. It now shows a single "New Cloud VM" row that runs `NewMachineSheetPresenter.presentNewMachineFetchingPlan`, the same path as the Machines panel ＋ button and the command palette.

The per-VM commands (fork, checkpoint, restore, status, ports, promote, tools, handoff) remain in the command palette. The unused `command.cloudVM.advanced.title` string is removed; `command.cloudVM.new.title` is added in English and Japanese.

https://claude.ai/code/session_012DskPjbscqPLLLDEnz1WBS

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11603"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790927530&installation_model_id=21920&pr_number=11603&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11603&signature=7de05e72d17d674553f34abaeb02b54e328ccd99645d81935e53eba55b6b2863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The ＋ dropdown and cloud button right-click menu now show a single "New Cloud VM" item instead of the Open, Fork, Checkpoint, Restore, and Advanced submenu entries. Selecting it opens the New Machine sheet via the same `NewMachineSheetPresenter` path used by the Machines panel ＋ button and command palette.

Per-VM commands (fork, checkpoint, restore, status, ports, promote, tools, handoff) remain available in the command palette, and the Advanced menu state for the cloud button is removed along with its unused `command.cloudVM.advanced.title` string. Adds the `command.cloudVM.new.title` string in English and Japanese.

<sup>Written for commit b0d51f1a2e135ee36a87f55b0e15c648a2c96366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11603?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

