### PR TITLE
Remove unused relay lane marker

### DIFF
--- a/cmux-tui/crates/cmux-remote-protocol/src/relay.rs
+++ b/cmux-tui/crates/cmux-remote-protocol/src/relay.rs
@@ -233,9 +233,6 @@ impl RelaySocketAttachment {
     }
 }
 
-#[allow(dead_code)]
-fn _lane_remains_endpoint_only(_: Lane) {}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/cmux-tui/crates/cmux-remote-protocol/src/relay.rs
+++ b/cmux-tui/crates/cmux-remote-protocol/src/relay.rs
@@ -2,8 +2,6 @@ use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-use crate::Lane;
-
 /// Maximum carrier message accepted by relay implementations that batch
 /// several encrypted remote frames into one WebSocket message.
 pub const MAX_RELAY_BATCH_BYTES: usize = 1024 * 1024;


### PR DESCRIPTION
Delete the private no-op `_lane_remains_endpoint_only` function and its dead-code suppression. Repository-wide search found no call sites or test references. `rustfmt --check` and `git diff --check` pass; no Cargo or Xcode commands run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `_lane_remains_endpoint_only` function and the `Lane` import it required from the relay protocol. No runtime behavior changes.

<sup>Written for commit 841be4562100d4ac4de09fee1a3024da6242d4c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused internal code without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->