### PR TITLE
Use hash sets for route hint deduplication

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -2186,9 +2186,10 @@ pub fn credential_free_route_hint(route: &str) -> Result<String, IdentityError> 
 
 fn credential_free_route_hints(routes: Vec<String>) -> Result<Vec<String>, IdentityError> {
     let mut sanitized = Vec::with_capacity(routes.len());
+    let mut seen = HashSet::with_capacity(routes.len());
     for route in routes {
         let route = credential_free_route_hint(&route)?;
-        if !sanitized.contains(&route) {
+        if seen.insert(route.clone()) {
             sanitized.push(route);
         }
     }
@@ -2197,9 +2198,10 @@ fn credential_free_route_hints(routes: Vec<String>) -> Result<Vec<String>, Ident
 
 fn credential_free_route_hints_lossy(routes: &[String]) -> Vec<String> {
     let mut sanitized = Vec::with_capacity(routes.len());
+    let mut seen = HashSet::with_capacity(routes.len());
     for route in routes {
         if let Ok(route) = credential_free_route_hint(route)
-            && !sanitized.contains(&route)
+            && seen.insert(route.clone())
         {
             sanitized.push(route);
         }

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -3944,6 +3944,22 @@ mod tests {
         assert!(matches!(error, IdentityError::Invalid(message) if message.contains("unique")));
     }
 
+    #[test]
+    fn credential_free_route_hints_deduplicate_without_reordering() {
+        let routes = vec![
+            "unix:///tmp/first".to_string(),
+            "unix:///tmp/second".to_string(),
+            "unix:///tmp/first".to_string(),
+        ];
+
+        let sanitized = credential_free_route_hints(routes).unwrap();
+
+        assert_eq!(
+            sanitized,
+            vec!["unix:///tmp/first".to_string(), "unix:///tmp/second".to_string()]
+        );
+    }
+
     #[tokio::test]
     async fn pending_enrollment_notification_cannot_be_lost_between_check_and_wait() {
         let temp = tempfile::tempdir().unwrap();


### PR DESCRIPTION
Replace repeated Vec::contains scans with HashSet membership while retaining ordered output.

Tests: rustfmt and git diff --check only (Cargo not run per task constraint).

Rust collection cost reference: https://doc.rust-lang.org/std/collections/index.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces repeated `Vec::contains` scans with `HashSet` membership to deduplicate credential-free route hints in both sanitizing functions, preserving first-seen order and output.

- Adds a regression test covering order-preserving deduplication.

<sup>Written for commit f003445fd393e19c52fd4a9ff9ae1c0b11249702. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11616?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed duplicate route hints while preserving their original order.
  * Improved handling of repeated route information for more consistent results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->