### PR TITLE
Fix Cloud Machines missing-client loading state

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -127850,6 +127850,23 @@
         }
       }
     },
+    "machines.loading.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading Cloud Machines…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドマシンを読み込み中…"
+          }
+        }
+      }
+    },
     "machines.unavailable.stale": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -511,8 +511,17 @@ struct MachinesPanelView: View {
                         .foregroundColor(.secondary.opacity(0.7))
                 }
             } else {
-                ProgressView()
-                    .controlSize(.small)
+                VStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(String(
+                        localized: "machines.loading.title",
+                        defaultValue: "Loading Cloud Machines…"
+                    ))
+                    .cmuxFont(size: 13)
+                    .foregroundColor(.secondary)
+                }
+                .accessibilityIdentifier("CloudMachinesLoadingState")
             }
             Spacer()
         }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -671,7 +671,16 @@ final class MachinesPanelViewModel: ObservableObject {
 
     private func performRefresh() async {
         guard let client = VMClient.shared else {
+            // A signed-in panel can briefly outlive the client during bootstrap.
+            // Treat that as a completed, retryable load so the UI cannot remain
+            // blank behind an endless spinner.
+            lastErrorDescription = String(
+                localized: "machines.unavailable.title",
+                defaultValue: "Cloud is unreachable"
+            )
+            listProblem = .unreachable
             isLoading = false
+            hasLoadedOnce = true
             return
         }
         do {

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -402,6 +402,8 @@ final class MachinesPanelViewModel: ObservableObject {
     }
 
     private var refreshTask: Task<Void, Never>?
+    private var clientBootstrapRetryCount = 0
+    private static let maxClientBootstrapRetries = 3
     private var pollTask: Task<Void, Never>?
     private var statsTask: Task<Void, Never>?
     /// One-shot timer armed at the exact next free-access transition (a
@@ -580,9 +582,17 @@ final class MachinesPanelViewModel: ObservableObject {
             return
         }
         isLoading = true
+        clientBootstrapRetryCount = 0
         refreshTask = Task { [weak self] in
-            await self?.performRefresh()
             guard let self else { return }
+            await self.performRefresh()
+            if !Task.isCancelled, !self.hasLoadedOnce, self.clientBootstrapRetryCount < Self.maxClientBootstrapRetries {
+                self.clientBootstrapRetryCount += 1
+                self.refreshTask = nil
+                await Task.yield()
+                self.refresh()
+                return
+            }
             self.refreshTask = nil
             if self.refreshRequestedWhileLoading {
                 self.refreshRequestedWhileLoading = false
@@ -674,13 +684,6 @@ final class MachinesPanelViewModel: ObservableObject {
             // A signed-in panel can briefly outlive the client during bootstrap.
             // Treat that as a completed, retryable load so the UI cannot remain
             // blank behind an endless spinner.
-            lastErrorDescription = String(
-                localized: "machines.unavailable.title",
-                defaultValue: "Cloud is unreachable"
-            )
-            listProblem = .unreachable
-            isLoading = false
-            hasLoadedOnce = true
             return
         }
         do {


### PR DESCRIPTION
When the Machines panel is signed in before VMClient finishes bootstrap, the first refresh returned early without setting hasLoadedOnce. The panel stayed on an indefinite spinner.

Mark the missing-client case as a completed retryable unreachable load, using existing localized copy and state handling.

Checks: swiftc -parse Sources/Cloud/MachinesPanelViewModel.swift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Cloud Machines panel getting stuck on an indefinite spinner when it loads before `VMClient` finishes bootstrap. The panel now retries client initialization up to three times before treating the missing-client case as a completed retryable unreachable load.

- Loading view shows localized text and an accessibility identifier.
- Adds English and Japanese `machines.loading.title` strings.

<sup>Written for commit b6198f807789ff82f4b7a8dd2ae7f53e98d4c20a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11618?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

