### PR TITLE
fix(web): retire provider rows as destroyed in the Blaxel and E2B/Daytona migrations

### DIFF
--- a/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
+++ b/web/db/migrations/20260901120000_remove_blaxel_vm_provider/migration.sql
@@ -7,11 +7,35 @@
 -- old type, so a missed column aborts the whole transaction instead of silently
 -- leaving a split schema.
 --
--- Any row still naming a Blaxel machine is rewritten to 'e2b' first. Those
--- machines are unreachable regardless (the driver is gone); this keeps history
--- rows readable rather than dropping them. Run the reaper to destroy live
--- Blaxel machines BEFORE applying this migration — afterwards nothing in the
--- control plane can address them.
+-- 'blaxel' is compared as text on purpose: on a fresh database the label was
+-- added by an earlier migration in the same transaction, and Postgres rejects
+-- an enum literal for a label that is not yet committed ("unsafe use of new
+-- value"). The text comparison reads the same rows without that lookup.
+--
+-- Blaxel machines are unreachable regardless: the driver is gone, so nothing
+-- in the control plane can address them. Every Blaxel machine that is not
+-- already destroyed is marked destroyed here, the same way markDestroyed does
+-- it at runtime, with failure_code 'provider_retired' so the row says why.
+-- Reads already hide destroyed rows, and a base whose active machine is
+-- destroyed opens a fresh generation on the default provider, so those bases
+-- heal on their next open. The sandboxes themselves must be deleted in the
+-- Blaxel console; this migration only records that they are gone.
+--
+-- The rows are then rewritten to 'e2b' so the enum can be rebuilt without
+-- dropping history (usage events, base generations). They are all destroyed
+-- by then, so no read path will ever hand one to the e2b driver.
+
+UPDATE "cloud_vms"
+SET
+  "status" = 'destroyed',
+  "destroyed_at" = COALESCE("destroyed_at", now()),
+  "updated_at" = now(),
+  "failure_code" = COALESCE("failure_code", 'provider_retired'),
+  "failure_message" = COALESCE(
+    "failure_message",
+    'Blaxel was retired as a Cloud VM provider; this machine can no longer be reached.'
+  )
+WHERE "provider"::text = 'blaxel' AND "status" <> 'destroyed';
 
 UPDATE "cloud_vms" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';
 UPDATE "cloud_vm_usage_events" SET "provider" = 'e2b' WHERE "provider"::text = 'blaxel';

--- a/web/db/migrations/20260902060000_remove_e2b_daytona_vm_providers/migration.sql
+++ b/web/db/migrations/20260902060000_remove_e2b_daytona_vm_providers/migration.sql
@@ -8,17 +8,48 @@
 -- old type, so a missed column aborts the whole transaction instead of silently
 -- leaving a split schema.
 --
--- Rows still naming a removed provider are rewritten to 'freestyle'
--- first. Those machines are unreachable regardless (both drivers are gone);
--- this keeps history and usage rows readable rather than dropping them, at the
--- cost of mislabelling their provider. Destroy any live machines on the
--- removed providers BEFORE applying this migration — afterwards nothing in the control plane can
--- address them.
+-- 'e2b' and 'daytona' are compared as text on purpose, the same way the Blaxel
+-- migration does it: on a fresh database every migration runs in one
+-- transaction, and Postgres rejects an enum literal for a label that was added
+-- by an earlier ALTER TYPE ... ADD VALUE in that transaction ("unsafe use of
+-- new value"). 'daytona' is such a label. Today the Blaxel migration re-creates
+-- the type just before this file runs, which is the only reason the literal
+-- would resolve; the text comparison keeps this file correct on its own.
+--
+-- E2B and Daytona machines are unreachable regardless: both drivers are gone,
+-- so nothing in the control plane can address them. Every machine on either
+-- provider that is not already destroyed is marked destroyed here, the same
+-- way markDestroyed does it at runtime, with failure_code 'provider_retired'
+-- so the row says why. Reads already hide destroyed rows, and a base whose
+-- active machine is destroyed opens a fresh generation on the default
+-- provider, so those bases heal on their next open. The sandboxes themselves
+-- must be deleted in the E2B and Daytona consoles; this migration only records
+-- that they are gone.
+--
+-- The rows are then rewritten to 'freestyle' so the enum can be rebuilt
+-- without dropping history (usage events, base generations). They are all
+-- destroyed by then, so no read path will ever hand one to the Freestyle
+-- driver.
 
-UPDATE "cloud_vms" SET "provider" = 'freestyle' WHERE "provider" IN ('e2b', 'daytona');
-UPDATE "cloud_vm_usage_events" SET "provider" = 'freestyle' WHERE "provider" IN ('e2b', 'daytona');
-UPDATE "cloud_vm_bases" SET "active_provider" = 'freestyle' WHERE "active_provider" IN ('e2b', 'daytona');
-UPDATE "cloud_vm_base_generations" SET "provider" = 'freestyle' WHERE "provider" IN ('e2b', 'daytona');
+UPDATE "cloud_vms"
+SET
+  "status" = 'destroyed',
+  "destroyed_at" = COALESCE("destroyed_at", now()),
+  "updated_at" = now(),
+  "failure_code" = COALESCE("failure_code", 'provider_retired'),
+  "failure_message" = COALESCE(
+    "failure_message",
+    CASE "provider"::text
+      WHEN 'e2b' THEN 'E2B was retired as a Cloud VM provider; this machine can no longer be reached.'
+      ELSE 'Daytona was retired as a Cloud VM provider; this machine can no longer be reached.'
+    END
+  )
+WHERE "provider"::text IN ('e2b', 'daytona') AND "status" <> 'destroyed';
+
+UPDATE "cloud_vms" SET "provider" = 'freestyle' WHERE "provider"::text IN ('e2b', 'daytona');
+UPDATE "cloud_vm_usage_events" SET "provider" = 'freestyle' WHERE "provider"::text IN ('e2b', 'daytona');
+UPDATE "cloud_vm_bases" SET "active_provider" = 'freestyle' WHERE "active_provider"::text IN ('e2b', 'daytona');
+UPDATE "cloud_vm_base_generations" SET "provider" = 'freestyle' WHERE "provider"::text IN ('e2b', 'daytona');
 
 ALTER TYPE "vm_provider" RENAME TO "vm_provider_old";
 CREATE TYPE "vm_provider" AS ENUM ('freestyle');


### PR DESCRIPTION
Two unapplied Cloud VM migrations relabel rows on a retired provider without touching `status`. `20260901120000_remove_blaxel_vm_provider` turned a running Blaxel machine into a running e2b machine; `20260902060000_remove_e2b_daytona_vm_providers` (https://github.com/manaflow-ai/cmux/pull/11590) turns a running e2b or Daytona machine into a running Freestyle machine that the Freestyle driver cannot find. Both files now mark every non-destroyed row on a retired provider destroyed first (status, destroyed_at, updated_at, failure_code `provider_retired`, a provider-specific failure_message), the way `markDestroyed` does at runtime, and only then relabel for the enum rebuild. Reads already hide destroyed rows, and a base whose active machine is destroyed opens a fresh generation on the default provider.

The Blaxel file is commit f75673ff431791407b534c7af630851ca17a327c re-applied verbatim; it was reverted from https://github.com/manaflow-ai/cmux/pull/11587 so the read-path fix could ship during the incident. Its dry run against production inside a rolled-back transaction retired 8 rows and relabeled 17. The E2B/Daytona file mirrors its structure.

Provider comparisons are cast to `::text` in both files. On a fresh database every migration runs in one transaction and Postgres rejects an enum literal for a label added by an earlier `ALTER TYPE ... ADD VALUE` ("unsafe use of new value"). `daytona` is such a label; today it resolves only because the Blaxel rebuild re-creates the type immediately before. `20260902090000_cloud_vm_private_networks` sorts after both and creates its tables against the rebuilt type, so ordering is unaffected.

This PR assumes both migrations are still unapplied in staging and production, as f75673ff's message states. No read-only staging status command is documented in the cloud-vm-ops skill, so I could not confirm it. drizzle's migrator skips any migration whose folder name is already present in `drizzle.__drizzle_migrations`, so editing an applied migration is silently ignored. The operator must check that table before applying.

Operator steps, in order: `select name from drizzle.__drizzle_migrations where name like '2026090%'` on staging and production and confirm neither `20260901120000_remove_blaxel_vm_provider` nor `20260902060000_remove_e2b_daytona_vm_providers` is listed; delete the live Blaxel, E2B, and Daytona sandboxes in their provider consoles (the migration only records that they are gone); `bun run cloud-vm:migrate -- staging`, verify, then `bun run cloud-vm:migrate -- production`.

Verification: `bun run db:check` passes. `bun run cloud-vm:preflight -- .` applied the full migration set twice to a fresh Docker Postgres (both migrations included) and `db-schema.test.ts` passed. The behavior-test phase then had 83 failures across 7 files, every one a 5000ms per-test timeout under a local load average of 30 (other agents' builds); none touches these migrations. A rerun of those 7 files against a fresh test database with a 120s per-test timeout passed every test (12, 26, 35, 24, 1, 1, 80). After that fresh run `drizzle.__drizzle_migrations` listed both migrations and `enum_range(null::vm_provider)` was `{freestyle}`. `bun run typecheck` exits 0. `bun test tests/vm-retired-provider-rows.test.ts` passes.

Local `$autoreview` (gpt-5.6-sol, high) returned one P1 claiming the Blaxel file does not rewrite `cloud_vm_bases.active_provider` or `cloud_vm_base_generations.provider`. It does (lines 42-43); those lines are unchanged against main, so they are outside the diff hunk the reviewer read, and the `DROP TYPE` interlock passing on the fresh database proves no column still referenced the old type. No code change was made for it.

Supersedes https://github.com/manaflow-ai/cmux/pull/11582, which only added the text cast to the Blaxel file (main already carries that cast).

https://claude.ai/code/session_01AvkeWizggvvUAngHyB7JUQ
