### PR TITLE
fix: roll back failed explicit task creates

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/Workstream/WorkstreamTaskToolTodos.swift
@@ -461,13 +461,15 @@ struct WorkstreamTaskToolTodos: Sendable {
         let response = object(from: responseJSON)
         let result = (response?["task"] as? [String: Any]) ?? response
         if isError || response?["success"] as? Bool == false {
-            if tool == .taskCreate,
-               let subject = content(in: input),
-               let provisional = popProvisionalID(for: subject) {
-                todos.removeAll { $0.id == provisional }
-                unclaim(provisional)
-                provisionalIDsInOrder.removeAll { $0 == provisional }
-                return .list(todos)
+            if tool == .taskCreate {
+                let failedID = taskID(in: input)
+                    ?? content(in: input).flatMap { popProvisionalID(for: $0) }
+                if let failedID {
+                    todos.removeAll { $0.id == failedID }
+                    unclaim(failedID)
+                    provisionalIDsInOrder.removeAll { $0 == failedID }
+                    return .list(todos)
+                }
             }
             return .ignored
         }

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamTaskToolTodoTests.swift
@@ -158,6 +158,28 @@ struct WorkstreamTaskToolTodoTests {
         #expect(store.ownedTaskIds(forWorkstream: "s1").isEmpty)
     }
 
+    @Test("A failed create with an explicit id retires its claimed row")
+    func failedExplicitIDCreateRemovesClaimedRow() {
+        let store = WorkstreamStore(ringCapacity: 50)
+        store.ingest(toolEvent(
+            sessionId: "s-explicit",
+            tool: "TaskCreate",
+            input: #"{"id":"explicit-1","subject":"will fail"}"#,
+            requestId: "create-explicit"
+        ))
+        store.ingest(toolEvent(
+            sessionId: "s-explicit",
+            hook: .postToolUse,
+            tool: "TaskCreate",
+            input: #"{"id":"explicit-1","subject":"will fail"}"#,
+            response: #"{"error":"denied"}"#,
+            requestId: "create-explicit",
+            isError: true
+        ))
+        #expect(latestTodos(store)?.isEmpty == true)
+        #expect(store.ownedTaskIds(forWorkstream: "s-explicit").isEmpty)
+    }
+
     @Test("Late PreToolUse does not duplicate an authoritative create")
     func postThenPreCreateIsDeduplicated() {
         let store = WorkstreamStore(ringCapacity: 50)


### PR DESCRIPTION
Fixes a task lifecycle hole in #11510. A pre-tool TaskCreate with an explicit id claims a checklist row, but failed post-tool handling only removed provisional ids. The failed explicit task remained visible and owned.

Test-first commits cover the failure and remove the claimed explicit row. Verification: Swift frontend parse and git diff --check. No local Xcode tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11604"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790927563&installation_model_id=21920&pr_number=11604&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11604&signature=6f05b297ba4de7e51a4a7907f431e780db732979fae8cf92851dc94bffeee4c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rolls back failed `TaskCreate` calls that specify an explicit id, so their claimed checklist rows no longer remain visible and owned. Previously, post-tool error handling only removed provisional ids, leaving the failed explicit task in the checklist.

<sup>Written for commit d3f806abcb066ba760f1491a1ea37dc94b1484d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

