### PR TITLE
Bound hosted TUI artifact retention

### DIFF
--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+preview="$tmp/.retention-preview"
+hash=abc123
+write_preview() { printf '%s\t%s\n' "$1" "$(date +%s)" > "$preview"; }
+valid_preview() { [[ -f "$preview" && "$(cut -f1 "$preview")" == "$hash" ]] && (( $(date +%s) - $(cut -f2 "$preview") <= 600 )); }
+! valid_preview
+write_preview "$hash"
+valid_preview
+printf '%s\t%s\n' "$hash" "$(( $(date +%s) - 601 ))" > "$preview"
+! valid_preview
+rm -f "$preview"
+echo 'hosted retention token behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -40,5 +40,12 @@ active_binary=/tmp/0000000000000000000000000000000000000001/cmux-tui
 active_lsof_output="n$active_binary"
 active_artifact_paths="$(printf '%s\n' "$active_lsof_output" | sed -n 's/^n//p')"
 printf '%s\n' "$active_artifact_paths" | grep -F -x -q -- "$active_binary"
+lsof_status=1
+lsof_stderr='lsof: status error on missing artifact'
+if (( lsof_status == 1 )) && [[ -n "$lsof_stderr" ]]; then
+  :
+else
+  exit 1
+fi
 rm -f "$preview"
 echo 'hosted retention token behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -61,9 +61,19 @@ expect_invalid() { if valid_retention_count 9223372036854775808; then return 1; 
 expect_invalid
 generation_dir="$tmp/generation"
 mkdir "$generation_dir"
-generation_before="$(stat -f '%i:%m' "$generation_dir" 2>/dev/null || stat -c '%i:%Y' "$generation_dir")"
+generation_identity() {
+  local value=""
+  if value="$(stat -f '%i:%m' "$1" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+  elif value="$(stat -c '%i:%Y' "$1" 2>/dev/null)" && [[ "$value" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$value"
+  else
+    return 1
+  fi
+}
+generation_before="$(generation_identity "$generation_dir")"
 touch -t 200001010000 "$generation_dir"
-generation_after="$(stat -f '%i:%m' "$generation_dir" 2>/dev/null || stat -c '%i:%Y' "$generation_dir")"
+generation_after="$(generation_identity "$generation_dir")"
 [[ "$generation_before" != "$generation_after" ]]
 rm -f "$preview"
 echo 'hosted retention token behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -36,5 +36,9 @@ write_preview "$(( $(date +%s) - 601 ))"
 expect_invalid
 write_preview "$(( $(date +%s) + 1 ))"
 expect_invalid
+active_binary=/tmp/0000000000000000000000000000000000000001/cmux-tui
+active_lsof_output="n$active_binary"
+active_artifact_paths="$(printf '%s\n' "$active_lsof_output" | sed -n 's/^n//p')"
+printf '%s\n' "$active_artifact_paths" | grep -F -x -q -- "$active_binary"
 rm -f "$preview"
 echo 'hosted retention token behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -51,5 +51,19 @@ if (( lsof_status == 1 )) && [[ -n "$lsof_stderr" ]]; then
 else
   exit 1
 fi
+valid_retention_count() {
+  [[ "$1" =~ ^[1-9][0-9]*$ ]] || return 1
+  ((${#1} <= 6)) || return 1
+  ((10#$1 <= 100000))
+}
+valid_retention_count 100000
+expect_invalid() { if valid_retention_count 9223372036854775808; then return 1; fi; }
+expect_invalid
+generation_dir="$tmp/generation"
+mkdir "$generation_dir"
+generation_before="$(stat -f '%i:%m' "$generation_dir" 2>/dev/null || stat -c '%i:%Y' "$generation_dir")"
+touch -t 200001010000 "$generation_dir"
+generation_after="$(stat -f '%i:%m' "$generation_dir" 2>/dev/null || stat -c '%i:%Y' "$generation_dir")"
+[[ "$generation_before" != "$generation_after" ]]
 rm -f "$preview"
 echo 'hosted retention token behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -3,13 +3,38 @@ set -euo pipefail
 tmp="$(mktemp -d)"
 trap 'rm -rf -- "$tmp"' EXIT
 preview="$tmp/.retention-preview"
-hash=abc123
-write_preview() { printf '%s\t%s\n' "$1" "$(date +%s)" > "$preview"; }
-valid_preview() { [[ -f "$preview" && "$(cut -f1 "$preview")" == "$hash" ]] && (( $(date +%s) - $(cut -f2 "$preview") <= 600 )); }
-! valid_preview
-write_preview "$hash"
+commit=abc123
+retention_count=2
+plan="$(printf 'commit\t%s\nretention_count\t%s\ncandidate\t%s\ncandidate\t%s' \
+  "$commit" "$retention_count" \
+  /tmp/0000000000000000000000000000000000000001 \
+  /tmp/0000000000000000000000000000000000000002)"
+write_preview() {
+  {
+    printf '%s\n' "$plan"
+    printf 'timestamp\t%s\n' "$1"
+  } > "$preview"
+}
+valid_preview() {
+  [[ -f "$preview" ]] || return 1
+  preview_timestamp="$(tail -n 1 "$preview" | cut -f2)"
+  [[ "$preview_timestamp" =~ ^[0-9]+$ ]] || return 1
+  [[ "$(sed '$d' "$preview")" == "$plan" ]] || return 1
+  now="$(date +%s)"
+  (( preview_timestamp <= now && now - preview_timestamp <= 600 ))
+}
+expect_invalid() { if valid_preview; then return 1; fi; }
+expect_invalid
+write_preview "$(date +%s)"
 valid_preview
-printf '%s\t%s\n' "$hash" "$(( $(date +%s) - 601 ))" > "$preview"
-! valid_preview
+plan=$'commit\tchanged\nretention_count\t2\ncandidate\t/tmp/0000000000000000000000000000000000000001\ncandidate\t/tmp/0000000000000000000000000000000000000002'
+expect_invalid
+plan=$'commit\tabc123\nretention_count\t3\ncandidate\t/tmp/0000000000000000000000000000000000000001\ncandidate\t/tmp/0000000000000000000000000000000000000002'
+expect_invalid
+plan=$'commit\tabc123\nretention_count\t2\ncandidate\t/tmp/0000000000000000000000000000000000000001\ncandidate\t/tmp/0000000000000000000000000000000000000002'
+write_preview "$(( $(date +%s) - 601 ))"
+expect_invalid
+write_preview "$(( $(date +%s) + 1 ))"
+expect_invalid
 rm -f "$preview"
 echo 'hosted retention token behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -40,6 +40,10 @@ active_binary=/tmp/0000000000000000000000000000000000000001/cmux-tui
 active_lsof_output="n$active_binary"
 active_artifact_paths="$(printf '%s\n' "$active_lsof_output" | sed -n 's/^n//p')"
 printf '%s\n' "$active_artifact_paths" | grep -F -x -q -- "$active_binary"
+plan="$(printf '%s\ndelete\t%s' "$plan" /tmp/0000000000000000000000000000000000000002)"
+expect_invalid
+write_preview "$(date +%s)"
+valid_preview
 lsof_status=1
 lsof_stderr='lsof: status error on missing artifact'
 if (( lsof_status == 1 )) && [[ -n "$lsof_stderr" ]]; then

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -342,6 +342,57 @@ artifact_binary="$artifact_dir/cmux-tui"
 mkdir -p "$artifact_dir"
 install -m 0755 "$downloaded_binary" "$artifact_binary"
 
+# Keep a small, bounded local cache. Cleanup is opt-in so existing callers do
+# not lose artifacts unexpectedly. Only directories owned by this user and
+# named for a complete commit SHA are eligible. The current commit and any
+# binary still open by a process are always retained.
+retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-5}"
+if [[ ! "$retention_count" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: CMUX_TUI_HOSTED_RETENTION_COUNT must be a positive integer" >&2
+  exit 2
+fi
+if [[ "${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}" == "1" ]]; then
+  retention_dry_run=true
+elif [[ "${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}" == "0" ]]; then
+  retention_dry_run=false
+else
+  echo "error: CMUX_TUI_HOSTED_RETENTION_DRY_RUN must be 0 or 1" >&2
+  exit 2
+fi
+
+hosted_artifact_dirs=()
+while IFS= read -r -d '' candidate_dir; do
+  candidate_commit="${candidate_dir##*/}"
+  [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
+  hosted_artifact_dirs+=("$candidate_dir")
+done < <(find cmux-tui/target/hosted -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
+if ((${#hosted_artifact_dirs[@]} > 1)); then
+  IFS=$'\n' hosted_artifact_dirs=($(printf '%s\n' "${hosted_artifact_dirs[@]}" | sort -r))
+  unset IFS
+fi
+retained=0
+for candidate_dir in "${hosted_artifact_dirs[@]}"; do
+  candidate_commit="${candidate_dir##*/}"
+  candidate_binary="$candidate_dir/cmux-tui"
+  if [[ "$candidate_commit" == "$commit" || ! -f "$candidate_binary" ]]; then
+    continue
+  fi
+  if (( retained < retention_count )); then
+    retained=$((retained + 1))
+    continue
+  fi
+  if command -v lsof >/dev/null 2>&1 && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
+    echo "Keeping active hosted artifact: $candidate_binary" >&2
+    continue
+  fi
+  if [[ "$retention_dry_run" == true ]]; then
+    echo "Would remove hosted artifact: $candidate_dir" >&2
+  else
+    rm -rf -- "$candidate_dir"
+    echo "Removed hosted artifact: $candidate_dir" >&2
+  fi
+done
+
 echo "Hosted verification passed: $run_url"
 echo "Artifact: $artifact_binary"
 echo "Dogfood: $artifact_binary --session verify-${commit:0:8}"

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -358,6 +358,11 @@ if [[ ! "$retention_count" =~ ^[1-9][0-9]*$ ]]; then
   echo "error: CMUX_TUI_HOSTED_RETENTION_COUNT must be a positive integer" >&2
   exit 2
 fi
+if ((${#retention_count} > 6)) ||
+  ((${#retention_count} == 6 && retention_count > 100000)); then
+  echo "error: hosted artifact retention count is too large" >&2
+  exit 2
+fi
 if [[ "${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}" == "1" ]]; then
   retention_dry_run=true
 elif [[ "${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}" == "0" ]]; then
@@ -452,15 +457,37 @@ for candidate_dir in "${cleanup_dirs[@]}"; do
   deletion_dirs+=("$candidate_dir")
 done
 
+artifact_identity() {
+  local artifact_dir="$1"
+  local identity=""
+  if identity="$(stat -f '%i:%m' "$artifact_dir" 2>/dev/null)" &&
+    [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$identity"
+  elif identity="$(stat -c '%i:%Y' "$artifact_dir" 2>/dev/null)" &&
+    [[ "$identity" =~ ^[0-9]+:[0-9]+$ ]]; then
+    printf '%s\n' "$identity"
+  else
+    return 1
+  fi
+}
+
 retention_plan_file="$temp_dir/retention-plan"
 {
   printf 'commit\t%s\n' "$commit"
   printf 'retention_count\t%s\n' "$retention_count"
   for candidate_dir in "${hosted_artifact_dirs[@]}"; do
-    printf 'candidate\t%s\n' "$candidate_dir"
+    candidate_identity="$(artifact_identity "$candidate_dir")" || {
+      echo "error: cannot identify hosted artifact generation: $candidate_dir" >&2
+      exit 2
+    }
+    printf 'candidate\t%s\t%s\n' "$candidate_dir" "$candidate_identity"
   done
   for candidate_dir in "${deletion_dirs[@]}"; do
-    printf 'delete\t%s\n' "$candidate_dir"
+    candidate_identity="$(artifact_identity "$candidate_dir")" || {
+      echo "error: cannot identify hosted artifact generation: $candidate_dir" >&2
+      exit 2
+    }
+    printf 'delete\t%s\t%s\n' "$candidate_dir" "$candidate_identity"
   done
 } > "$retention_plan_file"
 if [[ "$retention_dry_run" == true ]]; then
@@ -506,6 +533,15 @@ fi
 
 for candidate_dir in "${deletion_dirs[@]}"; do
   candidate_binary="$candidate_dir/cmux-tui"
+  candidate_identity="$(artifact_identity "$candidate_dir")" || {
+    echo "error: hosted artifact changed before cleanup: $candidate_dir" >&2
+    exit 2
+  }
+  expected_delete_line=$'delete\t'"$candidate_dir"$'\t'"$candidate_identity"
+  if ! grep -F -x -q -- "$expected_delete_line" "$retention_plan_file"; then
+    echo "error: hosted artifact changed before cleanup: $candidate_dir" >&2
+    exit 2
+  fi
   if [[ "$retention_dry_run" == true ]]; then
     echo "Would remove hosted artifact: $candidate_dir" >&2
   else

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -382,10 +382,16 @@ hosted_artifact_order=()
 while IFS= read -r -d '' candidate_dir; do
   candidate_commit="${candidate_dir##*/}"
   [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
-  if stat -f '%m' "$candidate_dir" >/dev/null 2>&1; then
-    candidate_mtime="$(stat -f '%m' "$candidate_dir")"
+  candidate_mtime=""
+  if candidate_mtime="$(stat -f '%m' "$candidate_dir" 2>/dev/null)" &&
+    [[ "$candidate_mtime" =~ ^[0-9]+$ ]]; then
+    :
+  elif candidate_mtime="$(stat -c '%Y' "$candidate_dir" 2>/dev/null)" &&
+    [[ "$candidate_mtime" =~ ^[0-9]+$ ]]; then
+    :
   else
-    candidate_mtime="$(stat -c '%Y' "$candidate_dir")"
+    echo "error: cannot read modification time for hosted artifact: $candidate_dir" >&2
+    exit 2
   fi
   hosted_artifact_order+=("$candidate_mtime	$candidate_commit	$candidate_dir")
 done < <(find cmux-tui/target/hosted -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
@@ -394,15 +400,57 @@ if ((${#hosted_artifact_order[@]} > 0)); then
     hosted_artifact_dirs+=("$candidate_dir")
   done < <(printf '%s\n' "${hosted_artifact_order[@]}" | sort -t $'\t' -k1,1nr -k2,2r)
 fi
-candidate_set_hash="$(printf '%s\n' "${hosted_artifact_dirs[@]}" | shasum -a 256 | awk '{print $1}')"
+retention_plan_file="$temp_dir/retention-plan"
+{
+  printf 'commit\t%s\n' "$commit"
+  printf 'retention_count\t%s\n' "$retention_count"
+  for candidate_dir in "${hosted_artifact_dirs[@]}"; do
+    printf 'candidate\t%s\n' "$candidate_dir"
+  done
+} > "$retention_plan_file"
 if [[ "$retention_dry_run" == true ]]; then
-  printf '%s\t%s\n' "$candidate_set_hash" "$(date +%s)" > "$preview_file"
-elif [[ ! -f "$preview_file" ]] || [[ "$(cut -f1 "$preview_file")" != "$candidate_set_hash" ]] || \
-  (( $(date +%s) - $(cut -f2 "$preview_file") > 600 )); then
-  echo "error: retention requires a fresh dry-run preview for this candidate set" >&2
-  exit 2
+  preview_tmp="$temp_dir/retention-preview"
+  {
+    cat "$retention_plan_file"
+    printf 'timestamp\t%s\n' "$(date +%s)"
+  } > "$preview_tmp"
+  mv -f "$preview_tmp" "$preview_file"
+else
+  if [[ ! -f "$preview_file" ]]; then
+    echo "error: retention requires a fresh dry-run preview for this plan" >&2
+    exit 2
+  fi
+  preview_timestamp="$(awk -F '\t' '
+    $1 == "timestamp" {
+      if (seen || $2 !~ /^[0-9]+$/) exit 1
+      seen = 1
+      value = $2
+      next
+    }
+    seen { exit 1 }
+    END {
+      if (!seen) exit 1
+      print value
+    }
+  ' "$preview_file")" || {
+    echo "error: retention preview timestamp is invalid" >&2
+    exit 2
+  }
+  now="$(date +%s)"
+  if (( preview_timestamp > now || now - preview_timestamp > 600 )); then
+    echo "error: retention preview is missing or expired; run a dry run first" >&2
+    exit 2
+  fi
+  preview_plan_file="$temp_dir/retention-preview-plan"
+  sed '$d' "$preview_file" > "$preview_plan_file"
+  if ! cmp -s "$retention_plan_file" "$preview_plan_file"; then
+    echo "error: retention preview does not match the current cleanup plan" >&2
+    exit 2
+  fi
 fi
+
 retained=0
+cleanup_dirs=()
 for candidate_dir in "${hosted_artifact_dirs[@]}"; do
   candidate_commit="${candidate_dir##*/}"
   candidate_binary="$candidate_dir/cmux-tui"
@@ -413,11 +461,36 @@ for candidate_dir in "${hosted_artifact_dirs[@]}"; do
     retained=$((retained + 1))
     continue
   fi
+  cleanup_dirs+=("$candidate_dir")
+done
+
+active_artifact_paths=""
+if ((${#cleanup_dirs[@]} > 0)); then
   if [[ "$lsof_available" != true ]]; then
     echo "error: cannot prove artifact is inactive because lsof is unavailable" >&2
     exit 2
   fi
-  if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
+  lsof_candidates=()
+  for candidate_dir in "${cleanup_dirs[@]}"; do
+    candidate_binary="$candidate_dir/cmux-tui"
+    [[ -f "$candidate_binary" ]] && lsof_candidates+=("$candidate_binary")
+  done
+  if ((${#lsof_candidates[@]} > 0)); then
+    set +e
+    active_artifact_paths="$(lsof -Fn -- "${lsof_candidates[@]}" 2>/dev/null)"
+    lsof_status=$?
+    set -e
+    if (( lsof_status > 1 )); then
+      echo "error: cannot determine whether hosted artifacts are active" >&2
+      exit 2
+    fi
+  fi
+fi
+
+for candidate_dir in "${cleanup_dirs[@]}"; do
+  candidate_binary="$candidate_dir/cmux-tui"
+  if [[ -f "$candidate_binary" ]] &&
+    printf '%s\n' "$active_artifact_paths" | grep -F -x -q -- "$candidate_binary"; then
     echo "Keeping active hosted artifact: $candidate_binary" >&2
     continue
   fi

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -400,7 +400,7 @@ while IFS= read -r -d '' candidate_dir; do
     exit 2
   fi
   hosted_artifact_order+=("$candidate_mtime	$candidate_commit	$candidate_dir")
-done < <(find "$hosted_artifact_root" -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
+done < <(find "$hosted_artifact_root" -mindepth 1 -maxdepth 1 -type d -uid "$(id -u)" -print0)
 if ((${#hosted_artifact_order[@]} > 0)); then
   while IFS=$'\t' read -r _ candidate_commit candidate_dir; do
     hosted_artifact_dirs+=("$candidate_dir")
@@ -422,27 +422,42 @@ for candidate_dir in "${hosted_artifact_dirs[@]}"; do
 done
 
 active_artifact_paths=""
+lsof_candidates=()
 if ((${#cleanup_dirs[@]} > 0)); then
   if [[ "$lsof_available" != true ]]; then
     echo "error: cannot prove artifact is inactive because lsof is unavailable" >&2
     exit 2
   fi
-  lsof_candidates=()
   for candidate_dir in "${cleanup_dirs[@]}"; do
     candidate_binary="$candidate_dir/cmux-tui"
     [[ -f "$candidate_binary" ]] && lsof_candidates+=("$candidate_binary")
   done
   if ((${#lsof_candidates[@]} > 0)); then
-    lsof_stderr_file="$temp_dir/lsof.stderr"
-    set +e
-    active_artifact_paths="$(lsof -Fn -- "${lsof_candidates[@]}" 2>"$lsof_stderr_file")"
-    lsof_status=$?
-    set -e
-    if (( lsof_status != 0 )) && [[ -s "$lsof_stderr_file" ]]; then
-      echo "error: cannot determine whether hosted artifacts are active" >&2
-      exit 2
-    fi
-    active_artifact_paths="$(printf '%s\n' "$active_artifact_paths" | sed -n 's/^n//p')"
+    collect_active_artifacts() {
+      local stderr_file="$1"
+      local paths_file="$temp_dir/lsof.paths"
+      local batch_size=100
+      local batch_start=0
+      local batch_output=""
+      local lsof_status=0
+      : > "$stderr_file"
+      : > "$paths_file"
+      while ((batch_start < ${#lsof_candidates[@]})); do
+        batch=("${lsof_candidates[@]:batch_start:batch_size}")
+        set +e
+        batch_output="$(lsof -Fn -- "${batch[@]}" 2>>"$stderr_file")"
+        lsof_status=$?
+        set -e
+        if (( lsof_status != 0 )) && [[ -s "$stderr_file" ]]; then
+          echo "error: cannot determine whether hosted artifacts are active" >&2
+          exit 2
+        fi
+        printf '%s\n' "$batch_output" >> "$paths_file"
+        batch_start=$((batch_start + batch_size))
+      done
+      active_artifact_paths="$(sed -n 's/^n//p' "$paths_file" | sort -u)"
+    }
+    collect_active_artifacts "$temp_dir/lsof.stderr"
   fi
 fi
 
@@ -527,6 +542,15 @@ else
   sed '$d' "$preview_file" > "$preview_plan_file"
   if ! cmp -s "$retention_plan_file" "$preview_plan_file"; then
     echo "error: retention preview does not match the current cleanup plan" >&2
+    exit 2
+  fi
+fi
+
+if ((${#lsof_candidates[@]} > 0)); then
+  active_artifact_paths_before="$active_artifact_paths"
+  collect_active_artifacts "$temp_dir/lsof-recheck.stderr"
+  if [[ "$active_artifact_paths" != "$active_artifact_paths_before" ]]; then
+    echo "error: hosted artifact activity changed before cleanup; run a new dry run" >&2
     exit 2
   fi
 fi

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -371,6 +371,7 @@ if [[ "$retention_dry_run" == false && "$retention_confirmed" != "1" ]]; then
   echo "error: destructive retention requires CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 after a dry run" >&2
   exit 2
 fi
+preview_file="cmux-tui/target/hosted/.retention-preview"
 lsof_available=false
 if command -v lsof >/dev/null 2>&1; then
   lsof_available=true
@@ -393,6 +394,14 @@ if ((${#hosted_artifact_order[@]} > 0)); then
     hosted_artifact_dirs+=("$candidate_dir")
   done < <(printf '%s\n' "${hosted_artifact_order[@]}" | sort -t $'\t' -k1,1nr -k2,2r)
 fi
+candidate_set_hash="$(printf '%s\n' "${hosted_artifact_dirs[@]}" | shasum -a 256 | awk '{print $1}')"
+if [[ "$retention_dry_run" == true ]]; then
+  printf '%s\t%s\n' "$candidate_set_hash" "$(date +%s)" > "$preview_file"
+elif [[ ! -f "$preview_file" ]] || [[ "$(cut -f1 "$preview_file")" != "$candidate_set_hash" ]] || \
+  (( $(date +%s) - $(cut -f2 "$preview_file") > 600 )); then
+  echo "error: retention requires a fresh dry-run preview for this candidate set" >&2
+  exit 2
+fi
 retained=0
 for candidate_dir in "${hosted_artifact_dirs[@]}"; do
   candidate_commit="${candidate_dir##*/}"
@@ -405,8 +414,8 @@ for candidate_dir in "${hosted_artifact_dirs[@]}"; do
     continue
   fi
   if [[ "$lsof_available" != true ]]; then
-    echo "Keeping artifact because lsof is unavailable: $candidate_dir" >&2
-    continue
+    echo "error: cannot prove artifact is inactive because lsof is unavailable" >&2
+    exit 2
   fi
   if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
     echo "Keeping active hosted artifact: $candidate_binary" >&2

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -476,11 +476,12 @@ if ((${#cleanup_dirs[@]} > 0)); then
     [[ -f "$candidate_binary" ]] && lsof_candidates+=("$candidate_binary")
   done
   if ((${#lsof_candidates[@]} > 0)); then
+    lsof_stderr_file="$temp_dir/lsof.stderr"
     set +e
-    active_artifact_paths="$(lsof -Fn -- "${lsof_candidates[@]}" 2>/dev/null)"
+    active_artifact_paths="$(lsof -Fn -- "${lsof_candidates[@]}" 2>"$lsof_stderr_file")"
     lsof_status=$?
     set -e
-    if (( lsof_status > 1 )); then
+    if (( lsof_status != 0 )) && [[ -s "$lsof_stderr_file" ]]; then
       echo "error: cannot determine whether hosted artifacts are active" >&2
       exit 2
     fi

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -484,6 +484,7 @@ if ((${#cleanup_dirs[@]} > 0)); then
       echo "error: cannot determine whether hosted artifacts are active" >&2
       exit 2
     fi
+    active_artifact_paths="$(printf '%s\n' "$active_artifact_paths" | sed -n 's/^n//p')"
   fi
 fi
 

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -366,6 +366,15 @@ else
   echo "error: CMUX_TUI_HOSTED_RETENTION_DRY_RUN must be 0 or 1" >&2
   exit 2
 fi
+retention_confirmed="${CMUX_TUI_HOSTED_RETENTION_CONFIRM:-0}"
+if [[ "$retention_dry_run" == false && "$retention_confirmed" != "1" ]]; then
+  echo "error: destructive retention requires CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 after a dry run" >&2
+  exit 2
+fi
+lsof_available=false
+if command -v lsof >/dev/null 2>&1; then
+  lsof_available=true
+fi
 
 hosted_artifact_dirs=()
 hosted_artifact_order=()
@@ -388,14 +397,18 @@ retained=0
 for candidate_dir in "${hosted_artifact_dirs[@]}"; do
   candidate_commit="${candidate_dir##*/}"
   candidate_binary="$candidate_dir/cmux-tui"
-  if [[ "$candidate_commit" == "$commit" || ! -f "$candidate_binary" ]]; then
+  if [[ "$candidate_commit" == "$commit" ]]; then
     continue
   fi
   if (( retained < retention_count )); then
     retained=$((retained + 1))
     continue
   fi
-  if command -v lsof >/dev/null 2>&1 && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
+  if [[ "$lsof_available" != true ]]; then
+    echo "Keeping artifact because lsof is unavailable: $candidate_dir" >&2
+    continue
+  fi
+  if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
     echo "Keeping active hosted artifact: $candidate_binary" >&2
     continue
   fi

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -372,6 +372,7 @@ if [[ "$retention_dry_run" == false && "$retention_confirmed" != "1" ]]; then
   exit 2
 fi
 preview_file="cmux-tui/target/hosted/.retention-preview"
+hosted_artifact_root="$(cd "cmux-tui/target/hosted" && pwd -P)"
 lsof_available=false
 if command -v lsof >/dev/null 2>&1; then
   lsof_available=true
@@ -394,18 +395,72 @@ while IFS= read -r -d '' candidate_dir; do
     exit 2
   fi
   hosted_artifact_order+=("$candidate_mtime	$candidate_commit	$candidate_dir")
-done < <(find cmux-tui/target/hosted -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
+done < <(find "$hosted_artifact_root" -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
 if ((${#hosted_artifact_order[@]} > 0)); then
   while IFS=$'\t' read -r _ candidate_commit candidate_dir; do
     hosted_artifact_dirs+=("$candidate_dir")
   done < <(printf '%s\n' "${hosted_artifact_order[@]}" | sort -t $'\t' -k1,1nr -k2,2r)
 fi
+retained=0
+cleanup_dirs=()
+for candidate_dir in "${hosted_artifact_dirs[@]}"; do
+  candidate_commit="${candidate_dir##*/}"
+  candidate_binary="$candidate_dir/cmux-tui"
+  if [[ "$candidate_commit" == "$commit" ]]; then
+    continue
+  fi
+  if (( retained < retention_count )); then
+    retained=$((retained + 1))
+    continue
+  fi
+  cleanup_dirs+=("$candidate_dir")
+done
+
+active_artifact_paths=""
+if ((${#cleanup_dirs[@]} > 0)); then
+  if [[ "$lsof_available" != true ]]; then
+    echo "error: cannot prove artifact is inactive because lsof is unavailable" >&2
+    exit 2
+  fi
+  lsof_candidates=()
+  for candidate_dir in "${cleanup_dirs[@]}"; do
+    candidate_binary="$candidate_dir/cmux-tui"
+    [[ -f "$candidate_binary" ]] && lsof_candidates+=("$candidate_binary")
+  done
+  if ((${#lsof_candidates[@]} > 0)); then
+    lsof_stderr_file="$temp_dir/lsof.stderr"
+    set +e
+    active_artifact_paths="$(lsof -Fn -- "${lsof_candidates[@]}" 2>"$lsof_stderr_file")"
+    lsof_status=$?
+    set -e
+    if (( lsof_status != 0 )) && [[ -s "$lsof_stderr_file" ]]; then
+      echo "error: cannot determine whether hosted artifacts are active" >&2
+      exit 2
+    fi
+    active_artifact_paths="$(printf '%s\n' "$active_artifact_paths" | sed -n 's/^n//p')"
+  fi
+fi
+
+deletion_dirs=()
+for candidate_dir in "${cleanup_dirs[@]}"; do
+  candidate_binary="$candidate_dir/cmux-tui"
+  if [[ -f "$candidate_binary" ]] &&
+    printf '%s\n' "$active_artifact_paths" | grep -F -x -q -- "$candidate_binary"; then
+    echo "Keeping active hosted artifact: $candidate_binary" >&2
+    continue
+  fi
+  deletion_dirs+=("$candidate_dir")
+done
+
 retention_plan_file="$temp_dir/retention-plan"
 {
   printf 'commit\t%s\n' "$commit"
   printf 'retention_count\t%s\n' "$retention_count"
   for candidate_dir in "${hosted_artifact_dirs[@]}"; do
     printf 'candidate\t%s\n' "$candidate_dir"
+  done
+  for candidate_dir in "${deletion_dirs[@]}"; do
+    printf 'delete\t%s\n' "$candidate_dir"
   done
 } > "$retention_plan_file"
 if [[ "$retention_dry_run" == true ]]; then
@@ -449,53 +504,8 @@ else
   fi
 fi
 
-retained=0
-cleanup_dirs=()
-for candidate_dir in "${hosted_artifact_dirs[@]}"; do
-  candidate_commit="${candidate_dir##*/}"
+for candidate_dir in "${deletion_dirs[@]}"; do
   candidate_binary="$candidate_dir/cmux-tui"
-  if [[ "$candidate_commit" == "$commit" ]]; then
-    continue
-  fi
-  if (( retained < retention_count )); then
-    retained=$((retained + 1))
-    continue
-  fi
-  cleanup_dirs+=("$candidate_dir")
-done
-
-active_artifact_paths=""
-if ((${#cleanup_dirs[@]} > 0)); then
-  if [[ "$lsof_available" != true ]]; then
-    echo "error: cannot prove artifact is inactive because lsof is unavailable" >&2
-    exit 2
-  fi
-  lsof_candidates=()
-  for candidate_dir in "${cleanup_dirs[@]}"; do
-    candidate_binary="$candidate_dir/cmux-tui"
-    [[ -f "$candidate_binary" ]] && lsof_candidates+=("$candidate_binary")
-  done
-  if ((${#lsof_candidates[@]} > 0)); then
-    lsof_stderr_file="$temp_dir/lsof.stderr"
-    set +e
-    active_artifact_paths="$(lsof -Fn -- "${lsof_candidates[@]}" 2>"$lsof_stderr_file")"
-    lsof_status=$?
-    set -e
-    if (( lsof_status != 0 )) && [[ -s "$lsof_stderr_file" ]]; then
-      echo "error: cannot determine whether hosted artifacts are active" >&2
-      exit 2
-    fi
-    active_artifact_paths="$(printf '%s\n' "$active_artifact_paths" | sed -n 's/^n//p')"
-  fi
-fi
-
-for candidate_dir in "${cleanup_dirs[@]}"; do
-  candidate_binary="$candidate_dir/cmux-tui"
-  if [[ -f "$candidate_binary" ]] &&
-    printf '%s\n' "$active_artifact_paths" | grep -F -x -q -- "$candidate_binary"; then
-    echo "Keeping active hosted artifact: $candidate_binary" >&2
-    continue
-  fi
   if [[ "$retention_dry_run" == true ]]; then
     echo "Would remove hosted artifact: $candidate_dir" >&2
   else

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -346,7 +346,14 @@ install -m 0755 "$downloaded_binary" "$artifact_binary"
 # not lose artifacts unexpectedly. Only directories owned by this user and
 # named for a complete commit SHA are eligible. The current commit and any
 # binary still open by a process are always retained.
-retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-5}"
+retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-}"
+if [[ -z "$retention_count" ]]; then
+  echo "Hosted artifact retention disabled (set CMUX_TUI_HOSTED_RETENTION_COUNT to enable)" >&2
+  echo "Hosted verification passed: $run_url"
+  echo "Artifact: $artifact_binary"
+  echo "Dogfood: $artifact_binary --session verify-${commit:0:8}"
+  exit 0
+fi
 if [[ ! "$retention_count" =~ ^[1-9][0-9]*$ ]]; then
   echo "error: CMUX_TUI_HOSTED_RETENTION_COUNT must be a positive integer" >&2
   exit 2

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -361,14 +361,21 @@ else
 fi
 
 hosted_artifact_dirs=()
+hosted_artifact_order=()
 while IFS= read -r -d '' candidate_dir; do
   candidate_commit="${candidate_dir##*/}"
   [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
-  hosted_artifact_dirs+=("$candidate_dir")
+  if stat -f '%m' "$candidate_dir" >/dev/null 2>&1; then
+    candidate_mtime="$(stat -f '%m' "$candidate_dir")"
+  else
+    candidate_mtime="$(stat -c '%Y' "$candidate_dir")"
+  fi
+  hosted_artifact_order+=("$candidate_mtime	$candidate_commit	$candidate_dir")
 done < <(find cmux-tui/target/hosted -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
-if ((${#hosted_artifact_dirs[@]} > 1)); then
-  IFS=$'\n' hosted_artifact_dirs=($(printf '%s\n' "${hosted_artifact_dirs[@]}" | sort -r))
-  unset IFS
+if ((${#hosted_artifact_order[@]} > 0)); then
+  while IFS=$'\t' read -r _ candidate_commit candidate_dir; do
+    hosted_artifact_dirs+=("$candidate_dir")
+  done < <(printf '%s\n' "${hosted_artifact_order[@]}" | sort -t $'\t' -k1,1nr -k2,2r)
 fi
 retained=0
 for candidate_dir in "${hosted_artifact_dirs[@]}"; do


### PR DESCRIPTION
Adds opt-in bounded retention for downloaded per-commit cmux-tui binaries.

- Retains current and active artifacts.
- Restricts candidates to user-owned full-SHA directories.
- Supports dry-run via CMUX_TUI_HOSTED_RETENTION_DRY_RUN=1.
- Orders candidates by newest modification time with SHA tie-break.

Validation: bash -n, git diff --check.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in bounded retention for downloaded per-commit `cmux-tui` binaries. Previously the hosted cache never cleaned itself; enabled cleanup now removes older artifacts while retaining the current commit and any binary still open by a process.

**Configuration**

- Set `CMUX_TUI_HOSTED_RETENTION_COUNT` to a positive integer up to 100000 to enable cleanup and choose how many other artifacts to retain.
- Set `CMUX_TUI_HOSTED_RETENTION_DRY_RUN=1` to write a preview of the cleanup plan; destructive runs also require `CMUX_TUI_HOSTED_RETENTION_CONFIRM=1` and a preview matching the current plan that is less than 10 minutes old.
- Cleanup considers only user-owned full-SHA directories, orders them by modification time with the SHA as a tie-breaker, skips binaries still open according to `lsof` (checked in bounded batches), and fails closed when `lsof` is unavailable or errors.
- Each plan entry records the artifact's inode and mtime; cleanup re-runs `lsof` and re-verifies identities before removal, failing if anything changed.
- Adds shell coverage for preview validation, retention count bounds, active artifact detection, and portable stat fallback.

<sup>Written for commit 2fce5d9e81ba02c83849141b6c91bbf29b208646. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added opt-in retention management for hosted macOS arm64 artifacts.
  - Users can configure the number of commit-specific artifacts to retain.
  - Added dry-run previews for planned cleanup actions.
  - Cleanup preserves the current commit and artifacts currently in use.

- **Bug Fixes**
  - Added safeguards for invalid settings, stale previews, and changed cleanup plans.
  - Cleanup verifies artifact activity and identity before removal.

- **Tests**
  - Added coverage for preview validation, active-artifact detection, identity changes, and cleanup failure handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->