### PR TITLE
feat(cloud): ask detach or kill when closing a cloud terminal pane

### DIFF
--- a/CLI/CMUXCLI+VMTransfer.swift
+++ b/CLI/CMUXCLI+VMTransfer.swift
@@ -1369,7 +1369,7 @@ extension CMUXCLI {
             return
         }
         print(String(
-            format: String(localized: "cli.vm.agent.started", defaultValue: "Started %1$@ on %2$@ \u{2014} terminal %3$@ in workspace %4$@ (detached: it keeps running if the pane closes)."),
+            format: String(localized: "cli.vm.agent.started", defaultValue: "Started %1$@ on %2$@ \u{2014} terminal %3$@ in workspace %4$@ (detached: it keeps running when the pane detaches)."),
             agent, selection.id, terminalId, workspaceId
         ))
         print(String(

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
@@ -137,6 +137,12 @@ public struct AppCatalogSection: SettingCatalogSection {
         userDefaultsKey: "warnBeforeQuitShortcut"
     )
 
+    public let closeCloudTerminal = DefaultsKey<CloudTerminalCloseAction>(
+        id: "app.closeCloudTerminal",
+        defaultValue: .ask,
+        userDefaultsKey: "closeCloudTerminalAction"
+    )
+
     public let warnBeforeClosingTab = DefaultsKey<Bool>(
         id: "app.warnBeforeClosingTab",
         defaultValue: true,

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/CloudTerminalCloseStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/CloudTerminalCloseStore.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// Repository for the cloud terminal close action, persisted in `UserDefaults`
+/// under the catalog's `app.closeCloudTerminal` key.
+///
+/// Isolation: a stateless `Sendable` struct, not an actor — the close gate
+/// reads synchronously on the main thread, the struct holds no mutable state,
+/// and `UserDefaults` is documented thread-safe.
+public struct CloudTerminalCloseStore: Sendable {
+    // UserDefaults is documented thread-safe and the reference is immutable.
+    private nonisolated(unsafe) let defaults: UserDefaults
+    private let keys = AppCatalogSection()
+
+    /// Creates a store reading and writing the given defaults suite.
+    public init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    /// The effective close action; an unrecognized stored value reads as the default (`ask`).
+    public var action: CloudTerminalCloseAction {
+        keys.closeCloudTerminal.value(in: defaults)
+    }
+
+    /// Persists `action` (the prompt's "Remember my choice", or the Settings picker).
+    public func setAction(_ action: CloudTerminalCloseAction) {
+        keys.closeCloudTerminal.set(action, in: defaults)
+    }
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/CloudTerminalCloseAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/CloudTerminalCloseAction.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// What closing a pane that shows a cloud terminal does to the terminal on its
+/// machine (`app.closeCloudTerminal`). The pane always goes away; the terminal
+/// either keeps running (detach) or its process ends (kill).
+public enum CloudTerminalCloseAction: String, CaseIterable, Sendable, SettingCodable {
+    /// Ask on every close: Detach, Kill Process, or Cancel.
+    case ask
+    /// Close the pane and leave the terminal running on the machine.
+    case detach
+    /// End the terminal's process on the machine, then close the pane.
+    case kill
+}

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
@@ -150,6 +150,28 @@ struct AgentIntegrationSettingsStoreTests {
     }
 }
 
+@Suite("CloudTerminalCloseStore")
+struct CloudTerminalCloseStoreTests {
+    @Test func neverSetDefaultsToAsk() {
+        let store = CloudTerminalCloseStore(defaults: makeScratchDefaults())
+        #expect(store.action == .ask)
+    }
+
+    @Test func storedActionRoundTrips() {
+        let defaults = makeScratchDefaults()
+        let store = CloudTerminalCloseStore(defaults: defaults)
+        store.setAction(.kill)
+        #expect(defaults.string(forKey: "closeCloudTerminalAction") == "kill")
+        #expect(CloudTerminalCloseStore(defaults: defaults).action == .kill)
+    }
+
+    @Test func unrecognizedStoredValueReadsAsAsk() {
+        let defaults = makeScratchDefaults()
+        defaults.set("explode", forKey: "closeCloudTerminalAction")
+        #expect(CloudTerminalCloseStore(defaults: defaults).action == .ask)
+    }
+}
+
 @Suite("QuitConfirmationStore")
 struct QuitConfirmationStoreTests {
     @Test func neverSetDefaultsToAlways() {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -56,6 +56,7 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .app, id: "telemetry", title: "Send anonymous telemetry", synonyms: "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy"),
             .init(section: .app, id: "warn-before-quit", title: "Warn Before Quit", synonyms: "app.confirmQuit quit confirmation command-q cmd-q exit close app"),
             .init(section: .app, id: "warn-before-closing-tab", title: "Warn Before Closing Tab", synonyms: "app.warnBeforeClosingTab close tab confirmation command-w cmd-w terminal surface"),
+            .init(section: .app, id: "close-cloud-terminal", title: "Closing a Cloud Terminal", synonyms: "app.closeCloudTerminal cloud terminal close detach kill process pty command-w cmd-w remote machine"),
             .init(section: .app, id: "warn-before-closing-tab-x-button", title: "Warn Before Tab Close Button", synonyms: "app.warnBeforeClosingTabXButton x button close tab confirmation terminal surface"),
             .init(section: .app, id: "hide-tab-close-button", title: "Hide Tab Close Button", synonyms: "app.hideTabCloseButton hide x button close tab terminal surface"),
             .init(section: .app, id: "rename-selects-name", title: "Rename Selects Existing Name", synonyms: "app.renameSelectsExistingName rename select all existing title command palette workspace name"),

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection+DisplayText.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection+DisplayText.swift
@@ -77,6 +77,14 @@ extension AppSection {
         }
     }
 
+    func closeCloudTerminalSubtitle(_ action: CloudTerminalCloseAction) -> String {
+        switch action {
+        case .ask: return String(localized: "settings.app.closeCloudTerminal.subtitleAsk", defaultValue: "Closing a cloud terminal pane asks whether to detach it or kill its process.")
+        case .detach: return String(localized: "settings.app.closeCloudTerminal.subtitleDetach", defaultValue: "Closing the pane keeps the terminal running on its machine. Kill it from the tab or pane menu.")
+        case .kill: return String(localized: "settings.app.closeCloudTerminal.subtitleKill", defaultValue: "Closing the pane ends the terminal's process on its machine. Detach it from the tab or pane menu.")
+        }
+    }
+
     func warnCloseXSubtitle(hideCloseButton: Bool, warnEnabled: Bool) -> String {
         // Mirrors legacy warnBeforeClosingTabXButtonSubtitle: hidden override
         // takes priority, then on/off wording.

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -62,6 +62,7 @@ public struct AppSection: View {
     @State private var telemetry: DefaultsValueModel<Bool>
     @State private var confirmQuit: DefaultsValueModel<ConfirmQuitMode>
     @State private var warnCloseTab: DefaultsValueModel<Bool>
+    @State private var closeCloudTerminal: DefaultsValueModel<CloudTerminalCloseAction>
     @State private var warnCloseX: DefaultsValueModel<Bool>
     @State private var hideCloseButton: DefaultsValueModel<Bool>
     @State private var renameSelects: DefaultsValueModel<Bool>
@@ -120,6 +121,7 @@ public struct AppSection: View {
         _telemetry = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.sendAnonymousTelemetry))
         _confirmQuit = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.confirmQuitMode))
         _warnCloseTab = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.warnBeforeClosingTab))
+        _closeCloudTerminal = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.closeCloudTerminal))
         _warnCloseX = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.warnBeforeClosingTabXButton))
         _hideCloseButton = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.hideTabCloseButton))
         _renameSelects = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.renameSelectsExistingName))
@@ -145,7 +147,7 @@ public struct AppSection: View {
             mainCard
         }
         .task {
-            startSettingsObservation([language, appearance, appIcon, placement, inheritDir, minimalMode, keepWorkspaceOpen, firstClick, focusHistoryIncludesPanesAndTabs, fileDrop, preferredEditor, openSupported, openMarkdown, globalFontMagnification, markdownFontSize, markdownFontFamily, markdownMaxWidth, canvasPaneGap, canvasSnapping, fileEditorWordWrap, iMessage, reorder, dockBadge, menuBarOnly, showInMenuBar, paneRing, paneFlash, desktopNotifications, agentPermissionPrompt, agentTurnComplete, agentIdleReminder, soundName, soundCommand, customSoundFile, soundOverrides, telemetry, confirmQuit, warnCloseTab, warnCloseX, hideCloseButton, renameSelects, paletteAllSurfaces])
+            startSettingsObservation([language, appearance, appIcon, placement, inheritDir, minimalMode, keepWorkspaceOpen, firstClick, focusHistoryIncludesPanesAndTabs, fileDrop, preferredEditor, openSupported, openMarkdown, globalFontMagnification, markdownFontSize, markdownFontFamily, markdownMaxWidth, canvasPaneGap, canvasSnapping, fileEditorWordWrap, iMessage, reorder, dockBadge, menuBarOnly, showInMenuBar, paneRing, paneFlash, desktopNotifications, agentPermissionPrompt, agentTurnComplete, agentIdleReminder, soundName, soundCommand, customSoundFile, soundOverrides, telemetry, confirmQuit, warnCloseTab, closeCloudTerminal, warnCloseX, hideCloseButton, renameSelects, paletteAllSurfaces])
             if soundAgents.isEmpty {
                 soundAgents = await hostActions.notificationSoundAgentOptions()
             }
@@ -764,6 +766,24 @@ public struct AppSection: View {
                 Toggle("", isOn: Binding(get: { warnCloseTab.current }, set: { warnCloseTab.set($0) }))
                     .labelsHidden()
                     .controlSize(.small)
+            }
+            SettingsCardDivider()
+
+            // Closing a Cloud Terminal
+            SettingsCardRow(
+                configurationReview: .json("app.closeCloudTerminal"),
+                String(localized: "settings.app.closeCloudTerminal", defaultValue: "Closing a Cloud Terminal"),
+                subtitle: closeCloudTerminalSubtitle(closeCloudTerminal.current),
+                controlWidth: Self.columnWidth
+            ) {
+                Picker("", selection: Binding(get: { closeCloudTerminal.current }, set: { closeCloudTerminal.set($0) })) {
+                    Text(String(localized: "settings.app.closeCloudTerminal.ask", defaultValue: "Ask")).tag(CloudTerminalCloseAction.ask)
+                    Text(String(localized: "settings.app.closeCloudTerminal.detach", defaultValue: "Detach")).tag(CloudTerminalCloseAction.detach)
+                    Text(String(localized: "settings.app.closeCloudTerminal.kill", defaultValue: "Kill")).tag(CloudTerminalCloseAction.kill)
+                }
+                .labelsHidden()
+                .pickerStyle(.segmented)
+                .controlSize(.small)
             }
             SettingsCardDivider()
 

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -36,6 +36,7 @@ struct SettingsRowAnchorResolutionTests {
     /// fails if a curated search result has no backing anchor, and
     /// ``rowAnchorsAreUniqueAcrossRows`` fails if two rows collide on one id.
     static let rowConfigPaths: [String] = [
+        "app.closeCloudTerminal",
         "app.commandPaletteSearchesAllSurfaces",
         "app.confirmQuit",
         "app.focusPaneOnFirstClick",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -60932,23 +60932,6 @@
         }
       }
     },
-    "cloudTree.menu.openInNewTab": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Open in New Tab"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "新しいタブで開く"
-          }
-        }
-      }
-    },
     "cloudTree.menu.refresh": {
       "extractionState": "manual",
       "localizations": {
@@ -273218,6 +273201,312 @@
           "stringUnit": {
             "state": "translated",
             "value": "作成"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.detachCloudTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detach Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルをデタッチ"
+          }
+        }
+      }
+    },
+    "terminalContextMenu.killCloudTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kill Process"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスを終了"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminal.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close cloud terminal “%@”?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナル“%@”を閉じますか？"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminal.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detach keeps it running on %@; reopen it from the Cloud sidebar. Kill Process ends it on the machine."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「デタッチ」は %@ 上で実行を続け、Cloud サイドバーから再び開けます。「プロセスを終了」はマシン上でプロセスを終了します。"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminals.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close %lld cloud terminals?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%lld 個のクラウドターミナルを閉じますか？"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminals.message": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detach keeps them running on %@; reopen them from the Cloud sidebar. Kill Process ends them on the machine."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「デタッチ」は %@ 上で実行を続け、Cloud サイドバーから再び開けます。「プロセスを終了」はマシン上でプロセスを終了します。"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminal.unnamed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminal.detach": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detach"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デタッチ"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminal.kill": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kill Process"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロセスを終了"
+          }
+        }
+      }
+    },
+    "dialog.closeCloudTerminal.remember": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remember my choice (change it in Settings › App)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択を記憶する（設定 › アプリで変更できます）"
+          }
+        }
+      }
+    },
+    "dialog.killCloudTerminal.failed.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn’t kill “%@”"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@”を終了できませんでした"
+          }
+        }
+      }
+    },
+    "settings.app.closeCloudTerminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closing a Cloud Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナルを閉じるとき"
+          }
+        }
+      }
+    },
+    "settings.app.closeCloudTerminal.ask": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ask"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認"
+          }
+        }
+      }
+    },
+    "settings.app.closeCloudTerminal.detach": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Detach"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デタッチ"
+          }
+        }
+      }
+    },
+    "settings.app.closeCloudTerminal.kill": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Kill"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "終了"
+          }
+        }
+      }
+    },
+    "settings.app.closeCloudTerminal.subtitleAsk": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closing a cloud terminal pane asks whether to detach it or kill its process."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドターミナルのペインを閉じるとき、デタッチするかプロセスを終了するかを確認します。"
+          }
+        }
+      }
+    },
+    "settings.app.closeCloudTerminal.subtitleDetach": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closing the pane keeps the terminal running on its machine. Kill it from the tab or pane menu."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインを閉じてもターミナルはマシン上で実行を続けます。終了はタブまたはペインのメニューから行えます。"
+          }
+        }
+      }
+    },
+    "settings.app.closeCloudTerminal.subtitleKill": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Closing the pane ends the terminal's process on its machine. Detach it from the tab or pane menu."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ペインを閉じるとマシン上のターミナルのプロセスを終了します。デタッチはタブまたはペインのメニューから行えます。"
           }
         }
       }

--- a/Sources/Cloud/CloudTreeOutlineView.swift
+++ b/Sources/Cloud/CloudTreeOutlineView.swift
@@ -56,6 +56,11 @@ struct CloudTreeOutlineView: NSViewRepresentable {
 
     @MainActor
     final class Coordinator: NSObject, NSOutlineViewDataSource, NSOutlineViewDelegate, NSMenuDelegate {
+        /// Where a row's open verb (one click, or "Open") lands its surface: a tab of the
+        /// selected workspace's current pane, so clicking through a machine's terminals
+        /// does not tile the workspace into splits. "Open in New Pane" is the split.
+        static let rowOpenPlacement: SurfacePlacement = .tab
+
         var machineActions: MachineRowActions
         var nodeActions: CloudTreeNodeActions
         let expansionStore: CloudTreeExpansionStore
@@ -415,14 +420,14 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                     if case .terminal(let row) = child.kind { return row.isOpen }
                     return false
                 }), case .terminal(let openRow) = shown.kind {
-                    nodeActions.project(openRow.resource.id, .split, true)
+                    nodeActions.project(openRow.resource.id, Self.rowOpenPlacement, true)
                 } else if let group = node.dragGroup, !group.isEmpty {
                     nodeActions.openGroupAsWorkspace(machine, group, workspace.id)
                 }
             case .localWorkspace(let row):
                 nodeActions.selectLocalWorkspace(row.workspaceID)
             case .terminal(let row):
-                nodeActions.project(row.resource.id, .split, true)
+                nodeActions.project(row.resource.id, Self.rowOpenPlacement, true)
             case .display(let resource, let openIn):
                 // A workspace's Desktop row opens INSIDE the local workspace showing
                 // that remote workspace — never a jump to a VNC pane in a different
@@ -430,12 +435,12 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                 if let openIn {
                     nodeActions.projectInLocalWorkspace(resource.id, openIn)
                 } else {
-                    nodeActions.project(resource.id, .split, true)
+                    nodeActions.project(resource.id, Self.rowOpenPlacement, true)
                 }
             case .port(let resource):
-                nodeActions.project(resource.id, .split, true)
+                nodeActions.project(resource.id, Self.rowOpenPlacement, true)
             case .browser(let row):
-                nodeActions.project(row.resource.id, .split, true)
+                nodeActions.project(row.resource.id, Self.rowOpenPlacement, true)
             case .placeholder(let machineID, let placeholder):
                 // "Asleep — open to wake": a fresh terminal on the machine is what wakes it.
                 if placeholder.style == .dimmed, let machine = machine(id: machineID) {
@@ -609,9 +614,9 @@ struct CloudTreeOutlineView: NSViewRepresentable {
             }
         }
 
-        /// The verbs every surface row shares: open (reusing an open pane), open as a
-        /// tab, a second pane (cloud resources only — a local terminal has one pane),
-        /// and copying the resource id agents use with `cmux vm open`.
+        /// The verbs every surface row shares: open (a tab of the current pane, reusing
+        /// an open pane), a second pane (cloud resources only — a local terminal has one
+        /// pane), and copying the resource id agents use with `cmux vm open`.
         private func resourceMenuItems(_ resource: SurfaceResource, isLocal: Bool, openInLocalWorkspace: UUID? = nil) -> [NSMenuItem] {
             var items: [NSMenuItem] = [
                 item(String(localized: "cloudTree.menu.open", defaultValue: "Open")) { [nodeActions] in
@@ -619,10 +624,9 @@ struct CloudTreeOutlineView: NSViewRepresentable {
                     if let openInLocalWorkspace {
                         nodeActions.projectInLocalWorkspace(resource.id, openInLocalWorkspace)
                     } else {
-                        nodeActions.project(resource.id, .split, true)
+                        nodeActions.project(resource.id, Self.rowOpenPlacement, true)
                     }
                 },
-                item(String(localized: "cloudTree.menu.openInNewTab", defaultValue: "Open in New Tab")) { [nodeActions] in nodeActions.project(resource.id, .tab, true) },
             ]
             if !isLocal {
                 items.append(item(String(localized: "cloudTree.menu.openInNewPane", defaultValue: "Open in New Pane")) { [nodeActions] in nodeActions.project(resource.id, .split, false) })

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -421,6 +421,7 @@ extension CmuxSettingsFileStore {
         "app.confirmQuit",
         "app.warnBeforeQuit",
         "app.warnBeforeClosingTab",
+        "app.closeCloudTerminal",
         "app.warnBeforeClosingTabXButton",
         "app.hideTabCloseButton",
         "app.renameSelectsExistingName",

--- a/Sources/DockSplitStore+TabContextActions.swift
+++ b/Sources/DockSplitStore+TabContextActions.swift
@@ -108,6 +108,8 @@ extension DockSplitStore {
         case .toggleFullWidthTab:
             _ = toggleDockFullWidthTab(panelId: panelId)
         case .disconnectRemote,
+             .detachCloudTerminal,
+             .killCloudTerminal,
              .forkConversation,
              .forkConversationRight,
              .forkConversationLeft,

--- a/Sources/GhosttyNSView+CloudTerminalContextMenu.swift
+++ b/Sources/GhosttyNSView+CloudTerminalContextMenu.swift
@@ -1,0 +1,44 @@
+import AppKit
+
+/// "Detach Terminal" / "Kill Process" on a pane that projects a cloud terminal:
+/// the same two verbs the tab context menu offers, on the same workspace path.
+extension GhosttyNSView {
+    func appendCloudTerminalContextMenuItems(to menu: NSMenu) {
+        guard let context = cloudTerminalPaneContext(),
+              context.workspace.cloudTerminalPane(forPanel: context.panelId) != nil else { return }
+        menu.addItem(.separator())
+        let detachItem = menu.addItem(
+            withTitle: String(localized: "terminalContextMenu.detachCloudTerminal", defaultValue: "Detach Terminal"),
+            action: #selector(detachCloudTerminalPane(_:)),
+            keyEquivalent: ""
+        )
+        detachItem.target = self
+        detachItem.image = NSImage(systemSymbolName: "rectangle.portrait.and.arrow.right", accessibilityDescription: nil)
+        let killItem = menu.addItem(
+            withTitle: String(localized: "terminalContextMenu.killCloudTerminal", defaultValue: "Kill Process"),
+            action: #selector(killCloudTerminalPane(_:)),
+            keyEquivalent: ""
+        )
+        killItem.target = self
+        killItem.image = NSImage(systemSymbolName: "xmark.octagon", accessibilityDescription: nil)
+    }
+
+    private func cloudTerminalPaneContext() -> (workspace: Workspace, panelId: UUID)? {
+        guard let tabId,
+              let panelId = terminalSurface?.id,
+              let app = AppDelegate.shared,
+              let manager = app.tabManagerFor(tabId: tabId) ?? app.tabManager,
+              let workspace = manager.tabs.first(where: { $0.id == tabId }) else { return nil }
+        return (workspace, panelId)
+    }
+
+    @objc private func detachCloudTerminalPane(_ sender: Any?) {
+        guard let context = cloudTerminalPaneContext() else { return }
+        context.workspace.detachCloudTerminal(panelId: context.panelId)
+    }
+
+    @objc private func killCloudTerminalPane(_ sender: Any?) {
+        guard let context = cloudTerminalPaneContext() else { return }
+        context.workspace.killCloudTerminal(panelId: context.panelId)
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8628,6 +8628,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             accessibilityDescription: nil
         )
         appendReconnectRemotePaneMenuItem(to: menu)
+        appendCloudTerminalContextMenuItems(to: menu)
         if terminalSurface != nil {
             menu.addItem(.separator())
             let identifiersItem = menu.addItem(

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -77,6 +77,7 @@ extension CmuxSettingsFileStore {
                     "sendAnonymousTelemetry": AppCatalogSection().sendAnonymousTelemetry.defaultValue,
                     "confirmQuit": AppCatalogSection().confirmQuitMode.defaultValue.rawValue,
                     "warnBeforeClosingTab": AppCatalogSection().warnBeforeClosingTab.defaultValue,
+                    "closeCloudTerminal": AppCatalogSection().closeCloudTerminal.defaultValue.rawValue,
                     "warnBeforeClosingTabXButton": AppCatalogSection().warnBeforeClosingTabXButton.defaultValue,
                     "hideTabCloseButton": AppCatalogSection().hideTabCloseButton.defaultValue,
                     "renameSelectsExistingName": AppCatalogSection().renameSelectsExistingName.defaultValue,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -507,6 +507,15 @@ final class CmuxSettingsFileStore {
         if let value = jsonBool(section["keepWorkspaceOpenWhenClosingLastSurface"]) {
             snapshot.managedUserDefaults[SettingCatalog().app.keepWorkspaceOpenWhenClosingLastSurface.userDefaultsKey] = .bool(!value)
         }
+        if let raw = jsonString(section["closeCloudTerminal"]) {
+            if let action = CloudTerminalCloseAction(rawValue: raw) {
+                snapshot.managedUserDefaults[AppCatalogSection().closeCloudTerminal.userDefaultsKey] = .string(action.rawValue)
+            } else {
+                logInvalid("app.closeCloudTerminal", sourcePath: sourcePath)
+            }
+        } else if section.keys.contains("closeCloudTerminal") {
+            logInvalid("app.closeCloudTerminal", sourcePath: sourcePath)
+        }
         var parsedConfirmQuitMode: ConfirmQuitMode?
         let confirmQuitKey = AppCatalogSection().confirmQuitMode.userDefaultsKey
         let warnBeforeQuitKey = AppCatalogSection().warnBeforeQuit.userDefaultsKey

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -386,6 +386,7 @@ enum SettingsSearchIndex {
         setting(.app, "default-terminal", String(localized: "settings.app.defaultTerminal", defaultValue: "Default Terminal"), "ssh links command tool unix executable launch services handler registration system default"),
         setting(.app, "warn-before-quit", String(localized: "settings.app.warnBeforeQuit", defaultValue: "Warn Before Quit"), "cmd q confirmation confirmQuit"),
         setting(.app, "warn-before-closing-tab", String(localized: "settings.app.warnBeforeClosingTab", defaultValue: "Warn Before Closing Tab"), "cmd w close tab confirmation"),
+        setting(.app, "close-cloud-terminal", String(localized: "settings.app.closeCloudTerminal", defaultValue: "Closing a Cloud Terminal"), "cmd w cloud terminal detach kill process pty remote machine closeCloudTerminal"),
         setting(
             .app,
             "warn-before-closing-tab-x-button",
@@ -555,6 +556,7 @@ enum SettingsSearchIndex {
         "app.confirmQuit": settingID(for: .app, idSuffix: "warn-before-quit"),
         "app.warnBeforeQuit": settingID(for: .app, idSuffix: "warn-before-quit"),
         "app.warnBeforeClosingTab": settingID(for: .app, idSuffix: "warn-before-closing-tab"),
+        "app.closeCloudTerminal": settingID(for: .app, idSuffix: "close-cloud-terminal"),
         "app.warnBeforeClosingTabXButton": settingID(for: .app, idSuffix: "warn-before-closing-tab-x-button"),
         "app.hideTabCloseButton": settingID(for: .app, idSuffix: "hide-tab-close-button"),
         "app.renameSelectsExistingName": settingID(for: .app, idSuffix: "rename-selects-name"),

--- a/Sources/Surfaces/CloudTerminalCloseAlertPresenter.swift
+++ b/Sources/Surfaces/CloudTerminalCloseAlertPresenter.swift
@@ -1,0 +1,69 @@
+import AppKit
+import CmuxSettings
+
+/// The Detach / Kill Process / Cancel prompt for closing a cloud terminal pane,
+/// with a "Remember my choice" box that writes `app.closeCloudTerminal`.
+@MainActor
+enum CloudTerminalCloseAlertPresenter {
+    struct Result: Equatable, Sendable {
+        let decision: CloudTerminalCloseDecision
+        let remember: Bool
+    }
+
+    /// Presents the prompt as a sheet on the main cmux window (app-modal when no
+    /// window can host a sheet) and returns what the person chose.
+    static func present(prompt: CloudTerminalClosePrompt, presentingWindow: NSWindow? = nil) -> Result {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = prompt.title
+        alert.informativeText = prompt.message
+        alert.addButton(withTitle: String(localized: "dialog.closeCloudTerminal.detach", defaultValue: "Detach"))
+        alert.addButton(withTitle: String(localized: "dialog.closeCloudTerminal.kill", defaultValue: "Kill Process"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+        if let detachButton = alert.buttons.first {
+            detachButton.keyEquivalent = "\r"
+            detachButton.keyEquivalentModifierMask = []
+            alert.window.defaultButtonCell = detachButton.cell as? NSButtonCell
+            alert.window.initialFirstResponder = detachButton
+        }
+        if alert.buttons.indices.contains(2) {
+            alert.buttons[2].keyEquivalent = "\u{1b}"
+        }
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = String(
+            localized: "dialog.closeCloudTerminal.remember",
+            defaultValue: "Remember my choice (change it in Settings \u{203A} App)"
+        )
+
+        let response = alert.runCmuxModal(
+            presentingWindow: presentingWindow,
+            content: CmuxAlertContent(informativeText: prompt.message)
+        )
+        let index: Int
+        switch response {
+        case .alertFirstButtonReturn: index = 0
+        case .alertSecondButtonReturn: index = 1
+        default: index = 2
+        }
+        return Result(
+            decision: CloudTerminalClosePolicy.decision(forButtonIndex: index),
+            remember: alert.suppressionButton?.state == .on
+        )
+    }
+
+    /// A kill that the machine refused (asleep, link down, terminal gone). The
+    /// pane stays open so the person knows the process is still running.
+    static func presentKillFailure(terminalName: String, error: Error, presentingWindow: NSWindow? = nil) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(
+            format: String(localized: "dialog.killCloudTerminal.failed.title", defaultValue: "Couldn\u{2019}t kill \u{201C}%@\u{201D}"),
+            locale: .current,
+            terminalName
+        )
+        let detail = CloudMachineLink.errorText(error)
+        alert.informativeText = detail.isEmpty ? String(describing: error) : detail
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        _ = alert.runCmuxModal(presentingWindow: presentingWindow)
+    }
+}

--- a/Sources/Surfaces/CloudTerminalClosePolicy.swift
+++ b/Sources/Surfaces/CloudTerminalClosePolicy.swift
@@ -1,0 +1,92 @@
+import CmuxSettings
+import Foundation
+
+/// What the person chose when closing a pane that shows a cloud terminal.
+enum CloudTerminalCloseDecision: Equatable, Sendable {
+    /// Close the pane; the terminal keeps running on its machine.
+    case detach
+    /// End the terminal's process on its machine, then close the pane.
+    case kill
+    /// Leave the pane open.
+    case cancel
+}
+
+/// Pure decision logic for closing a cloud terminal pane (Cmd+W, the tab close
+/// button, the pane close button). The pane is only a projection of a terminal
+/// that lives in the machine's cmux-tui session, so "close" has to say whether
+/// the terminal survives. `app.closeCloudTerminal` decides; `ask` prompts.
+enum CloudTerminalClosePolicy {
+    enum Resolution: Equatable, Sendable {
+        case detach
+        case kill
+        case prompt
+    }
+
+    static func resolution(for action: CloudTerminalCloseAction) -> Resolution {
+        switch action {
+        case .ask: return .prompt
+        case .detach: return .detach
+        case .kill: return .kill
+        }
+    }
+
+    /// The action "Remember my choice" persists. Cancelling never persists,
+    /// and an unchecked box changes nothing.
+    static func actionToRemember(decision: CloudTerminalCloseDecision, remember: Bool) -> CloudTerminalCloseAction? {
+        guard remember else { return nil }
+        switch decision {
+        case .detach: return .detach
+        case .kill: return .kill
+        case .cancel: return nil
+        }
+    }
+
+    /// Prompt buttons in `NSAlert` order: Detach (default), Kill Process, Cancel.
+    static func decision(forButtonIndex index: Int) -> CloudTerminalCloseDecision {
+        switch index {
+        case 0: return .detach
+        case 1: return .kill
+        default: return .cancel
+        }
+    }
+}
+
+/// Copy for the close prompt: one terminal names it, a pane close counts them.
+struct CloudTerminalClosePrompt: Equatable, Sendable {
+    let title: String
+    let message: String
+
+    init(terminalNames: [String], machineName: String) {
+        let names = terminalNames.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }.filter { !$0.isEmpty }
+        if names.count <= 1 {
+            let name = names.first ?? String(localized: "dialog.closeCloudTerminal.unnamed", defaultValue: "terminal")
+            title = String(
+                format: String(localized: "dialog.closeCloudTerminal.title", defaultValue: "Close cloud terminal \u{201C}%@\u{201D}?"),
+                locale: .current,
+                name
+            )
+            message = String(
+                format: String(
+                    localized: "dialog.closeCloudTerminal.message",
+                    defaultValue: "Detach keeps it running on %@; reopen it from the Cloud sidebar. Kill Process ends it on the machine."
+                ),
+                locale: .current,
+                machineName
+            )
+        } else {
+            title = String(
+                format: String(localized: "dialog.closeCloudTerminals.title", defaultValue: "Close %lld cloud terminals?"),
+                locale: .current,
+                Int64(names.count)
+            )
+            message = String(
+                format: String(
+                    localized: "dialog.closeCloudTerminals.message",
+                    defaultValue: "Detach keeps them running on %@; reopen them from the Cloud sidebar. Kill Process ends them on the machine."
+                ),
+                locale: .current,
+                machineName
+            )
+        }
+    }
+}

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -136,7 +136,9 @@ final class CmuxTuiSurfaceProviderRegistry {
 
 /// One cloud machine's resources: its cmux-tui terminals (over the headless link), its
 /// noVNC screen, and its forwarded ports. Terminals live in the machine's cmux-tui
-/// session, so a local pane closing never touches them (`projectionDidEnd` is a no-op).
+/// session, so a local pane closing never touches them (`projectionDidEnd` is a no-op);
+/// killing is `closeTerminal`, which the workspace's cloud close gate calls when the
+/// person picks Kill Process (`Workspace+CloudTerminalClose.swift`).
 @MainActor
 final class CmuxTuiSurfaceProvider: SurfaceProvider {
     enum ProviderError: Error, LocalizedError {
@@ -506,7 +508,8 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
         scheduleRefresh()
     }
 
-    /// The terminal lives in the machine's session; only the local pane went away.
+    /// The terminal lives in the machine's session; only the local pane went away
+    /// (a detach). A kill went through `closeTerminal` before the pane closed.
     func projectionDidEnd(_ projection: SurfaceProjection) {
         materializedPanels.remove(projection.panelID)
     }

--- a/Sources/Surfaces/SurfaceCatalog.swift
+++ b/Sources/Surfaces/SurfaceCatalog.swift
@@ -664,7 +664,8 @@ final class SurfaceCatalog {
         projections.insert(projection)
     }
 
-    /// A pane went away (closed, or its workspace closed). Remote resources live on.
+    /// A pane went away (closed, or its workspace closed). Remote resources live on;
+    /// a kill is a separate provider verb (`closeTerminal`) the close gate runs first.
     func endProjections(panelID: UUID) {
         let ended = projections.filter { $0.panelID == panelID }
         guard !ended.isEmpty else { return }

--- a/Sources/Surfaces/Workspace+CloudTerminalClose.swift
+++ b/Sources/Surfaces/Workspace+CloudTerminalClose.swift
@@ -1,0 +1,222 @@
+import AppKit
+import Bonsplit
+import CmuxSettings
+import Foundation
+
+/// Closing a pane that projects a cloud terminal is two different verbs: detach
+/// (the pane goes, the terminal keeps running in the machine's cmux-tui session)
+/// and kill (`terminal <id> close` ends the process, then the pane goes). Every
+/// entrypoint — Cmd+W, the tab close button, the pane close button, the tab
+/// context menu, the terminal context menu — lands on `detachCloudTerminal` or
+/// `killCloudTerminal`; `app.closeCloudTerminal` decides which one a plain close
+/// means, and `ask` prompts (with "Remember my choice" writing the setting).
+extension Workspace {
+    struct CloudTerminalPane: Equatable {
+        let tabId: TabID
+        let panelId: UUID
+        let resource: SurfaceResource
+    }
+
+    /// The cloud terminal a tab projects, when it does.
+    func cloudTerminalPane(forTab tabId: TabID) -> CloudTerminalPane? {
+        guard let panelId = panelIdFromSurfaceId(tabId),
+              let resource = cloudProjectedResource(forPanel: panelId),
+              resource.kind == .terminal else { return nil }
+        return CloudTerminalPane(tabId: tabId, panelId: panelId, resource: resource)
+    }
+
+    func cloudTerminalPane(forPanel panelId: UUID) -> CloudTerminalPane? {
+        guard let tabId = surfaceIdFromPanelId(panelId) else { return nil }
+        return cloudTerminalPane(forTab: tabId)
+    }
+
+    func configureCloudTerminalContextMenuAvailability() {
+        bonsplitController.tabContextCloudTerminalAvailabilityProvider = { [weak self] tabId, _ in
+            self?.cloudTerminalPane(forTab: tabId) != nil
+        }
+    }
+
+    // MARK: - Close gates
+
+    /// The tab close gate (Cmd+W, the tab close button, Close Tab in the menu).
+    /// Returns true when the close was taken over: the decision is made here
+    /// (or asked for) and the pane is closed again through the decided path,
+    /// so the caller must return `false` to bonsplit.
+    func interceptCloudTerminalTabClose(
+        tab: Bonsplit.Tab,
+        tabCloseButton: Bool?,
+        explicitUserClose: Bool
+    ) -> Bool {
+        if cloudTerminalCloseDecidedTabIds.remove(tab.id) != nil { return false }
+        guard let pane = cloudTerminalPane(forTab: tab.id) else { return false }
+        let reclose = CloudTerminalReclose(tabCloseButton: tabCloseButton, explicitUserClose: explicitUserClose)
+        switch CloudTerminalClosePolicy.resolution(for: CloudTerminalCloseStore(defaults: closeTabWarningDefaults).action) {
+        case .detach:
+            return false
+        case .kill:
+            killCloudTerminals([pane], reclose: reclose)
+            return true
+        case .prompt:
+            promptCloudTerminalClose(panes: [pane], reclose: reclose) { [weak self] decision in
+                guard let self else { return }
+                switch decision {
+                case .detach:
+                    _ = self.requestCloseCloudTerminalTab(pane.tabId, reclose: reclose)
+                case .kill:
+                    self.killCloudTerminals([pane], reclose: reclose)
+                case .cancel:
+                    self.clearCloseHistoryEligibility(tabId: pane.tabId, panelId: pane.panelId)
+                }
+            }
+            return true
+        }
+    }
+
+    /// The pane close gate: every cloud terminal in the pane gets the same
+    /// answer. Returns true when the close was taken over (caller returns `false`).
+    func interceptCloudTerminalPaneClose(pane: PaneID, tabs: [Bonsplit.Tab]) -> Bool {
+        let tabIds = tabs.map(\.id)
+        if cloudTerminalCloseDecidedPaneIds.remove(pane.id) != nil { return false }
+        let cloudPanes = tabs.compactMap { tab -> CloudTerminalPane? in
+            guard !isForceClosingTab(tab.id) else { return nil }
+            return cloudTerminalPane(forTab: tab.id)
+        }
+        guard !cloudPanes.isEmpty else { return false }
+        switch CloudTerminalClosePolicy.resolution(for: CloudTerminalCloseStore(defaults: closeTabWarningDefaults).action) {
+        case .detach:
+            return false
+        case .kill:
+            killCloudTerminals(cloudPanes, reclose: nil) { [weak self] in
+                self?.forceClosePaneAfterCloudTerminalDecision(pane, tabIds: tabIds)
+            }
+            return true
+        case .prompt:
+            promptCloudTerminalClose(panes: cloudPanes, reclose: nil) { [weak self] decision in
+                guard let self else { return }
+                switch decision {
+                case .detach:
+                    self.forceClosePaneAfterCloudTerminalDecision(pane, tabIds: tabIds)
+                case .kill:
+                    self.killCloudTerminals(cloudPanes, reclose: nil) { [weak self] in
+                        self?.forceClosePaneAfterCloudTerminalDecision(pane, tabIds: tabIds)
+                    }
+                case .cancel:
+                    break
+                }
+            }
+            return true
+        }
+    }
+
+    // MARK: - Verbs (menus)
+
+    /// "Detach Terminal": close the pane, keep the terminal running.
+    func detachCloudTerminal(panelId: UUID) {
+        guard let pane = cloudTerminalPane(forPanel: panelId) else { return }
+        _ = requestCloseCloudTerminalTab(pane.tabId, reclose: CloudTerminalReclose(tabCloseButton: nil, explicitUserClose: true))
+    }
+
+    /// "Kill Process": end the terminal on its machine, then close the pane.
+    func killCloudTerminal(panelId: UUID) {
+        guard let pane = cloudTerminalPane(forPanel: panelId) else { return }
+        killCloudTerminals([pane], reclose: CloudTerminalReclose(tabCloseButton: nil, explicitUserClose: true))
+    }
+
+    // MARK: - Internals
+
+    private func promptCloudTerminalClose(
+        panes: [CloudTerminalPane],
+        reclose: CloudTerminalReclose?,
+        completion: @escaping @MainActor (CloudTerminalCloseDecision) -> Void
+    ) {
+        let tabIds = panes.map(\.tabId)
+        guard cloudTerminalClosePromptTabIds.isDisjoint(with: tabIds) else { return }
+        let confirmationManager = owningTabManager
+            ?? AppDelegate.shared?.tabManagerFor(tabId: id)
+            ?? AppDelegate.shared?.tabManager
+        if let confirmationManager, !confirmationManager.beginCloseConfirmationSession() {
+            for pane in panes { clearCloseHistoryEligibility(tabId: pane.tabId, panelId: pane.panelId) }
+            return
+        }
+        cloudTerminalClosePromptTabIds.formUnion(tabIds)
+        let prompt = CloudTerminalClosePrompt(
+            terminalNames: panes.map { cloudTerminalDisplayName($0) },
+            machineName: cloudMachineDisplayName(panes[0].resource.id.machine)
+        )
+        let store = CloudTerminalCloseStore(defaults: closeTabWarningDefaults)
+        // Present on the next main-actor turn: bonsplit is still inside its close
+        // request, and a modal loop from within that callback re-enters it.
+        Task { @MainActor [weak self] in
+            defer {
+                self?.cloudTerminalClosePromptTabIds.subtract(tabIds)
+                confirmationManager?.endCloseConfirmationSession()
+            }
+            guard let self else { return }
+            // Anything that disappeared while the prompt was queued is not closed twice.
+            guard panes.allSatisfy({ self.panels[$0.panelId] != nil }) else { return }
+            let result = CloudTerminalCloseAlertPresenter.present(prompt: prompt)
+            if let remembered = CloudTerminalClosePolicy.actionToRemember(decision: result.decision, remember: result.remember) {
+                store.setAction(remembered)
+            }
+            completion(result.decision)
+        }
+    }
+
+    /// Ends each terminal on its machine, then closes the local panes. The
+    /// provider force-closes every pane projecting a killed terminal except a
+    /// workspace's last surface, which is closed through the normal path so the
+    /// last-surface preference (close workspace vs keep it open) still applies.
+    private func killCloudTerminals(
+        _ panes: [CloudTerminalPane],
+        reclose: CloudTerminalReclose?,
+        then followUp: (@MainActor () -> Void)? = nil
+    ) {
+        let catalog = SurfaceCatalog.shared
+        Task { @MainActor [weak self] in
+            for pane in panes {
+                guard let provider = catalog.provider(for: pane.resource.id.machine) else {
+                    CloudTerminalCloseAlertPresenter.presentKillFailure(
+                        terminalName: self?.cloudTerminalDisplayName(pane) ?? pane.resource.id.key,
+                        error: SurfaceCatalogError.noProvider(pane.resource.id.machine)
+                    )
+                    return
+                }
+                do {
+                    try await provider.closeTerminal(pane.resource.id)
+                } catch {
+                    CloudTerminalCloseAlertPresenter.presentKillFailure(
+                        terminalName: self?.cloudTerminalDisplayName(pane) ?? pane.resource.id.key,
+                        error: error
+                    )
+                    return
+                }
+                guard let self, self.panels[pane.panelId] != nil,
+                      let tabId = self.surfaceIdFromPanelId(pane.panelId) else { continue }
+                _ = self.requestCloseCloudTerminalTab(
+                    tabId,
+                    reclose: reclose ?? CloudTerminalReclose(tabCloseButton: nil, explicitUserClose: true)
+                )
+            }
+            followUp?()
+        }
+    }
+
+    private func cloudTerminalDisplayName(_ pane: CloudTerminalPane) -> String {
+        let panelTitle = panels[pane.panelId]?.displayTitle.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if !panelTitle.isEmpty { return panelTitle }
+        let title = pane.resource.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return title.isEmpty ? pane.resource.id.key : title
+    }
+
+    private func cloudMachineDisplayName(_ machine: SurfaceMachineID) -> String {
+        SurfaceCatalog.shared.provider(for: machine)?.info.name ?? machine.rawValue
+    }
+}
+
+/// How a close is re-requested after the decision, so the second pass through
+/// the close gate keeps the original gesture's meaning (tab close button vs
+/// shortcut, explicit user close vs programmatic).
+struct CloudTerminalReclose: Equatable, Sendable {
+    let tabCloseButton: Bool?
+    let explicitUserClose: Bool
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -920,7 +920,7 @@ extension Workspace {
         return eligibleByTab || eligibleByPanel
     }
 
-    private func clearCloseHistoryEligibility(tabId: TabID, panelId: UUID? = nil) {
+    func clearCloseHistoryEligibility(tabId: TabID, panelId: UUID? = nil) {
         closeHistoryEligibleTabIds.remove(tabId)
         let resolvedPanelId = panelId ?? panelIdFromSurfaceId(tabId)
         if let resolvedPanelId {
@@ -4033,6 +4033,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
             self?.bonsplitTabMoveDestinations(for: tabId) ?? []
         }
         configureForkAgentConversationContextMenuAvailability()
+        configureCloudTerminalContextMenuAvailability()
         bonsplitController.tabContextForkConversationDefaultActionProvider = { _, _ in
             AgentConversationForkDefaultSettings.current().tabContextAction
         }
@@ -4324,6 +4325,14 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
 
     /// User-initiated close attempts, distinct from internal close/move flows.
     private var explicitUserCloseTabIds: Set<TabID> = []
+    /// Cloud terminal tabs whose detach/kill decision is already made (a menu verb,
+    /// a prompt answer, or a finished kill), so the re-requested close skips the gate.
+    var cloudTerminalCloseDecidedTabIds: Set<TabID> = []
+    /// Panes whose cloud terminals were decided as a group (pane close), likewise.
+    var cloudTerminalCloseDecidedPaneIds: Set<UUID> = []
+    /// Cloud terminal tabs with the detach/kill prompt queued or showing, so a
+    /// repeated close gesture cannot stack prompts.
+    var cloudTerminalClosePromptTabIds: Set<TabID> = []
     private var closeHistoryEligibleTabIds: Set<TabID> = []
     private var closeHistoryEligiblePanelIds: Set<UUID> = []
     private var suppressClosedPanelHistory = false
@@ -6132,6 +6141,12 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
            let activity = AppDelegate.shared?.remoteTmuxController
                .cachedMirrorTabActivity(workspaceId: id, panelId: panelId) {
             return activity.hasActiveCommand
+        }
+        // A cloud terminal pane runs only the local attach client; closing it loses
+        // nothing (detach) and the kill decision is the cloud close gate's, so the
+        // generic "Close tab?" never applies.
+        if cloudProjectedResource(forPanel: panelId)?.kind == .terminal {
+            return false
         }
         if let terminalPanel = panel as? TerminalPanel {
             return panelNeedsConfirmClose(
@@ -10461,6 +10476,41 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
         return closed
     }
 
+    func isForceClosingTab(_ tabId: TabID) -> Bool {
+        forceCloseTabIds.contains(tabId)
+    }
+
+    /// Re-requests a cloud terminal tab close after its detach/kill decision. The
+    /// original gesture's markers are restored so the second pass keeps its meaning
+    /// (tab close button vs shortcut, explicit vs programmatic), and the cloud gate
+    /// is skipped once; every other rule (pinned, last surface, history) still runs.
+    func requestCloseCloudTerminalTab(_ tabId: TabID, reclose: CloudTerminalReclose) -> Bool {
+        cloudTerminalCloseDecidedTabIds.insert(tabId)
+        if let tabCloseButton = reclose.tabCloseButton {
+            tabStripCloseButtonByTabId[tabId] = tabCloseButton
+        } else if reclose.explicitUserClose {
+            explicitUserCloseTabIds.insert(tabId)
+        }
+        let closed = bonsplitController.closeTab(tabId)
+        if !closed {
+            cloudTerminalCloseDecidedTabIds.remove(tabId)
+            tabStripCloseButtonByTabId.removeValue(forKey: tabId)
+            explicitUserCloseTabIds.remove(tabId)
+        }
+        return closed
+    }
+
+    /// Closes a pane whose cloud terminals were decided as a group: the pane gate
+    /// is skipped once and its tabs are force-closed (they no longer need any prompt).
+    func forceClosePaneAfterCloudTerminalDecision(_ pane: PaneID, tabIds: [TabID]) {
+        cloudTerminalCloseDecidedPaneIds.insert(pane.id)
+        forceCloseTabIds.formUnion(tabIds)
+        if !bonsplitController.closePane(pane) {
+            cloudTerminalCloseDecidedPaneIds.remove(pane.id)
+            forceCloseTabIds.subtract(tabIds)
+        }
+    }
+
     /// Returns the nearest right-side sibling pane for browser/file-preview placement.
     /// The search is local to the source pane's ancestry in the split tree:
     /// use the closest horizontal ancestor where the source is in the first (left) branch.
@@ -13713,6 +13763,13 @@ extension Workspace: BonsplitDelegate {
             return false
         }
 
+        // A cloud terminal pane is a projection: closing it must say whether the
+        // terminal on the machine survives (detach) or ends (kill).
+        if interceptCloudTerminalTabClose(tab: tab, tabCloseButton: tabCloseButtonClose, explicitUserClose: explicitUserClose) {
+            clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
+            return false
+        }
+
         if explicitUserClose && shouldCloseWorkspaceOnLastSurface(for: tab.id, tabStripClose: tabStripClose) {
             clearStagedClosedBrowserRestoreSnapshot(for: tab.id)
             clearCloseHistoryEligibility(tabId: tab.id)
@@ -14134,6 +14191,11 @@ extension Workspace: BonsplitDelegate {
     func splitTabBar(_ controller: BonsplitController, shouldClosePane pane: PaneID) -> Bool {
         // Check if any panel in this pane needs close confirmation
         let tabs = controller.tabs(inPane: pane)
+        if interceptCloudTerminalPaneClose(pane: pane, tabs: tabs) {
+            pendingPaneClosePanelIds.removeValue(forKey: pane.id)
+            pendingPaneCloseHistoryEntries.removeValue(forKey: pane.id)
+            return false
+        }
         for tab in tabs {
             if forceCloseTabIds.contains(tab.id) { continue }
             if let panelId = panelIdFromSurfaceId(tab.id),
@@ -14590,6 +14652,12 @@ extension Workspace: BonsplitDelegate {
         case .toggleFullWidthTab:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             toggleFullWidthTabMode(panelId: panelId)
+        case .detachCloudTerminal:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            detachCloudTerminal(panelId: panelId)
+        case .killCloudTerminal:
+            guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
+            killCloudTerminal(panelId: panelId)
         case .forkConversation,
              .forkConversationRight,
              .forkConversationLeft,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -623,6 +623,9 @@
 		E0C1BF3A1CF2C22FF100B77B /* CloudMachineLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DC04B459E0132708ACD366 /* CloudMachineLink.swift */; };
 		5C6CEB17F0A6776F357BAF09 /* CloudMachineLinkManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */; };
 		0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9143D900F124494A55F859F /* CloudMachinesFeature.swift */; };
+		DB56FE08AAB5A63D6D2FE946 /* CloudTerminalCloseAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3052219EF241507220EF74C /* CloudTerminalCloseAlertPresenter.swift */; };
+		B816DFA1FC8FB626B7CBD41D /* CloudTerminalClosePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3BAB694691AE65C7C0DE8C08 /* CloudTerminalClosePolicy.swift */; };
+		C588F3C8F9A8C27CDDF1D185 /* CloudTerminalClosePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3A15FF98D2E6AAB24FE10D1 /* CloudTerminalClosePolicyTests.swift */; };
 		C986A0080000000000000001 /* CloudTreeActiveDrag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C986A0070000000000000001 /* CloudTreeActiveDrag.swift */; };
 		3BCFA4F10BC6F6673CFA3BFC /* CloudTreeCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47E286761D314959F64AA002 /* CloudTreeCellView.swift */; };
 		46C9B49F24011903C31179A7 /* CloudTreeExpansionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93142FA1472ACA28B993606 /* CloudTreeExpansionStore.swift */; };
@@ -1323,6 +1326,7 @@
 		D78971000000000000000001 /* GhosttyNotificationScrollRuntimeBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D78971000000000000000002 /* GhosttyNotificationScrollRuntimeBridge.swift */; };
 		B88357000000000000000001 /* GhosttyNSView+ClipboardActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88357000000000000000002 /* GhosttyNSView+ClipboardActions.swift */; };
 		B88357000000000000000003 /* GhosttyNSView+ClipboardInputSequencing.swift in Sources */ = {isa = PBXBuildFile; fileRef = B88357000000000000000004 /* GhosttyNSView+ClipboardInputSequencing.swift */; };
+		46500A396E02599CFDC7EC41 /* GhosttyNSView+CloudTerminalContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = 35EF4D1A174C75E05AF69D74 /* GhosttyNSView+CloudTerminalContextMenu.swift */; };
 		F0ACC0DE0000000000000001 /* GhosttyNSView+ForkConversationContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000002 /* GhosttyNSView+ForkConversationContextMenu.swift */; };
 		D3571000A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */; };
 		D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */; };
@@ -2841,6 +2845,7 @@
 		8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */; };
 		CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */; };
 		65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */; };
+		BDCBC4C7939ECD418C0D9A8B /* Workspace+CloudTerminalClose.swift in Sources */ = {isa = PBXBuildFile; fileRef = A8AE0F4C9729EA66321FC0E0 /* Workspace+CloudTerminalClose.swift */; };
 		C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */; };
 		A5FB120D /* Workspace+CustomLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB120E /* Workspace+CustomLayout.swift */; };
 		C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */; };
@@ -3710,6 +3715,9 @@
 		49DC04B459E0132708ACD366 /* CloudMachineLink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachineLink.swift; sourceTree = "<group>"; };
 		874061DC8AD0C4E7297BF267 /* CloudMachineLinkManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachineLinkManager.swift; sourceTree = "<group>"; };
 		D9143D900F124494A55F859F /* CloudMachinesFeature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudMachinesFeature.swift; sourceTree = "<group>"; };
+		D3052219EF241507220EF74C /* CloudTerminalCloseAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTerminalCloseAlertPresenter.swift; sourceTree = "<group>"; };
+		3BAB694691AE65C7C0DE8C08 /* CloudTerminalClosePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTerminalClosePolicy.swift; sourceTree = "<group>"; };
+		B3A15FF98D2E6AAB24FE10D1 /* CloudTerminalClosePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTerminalClosePolicyTests.swift; sourceTree = "<group>"; };
 		C986A0070000000000000001 /* CloudTreeActiveDrag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloudTreeActiveDrag.swift; sourceTree = "<group>"; };
 		47E286761D314959F64AA002 /* CloudTreeCellView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeCellView.swift; sourceTree = "<group>"; };
 		B93142FA1472ACA28B993606 /* CloudTreeExpansionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CloudTreeExpansionStore.swift; sourceTree = "<group>"; };
@@ -4330,6 +4338,7 @@
 		D78971000000000000000002 /* GhosttyNotificationScrollRuntimeBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyNotificationScrollRuntimeBridge.swift; sourceTree = "<group>"; };
 		B88357000000000000000002 /* GhosttyNSView+ClipboardActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+ClipboardActions.swift"; sourceTree = "<group>"; };
 		B88357000000000000000004 /* GhosttyNSView+ClipboardInputSequencing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+ClipboardInputSequencing.swift"; sourceTree = "<group>"; };
+		35EF4D1A174C75E05AF69D74 /* GhosttyNSView+CloudTerminalContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+CloudTerminalContextMenu.swift"; sourceTree = "<group>"; };
 		F0ACC0DE0000000000000002 /* GhosttyNSView+ForkConversationContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+ForkConversationContextMenu.swift"; sourceTree = "<group>"; };
 		D3571001A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+IMEComposition.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttyNSView+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
@@ -5830,6 +5839,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		8777E0028777E0028777E002 /* Workspace+AttentionFlashRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+AttentionFlashRouting.swift"; sourceTree = "<group>"; };
 		CA52C0150000000000000000 /* Workspace+CanvasLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CanvasLayout.swift"; sourceTree = "<group>"; };
 		C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudPaneRouting.swift"; sourceTree = "<group>"; };
+		A8AE0F4C9729EA66321FC0E0 /* Workspace+CloudTerminalClose.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CloudTerminalClose.swift"; sourceTree = "<group>"; };
 		C54860020000000000000002 /* Workspace+CmuxNavigationDescriptor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CmuxNavigationDescriptor.swift"; sourceTree = "<group>"; };
 		A5FB120E /* Workspace+CustomLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomLayout.swift"; sourceTree = "<group>"; };
 		C57B00030000000000000002 /* Workspace+CustomSidebarPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+CustomSidebarPane.swift"; sourceTree = "<group>"; };
@@ -6387,6 +6397,9 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				278BEFB3583AED9627966DFF /* SurfaceSocketCommands.swift */,
 				47BBA1A8703756FDDFD53CF3 /* Workspace+SurfaceCatalog.swift */,
 				C5797FE9CD70513E4FFAC6EB /* Workspace+CloudPaneRouting.swift */,
+				A8AE0F4C9729EA66321FC0E0 /* Workspace+CloudTerminalClose.swift */,
+				D3052219EF241507220EF74C /* CloudTerminalCloseAlertPresenter.swift */,
+				3BAB694691AE65C7C0DE8C08 /* CloudTerminalClosePolicy.swift */,
 				1EDD243C7C87A2AB78B12BAD /* LocalSurfaceProvider.swift */,
 				63F5BDFB110A8A96C9CA0A75 /* CmuxTuiSurfaceProviders.swift */,
 				1FE7223A65E72C46927A4F02 /* SurfacePaneFactory.swift */,
@@ -7230,6 +7243,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7AB00000000000000000006 /* GhosttyNSView+MoveTabToNewWorkspace.swift */,
 				C7261F030000000000000002 /* GhosttyNSView+PointerFocusActivation.swift */,
 				47895BD8BBB2418438E708F5 /* GhosttyNSView+RemoteReconnect.swift */,
+				35EF4D1A174C75E05AF69D74 /* GhosttyNSView+CloudTerminalContextMenu.swift */,
 				C75100010000000000000002 /* GhosttyNSView+SelectionTranslation.swift */,
 				D0B1000BA1B2C3D4E5F60001 /* GhosttyTerminalViewSupport.swift */,
 				D0B10013A1B2C3D4E5F60001 /* GhosttyApp+SurfaceConfigurationReload.swift */,
@@ -9128,6 +9142,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				FE002002 /* FileExplorerStoreTests.swift */,
 				9860F0039860F0039860F003 /* FileExplorerNativeDragOwnershipTests.swift */,
 				C986A0040000000000000001 /* CloudTreeNativeDragOwnershipTests.swift */,
+				B3A15FF98D2E6AAB24FE10D1 /* CloudTerminalClosePolicyTests.swift */,
 				FE002010 /* FileExplorerDoubleClickActionTests.swift */,
 				FE002003 /* FileSearchRipgrepParserTests.swift */,
 				9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */,
@@ -10063,6 +10078,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				E0C1BF3A1CF2C22FF100B77B /* CloudMachineLink.swift in Sources */,
 				5C6CEB17F0A6776F357BAF09 /* CloudMachineLinkManager.swift in Sources */,
 				0F5C2DDC1A39436E867D28BB /* CloudMachinesFeature.swift in Sources */,
+				DB56FE08AAB5A63D6D2FE946 /* CloudTerminalCloseAlertPresenter.swift in Sources */,
+				B816DFA1FC8FB626B7CBD41D /* CloudTerminalClosePolicy.swift in Sources */,
 				C986A0080000000000000001 /* CloudTreeActiveDrag.swift in Sources */,
 				3BCFA4F10BC6F6673CFA3BFC /* CloudTreeCellView.swift in Sources */,
 				46C9B49F24011903C31179A7 /* CloudTreeExpansionStore.swift in Sources */,
@@ -10412,6 +10429,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D78971000000000000000001 /* GhosttyNotificationScrollRuntimeBridge.swift in Sources */,
 				B88357000000000000000001 /* GhosttyNSView+ClipboardActions.swift in Sources */,
 				B88357000000000000000003 /* GhosttyNSView+ClipboardInputSequencing.swift in Sources */,
+				46500A396E02599CFDC7EC41 /* GhosttyNSView+CloudTerminalContextMenu.swift in Sources */,
 				F0ACC0DE0000000000000001 /* GhosttyNSView+ForkConversationContextMenu.swift in Sources */,
 				D3571000A1B2C3D4E5F60718 /* GhosttyNSView+IMEComposition.swift in Sources */,
 				D7AB00000000000000000005 /* GhosttyNSView+MoveTabToNewWorkspace.swift in Sources */,
@@ -11483,6 +11501,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8777E0018777E0018777E001 /* Workspace+AttentionFlashRouting.swift in Sources */,
 				CA52B0150000000000000000 /* Workspace+CanvasLayout.swift in Sources */,
 				65221C81A129236D52702D99 /* Workspace+CloudPaneRouting.swift in Sources */,
+				BDCBC4C7939ECD418C0D9A8B /* Workspace+CloudTerminalClose.swift in Sources */,
 				C54860020000000000000001 /* Workspace+CmuxNavigationDescriptor.swift in Sources */,
 				A5FB120D /* Workspace+CustomLayout.swift in Sources */,
 				C57B00030000000000000001 /* Workspace+CustomSidebarPane.swift in Sources */,
@@ -12031,6 +12050,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					799100000000000000000003 /* CLIWorkspaceStableIDTests.swift in Sources */,
 				7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */,
 				C6D4C5A38097BB05AB98E460 /* CloudAgentSkillLauncherTests.swift in Sources */,
+				C588F3C8F9A8C27CDDF1D185 /* CloudTerminalClosePolicyTests.swift in Sources */,
 				C986A0030000000000000001 /* CloudTreeNativeDragOwnershipTests.swift in Sources */,
 				C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */,
 				C0DE43000000000000000009 /* CmuxAgentChatConfigTests.swift in Sources */,

--- a/cmuxTests/CloudTerminalClosePolicyTests.swift
+++ b/cmuxTests/CloudTerminalClosePolicyTests.swift
@@ -1,0 +1,59 @@
+import CmuxSettings
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Closing a cloud terminal pane: the stored action decides detach vs kill vs
+/// prompt, and only a remembered non-cancel answer writes the setting back.
+@Suite
+struct CloudTerminalClosePolicyTests {
+    @Test func storedActionDecidesWithoutPrompting() {
+        #expect(CloudTerminalClosePolicy.resolution(for: .detach) == .detach)
+        #expect(CloudTerminalClosePolicy.resolution(for: .kill) == .kill)
+        #expect(CloudTerminalClosePolicy.resolution(for: .ask) == .prompt)
+    }
+
+    @Test func rememberPersistsOnlyDetachOrKill() {
+        #expect(CloudTerminalClosePolicy.actionToRemember(decision: .detach, remember: true) == .detach)
+        #expect(CloudTerminalClosePolicy.actionToRemember(decision: .kill, remember: true) == .kill)
+        #expect(CloudTerminalClosePolicy.actionToRemember(decision: .cancel, remember: true) == nil)
+        #expect(CloudTerminalClosePolicy.actionToRemember(decision: .kill, remember: false) == nil)
+    }
+
+    @Test func promptButtonsMapDetachKillCancel() {
+        #expect(CloudTerminalClosePolicy.decision(forButtonIndex: 0) == .detach)
+        #expect(CloudTerminalClosePolicy.decision(forButtonIndex: 1) == .kill)
+        #expect(CloudTerminalClosePolicy.decision(forButtonIndex: 2) == .cancel)
+        #expect(CloudTerminalClosePolicy.decision(forButtonIndex: 7) == .cancel)
+    }
+
+    @Test func promptNamesOneTerminalAndCountsSeveral() {
+        let one = CloudTerminalClosePrompt(terminalNames: ["claude"], machineName: "vivid-newt")
+        #expect(one.title.contains("claude"))
+        #expect(one.message.contains("vivid-newt"))
+
+        let several = CloudTerminalClosePrompt(terminalNames: ["claude", "bun test", " "], machineName: "vivid-newt")
+        #expect(several.title.contains("2"))
+        #expect(!several.title.contains("claude"))
+        #expect(several.message.contains("vivid-newt"))
+
+        let unnamed = CloudTerminalClosePrompt(terminalNames: ["  "], machineName: "vivid-newt")
+        #expect(unnamed.title.contains("terminal"))
+    }
+
+    @Test func rememberedChoiceRoundTripsThroughTheStore() {
+        let defaults = UserDefaults(suiteName: "CloudTerminalClosePolicyTests.\(UUID().uuidString)")!
+        defer { defaults.removePersistentDomain(forName: defaults.description) }
+        let store = CloudTerminalCloseStore(defaults: defaults)
+        #expect(store.action == .ask)
+        if let remembered = CloudTerminalClosePolicy.actionToRemember(decision: .kill, remember: true) {
+            store.setAction(remembered)
+        }
+        #expect(CloudTerminalCloseStore(defaults: defaults).action == .kill)
+        #expect(CloudTerminalClosePolicy.resolution(for: CloudTerminalCloseStore(defaults: defaults).action) == .kill)
+    }
+}

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -6,6 +6,8 @@ import AppKit
 import struct CmuxSettings.AppCatalogSection
 import struct CmuxSettings.QuitConfirmationStore
 import enum CmuxSettings.ConfirmQuitMode
+import enum CmuxSettings.CloudTerminalCloseAction
+import struct CmuxSettings.CloudTerminalCloseStore
 import enum CmuxSettings.BrowserSearchEngine
 import struct CmuxSettings.BrowserSearchSettingsStore
 import struct CmuxSettings.NotificationSoundOverride

--- a/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
+++ b/cmuxTests/KeyboardShortcutSettingsFileStoreStartupTests.swift
@@ -784,6 +784,77 @@ final class KeyboardShortcutSettingsFileStoreStartupTests: XCTestCase {
         }
     }
 
+    func testCloseCloudTerminalImportsEnumFromCmuxJSON() throws {
+        let defaults = UserDefaults.standard
+        let key = AppCatalogSection().closeCloudTerminal.userDefaultsKey
+
+        try preservingDefaults(keys: [key, settingsFileBackupsDefaultsKey, importedManagedDefaultsKey]) {
+            defaults.removeObject(forKey: key)
+            defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            defaults.removeObject(forKey: importedManagedDefaultsKey)
+
+            let directoryURL = try makeTemporaryDirectory()
+            defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+            let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+            try writeSettingsFile(
+                """
+                {
+                  "app": {
+                    "closeCloudTerminal": "kill"
+                  }
+                }
+                """,
+                to: settingsFileURL
+            )
+
+            _ = KeyboardShortcutSettingsFileStore(
+                primaryPath: settingsFileURL.path,
+                fallbackPath: nil,
+                additionalFallbackPaths: [],
+                startWatching: false
+            )
+
+            XCTAssertEqual(defaults.string(forKey: key), CloudTerminalCloseAction.kill.rawValue)
+            XCTAssertEqual(CloudTerminalCloseStore(defaults: defaults).action, .kill)
+        }
+    }
+
+    func testCloseCloudTerminalRejectsUnknownValue() throws {
+        let defaults = UserDefaults.standard
+        let key = AppCatalogSection().closeCloudTerminal.userDefaultsKey
+
+        try preservingDefaults(keys: [key, settingsFileBackupsDefaultsKey, importedManagedDefaultsKey]) {
+            defaults.set(CloudTerminalCloseAction.detach.rawValue, forKey: key)
+            defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
+            defaults.removeObject(forKey: importedManagedDefaultsKey)
+
+            let directoryURL = try makeTemporaryDirectory()
+            defer { try? FileManager.default.removeItem(at: directoryURL) }
+
+            let settingsFileURL = directoryURL.appendingPathComponent("cmux.json", isDirectory: false)
+            try writeSettingsFile(
+                """
+                {
+                  "app": {
+                    "closeCloudTerminal": "explode"
+                  }
+                }
+                """,
+                to: settingsFileURL
+            )
+
+            _ = KeyboardShortcutSettingsFileStore(
+                primaryPath: settingsFileURL.path,
+                fallbackPath: nil,
+                additionalFallbackPaths: [],
+                startWatching: false
+            )
+
+            XCTAssertEqual(CloudTerminalCloseStore(defaults: defaults).action, .detach)
+        }
+    }
+
     func testLegacyWarnBeforeQuitMapsToConfirmQuitWhenConfirmQuitIsAbsent() throws {
         let defaults = UserDefaults.standard
         let confirmQuitKey = AppCatalogSection().confirmQuitMode.userDefaultsKey

--- a/docs/cloud-cmux-tui-daemon.md
+++ b/docs/cloud-cmux-tui-daemon.md
@@ -269,7 +269,7 @@ resources in: `LocalSurfaceProvider` (this Mac's terminals and browsers) and one
 from the headless link, its noVNC screen `display:1`, its forwarded ports).
 `catalog.project(resource, into:)` is the single open path — the sidebar tree,
 drag and drop, the CLI and agents all go through it — so an already-open
-resource is focused instead of duplicated, a closed pane never destroys a
+resource is focused instead of duplicated, a closed pane detaches rather than destroys a
 remote resource, and restored panes re-project when their provider reports the
 resource again.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -70,6 +70,24 @@ Default: `always` for stable and nightly builds. DEV builds always behave as `ne
 
 The older boolean `app.warnBeforeQuit` still works as a fallback when `app.confirmQuit` is not set. `true` maps to `always`; `false` maps to `never`.
 
+## `app.closeCloudTerminal`
+
+Controls what closing a pane that shows a cloud terminal (a terminal running in a machine's cmux-tui session) does to the terminal. Cmd+W, the tab close button, the pane close button, and Close Tab all go through it. The tab and terminal context menus always offer both verbs (`Detach Terminal`, `Kill Process`).
+
+- `ask`: prompt with Detach, Kill Process, or Cancel. "Remember my choice" writes `detach` or `kill` here.
+- `detach`: close the pane and keep the terminal running on the machine; reopen it from the Cloud sidebar.
+- `kill`: end the terminal's process on the machine, then close the pane.
+
+Default: `ask`.
+
+```json
+{
+  "app": {
+    "closeCloudTerminal": "detach"
+  }
+}
+```
+
 ## `app.forkConversationDefaultDestination`
 
 Controls what the tab right-click `Fork Conversation` item does. The submenu still exposes every destination.

--- a/skills/cmux-cloud-vm/SKILL.md
+++ b/skills/cmux-cloud-vm/SKILL.md
@@ -14,7 +14,7 @@ Everything the Cloud sidebar can do, from the CLI — plus agent-only primitives
 | **Machine** | A persistent cloud VM (`cmux vm ls`). Sleeps when idle (free while asleep), wakes on connect or exec. `/root` is a 16 GB persistent volume; the rest of the filesystem is disposable compute. |
 | **Contents** | Ubuntu (shared devbox image): node, bun, uv, git, gh, ripgrep, fd, jq, tmux, xdotool. **Claude Code, Codex, OpenCode, and Pi are preinstalled**. Machines are shell-only today — no provider ships a desktop image, so there is no VNC screen to open. Provisioning runs in the background on first boot — `cat /tmp/cmux/provision.log` on a brand-new machine if a tool is missing. |
 | **Session** | Every machine runs the **cmux-tui remote daemon**: its own workspaces → terminals, visible in `cmux vm tree`. A terminal you start there keeps running when the Mac disconnects. |
-| **Surface** | A terminal, VNC screen or browser — on This Mac or on a machine — with a stable id `<machine>/<kind>/<key>` (`cmux surface ls --json`). Panes *project* surfaces: `cmux surface open <id>` reuses the pane already showing one, or lands it at a pane edge you choose; closing a pane never kills a machine's terminal. |
+| **Surface** | A terminal, VNC screen or browser — on This Mac or on a machine — with a stable id `<machine>/<kind>/<key>` (`cmux surface ls --json`). Panes *project* surfaces: `cmux surface open <id>` reuses the pane already showing one, or lands it at a pane edge you choose; closing a pane detaches the machine's terminal by default (`app.closeCloudTerminal`: `ask` prompts Detach / Kill Process, `detach` or `kill` decide silently). |
 | **Base** | The one pinned persistent machine (`cmux vm base open`) — use it for the user's ongoing work. |
 | **Pool** | Machines the router provisioned for agent work (`agent-pool` in `vm ls`). `vm run`/`vm agent` only draft these; hand-made machines need `--machine <id>`. |
 | **Plan meter** | `cmux vm ls` prints `N of M machines`. Free plans get **1 machine and a 7-day cloud window**; `vm ls --json` carries `limits.freeAccessExpiresAt`. At the cap, creates fail with an upgrade action — never delete machines to make room without asking. |
@@ -53,7 +53,7 @@ Repeat runs from the same directory hit the same machine (sticky binding), so sy
 
 ## Running work
 
-Opening a machine (`cmux vm shell <id>`, `vm new`, `vm base open`, the sidebar) gives a **plain terminal** on it — one terminal in the machine's cmux-tui session, attached in a pane like an ssh session; it keeps running if the pane closes and shows up in `cmux vm tree` (reattach with the `cmux vm open <m>/<ws>/<term>` address the `OK` line prints). `cmux vm tui <id>` is the only command that opens the full cmux-tui client.
+Opening a machine (`cmux vm shell <id>`, `vm new`, `vm base open`, the sidebar) gives a **plain terminal** on it — one terminal in the machine's cmux-tui session, attached in a pane like an ssh session; it keeps running when the pane detaches (Cmd+W asks Detach or Kill Process unless `app.closeCloudTerminal` decides) and shows up in `cmux vm tree` (reattach with the `cmux vm open <m>/<ws>/<term>` address the `OK` line prints). `cmux vm tui <id>` is the only command that opens the full cmux-tui client.
 
 ```bash
 cmux vm run --sync --pull work/app/dist -- sh -c 'cd work/app && bun run build'
@@ -89,7 +89,7 @@ cmux notify --title "Cloud build done" --body "…"
 
 The user cannot see inside the machine: print URLs, pull artifacts, or open a pane when there is something to look at, and `cmux notify` for long work. Only share URLs minted by `cmux vm open` — never guess raw provider URLs.
 
-A pane showing a machine surface is an ordinary local pane: move, split, reorder, or close it with the local topology verbs (`../cmux/SKILL.md`) and the surface catalog follows the pane; closing a pane never kills the machine's terminal. Rearranging the machine's own cmux-tui topology from inside is what `cmux vm tui <id>` is for.
+A pane showing a machine surface is an ordinary local pane: move, split, reorder, or close it with the local topology verbs (`../cmux/SKILL.md`) and the surface catalog follows the pane; closing a pane detaches unless the person picks Kill Process (or `app.closeCloudTerminal` is `kill`). Rearranging the machine's own cmux-tui topology from inside is what `cmux vm tui <id>` is for.
 
 ## CodeRouter and model credentials
 

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -535,6 +535,13 @@
           "default": true,
           "description": "Show a confirmation before closing a tab."
         },
+        "closeCloudTerminal": {
+          "type": "string",
+          "enum": ["ask", "detach", "kill"],
+          "default": "ask",
+          "descriptionKey": "schemaDescriptions.app.closeCloudTerminal",
+          "description": "What closing a pane that shows a cloud terminal does to the terminal on its machine: ask (prompt Detach / Kill Process), detach (keep it running), or kill (end its process). The tab and terminal context menus always offer both verbs."
+        },
         "warnBeforeClosingTabXButton": {
           "type": "boolean",
           "default": false,

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1947,6 +1947,7 @@
           "windowTitleTemplate": "Optional NSWindow title template. Blank preserves cmux's existing default title behavior, including the current-directory fallback. Supported placeholders: '{windowId}', '{windowToken}', '{activeWorkspace}', '{activeDirectory}', '{defaultTitle}', '{appName}'.",
           "warnBeforeQuit": "Legacy boolean fallback for quit confirmation. Use app.confirmQuit for new configs.",
           "warnBeforeClosingTabXButton": "Show a confirmation before closing a tab with the tab close button.",
+          "closeCloudTerminal": "What closing a pane that shows a cloud terminal does to the terminal on its machine: ask (prompt Detach / Kill Process), detach (keep it running), or kill (end its process). The tab and terminal context menus always offer both verbs.",
           "hideTabCloseButton": "Hide tab close buttons in the pane tab bar.",
           "forkConversationDefaultDestination": "Default destination for the tab context menu's primary Fork Conversation action. The submenu still exposes every destination.",
           "globalFontMagnification": "Scales cmux-owned terminals, tab titles, sidebars, settings, overlays, and app chrome by this percentage. Rendered browser page content is excluded."

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1870,6 +1870,7 @@
           "windowTitleTemplate": "任意の NSWindow タイトルテンプレートです。空欄のままなら、現在のディレクトリへのフォールバックを含む cmux 既存の既定タイトル動作を保ちます。対応するプレースホルダー: '{windowId}', '{windowToken}', '{activeWorkspace}', '{activeDirectory}', '{defaultTitle}', '{appName}'。",
           "warnBeforeQuit": "終了確認用の従来の boolean フォールバックです。新しい設定では app.confirmQuit を使ってください。",
           "warnBeforeClosingTabXButton": "タブの閉じるボタンでタブを閉じる前に確認を表示します。",
+          "closeCloudTerminal": "クラウドターミナルを表示するペインを閉じたときにマシン上のターミナルをどうするか: ask（デタッチ / プロセスを終了 を確認）、detach（実行を続ける）、kill（プロセスを終了）。タブとターミナルのコンテキストメニューには常に両方の操作があります。",
           "hideTabCloseButton": "ペインのタブバーでタブの閉じるボタンを非表示にします。",
           "forkConversationDefaultDestination": "タブのコンテキストメニューにある主要な「会話をフォーク」操作のデフォルトのフォーク先です。サブメニューには引き続きすべてのフォーク先が表示されます。",
           "globalFontMagnification": "cmux が所有するターミナル、タブタイトル、サイドバー、設定、オーバーレイ、アプリの chrome をこの割合で拡大縮小します。レンダリングされたブラウザページ内容は対象外です。"


### PR DESCRIPTION
Closing a pane that shows a cloud terminal used to detach by omission: the pane only killed its local `cmux-tui attach` client, the terminal kept running on the machine, and nothing on the pane could end it. Now Cmd+W, the tab close button, the pane close button and Close Tab go through one cloud close gate on the workspace (`Workspace+CloudTerminalClose.swift`).

`app.closeCloudTerminal` (Settings › App, `cmux.json`) decides what a plain close means: `ask` (default) prompts Detach / Kill Process / Cancel, and "Remember my choice" writes `detach` or `kill` back; `detach` and `kill` decide silently. Kill runs the provider's `terminal <id> close` and closes the pane only after the machine confirmed; a refused kill keeps the pane open and shows the error. Cloud terminal panes no longer trigger the generic "Close tab?" prompt, since detaching loses nothing.

The tab context menu and the terminal pane context menu always offer both verbs, `Detach Terminal` and `Kill Process`, on the same workspace path. The tab menu items come from the bonsplit fork: https://github.com/manaflow-ai/bonsplit/pull/232 (`TabContextAction.detachCloudTerminal` / `.killCloudTerminal`, `tabContextCloudTerminalAvailabilityProvider`). That PR must merge before this one so the submodule pointer is an ancestor of the fork's `main`.

Cloud tree rows (terminals, browsers, ports, desktops) now open as a tab of the current pane instead of a split; "Open in New Pane" remains the split. "Open in New Tab" was removed since it became identical to "Open".

Not covered: closing a whole workspace or a window still detaches every cloud terminal in it regardless of the setting, and cloud terminals living in a window Dock have no detach/kill menu items (Dock tabs ignore the new actions).

Tests: `CloudTerminalClosePolicyTests` (policy, remember semantics, prompt copy), `CloudTerminalCloseStoreTests` (CmuxSettings), two `cmux.json` import tests in `KeyboardShortcutSettingsFileStoreStartupTests`, `SettingsRowAnchorResolutionTests` path list, and the bonsplit menu test.

https://claude.ai/code/session_01GQmDjyqqNB2WvycYdaM64v

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790930721&installation_model_id=21920&pr_number=11624&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11624&signature=4c20cddf621cedda61c41020f4bd28c3205f791bcefad69954c734b34a593e41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Closing a cloud terminal pane used to detach silently, leaving the remote process running; now Cmd+W, tab and pane close controls, and Close Tab choose between detaching and killing it by default. Killing closes the pane only after the provider confirms, while failures keep it open and show the error.

**New Features**

- The choice can be remembered in Settings › App or `cmux.json` through `app.closeCloudTerminal`; tab and terminal context menus always offer both actions.
- Cloud tree resources open as tabs in the current pane, while Open in New Pane still creates a split.
- Cloud terminal panes skip the generic close prompt; workspace and window closes still detach, and Dock tabs omit these actions.

**Migration**

- Update `vendor/bonsplit` to the revision that provides the cloud-terminal context actions; its pointer must be an ancestor of the fork's `main`.

<sup>Written for commit f2445c77480d5decf08301f9977811f279881270. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11624?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added controls for closing cloud terminals: Ask, Detach, or Kill.
  - Added confirmation prompts with “Remember my choice.”
  - Added context-menu actions to detach terminals or terminate their processes.
  - Cloud terminal panes now open resources in tabs by default.
  - Added support for configuring this behavior through settings and configuration files.

- **Documentation**
  - Updated configuration and cloud-terminal guidance to describe detach and kill behavior.
  - Added localized text for the new settings, prompts, and actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->