### PR TITLE
fix(cloud): Cmd+T on a cloud pane selects the new remote terminal

### DIFF
--- a/Sources/Surfaces/SurfacePaneFactory.swift
+++ b/Sources/Surfaces/SurfacePaneFactory.swift
@@ -135,17 +135,26 @@ enum SurfacePaneFactory {
         guard let workspace = workspace(id: workspaceID) else { throw FactoryError.workspaceNotFound(workspaceID) }
         let controller = TerminalController.shared
         let routing = routing(workspaceID: workspaceID)
-        switch destination {
-        case .tab(_, let paneID, _):
-            guard let requestedPane = UUID(uuidString: paneID) else { throw FactoryError.paneNotFound(paneID) }
-            return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: requestedPane, focus: focus)
-        case .workspace(_, .tab):
-            return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: nil, focus: focus)
-        case .split(_, let paneID, let direction):
-            let anchor = try anchorSurface(paneID: paneID, in: workspace)
-            return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: direction, anchor: anchor, focus: focus)
-        case .workspace(_, .split):
-            return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: .right, anchor: nil, focus: focus)
+        // The create/split handlers honor a focus request only inside a socket command
+        // whose policy allows focus (`v2FocusAllowed`); with no command active the
+        // stack is empty and the request is dropped, so a Cmd+T / Cmd+D / sidebar
+        // gesture would add the tab without selecting it. `focus` here is the caller's
+        // already-decided intent (the socket handlers read their `focus` param before
+        // suspending), so run the handler under exactly that policy. Activation stays
+        // suppressed either way (`shouldSuppressSocketCommandActivation`).
+        return try TerminalController.withSocketCommandPolicyStack([focus]) {
+            switch destination {
+            case .tab(_, let paneID, _):
+                guard let requestedPane = UUID(uuidString: paneID) else { throw FactoryError.paneNotFound(paneID) }
+                return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: requestedPane, focus: focus)
+            case .workspace(_, .tab):
+                return try tab(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, requestedPane: nil, focus: focus)
+            case .split(_, let paneID, let direction):
+                let anchor = try anchorSurface(paneID: paneID, in: workspace)
+                return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: direction, anchor: anchor, focus: focus)
+            case .workspace(_, .split):
+                return try split(controller: controller, routing: routing, typeRaw: typeRaw, url: url, initialCommand: initialCommand, workingDirectory: workingDirectory, direction: .right, anchor: nil, focus: focus)
+            }
         }
     }
 

--- a/Sources/Surfaces/SurfacePaneFactory.swift
+++ b/Sources/Surfaces/SurfacePaneFactory.swift
@@ -138,11 +138,13 @@ enum SurfacePaneFactory {
         // The create/split handlers honor a focus request only inside a socket command
         // whose policy allows focus (`v2FocusAllowed`); with no command active the
         // stack is empty and the request is dropped, so a Cmd+T / Cmd+D / sidebar
-        // gesture would add the tab without selecting it. `focus` here is the caller's
-        // already-decided intent (the socket handlers read their `focus` param before
-        // suspending), so run the handler under exactly that policy. Activation stays
-        // suppressed either way (`shouldSuppressSocketCommandActivation`).
-        return try TerminalController.withSocketCommandPolicyStack([focus]) {
+        // gesture would add the tab without selecting it. `focus` is the caller's
+        // already-decided intent, so run the handler under a frame carrying it. A
+        // frame already on the stack is a socket command's policy and still wins: a
+        // command that may not move focus cannot regain it through the factory.
+        // Activation stays suppressed either way (`shouldSuppressSocketCommandActivation`).
+        let outerAllowsFocus = TerminalController.currentSocketCommandFocusAllowanceStack().last ?? true
+        return try TerminalController.withSocketCommandPolicyStack([focus && outerAllowsFocus]) {
             switch destination {
             case .tab(_, let paneID, _):
                 guard let requestedPane = UUID(uuidString: paneID) else { throw FactoryError.paneNotFound(paneID) }

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -677,11 +677,11 @@ class TerminalController {
         }
     }
 
-    nonisolated static func withSocketCommandPolicyStack<T>(_ stack: [Bool], _ body: () -> T) -> T {
+    nonisolated static func withSocketCommandPolicyStack<T>(_ stack: [Bool], _ body: () throws -> T) rethrows -> T {
         let previous = currentSocketCommandFocusAllowanceStack()
         setCurrentSocketCommandFocusAllowanceStack(stack)
         defer { setCurrentSocketCommandFocusAllowanceStack(previous) }
-        return body()
+        return try body()
     }
 
     /// The stack of socket command keys currently executing on this thread

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2388,6 +2388,7 @@
 		31B62CAEA63AA5B0F737F227 /* SurfaceCatalogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 66CA02CE5FE3E9DC871AD810 /* SurfaceCatalogModel.swift */; };
 		5873A6BE37C34CC1082864E2 /* SurfaceCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 877BC9A2B697FEF2957397FA /* SurfaceCatalogTests.swift */; };
 		2DA7E01B03004BDCEE13A289 /* SurfacePaneFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FE7223A65E72C46927A4F02 /* SurfacePaneFactory.swift */; };
+		560A57B0605EC30E23A20456 /* SurfacePaneFactoryFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C58FB3F39EB94D3072C0B51 /* SurfacePaneFactoryFocusTests.swift */; };
 		875200000000000000000014 /* SurfacePaneMovement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 875200000000000000000004 /* SurfacePaneMovement.swift */; };
 		A9C10D000000000000000002 /* SurfaceProjectionMaterialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9C10D000000000000000001 /* SurfaceProjectionMaterialization.swift */; };
 		F96CAE8A14774122A5F8613B /* SurfaceResourceDragPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48A1307BCCDB493F49179E0B /* SurfaceResourceDragPayload.swift */; };
@@ -5378,6 +5379,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		66CA02CE5FE3E9DC871AD810 /* SurfaceCatalogModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceCatalogModel.swift; sourceTree = "<group>"; };
 		877BC9A2B697FEF2957397FA /* SurfaceCatalogTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceCatalogTests.swift; sourceTree = "<group>"; };
 		1FE7223A65E72C46927A4F02 /* SurfacePaneFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfacePaneFactory.swift; sourceTree = "<group>"; };
+		1C58FB3F39EB94D3072C0B51 /* SurfacePaneFactoryFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfacePaneFactoryFocusTests.swift; sourceTree = "<group>"; };
 		875200000000000000000004 /* SurfacePaneMovement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SurfacePaneMovement.swift; sourceTree = "<group>"; };
 		A9C10D000000000000000001 /* SurfaceProjectionMaterialization.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceProjectionMaterialization.swift; sourceTree = "<group>"; };
 		48A1307BCCDB493F49179E0B /* SurfaceResourceDragPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SurfaceResourceDragPayload.swift; sourceTree = "<group>"; };
@@ -8907,6 +8909,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */,
 				B0555304B0555304B0555304 /* DetachedFolderPathLookupCacheTests.swift */,
 				A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */,
+				1C58FB3F39EB94D3072C0B51 /* SurfacePaneFactoryFocusTests.swift */,
 				7738B0017738B0017738B001 /* RemoteTmuxMirrorCLIObservabilityTests.swift */,
 				7738B0027738B0027738B002 /* RemoteTmuxMirrorCLIFailClosedTests.swift */,
 				7837E0047837E0047837E004 /* RemoteTmuxMirrorResizeRoutingTests.swift */,
@@ -12462,6 +12465,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				EF70B7123200D1FB6F03DB26 /* SSHStartupManualReconnectTests.swift in Sources */,
 				F6355600A1B2C3D4E5F60718 /* SSHStartupSignalLifecycleTests.swift in Sources */,
 				5873A6BE37C34CC1082864E2 /* SurfaceCatalogTests.swift in Sources */,
+				560A57B0605EC30E23A20456 /* SurfacePaneFactoryFocusTests.swift in Sources */,
 				842300000000000000000007 /* SurfaceResumeAgentBindingGenerationTests.swift in Sources */,
 				F6572012A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift in Sources */,
 				842300000000000000000001 /* SurfaceResumeExitedAgentLivenessTests.swift in Sources */,

--- a/cmuxTests/SurfacePaneFactoryFocusTests.swift
+++ b/cmuxTests/SurfacePaneFactoryFocusTests.swift
@@ -100,6 +100,30 @@ import Testing
         #expect(workspace.panelIdFromSurfaceId(selectedSurface) == created.panelID)
     }
 
+    /// Inside a socket command whose policy forbids focus mutations, the factory must
+    /// not re-enable them: the outer policy wins over the caller's `focus: true`.
+    @Test func focusRequestCannotEscapeAFocusForbiddingSocketPolicy() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let workspace = harness.workspace
+        let paneID = try #require(workspace.bonsplitController.focusedPaneId)
+        let before = try #require(workspace.focusedPanelId)
+
+        let created = try TerminalController.withSocketCommandPolicyStack([false]) {
+            try SurfacePaneFactory.makeTerminalPane(
+                initialCommand: nil,
+                workingDirectory: nil,
+                at: .tab(workspaceID: workspace.id, paneID: paneID.id.uuidString, index: nil),
+                focus: true
+            )
+        }
+
+        #expect(created.panelID != before)
+        #expect(workspace.focusedPanelId == before)
+        let selectedSurface = try #require(workspace.bonsplitController.selectedTab(inPane: paneID)?.id)
+        #expect(workspace.panelIdFromSurfaceId(selectedSurface) == before)
+    }
+
     @MainActor
     private struct Harness {
         let appDelegate: AppDelegate

--- a/cmuxTests/SurfacePaneFactoryFocusTests.swift
+++ b/cmuxTests/SurfacePaneFactoryFocusTests.swift
@@ -58,6 +58,48 @@ import Testing
         #expect(workspace.panelIdFromSurfaceId(selectedSurface) == before)
     }
 
+    /// Cmd+D from a cloud pane (`routeCloudPaneTerminalSplit`) lands in the split
+    /// handler with the same gate; the new pane must take focus when asked.
+    @Test func focusedSplitFocusesTheNewPane() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let workspace = harness.workspace
+        let paneID = try #require(workspace.bonsplitController.focusedPaneId)
+        let before = try #require(workspace.focusedPanelId)
+
+        let created = try SurfacePaneFactory.makeTerminalPane(
+            initialCommand: nil,
+            workingDirectory: nil,
+            at: .split(workspaceID: workspace.id, paneID: paneID.id.uuidString, direction: .right),
+            focus: true
+        )
+
+        #expect(created.panelID != before)
+        #expect(workspace.focusedPanelId == created.panelID)
+        #expect(workspace.paneId(forPanelId: created.panelID) != paneID)
+    }
+
+    /// A projected browser (VM desktop or port preview) goes through the same create
+    /// handler as a terminal; `focus: true` must select it too.
+    @Test func focusedBrowserTabIsSelected() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let workspace = harness.workspace
+        let paneID = try #require(workspace.bonsplitController.focusedPaneId)
+        let before = try #require(workspace.focusedPanelId)
+
+        let created = try SurfacePaneFactory.makeBrowserPane(
+            url: SurfacePaneFactory.blankURL,
+            at: .tab(workspaceID: workspace.id, paneID: paneID.id.uuidString, index: nil),
+            focus: true
+        )
+
+        #expect(created.panelID != before)
+        #expect(workspace.focusedPanelId == created.panelID)
+        let selectedSurface = try #require(workspace.bonsplitController.selectedTab(inPane: paneID)?.id)
+        #expect(workspace.panelIdFromSurfaceId(selectedSurface) == created.panelID)
+    }
+
     @MainActor
     private struct Harness {
         let appDelegate: AppDelegate

--- a/cmuxTests/SurfacePaneFactoryFocusTests.swift
+++ b/cmuxTests/SurfacePaneFactoryFocusTests.swift
@@ -1,0 +1,82 @@
+import AppKit
+import Bonsplit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Cmd+T / Cmd+D in a pane that projects a cloud terminal create the machine's new
+/// terminal through ``SurfacePaneFactory`` (`Workspace+CloudPaneRouting`). The factory
+/// drives the socket `surface.create` / `surface.split` handlers, which honor a focus
+/// request only inside a focus-allowed socket command. An in-app gesture runs with no
+/// socket command active, so without the factory setting that policy itself the new tab
+/// appears behind the current one and Cmd+T looks like it did nothing.
+@MainActor
+@Suite(.serialized) struct SurfacePaneFactoryFocusTests {
+    @Test func focusedTabIsSelectedOutsideASocketCommand() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let workspace = harness.workspace
+        let paneID = try #require(workspace.bonsplitController.focusedPaneId)
+        let before = try #require(workspace.focusedPanelId)
+        #expect(TerminalController.currentSocketCommandFocusAllowanceStack().isEmpty)
+
+        let created = try SurfacePaneFactory.makeTerminalPane(
+            initialCommand: nil,
+            workingDirectory: nil,
+            at: .tab(workspaceID: workspace.id, paneID: paneID.id.uuidString, index: nil),
+            focus: true
+        )
+
+        #expect(created.workspaceID == workspace.id)
+        #expect(created.panelID != before)
+        #expect(workspace.focusedPanelId == created.panelID)
+        let selectedSurface = try #require(workspace.bonsplitController.selectedTab(inPane: paneID)?.id)
+        #expect(workspace.panelIdFromSurfaceId(selectedSurface) == created.panelID)
+    }
+
+    @Test func unfocusedTabStaysBehindTheCurrentOne() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let workspace = harness.workspace
+        let paneID = try #require(workspace.bonsplitController.focusedPaneId)
+        let before = try #require(workspace.focusedPanelId)
+
+        let created = try SurfacePaneFactory.makeTerminalPane(
+            initialCommand: nil,
+            workingDirectory: nil,
+            at: .tab(workspaceID: workspace.id, paneID: paneID.id.uuidString, index: nil),
+            focus: false
+        )
+
+        #expect(created.panelID != before)
+        #expect(workspace.focusedPanelId == before)
+        let selectedSurface = try #require(workspace.bonsplitController.selectedTab(inPane: paneID)?.id)
+        #expect(workspace.panelIdFromSurfaceId(selectedSurface) == before)
+    }
+
+    @MainActor
+    private struct Harness {
+        let appDelegate: AppDelegate
+        let windowId: UUID
+        let workspace: Workspace
+
+        init() throws {
+            appDelegate = try #require(AppDelegate.shared)
+            windowId = appDelegate.createMainWindow()
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            workspace = try #require(manager.selectedWorkspace)
+        }
+
+        func tearDown() {
+            let identifier = "cmux.main.\(windowId.uuidString)"
+            if let window = NSApp.windows.first(where: { $0.identifier?.rawValue == identifier }) {
+                window.performClose(nil)
+                RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            }
+        }
+    }
+}


### PR DESCRIPTION
Cmd+T in a pane that projects a cloud terminal created the new terminal on the machine but left it behind the current tab, so the shortcut looked dead.

SurfacePaneFactory maps a projection onto the socket `surface.create` / `surface.split` handlers. Those honor `requestedFocus` only while a socket command with a focus-allowing policy is on the thread-local stack (`v2FocusAllowed`). In-app gestures (Cmd+T, Cmd+D, sidebar New Terminal Here) run with an empty stack, so the request was dropped. The factory now runs the handler under a policy frame equal to its `focus` argument, the same frame a focus-intent socket command pushes; app activation stays suppressed because the stack is non-empty. `withSocketCommandPolicyStack` becomes `rethrows` so the throwing factory body can run inside it.

Commit 1 adds `SurfacePaneFactoryFocusTests` (red on main), commit 2 the fix.

https://claude.ai/code/session_01Dg5MLmzriwRLTRCi8oh5R6

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd+T in a pane projecting a cloud terminal now selects the new remote terminal instead of leaving it behind the current tab. Cmd+D and sidebar "New Terminal Here" also honor their focus intent, while unfocused creates remain unfocused.

**Bug Fixes**

- Runs factory routing under a focus policy frame composed from the caller's intent and the innermost active socket policy.
- A focus-forbidding socket command can no longer regain focus through the factory, and app activation stays suppressed.
- Adds tests for focused and unfocused creation of terminal tabs, splits, and browser projections.

<sup>Written for commit a95823c9e3ada8c0bd6172989f4890f365102ee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11612?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

