### PR TITLE
security: migrate CLA Assistant to guarded v3

### DIFF
--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -186,8 +186,18 @@ jq -e \
    (.user.id | tostring) == $author_id and
    .user.login == $author_login and
    .user.type == $author_type and
+   (.author_association | type == "string") and
    .created_at == $created_at and
    .updated_at == $created_at' <<<"${comment_json}" >/dev/null || fail "The triggering CLA comment was edited, deleted, or moved"
+
+# The event's author_association is a historical snapshot. Re-authorize a
+# privileged recheck from the freshly fetched comment, so a contributor who
+# lost repository access cannot keep using an old trusted event payload.
+current_comment_author_association="$(jq -r '.author_association' <<<"${comment_json}")"
+case "${current_comment_author_association}" in
+  OWNER|MEMBER|COLLABORATOR|CONTRIBUTOR|FIRST_TIME_CONTRIBUTOR|FIRST_TIMER|NONE) ;;
+  *) fail "The triggering comment author association is invalid" ;;
+esac
 
 pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
 jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
@@ -228,7 +238,7 @@ fi
 # commenter must be a trusted repository participant, which limits
 # unauthenticated users to the harmless no-op path.
 if [[ "${COMMENT_BODY}" == "recheck" && "${COMMENT_AUTHOR_ID}" != "${pr_author_id}" ]]; then
-  case "${COMMENT_AUTHOR_ASSOCIATION}" in
+  case "${current_comment_author_association}" in
     OWNER|MEMBER|COLLABORATOR) ;;
     *) fail "Only the pull request author or a trusted repository participant may request a CLA rerun" ;;
   esac
@@ -616,13 +626,16 @@ if ! candidate_list_json="$(jq -c \
             run_binds_to_pr
           )
       ]
+      # Recency is the selection contract. Binding mode is only a tie-breaker,
+      # because a newer base-bound fallback is safer to retry than an older
+      # populated association that may belong to a stale workflow generation.
       | sort_by([
+          .created_at,
+          .id,
           if ((.pull_requests | type) == "array" and (.pull_requests | length) > 0) then 3
           elif (.head_repository | type) == "object" and .head_sha == $base_sha then 2
           elif .head_sha == $sha then 1
-          else 0 end,
-          .created_at,
-          .id
+          else 0 end
         ])
     ' <<<"${runs_json}")"; then
   fail "Could not validate CLA workflow run data"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -1,0 +1,1498 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "::error::$1"
+  exit 1
+}
+
+# The job-level expression is the first gate. Repeat it here so a
+# future edit to that expression cannot turn this token into a
+# general-purpose workflow rerunner.
+[[ "${EVENT_NAME}" == "issue_comment" ]] || fail "Unexpected event for CLA rerun"
+[[ "${ISSUE_NUMBER}" =~ ^[1-9][0-9]*$ ]] || fail "Invalid issue number"
+[[ "${PR_NUMBER}" == "${ISSUE_NUMBER}" ]] || fail "Issue and pull request numbers differ"
+[[ "${COMMENT_BODY}" == "recheck" || "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]] || fail "Comment is not an accepted CLA trigger"
+[[ "${COMMENT_CREATED_AT}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]] || fail "Invalid comment timestamp"
+[[ "${COMMENT_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment ID is invalid"
+[[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment author ID is invalid"
+[[ -n "${COMMENT_AUTHOR_LOGIN}" ]] || fail "Comment author is missing"
+[[ "${COMMENT_AUTHOR_LOGIN}" != *$'\n'* && "${COMMENT_AUTHOR_LOGIN}" != *$'\r'* ]] || fail "Comment author is malformed"
+[[ "${COMMENT_AUTHOR_TYPE}" == "User" ]] || fail "Comment author is not a human user"
+case "${COMMENT_AUTHOR_LOGIN,,}" in
+  *"[bot]") fail "Bot comments cannot trigger a CLA rerun" ;;
+esac
+case "${COMMENT_AUTHOR_ASSOCIATION}" in
+  OWNER|MEMBER|COLLABORATOR|CONTRIBUTOR|FIRST_TIME_CONTRIBUTOR|FIRST_TIMER|NONE) ;;
+  *) fail "Comment author association is invalid" ;;
+esac
+case "${SIGNATURE_RECORDED}" in
+  true|false|'') ;;
+  *) fail "The CLA action did not provide a valid signature result" ;;
+esac
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" &&
+      "${SIGNATURE_RECORDED}" != "true" ]]; then
+  fail "The signing comment did not result in a persisted signature"
+fi
+readonly EXPECTED_CLA_GENERATION='v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af'
+[[ "${CLA_GENERATION}" == "${EXPECTED_CLA_GENERATION}" ]] || fail "Unexpected CLA generation marker"
+[[ "${WORKFLOW_SHA}" =~ ^[0-9a-f]{40}$ ]] || fail "Invalid trusted workflow revision"
+checked_out_sha="$(git rev-parse HEAD 2>/dev/null)" || fail "Could not verify the trusted workflow checkout"
+[[ "${checked_out_sha}" == "${WORKFLOW_SHA}" ]] || fail "The checkout is not the immutable workflow revision"
+[[ "${WORKFLOW_PATH}" == ".github/workflows/cla.yml" ]] || fail "Unexpected CLA workflow path"
+[[ -f .github/scripts/rerun-failed-cla.sh ]] || fail "The trusted CLA rerun helper is missing"
+
+# These values are part of the trusted workflow contract. They are deliberately
+# constants, not event or comment input, so a contributor cannot redirect this
+# check to a different ledger.
+readonly SIGNATURES_BRANCH='cla-signatures'
+readonly SIGNATURES_PATH='signatures/version2/cla.json'
+readonly MAX_RUN_PAGES=10
+readonly MAX_CHECK_PAGES=2
+# Keep every GitHub JSON response below a fixed byte budget before it enters a
+# shell variable. GitHub's pagination limits bound item counts, not the size of
+# individual fields, so a response-size guard is still required.
+readonly MAX_API_RESPONSE_BYTES=2000000
+readonly MAX_API_ERROR_BYTES=65536
+readonly MAX_LEDGER_BYTES=1000000
+readonly MAX_LEDGER_SIGNATURES=10000
+# GitHub wraps Contents API Base64 responses with newlines. Allow that
+# transport overhead while bounding the raw field before normalization.
+readonly MAX_LEDGER_RAW_BYTES=2000000
+# These rendered job names are part of the v3 workflow contract. Keep them
+# fixed here so a workflow edit cannot make this actions:write helper rerun an
+# arbitrary failed job. The writer and compatibility jobs are optional failed
+# members because a recheck can target a result-only failure; when either is
+# failed, rerun-failed-jobs refreshes every failed v3 context together.
+readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
+readonly CLA_WRITER_JOB='CLA ledger writer'
+readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
+readonly CLA_COMPATIBILITY_STEP='Mirror CLA Assistant compatibility result'
+readonly CLA_WORKFLOW_NAME='CLA Assistant v3'
+readonly CLA_ACTION_APP_ID=15368
+
+# Capture one byte past the limit in a temporary file. This keeps an oversized
+# response out of shell memory and bounds disk use before command substitution
+# can expose the response to jq. Bound stderr separately because GitHub can
+# include response text in gh diagnostics.
+gh_api_bounded() {
+  local temp_dir body_file response_bytes gh_status head_status cat_status
+  local -a pipeline_status
+  temp_dir="$(mktemp -d)" || return 1
+  body_file="${temp_dir}/body"
+  set +e
+  gh api "$@" 2> >(head -c "${MAX_API_ERROR_BYTES}" >&2) |
+    head -c "$((MAX_API_RESPONSE_BYTES + 1))" >"${body_file}"
+  pipeline_status=("${PIPESTATUS[@]}")
+  set -e
+  gh_status="${pipeline_status[0]:-1}"
+  head_status="${pipeline_status[1]:-1}"
+  response_bytes="$(LC_ALL=C wc -c <"${body_file}" | tr -d '[:space:]')"
+  if [[ ! "${response_bytes}" =~ ^[0-9]+$ ]] || (( response_bytes > MAX_API_RESPONSE_BYTES )); then
+    rm -rf -- "${temp_dir}"
+    return 2
+  fi
+  if (( head_status != 0 )); then
+    rm -rf -- "${temp_dir}"
+    return 1
+  fi
+  cat "${body_file}"
+  cat_status=$?
+  rm -rf -- "${temp_dir}"
+  if (( gh_status != 0 )); then
+    return "${gh_status}"
+  fi
+  return "${cat_status}"
+}
+
+validate_triggering_signature_record() {
+  local ledger_response ledger_content ledger_content_compact ledger_json ledger_raw_bytes ledger_encoded_bytes ledger_decoded_bytes
+  ledger_response="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field ref="${SIGNATURES_BRANCH}" \
+    "repos/${GH_REPO}/contents/${SIGNATURES_PATH}" 2>/dev/null)" || fail "Could not query the trusted CLA signature ledger"
+  jq -e '.type == "file" and .encoding == "base64" and (.content | type == "string") and (.content | length > 0)' <<<"${ledger_response}" >/dev/null || fail "The trusted CLA signature ledger response is malformed"
+  ledger_content="$(jq -r '.content' <<<"${ledger_response}")"
+  ledger_raw_bytes="$(printf '%s' "${ledger_content}" | wc -c | tr -d '[:space:]')"
+  [[ "${ledger_raw_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the trusted CLA signature ledger"
+  (( ledger_raw_bytes <= MAX_LEDGER_RAW_BYTES )) || fail "The trusted CLA signature ledger response is too large"
+  # The Contents API inserts line breaks into Base64 content. Remove only
+  # transport whitespace before applying the encoded-size limit; otherwise a
+  # valid near-limit ledger is rejected solely because it is wrapped.
+  ledger_content_compact="$(printf '%s' "${ledger_content}" | LC_ALL=C tr -d '[:space:]')"
+  [[ "${ledger_content_compact}" =~ ^[A-Za-z0-9+/]+={0,2}$ ]] || fail "The trusted CLA signature ledger is not valid base64"
+  ledger_encoded_bytes="$(printf '%s' "${ledger_content_compact}" | wc -c | tr -d '[:space:]')"
+  [[ "${ledger_encoded_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the trusted CLA signature ledger"
+  (( ledger_encoded_bytes % 4 == 0 )) || fail "The trusted CLA signature ledger is not valid base64"
+  # The maintained action rejects ledgers larger than 1 MB. Enforce the same
+  # bound before decoding, so a malformed Contents response cannot make this
+  # privileged job retain an unbounded payload.
+  (( ledger_encoded_bytes <= ((MAX_LEDGER_BYTES + 2) * 4 / 3 + 4) )) || fail "The trusted CLA signature ledger exceeds the 1 MB limit; ask an administrator to compact or migrate it before signing"
+  if ! ledger_json="$(
+    if base64 --decode >/dev/null 2>&1 <<<''; then
+      printf '%s' "${ledger_content_compact}" | base64 --decode
+    else
+      printf '%s' "${ledger_content_compact}" | base64 -D
+    fi
+  )"; then
+    fail "The trusted CLA signature ledger is not valid base64"
+  fi
+  ledger_decoded_bytes="$(printf '%s' "${ledger_json}" | wc -c | tr -d ' ')"
+  [[ "${ledger_decoded_bytes}" =~ ^[0-9]+$ ]] || fail "Could not measure the decoded CLA signature ledger"
+  (( ledger_decoded_bytes <= MAX_LEDGER_BYTES )) || fail "The trusted CLA signature ledger exceeds the 1 MB limit; ask an administrator to compact or migrate it before signing"
+  jq -e \
+    --arg login "${COMMENT_AUTHOR_LOGIN}" \
+    --argjson id "${COMMENT_AUTHOR_ID}" \
+    --argjson comment_id "${COMMENT_ID}" \
+    --arg created_at "${COMMENT_CREATED_AT}" \
+    --argjson repo_id "${repo_id}" \
+    --argjson pr_number "${PR_NUMBER}" \
+    --argjson max_signatures "${MAX_LEDGER_SIGNATURES}" \
+    'type == "object" and
+     (.signedContributors | type == "array") and
+     (.signedContributors | length <= $max_signatures) and
+     any(.signedContributors[]?;
+       (.name | type == "string") and .name == $login and
+       (.id | type == "number") and .id == $id and
+       (.comment_id | type == "number") and .comment_id == $comment_id and
+       (.created_at | type == "string") and .created_at == $created_at and
+       (.repoId | type == "number") and .repoId == $repo_id and
+       (.pullRequestNo | type == "number") and .pullRequestNo == $pr_number
+     )' <<<"${ledger_json}" >/dev/null || fail "The signing comment was not the signature persisted by the CLA action"
+}
+
+issue_json="$(gh_api_bounded "repos/${GH_REPO}/issues/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the issue"
+issue_state="$(jq -r '.state // empty' <<<"${issue_json}")"
+issue_pr_url="$(jq -r '.pull_request.url // empty' <<<"${issue_json}")"
+[[ "${issue_state}" == "open" ]] || fail "The issue is not an open pull request"
+[[ "${issue_pr_url}" == "https://api.github.com/repos/${GH_REPO}/pulls/${PR_NUMBER}" ]] || fail "The issue is not the exact repository pull request"
+
+# Re-fetch the triggering comment immediately before using its ledger entry.
+# A comment can be edited or deleted after the writer records a signature; a
+# stale event payload must never authorize a rerun of the failed check.
+comment_json="$(gh_api_bounded "repos/${GH_REPO}/issues/comments/${COMMENT_ID}" 2>/dev/null)" || fail "Could not query the triggering comment"
+jq -e \
+  --arg issue_url "https://api.github.com/repos/${GH_REPO}/issues/${PR_NUMBER}" \
+  --arg body "${COMMENT_BODY}" \
+  --arg author_id "${COMMENT_AUTHOR_ID}" \
+  --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
+  --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+  --arg created_at "${COMMENT_CREATED_AT}" \
+  '.issue_url == $issue_url and
+   .body == $body and
+   (.user | type == "object") and
+   (.user.id | type == "number") and
+   (.user.id | tostring) == $author_id and
+   .user.login == $author_login and
+   .user.type == $author_type and
+   .created_at == $created_at and
+   .updated_at == $created_at' <<<"${comment_json}" >/dev/null || fail "The triggering CLA comment was edited, deleted, or moved"
+
+pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not query the pull request"
+jq -e --arg repo "${GH_REPO}" --argjson number "${PR_NUMBER}" --arg base "${TARGET_BASE_REF}" '
+  .number == $number and
+  .state == "open" and
+  .base.ref == $base and
+  (.base.repo.id | type == "number") and
+  .base.repo.full_name == $repo and
+  (.base.sha | type == "string") and
+  (.base.sha | test("^[0-9a-f]{40}$")) and
+  (.head.sha | type == "string") and
+  (.head.sha | test("^[0-9a-f]{40}$")) and
+  (.head.repo.id | type == "number") and
+  (.head.repo.full_name | type == "string") and
+  (.user.login | type == "string") and
+  (.user.id | type == "number")
+' <<<"${pr_json}" >/dev/null || fail "The live pull request is not valid"
+head_sha="$(jq -r '.head.sha' <<<"${pr_json}")"
+head_ref="$(jq -r '.head.ref // empty' <<<"${pr_json}")"
+head_repo="$(jq -r '.head.repo.full_name // empty' <<<"${pr_json}")"
+head_repo_id="$(jq -r '.head.repo.id // empty' <<<"${pr_json}")"
+base_sha="$(jq -r '.base.sha // empty' <<<"${pr_json}")"
+repo_id="$(jq -r '.base.repo.id // empty' <<<"${pr_json}")"
+pr_author_login="$(jq -r '.user.login // empty' <<<"${pr_json}")"
+pr_author_id="$(jq -r '.user.id // empty' <<<"${pr_json}")"
+[[ "${head_ref}" != "" && "${head_repo}" != "" ]] || fail "The pull request head repository is missing"
+[[ "${head_ref}" != *$'\n'* && "${head_ref}" != *$'\r'* ]] || fail "The pull request head branch is malformed"
+[[ "${head_repo}" != *$'\n'* && "${head_repo}" != *$'\r'* ]] || fail "The pull request head repository is malformed"
+[[ "${head_repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request head repository ID is missing"
+[[ "${base_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The pull request base SHA is missing"
+[[ "${repo_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request base repository ID is missing"
+[[ "${pr_author_login}" != "" ]] || fail "The pull request author is missing"
+[[ "${pr_author_id}" =~ ^[1-9][0-9]*$ ]] || fail "The pull request author ID is missing"
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+  validate_triggering_signature_record
+fi
+# A contributor may recheck their own pull request. A different
+# commenter must be a trusted repository participant, which limits
+# unauthenticated users to the harmless no-op path.
+if [[ "${COMMENT_BODY}" == "recheck" && "${COMMENT_AUTHOR_ID}" != "${pr_author_id}" ]]; then
+  case "${COMMENT_AUTHOR_ASSOCIATION}" in
+    OWNER|MEMBER|COLLABORATOR) ;;
+    *) fail "Only the pull request author or a trusted repository participant may request a CLA rerun" ;;
+  esac
+fi
+
+# The workflow-run list can omit pull_requests for pull_request_target runs.
+# Fetch the source-head associations once, allowing only GitHub's documented
+# fork-only missing-commit response to fall through to the live PR check.
+fetch_commit_associations() {
+  local commit_sha="$1"
+  local allow_missing="$2"
+  local response error_text stderr_file page_count page2_count page2
+  stderr_file="$(mktemp)" || return 1
+  if response="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/commits/${commit_sha}/pulls" 2>"${stderr_file}")"; then
+    :
+  else
+    error_text="${response}"$'\n'"$(head -c "${MAX_API_ERROR_BYTES}" "${stderr_file}" 2>/dev/null || true)"
+    if [[ "${allow_missing}" == true ]] && (jq -e '
+      ((.status == 404 or .status == "404") and
+        (.message == "Not Found" or .message == "Resource not found")) or
+      ((.status == 422 or .status == "422") and
+        (.message | type == "string" and startswith("No commit found for SHA: ")))
+    ' <<<"${response}" >/dev/null 2>&1 ||
+      { grep -Eq 'HTTP 404' <<<"${error_text}" &&
+        grep -Eq 'Not Found|Resource not found' <<<"${error_text}"; } ||
+      { grep -Eq 'HTTP 422' <<<"${error_text}" &&
+        grep -Eq 'No commit found for SHA: [0-9a-f]{40}' <<<"${error_text}"; }); then
+      response='[]'
+    else
+      rm -f -- "${stderr_file}"
+      return 1
+    fi
+  fi
+  rm -f -- "${stderr_file}"
+  jq -e 'type == "array"' <<<"${response}" >/dev/null || return 1
+  page_count="$(jq -r 'length' <<<"${response}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/commits/${commit_sha}/pulls" 2>/dev/null)" || return 1
+    jq -e 'type == "array"' <<<"${page2}" >/dev/null || return 1
+    page2_count="$(jq -r 'length' <<<"${page2}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    response="$(jq -c --argjson page2 "${page2}" '. + $page2' <<<"${response}")"
+    if (( page2_count == 100 )); then
+      echo "::error::Too many pull request associations for this head after two pages" >&2
+      return 1
+    fi
+  fi
+  printf '%s\n' "${response}"
+}
+
+assert_exact_pr_association() {
+  local associations="$1"
+  local expected_sha="$2"
+  jq -e \
+    --arg repo "${GH_REPO}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg sha "${expected_sha}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" '
+      any(.[]?;
+        (.number | type == "number") and
+        (.number | tostring) == $pr and
+        .base.ref == $base and
+        .base.repo.full_name == $repo and
+        (.base.repo.id | type == "number") and
+        .base.repo.id == $repo_id and
+        (.base.sha | type == "string") and
+        .base.sha == $base_sha and
+        .head.ref == $head_ref and
+        .head.sha == $sha and
+        .head.repo.full_name == $head_repo and
+        (.head.repo.id | type == "number") and
+        .head.repo.id == $head_repo_id
+      )
+    ' <<<"${associations}" >/dev/null
+}
+
+if ! commit_prs_json="$(fetch_commit_associations "${head_sha}" true)"; then
+  fail "Could not query pull request associations"
+fi
+if [[ "$(jq -r 'length' <<<"${commit_prs_json}")" != 0 ]]; then
+  assert_exact_pr_association "${commit_prs_json}" "${head_sha}" || fail "The current head is not associated with this pull request"
+elif [[ "${head_repo}" == "${GH_REPO}" ]]; then
+  fail "The base-repository head has no pull request association"
+fi
+
+# A fork-only commit can be absent from the commit association API.
+# Resolve it through the live open-PR list instead. The head filter
+# is owner:ref, so the result must contain exactly one PR with the
+# exact number, SHA, head repository, and base repository. This
+# rejects duplicate or cross-PR matches before a run is selected,
+# and the helper is called again immediately before the POST.
+validate_live_open_head_association() {
+  local head_owner head_name open_prs_page open_pr_count open_prs_json matching_open_prs_json open_association_count
+  [[ "${head_repo}" == */* && "${head_repo}" != */*/* ]] || fail "The pull request head repository name is invalid"
+  head_owner="${head_repo%%/*}"
+  head_name="${head_repo#*/}"
+  [[ -n "${head_owner}" && -n "${head_name}" ]] || fail "The pull request head repository name is invalid"
+  open_prs_page="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field state=open \
+    --raw-field base="${TARGET_BASE_REF}" \
+    --raw-field head="${head_owner}:${head_ref}" \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/pulls" 2>/dev/null)" || fail "Could not query live open pull requests for this head"
+  jq -e 'type == "array"' <<<"${open_prs_page}" >/dev/null || fail "Could not validate live open pull requests"
+  open_pr_count="$(jq -r 'length' <<<"${open_prs_page}")"
+  [[ "${open_pr_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests"
+  (( open_pr_count <= 100 )) || fail "The live open pull request page is oversized"
+  if (( open_pr_count == 100 )); then
+    open_prs_page2="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field state=open \
+      --raw-field base="${TARGET_BASE_REF}" \
+      --raw-field head="${head_owner}:${head_ref}" \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/pulls" 2>/dev/null)" || fail "Could not query live open pull requests page 2"
+    jq -e 'type == "array"' <<<"${open_prs_page2}" >/dev/null || fail "Could not validate live open pull requests page 2"
+    open_pr_count2="$(jq -r 'length' <<<"${open_prs_page2}")"
+    [[ "${open_pr_count2}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull requests page 2"
+    (( open_pr_count2 <= 100 )) || fail "The live open pull request page is oversized"
+    open_prs_page="$(jq -c --argjson page2 "${open_prs_page2}" '. + $page2' <<<"${open_prs_page}")"
+    open_pr_count=$((open_pr_count + open_pr_count2))
+    (( open_pr_count2 < 100 )) || fail "Too many open pull requests share this head after two pages; push a new head or ask an administrator to resolve the association before requesting a rerun"
+  fi
+  open_prs_json="$(jq -c '[.]' <<<"${open_prs_page}")"
+  if ! matching_open_prs_json="$(jq -c \
+      --arg repo "${GH_REPO}" \
+      --arg sha "${head_sha}" \
+      --arg base_sha "${base_sha}" \
+      --arg base "${TARGET_BASE_REF}" \
+      --arg head_ref "${head_ref}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" \
+      --argjson repo_id "${repo_id}" '
+        [ .[] | .[]?
+          | select(
+              (.number | type == "number") and
+              .state == "open" and
+              .base.ref == $base and
+              .base.repo.full_name == $repo and
+              (.base.repo.id | type == "number") and
+              .base.repo.id == $repo_id and
+              (.base.sha | type == "string") and
+              .base.sha == $base_sha and
+              .head.ref == $head_ref and
+              .head.sha == $sha and
+              .head.repo.full_name == $head_repo and
+              (.head.repo.id | type == "number") and
+              .head.repo.id == $head_repo_id
+            )
+        ]
+        | sort_by(.number)
+      ' <<<"${open_prs_json}")"; then
+    fail "Could not validate live open pull request data"
+  fi
+  open_association_count="$(jq -r 'length' <<<"${matching_open_prs_json}")"
+  [[ "${open_association_count}" =~ ^[0-9]+$ ]] || fail "Could not count live open pull request associations"
+  [[ "${open_association_count}" == "1" ]] || fail "Expected exactly one open pull request for this head"
+  jq -e --argjson number "${PR_NUMBER}" '.[0].number == $number' <<<"${matching_open_prs_json}" >/dev/null || fail "The live head is associated with a different pull request"
+}
+validate_live_open_head_association
+
+# Use one immutable PR predicate for each re-read. Keeping base and source
+# identity in one helper prevents a late check from validating fewer fields
+# than the initial snapshot.
+validate_exact_pr_snapshot() {
+  local payload="$1"
+  jq -e \
+    --arg repo "${GH_REPO}" \
+    --argjson number "${PR_NUMBER}" \
+    --arg sha "${head_sha}" \
+    --arg base_sha "${base_sha}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson base_repo_id "${repo_id}" \
+    --arg opener "${pr_author_login}" '
+      .number == $number and
+      .state == "open" and
+      .base.ref == $base and
+      .base.repo.full_name == $repo and
+      .base.repo.id == $base_repo_id and
+      (.base.sha | type == "string") and
+      .base.sha == $base_sha and
+      .head.sha == $sha and
+      .head.ref == $head_ref and
+      .head.repo.full_name == $head_repo and
+      .head.repo.id == $head_repo_id and
+      .user.login == $opener
+    ' <<<"${payload}" >/dev/null
+}
+
+workflow_page="$(gh_api_bounded \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/actions/workflows" 2>/dev/null)" || fail "Could not query repository workflows"
+jq -e 'type == "object" and (.workflows | type == "array")' <<<"${workflow_page}" >/dev/null || fail "Could not validate repository workflows"
+workflow_count="$(jq -r '.workflows | length' <<<"${workflow_page}")"
+[[ "${workflow_count}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows"
+(( workflow_count <= 100 )) || fail "The repository workflow page is oversized"
+if (( workflow_count == 100 )); then
+  workflow_page2="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=2 \
+    "repos/${GH_REPO}/actions/workflows" 2>/dev/null)" || fail "Could not query repository workflows page 2"
+  jq -e 'type == "object" and (.workflows | type == "array")' <<<"${workflow_page2}" >/dev/null || fail "Could not validate repository workflows page 2"
+  workflow_count2="$(jq -r '.workflows | length' <<<"${workflow_page2}")"
+  [[ "${workflow_count2}" =~ ^[0-9]+$ ]] || fail "Could not count repository workflows page 2"
+  (( workflow_count2 <= 100 )) || fail "The repository workflow page is oversized"
+  workflow_page="$(jq -c --argjson page2 "${workflow_page2}" '.workflows += $page2.workflows' <<<"${workflow_page}")"
+  workflow_count=$((workflow_count + workflow_count2))
+  (( workflow_count2 < 100 )) || fail "Too many active repository workflows after two pages; ask an administrator to reduce the workflow list before requesting a rerun"
+fi
+workflow_json="$(jq -c '[.]' <<<"${workflow_page}")"
+workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | select(.path == $path and .state == "active") | .id] | if length == 1 then .[0] else empty end' <<<"${workflow_json}")"
+[[ "${workflow_id}" =~ ^[1-9][0-9]*$ ]] || fail "The expected CLA workflow is not active"
+
+# Search a bounded first page, then choose the newest completed
+# failure created no later than this comment. Edited, reopened, and
+# synchronize events can leave several eligible failures for one
+# exact head, so sort by creation time and run ID and select the
+# newest one. Every candidate is tied to the exact workflow path and event.
+# When GitHub includes pull_requests on a run, bind the candidate to the exact
+# PR object, including its source head and live base SHAs. GitHub can return an
+# empty array for pull_request_target runs. Those candidates are accepted only
+# when the run has complete source-repository metadata and its execution SHA is
+# the live PR base SHA. Missing metadata cannot identify which fork produced a
+# branch, so it is always rejected before any check is rerun.
+runs_page="$(gh_api_bounded \
+  --method GET \
+  --header 'Accept: application/vnd.github+json' \
+  --raw-field event="${TARGET_EVENT}" \
+  --raw-field branch="${head_ref}" \
+  --raw-field per_page=100 \
+  --raw-field page=1 \
+  "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs"
+jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${runs_page}" >/dev/null || fail "Could not validate CLA workflow runs"
+run_count="$(jq -r '.workflow_runs | length' <<<"${runs_page}")"
+[[ "${run_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs"
+(( run_count <= 100 )) || fail "The CLA workflow run page is oversized"
+runs_json="$(jq -c '[.]' <<<"${runs_page}")"
+
+# The API returns newest runs first. Probe additional bounded pages when the
+# first page is full, so normal workflow history growth does not strand a
+# failed check. GitHub documents a 1,000-result cap for filtered workflow-run
+# queries, so ten 100-item pages cover the complete API result window. Search
+# the complete bounded window before deciding whether it is full: a valid
+# candidate on page ten is still actionable. If the window is full and no
+# candidate matches, fail with an actionable message instead of pretending page
+# 11 can reveal an unreported run. `runs_json` stays an array of response
+# objects; the candidate query below flattens each `.workflow_runs` array
+# explicitly.
+page_count="${run_count}"
+page_number=2
+while (( page_count == 100 && page_number <= MAX_RUN_PAGES )); do
+  next_runs_page="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field event="${TARGET_EVENT}" \
+    --raw-field branch="${head_ref}" \
+    --raw-field per_page=100 \
+    --raw-field page="${page_number}" \
+    "repos/${GH_REPO}/actions/workflows/${workflow_id}/runs" 2>/dev/null)" || fail "Could not query CLA workflow runs page ${page_number}"
+  jq -e 'type == "object" and (.workflow_runs | type == "array")' <<<"${next_runs_page}" >/dev/null || fail "Could not validate CLA workflow runs page ${page_number}"
+  page_count="$(jq -r '.workflow_runs | length' <<<"${next_runs_page}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || fail "Could not count CLA workflow runs page ${page_number}"
+  (( page_count <= 100 )) || fail "The CLA workflow returned an oversized run page"
+  runs_json="$(jq -c --argjson next_page "${next_runs_page}" '. + [$next_page]' <<<"${runs_json}")"
+  (( page_number++ ))
+done
+run_window_full=false
+(( page_count == 100 )) && run_window_full=true
+
+# `pull_requests` is optional for fork runs, but when GitHub sends it, the
+# field must keep its documented array shape. Treat a changed or malformed
+# response as an infrastructure error. Silently treating it as an unmatched
+# run could strand a required failed check with no recovery path.
+if ! jq -e '
+  all(.[] | .workflow_runs[]?;
+    (type == "object") and
+    (.pull_requests == null or
+     ((.pull_requests | type) == "array" and
+      (.pull_requests | length <= 100)))
+  )
+' <<<"${runs_json}" >/dev/null; then
+  fail "The CLA workflow returned malformed pull request associations"
+fi
+
+if ! candidate_list_json="$(jq -c \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg base_sha "${base_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg head_ref "${head_ref}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg before "${COMMENT_CREATED_AT}" '
+      def run_binds_to_pr:
+        (.pull_requests) as $raw_prs
+        | (if $raw_prs == null then []
+           elif ($raw_prs | type) == "array" then $raw_prs
+           else null end) as $prs
+        | if $prs == null then false
+          elif ($prs | length > 100) then false
+          elif ($prs | length) == 0 then
+            .head_sha == $base_sha and
+            .head_branch == $head_ref and
+            (.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            (.head_repository.id | type == "number") and
+            .head_repository.id == $head_repo_id
+          else any($prs[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            .base.ref == $base and
+            (.base.sha | type == "string") and
+            (.base.sha | test("^[0-9a-f]{40}$")) and
+            .base.sha == $base_sha and
+            ((.base.repo.full_name // "") == "" or
+             .base.repo.full_name == $repo) and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            ((.head.repo.full_name // "") == "" or
+             .head.repo.full_name == $head_repo)
+          )
+          end;
+      [ .[] | .workflow_runs[]?
+        | select(
+            .path == $path and
+            .event == $event and
+            (.workflow_id | type == "number") and
+            .workflow_id == ($workflow_id | tonumber) and
+            (.name | type == "string") and
+            .name == $workflow_name and
+            (.head_sha | type == "string") and
+            (.head_sha | test("^[0-9a-f]{40}$")) and
+            (.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            (.head_repository.id | type == "number") and
+            .head_repository.id == $head_repo_id and
+            (.id | type == "number") and
+            .id > 0 and
+            .status == "completed" and
+            .conclusion == "failure" and
+            (.created_at | type == "string") and
+            (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+            .created_at <= $before and
+            run_binds_to_pr
+          )
+      ]
+      | sort_by([
+          if ((.pull_requests | type) == "array" and (.pull_requests | length) > 0) then 3
+          elif (.head_repository | type) == "object" and .head_sha == $base_sha then 2
+          elif .head_sha == $sha then 1
+          else 0 end,
+          .created_at,
+          .id
+        ])
+    ' <<<"${runs_json}")"; then
+  fail "Could not validate CLA workflow run data"
+fi
+candidate_count="$(jq -r 'length' <<<"${candidate_list_json}")"
+[[ "${candidate_count}" =~ ^[0-9]+$ ]] || fail "Could not count matching CLA workflow runs"
+if [[ "${candidate_count}" == "0" ]]; then
+  if [[ "${run_window_full}" == true ]]; then
+    fail "The GitHub workflow-run result window is full after ${MAX_RUN_PAGES} pages and contains no matching failed CLA run; push a new commit or ask an administrator to prune old runs before requesting a rerun"
+  fi
+  # Do not silently treat a failed run with an empty association and incomplete
+  # source metadata as a successful no-op. A branch name or a null repository
+  # can describe another fork, so every such run gets an explicit fail-closed
+  # error before the helper can return.
+  empty_execution_mismatch_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --arg head_ref "${head_ref}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    '[ .[] | .workflow_runs[]?
+      | select(
+          .path == $path and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.name | type == "string") and
+          .name == $workflow_name and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          (
+            .head_sha != $sha or
+            (.head_repository | type) != "object" or
+            .head_repository.full_name != $head_repo or
+            (.head_repository.id | type) != "number" or
+            .head_repository.id != $head_repo_id
+          ) and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+          .created_at <= $before and
+          .head_branch == $head_ref and
+          (.pull_requests == null or
+           ((.pull_requests | type) == "array" and
+            (.pull_requests | length) == 0))
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${empty_execution_mismatch_count}" =~ ^[0-9]+$ ]] || fail "Could not count unbound CLA workflow runs"
+  if (( empty_execution_mismatch_count > 0 )); then
+    fail "The workflow run has no pull request association with complete source metadata and an exact execution SHA"
+  fi
+
+  # A populated association with an old base SHA is not an absent check. It is
+  # a stale failed run that must fail closed, otherwise a later rerun could
+  # execute policy against a different target revision. Count only an exact
+  # PR/source identity and treat a missing or malformed association base SHA as
+  # stale as well.
+  stale_base_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    '[ .[] | .workflow_runs[]?
+      | select(
+          .path == $path and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.name | type == "string") and
+          .name == $workflow_name and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          (.head_repository | type) == "object" and
+          .head_repository.full_name == $head_repo and
+          (.head_repository.id | type == "number") and
+          .head_repository.id == $head_repo_id and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+          .created_at <= $before and
+          (.pull_requests | type) == "array" and
+          (.pull_requests | length > 0) and
+          any(.pull_requests[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            .base.ref == $base and
+            .base.repo.full_name == $repo and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            .head.repo.full_name == $head_repo and
+            (if (.base.sha | type) == "string"
+             then ((.base.sha | test("^[0-9a-f]{40}$") | not) or .base.sha != $base_sha)
+             else true
+             end)
+          )
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${stale_base_count}" =~ ^[0-9]+$ ]] || fail "Could not count stale CLA workflow base associations"
+  if (( stale_base_count > 0 )); then
+    fail "The failed CLA check is bound to an outdated or malformed pull request base SHA; push a new commit before requesting a rerun"
+  fi
+  # A run from before this workflow generation cannot be safely
+  # rerun: GitHub reruns the old workflow revision, which could
+  # execute the archived action or an obsolete policy. Distinguish
+  # that migration case from a normal no-op after a successful CLA
+  # check so contributors receive an actionable recovery path.
+  stale_run_count="$(jq -r \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_ref "${head_ref}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg before "${COMMENT_CREATED_AT}" \
+    'def run_binds_to_pr:
+       (.pull_requests) as $raw_prs
+       | (if $raw_prs == null then []
+          elif ($raw_prs | type) == "array" then $raw_prs
+          else null end) as $prs
+       | if $prs == null then false
+         elif ($prs | length > 100) then false
+         elif ($prs | length) == 0 then
+           .head_sha == $sha and
+           .head_branch == $head_ref and
+           (.head_repository | type) == "object" and
+           .head_repository.full_name == $head_repo and
+           (.head_repository.id | type == "number") and
+           .head_repository.id == $head_repo_id
+         else any($prs[]?;
+           (.number | type == "number") and
+           (.number | tostring) == $pr and
+           .base.ref == $base and
+           (.base.sha | type == "string") and
+           (.base.sha | test("^[0-9a-f]{40}$")) and
+           .base.sha == $base_sha and
+           ((.base.repo.full_name // "") == "" or
+            .base.repo.full_name == $repo) and
+           (.base.repo.id | type == "number") and
+           .base.repo.id == $repo_id and
+           .head.ref == $head_ref and
+           .head.sha == $sha and
+           (.head.repo.id | type == "number") and
+           .head.repo.id == $head_repo_id and
+           ((.head.repo.full_name // "") == "" or
+            .head.repo.full_name == $head_repo)
+         )
+         end;
+     [ .[] | .workflow_runs[]?
+      | select(
+          .path == $path and
+          .event == $event and
+          (.workflow_id | type == "number") and
+          .workflow_id == ($workflow_id | tonumber) and
+          (.name | type == "string") and
+          .name == $workflow_name and
+          (.head_sha | type == "string") and
+          (.head_sha | test("^[0-9a-f]{40}$")) and
+          (.id | type == "number") and
+          .id > 0 and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.created_at | type == "string") and
+          (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+          .created_at <= $before and
+          run_binds_to_pr
+        )
+    ] | length' <<<"${runs_json}")"
+  [[ "${stale_run_count}" =~ ^[0-9]+$ ]] || fail "Could not count stale CLA workflow runs"
+  if (( stale_run_count > 0 )); then
+    fail "The failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  fi
+  # A valid signature can arrive after the check already passed. Keep this
+  # path read-only and report the absence of a failed current-head run.
+  echo "No failed CLA run exists for this pull request head"
+  exit 0
+fi
+# candidate_list_json is sorted oldest-first above. The selected run
+# is fully fetched and validated below before any state-changing API
+# call, so multiple historical failures do not create ambiguity.
+candidate_json="$(jq -c '.[-1]' <<<"${candidate_list_json}")"
+run_id="$(jq -r '.id // empty' <<<"${candidate_json}")"
+[[ "${run_id}" =~ ^[1-9][0-9]*$ ]] || fail "The selected CLA run ID is invalid"
+run_execution_sha="$(jq -r '.head_sha // empty' <<<"${candidate_json}")"
+[[ "${run_execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The selected CLA run execution SHA is invalid"
+run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
+[[ -n "${run_head_branch}" && "${run_head_branch}" != *$'\n'* && "${run_head_branch}" != *$'\r'* ]] || fail "The selected CLA run head branch is invalid"
+
+# A run with a populated pull_requests array carries a source-PR association,
+# but that association is still only discovery data. For pull_request_target,
+# GitHub records the Actions check on the workflow execution SHA (normally the
+# live PR base SHA), not on the untrusted source head. Empty associations need
+# one extra branch: when GitHub omits or cannot prove the source repository and
+# base execution SHA, require a failed check on the exact source head instead.
+# The selected check always names the exact run and job in its details URL.
+
+# These values are set by validate_run_source_binding before each check lookup.
+# Keeping the lookup SHA separate from the PR source SHA avoids silently using
+# the wrong commit when GitHub returns pull_request_target metadata.
+CHECK_LOOKUP_SHA=""
+CHECK_EXPECTED_SHA=""
+CHECK_BINDING_MODE=""
+
+fetch_check_runs_for_sha() {
+  local commit_sha="$1"
+  local check_name="$2"
+  local response page_count page2 page2_count page=1
+  response="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field check_name="${check_name}" \
+    --raw-field app_id="${CLA_ACTION_APP_ID}" \
+    --raw-field filter=all \
+    --raw-field per_page=100 \
+    --raw-field page="${page}" \
+    "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
+  jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${response}" >/dev/null || return 1
+  page_count="$(jq -r '.check_runs | length' <<<"${response}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  while (( page_count == 100 && page < MAX_CHECK_PAGES )); do
+    (( page++ ))
+    page2="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field check_name="${check_name}" \
+      --raw-field app_id="${CLA_ACTION_APP_ID}" \
+      --raw-field filter=all \
+      --raw-field per_page=100 \
+      --raw-field page="${page}" \
+      "repos/${GH_REPO}/commits/${commit_sha}/check-runs" 2>/dev/null)" || return 1
+    jq -e 'type == "object" and (.check_runs | type == "array")' <<<"${page2}" >/dev/null || return 1
+    page2_count="$(jq -r '.check_runs | length' <<<"${page2}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    response="$(jq -c --argjson page2 "${page2}" '.check_runs += $page2.check_runs' <<<"${response}")"
+    page_count="${page2_count}"
+  done
+  (( page_count < 100 )) || return 1
+  printf '%s\n' "${response}"
+}
+
+assert_failed_check_binding() {
+  local checks="$1"
+  local expected_run_id="$2"
+  local expected_job_id="$3"
+  local expected_check_sha="$4"
+  local expected_check_name="$5"
+  local details_url="https://github.com/${GH_REPO}/actions/runs/${expected_run_id}/job/${expected_job_id}"
+  local matching_count
+  [[ "${expected_check_sha}" =~ ^[0-9a-f]{40}$ ]] || return 1
+  matching_count="$(jq -r \
+    --arg job "${expected_check_name}" \
+    --arg sha "${expected_check_sha}" \
+    --arg url "${details_url}" \
+    --argjson app_id "${CLA_ACTION_APP_ID}" '
+      [ .check_runs[]?
+        | select(
+        (.id | type == "number") and
+        .id > 0 and
+        .name == $job and
+        .status == "completed" and
+        .conclusion == "failure" and
+        (.head_sha | type == "string") and
+        .head_sha == $sha and
+        (.app | type == "object") and
+        (.app.id | type == "number") and
+        .app.id == $app_id and
+        .app.slug == "github-actions" and
+        (.details_url | type == "string") and
+        (.details_url == $url or
+         (.details_url | startswith($url + "?") or startswith($url + "#")))
+        )
+      ] | length
+    ' <<<"${checks}")"
+  [[ "${matching_count}" =~ ^[0-9]+$ && "${matching_count}" == 1 ]]
+}
+
+validate_failed_check_binding() {
+  local expected_run_id="$1"
+  local expected_job_id="$2"
+  local expected_check_name="$3"
+  local check_sha="${CHECK_LOOKUP_SHA}"
+  local expected_check_sha="${CHECK_EXPECTED_SHA}"
+  local checks
+  [[ "${check_sha}" =~ ^[0-9a-f]{40}$ && "${expected_check_sha}" =~ ^[0-9a-f]{40}$ ]] ||
+    fail "The selected CLA run has no valid check binding context"
+  checks="$(fetch_check_runs_for_sha "${check_sha}" "${expected_check_name}")" ||
+    fail "Could not query checks for the selected CLA execution"
+  assert_failed_check_binding "${checks}" "${expected_run_id}" "${expected_job_id}" "${expected_check_sha}" "${expected_check_name}" ||
+    if [[ "${CHECK_BINDING_MODE}" == source-fallback ]]; then
+      fail "No failed CLA check is bound to the exact pull request source head and selected job"
+    else
+      fail "No failed CLA check is bound to the workflow execution SHA and selected job"
+    fi
+}
+
+validate_run_source_binding() {
+  local run_payload="$1"
+  local execution_sha pull_requests_type pull_request_count head_repository_type
+  execution_sha="$(jq -r '.head_sha // empty' <<<"${run_payload}")"
+  [[ "${execution_sha}" =~ ^[0-9a-f]{40}$ ]] || fail "The workflow run execution SHA is invalid"
+  CHECK_LOOKUP_SHA="${execution_sha}"
+  CHECK_EXPECTED_SHA="${execution_sha}"
+  CHECK_BINDING_MODE=execution
+  pull_requests_type="$(jq -r 'if .pull_requests == null then "null" else (.pull_requests | type) end' <<<"${run_payload}")"
+  case "${pull_requests_type}" in
+    null) pull_request_count=0 ;;
+    array) pull_request_count="$(jq -r '.pull_requests | length' <<<"${run_payload}")" ;;
+    *) fail "The workflow run pull request association is malformed" ;;
+  esac
+  [[ "${pull_request_count}" =~ ^[0-9]+$ ]] || fail "The workflow run pull request association count is invalid"
+  if (( pull_request_count == 0 )); then
+    # GitHub may omit pull_requests on a pull_request_target run. A complete
+    # source repository plus the live PR base SHA binds the run directly. A
+    # null source repository cannot identify which fork produced the branch,
+    # so it is never eligible for the source-head fallback.
+    head_repository_type="$(jq -r 'if .head_repository == null then "null" else (.head_repository | type) end' <<<"${run_payload}")"
+    case "${head_repository_type}" in
+      null) fail "The workflow run source repository metadata is missing" ;;
+      object)
+        jq -e \
+          --arg head_repo "${head_repo}" \
+          --argjson head_repo_id "${head_repo_id}" \
+          '.head_repository.full_name == $head_repo and
+           (.head_repository.id | type == "number") and
+           .head_repository.id == $head_repo_id' <<<"${run_payload}" >/dev/null ||
+          fail "The workflow run source repository does not match the pull request"
+        ;;
+      *) fail "The workflow run source repository metadata is malformed" ;;
+    esac
+    validate_live_open_head_association
+    if [[ "${execution_sha}" == "${base_sha}" ]]; then
+      CHECK_LOOKUP_SHA="${execution_sha}"
+      CHECK_EXPECTED_SHA="${execution_sha}"
+      CHECK_BINDING_MODE=execution
+    else
+      # Some pull_request_target API responses expose a non-base execution
+      # SHA. Bind those runs to the immutable live source head and its exact
+      # job URL only after the complete repository metadata and live PR
+      # association above have been verified.
+      CHECK_LOOKUP_SHA="${head_sha}"
+      CHECK_EXPECTED_SHA="${head_sha}"
+      CHECK_BINDING_MODE=source-fallback
+    fi
+  fi
+}
+
+# Keep one exact run predicate for discovery rechecks and the final TOCTOU
+# re-read. The list response is discovery only, never authorization.
+validate_exact_run_payload() {
+  local payload="$1"
+  jq -e \
+    --arg run_id "${run_id}" \
+    --arg path "${WORKFLOW_PATH}" \
+    --arg event "${TARGET_EVENT}" \
+    --arg sha "${head_sha}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg run_head_branch "${run_head_branch}" \
+    --arg pr "${PR_NUMBER}" \
+    --arg repo "${GH_REPO}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    --argjson repo_id "${repo_id}" \
+    --arg head_ref "${head_ref}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg base "${TARGET_BASE_REF}" \
+    --arg base_sha "${base_sha}" \
+    --arg before "${COMMENT_CREATED_AT}" '
+      def run_binds_to_pr:
+        (.pull_requests) as $raw_prs
+        | (if $raw_prs == null then []
+           elif ($raw_prs | type) == "array" then $raw_prs
+           else null end) as $prs
+        | if $prs == null then false
+          elif ($prs | length) == 0 then
+            .head_sha == $base_sha and
+            .head_branch == $head_ref and
+            (.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            (.head_repository.id | type == "number") and
+            .head_repository.id == $head_repo_id
+          else any($prs[]?;
+            (.number | type == "number") and
+            (.number | tostring) == $pr and
+            .base.ref == $base and
+            (.base.sha | type == "string") and
+            (.base.sha | test("^[0-9a-f]{40}$")) and
+            .base.sha == $base_sha and
+            ((.base.repo.full_name // "") == "" or
+             .base.repo.full_name == $repo) and
+            (.base.repo.id | type == "number") and
+            .base.repo.id == $repo_id and
+            .head.ref == $head_ref and
+            .head.sha == $sha and
+            (.head.repo.id | type == "number") and
+            .head.repo.id == $head_repo_id and
+            ((.head.repo.full_name // "") == "" or
+             .head.repo.full_name == $head_repo)
+          )
+          end;
+      (.id | type == "number") and
+      .id == ($run_id | tonumber) and
+      (.workflow_id | type == "number") and
+      .workflow_id == ($workflow_id | tonumber) and
+      (.name | type == "string") and
+      .name == $workflow_name and
+      (.path | type == "string") and
+      .path == $path and
+      .event == $event and
+      .status == "completed" and
+      .conclusion == "failure" and
+      .head_sha == $run_sha and
+      .head_branch == $run_head_branch and
+      (.head_repository | type) == "object" and
+      .head_repository.full_name == $head_repo and
+      (.head_repository.id | type == "number") and
+      .head_repository.id == $head_repo_id and
+      (.created_at | type == "string") and
+      (.created_at | test("^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$")) and
+      .created_at <= $before and
+      run_binds_to_pr
+    ' <<<"${payload}" >/dev/null
+}
+
+# Re-read the individual run. The list response is only a discovery result.
+run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not query the selected CLA run"
+validate_exact_run_payload "${run_json}" || fail "The selected run no longer matches the exact failed CLA check"
+validate_run_source_binding "${run_json}"
+
+# Close the main TOCTOU window. A push, close, or another rerun can
+# happen while the API calls above run. Never rerun a stale head.
+latest_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request"
+validate_exact_pr_snapshot "${latest_pr_json}" || fail "The pull request changed while selecting the CLA run"
+
+# Ensure another queued invocation did not already rerun this run.
+final_run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run"
+validate_exact_run_payload "${final_run_json}" || fail "The exact failed CLA run is no longer eligible"
+validate_run_source_binding "${final_run_json}"
+
+# Fetch the complete bounded job set for one exact run. The rerun endpoint
+# requires actions:write, so discovery must fail closed if pagination or shape
+# checks cannot prove that every failed job belongs to this CLA workflow.
+# The workflow-run response is authoritative for workflow name, head branch,
+# and source repository. GitHub's jobs endpoint does not document those fields
+# and omits them in production, so job validation uses only its documented
+# identity fields, plus optional source metadata when GitHub supplies it.
+fetch_jobs_for_run() {
+  local target_run_id="$1"
+  local page_json page_count page2_json page2_count
+  page_json="$(gh_api_bounded \
+    --method GET \
+    --header 'Accept: application/vnd.github+json' \
+    --raw-field per_page=100 \
+    --raw-field page=1 \
+    "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+  jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page_json}" >/dev/null || return 1
+  page_count="$(jq -r '.jobs | length' <<<"${page_json}")"
+  [[ "${page_count}" =~ ^[0-9]+$ ]] || return 1
+  (( page_count <= 100 )) || return 1
+  if (( page_count == 100 )); then
+    page2_json="$(gh_api_bounded \
+      --method GET \
+      --header 'Accept: application/vnd.github+json' \
+      --raw-field per_page=100 \
+      --raw-field page=2 \
+      "repos/${GH_REPO}/actions/runs/${target_run_id}/jobs" 2>/dev/null)" || return 1
+    jq -e 'type == "object" and (.jobs | type == "array")' <<<"${page2_json}" >/dev/null || return 1
+    page2_count="$(jq -r '.jobs | length' <<<"${page2_json}")"
+    [[ "${page2_count}" =~ ^[0-9]+$ ]] || return 1
+    (( page2_count <= 100 )) || return 1
+    page_json="$(jq -c --argjson page2 "${page2_json}" '.jobs += $page2.jobs' <<<"${page_json}")"
+    (( page2_count < 100 )) || return 1
+  fi
+  jq -c '[.]' <<<"${page_json}"
+}
+
+jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not query and validate jobs for the selected CLA run"
+RERUN_TARGET_JOB_NAME=""
+RERUN_FAILED_JOBS=false
+
+# Validate every failed job before granting the state-changing API call. The
+# v3 writer, required result, and migration compatibility jobs are the only
+# failures this helper may replay. If the writer or compatibility job failed,
+# use the failed-jobs endpoint so GitHub refreshes every head-bound context;
+# otherwise replay only the required result job. Any extra failure,
+# cancellation, malformed job, or stale source identity aborts the request.
+validate_failed_job_set() {
+  local payload="$1"
+  local all_jobs_json failed_jobs_json failed_count nonfailure_count
+  local unexpected_count assistant_count assistant_valid_count assistant_failed_count assistant_success_count
+  local writer_count writer_valid_count
+  local compatibility_count compatibility_valid_count
+  if ! all_jobs_json="$(jq -c '[.[] | .jobs[]?]' <<<"${payload}")"; then
+    fail "Could not flatten jobs for the selected CLA run"
+  fi
+  jq -e \
+    --arg run_id "${run_id}" \
+    'type == "array" and all(.[];
+      (.id | type == "number") and
+      .id > 0 and
+      (.run_id | type == "number") and
+      .run_id == ($run_id | tonumber) and
+      (.name | type == "string") and
+      (.status == "completed") and
+      (.conclusion | type == "string") and
+      (.head_sha | type == "string") and
+      (.head_sha | test("^[0-9a-f]{40}$")) and
+      (.steps | type == "array") and
+      (.steps | length <= 100) and
+      all(.steps[]?; type == "object") and
+      ((has("head_repository") | not) or
+       .head_repository == null or
+       ((.head_repository | type) == "object" and
+        (.head_repository.full_name | type) == "string" and
+        (.head_repository.id | type == "number"))) and
+      ((has("workflow_name") | not) or
+       (.workflow_name | type) == "string") and
+      ((has("workflow_id") | not) or
+       (.workflow_id | type == "number"))
+    )' <<<"${all_jobs_json}" >/dev/null || fail "The selected CLA run contains a malformed or incomplete job"
+
+  failed_jobs_json="$(jq -c '[.[] | select(.conclusion != "success" and .conclusion != "skipped")]' <<<"${all_jobs_json}")"
+  failed_count="$(jq -r 'length' <<<"${failed_jobs_json}")"
+  [[ "${failed_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed jobs for the selected CLA run"
+  nonfailure_count="$(jq -r '[.[] | select(.conclusion != "failure")] | length' <<<"${failed_jobs_json}")"
+  (( nonfailure_count == 0 )) || fail "The selected CLA run contains a cancelled or non-failure job; refusing to rerun it"
+  unexpected_count="$(jq -r \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg writer_job "${CLA_WRITER_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    '[.[] | select(.name != $assistant_job and .name != $writer_job and .name != $compatibility_job)] | length' \
+    <<<"${failed_jobs_json}")"
+  (( unexpected_count == 0 )) || fail "The selected CLA run contains an unexpected failed job; refusing to rerun it"
+
+  # The v3 job is the generation anchor even when only the compatibility
+  # mirror failed. Validate exactly one current-generation v3 job across the
+  # whole run, then select a failed v3 or compatibility job below.
+  if ! assistant_count="$(jq -r \
+      --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+      '[.[] | select(.name == $assistant_job)] | length' <<<"${all_jobs_json}")" ||
+     ! assistant_failed_count="$(jq -r \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       '[.[] | select(.name == $assistant_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! assistant_success_count="$(jq -r \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       '[.[] | select(.name == $assistant_job and .conclusion == "success")] | length' <<<"${all_jobs_json}")" ||
+     ! assistant_valid_count="$(jq -r \
+       --arg run_id "${run_id}" \
+       --arg run_sha "${run_execution_sha}" \
+       --arg head_repo "${head_repo}" \
+       --argjson head_repo_id "${head_repo_id}" \
+       --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+       --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+       --arg workflow_id "${workflow_id}" \
+       --arg generation_step "CLA generation ${CLA_GENERATION}" \
+       '[.[] | select(
+          .name == $assistant_job and
+          ((has("workflow_name") | not) or
+           ((.workflow_name | type) == "string" and
+            .workflow_name == $workflow_name)) and
+          ((has("workflow_id") | not) or
+           ((.workflow_id | type) == "number" and
+            .workflow_id == ($workflow_id | tonumber))) and
+          .run_id == ($run_id | tonumber) and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          ((has("head_repository") | not) or
+           (.head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id))) and
+          any(.steps[]?;
+            .name == $generation_step and
+            .status == "completed"
+          )
+       )] | length' <<<"${all_jobs_json}")"; then
+    fail "Could not validate CLA Assistant v3 generation anchor"
+  fi
+  [[ "${assistant_count}" =~ ^[0-9]+$ && "${assistant_failed_count}" =~ ^[0-9]+$ &&
+     "${assistant_success_count}" =~ ^[0-9]+$ && "${assistant_valid_count}" =~ ^[0-9]+$ ]] ||
+    fail "Could not count CLA Assistant v3 jobs"
+  (( assistant_count == 1 )) || fail "Expected exactly one CLA Assistant v3 generation anchor"
+  (( assistant_valid_count == 1 )) || fail "The selected failed CLA check was created by an older workflow generation. Push a new commit or close and reopen this pull request to create a current-generation CLA check, then post the exact signing declaration again."
+  (( assistant_failed_count <= 1 )) || fail "The selected CLA run contains multiple failed CLA Assistant v3 jobs"
+  if (( assistant_failed_count == 0 && assistant_success_count != 1 )); then
+    fail "The CLA Assistant v3 generation anchor did not complete successfully"
+  fi
+
+  if ! writer_count="$(jq -r \
+      --arg writer_job "${CLA_WRITER_JOB}" \
+      '[.[] | select(.name == $writer_job)] | length' <<<"${failed_jobs_json}")" ||
+     ! writer_valid_count="$(jq -r \
+       --arg run_id "${run_id}" \
+       --arg run_sha "${run_execution_sha}" \
+       --arg head_repo "${head_repo}" \
+       --argjson head_repo_id "${head_repo_id}" \
+       --arg writer_job "${CLA_WRITER_JOB}" \
+       --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+       --arg workflow_id "${workflow_id}" \
+       '[.[] | select(
+          .name == $writer_job and
+          ((has("workflow_name") | not) or
+           ((.workflow_name | type) == "string" and
+            .workflow_name == $workflow_name)) and
+          ((has("workflow_id") | not) or
+           ((.workflow_id | type) == "number" and
+            .workflow_id == ($workflow_id | tonumber))) and
+          .run_id == ($run_id | tonumber) and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          ((has("head_repository") | not) or
+           (.head_repository == null or
+            ((.head_repository | type) == "object" and
+             .head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)))
+       )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA ledger writer jobs"
+  fi
+  [[ "${writer_count}" =~ ^[0-9]+$ && "${writer_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA ledger writer jobs"
+  (( writer_count <= 1 )) || fail "The selected CLA run contains multiple failed CLA ledger writer jobs"
+  (( writer_valid_count == writer_count )) || fail "The failed CLA ledger writer job is malformed or bound to a different source"
+
+  compatibility_count="$(jq -r --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" '[.[] | select(.name == $compatibility_job)] | length' <<<"${failed_jobs_json}")"
+  if ! compatibility_valid_count="$(jq -r \
+      --arg run_id "${run_id}" \
+      --arg run_sha "${run_execution_sha}" \
+      --arg head_repo "${head_repo}" \
+      --argjson head_repo_id "${head_repo_id}" \
+      --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+      --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+      --arg workflow_id "${workflow_id}" \
+      --arg compatibility_step "${CLA_COMPATIBILITY_STEP}" \
+      '[.[] | select(
+         .name == $compatibility_job and
+         ((has("workflow_name") | not) or
+          ((.workflow_name | type) == "string" and
+           .workflow_name == $workflow_name)) and
+         ((has("workflow_id") | not) or
+          ((.workflow_id | type) == "number" and
+           .workflow_id == ($workflow_id | tonumber))) and
+         .run_id == ($run_id | tonumber) and
+         (.head_sha | type == "string") and
+         .head_sha == $run_sha and
+         ((has("head_repository") | not) or
+          (.head_repository == null or
+           ((.head_repository | type) == "object" and
+            .head_repository.full_name == $head_repo and
+            .head_repository.id == $head_repo_id)))
+          and any(.steps[]?;
+            .name == $compatibility_step and
+            .status == "completed"
+          )
+       )] | length' <<<"${failed_jobs_json}")"; then
+    fail "Could not validate failed CLA compatibility jobs"
+  fi
+  [[ "${compatibility_count}" =~ ^[0-9]+$ && "${compatibility_valid_count}" =~ ^[0-9]+$ ]] || fail "Could not count failed CLA compatibility jobs"
+  (( compatibility_count <= 1 )) || fail "The selected CLA run contains multiple failed compatibility jobs"
+  (( compatibility_valid_count == compatibility_count )) || fail "The failed CLA compatibility job is malformed or bound to a different source"
+  if (( assistant_failed_count == 1 )); then
+    RERUN_TARGET_JOB_NAME="${CLA_ASSISTANT_JOB}"
+  elif (( compatibility_count == 1 && writer_count == 0 )); then
+    # A transient compatibility-mirror failure can block a repository that
+    # still requires the legacy context during migration. The successful v3
+    # job above remains the independently validated generation anchor.
+    RERUN_TARGET_JOB_NAME="${CLA_COMPATIBILITY_JOB}"
+  else
+    fail "The selected CLA run has no eligible failed result job"
+  fi
+  if (( writer_count == 1 || compatibility_count == 1 )); then
+    RERUN_FAILED_JOBS=true
+  else
+    RERUN_FAILED_JOBS=false
+  fi
+}
+validate_failed_job_set "${jobs_json}"
+# Select the sole failed result job from a validated job set. The v3 job
+# carries the generation marker. A compatibility-only failure uses the
+# separately validated successful v3 job as its generation anchor.
+select_rerun_job() {
+  local payload="$1"
+  jq -c \
+    --arg run_id "${run_id}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg target_job "${RERUN_TARGET_JOB_NAME}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg generation_step "CLA generation ${CLA_GENERATION}" \
+    --arg compatibility_step "${CLA_COMPATIBILITY_STEP}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" \
+    '[.[] | .jobs[]?
+      | select(
+          (.run_id | tostring) == $run_id and
+          .name == $target_job and
+          ((has("workflow_name") | not) or
+           ((.workflow_name | type) == "string" and
+            .workflow_name == $workflow_name)) and
+          ((has("workflow_id") | not) or
+           ((.workflow_id | type) == "number" and
+            .workflow_id == ($workflow_id | tonumber))) and
+          .status == "completed" and
+          .conclusion == "failure" and
+          (.head_sha | type == "string") and
+          .head_sha == $run_sha and
+          (
+            .head_repository == null or
+            (.head_repository.full_name == $head_repo and
+             .head_repository.id == $head_repo_id)
+          ) and
+          (($target_job == $assistant_job and
+            any(.steps[]?;
+              .name == $generation_step and
+              .status == "completed"
+            )) or
+           ($target_job == $compatibility_job and
+            any(.steps[]?;
+              .name == $compatibility_step and
+              .status == "completed"
+            )))
+        )
+    ]
+    | if length == 1 then .[0] else empty end
+  ' <<<"${payload}"
+}
+
+# Validate the exact failed result job for every discovery and final re-read.
+validate_exact_job_payload() {
+  local payload="$1"
+  jq -e \
+    --arg job_id "${job_id}" \
+    --arg run_id "${run_id}" \
+    --arg run_sha "${run_execution_sha}" \
+    --arg target_job "${RERUN_TARGET_JOB_NAME}" \
+    --arg assistant_job "${CLA_ASSISTANT_JOB}" \
+    --arg compatibility_job "${CLA_COMPATIBILITY_JOB}" \
+    --arg workflow_name "${CLA_WORKFLOW_NAME}" \
+    --arg workflow_id "${workflow_id}" \
+    --arg generation_step "CLA generation ${CLA_GENERATION}" \
+    --arg compatibility_step "${CLA_COMPATIBILITY_STEP}" \
+    --arg head_repo "${head_repo}" \
+    --argjson head_repo_id "${head_repo_id}" '
+      (.id | type == "number") and
+      .id == ($job_id | tonumber) and
+      (.run_id | type == "number") and
+      .run_id == ($run_id | tonumber) and
+      .name == $target_job and
+      ((has("workflow_name") | not) or
+       ((.workflow_name | type) == "string" and
+        .workflow_name == $workflow_name)) and
+      ((has("workflow_id") | not) or
+       ((.workflow_id | type) == "number" and
+        .workflow_id == ($workflow_id | tonumber))) and
+      .status == "completed" and
+      .conclusion == "failure" and
+      (.head_sha | type == "string") and
+      .head_sha == $run_sha and
+      (
+        (has("head_repository") | not) or
+        .head_repository == null or
+        ((.head_repository | type) == "object" and
+         .head_repository.full_name == $head_repo and
+         .head_repository.id == $head_repo_id)
+      ) and
+      (($target_job == $assistant_job and
+        any(.steps[]?;
+          .name == $generation_step and
+          .status == "completed"
+        )) or
+       ($target_job == $compatibility_job and
+        any(.steps[]?;
+          .name == $compatibility_step and
+          .status == "completed"
+        )))
+    ' <<<"${payload}" >/dev/null
+}
+
+target_job_name="${RERUN_TARGET_JOB_NAME}"
+[[ -n "${target_job_name}" ]] || fail "The selected CLA run has no eligible failed result job"
+if ! cla_job_json="$(select_rerun_job "${jobs_json}")"; then
+  fail "Could not validate the selected CLA result job"
+fi
+if [[ -z "${cla_job_json}" ]]; then
+  fail "The selected failed CLA result job is malformed or bound to an older workflow generation"
+fi
+job_id="$(jq -r '.id // empty' <<<"${cla_job_json}")"
+[[ "${job_id}" =~ ^[1-9][0-9]*$ ]] || fail "The selected CLA job ID is invalid"
+validate_failed_check_binding "${run_id}" "${job_id}" "${target_job_name}"
+
+# Re-read the individual job. The jobs list is discovery only, just
+# like the workflow-run list above.
+job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not query the selected CLA result job"
+validate_exact_job_payload "${job_json}" || fail "The selected CLA result job no longer matches the failed job in this run"
+
+# Recheck both resources immediately before the state-changing call.
+# This prevents a push or a concurrent rerun from making the job
+# stale while the preceding API requests were in flight.
+latest_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+validate_exact_pr_snapshot "${latest_pr_json}" || fail "The pull request changed while selecting the CLA job"
+final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job"
+validate_exact_job_payload "${final_job_json}" || fail "The exact failed CLA result job is no longer eligible"
+
+# Re-fetch the whole job set immediately before the state-changing call. This
+# catches a newly cancelled or unrelated failed job that could otherwise be
+# pulled into a failed-jobs rerun after the first validation.
+final_jobs_json="$(fetch_jobs_for_run "${run_id}")" || fail "Could not recheck and validate jobs for the selected CLA run"
+validate_failed_job_set "${final_jobs_json}"
+[[ "${RERUN_TARGET_JOB_NAME}" == "${target_job_name}" ]] || fail "The failed CLA result job changed while preparing the rerun"
+final_cla_job_json="$(select_rerun_job "${final_jobs_json}")" || fail "Could not select the final CLA result job"
+final_job_id="$(jq -r '.id // empty' <<<"${final_cla_job_json}")"
+[[ "${final_job_id}" == "${job_id}" ]] || fail "The selected CLA job changed while preparing the rerun"
+
+# Re-read the live PR, run, and job as one final authorization set. A source
+# push, branch retarget, job replacement, or concurrent rerun must invalidate
+# the request before the state-changing call. For fallback runs, the failed
+# check is fetched last and must bind both the exact source SHA and this job.
+final_pr_json="$(gh_api_bounded "repos/${GH_REPO}/pulls/${PR_NUMBER}" 2>/dev/null)" || fail "Could not recheck the pull request before rerun"
+validate_exact_pr_snapshot "${final_pr_json}" || fail "The pull request changed before rerun"
+final_run_json="$(gh_api_bounded "repos/${GH_REPO}/actions/runs/${run_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA run before rerun"
+validate_exact_run_payload "${final_run_json}" || fail "The selected CLA run changed before rerun"
+validate_run_source_binding "${final_run_json}"
+final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/dev/null)" || fail "Could not recheck the selected CLA job before rerun"
+validate_exact_job_payload "${final_job_json}" || fail "The selected CLA job changed before rerun"
+validate_failed_check_binding "${run_id}" "${job_id}" "${target_job_name}"
+
+if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
+  rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"
+  rerun_description="failed CLA result jobs (writer, v3, and compatibility)"
+else
+  rerun_endpoint="repos/${GH_REPO}/actions/jobs/${job_id}/rerun"
+  rerun_description="CLA job ${job_id}"
+fi
+if ! gh api \
+  --method POST \
+  --header 'Accept: application/vnd.github+json' \
+  --header 'X-GitHub-Api-Version: 2022-11-28' \
+  "${rerun_endpoint}" >/dev/null 2>&1; then
+  fail "Could not rerun the exact failed CLA job set"
+fi
+echo "Requested rerun for ${rerun_description} in workflow run ${run_id} at execution ${run_execution_sha} for PR head ${head_sha}"

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -66,7 +66,7 @@ readonly MAX_LEDGER_RAW_BYTES=2000000
 # is different: the historical writer may have completed successfully with
 # cla_passed=false before the signer recorded the new ledger entry. A
 # failed-jobs rerun would reuse that successful, stale writer result, so
-# signing events rerun the complete trusted CLA workflow below.
+# signing and recheck events rerun the complete trusted CLA workflow below.
 readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
 readonly CLA_WRITER_JOB='CLA ledger writer'
 readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
@@ -1496,11 +1496,13 @@ final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/de
 validate_exact_job_payload "${final_job_json}" || fail "The selected CLA job changed before rerun"
 validate_failed_check_binding "${run_id}" "${job_id}" "${target_job_name}"
 
-if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ||
+      "${COMMENT_BODY}" == "recheck" ]]; then
   # The writer can be successful while cla_passed=false in the selected
   # pull_request_target run. Re-run the whole small, trusted CLA workflow so
-  # the writer reads the signature just recorded before the required result
-  # and compatibility jobs evaluate its outputs.
+  # the writer reads the current ledger before the required result and
+  # compatibility jobs evaluate its outputs. A job-only rerun would reuse
+  # the stale successful writer output.
   rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun"
   rerun_description="CLA workflow run ${run_id} (refresh writer and result jobs)"
 elif [[ "${RERUN_FAILED_JOBS}" == true ]]; then

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -62,8 +62,11 @@ readonly MAX_LEDGER_RAW_BYTES=2000000
 # These rendered job names are part of the v3 workflow contract. Keep them
 # fixed here so a workflow edit cannot make this actions:write helper rerun an
 # arbitrary failed job. The writer and compatibility jobs are optional failed
-# members because a recheck can target a result-only failure; when either is
-# failed, rerun-failed-jobs refreshes every failed v3 context together.
+# members because a recheck can target a result-only failure. A signing event
+# is different: the historical writer may have completed successfully with
+# cla_passed=false before the signer recorded the new ledger entry. A
+# failed-jobs rerun would reuse that successful, stale writer result, so
+# signing events rerun the complete trusted CLA workflow below.
 readonly CLA_ASSISTANT_JOB='CLA Assistant v3'
 readonly CLA_WRITER_JOB='CLA ledger writer'
 readonly CLA_COMPATIBILITY_JOB='CLA Assistant'
@@ -1493,7 +1496,14 @@ final_job_json="$(gh_api_bounded "repos/${GH_REPO}/actions/jobs/${job_id}" 2>/de
 validate_exact_job_payload "${final_job_json}" || fail "The selected CLA job changed before rerun"
 validate_failed_check_binding "${run_id}" "${job_id}" "${target_job_name}"
 
-if [[ "${RERUN_FAILED_JOBS}" == true ]]; then
+if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+  # The writer can be successful while cla_passed=false in the selected
+  # pull_request_target run. Re-run the whole small, trusted CLA workflow so
+  # the writer reads the signature just recorded before the required result
+  # and compatibility jobs evaluate its outputs.
+  rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun"
+  rerun_description="CLA workflow run ${run_id} (refresh writer and result jobs)"
+elif [[ "${RERUN_FAILED_JOBS}" == true ]]; then
   rerun_endpoint="repos/${GH_REPO}/actions/runs/${run_id}/rerun-failed-jobs"
   rerun_description="failed CLA result jobs (writer, v3, and compatibility)"
 else

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -594,16 +594,16 @@ if ! candidate_list_json="$(jq -c \
             (.base.sha | type == "string") and
             (.base.sha | test("^[0-9a-f]{40}$")) and
             .base.sha == $base_sha and
-            ((.base.repo.full_name // "") == "" or
-             .base.repo.full_name == $repo) and
+            (.base.repo.full_name | type == "string") and
+            .base.repo.full_name == $repo and
             (.base.repo.id | type == "number") and
             .base.repo.id == $repo_id and
             .head.ref == $head_ref and
             .head.sha == $sha and
             (.head.repo.id | type == "number") and
             .head.repo.id == $head_repo_id and
-            ((.head.repo.full_name // "") == "" or
-             .head.repo.full_name == $head_repo)
+            (.head.repo.full_name | type == "string") and
+            .head.repo.full_name == $head_repo
           )
           end;
       [ .[] | .workflow_runs[]?
@@ -805,16 +805,16 @@ if [[ "${candidate_count}" == "0" ]]; then
            (.base.sha | type == "string") and
            (.base.sha | test("^[0-9a-f]{40}$")) and
            .base.sha == $base_sha and
-           ((.base.repo.full_name // "") == "" or
-            .base.repo.full_name == $repo) and
+           (.base.repo.full_name | type == "string") and
+           .base.repo.full_name == $repo and
            (.base.repo.id | type == "number") and
            .base.repo.id == $repo_id and
            .head.ref == $head_ref and
            .head.sha == $sha and
            (.head.repo.id | type == "number") and
            .head.repo.id == $head_repo_id and
-           ((.head.repo.full_name // "") == "" or
-            .head.repo.full_name == $head_repo)
+           (.head.repo.full_name | type == "string") and
+           .head.repo.full_name == $head_repo
          )
          end;
      [ .[] | .workflow_runs[]?
@@ -1058,16 +1058,16 @@ validate_exact_run_payload() {
             (.base.sha | type == "string") and
             (.base.sha | test("^[0-9a-f]{40}$")) and
             .base.sha == $base_sha and
-            ((.base.repo.full_name // "") == "" or
-             .base.repo.full_name == $repo) and
+            (.base.repo.full_name | type == "string") and
+            .base.repo.full_name == $repo and
             (.base.repo.id | type == "number") and
             .base.repo.id == $repo_id and
             .head.ref == $head_ref and
             .head.sha == $sha and
             (.head.repo.id | type == "number") and
             .head.repo.id == $head_repo_id and
-            ((.head.repo.full_name // "") == "" or
-             .head.repo.full_name == $head_repo)
+            (.head.repo.full_name | type == "string") and
+            .head.repo.full_name == $head_repo
           )
           end;
       (.id | type == "number") and

--- a/.github/scripts/rerun-failed-cla.sh
+++ b/.github/scripts/rerun-failed-cla.sh
@@ -491,9 +491,11 @@ workflow_id="$(jq -r --arg path "${WORKFLOW_PATH}" '[.[] | .workflows[]? | selec
 # When GitHub includes pull_requests on a run, bind the candidate to the exact
 # PR object, including its source head and live base SHAs. GitHub can return an
 # empty array for pull_request_target runs. Those candidates are accepted only
-# when the run has complete source-repository metadata and its execution SHA is
-# the live PR base SHA. Missing metadata cannot identify which fork produced a
-# branch, so it is always rejected before any check is rerun.
+# when the run has complete source-repository metadata. The later binding step
+# accepts the live base execution directly, or binds a non-base execution to
+# the live source head and its exact failed check. Missing metadata cannot
+# identify which fork produced a branch, so it is always rejected before any
+# check is rerun.
 runs_page="$(gh_api_bounded \
   --method GET \
   --header 'Accept: application/vnd.github+json' \
@@ -577,7 +579,6 @@ if ! candidate_list_json="$(jq -c \
         | if $prs == null then false
           elif ($prs | length > 100) then false
           elif ($prs | length) == 0 then
-            .head_sha == $base_sha and
             .head_branch == $head_ref and
             (.head_repository | type) == "object" and
             .head_repository.full_name == $head_repo and
@@ -789,7 +790,6 @@ if [[ "${candidate_count}" == "0" ]]; then
        | if $prs == null then false
          elif ($prs | length > 100) then false
          elif ($prs | length) == 0 then
-           .head_sha == $sha and
            .head_branch == $head_ref and
            (.head_repository | type) == "object" and
            .head_repository.full_name == $head_repo and
@@ -856,11 +856,11 @@ run_head_branch="$(jq -r '.head_branch // empty' <<<"${candidate_json}")"
 
 # A run with a populated pull_requests array carries a source-PR association,
 # but that association is still only discovery data. For pull_request_target,
-# GitHub records the Actions check on the workflow execution SHA (normally the
-# live PR base SHA), not on the untrusted source head. Empty associations need
-# one extra branch: when GitHub omits or cannot prove the source repository and
-# base execution SHA, require a failed check on the exact source head instead.
-# The selected check always names the exact run and job in its details URL.
+# GitHub normally records the Actions check on the workflow execution SHA,
+# which is the live PR base. If the execution SHA differs, the helper requires
+# complete source metadata, a fresh exact live-PR association, and a failed
+# check on the immutable source head. The selected check always names the
+# exact run and job in its details URL.
 
 # These values are set by validate_run_source_binding before each check lookup.
 # Keeping the lookup SHA separate from the PR source SHA avoids silently using
@@ -1043,7 +1043,6 @@ validate_exact_run_payload() {
            else null end) as $prs
         | if $prs == null then false
           elif ($prs | length) == 0 then
-            .head_sha == $base_sha and
             .head_branch == $head_ref and
             (.head_repository | type) == "object" and
             .head_repository.full_name == $head_repo and

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,12 @@ on:
       - scripts/ghosttykit-checksums.txt
       - tests/test_ci_ghosttykit_release_check.sh
       - tests/test_ci_change_areas.py
+      - .github/workflows/cla.yml
       - .github/workflows/ci.yml
+      - .github/scripts/rerun-failed-cla.sh
+      - tests/test_cla_rerun_workflow.sh
+      - tests/test_cla_lock_workflow.sh
+      - tests/test_cla_trigger_gate.sh
   workflow_dispatch:
 
 permissions:
@@ -185,6 +190,18 @@ jobs:
 
       - name: Install workflow guard Python dependencies
         run: python3 -m pip install --disable-pip-version-check --no-input PyYAML==6.0.3 bashlex==0.18
+
+      # These fixtures run only in this unprivileged pull_request job. They
+      # exercise the candidate workflow for developer feedback, never serve as
+      # the security boundary, and never run from pull_request_target.
+      - name: Validate CLA trigger admission behavior
+        run: ./tests/test_cla_trigger_gate.sh
+
+      - name: Validate CLA rerun authorization behavior
+        run: ./tests/test_cla_rerun_workflow.sh
+
+      - name: Validate merged pull request lock behavior
+        run: ./tests/test_cla_lock_workflow.sh
 
       - name: Validate Blacksmith Testbox broker trust boundary
         run: python3 tests/test_ci_testbox_broker_guard.py

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,86 +1,486 @@
-name: "CLA Assistant"
+name: "CLA Assistant v3"
 
-# Contributor License Agreement check. The action lives in our fork,
-# manaflow-ai/cla-github-action, and is pinned to a commit. Signers are the
-# pull request opener plus every primary commit author GitHub maps to an
-# account. Co-authored-by trailers (pairing partners, AI agents) and the git
-# committer field never need to sign, and a signature is reused in every
-# later pull request. Maintainer accounts in allowlist-ids never sign.
 on:
   issue_comment:
     types: [created]
   pull_request_target:
     branches: [main]
-    types: [opened, closed, reopened, synchronize]
+    types: [opened,closed,edited,reopened,synchronize,ready_for_review]
 
 permissions: {}
 
+# This marker changes only when the policy or maintained action changes. It
+# gives the rerun worker a stable generation that is independent of unrelated
+# commits on main.
+env:
+  CLA_GENERATION: "v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+
 jobs:
-  CLAAssistant:
-    name: "CLA Assistant"
-    # Comment admission is a coarse filter: GitHub appends CRLF to plain
-    # comments, so equality would drop real declarations. The action does the
-    # exact match itself and ignores anything else.
+  # This job has read-only permissions. It performs the exact event check and
+  # authenticates a new signing comment before any write-capable job starts.
+  CLACommentGate:
+    name: "Validate CLA trigger"
     if: >-
-      github.event_name == 'pull_request_target' ||
       (
+        github.event_name == 'pull_request_target' &&
+        (
+          github.event.action == 'opened' ||
+          github.event.action == 'edited' ||
+          github.event.action == 'reopened' ||
+          github.event.action == 'synchronize' ||
+          github.event.action == 'ready_for_review'
+        )
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.action == 'created' &&
+        github.event.issue.state == 'open' &&
         github.event.issue.pull_request &&
         github.event.comment.user.type == 'User' &&
         (
-          contains(github.event.comment.body, 'recheck') ||
-          contains(github.event.comment.body, 'I have read the CLA Document v2.2 and I hereby sign the CLA')
+          (
+            github.event.comment.body == 'recheck' &&
+            (
+              github.event.comment.user.id == github.event.issue.user.id ||
+              github.event.comment.author_association == 'OWNER' ||
+              github.event.comment.author_association == 'MEMBER' ||
+              github.event.comment.author_association == 'COLLABORATOR'
+            )
+          ) ||
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
         )
       )
-    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
     timeout-minutes: 10
-    # One run at a time per pull request so two signature events cannot write
-    # the ledger from different snapshots. Independent pull requests proceed.
     concurrency:
-      group: cla-${{ github.event.pull_request.number || github.event.issue.number }}
+      group: cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.run_id }}
       cancel-in-progress: false
     permissions:
-      # Signature ledger commits on the cla-signatures branch.
-      contents: write
-      # Bot comment on the pull request. issues:write is needed for reactions
-      # and comments on fork pull requests.
-      issues: write
-      pull-requests: write
-      # Re-run the pull_request_target check after a signature comment.
-      actions: write
+      contents: read
+      issues: read
+      pull-requests: read
+    outputs:
+      admitted: ${{ steps.admission.outputs.admitted }}
+      signer_authorized: ${{ steps.signer_preflight.outputs.signer_authorized }}
+      head_sha: ${{ steps.signer_preflight.outputs.head_sha }}
+      base_sha: ${{ steps.signer_preflight.outputs.base_sha }}
+      comment_id: ${{ steps.signer_preflight.outputs.comment_id }}
+      comment_created_at: ${{ steps.signer_preflight.outputs.comment_created_at }}
+      comment_author_id: ${{ steps.signer_preflight.outputs.comment_author_id }}
     steps:
-      - name: "CLA Assistant"
-        id: cla
-        uses: manaflow-ai/cla-github-action@f567430d44e22bc0bb6ecd1e00d383ef22886025
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Validate exact CLA trigger"
+        id: admission
+        if: runner.environment == 'github-hosted'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_ACTION: ${{ github.event.action }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id || '' }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login || '' }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type || '' }}
+          PR_AUTHOR_ID: ${{ github.event.issue.user.id || '' }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association || '' }}
+        run: |
+          set -euo pipefail
+          fail() {
+            echo "::error::$1"
+            exit 1
+          }
+          emit() {
+            [[ -n "${GITHUB_OUTPUT+x}" && -n "${GITHUB_OUTPUT}" ]] || fail "GITHUB_OUTPUT is unavailable"
+            printf 'admitted=%s\n' "$1" >>"${GITHUB_OUTPUT}"
+          }
+          [[ -n "${EVENT_NAME:-}" && -n "${EVENT_ACTION:-}" ]] || fail "Event metadata is incomplete"
+          if [[ "${EVENT_NAME}" == "issue_comment" ]]; then
+            [[ "${EVENT_ACTION}" == "created" ]] || fail "Issue-comment event action is unsupported"
+            [[ "${COMMENT_AUTHOR_TYPE}" == "User" && -n "${COMMENT_AUTHOR_LOGIN}" ]] || fail "Comment author is not a human user"
+            [[ "${COMMENT_AUTHOR_LOGIN,,}" != *"[bot]" ]] || fail "Bot comments cannot trigger the CLA action"
+            [[ "${COMMENT_AUTHOR_ID}" =~ ^[1-9][0-9]*$ && "${PR_AUTHOR_ID}" =~ ^[1-9][0-9]*$ ]] || fail "Comment identity is malformed"
+            [[ -n "${COMMENT_AUTHOR_ASSOCIATION}" && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\n'* && "${COMMENT_AUTHOR_ASSOCIATION}" != *$'\r'* ]] || fail "Comment association is malformed"
+            if [[ "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" ]]; then
+              printf 'admitted=true\n' >>"${GITHUB_OUTPUT}"
+            elif [[ "${COMMENT_BODY}" == "recheck" ]]; then
+              if [[ "${COMMENT_AUTHOR_ID}" == "${PR_AUTHOR_ID}" ]]; then
+                emit true
+              else
+                case "${COMMENT_AUTHOR_ASSOCIATION}" in
+                  OWNER|MEMBER|COLLABORATOR) emit true ;;
+                  *) emit false ;;
+                esac
+              fi
+            else
+              emit false
+            fi
+          elif [[ "${EVENT_NAME}" == "pull_request_target" ]]; then
+            case "${EVENT_ACTION}" in
+              opened|edited|reopened|synchronize|ready_for_review) emit true ;;
+              *) fail "Pull-request event action is unsupported" ;;
+            esac
+          else
+            fail "Event is not an accepted CLA trigger"
+          fi
+
+      - name: "Authenticate exact CLA signer"
+        id: signer_preflight
+        if: >-
+          runner.environment == 'github-hosted' &&
+          success() &&
+          github.event_name == 'issue_comment' &&
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          path-to-signatures: 'signatures/version2/cla.json'
-          path-to-document: 'https://github.com/manaflow-ai/cmux/blob/main/CLA.md'
-          # Signatures live on an unprotected branch so main's checks never
-          # block the bot's ledger commits.
-          branch: 'cla-signatures'
-          required-base-ref: 'main'
-          custom-pr-sign-comment: 'I have read the CLA Document v2.2 and I hereby sign the CLA'
-          lock-pullrequest-aftermerge: 'false'
-          # Numeric GitHub IDs of maintainers who never sign, as opener or as
-          # commit author: @lawrencecchen, @austinywang, @azooz2003-bit.
-          allowlist-ids: '54008264,38676809,67667005'
+          mode: "signer-preflight"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          require-opener-as-author: "true"
+          allowlist-ids: "38676809,67667005"
 
-      # A signature comment runs this workflow from main, so its check run
-      # attaches to main, not to the pull request head. Re-run the failed
-      # pull_request_target run for the head so the pull request turns green
-      # without another push.
-      - name: "Refresh the pull request check after a new signature"
-        if: github.event_name == 'issue_comment' && steps.cla.outputs.signature_recorded == 'true'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.issue.number }}
+  # This is the only job with ledger and comment write permissions. It has no
+  # shell step, so policy text cannot execute with its token. The action repeats
+  # live PR/comment validation and binds a signing write to the exact head SHA
+  # observed by the read-only gate.
+  CLALedgerWriter:
+    name: "CLA ledger writer"
+    needs: CLACommentGate
+    if: >-
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize' ||
+            github.event.action == 'ready_for_review'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
+          (
+            (
+              github.event.comment.body == 'recheck' &&
+              (
+                github.event.comment.user.id == github.event.issue.user.id ||
+                github.event.comment.author_association == 'OWNER' ||
+                github.event.comment.author_association == 'MEMBER' ||
+                github.event.comment.author_association == 'COLLABORATOR'
+              )
+            ) ||
+              (
+                github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+                needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+                needs.CLACommentGate.outputs.head_sha != '' &&
+                needs.CLACommentGate.outputs.base_sha != ''
+            )
+          )
+        )
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 15
+    concurrency:
+      group: cla-signatures-${{ github.repository }}-${{ github.event.pull_request.number || github.event.issue.number }}
+      cancel-in-progress: false
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    outputs:
+      signature_recorded: ${{ steps.cla_action.outputs.signature_recorded }}
+      cla_passed: ${{ steps.cla_action.outputs.cla_passed }}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
         run: |
           set -euo pipefail
-          head="$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json headRefOid --jq .headRefOid)"
-          run_id="$(gh run list --repo "$GITHUB_REPOSITORY" --workflow cla.yml --event pull_request_target --commit "$head" --status failure --limit 1 --json databaseId --jq '.[0].databaseId // empty')"
-          if [[ -z "$run_id" ]]; then
-            echo "No failed CLA run for $head; nothing to refresh."
-            exit 0
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Write CLA result"
+        id: cla_action
+        if: runner.environment == 'github-hosted'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          path-to-signatures: "signatures/version2/cla.json"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "false"
+          expected-head-sha: "${{ needs.CLACommentGate.outputs.head_sha }}"
+          expected-base-sha: "${{ needs.CLACommentGate.outputs.base_sha }}"
+          expected-comment-id: "${{ needs.CLACommentGate.outputs.comment_id }}"
+          expected-comment-created-at: "${{ needs.CLACommentGate.outputs.comment_created_at }}"
+          expected-comment-author-id: "${{ needs.CLACommentGate.outputs.comment_author_id }}"
+
+  # This no-permission job owns the required v3 check context. A gate or writer
+  # failure is visible as a failed check instead of being hidden as a skipped
+  # privileged job.
+  CLAAssistant:
+    name: "CLA Assistant v3"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+    if: >-
+      always() &&
+      (
+        (
+          github.event_name == 'pull_request_target' &&
+          (
+            github.event.action == 'opened' ||
+            github.event.action == 'edited' ||
+            github.event.action == 'reopened' ||
+            github.event.action == 'synchronize' ||
+            github.event.action == 'ready_for_review'
+          )
+        ) ||
+        (
+          github.event_name == 'issue_comment' &&
+          github.event.action == 'created' &&
+          github.event.issue.state == 'open' &&
+          github.event.issue.pull_request &&
+          github.event.comment.user.type == 'User' &&
+          (
+            (
+              github.event.comment.body == 'recheck' &&
+              needs.CLACommentGate.result == 'success' &&
+              needs.CLACommentGate.outputs.admitted == 'true' &&
+              (
+                github.event.comment.user.id == github.event.issue.user.id ||
+                github.event.comment.author_association == 'OWNER' ||
+                github.event.comment.author_association == 'MEMBER' ||
+                github.event.comment.author_association == 'COLLABORATOR'
+              )
+            ) ||
+            github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
+          )
+        )
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      # Keep the generation marker on the required check's only step. The
+      # marker must remain visible when this result fails because the writer
+      # failed in the original pull_request_target run. The immutable rerun
+      # helper uses the rendered step name to reject older workflow runs.
+      - name: "CLA generation v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af"
+        if: runner.environment == 'github-hosted'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          COMMENT_BODY: ${{ github.event.comment.body || '' }}
+          GATE_RESULT: ${{ needs.CLACommentGate.result }}
+          ADMITTED: ${{ needs.CLACommentGate.outputs.admitted || '' }}
+          SIGNER_AUTHORIZED: ${{ needs.CLACommentGate.outputs.signer_authorized || '' }}
+          WRITER_RESULT: ${{ needs.CLALedgerWriter.result }}
+          CLA_PASSED: ${{ needs.CLALedgerWriter.outputs.cla_passed || '' }}
+        run: |
+          set -euo pipefail
+          echo "CLA generation ${CLA_GENERATION}"
+          if [[ "${GATE_RESULT}" != "success" || "${ADMITTED}" != "true" ]]; then
+            echo "::error::CLA trigger admission failed"
+            exit 1
           fi
-          gh run rerun "$run_id" --failed --repo "$GITHUB_REPOSITORY"
+          if [[ "${EVENT_NAME}" == "issue_comment" &&
+                "${COMMENT_BODY}" == "I have read the CLA Document v2.2 and I hereby sign the CLA" &&
+                "${SIGNER_AUTHORIZED}" != "true" ]]; then
+            echo "::error::CLA signer preflight failed"
+            exit 1
+          fi
+          if [[ "${WRITER_RESULT}" != "success" ]]; then
+            echo "::error::CLA ledger writer failed"
+            exit 1
+          fi
+          if [[ "${CLA_PASSED}" != "true" ]]; then
+            echo "::error::CLA action did not confirm that all contributors have signed"
+            exit 1
+          fi
+
+  # Keep the old context during migration. It has no token and is not the
+  # required context after the v3 ruleset migration.
+  CLACompatibility:
+    name: "CLA Assistant"
+    needs:
+      - CLACommentGate
+      - CLAAssistant
+    if: >-
+      always() &&
+      github.event_name == 'pull_request_target' &&
+      (
+        github.event.action == 'opened' ||
+        github.event.action == 'edited' ||
+        github.event.action == 'reopened' ||
+        github.event.action == 'synchronize' ||
+        github.event.action == 'ready_for_review'
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Mirror CLA Assistant compatibility result"
+        if: runner.environment == 'github-hosted'
+        env:
+          RESULT: ${{ needs.CLAAssistant.result }}
+        run: |
+          set -euo pipefail
+          [[ "${RESULT}" == "success" ]] || {
+            echo "::error::CLA Assistant v3 did not pass"
+            exit 1
+          }
+
+  # This job can refresh a failed check only through the immutable helper from
+  # the base workflow revision. It receives actions:write, never contents or
+  # comment write access, and its shell command and environment are fixed by
+  # the base-controlled policy validator.
+  RerunFailedCLA:
+    name: "Rerun failed CLA check"
+    needs:
+      - CLACommentGate
+      - CLALedgerWriter
+      - CLAAssistant
+    if: >-
+      always() &&
+      needs.CLACommentGate.result == 'success' &&
+      needs.CLACommentGate.outputs.admitted == 'true' &&
+      needs.CLAAssistant.result != 'skipped' &&
+      github.event_name == 'issue_comment' &&
+      github.event.action == 'created' &&
+      github.event.issue.state == 'open' &&
+      github.event.issue.pull_request &&
+      github.event.comment.user.type == 'User' &&
+      (
+        (
+          github.event.comment.body == 'recheck' &&
+          (
+            github.event.comment.user.id == github.event.issue.user.id ||
+            github.event.comment.author_association == 'OWNER' ||
+            github.event.comment.author_association == 'MEMBER' ||
+            github.event.comment.author_association == 'COLLABORATOR'
+          ) &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.cla_passed == 'true'
+        ) ||
+        (
+          github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA' &&
+          needs.CLACommentGate.outputs.signer_authorized == 'true' &&
+          needs.CLALedgerWriter.result == 'success' &&
+          needs.CLALedgerWriter.outputs.cla_passed == 'true' &&
+          needs.CLALedgerWriter.outputs.signature_recorded == 'true'
+        )
+      )
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 15
+    concurrency:
+      group: cla-rerun-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      actions: write
+      checks: read
+      contents: read
+      issues: read
+      pull-requests: read
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Checkout trusted CLA rerun helper"
+        if: runner.environment == 'github-hosted'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd
+        with:
+          repository: ${{ github.repository }}
+          ref: ${{ github.workflow_sha }}
+          persist-credentials: false
+          sparse-checkout: .github/scripts/rerun-failed-cla.sh
+          sparse-checkout-cone-mode: false
+      - name: "Rerun exact failed pull_request_target run"
+        if: runner.environment == 'github-hosted'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_NAME: ${{ github.event_name }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          COMMENT_BODY: ${{ github.event.comment.body }}
+          COMMENT_CREATED_AT: ${{ github.event.comment.created_at }}
+          COMMENT_AUTHOR_ID: ${{ github.event.comment.user.id }}
+          COMMENT_AUTHOR_LOGIN: ${{ github.event.comment.user.login }}
+          COMMENT_AUTHOR_TYPE: ${{ github.event.comment.user.type }}
+          COMMENT_AUTHOR_ASSOCIATION: ${{ github.event.comment.author_association }}
+          WORKFLOW_PATH: ".github/workflows/cla.yml"
+          WORKFLOW_SHA: ${{ github.workflow_sha }}
+          CLA_GENERATION: ${{ env.CLA_GENERATION }}
+          TARGET_EVENT: "pull_request_target"
+          TARGET_BASE_REF: "main"
+          SIGNATURE_RECORDED: ${{ needs.CLALedgerWriter.outputs.signature_recorded || '' }}
+        run: bash .github/scripts/rerun-failed-cla.sh
+
+  LockMergedPullRequest:
+    name: "Lock merged pull request"
+    if: >-
+      github.event_name == 'pull_request_target' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.merged == true
+    runs-on: ubuntu-24.04 # github-hosted-required: CLA policy jobs
+    timeout-minutes: 10
+    concurrency:
+      group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
+      cancel-in-progress: false
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: "Require GitHub-hosted runner"
+        if: runner.environment != 'github-hosted'
+        run: |
+          set -euo pipefail
+          echo "::error::CLA policy requires a GitHub-hosted runner"
+          exit 1
+      - name: "Lock merged pull request"
+        if: runner.environment == 'github-hosted'
+        uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          mode: "sign"
+          path-to-signatures: "signatures/version2/cla.json"
+          path-to-document: "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md"
+          branch: "cla-signatures"
+          required-base-ref: "main"
+          custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          allowlist-ids: "38676809,67667005"
+          require-opener-as-author: "true"
+          lock-pullrequest-aftermerge: "true"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -461,7 +461,6 @@ jobs:
       group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
-      contents: read
       issues: write
       pull-requests: write
     steps:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -489,6 +489,9 @@ jobs:
           branch: "cla-signatures"
           required-base-ref: "main"
           custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          # Keep this exemption set limited to the two independent maintainers.
+          # Maintainer IDs are intentionally absent so merge locking cannot
+          # become a second maintainer self-bypass path.
           allowlist-ids: "38676809,67667005"
           require-opener-as-author: "true"
           lock-pullrequest-aftermerge: "true"

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -461,6 +461,7 @@ jobs:
       group: cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}
       cancel-in-progress: false
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     steps:

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -131,6 +131,7 @@ jobs:
         if: >-
           runner.environment == 'github-hosted' &&
           success() &&
+          steps.admission.outputs.admitted == 'true' &&
           github.event_name == 'issue_comment' &&
           github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'
         uses: manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -145,6 +145,9 @@ jobs:
           required-base-ref: "main"
           custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
           require-opener-as-author: "true"
+          # Keep this exemption set limited to the two independent maintainers.
+          # Maintainer IDs are intentionally absent: an opener exemption would
+          # let a maintainer bypass the same CLA ledger required of contributors.
           allowlist-ids: "38676809,67667005"
 
   # This is the only job with ledger and comment write permissions. It has no
@@ -223,6 +226,9 @@ jobs:
           branch: "cla-signatures"
           required-base-ref: "main"
           custom-pr-sign-comment: "I have read the CLA Document v2.2 and I hereby sign the CLA"
+          # Keep this exemption set limited to the two independent maintainers.
+          # Maintainer IDs are intentionally absent for the same self-bypass
+          # reason as the signer preflight above.
           allowlist-ids: "38676809,67667005"
           require-opener-as-author: "true"
           lock-pullrequest-aftermerge: "false"

--- a/scripts/ci/validate-cla-policy.rb
+++ b/scripts/ci/validate-cla-policy.rb
@@ -2142,7 +2142,7 @@ def validate_workflow(raw)
   fail!("RerunFailedCLA permissions are not least-privilege") unless
     rerun["permissions"] == { "actions" => "write", "checks" => "read", "contents" => "read", "issues" => "read", "pull-requests" => "read" }
   fail!("LockMergedPullRequest permissions are not least-privilege") unless
-    lock["permissions"] == { "issues" => "write", "pull-requests" => "write" }
+    lock["permissions"] == { "contents" => "read", "issues" => "write", "pull-requests" => "write" }
 
   action_step = step_using(writer, CLA_ACTION, "CLALedgerWriter")
   with_values = action_step["with"]

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -15,6 +15,22 @@ COMPAT_FILE="$ROOT_DIR/.github/workflows/ci-macos-compat.yml"
 E2E_FILE="$ROOT_DIR/.github/workflows/test-e2e.yml"
 TMUX_CORPUS_FILE="$ROOT_DIR/.github/workflows/tmux-corpus.yml"
 IOS_FILE="$ROOT_DIR/.github/workflows/test-ios.yml"
+CLA_GUARD_FILE="$ROOT_DIR/.github/workflows/cla-policy-guard.yml"
+
+check_cla_guard_runner() {
+  if ! grep -Fqx '    runs-on: ubuntu-24.04' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must use the fixed GitHub-hosted ubuntu-24.04 runner"
+    exit 1
+  fi
+
+  if grep -Eq '^    runs-on:.*(vars\.LINUX_RUNNER|blacksmith-|self-hosted)' "$CLA_GUARD_FILE"; then
+    echo "FAIL: cla-policy-guard.yml must not allow a variable or self-hosted runner override"
+    exit 1
+  fi
+
+  echo "PASS: CLA policy guard uses the fixed GitHub-hosted runner"
+}
+
 check_macos_runner() {
   local file="$1" job="$2"
   if ! awk -v job="$job" '
@@ -1109,6 +1125,9 @@ check_no_bare_github_hosted_runners() {
   # MACOS_RUNNER_*) so the Blacksmith<->Warp / Blacksmith<->macos-26 overflow
   # switch is a single repo-variable flip with no PR. A bare GitHub-hosted
   # label (ubuntu-*, macos-NN) cannot be redirected, so it is forbidden.
+  # The CLA policy guard is a separate immutable control-plane job and is
+  # intentionally exempted below because it must never honor a repository
+  # variable or self-hosted runner override.
   # Bare paid-provider labels (blacksmith-*, warp-*, depot-*) stay allowed for
   # deliberate single-runner pins such as the testmanagerd-wedged
   # `app-host-unit-tests` job.
@@ -1117,7 +1136,7 @@ check_no_bare_github_hosted_runners() {
   # ephemeral runner that no repo variable can redirect, and every edit to it
   # needs a trusted approval through the CLA policy validator, so the marker
   # comment cannot be added there. Exempt the file here instead.
-  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)([[:space:]]*$|[[:space:]]+#)" "$ROOT_DIR/.github/workflows" | grep -v "github-hosted-required" | grep -v "/cla-policy-guard.yml:" || true)"
+  hits="$(grep -rnE "runs-on:[[:space:]]*(ubuntu-[a-z0-9.]+|macos-[a-z0-9]+)([[:space:]]*$|[[:space:]]+#)" "$ROOT_DIR/.github/workflows" | grep -v "github-hosted-required" | grep -v '/.github/workflows/cla-policy-guard.yml:' || true)"
   if [[ -n "$hits" ]]; then
     echo "FAIL: these jobs use a bare GitHub-hosted runner; route them through vars.LINUX_RUNNER / vars.MACOS_RUNNER_IOS so Blacksmith<->overflow stays a repo-variable flip:"
     echo "$hits"
@@ -1241,6 +1260,7 @@ check_no_self_hosted_fleet_runners() {
 }
 
 # ci.yml jobs
+check_cla_guard_runner
 check_no_bare_github_hosted_runners
 check_no_self_hosted_fleet_runners
 check_macos_runner "$CI_FILE" "app-host-unit-tests"

--- a/tests/test_cla_lock_workflow.sh
+++ b/tests/test_cla_lock_workflow.sh
@@ -18,6 +18,7 @@ jobs = workflow.fetch("jobs")
 lock = jobs.fetch("LockMergedPullRequest")
 
 abort "lock job has unexpected permissions" unless lock.fetch("permissions") == {
+  "contents" => "read",
   "issues" => "write",
   "pull-requests" => "write"
 }

--- a/tests/test_cla_lock_workflow.sh
+++ b/tests/test_cla_lock_workflow.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Verify the merged-PR lock job as a workflow artifact. The maintained action
+# owns the API behavior and has its own tests; this check proves that the
+# privileged cmux workflow invokes it only for a merged pull request with the
+# narrow lock contract.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
+test -f "$WORKFLOW"
+command -v ruby >/dev/null
+
+WORKFLOW="$WORKFLOW" ruby <<'RUBY'
+require "yaml"
+
+workflow = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+jobs = workflow.fetch("jobs")
+lock = jobs.fetch("LockMergedPullRequest")
+
+abort "lock job has unexpected permissions" unless lock.fetch("permissions") == {
+  "issues" => "write",
+  "pull-requests" => "write"
+}
+abort "lock job must run only for merged pull requests" unless lock.fetch("if").include?("github.event.action == 'closed'") && lock.fetch("if").include?("github.event.pull_request.merged == true")
+abort "lock queue is not per pull request" unless lock.fetch("concurrency").fetch("group") == "cla-lock-${{ github.repository }}-${{ github.event.pull_request.number }}"
+abort "lock queue must not cancel an earlier lock" unless lock.fetch("concurrency").fetch("cancel-in-progress") == false
+
+steps = lock.fetch("steps")
+abort "lock job must contain a runner guard and one action step" unless steps.length == 2
+runner_guard = steps.fetch(0)
+abort "lock runner guard is not fail-closed" unless runner_guard == {
+  "name" => "Require GitHub-hosted runner",
+  "if" => "runner.environment != 'github-hosted'",
+  "run" => "set -euo pipefail\necho \"::error::CLA policy requires a GitHub-hosted runner\"\nexit 1\n"
+}
+step = steps.fetch(1)
+abort "lock action is not restricted to a hosted runner" unless step.fetch("if") == "runner.environment == 'github-hosted'"
+abort "lock job may not execute workflow shell text" if step.key?("run")
+uses = step.fetch("uses")
+abort "lock action is not pinned to the maintained release" unless
+  uses == "manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af"
+abort "lock action token is not the workflow token" unless step.fetch("env") == { "GITHUB_TOKEN" => "${{ secrets.GITHUB_TOKEN }}" }
+expected = {
+  "mode" => "sign",
+  "path-to-signatures" => "signatures/version2/cla.json",
+  "path-to-document" => "https://github.com/${{ github.repository }}/blob/${{ github.workflow_sha }}/CLA.md",
+  "branch" => "cla-signatures",
+  "required-base-ref" => "main",
+  "custom-pr-sign-comment" => "I have read the CLA Document v2.2 and I hereby sign the CLA",
+  "allowlist-ids" => "38676809,67667005",
+  "require-opener-as-author" => "true",
+  "lock-pullrequest-aftermerge" => "true"
+}
+abort "lock action inputs changed" unless step.fetch("with") == expected
+puts "PASS: merged-PR lock workflow contract"
+RUBY

--- a/tests/test_cla_lock_workflow.sh
+++ b/tests/test_cla_lock_workflow.sh
@@ -18,7 +18,6 @@ jobs = workflow.fetch("jobs")
 lock = jobs.fetch("LockMergedPullRequest")
 
 abort "lock job has unexpected permissions" unless lock.fetch("permissions") == {
-  "contents" => "read",
   "issues" => "write",
   "pull-requests" => "write"
 }

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -482,6 +482,15 @@ gh() {
             {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
             {id:506,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:"Mirror CLA Assistant compatibility result",status:"completed",conclusion:"failure"}]}
           ]}'
+      elif [[ "${FAKE_MODE}" == recheck-stale-writer ]]; then
+        # The Jobs API does not expose workflow outputs. A successful writer
+        # followed by a failed v3 result is the observable shape of a
+        # historical run whose writer output was cla_passed=false.
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"success",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]}
+          ]}'
       elif [[ "${FAKE_MODE}" == writer-failed ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
@@ -691,6 +700,8 @@ run_case late-ambiguous 0 "Requested rerun for CLA job 500 in workflow run 400" 
 run_case external-signer 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case signing-stale-writer 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun"
+run_case recheck-stale-writer 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case unrecorded-signer 1 "did not result in a persisted signature" 0
 run_case unbound-signer 1 "signing comment was not the signature persisted" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -94,9 +94,10 @@ export SIGNATURE_RECORDED=false
 # fork-only commit has no result from /commits/:sha/pulls, while the workflow
 # run still carries head_repository identity. GitHub may report the source PR
 # SHA or a different execution SHA on a pull_request_target run, so this fixture
-# keeps the live PR head at `aaaa...` and the selected run/job execution SHA at
-# `bbbb...`. A production-shaped empty association is accepted only when the
-# run has complete source metadata and uses the live PR base SHA. A source-SHA,
+# keeps the live PR head at `aaaa...` and the normal selected run/job execution
+# SHA at the live base `cccc...`. A production-shaped empty association is accepted only when the
+# run has complete source metadata and can be bound to the live PR. A source
+# or execution SHA then needs the matching live association and check. A
 # null-repository, stale-base, or mismatched metadata run must fail closed.
 gh() {
   local endpoint=""
@@ -151,7 +152,9 @@ gh() {
   local run_head_repo_id=200
   local run_head_repository_null=false
   local omit_job_head_repository=false
-  local run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  local run_sha=cccccccccccccccccccccccccccccccccccccccc
+  local older_run_sha="${run_sha}"
+  local newer_run_sha="${run_sha}"
   local marker="CLA generation ${CLA_GENERATION}"
   local run_path=.github/workflows/cla.yml
   local run_name='CLA Assistant v3'
@@ -202,7 +205,10 @@ gh() {
       ;;
     stale-empty-execution) run_prs='[]'; run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
     empty-mismatched-newer) run_prs='[]' ;;
-    binding-mode-newer) run_sha=cccccccccccccccccccccccccccccccccccccccc ;;
+    binding-mode-newer)
+      older_run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      newer_run_sha=cccccccccccccccccccccccccccccccccccccccc
+      ;;
     stale-comment-association) fetched_comment_association=NONE ;;
     unbound-signer) ledger_id=401; ledger_login=other-signer; ledger_comment_id=901 ;;
     minimal-run-association) run_prs='[{"number":123,"base":{"ref":"main","repo":{"id":100}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200}}}]' ;;
@@ -325,6 +331,8 @@ gh() {
         jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 2 ]]; then
         jq -nc --arg base_sha "$live_base_sha" '[{number:123,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == empty-different-execution-source-mismatch ]]; then
+        jq -nc --arg base_sha "$live_base_sha" '[{number:124,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
       elif [[ "${FAKE_MODE}" == ambiguous-association || ( "${FAKE_MODE}" == late-ambiguous && "$association_call" -gt 1 ) ]]; then
         jq -nc '[
           {number:123,state:"open",base:{ref:"main",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}},
@@ -357,10 +365,11 @@ gh() {
       if [[ "${FAKE_MODE}" == fork-null-head-no-check ||
             "${FAKE_MODE}" == empty-different-execution-check-mismatch ||
             "${FAKE_MODE}" == empty-different-execution-associated ||
-            "${FAKE_MODE}" == empty-different-execution-source-mismatch ||
             "${FAKE_MODE}" == stale-empty-execution ||
             "${FAKE_MODE}" == check-missing-final && "${check_call}" -gt 1 ]]; then
         printf '%s\n' '{"check_runs":[]}'
+      elif [[ "${FAKE_MODE}" == empty-different-execution-check-bound ]]; then
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
       elif [[ "${FAKE_MODE}" == oversized-check-response ]]; then
         printf '%s' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500","padding":"'
         head -c 2100000 /dev/zero | tr '\0' 'A'
@@ -374,7 +383,7 @@ gh() {
       elif [[ "${FAKE_MODE}" == check-wrong-job ]]; then
         printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/999"}]}'
       elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
-        printf '%s\n' '{"id":9000,"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"}]}'
+        jq -nc --arg sha "$check_sha" '{id:9000,check_runs:[{id:9000,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$sha,app:{id:15368,slug:"github-actions"},details_url:"https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"}]}'
       else
         jq -nc --arg sha "$check_sha" --arg slug "$check_app_slug" --argjson app_id "$check_app_id" --argjson id "$check_id" --arg name "$check_name" --arg details "$check_details" \
           '{check_runs:[{id:$id,name:$name,status:"completed",conclusion:"failure",head_sha:$sha,app:{id:$app_id,slug:$slug},details_url:$details}]}'
@@ -405,9 +414,9 @@ gh() {
           {id:401,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
         ]}'
       elif [[ "${FAKE_MODE}" == binding-mode-newer ]]; then
-        jq -nc --arg name "$run_name" --arg run_sha "$run_sha" --argjson run_prs "$run_prs" '{workflow_runs:[
-          {id:400,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"},
-          {id:401,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
+        jq -nc --arg name "$run_name" --arg older_sha "$older_run_sha" --arg newer_sha "$newer_run_sha" --argjson run_prs "$run_prs" '{workflow_runs:[
+          {id:400,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$older_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"},
+          {id:401,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$newer_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
         ]}'
       elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
         jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
@@ -433,7 +442,10 @@ gh() {
         if [[ "$run_id" == 400 ]]; then detail_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; else detail_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; fi
       fi
       if [[ "${FAKE_MODE}" == binding-mode-newer && "$run_id" == 401 ]]; then
+        detail_sha="${newer_run_sha}"
         detail_prs='[]'
+      elif [[ "${FAKE_MODE}" == binding-mode-newer && "$run_id" == 400 ]]; then
+        detail_sha="${older_run_sha}"
       fi
       jq -nc --argjson run_id "$run_id" --arg created_at "$created_at" --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$detail_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$detail_prs" \
         '{id:$run_id,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:$created_at}'
@@ -448,6 +460,12 @@ gh() {
       local jobs_sha="$run_sha"
       if [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 400 ]]; then
         jobs_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      elif [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 401 ]]; then
+        jobs_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      elif [[ "${FAKE_MODE}" == binding-mode-newer && "$run_id" == 400 ]]; then
+        jobs_sha="${older_run_sha}"
+      elif [[ "${FAKE_MODE}" == binding-mode-newer && "$run_id" == 401 ]]; then
+        jobs_sha="${newer_run_sha}"
       fi
       if [[ "${FAKE_MODE}" == paginated-jobs && "${api_page}" == 1 ]]; then
         jq -nc --argjson run_id "$run_id" --arg run_sha "$jobs_sha" '{jobs:[range(0; 100) | {id:(1000 + .),run_id:$run_id,name:"unrelated",status:"completed",conclusion:"success",head_sha:$run_sha,steps:[]}]}'
@@ -497,6 +515,12 @@ gh() {
       local job_sha="$run_sha"
       if [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 400 ]]; then
         job_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      elif [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 401 ]]; then
+        job_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      elif [[ "${FAKE_MODE}" == binding-mode-newer && "$run_id" == 400 ]]; then
+        job_sha="${older_run_sha}"
+      elif [[ "${FAKE_MODE}" == binding-mode-newer && "$run_id" == 401 ]]; then
+        job_sha="${newer_run_sha}"
       fi
       jq -nc --argjson job_id "$job_id" --argjson run_id "$run_id" --arg marker "$marker" --arg run_sha "$job_sha" --argjson omit "$omit_job_head_repository" \
         '({id:$job_id,run_id:$run_id,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"failure"}]} + (if $omit then {} else {head_repository:null} end))'
@@ -609,13 +633,13 @@ run_case() {
 run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case oversized-api-response 1 "Could not query the issue" 0
 run_case minimal-run-association 0 "No failed CLA run exists for this pull request head" 0
-run_case fork-current 1 "older workflow generation" 0
+run_case fork-current 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-stderr-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-stderr-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case association-api-failure 1 "Could not query pull request associations" 0
-run_case empty-run-association 1 "older workflow generation" 0
+run_case empty-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case same-repo-empty 1 "no pull request association with complete source metadata" 0
 run_case association-overflow 1 "Too many pull request associations" 0
 run_case paginated-associations 0 "Requested rerun for CLA job 500 in workflow run 400" 1
@@ -625,11 +649,11 @@ run_case paginated-runs 0 "Requested rerun for CLA job 500 in workflow run 400" 
 run_case full-run-window 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case full-run-window-no-match 1 "workflow-run result window is full" 0
 run_case paginated-jobs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case empty-different-execution-associated 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-associated 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
 run_case empty-different-execution-source-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
-run_case empty-different-execution-source-mismatch 1 "no pull request association with complete source metadata" 0
-run_case empty-different-execution-check-bound 1 "no pull request association with complete source metadata" 0
-run_case empty-different-execution-check-mismatch 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-source-mismatch 1 "live head is associated with a different pull request" 0
+run_case empty-different-execution-check-bound 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
+run_case empty-different-execution-check-mismatch 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
 run_case fork-null-head-check-bound 1 "no pull request association with complete source metadata" 0
 run_case fork-null-head-no-check 1 "no pull request association with complete source metadata" 0
 run_case check-wrong-app 1 "No failed CLA check is bound" 0 "" 1
@@ -638,8 +662,8 @@ run_case check-wrong-sha 1 "No failed CLA check is bound" 0 "" 1
 run_case check-wrong-job 1 "No failed CLA check is bound" 0 "" 1
 run_case check-missing-final 1 "No failed CLA check is bound" 0 "" 2
 run_case oversized-check-response 1 "Could not query checks for the selected CLA execution" 0 "" 1
-run_case stale-empty-execution 1 "no pull request association with complete source metadata" 0
-run_case empty-mismatched-newer 1 "no pull request association with complete source metadata" 0
+run_case stale-empty-execution 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
+run_case empty-mismatched-newer 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
 run_case wrong-run-association 0 "No failed CLA run exists for this pull request head" 0
 run_case malformed-run-association 1 "malformed pull request associations" 0
 run_case invalid-run-association 1 "malformed pull request associations" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -1,0 +1,654 @@
+#!/usr/bin/env bash
+# Exercise the trusted CLA rerun script against deterministic GitHub API
+# fixtures. This runs the workflow code itself, rather than checking text
+# shape, so stale generations and fork associations stay covered.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
+test -f "$WORKFLOW"
+command -v jq >/dev/null
+
+# The pull_request CI workflow executes this harness against PR-controlled
+# workflow text. It must never receive Actions write authority. Only the
+# isolated CLA rerun job may have that permission. Use awk here because this
+# check runs before CI installs its optional Python dependencies.
+if awk '
+  /^permissions:[[:space:]]*$/ { in_permissions=1; next }
+  in_permissions && /^[^[:space:]]/ { in_permissions=0 }
+  in_permissions && /^[[:space:]]+actions:[[:space:]]*write([[:space:]]*#.*)?$/ { found=1 }
+  END { exit found ? 0 : 1 }
+' "$ROOT_DIR/.github/workflows/ci.yml"; then
+  echo "CI must not grant top-level actions: write to pull_request jobs" >&2
+  exit 1
+fi
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+rerun_script="$ROOT_DIR/.github/scripts/rerun-failed-cla.sh"
+test -f "$rerun_script"
+bash -n "$rerun_script"
+
+# The privileged job checks out only the immutable workflow revision and
+# launches the checked-in guard. Keep the launcher below the Actions step-size
+# limit, and reject any future attempt to execute the pull-request head.
+grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' "$WORKFLOW"
+grep -Fq "repository: \${{ github.repository }}" "$WORKFLOW"
+grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
+grep -Fq 'sparse-checkout: .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
+grep -Fq 'bash .github/scripts/rerun-failed-cla.sh' "$WORKFLOW"
+grep -Fq "COMMENT_ID: \${{ github.event.comment.id }}" "$WORKFLOW"
+grep -Fq '      - .github/scripts/rerun-failed-cla.sh' "$ROOT_DIR/.github/workflows/ci.yml"
+if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
+  echo 'FAIL: CLA rerun checkout must never use a pull-request ref' >&2
+  exit 1
+fi
+WORKFLOW="$WORKFLOW" ruby -ryaml <<'RUBY'
+workflow = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+rerun = workflow.fetch("jobs").fetch("RerunFailedCLA")
+expected_group = "cla-rerun-${{ github.repository }}-${{ github.event.issue.number || github.event.pull_request.number }}"
+abort "CLA rerun queue is not serialized per pull request" unless
+  rerun.fetch("concurrency") == {
+    "group" => expected_group,
+    "cancel-in-progress" => false
+  }
+abort "CLA rerun job cannot read check runs" unless rerun.fetch("permissions") == {
+  "actions" => "write",
+  "checks" => "read",
+  "contents" => "read",
+  "issues" => "read",
+  "pull-requests" => "read"
+}
+RUBY
+launcher_bytes="$(awk '
+  /^  RerunFailedCLA:/ { in_job=1; next }
+  in_job && /^  LockMergedPullRequest:/ { exit }
+  in_job && /^        run: \|$/ { in_run=1; next }
+  in_run { sub(/^          /, ""); print }
+' "$WORKFLOW" | wc -c | tr -d ' ')"
+[[ "$launcher_bytes" =~ ^[0-9]+$ && "$launcher_bytes" -lt 21000 ]] || {
+  echo "FAIL: CLA rerun launcher is too large (${launcher_bytes} bytes)" >&2
+  exit 1
+}
+
+export GH_REPO=manaflow-ai/cmux
+export EVENT_NAME=issue_comment
+export ISSUE_NUMBER=123
+export PR_NUMBER=123
+export COMMENT_ID=900
+export COMMENT_BODY=recheck
+export COMMENT_CREATED_AT=2026-08-31T08:00:00Z
+export COMMENT_AUTHOR_ID=300
+export COMMENT_AUTHOR_LOGIN=contributor
+export COMMENT_AUTHOR_TYPE=User
+export COMMENT_AUTHOR_ASSOCIATION=NONE
+export WORKFLOW_PATH=.github/workflows/cla.yml
+WORKFLOW_SHA="$(git rev-parse HEAD)"
+export WORKFLOW_SHA
+export CLA_GENERATION=v2.2-action-212a0f2dd659b24b48a30ba35966e06dc41736af
+export TARGET_EVENT=pull_request_target
+export TARGET_BASE_REF=main
+export SIGNATURE_RECORDED=false
+
+# This stub models the API fields used by the rerun guard. In particular, a
+# fork-only commit has no result from /commits/:sha/pulls, while the workflow
+# run still carries head_repository identity. GitHub may report the source PR
+# SHA or a different execution SHA on a pull_request_target run, so this fixture
+# keeps the live PR head at `aaaa...` and the selected run/job execution SHA at
+# `bbbb...`. A production-shaped empty association is accepted only when the
+# run has complete source metadata and uses the live PR base SHA. A source-SHA,
+# null-repository, stale-base, or mismatched metadata run must fail closed.
+gh() {
+  local endpoint=""
+  local api_page=1
+  local api_filter=""
+  local api_check_name=""
+  local api_app_id=""
+  local arg
+  for arg in "$@"; do
+    if [[ "$arg" == page=* ]]; then
+      api_page="${arg#page=}"
+    fi
+    if [[ "$arg" == filter=* ]]; then
+      api_filter="${arg#filter=}"
+    fi
+    if [[ "$arg" == check_name=* ]]; then
+      api_check_name="${arg#check_name=}"
+    fi
+    if [[ "$arg" == app_id=* ]]; then
+      api_app_id="${arg#app_id=}"
+    fi
+    if [[ "$arg" == repos/* ]]; then
+      endpoint="$arg"
+    fi
+  done
+  [[ -n "$endpoint" ]] || {
+    echo "missing API endpoint" >&2
+    return 1
+  }
+  if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/check-runs &&
+        "$api_filter" != all ]]; then
+    echo "check-runs lookup must request filter=all" >&2
+    return 1
+  fi
+  if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/check-runs &&
+        ( "$api_check_name" != "CLA Assistant v3" && "$api_check_name" != "CLA Assistant" ||
+          "$api_app_id" != 15368 ) ]]; then
+    echo "check-runs lookup must bind the expected CLA check and app" >&2
+    return 1
+  fi
+  if [[ "$endpoint" == repos/manaflow-ai/cmux/commits/*/pulls &&
+        " $* " != *" --method GET "* ]]; then
+    echo "commit association lookup must use GET" >&2
+    return 1
+  fi
+  local live_state=open
+  local live_base=main
+  local live_base_sha=cccccccccccccccccccccccccccccccccccccccc
+  local live_head_repo=contributor/cmux
+  local live_head_repo_id=200
+  local run_head_repo=contributor/cmux
+  local run_head_repo_id=200
+  local run_head_repository_null=false
+  local omit_job_head_repository=false
+  local run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+  local marker="CLA generation ${CLA_GENERATION}"
+  local run_path=.github/workflows/cla.yml
+  local run_name='CLA Assistant v3'
+  local check_app_id=15368
+  local run_prs='[{"number":123,"base":{"ref":"main","sha":"cccccccccccccccccccccccccccccccccccccccc","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]'
+  local ledger_id=400
+  local ledger_login=coauthor
+  local ledger_comment_id=900
+
+  case "${FAKE_MODE}" in
+    stale-marker) marker="CLA generation v2.2-action-0000000000000000000000000000000000000000" ;;
+    unrelated-main-commit) marker="CLA generation ${CLA_GENERATION}" ;;
+    wrong-head-repo) run_head_repo=attacker/cmux; run_head_repo_id=201; run_prs='[]' ;;
+    stale-base-association)
+      run_prs='[{"number":123,"base":{"ref":"main","sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]'
+      ;;
+    association-overflow) run_prs='[]' ;;
+    fork-current|empty-run-association) run_prs='[]'; run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa ;;
+    empty-different-execution-associated|empty-different-execution-source-mismatch|empty-different-execution-check-bound|empty-different-execution-check-mismatch)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    empty-different-execution-source-bound)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    check-wrong-app|check-wrong-app-id|check-wrong-sha|check-wrong-job|check-missing-final|oversized-check-response)
+      run_prs='[]'
+      run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    wrong-workflow-name) run_name='Untrusted workflow' ;;
+    fork-null-head-check-bound|fork-null-head-no-check)
+      run_prs='[]'
+      run_head_repository_null=true
+      live_base_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      ;;
+    same-repo-empty)
+      run_prs='[]'
+      run_head_repo=manaflow-ai/cmux
+      run_head_repo_id=100
+      run_head_repository_null=true
+      run_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      live_head_repo=manaflow-ai/cmux
+      live_head_repo_id=100
+      ;;
+    stale-empty-execution) run_prs='[]'; run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
+    empty-mismatched-newer) run_prs='[]' ;;
+    unbound-signer) ledger_id=401; ledger_login=other-signer; ledger_comment_id=901 ;;
+    minimal-run-association) run_prs='[{"number":123,"base":{"ref":"main","repo":{"id":100}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200}}}]' ;;
+    wrong-run-association) run_prs='[{"number":124,"base":{"ref":"main","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]' ;;
+    malformed-run-association) run_prs='{}' ;;
+    invalid-run-association) run_prs='false' ;;
+    closed-pr) live_state=closed ;;
+    retargeted-pr) live_base=release ;;
+    suffixed-path) run_path=.github/workflows/cla.yml@main ;;
+    job-missing-head-repository) omit_job_head_repository=true ;;
+  esac
+
+  if [[ " $* " == *" --method POST "* ]]; then
+    printf '%s\n' "$endpoint" >>"$FAKE_POST_FILE"
+    return 0
+  fi
+
+  case "$endpoint" in
+    repos/manaflow-ai/cmux/issues/123)
+      if [[ "${FAKE_MODE}" == oversized-api-response ]]; then
+        printf '%s' '{"state":"open","pull_request":{"url":"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"},"padding":"'
+        head -c 2100000 /dev/zero | tr '\0' 'A'
+        printf '%s\n' '"}'
+      else
+        jq -nc --arg state "$live_state" '{state:$state,pull_request:{url:"https://api.github.com/repos/manaflow-ai/cmux/pulls/123"}}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/issues/comments/900)
+      jq -nc \
+        --arg body "${COMMENT_BODY}" \
+        --argjson author_id "${COMMENT_AUTHOR_ID}" \
+        --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
+        --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+        --arg created_at "${COMMENT_CREATED_AT}" \
+        '{issue_url:"https://api.github.com/repos/manaflow-ai/cmux/issues/123",body:$body,user:{id:$author_id,login:$author_login,type:$author_type},created_at:$created_at,updated_at:$created_at}'
+      ;;
+    repos/manaflow-ai/cmux/pulls/123)
+      jq -nc --arg state "$live_state" --arg base "$live_base" --arg base_sha "$live_base_sha" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" \
+        '{number:123,state:$state,user:{id:300,login:"contributor"},base:{ref:$base,sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}'
+      ;;
+    repos/manaflow-ai/cmux/commits/*/pulls)
+      if [[ "${FAKE_MODE}" == association-not-found ]]; then
+        printf '{"message":"Not Found","status":404}\n'
+        return 1
+      elif [[ "${FAKE_MODE}" == association-validation-error ]]; then
+        printf '{"message":"No commit found for SHA: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","status":"422"}\n'
+        return 1
+      elif [[ "${FAKE_MODE}" == association-stderr-not-found ]]; then
+        printf 'gh: Not Found (HTTP 404)\n' >&2
+        return 1
+      elif [[ "${FAKE_MODE}" == association-stderr-validation-error ]]; then
+        printf 'gh: No commit found for SHA: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa (HTTP 422)\n' >&2
+        return 1
+      elif [[ "${FAKE_MODE}" == association-api-failure ]]; then
+        printf '{"message":"API unavailable","status":503}\n'
+        return 1
+      elif [[ "${FAKE_MODE}" == empty-different-execution-source-bound ||
+              "${FAKE_MODE}" == empty-different-execution-source-mismatch ]]; then
+        local commit_sha="${endpoint#repos/manaflow-ai/cmux/commits/}"
+        commit_sha="${commit_sha%/pulls}"
+        if [[ "${FAKE_MODE}" == empty-different-execution-source-bound &&
+              "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
+          jq -nc --arg base_sha "$live_base_sha" '[{number:123,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        elif [[ "${FAKE_MODE}" == empty-different-execution-source-mismatch &&
+                "${commit_sha}" == bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ]]; then
+          jq -nc --arg base_sha "$live_base_sha" '[{number:124,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+        else
+          printf '[]\n'
+        fi
+      elif [[ "${FAKE_MODE}" == association-overflow ]]; then
+        jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 1 ]]; then
+        jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == paginated-associations && "${api_page}" == 2 ]]; then
+          jq -nc --arg base_sha "$live_base_sha" '[{number:123,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == same-repo-empty ]]; then
+        jq -nc --arg base_sha "$live_base_sha" '[{number:123,base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:100,full_name:"manaflow-ai/cmux"}}}]'
+      else
+        printf '[]\n'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/contents/signatures/version2/cla.json)
+      ledger_content="{\"signedContributors\":[{\"name\":\"${ledger_login}\",\"id\":${ledger_id},\"comment_id\":${ledger_comment_id},\"created_at\":\"2026-08-31T08:00:00Z\",\"repoId\":100,\"pullRequestNo\":123}]}"
+      if [[ "${FAKE_MODE}" == wrapped-ledger || "${FAKE_MODE}" == oversized-ledger ]]; then
+        local target_bytes=1000000
+        [[ "${FAKE_MODE}" == oversized-ledger ]] && target_bytes=1000001
+        local padding=$((target_bytes - ${#ledger_content} - 13))
+        local padding_text
+        (( padding > 0 )) || {
+          echo "ledger fixture core unexpectedly exceeds target size" >&2
+          return 1
+        }
+        padding_text="$(printf '%*s' "$padding" '' | tr ' ' 'A')"
+        ledger_content="${ledger_content%?},\"padding\":\"${padding_text}\"}"
+      fi
+      if [[ "${FAKE_MODE}" == malformed-ledger ]]; then
+        encoded_ledger='not-valid-base64'
+      elif [[ "${FAKE_MODE}" == wrapped-ledger || "${FAKE_MODE}" == oversized-ledger ]]; then
+        encoded_ledger="$(printf '%s' "$ledger_content" | base64)"
+      else
+        encoded_ledger="$(printf '%s' "$ledger_content" | base64 | tr -d '\n')"
+      fi
+      # Stream the potentially near-limit fixture through jq instead of
+      # passing it as an argv value, which exceeds macOS ARG_MAX.
+      printf '{"type":"file","encoding":"base64","content":'
+      printf '%s' "$encoded_ledger" | jq -Rs .
+      printf '}\n'
+      ;;
+    repos/manaflow-ai/cmux/pulls)
+      local association_call=1
+      if [[ -n "${FAKE_ASSOC_CALL_FILE:-}" ]]; then
+        if [[ -s "${FAKE_ASSOC_CALL_FILE}" ]]; then
+          read -r association_call <"${FAKE_ASSOC_CALL_FILE}"
+          association_call=$((association_call + 1))
+        fi
+        printf '%s\n' "$association_call" >"${FAKE_ASSOC_CALL_FILE}"
+      fi
+      if [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 1 ]]; then
+        jq -nc --arg base_sha "$live_base_sha" '[range(0; 100) | {number:(1000 + .),state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == paginated-open-prs && "${api_page}" == 2 ]]; then
+        jq -nc --arg base_sha "$live_base_sha" '[{number:123,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}]'
+      elif [[ "${FAKE_MODE}" == ambiguous-association || ( "${FAKE_MODE}" == late-ambiguous && "$association_call" -gt 1 ) ]]; then
+        jq -nc '[
+          {number:123,state:"open",base:{ref:"main",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}},
+          {number:124,state:"open",base:{ref:"main",sha:"cccccccccccccccccccccccccccccccccccccccc",repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:200,full_name:"contributor/cmux"}}}
+        ]'
+      else
+        jq -nc --arg base_sha "$live_base_sha" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" '[{number:123,state:"open",base:{ref:"main",sha:$base_sha,repo:{id:100,full_name:"manaflow-ai/cmux"}},head:{ref:"feature",sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",repo:{id:$head_repo_id,full_name:$head_repo}}}]'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/commits/*/check-runs)
+      local check_call=1
+      local check_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      local check_app_slug=github-actions
+      local check_id=9000
+      local check_name="CLA Assistant v3"
+      local check_details="https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"
+      local check_prefix=repos/manaflow-ai/cmux/commits/
+      check_sha="${endpoint#"${check_prefix}"}"
+      check_sha="${check_sha%/check-runs}"
+      if [[ -n "${FAKE_CHECK_CALL_FILE:-}" ]]; then
+        if [[ -s "${FAKE_CHECK_CALL_FILE}" ]]; then
+          read -r check_call <"${FAKE_CHECK_CALL_FILE}"
+          check_call=$((check_call + 1))
+        fi
+        printf '%s\n' "$check_call" >"${FAKE_CHECK_CALL_FILE}"
+      fi
+      if [[ "${FAKE_MODE}" == fork-null-head-no-check ||
+            "${FAKE_MODE}" == empty-different-execution-check-mismatch ||
+            "${FAKE_MODE}" == empty-different-execution-associated ||
+            "${FAKE_MODE}" == empty-different-execution-source-mismatch ||
+            "${FAKE_MODE}" == stale-empty-execution ||
+            "${FAKE_MODE}" == check-missing-final && "${check_call}" -gt 1 ]]; then
+        printf '%s\n' '{"check_runs":[]}'
+      elif [[ "${FAKE_MODE}" == oversized-check-response ]]; then
+        printf '%s' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500","padding":"'
+        head -c 2100000 /dev/zero | tr '\0' 'A'
+        printf '%s\n' '"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-app ]]; then
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"untrusted-app"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-app-id ]]; then
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":999,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-sha ]]; then
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/500"}]}'
+      elif [[ "${FAKE_MODE}" == check-wrong-job ]]; then
+        printf '%s\n' '{"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/400/job/999"}]}'
+      elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
+        printf '%s\n' '{"id":9000,"check_runs":[{"id":9000,"name":"CLA Assistant v3","status":"completed","conclusion":"failure","head_sha":"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb","app":{"id":15368,"slug":"github-actions"},"details_url":"https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"}]}'
+      else
+        jq -nc --arg sha "$check_sha" --arg slug "$check_app_slug" --argjson app_id "$check_app_id" --argjson id "$check_id" --arg name "$check_name" --arg details "$check_details" \
+          '{check_runs:[{id:$id,name:$name,status:"completed",conclusion:"failure",head_sha:$sha,app:{id:$app_id,slug:$slug},details_url:$details}]}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/workflows)
+      if [[ "${FAKE_MODE}" == paginated-workflows && "${api_page}" == 1 ]]; then
+        jq -nc '{workflows:[range(0; 100) | {id:(1000 + .),path:(".github/workflows/other-" + (.|tostring) + ".yml"),state:"active"}]}'
+      else
+        printf '{"workflows":[{"id":300,"path":".github/workflows/cla.yml","state":"active"}]}\n'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/workflows/300/runs)
+      if [[ "${FAKE_MODE}" == full-run-window ]]; then
+        if [[ "${api_page}" == 10 ]]; then
+          jq -nc --arg path "$run_path" --arg name "$run_name" --arg run_sha "$run_sha" --argjson run_prs "$run_prs" \
+            '{workflow_runs:([range(0; 99) | {id:(1000 + .),workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}] + [{id:400,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}])}'
+        else
+          jq -nc --arg name "$run_name" '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+        fi
+      elif [[ "${FAKE_MODE}" == full-run-window-no-match ]]; then
+        jq -nc --arg name "$run_name" '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+      elif [[ "${FAKE_MODE}" == paginated-runs && "${api_page}" == 1 ]]; then
+        jq -nc --arg name "$run_name" '{workflow_runs:[range(0; 100) | {id:(1000 + .),workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"success",head_sha:"cccccccccccccccccccccccccccccccccccccccc",head_branch:"other",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:45:00Z"}]}'
+      elif [[ "${FAKE_MODE}" == empty-mismatched-newer ]]; then
+        jq -nc --arg name "$run_name" '{workflow_runs:[
+          {id:400,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:00:00Z"},
+          {id:401,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
+        ]}'
+      elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
+        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
+          '{workflow_runs:[
+            {id:400,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"},
+            {id:401,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:30:00Z"}
+          ]}'
+      else
+        jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
+          '{workflow_runs:[{id:400,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"}]}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/runs/400|repos/manaflow-ai/cmux/actions/runs/401)
+      local run_id=400
+      local created_at=2026-08-31T07:00:00Z
+      if [[ "$endpoint" == repos/manaflow-ai/cmux/actions/runs/401 ]]; then
+        run_id=401
+        created_at=2026-08-31T07:30:00Z
+      fi
+      local detail_sha="$run_sha"
+      if [[ "${FAKE_MODE}" == empty-mismatched-newer ]]; then
+        if [[ "$run_id" == 400 ]]; then detail_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; else detail_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; fi
+      fi
+      jq -nc --argjson run_id "$run_id" --arg created_at "$created_at" --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$detail_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
+        '{id:$run_id,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:$created_at}'
+      ;;
+    repos/manaflow-ai/cmux/actions/runs/400/jobs|repos/manaflow-ai/cmux/actions/runs/401/jobs)
+      local run_id=400
+      local job_id=500
+      if [[ "$endpoint" == repos/manaflow-ai/cmux/actions/runs/401/jobs ]]; then
+        run_id=401
+        job_id=501
+      fi
+      local jobs_sha="$run_sha"
+      if [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 400 ]]; then
+        jobs_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      fi
+      if [[ "${FAKE_MODE}" == paginated-jobs && "${api_page}" == 1 ]]; then
+        jq -nc --argjson run_id "$run_id" --arg run_sha "$jobs_sha" '{jobs:[range(0; 100) | {id:(1000 + .),run_id:$run_id,name:"unrelated",status:"completed",conclusion:"success",head_sha:$run_sha,steps:[]}]}'
+      elif [[ "${FAKE_MODE}" == compatibility-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:"Mirror CLA Assistant compatibility result",status:"completed",conclusion:"failure"}]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == writer-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:506,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:"Mirror CLA Assistant compatibility result",status:"completed",conclusion:"failure"}]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == writer-only-failed ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == unexpected-failure ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:503,run_id:$run_id,name:"Unexpected privileged job",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      elif [[ "${FAKE_MODE}" == cancelled-job ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:504,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"cancelled",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]}
+          ]}'
+      else
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$jobs_sha" --argjson omit "$omit_job_head_repository" \
+          '{jobs:[({id:$job_id,run_id:$run_id,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"failure"}]} + (if $omit then {} else {head_repository:null} end))]}'
+      fi
+      ;;
+    repos/manaflow-ai/cmux/actions/jobs/500|repos/manaflow-ai/cmux/actions/jobs/501)
+      local job_id=500
+      local run_id=400
+      if [[ "$endpoint" == repos/manaflow-ai/cmux/actions/jobs/501 ]]; then
+        job_id=501
+        run_id=401
+      fi
+      local job_sha="$run_sha"
+      if [[ "${FAKE_MODE}" == empty-mismatched-newer && "$run_id" == 400 ]]; then
+        job_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      fi
+      jq -nc --argjson job_id "$job_id" --argjson run_id "$run_id" --arg marker "$marker" --arg run_sha "$job_sha" --argjson omit "$omit_job_head_repository" \
+        '({id:$job_id,run_id:$run_id,name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,steps:[{name:$marker,status:"completed",conclusion:"failure"}]} + (if $omit then {} else {head_repository:null} end))'
+      ;;
+    *)
+      echo "unexpected API endpoint: $endpoint" >&2
+      return 1
+      ;;
+  esac
+}
+export -f gh
+
+run_case() {
+  local mode="$1"
+  local expected_status="$2"
+  local expected_text="$3"
+  local expected_posts="$4"
+  local expected_post="${5:-}"
+  local expected_checks="${6:-}"
+  local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false generation="${CLA_GENERATION}"
+  if [[ -n "${ONLY_MODE:-}" && "${ONLY_MODE}" != "${mode}" ]]; then
+    return 0
+  fi
+  if [[ "$mode" == untrusted-recheck ]]; then
+    comment_author=untrusted-user
+    comment_author_id=301
+  elif [[ "$mode" == recheck-unset-output ]]; then
+    signature_recorded=''
+  elif [[ "$mode" == external-signer ]]; then
+    comment_author=coauthor
+    comment_author_id=400
+    comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
+    signature_recorded=true
+  elif [[ "$mode" == unrecorded-signer || "$mode" == unbound-signer ]]; then
+    comment_author=coauthor
+    comment_author_id=400
+    comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
+    if [[ "$mode" == unbound-signer ]]; then
+      signature_recorded=true
+    fi
+  elif [[ "$mode" == wrapped-ledger || "$mode" == oversized-ledger || "$mode" == malformed-ledger ]]; then
+    comment_author=coauthor
+    comment_author_id=400
+    comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
+    signature_recorded=true
+  elif [[ "$mode" == alternate-generation ]]; then
+    generation=v2.2-action-deadbeef
+  elif [[ "$mode" == malformed-comment-login ]]; then
+    comment_author=$'contributor\nattacker'
+  fi
+  : >"$work/posts-$mode"
+  printf '0\n' >"$work/association-$mode"
+  printf '0\n' >"$work/check-$mode"
+  set +e
+  output="$(
+    FAKE_MODE="$mode" \
+    FAKE_POST_FILE="$work/posts-$mode" \
+    FAKE_ASSOC_CALL_FILE="$work/association-$mode" \
+    FAKE_CHECK_CALL_FILE="$work/check-$mode" \
+    COMMENT_BODY="$comment_body" \
+    COMMENT_AUTHOR_ID="$comment_author_id" \
+    COMMENT_AUTHOR_LOGIN="$comment_author" \
+    COMMENT_AUTHOR_TYPE="$comment_type" \
+    COMMENT_AUTHOR_ASSOCIATION="$comment_association" \
+    SIGNATURE_RECORDED="$signature_recorded" \
+    CLA_GENERATION="$generation" \
+    bash "$rerun_script" 2>&1
+  )"
+  status=$?
+  set -e
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: $mode exited $status, expected $expected_status" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ "$output" != *"$expected_text"* ]]; then
+    echo "FAIL: $mode did not report '$expected_text'" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  posts="$(wc -l <"$work/posts-$mode" | tr -d ' ')"
+  if [[ "$posts" != "$expected_posts" ]]; then
+    echo "FAIL: $mode made $posts rerun calls, expected $expected_posts" >&2
+    exit 1
+  fi
+  if [[ -n "$expected_post" ]] && ! grep -Fxq "$expected_post" "$work/posts-$mode"; then
+    echo "FAIL: $mode did not rerun the expected endpoint '$expected_post'" >&2
+    cat "$work/posts-$mode" >&2
+    exit 1
+  fi
+  if [[ -n "$expected_checks" ]]; then
+    local checks=0
+    if [[ -s "$work/check-$mode" ]]; then
+      read -r checks <"$work/check-$mode"
+    fi
+    if [[ "$checks" != "$expected_checks" ]]; then
+      echo "FAIL: $mode made $checks check lookups, expected $expected_checks" >&2
+      exit 1
+    fi
+  fi
+  echo "PASS: $mode"
+}
+
+run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case oversized-api-response 1 "Could not query the issue" 0
+run_case minimal-run-association 0 "No failed CLA run exists for this pull request head" 0
+run_case fork-current 1 "older workflow generation" 0
+run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-stderr-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-stderr-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case association-api-failure 1 "Could not query pull request associations" 0
+run_case empty-run-association 1 "older workflow generation" 0
+run_case same-repo-empty 1 "no pull request association with complete source metadata" 0
+run_case association-overflow 1 "Too many pull request associations" 0
+run_case paginated-associations 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-open-prs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-workflows 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-runs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case full-run-window 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case full-run-window-no-match 1 "workflow-run result window is full" 0
+run_case paginated-jobs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case empty-different-execution-associated 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-source-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
+run_case empty-different-execution-source-mismatch 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-check-bound 1 "no pull request association with complete source metadata" 0
+run_case empty-different-execution-check-mismatch 1 "no pull request association with complete source metadata" 0
+run_case fork-null-head-check-bound 1 "no pull request association with complete source metadata" 0
+run_case fork-null-head-no-check 1 "no pull request association with complete source metadata" 0
+run_case check-wrong-app 1 "No failed CLA check is bound" 0 "" 1
+run_case check-wrong-app-id 1 "No failed CLA check is bound" 0 "" 1
+run_case check-wrong-sha 1 "No failed CLA check is bound" 0 "" 1
+run_case check-wrong-job 1 "No failed CLA check is bound" 0 "" 1
+run_case check-missing-final 1 "No failed CLA check is bound" 0 "" 2
+run_case oversized-check-response 1 "Could not query checks for the selected CLA execution" 0 "" 1
+run_case stale-empty-execution 1 "no pull request association with complete source metadata" 0
+run_case empty-mismatched-newer 1 "no pull request association with complete source metadata" 0
+run_case wrong-run-association 0 "No failed CLA run exists for this pull request head" 0
+run_case malformed-run-association 1 "malformed pull request associations" 0
+run_case invalid-run-association 1 "malformed pull request associations" 0
+run_case stale-marker 1 "older workflow generation" 0
+run_case unrelated-main-commit 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case wrong-head-repo 1 "no pull request association with complete source metadata" 0
+run_case closed-pr 1 "The issue is not an open pull request" 0
+run_case retargeted-pr 1 "The live pull request is not valid" 0
+run_case ambiguous-association 1 "Expected exactly one open pull request for this head" 0
+run_case untrusted-recheck 1 "Only the pull request author or a trusted repository participant" 0
+run_case recheck-unset-output 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case suffixed-path 0 "No failed CLA run exists for this pull request head" 0
+run_case wrong-workflow-name 0 "No failed CLA run exists for this pull request head" 0
+run_case stale-base-association 1 "outdated or malformed pull request base SHA" 0
+run_case alternate-generation 1 "Unexpected CLA generation marker" 0
+run_case malformed-comment-login 1 "Comment author is malformed" 0
+run_case late-ambiguous 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case external-signer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case unrecorded-signer 1 "did not result in a persisted signature" 0
+run_case unbound-signer 1 "signing comment was not the signature persisted" 0
+run_case duplicate-runs 0 "Requested rerun for CLA job 501 in workflow run 401" 1 \
+  "repos/manaflow-ai/cmux/actions/jobs/501/rerun"
+run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case wrapped-ledger 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case oversized-ledger 1 "exceeds the 1 MB limit" 0
+run_case malformed-ledger 1 "not valid base64" 0
+run_case compatibility-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case writer-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case writer-only-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case unexpected-failure 1 "unexpected failed job" 0
+run_case cancelled-job 1 "cancelled or non-failure job" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -646,27 +646,27 @@ run_case() {
   echo "PASS: $mode"
 }
 
-run_case run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case run-association 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case oversized-api-response 1 "Could not query the issue" 0
 run_case minimal-run-association 0 "No failed CLA run exists for this pull request head" 0
-run_case fork-current 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case association-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case association-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case association-stderr-not-found 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case association-stderr-validation-error 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case fork-current 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case association-not-found 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case association-validation-error 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case association-stderr-not-found 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case association-stderr-validation-error 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case association-api-failure 1 "Could not query pull request associations" 0
-run_case empty-run-association 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case empty-run-association 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case same-repo-empty 1 "no pull request association with complete source metadata" 0
 run_case association-overflow 1 "Too many pull request associations" 0
-run_case paginated-associations 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case paginated-open-prs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case paginated-workflows 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case paginated-runs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case full-run-window 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-associations 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case paginated-open-prs 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case paginated-workflows 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case paginated-runs 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
+run_case full-run-window 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case full-run-window-no-match 1 "workflow-run result window is full" 0
-run_case paginated-jobs 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case paginated-jobs 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case empty-different-execution-associated 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
-run_case empty-different-execution-source-bound 0 "Requested rerun for CLA job 500 in workflow run 400" 1 "" 2
+run_case empty-different-execution-source-bound 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 "" 2
 run_case empty-different-execution-source-mismatch 1 "live head is associated with a different pull request" 0
 run_case empty-different-execution-check-bound 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
 run_case empty-different-execution-check-mismatch 1 "No failed CLA check is bound to the exact pull request source head" 0 "" 1
@@ -684,19 +684,19 @@ run_case wrong-run-association 0 "No failed CLA run exists for this pull request
 run_case malformed-run-association 1 "malformed pull request associations" 0
 run_case invalid-run-association 1 "malformed pull request associations" 0
 run_case stale-marker 1 "older workflow generation" 0
-run_case unrelated-main-commit 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case unrelated-main-commit 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case wrong-head-repo 1 "no pull request association with complete source metadata" 0
 run_case closed-pr 1 "The issue is not an open pull request" 0
 run_case retargeted-pr 1 "The live pull request is not valid" 0
 run_case ambiguous-association 1 "Expected exactly one open pull request for this head" 0
 run_case untrusted-recheck 1 "Only the pull request author or a trusted repository participant" 0
-run_case recheck-unset-output 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case recheck-unset-output 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case suffixed-path 0 "No failed CLA run exists for this pull request head" 0
 run_case wrong-workflow-name 0 "No failed CLA run exists for this pull request head" 0
 run_case stale-base-association 1 "outdated or malformed pull request base SHA" 0
 run_case alternate-generation 1 "Unexpected CLA generation marker" 0
 run_case malformed-comment-login 1 "Comment author is malformed" 0
-run_case late-ambiguous 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case late-ambiguous 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case external-signer 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case signing-stale-writer 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
@@ -705,21 +705,21 @@ run_case recheck-stale-writer 0 "Requested rerun for CLA workflow run 400 (refre
   "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case unrecorded-signer 1 "did not result in a persisted signature" 0
 run_case unbound-signer 1 "signing comment was not the signature persisted" 0
-run_case duplicate-runs 0 "Requested rerun for CLA job 501 in workflow run 401" 1 \
-  "repos/manaflow-ai/cmux/actions/jobs/501/rerun"
-run_case binding-mode-newer 0 "Requested rerun for CLA job 501 in workflow run 401" 1 \
-  "repos/manaflow-ai/cmux/actions/jobs/501/rerun"
+run_case duplicate-runs 0 "Requested rerun for CLA workflow run 401 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/401/rerun"
+run_case binding-mode-newer 0 "Requested rerun for CLA workflow run 401 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/401/rerun"
 run_case stale-comment-association 1 "Only the pull request author or a trusted repository participant" 0
-run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case job-missing-head-repository 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1
 run_case wrapped-ledger 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
   "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case oversized-ledger 1 "exceeds the 1 MB limit" 0
 run_case malformed-ledger 1 "not valid base64" 0
-run_case compatibility-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
-  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
-run_case writer-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
-  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
-run_case writer-only-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \
-  "repos/manaflow-ai/cmux/actions/runs/400/rerun-failed-jobs"
+run_case compatibility-failed 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun"
+run_case writer-failed 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun"
+run_case writer-only-failed 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case unexpected-failure 1 "unexpected failed job" 0
 run_case cancelled-job 1 "cancelled or non-failure job" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -156,6 +156,7 @@ gh() {
   local run_path=.github/workflows/cla.yml
   local run_name='CLA Assistant v3'
   local check_app_id=15368
+  local fetched_comment_association="${FAKE_COMMENT_ASSOCIATION:-${COMMENT_AUTHOR_ASSOCIATION}}"
   local run_prs='[{"number":123,"base":{"ref":"main","sha":"cccccccccccccccccccccccccccccccccccccccc","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]'
   local ledger_id=400
   local ledger_login=coauthor
@@ -201,6 +202,8 @@ gh() {
       ;;
     stale-empty-execution) run_prs='[]'; run_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb ;;
     empty-mismatched-newer) run_prs='[]' ;;
+    binding-mode-newer) run_sha=cccccccccccccccccccccccccccccccccccccccc ;;
+    stale-comment-association) fetched_comment_association=NONE ;;
     unbound-signer) ledger_id=401; ledger_login=other-signer; ledger_comment_id=901 ;;
     minimal-run-association) run_prs='[{"number":123,"base":{"ref":"main","repo":{"id":100}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200}}}]' ;;
     wrong-run-association) run_prs='[{"number":124,"base":{"ref":"main","repo":{"id":100,"full_name":"manaflow-ai/cmux"}},"head":{"ref":"feature","sha":"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa","repo":{"id":200,"full_name":"contributor/cmux"}}}]' ;;
@@ -233,8 +236,9 @@ gh() {
         --argjson author_id "${COMMENT_AUTHOR_ID}" \
         --arg author_login "${COMMENT_AUTHOR_LOGIN}" \
         --arg author_type "${COMMENT_AUTHOR_TYPE}" \
+        --arg author_association "${fetched_comment_association}" \
         --arg created_at "${COMMENT_CREATED_AT}" \
-        '{issue_url:"https://api.github.com/repos/manaflow-ai/cmux/issues/123",body:$body,user:{id:$author_id,login:$author_login,type:$author_type},created_at:$created_at,updated_at:$created_at}'
+        '{issue_url:"https://api.github.com/repos/manaflow-ai/cmux/issues/123",body:$body,user:{id:$author_id,login:$author_login,type:$author_type},author_association:$author_association,created_at:$created_at,updated_at:$created_at}'
       ;;
     repos/manaflow-ai/cmux/pulls/123)
       jq -nc --arg state "$live_state" --arg base "$live_base" --arg base_sha "$live_base_sha" --arg head_repo "$live_head_repo" --argjson head_repo_id "$live_head_repo_id" \
@@ -340,6 +344,9 @@ gh() {
       local check_prefix=repos/manaflow-ai/cmux/commits/
       check_sha="${endpoint#"${check_prefix}"}"
       check_sha="${check_sha%/check-runs}"
+      if [[ "${FAKE_MODE}" == binding-mode-newer ]]; then
+        check_details="https://github.com/manaflow-ai/cmux/actions/runs/401/job/501"
+      fi
       if [[ -n "${FAKE_CHECK_CALL_FILE:-}" ]]; then
         if [[ -s "${FAKE_CHECK_CALL_FILE}" ]]; then
           read -r check_call <"${FAKE_CHECK_CALL_FILE}"
@@ -397,6 +404,11 @@ gh() {
           {id:400,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:00:00Z"},
           {id:401,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:"bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
         ]}'
+      elif [[ "${FAKE_MODE}" == binding-mode-newer ]]; then
+        jq -nc --arg name "$run_name" --arg run_sha "$run_sha" --argjson run_prs "$run_prs" '{workflow_runs:[
+          {id:400,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:$run_prs,created_at:"2026-08-31T07:00:00Z"},
+          {id:401,workflow_id:300,name:$name,path:".github/workflows/cla.yml",event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:{id:200,full_name:"contributor/cmux"},pull_requests:[],created_at:"2026-08-31T07:30:00Z"}
+        ]}'
       elif [[ "${FAKE_MODE}" == duplicate-runs ]]; then
         jq -nc --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$run_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
           '{workflow_runs:[
@@ -416,10 +428,14 @@ gh() {
         created_at=2026-08-31T07:30:00Z
       fi
       local detail_sha="$run_sha"
+      local detail_prs="$run_prs"
       if [[ "${FAKE_MODE}" == empty-mismatched-newer ]]; then
         if [[ "$run_id" == 400 ]]; then detail_sha=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa; else detail_sha=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb; fi
       fi
-      jq -nc --argjson run_id "$run_id" --arg created_at "$created_at" --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$detail_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$run_prs" \
+      if [[ "${FAKE_MODE}" == binding-mode-newer && "$run_id" == 401 ]]; then
+        detail_prs='[]'
+      fi
+      jq -nc --argjson run_id "$run_id" --arg created_at "$created_at" --arg head_repo "$run_head_repo" --argjson head_repo_id "$run_head_repo_id" --argjson head_repo_null "$run_head_repository_null" --arg run_sha "$detail_sha" --arg path "$run_path" --arg name "$run_name" --argjson run_prs "$detail_prs" \
         '{id:$run_id,workflow_id:300,name:$name,path:$path,event:"pull_request_target",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:(if $head_repo_null then null else {id:$head_repo_id,full_name:$head_repo} end),pull_requests:$run_prs,created_at:$created_at}'
       ;;
     repos/manaflow-ai/cmux/actions/runs/400/jobs|repos/manaflow-ai/cmux/actions/runs/401/jobs)
@@ -500,7 +516,7 @@ run_case() {
   local expected_posts="$4"
   local expected_post="${5:-}"
   local expected_checks="${6:-}"
-  local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE comment_body=recheck signature_recorded=false generation="${CLA_GENERATION}"
+  local output status posts comment_author=contributor comment_author_id=300 comment_type=User comment_association=NONE fetched_comment_association=NONE comment_body=recheck signature_recorded=false generation="${CLA_GENERATION}"
   if [[ -n "${ONLY_MODE:-}" && "${ONLY_MODE}" != "${mode}" ]]; then
     return 0
   fi
@@ -530,6 +546,11 @@ run_case() {
     generation=v2.2-action-deadbeef
   elif [[ "$mode" == malformed-comment-login ]]; then
     comment_author=$'contributor\nattacker'
+  elif [[ "$mode" == stale-comment-association ]]; then
+    comment_author=untrusted-user
+    comment_author_id=301
+    comment_association=OWNER
+    fetched_comment_association=NONE
   fi
   : >"$work/posts-$mode"
   printf '0\n' >"$work/association-$mode"
@@ -545,6 +566,7 @@ run_case() {
     COMMENT_AUTHOR_LOGIN="$comment_author" \
     COMMENT_AUTHOR_TYPE="$comment_type" \
     COMMENT_AUTHOR_ASSOCIATION="$comment_association" \
+    FAKE_COMMENT_ASSOCIATION="$fetched_comment_association" \
     SIGNATURE_RECORDED="$signature_recorded" \
     CLA_GENERATION="$generation" \
     bash "$rerun_script" 2>&1
@@ -640,6 +662,9 @@ run_case unrecorded-signer 1 "did not result in a persisted signature" 0
 run_case unbound-signer 1 "signing comment was not the signature persisted" 0
 run_case duplicate-runs 0 "Requested rerun for CLA job 501 in workflow run 401" 1 \
   "repos/manaflow-ai/cmux/actions/jobs/501/rerun"
+run_case binding-mode-newer 0 "Requested rerun for CLA job 501 in workflow run 401" 1 \
+  "repos/manaflow-ai/cmux/actions/jobs/501/rerun"
+run_case stale-comment-association 1 "Only the pull request author or a trusted repository participant" 0
 run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case wrapped-ledger 0 "Requested rerun for CLA job 500 in workflow run 400" 1
 run_case oversized-ledger 1 "exceeds the 1 MB limit" 0

--- a/tests/test_cla_rerun_workflow.sh
+++ b/tests/test_cla_rerun_workflow.sh
@@ -475,6 +475,13 @@ gh() {
             {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
             {id:502,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:"Mirror CLA Assistant compatibility result",status:"completed",conclusion:"failure"}]}
           ]}'
+      elif [[ "${FAKE_MODE}" == signing-stale-writer ]]; then
+        jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
+          '{jobs:[
+            {id:505,run_id:$run_id,name:"CLA ledger writer",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"success",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[]},
+            {id:$job_id,run_id:$run_id,name:"CLA Assistant v3",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:$marker,status:"completed",conclusion:"failure"}]},
+            {id:506,run_id:$run_id,name:"CLA Assistant",workflow_name:"CLA Assistant v3",status:"completed",conclusion:"failure",head_sha:$run_sha,head_branch:"feature",head_repository:null,steps:[{name:"Mirror CLA Assistant compatibility result",status:"completed",conclusion:"failure"}]}
+          ]}'
       elif [[ "${FAKE_MODE}" == writer-failed ]]; then
         jq -nc --argjson run_id "$run_id" --argjson job_id "$job_id" --arg marker "$marker" --arg run_sha "$run_sha" \
           '{jobs:[
@@ -549,7 +556,7 @@ run_case() {
     comment_author_id=301
   elif [[ "$mode" == recheck-unset-output ]]; then
     signature_recorded=''
-  elif [[ "$mode" == external-signer ]]; then
+  elif [[ "$mode" == external-signer || "$mode" == signing-stale-writer ]]; then
     comment_author=coauthor
     comment_author_id=400
     comment_body='I have read the CLA Document v2.2 and I hereby sign the CLA'
@@ -681,7 +688,10 @@ run_case stale-base-association 1 "outdated or malformed pull request base SHA" 
 run_case alternate-generation 1 "Unexpected CLA generation marker" 0
 run_case malformed-comment-login 1 "Comment author is malformed" 0
 run_case late-ambiguous 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case external-signer 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case external-signer 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun"
+run_case signing-stale-writer 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case unrecorded-signer 1 "did not result in a persisted signature" 0
 run_case unbound-signer 1 "signing comment was not the signature persisted" 0
 run_case duplicate-runs 0 "Requested rerun for CLA job 501 in workflow run 401" 1 \
@@ -690,7 +700,8 @@ run_case binding-mode-newer 0 "Requested rerun for CLA job 501 in workflow run 4
   "repos/manaflow-ai/cmux/actions/jobs/501/rerun"
 run_case stale-comment-association 1 "Only the pull request author or a trusted repository participant" 0
 run_case job-missing-head-repository 0 "Requested rerun for CLA job 500 in workflow run 400" 1
-run_case wrapped-ledger 0 "Requested rerun for CLA job 500 in workflow run 400" 1
+run_case wrapped-ledger 0 "Requested rerun for CLA workflow run 400 (refresh writer and result jobs)" 1 \
+  "repos/manaflow-ai/cmux/actions/runs/400/rerun"
 run_case oversized-ledger 1 "exceeds the 1 MB limit" 0
 run_case malformed-ledger 1 "not valid base64" 0
 run_case compatibility-failed 0 "Requested rerun for failed CLA result jobs (writer, v3, and compatibility) in workflow run 400" 1 \

--- a/tests/test_cla_trigger_gate.sh
+++ b/tests/test_cla_trigger_gate.sh
@@ -136,6 +136,7 @@ run_gate non-author-sign 0 true env COMMENT_BODY='I have read the CLA Document v
 run_gate ordinary-comment 0 false env COMMENT_BODY='Thanks for the review!'
 run_gate padded-comment 0 false env COMMENT_BODY=' recheck'
 run_gate uppercase-comment 0 false env COMMENT_BODY=RECHECK
+run_gate uppercase-signing-comment 0 false env COMMENT_BODY='I HAVE READ THE CLA DOCUMENT V2.2 AND I HEREBY SIGN THE CLA'
 run_gate bot-comment 1 none env COMMENT_AUTHOR_TYPE=Bot COMMENT_AUTHOR_LOGIN='github-actions[bot]'
 
 for action in opened edited reopened synchronize ready_for_review; do

--- a/tests/test_cla_trigger_gate.sh
+++ b/tests/test_cla_trigger_gate.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# Run the executable admission and result guards from the v3 workflow. These
+# checks cover the event boundary and the failed-check path without granting a
+# test process a GitHub token or pretending that YAML text alone proves it.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/cla.yml"
+test -f "$WORKFLOW"
+
+grep -Fq 'name: "CLA Assistant v3"' "$WORKFLOW"
+if grep -Fq 'name: "CLA Assistant v2"' "$WORKFLOW"; then
+  echo 'FAIL: the retired v2 check name remains in the workflow' >&2
+  exit 1
+fi
+generation="$(WORKFLOW="$WORKFLOW" ruby -ryaml -e 'puts YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false).fetch("env").fetch("CLA_GENERATION")')"
+[[ "$generation" =~ ^v[0-9]+\.[0-9]+-action-[0-9a-f]{40}$ ]]
+grep -Fq "name: \"CLA generation $generation\"" "$WORKFLOW"
+grep -Fq "echo \"CLA generation \${CLA_GENERATION}\"" "$WORKFLOW"
+grep -Fq 'name: "CLA ledger writer"' "$WORKFLOW"
+grep -Fq '      issues: write' "$WORKFLOW"
+grep -Fq 'allowlist-ids: "38676809,67667005"' "$WORKFLOW"
+grep -Fq "cla_passed: \${{ steps.cla_action.outputs.cla_passed }}" "$WORKFLOW"
+grep -Fq 'CLA_PASSED:' "$WORKFLOW"
+# shellcheck disable=SC2016
+WORKFLOW="$WORKFLOW" ruby -ryaml -e '
+  document = YAML.safe_load(File.read(ENV.fetch("WORKFLOW")), aliases: false)
+  expected = "ubuntu-24.04"
+  jobs = %w[CLACommentGate CLALedgerWriter CLAAssistant CLACompatibility RerunFailedCLA LockMergedPullRequest]
+  actual = jobs.to_h { |name| [name, document.fetch("jobs").fetch(name).fetch("runs-on")] }
+  abort "CLA jobs do not use the fixed GitHub-hosted runner" unless actual.values.all? { |runner| runner == expected }
+  gate_group = document.fetch("jobs").fetch("CLACommentGate").fetch("concurrency").fetch("group")
+  expected_gate_group = "cla-admission-${{ github.repository }}-${{ github.event_name }}-${{ github.event.issue.number || github.event.pull_request.number }}-${{ github.event.comment.id || github.run_id }}"
+  abort "CLA admission queue is not event-unique" unless gate_group == expected_gate_group
+  recheck_guard_terms = [
+    "github.event.comment.body == \x27recheck\x27",
+    "github.event.comment.user.id == github.event.issue.user.id",
+    "github.event.comment.author_association == \x27OWNER\x27",
+    "github.event.comment.author_association == \x27MEMBER\x27",
+    "github.event.comment.author_association == \x27COLLABORATOR\x27"
+  ]
+  %w[CLACommentGate CLAAssistant].each do |name|
+    condition = document.fetch("jobs").fetch(name).fetch("if").gsub(/\s+/, " ")
+    abort "#{name} admits untrusted recheck comments" unless
+      recheck_guard_terms.all? { |term| condition.include?(term) }
+  end
+  action_ref = "manaflow-ai/cla-github-action@212a0f2dd659b24b48a30ba35966e06dc41736af"
+  action_refs = []
+  walk = lambda do |value|
+    case value
+    when Hash
+      value.each { |key, child| action_refs << child if key == "uses" && child.is_a?(String) && child.start_with?("manaflow-ai/cla-github-action@"); walk.call(child) }
+    when Array
+      value.each { |child| walk.call(child) }
+    end
+  end
+  walk.call(document)
+  abort "CLA workflow uses an unexpected action reference" unless action_refs == [action_ref, action_ref, action_ref]
+'
+grep -Fq 'uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd' "$WORKFLOW"
+grep -Fq "ref: \${{ github.workflow_sha }}" "$WORKFLOW"
+if grep -Fq "ref: \${{ github.event.pull_request" "$WORKFLOW"; then
+  echo 'FAIL: the rerun helper may not check out a pull-request revision' >&2
+  exit 1
+fi
+
+workflow_types='types: [opened,closed,edited,reopened,synchronize,ready_for_review]'
+grep -Fq "$workflow_types" "$WORKFLOW"
+grep -Fq "github.event.comment.body == 'recheck'" "$WORKFLOW"
+grep -Fq "github.event.comment.body == 'I have read the CLA Document v2.2 and I hereby sign the CLA'" "$WORKFLOW"
+grep -Fq "group: cla-signatures-\${{ github.repository }}-\${{ github.event.pull_request.number || github.event.issue.number }}" "$WORKFLOW"
+
+work="$(mktemp -d)"
+trap 'rm -rf "$work"' EXIT
+
+extract_run() {
+  local job="$1" marker="$2" output="$3"
+  awk -v job="$job" -v marker="$marker" '
+    $0 == "  " job ":" { in_job=1; next }
+    in_job && /^  [A-Za-z0-9_]+:/ { exit }
+    in_job && index($0, marker) { target_step=1; next }
+    in_run && /^      - name:/ { exit }
+    target_step && /^        run: \|$/ { in_run=1; next }
+    in_run { sub(/^          /, ""); print }
+  ' "$WORKFLOW" >"$output"
+  test -s "$output"
+  bash -n "$output"
+}
+
+extract_run CLACommentGate 'id: admission' "$work/admission.sh"
+
+run_gate() {
+  local name="$1" expected_status="$2" expected_output="$3"
+  shift 3
+  local output_file="$work/gate-$name.out" output status
+  rm -f "$output_file"
+  set +e
+  output="$(
+    GITHUB_OUTPUT="$output_file" \
+    EVENT_NAME=issue_comment EVENT_ACTION=created \
+    COMMENT_BODY='recheck' COMMENT_AUTHOR_ID=300 COMMENT_AUTHOR_LOGIN=contributor \
+    COMMENT_AUTHOR_TYPE=User PR_AUTHOR_ID=300 COMMENT_AUTHOR_ASSOCIATION=NONE \
+    "$@" bash "$work/admission.sh" 2>&1
+  )"
+  status=$?
+  set -e
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: gate $name exited $status, expected $expected_status" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  if [[ "$expected_output" == none ]]; then
+    [[ ! -s "$output_file" ]] || {
+      echo "FAIL: gate $name emitted an admission result" >&2
+      exit 1
+    }
+  else
+    [[ "$(<"$output_file")" == "admitted=$expected_output" ]] || {
+      echo "FAIL: gate $name emitted an unexpected admission result" >&2
+      cat "$output_file" >&2
+      exit 1
+    }
+  fi
+  echo "PASS: gate $name"
+}
+
+# The gate admits a syntactically valid declaration before the maintained
+# action authenticates the signer. This keeps the write-capable job from
+# duplicating identity policy while still exposing unauthorized signers as a
+# failed preflight result.
+run_gate exact-recheck 0 true
+run_gate unauthorized-recheck 0 false env COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=reviewer COMMENT_AUTHOR_ASSOCIATION=NONE
+run_gate member-recheck 0 true env COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=maintainer COMMENT_AUTHOR_ASSOCIATION=MEMBER
+run_gate exact-sign 0 true env COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA'
+run_gate non-author-sign 0 true env COMMENT_BODY='I have read the CLA Document v2.2 and I hereby sign the CLA' COMMENT_AUTHOR_ID=301 COMMENT_AUTHOR_LOGIN=reviewer COMMENT_AUTHOR_ASSOCIATION=MEMBER
+run_gate ordinary-comment 0 false env COMMENT_BODY='Thanks for the review!'
+run_gate padded-comment 0 false env COMMENT_BODY=' recheck'
+run_gate uppercase-comment 0 false env COMMENT_BODY=RECHECK
+run_gate bot-comment 1 none env COMMENT_AUTHOR_TYPE=Bot COMMENT_AUTHOR_LOGIN='github-actions[bot]'
+
+for action in opened edited reopened synchronize ready_for_review; do
+  run_gate "pull-$action" 0 true env EVENT_NAME=pull_request_target EVENT_ACTION="$action" COMMENT_BODY=''
+done
+run_gate pull-closed 1 none env EVENT_NAME=pull_request_target EVENT_ACTION=closed COMMENT_BODY=''
+
+extract_run CLAAssistant "CLA generation $generation" "$work/assistant.sh"
+CLA_GENERATION="$generation"
+export CLA_GENERATION
+run_result() {
+  local name="$1" expected_status="$2" event_name="$3" comment_body="$4" gate_result="$5" admitted="$6" signer="$7" writer="$8" cla_passed="$9"
+  local output status
+  set +e
+  output="$(
+    EVENT_NAME="$event_name" COMMENT_BODY="$comment_body" GATE_RESULT="$gate_result" \
+    ADMITTED="$admitted" SIGNER_AUTHORIZED="$signer" WRITER_RESULT="$writer" \
+    CLA_PASSED="$cla_passed" \
+    CLA_GENERATION="$CLA_GENERATION" bash "$work/assistant.sh" 2>&1
+  )"
+  status=$?
+  set -e
+  if [[ "$status" != "$expected_status" ]]; then
+    echo "FAIL: assistant $name exited $status, expected $expected_status" >&2
+    echo "$output" >&2
+    exit 1
+  fi
+  echo "PASS: assistant $name"
+}
+run_result lifecycle-success 0 pull_request_target '' success true false success true
+run_result recheck-success 0 issue_comment recheck success true false success true
+run_result signing-success 0 issue_comment 'I have read the CLA Document v2.2 and I hereby sign the CLA' success true true success true
+run_result policy-failure 1 issue_comment recheck success true false success false
+run_result missing-policy-result 1 issue_comment recheck success true false success ''
+run_result unauthorized-sign 1 issue_comment 'I have read the CLA Document v2.2 and I hereby sign the CLA' success true false success false
+run_result writer-failure 1 issue_comment recheck success true false failure false
+run_result gate-failure 1 issue_comment recheck failure false false skipped false
+
+extract_run CLACompatibility 'Mirror CLA Assistant compatibility result' "$work/compatibility.sh"
+for result in success failure skipped; do
+  set +e
+  RESULT="$result" bash "$work/compatibility.sh" >/dev/null 2>&1
+  status=$?
+  set -e
+  if [[ "$result" == success && "$status" -ne 0 ]] ||
+     [[ "$result" != success && "$status" -eq 0 ]]; then
+    echo "FAIL: compatibility mirror returned $status for $result" >&2
+    exit 1
+  fi
+done
+echo 'PASS: compatibility result mirror'
+
+echo 'PASS: CLA v3 trigger and result guards'


### PR DESCRIPTION
Replaces the weak legacy CLA workflow with the maintained, pinned v3 action and strict admission, ledger, rerun, and merge-lock paths.

This PR intentionally excludes the policy guard and depends on [#11606](https://github.com/manaflow-ai/cmux/pull/11606), which must land first. The guard then validates this workflow and helper from the base revision.

Security properties:
- exact signing phrase and live PR/comment identity
- Austin (`38676809`) and Aziz (`67667005`) are the only opener exemptions
- one write-capable ledger job with least-privilege permissions
- immutable action and helper references
- strict rerun binding to the exact workflow, head, base, and check

Local verification: 62 rerun cases, trigger and lock suites, 97 validator cases from the guard branch, actionlint, ShellCheck warning-level, Ruby syntax, and diff checks.

Please review after #11606 merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrates the CLA workflow to a commit-pinned CLA Assistant v3 with guarded admission. It validates the live PR and exact signing comment, requires an admitted signer with complete association identities, binds reruns to the workflow/head/base/check (empty reruns use the source head), refreshes a stale writer after signing, and gives the merge-lock job ledger read access; only Austin (`38676809`) and Aziz (`67667005`) remain opener exemptions, and both exemption policies are documented in the workflow.

**Verification**
- Adds fixtures for trigger admission, stale-writer recovery and rechecks, reruns, merge locks, and workflow guards.
- Keeps ledger jobs least-privilege, pins the action and helper to immutable references, and requires `ubuntu-24.04` for the policy guard.

**Migration**
- Merge the policy guard first so it can validate this workflow and helper from the base revision.

<sup>Written for commit 66403af5cdd03812231ac92a5b5e2526f557eb1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11608?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a strengthened Contributor License Agreement (CLA) workflow with improved signing-comment validation and signature recording.
  * Added secure reruns for failed CLA checks.
  * Added automatic locking of CLA-related status after pull requests are merged.
  * Added validation for pull request updates and review-state changes.

* **Bug Fixes**
  * Improved protection against stale, invalid, or ambiguous workflow results authorizing CLA reruns.

* **Tests**
  * Expanded automated coverage for CLA validation, reruns, workflow security, and merged pull request handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->