### PR TITLE
Honor Debug build callback schemes on the deployed after-sign-in handoff

### DIFF
--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -448,7 +448,7 @@ export function makeAfterSignInHandler(dependencies: AfterSignInHandlerDependenc
       );
       if (
         trustedPurchaseReturnTo === nativeReturnTo ||
-        isAllowedNativeReturnTo(nativeReturnTo, request)
+        isAllowedNativeReturnTo(nativeReturnTo)
       ) {
         const href = buildNativeHref(nativeReturnTo, refreshToken, accessCookie);
         if (href) {

--- a/web/app/lib/native-callback.ts
+++ b/web/app/lib/native-callback.ts
@@ -4,6 +4,7 @@ export const DEFAULT_NATIVE_CALLBACK_SCHEME = "cmux";
 export const NATIVE_CALLBACK_HOST = "auth-callback";
 
 const NATIVE_SCHEMES = new Set([DEFAULT_NATIVE_CALLBACK_SCHEME, "cmux-nightly"]);
+const TAGGED_DEV_SCHEME_PATTERN = /^cmux-dev-[a-z0-9-]+$/;
 
 export function nativeCallbackHrefForScheme(scheme: string): string {
   return `${scheme}://${NATIVE_CALLBACK_HOST}`;
@@ -18,23 +19,42 @@ export function validatedNativeCallbackScheme(
   return DEFAULT_NATIVE_CALLBACK_SCHEME;
 }
 
+/**
+ * Whether `scheme` is one a cmux build registers for its auth callback: the
+ * stable app, the nightly, an untagged Debug build (`cmux-dev`), or a tagged
+ * Debug build (`cmux-dev-<tag>`, the tag as the app's callback-scheme
+ * sanitizer writes it: lowercase letters, digits, and hyphens).
+ */
+export function isNativeCallbackScheme(scheme: string): boolean {
+  if (NATIVE_SCHEMES.has(scheme) || scheme === "cmux-dev") return true;
+  return TAGGED_DEV_SCHEME_PATTERN.test(scheme);
+}
+
 export function trustedNativeCallbackScheme(
   rawScheme: string | null | undefined,
 ): string | null {
   const scheme = rawScheme?.trim().toLowerCase() ?? "";
-  if (NATIVE_SCHEMES.has(scheme) || scheme === "cmux-dev") return scheme;
-  return /^cmux-dev-[a-z0-9-]+$/.test(scheme) ? scheme : null;
+  return isNativeCallbackScheme(scheme) ? scheme : null;
 }
 
-export function isAllowedNativeReturnTo(
-  href: string,
-  request: NextRequest,
-): boolean {
+/**
+ * Whether the after-sign-in handler may hand the fresh session to `href`.
+ *
+ * Every cmux build's callback is honored on every host, the deployed one
+ * included: a Debug build pointed at production (`reload.sh --prod-auth`)
+ * signs in through the same hosted flow as the stable app, and the build that
+ * started the sign-in verifies the callback's `cmux_auth_state` against its
+ * own attempt, so the web never decides which build a session belongs to. It
+ * only refuses targets no cmux build registers. Purchase returns keep their
+ * separate relay signature (see `billing.ts`); it binds the checkout session,
+ * not the scheme.
+ */
+export function isAllowedNativeReturnTo(href: string): boolean {
   try {
     const url = new URL(href);
     if (url.hostname !== NATIVE_CALLBACK_HOST) return false;
     if (url.pathname !== "" && url.pathname !== "/") return false;
-    return isAllowedNativeScheme(url.protocol.replace(":", ""), request);
+    return isNativeCallbackScheme(url.protocol.replace(":", ""));
   } catch {
     return false;
   }
@@ -46,7 +66,7 @@ export function isAllowedNativeScheme(
 ): boolean {
   if (NATIVE_SCHEMES.has(scheme)) return true;
   if (scheme === "cmux-dev") return isLocalRequest(request);
-  if (!/^cmux-dev-[a-z0-9-]+$/.test(scheme)) return false;
+  if (!TAGGED_DEV_SCHEME_PATTERN.test(scheme)) return false;
   return isLocalRequest(request) && localAllowedNativeSchemes().has(scheme);
 }
 
@@ -66,7 +86,7 @@ function localAllowedNativeSchemes(): Set<string> {
   for (const value of values) {
     for (const raw of value?.split(/[\s,]+/) ?? []) {
       const scheme = raw.trim().replace(/:\/\/.*$/, "").replace(/:$/, "");
-      if (/^cmux-dev-[a-z0-9-]+$/.test(scheme)) schemes.add(scheme);
+      if (TAGGED_DEV_SCHEME_PATTERN.test(scheme)) schemes.add(scheme);
     }
   }
   return schemes;

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -193,6 +193,58 @@ describe("after sign-in native handoff", () => {
     expect(afterSignInTarget.searchParams.has("after_auth_return_to")).toBe(false);
   });
 
+  // A Debug build pointed at the deployed web (`./scripts/reload.sh --tag <tag>
+  // --prod-auth`) signs in through this same hosted flow, so its callback scheme
+  // must be honored here exactly like the stable app's. The build that started
+  // the sign-in verifies the callback's `cmux_auth_state` against its own
+  // attempt, so the web only has to refuse targets no cmux build registers.
+  const DEBUG_BUILD_SCHEMES = [
+    "cmux-dev",
+    "cmux-dev-issue-11397-nonblocking-machine-create",
+  ];
+
+  for (const scheme of DEBUG_BUILD_SCHEMES) {
+    test(`redirects verified handoffs to the ${scheme} build on the deployed host`, async () => {
+      handoffCookie = "handoff-nonce";
+      const nativeReturnTo = `${scheme}://auth-callback?cmux_auth_state=state-123`;
+
+      const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+
+      expect(response.status).toBe(307);
+      const location = response.headers.get("location");
+      expect(location).toBeTruthy();
+      const callbackURL = new URL(location!);
+      expect(callbackURL.protocol).toBe(`${scheme}:`);
+      expect(callbackURL.hostname).toBe("auth-callback");
+      expect(callbackURL.searchParams.get("cmux_auth_state")).toBe("state-123");
+      expect(callbackURL.searchParams.get("stack_refresh")).toBe("refresh-token");
+    });
+
+    test(`keeps the manual return page for the ${scheme} build on the deployed host`, async () => {
+      handoffCookie = "different-nonce";
+      const nativeReturnTo = `${scheme}://auth-callback?cmux_auth_state=state-123`;
+
+      const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+
+      expect(response.status).toBe(200);
+      expect(returnHref(await response.text())).toContain(`${scheme}://auth-callback`);
+    });
+  }
+
+  test("refuses native return targets outside the cmux scheme family", async () => {
+    handoffCookie = "handoff-nonce";
+    for (const nativeReturnTo of [
+      "evil://auth-callback?cmux_auth_state=state-123",
+      "cmux-devx://auth-callback?cmux_auth_state=state-123",
+      "cmux-dev-bad_tag://auth-callback?cmux_auth_state=state-123",
+      "cmux-dev-test://elsewhere?cmux_auth_state=state-123",
+    ]) {
+      const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe("https://cmux.test/");
+    }
+  });
+
   test("preserves the embedded pricing return path when switching accounts", async () => {
     handoffCookie = "different-nonce";
     const nativeReturnTo = "cmux://auth-callback";
@@ -367,7 +419,7 @@ describe("after sign-in native handoff", () => {
     );
   });
 
-  test("accepts only signed tagged purchase callbacks on the deployed host", async () => {
+  test("accepts signed tagged purchase callbacks on the deployed host", async () => {
     const previousSecret = process.env.CMUX_APP_PRICING_RELAY_SECRET;
     process.env.CMUX_APP_PRICING_RELAY_SECRET =
       "pricing-relay-test-secret-with-at-least-32-bytes";
@@ -399,9 +451,11 @@ describe("after sign-in native handoff", () => {
       expect(preservedAfterSignIn.searchParams.get("cmux_native_return_signature"))
         .toMatch(/^[a-f0-9]{64}$/);
 
+      // A tampered target that no cmux build registers is still refused, even
+      // beside an otherwise valid purchase signature.
       afterSignIn.searchParams.set(
         "native_app_return_to",
-        "cmux-dev-other://auth-callback",
+        "evil-app://auth-callback",
       );
       const tamperedResponse = await GET(new NextRequest(afterSignIn));
       expect(tamperedResponse.status).toBe(307);


### PR DESCRIPTION
## Problem

A tagged Debug build pointed at production (`./scripts/reload.sh --tag <tag> --prod-auth`) cannot finish signing in. `cmux auth login` opens the hosted sign-in, the person completes it, and the popup lands on the cmux.com homepage instead of deep-linking back into the build. `cmux auth status` stays "Not signed in."

## Cause

`/handler/after-sign-in` only honored `cmux://` and `cmux-nightly://` on the deployed host. `cmux-dev://` and `cmux-dev-<tag>://` were accepted only when the request host was localhost (`isAllowedNativeScheme`), so the handler fell through to `redirect("/")` and never handed the session to the build.

## What changed

- `isAllowedNativeReturnTo` (after-sign-in) now trusts the whole cmux scheme family on every host: `cmux`, `cmux-nightly`, `cmux-dev`, `cmux-dev-<tag>`. The new `isNativeCallbackScheme` predicate is shared with `trustedNativeCallbackScheme`. Targets outside the family, or with the wrong host or path, stay refused.
- Billing is untouched: checkout, complete, and the success page still accept a Debug scheme on a deployed host only through the signed app-pricing relay (`validatedNativeCallbackScheme` / `isAllowedNativeScheme` unchanged).

## Why this is safe

The web never decided which build a session belongs to. The build that started the sign-in verifies the callback's `cmux_auth_state` against its own attempt (`HostBrowserSignInFlow` rejects `stateMismatch`), and the in-app browser delivers only its own registered scheme (`BrowserAuthCallbackNavigationPolicy`). Handing tokens to `cmux-dev-<tag>://` carries the same exposure `cmux://` already has: a handler for the scheme has to be installed on the Mac.

## Trade-offs (stated, not absorbed)

1. Production now hands sessions to any Debug build scheme, not only to signed purchase returns. That is the point: `--prod-auth` builds exist to sign in against production.
2. The purchase-callback test's tamper case now uses a foreign scheme (`evil-app://`), because a tagged scheme is a legitimate target on its own.
3. The env allowlist (`CMUX_AUTH_CALLBACK_SCHEME`, `CMUX_DEV_NATIVE_CALLBACK_SCHEMES`) now gates only the billing relay on localhost. Left as is to keep this change to the sign-in handoff.

## Verification

- Two commits: the first adds the regression cases (four fail on main: the verified-handoff redirect and the manual return page for `cmux-dev` and `cmux-dev-issue-11397-nonblocking-machine-create` on `https://cmux.test`), the second adds the fix.
- `bash scripts/run-tests.sh tests/after-sign-in-route.test.ts tests/billing-checkout-route.test.ts tests/billing-complete-route.test.ts tests/app-pricing-page.test.tsx`: 67 pass, 0 fail.
- `bun run typecheck` and eslint on the changed files: clean.
- Not verified end to end against production; that needs this deployed. Repro build: `./scripts/reload.sh --tag issue-11397-nonblocking-machine-create --prod-auth --auth-profile personal --launch` on the branch of #11421, then `cmux auth login` from the tagged CLI.
- No user-facing strings changed, so no localization audit was needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
A deployed after-sign-in handoff previously rejected `cmux-dev` and `cmux-dev-<tag>` callbacks, so Debug builds using `--prod-auth` fell back to the homepage and never received their session. It now honors the full cmux callback scheme family on every host while continuing to reject unregistered targets and preserve signed billing returns.

- Accepts `cmux`, `cmux-nightly`, `cmux-dev`, and sanitized `cmux-dev-<tag>` callbacks only at the `auth-callback` root.
- The originating build still validates the auth state, so the web does not choose which build receives the session.
- Adds regression coverage for deployed-host redirects, manual return pages, and invalid targets.

<sup>Written for commit 99a5e50faafef8e0f8f69fc74bf58637f4ca96ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

