### PR TITLE
cli: animate the welcome logo from a background thread

### DIFF
--- a/CLI/WelcomeLogoAnimation.swift
+++ b/CLI/WelcomeLogoAnimation.swift
@@ -1,12 +1,14 @@
 import Darwin
 import Foundation
 
-/// Renders the seven-row `::` cmux logo for one frame of the welcome color wave.
+/// Renders the seven-row `::` cmux logo for one frame of the welcome ripple.
 ///
 /// Pure: no I/O, so tests can assert exact frame bytes. Frame 0 is the canonical
-/// static gradient; frames cycle through an extended ping-pong palette so the
-/// wave has no visible seam and returns to the canonical gradient every
-/// `cycleLength` frames.
+/// static gradient. During the animation a pulse travels left to right across
+/// the diamond; every `::` pair it passes is shifted along a ping-pong palette
+/// (cyan → purple → cyan) by an amount that peaks at the pulse center, so the
+/// colors ripple horizontally and settle back to the canonical gradient once
+/// the pulse has left the logo.
 struct WelcomeLogoFrameRenderer {
     struct RGB: Equatable {
         let red: Int
@@ -29,35 +31,64 @@ struct WelcomeLogoFrameRenderer {
         RGB(red: 124, green: 58, blue: 237),
     ]
 
-    /// Gradient followed by its interior reversed, so walking the cycle goes
-    /// cyan → purple → cyan without a hard jump at the wrap.
+    /// Gradient followed by its interior reversed, so shifting along the cycle
+    /// goes cyan → purple → cyan without a hard jump at the wrap.
     static let pingPongPalette: [RGB] = gradient + gradient.dropFirst().dropLast().reversed()
 
     static var cycleLength: Int { pingPongPalette.count }
 
     static let reset = "\u{001B}[0m"
 
-    /// SGR prefix for the tagline text to the right of the logo.
-    let taglineColor: String
-
-    /// Color of `row` at `frameIndex`. Colors flow upward one row per frame.
-    static func color(row: Int, frameIndex: Int) -> RGB {
-        let palette = pingPongPalette
-        let count = palette.count
-        let index = ((row + frameIndex) % count + count) % count
-        return palette[index]
-    }
+    /// Leading spaces and number of `::` pairs on each row.
+    static let rowShapes: [(indent: Int, pairs: Int)] = [
+        (2, 1), (4, 2), (6, 3), (8, 3), (6, 3), (4, 2), (2, 1),
+    ]
 
     /// The `::` glyph block for each row, without color codes.
-    static let glyphs: [String] = [
-        "  ::",
-        "    ::::",
-        "      ::::::",
-        "        ::::::",
-        "      ::::::",
-        "    ::::",
-        "  ::",
-    ]
+    static let glyphs: [String] = rowShapes.map {
+        String(repeating: " ", count: $0.indent) + String(repeating: "::", count: $0.pairs)
+    }
+
+    /// Horizontal position of a pair, in pair units (two columns each).
+    static func pairColumn(row: Int, pair: Int) -> Int {
+        rowShapes[row].indent / 2 + pair
+    }
+
+    /// Half-width of the pulse in pair units, and the maximum palette shift at
+    /// its center.
+    static let pulseWidth = 6
+
+    /// Pair columns the pulse advances per frame.
+    static let pulseSpeed = 0.5
+
+    /// Frames until the pulse has left the widest row on the right. Frame 0 and
+    /// every frame from `frameCount` on render the canonical gradient.
+    static var frameCount: Int {
+        let lastColumn = rowShapes.map { $0.indent / 2 + $0.pairs - 1 }.max() ?? 0
+        // Pulse center starts at -pulseWidth (fully left of column 0) and must
+        // reach lastColumn + pulseWidth.
+        return Int((Double(lastColumn + 2 * pulseWidth) / pulseSpeed).rounded(.up))
+    }
+
+    /// Pulse center in pair units at `frameIndex`.
+    static func pulseCenter(frameIndex: Int) -> Double {
+        Double(frameIndex) * pulseSpeed - Double(pulseWidth)
+    }
+
+    /// Palette steps a pair at `pairColumn` is shifted by at `frameIndex`.
+    static func paletteShift(pairColumn: Int, frameIndex: Int) -> Int {
+        let distance = abs(Double(pairColumn) - pulseCenter(frameIndex: frameIndex))
+        return max(0, Int((Double(pulseWidth) - distance).rounded()))
+    }
+
+    /// Color of one `::` pair at `frameIndex`.
+    static func color(row: Int, pair: Int, frameIndex: Int) -> RGB {
+        let shift = paletteShift(pairColumn: pairColumn(row: row, pair: pair), frameIndex: frameIndex)
+        return pingPongPalette[(row + shift) % cycleLength]
+    }
+
+    /// SGR prefix for the tagline text to the right of the logo.
+    let taglineColor: String
 
     /// Static text that follows the glyph block on each row. It keeps its own
     /// colors so only the `::` block animates.
@@ -75,10 +106,26 @@ struct WelcomeLogoFrameRenderer {
         }
     }
 
-    /// One logo row with SGR codes and no trailing newline.
+    /// One logo row with SGR codes and no trailing newline. Adjacent pairs with
+    /// the same color share one SGR prefix, so frame 0 is byte-identical to the
+    /// original static logo.
     func row(_ row: Int, frameIndex: Int) -> String {
-        let color = Self.color(row: row, frameIndex: frameIndex)
-        return "\(color.sgr)\(Self.glyphs[row])\(Self.reset)\(trailer(row: row))"
+        let shape = Self.rowShapes[row]
+        var out = ""
+        var current: RGB?
+        for pair in 0..<shape.pairs {
+            let color = Self.color(row: row, pair: pair, frameIndex: frameIndex)
+            if color != current {
+                out += color.sgr
+                if pair == 0 {
+                    // The SGR precedes the indent, matching the original static logo bytes.
+                    out += String(repeating: " ", count: shape.indent)
+                }
+                current = color
+            }
+            out += "::"
+        }
+        return out + Self.reset + trailer(row: row)
     }
 
     /// All `rowCount` rows for `frameIndex`.
@@ -87,18 +134,28 @@ struct WelcomeLogoFrameRenderer {
     }
 }
 
-/// Repaints the logo in place from a background thread after the welcome
-/// screen has been printed. The main thread owns the lifecycle: it starts the
-/// animator, waits with a bounded deadline, and cancels if the terminal is slow.
+/// Repaints the logo in place after the welcome screen has been printed.
+///
+/// Two modes. Detached: `cmux welcome` queries the cursor row, spawns
+/// `cmux __welcome-animate <topRow>` in its own session, and exits so the
+/// shell prompt appears immediately while the helper repaints absolute rows
+/// above it. In-process fallback: a render thread repaints rows relative to
+/// the cursor while the main thread waits on a bounded deadline.
 final class WelcomeLogoAnimator {
-    struct Configuration: Equatable {
-        /// Number of animated frames after the static frame 0. A multiple of
-        /// `WelcomeLogoFrameRenderer.cycleLength` ends on the canonical gradient.
-        var frameCount: Int = 2 * WelcomeLogoFrameRenderer.cycleLength
-        var frameInterval: TimeInterval = 0.05
+    enum Placement: Equatable {
         /// Rows between the logo's first row and the cursor row, exclusive of
-        /// the cursor row. The cursor must sit on a line below the logo.
-        var linesAboveCursor: Int
+        /// the cursor row. Only valid while this process owns the cursor.
+        case relative(linesAboveCursor: Int)
+        /// One-based terminal row of the logo's first row. Survives the shell
+        /// printing its prompt below, but not scrolling.
+        case absolute(topRow: Int)
+    }
+
+    struct Configuration: Equatable {
+        /// Number of animated frames after the static frame 0.
+        var frameCount: Int = WelcomeLogoFrameRenderer.frameCount - 1
+        var frameInterval: TimeInterval = 0.03
+        var placement: Placement
 
         var duration: TimeInterval { Double(frameCount) * frameInterval }
     }
@@ -155,7 +212,7 @@ final class WelcomeLogoAnimator {
         self.configuration = configuration
     }
 
-    /// Decides whether the in-place repaint is safe and wanted.
+    /// Whether any in-place repaint is safe and wanted.
     ///
     /// - `isTTY`: stdout is a terminal. Pipes and files get the static frame only.
     /// - `terminalRows`: rows reported by `TIOCGWINSZ`, or nil when unknown. The
@@ -177,19 +234,39 @@ final class WelcomeLogoAnimator {
         return true
     }
 
+    /// Rows the cursor may still move down (prompt newlines) before the screen
+    /// scrolls and absolute rows go stale.
+    static let detachedScrollMargin = 2
+
+    /// Absolute placement for a detached helper, or nil when the logo could
+    /// scroll off before the ripple ends. `cursorRow` is the one-based row the
+    /// shell prompt will be printed on.
+    static func detachedPlacement(cursorRow: Int, linesAboveCursor: Int, terminalRows: Int) -> Placement? {
+        let topRow = cursorRow - linesAboveCursor
+        guard topRow >= 1 else { return nil }
+        guard cursorRow + detachedScrollMargin <= terminalRows else { return nil }
+        return .absolute(topRow: topRow)
+    }
+
     /// One complete in-place repaint. Every row is positioned from the saved
-    /// cursor so the sequence is self-contained: emit it in a single `write`
-    /// and the terminal is consistent between frames no matter when the
-    /// process exits.
-    static func repaintSequence(rows: [String], linesAboveCursor: Int) -> String {
+    /// cursor (relative) or by absolute row, so the sequence is self-contained:
+    /// emit it in a single `write` and the terminal is consistent between
+    /// frames no matter when the process exits.
+    static func repaintSequence(rows: [String], placement: Placement) -> String {
         var out = "\u{001B}7"
         for (index, row) in rows.enumerated() {
-            let up = linesAboveCursor - index
-            out += "\u{001B}8"
-            if up > 0 {
-                out += "\u{001B}[\(up)A"
+            switch placement {
+            case .relative(let linesAboveCursor):
+                let up = linesAboveCursor - index
+                out += "\u{001B}8"
+                if up > 0 {
+                    out += "\u{001B}[\(up)A"
+                }
+                out += "\r"
+            case .absolute(let topRow):
+                out += "\u{001B}[\(topRow + index);1H"
             }
-            out += "\r\u{001B}[2K"
+            out += "\u{001B}[2K"
             out += row
         }
         out += "\u{001B}8"
@@ -212,7 +289,7 @@ final class WelcomeLogoAnimator {
             sleep(configuration.frameInterval)
             if isCancelled() { break }
             let rows = renderer.rows(frameIndex: frame)
-            let sequence = Self.repaintSequence(rows: rows, linesAboveCursor: configuration.linesAboveCursor)
+            let sequence = Self.repaintSequence(rows: rows, placement: configuration.placement)
             guard write(sequence) else {
                 writerAlive = false
                 break
@@ -220,7 +297,7 @@ final class WelcomeLogoAnimator {
         }
         guard writerAlive else { return }
         let finalRows = renderer.rows(frameIndex: 0)
-        _ = write(Self.repaintSequence(rows: finalRows, linesAboveCursor: configuration.linesAboveCursor))
+        _ = write(Self.repaintSequence(rows: finalRows, placement: configuration.placement))
     }
 
     /// Starts the render loop on a background thread and returns immediately.
@@ -275,5 +352,128 @@ final class WelcomeLogoAnimator {
             handle.cancel()
             handle.wait(timeout: grace)
         }
+    }
+
+    // MARK: - Cursor position report
+
+    /// Parses a `CSI row ; col R` cursor position report anywhere in `bytes`.
+    /// Returns the one-based row, or nil when no complete report is present.
+    static func parseCursorReportRow(_ bytes: [UInt8]) -> Int? {
+        var index = 0
+        while index + 1 < bytes.count {
+            guard bytes[index] == 0x1B, bytes[index + 1] == UInt8(ascii: "[") else {
+                index += 1
+                continue
+            }
+            var cursor = index + 2
+            var row = 0
+            var digits = 0
+            while cursor < bytes.count, bytes[cursor] >= UInt8(ascii: "0"), bytes[cursor] <= UInt8(ascii: "9") {
+                row = row * 10 + Int(bytes[cursor] - UInt8(ascii: "0"))
+                digits += 1
+                cursor += 1
+            }
+            guard digits > 0, cursor < bytes.count, bytes[cursor] == UInt8(ascii: ";") else {
+                index += 1
+                continue
+            }
+            cursor += 1
+            var colDigits = 0
+            while cursor < bytes.count, bytes[cursor] >= UInt8(ascii: "0"), bytes[cursor] <= UInt8(ascii: "9") {
+                colDigits += 1
+                cursor += 1
+            }
+            guard colDigits > 0, cursor < bytes.count else {
+                // Incomplete report so far.
+                return nil
+            }
+            if bytes[cursor] == UInt8(ascii: "R") {
+                return row
+            }
+            index += 1
+        }
+        return nil
+    }
+
+    /// Asks the terminal where the cursor is (`DSR 6`) and returns the one-based
+    /// row, or nil when stdin/stdout are not the same interactive terminal or
+    /// the reply does not arrive within `timeout`. Puts stdin in raw mode for
+    /// the duration so the reply is not echoed or line-buffered.
+    static func queryCursorRow(
+        inputFD: Int32 = STDIN_FILENO,
+        outputFD: Int32 = STDOUT_FILENO,
+        timeout: TimeInterval = 0.25
+    ) -> Int? {
+        guard isatty(inputFD) == 1, isatty(outputFD) == 1 else { return nil }
+        var original = termios()
+        guard tcgetattr(inputFD, &original) == 0 else { return nil }
+        var raw = original
+        cfmakeraw(&raw)
+        guard tcsetattr(inputFD, TCSANOW, &raw) == 0 else { return nil }
+        defer { _ = tcsetattr(inputFD, TCSANOW, &original) }
+
+        guard writeAll(fd: outputFD, "\u{001B}[6n") else { return nil }
+
+        var buffer: [UInt8] = []
+        let deadline = Date().addingTimeInterval(timeout)
+        while buffer.count < 64 {
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { return nil }
+            var descriptor = pollfd(fd: inputFD, events: Int16(POLLIN), revents: 0)
+            let ready = poll(&descriptor, 1, Int32((remaining * 1000).rounded(.up)))
+            if ready < 0 {
+                if errno == EINTR { continue }
+                return nil
+            }
+            if ready == 0 { return nil }
+            var byte: UInt8 = 0
+            let count = Darwin.read(inputFD, &byte, 1)
+            guard count == 1 else { return nil }
+            buffer.append(byte)
+            if let row = parseCursorReportRow(buffer) {
+                return row
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Detached helper
+
+    static let detachedCommand = "__welcome-animate"
+
+    /// Spawns `<executable> __welcome-animate <topRow>` in its own session with
+    /// stdin and stderr on /dev/null and stdout inherited, so it keeps painting
+    /// the terminal after this process exits and the shell shows its prompt.
+    static func spawnDetached(executablePath: String, topRow: Int) -> Bool {
+        var fileActions: posix_spawn_file_actions_t?
+        guard posix_spawn_file_actions_init(&fileActions) == 0 else { return false }
+        defer { posix_spawn_file_actions_destroy(&fileActions) }
+        for fd in [STDIN_FILENO, STDERR_FILENO] {
+            let status = "/dev/null".withCString { path in
+                posix_spawn_file_actions_addopen(&fileActions, fd, path, fd == STDIN_FILENO ? O_RDONLY : O_WRONLY, 0)
+            }
+            guard status == 0 else { return false }
+        }
+        guard posix_spawn_file_actions_addinherit_np(&fileActions, STDOUT_FILENO) == 0 else { return false }
+
+        var attributes: posix_spawnattr_t?
+        guard posix_spawnattr_init(&attributes) == 0 else { return false }
+        defer { posix_spawnattr_destroy(&attributes) }
+        guard posix_spawnattr_setflags(&attributes, Int16(POSIX_SPAWN_SETSID | POSIX_SPAWN_CLOEXEC_DEFAULT)) == 0 else {
+            return false
+        }
+
+        let environmentStrings = ProcessInfo.processInfo.environment.map { "\($0.key)=\($0.value)" }
+        let arguments: [String] = [executablePath, detachedCommand, String(topRow)]
+        var argv: [UnsafeMutablePointer<CChar>?] = arguments.map { strdup($0) }
+        var envp: [UnsafeMutablePointer<CChar>?] = environmentStrings.map { strdup($0) }
+        defer {
+            for item in argv { free(item) }
+            for item in envp { free(item) }
+        }
+        argv.append(nil)
+        envp.append(nil)
+        var pid: pid_t = 0
+        return posix_spawn(&pid, executablePath, &fileActions, &attributes, &argv, &envp) == 0
     }
 }

--- a/CLI/WelcomeLogoAnimation.swift
+++ b/CLI/WelcomeLogoAnimation.swift
@@ -1,0 +1,279 @@
+import Darwin
+import Foundation
+
+/// Renders the seven-row `::` cmux logo for one frame of the welcome color wave.
+///
+/// Pure: no I/O, so tests can assert exact frame bytes. Frame 0 is the canonical
+/// static gradient; frames cycle through an extended ping-pong palette so the
+/// wave has no visible seam and returns to the canonical gradient every
+/// `cycleLength` frames.
+struct WelcomeLogoFrameRenderer {
+    struct RGB: Equatable {
+        let red: Int
+        let green: Int
+        let blue: Int
+
+        var sgr: String { "\u{001B}[38;2;\(red);\(green);\(blue)m" }
+    }
+
+    static let rowCount = 7
+
+    /// Top-to-bottom gradient of the static logo.
+    static let gradient: [RGB] = [
+        RGB(red: 0, green: 212, blue: 255),
+        RGB(red: 24, green: 181, blue: 250),
+        RGB(red: 48, green: 150, blue: 245),
+        RGB(red: 72, green: 119, blue: 241),
+        RGB(red: 96, green: 88, blue: 239),
+        RGB(red: 110, green: 73, blue: 238),
+        RGB(red: 124, green: 58, blue: 237),
+    ]
+
+    /// Gradient followed by its interior reversed, so walking the cycle goes
+    /// cyan → purple → cyan without a hard jump at the wrap.
+    static let pingPongPalette: [RGB] = gradient + gradient.dropFirst().dropLast().reversed()
+
+    static var cycleLength: Int { pingPongPalette.count }
+
+    static let reset = "\u{001B}[0m"
+
+    /// SGR prefix for the tagline text to the right of the logo.
+    let taglineColor: String
+
+    /// Color of `row` at `frameIndex`. Colors flow upward one row per frame.
+    static func color(row: Int, frameIndex: Int) -> RGB {
+        let palette = pingPongPalette
+        let count = palette.count
+        let index = ((row + frameIndex) % count + count) % count
+        return palette[index]
+    }
+
+    /// The `::` glyph block for each row, without color codes.
+    static let glyphs: [String] = [
+        "  ::",
+        "    ::::",
+        "      ::::::",
+        "        ::::::",
+        "      ::::::",
+        "    ::::",
+        "  ::",
+    ]
+
+    /// Static text that follows the glyph block on each row. It keeps its own
+    /// colors so only the `::` block animates.
+    func trailer(row: Int) -> String {
+        let g = Self.gradient
+        switch row {
+        case 1:
+            return "              \(g[0].sgr)c\(g[1].sgr)m\(g[2].sgr)u\(g[6].sgr)x\(Self.reset)"
+        case 3:
+            return "        \(taglineColor)the open source terminal\(Self.reset)"
+        case 4:
+            return "          \(taglineColor)built for coding agents\(Self.reset)"
+        default:
+            return ""
+        }
+    }
+
+    /// One logo row with SGR codes and no trailing newline.
+    func row(_ row: Int, frameIndex: Int) -> String {
+        let color = Self.color(row: row, frameIndex: frameIndex)
+        return "\(color.sgr)\(Self.glyphs[row])\(Self.reset)\(trailer(row: row))"
+    }
+
+    /// All `rowCount` rows for `frameIndex`.
+    func rows(frameIndex: Int) -> [String] {
+        (0..<Self.rowCount).map { row($0, frameIndex: frameIndex) }
+    }
+}
+
+/// Repaints the logo in place from a background thread after the welcome
+/// screen has been printed. The main thread owns the lifecycle: it starts the
+/// animator, waits with a bounded deadline, and cancels if the terminal is slow.
+final class WelcomeLogoAnimator {
+    struct Configuration: Equatable {
+        /// Number of animated frames after the static frame 0. A multiple of
+        /// `WelcomeLogoFrameRenderer.cycleLength` ends on the canonical gradient.
+        var frameCount: Int = 2 * WelcomeLogoFrameRenderer.cycleLength
+        var frameInterval: TimeInterval = 0.05
+        /// Rows between the logo's first row and the cursor row, exclusive of
+        /// the cursor row. The cursor must sit on a line below the logo.
+        var linesAboveCursor: Int
+
+        var duration: TimeInterval { Double(frameCount) * frameInterval }
+    }
+
+    /// Thread-safe cancellation flag shared between the main thread and the
+    /// render thread.
+    final class CancellationToken {
+        private let lock = NSLock()
+        private var cancelled = false
+
+        var isCancelled: Bool {
+            lock.lock()
+            defer { lock.unlock() }
+            return cancelled
+        }
+
+        func cancel() {
+            lock.lock()
+            cancelled = true
+            lock.unlock()
+        }
+    }
+
+    /// Handle for a running background animation.
+    final class Handle {
+        private let done = DispatchSemaphore(value: 0)
+        private let token: CancellationToken
+
+        fileprivate init(token: CancellationToken) {
+            self.token = token
+        }
+
+        fileprivate func finish() {
+            done.signal()
+        }
+
+        func cancel() {
+            token.cancel()
+        }
+
+        /// Waits up to `timeout` for the render thread to finish. Returns
+        /// `true` when it finished in time.
+        @discardableResult
+        func wait(timeout: TimeInterval) -> Bool {
+            done.wait(timeout: .now() + timeout) == .success
+        }
+    }
+
+    let renderer: WelcomeLogoFrameRenderer
+    let configuration: Configuration
+
+    init(renderer: WelcomeLogoFrameRenderer, configuration: Configuration) {
+        self.renderer = renderer
+        self.configuration = configuration
+    }
+
+    /// Decides whether the in-place repaint is safe and wanted.
+    ///
+    /// - `isTTY`: stdout is a terminal. Pipes and files get the static frame only.
+    /// - `terminalRows`: rows reported by `TIOCGWINSZ`, or nil when unknown. The
+    ///   whole welcome must fit so the logo's first row is still on screen.
+    /// - Environment: `TERM=dumb`, `NO_COLOR`, `CI`, or `CMUX_WELCOME_ANIMATE=0`
+    ///   disable the animation.
+    static func shouldAnimate(
+        environment: [String: String],
+        isTTY: Bool,
+        terminalRows: Int?,
+        linesAboveCursor: Int
+    ) -> Bool {
+        guard isTTY else { return false }
+        guard let rows = terminalRows, rows >= linesAboveCursor + 1 else { return false }
+        if environment["CMUX_WELCOME_ANIMATE"] == "0" { return false }
+        if let noColor = environment["NO_COLOR"], !noColor.isEmpty { return false }
+        if let ci = environment["CI"], !ci.isEmpty { return false }
+        guard let term = environment["TERM"], !term.isEmpty, term != "dumb" else { return false }
+        return true
+    }
+
+    /// One complete in-place repaint. Every row is positioned from the saved
+    /// cursor so the sequence is self-contained: emit it in a single `write`
+    /// and the terminal is consistent between frames no matter when the
+    /// process exits.
+    static func repaintSequence(rows: [String], linesAboveCursor: Int) -> String {
+        var out = "\u{001B}7"
+        for (index, row) in rows.enumerated() {
+            let up = linesAboveCursor - index
+            out += "\u{001B}8"
+            if up > 0 {
+                out += "\u{001B}[\(up)A"
+            }
+            out += "\r\u{001B}[2K"
+            out += row
+        }
+        out += "\u{001B}8"
+        return out
+    }
+
+    /// Synchronous render loop. `write` receives one complete repaint per call
+    /// and returns `false` to stop (for example on `EPIPE`). `sleep` paces
+    /// frames. The loop always ends by writing the canonical frame unless the
+    /// writer has already failed, so a cancelled animation still leaves the
+    /// static logo on screen.
+    func renderLoop(
+        write: (String) -> Bool,
+        sleep: (TimeInterval) -> Void,
+        isCancelled: () -> Bool
+    ) {
+        var writerAlive = true
+        for frame in 1...max(configuration.frameCount, 1) {
+            if isCancelled() { break }
+            sleep(configuration.frameInterval)
+            if isCancelled() { break }
+            let rows = renderer.rows(frameIndex: frame)
+            let sequence = Self.repaintSequence(rows: rows, linesAboveCursor: configuration.linesAboveCursor)
+            guard write(sequence) else {
+                writerAlive = false
+                break
+            }
+        }
+        guard writerAlive else { return }
+        let finalRows = renderer.rows(frameIndex: 0)
+        _ = write(Self.repaintSequence(rows: finalRows, linesAboveCursor: configuration.linesAboveCursor))
+    }
+
+    /// Starts the render loop on a background thread and returns immediately.
+    func start(
+        write: @escaping (String) -> Bool,
+        sleep: @escaping (TimeInterval) -> Void
+    ) -> Handle {
+        let token = CancellationToken()
+        let handle = Handle(token: token)
+        let thread = Thread { [self] in
+            self.renderLoop(write: write, sleep: sleep, isCancelled: { token.isCancelled })
+            handle.finish()
+        }
+        thread.name = "cmux.welcome.logo-animation"
+        thread.qualityOfService = .userInteractive
+        thread.start()
+        return handle
+    }
+
+    /// Writes all of `text` to `fd`, retrying on `EINTR`/`EAGAIN`. Returns
+    /// `false` on any other error.
+    static func writeAll(fd: Int32, _ text: String) -> Bool {
+        let data = Array(text.utf8)
+        var offset = 0
+        while offset < data.count {
+            let written = data.withUnsafeBufferPointer { buffer -> Int in
+                Darwin.write(fd, buffer.baseAddress! + offset, buffer.count - offset)
+            }
+            if written > 0 {
+                offset += written
+                continue
+            }
+            if written < 0 && (errno == EINTR || errno == EAGAIN) {
+                continue
+            }
+            return false
+        }
+        return true
+    }
+
+    /// Runs the animation on stdout from a background thread and blocks the
+    /// caller until it finishes or the deadline passes. On a slow terminal the
+    /// loop is cancelled; the render thread then paints the canonical frame
+    /// and exits.
+    func runOnStdout() {
+        let handle = start(
+            write: { Self.writeAll(fd: STDOUT_FILENO, $0) },
+            sleep: { Thread.sleep(forTimeInterval: $0) }
+        )
+        let grace: TimeInterval = 1.0
+        if !handle.wait(timeout: configuration.duration + grace) {
+            handle.cancel()
+            handle.wait(timeout: grace)
+        }
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -40347,6 +40347,7 @@ export default CMUXSessionRestore;
           \(subdued)Run \(reset)\(bold)cmux shortcuts\(reset)\(subdued) to edit shortcuts.\(reset)
           \(subdued)Run \(reset)\(bold)cmux feedback\(reset)\(subdued) to report a bug.\(reset)
 
+
         """
 
         let screen = "\n" + logo + "\n" + belowLogo

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5080,6 +5080,7 @@ struct CMUXCLI {
         if command == "vm-pty-connect" { try runVMPtyConnect(commandArgs: commandArgs); return }
         if command == "docs" { try runDocsCommand(commandArgs: commandArgs, jsonOutput: jsonOutput); return }
         if command == "welcome" { printWelcome(); return }
+        if command == WelcomeLogoAnimator.detachedCommand { runWelcomeAnimateHelper(commandArgs: commandArgs); return }
         if command == "sessions" || command == "session-debug" { try runSessionsCommand(commandArgs: command == "session-debug" ? ["debug"] + commandArgs : commandArgs, jsonOutput: jsonOutput, processEnv: processEnv); return }
         if command == "__sigpipe-probe" { try runSIGPIPEProbe(commandArgs: commandArgs); return }
         if command == "__sigpipe-stdin-pipe-probe" { try runSIGPIPEStdinPipeProbe(); return }
@@ -40300,17 +40301,8 @@ export default CMUXSessionRestore;
         }
 
         let isDark = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark"
-
-        let tagline: String
-        let subdued: String
-
-        if isDark {
-            tagline = trueColor(130, 130, 140)
-            subdued = "\u{001B}[2m"
-        } else {
-            tagline = trueColor(90, 90, 98)
-            subdued = trueColor(100, 100, 108)
-        }
+        let tagline = welcomeTaglineColor()
+        let subdued = isDark ? "\u{001B}[2m" : trueColor(100, 100, 108)
 
         let renderer = WelcomeLogoFrameRenderer(taglineColor: tagline)
         let logo = renderer.rows(frameIndex: 0).joined(separator: "\n")
@@ -40370,9 +40362,44 @@ export default CMUXSessionRestore;
             linesAboveCursor: linesAboveCursor
         ) else { return }
 
+        // Preferred: hand the ripple to a detached helper so this process exits
+        // and the shell prompt appears at once. Needs the cursor row (absolute
+        // addressing survives the prompt being printed below the logo) and room
+        // so the prompt cannot scroll the logo.
+        if let terminalRows,
+           let cursorRow = WelcomeLogoAnimator.queryCursorRow(),
+           case .absolute(let topRow)? = WelcomeLogoAnimator.detachedPlacement(
+               cursorRow: cursorRow,
+               linesAboveCursor: linesAboveCursor,
+               terminalRows: terminalRows
+           ),
+           let executablePath = resolvedExecutableURL()?.path,
+           WelcomeLogoAnimator.spawnDetached(executablePath: executablePath, topRow: topRow) {
+            return
+        }
+
+        // Fallback: animate in-process from a render thread while this process
+        // still owns the cursor.
         WelcomeLogoAnimator(
             renderer: renderer,
-            configuration: .init(linesAboveCursor: linesAboveCursor)
+            configuration: .init(placement: .relative(linesAboveCursor: linesAboveCursor))
+        ).runOnStdout()
+    }
+
+    /// Tagline color for the welcome logo, matching the system appearance.
+    private func welcomeTaglineColor() -> String {
+        let isDark = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark"
+        return isDark ? "\u{001B}[38;2;130;130;140m" : "\u{001B}[38;2;90;90;98m"
+    }
+
+    /// `cmux __welcome-animate <topRow>`: detached helper spawned by `cmux welcome`.
+    /// Repaints the logo at absolute rows on the inherited stdout, then exits.
+    private func runWelcomeAnimateHelper(commandArgs: [String]) {
+        guard let first = commandArgs.first, let topRow = Int(first), topRow >= 1 else { return }
+        guard isatty(STDOUT_FILENO) == 1 else { return }
+        WelcomeLogoAnimator(
+            renderer: WelcomeLogoFrameRenderer(taglineColor: welcomeTaglineColor()),
+            configuration: .init(placement: .absolute(topRow: topRow))
         ).runOnStdout()
     }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -40301,14 +40301,6 @@ export default CMUXSessionRestore;
 
         let isDark = UserDefaults.standard.string(forKey: "AppleInterfaceStyle") == "Dark"
 
-        let c1 = trueColor(0, 212, 255)
-        let c2 = trueColor(24, 181, 250)
-        let c3 = trueColor(48, 150, 245)
-        let c4 = trueColor(72, 119, 241)
-        let c5 = trueColor(96, 88, 239)
-        let c6 = trueColor(110, 73, 238)
-        let c7 = trueColor(124, 58, 237)
-
         let tagline: String
         let subdued: String
 
@@ -40320,15 +40312,8 @@ export default CMUXSessionRestore;
             subdued = trueColor(100, 100, 108)
         }
 
-        let logo = """
-        \(c1)  ::\(reset)
-        \(c2)    ::::\(reset)              \(c1)c\(c2)m\(c3)u\(c7)x\(reset)
-        \(c3)      ::::::\(reset)
-        \(c4)        ::::::\(reset)        \(tagline)the open source terminal\(reset)
-        \(c5)      ::::::\(reset)          \(tagline)built for coding agents\(reset)
-        \(c6)    ::::\(reset)
-        \(c7)  ::\(reset)
-        """
+        let renderer = WelcomeLogoFrameRenderer(taglineColor: tagline)
+        let logo = renderer.rows(frameIndex: 0).joined(separator: "\n")
 
         let shortcuts = """
           \(bold)Shortcuts\(reset)
@@ -40347,20 +40332,47 @@ export default CMUXSessionRestore;
           \(bold)\u{2325}\u{2318}U\(reset)\(subdued)                 Toggle unread\(reset)
         """
 
-        print()
-        print(logo)
-        print()
-        print(shortcuts)
-        print()
-        print("  \(bold)Docs\(reset)\(subdued)                https://cmux.com/docs\(reset)")
-        print("  \(bold)Discord\(reset)\(subdued)             https://discord.gg/xsgFEVrWCZ\(reset)")
-        print("  \(bold)GitHub\(reset)\(subdued)              https://github.com/manaflow-ai/cmux (please leave a star ⭐)\(reset)")
-        print("  \(bold)Email\(reset)\(subdued)               founders@manaflow.com\(reset)")
-        print()
-        print("  \(subdued)Run \(reset)\(bold)cmux --help\(reset)\(subdued) for all commands.\(reset)")
-        print("  \(subdued)Run \(reset)\(bold)cmux shortcuts\(reset)\(subdued) to edit shortcuts.\(reset)")
-        print("  \(subdued)Run \(reset)\(bold)cmux feedback\(reset)\(subdued) to report a bug.\(reset)")
-        print()
+        // Everything after the logo's first row, so the animator knows how many
+        // rows the cursor ends up below the logo.
+        let belowLogo = """
+
+        \(shortcuts)
+
+          \(bold)Docs\(reset)\(subdued)                https://cmux.com/docs\(reset)
+          \(bold)Discord\(reset)\(subdued)             https://discord.gg/xsgFEVrWCZ\(reset)
+          \(bold)GitHub\(reset)\(subdued)              https://github.com/manaflow-ai/cmux (please leave a star ⭐)\(reset)
+          \(bold)Email\(reset)\(subdued)               founders@manaflow.com\(reset)
+
+          \(subdued)Run \(reset)\(bold)cmux --help\(reset)\(subdued) for all commands.\(reset)
+          \(subdued)Run \(reset)\(bold)cmux shortcuts\(reset)\(subdued) to edit shortcuts.\(reset)
+          \(subdued)Run \(reset)\(bold)cmux feedback\(reset)\(subdued) to report a bug.\(reset)
+
+        """
+
+        let screen = "\n" + logo + "\n" + belowLogo
+        print(screen, terminator: "")
+        fflush(stdout)
+
+        // Number of rows from the logo's first row down to the cursor row.
+        let linesAboveCursor = (logo + "\n" + belowLogo).reduce(into: 0) { count, character in
+            if character == "\n" { count += 1 }
+        }
+        let isTTY = isatty(STDOUT_FILENO) == 1
+        var size = winsize()
+        let terminalRows: Int? = (isTTY && ioctl(STDOUT_FILENO, TIOCGWINSZ, &size) == 0 && size.ws_row > 0)
+            ? Int(size.ws_row)
+            : nil
+        guard WelcomeLogoAnimator.shouldAnimate(
+            environment: ProcessInfo.processInfo.environment,
+            isTTY: isTTY,
+            terminalRows: terminalRows,
+            linesAboveCursor: linesAboveCursor
+        ) else { return }
+
+        WelcomeLogoAnimator(
+            renderer: renderer,
+            configuration: .init(linesAboveCursor: linesAboveCursor)
+        ).runOnStdout()
     }
 
     private func resolvedVersionInfo() -> [String: String] {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2808,6 +2808,9 @@
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
 		B43AFCE7099305905825EA0A /* VMTunnelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */; };
 		ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A47FAD328D6669A5B40CE3 /* VMTunnelManagerTests.swift */; };
+			E1C0A11A0000000000000002 /* WelcomeLogoAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A11A0000000000000001 /* WelcomeLogoAnimation.swift */; };
+			E1C0A11A0000000000000003 /* WelcomeLogoAnimation.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A11A0000000000000001 /* WelcomeLogoAnimation.swift */; };
+			E1C0A11B0000000000000002 /* WelcomeLogoAnimationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1C0A11B0000000000000001 /* WelcomeLogoAnimationTests.swift */; };
 		A500120C /* WindowAccessor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001222 /* WindowAccessor.swift */; };
 		063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */; };
 		A59170000000000000000001 /* WindowAppearanceSnapshotPaneBackgroundTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A59170000000000000000002 /* WindowAppearanceSnapshotPaneBackgroundTests.swift */; };
@@ -5805,6 +5808,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
 		03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelManager.swift; sourceTree = "<group>"; };
 		74A47FAD328D6669A5B40CE3 /* VMTunnelManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMTunnelManagerTests.swift; sourceTree = "<group>"; };
+			E1C0A11A0000000000000001 /* WelcomeLogoAnimation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeLogoAnimation.swift; sourceTree = "<group>"; };
+			E1C0A11B0000000000000001 /* WelcomeLogoAnimationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeLogoAnimationTests.swift; sourceTree = "<group>"; };
 		A5001222 /* WindowAccessor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAccessor.swift; sourceTree = "<group>"; };
 		BEE83F8394D90ACACD8E19DD /* WindowAndDragTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAndDragTests.swift; sourceTree = "<group>"; };
 		A59170000000000000000002 /* WindowAppearanceSnapshotPaneBackgroundTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowAppearanceSnapshotPaneBackgroundTests.swift; sourceTree = "<group>"; };
@@ -8291,6 +8296,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */,
 				E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */,
 				E60610300000000000000001 /* SSHPTYAttachReconnectInputFilterState.swift */,
+				E1C0A11A0000000000000001 /* WelcomeLogoAnimation.swift */,
 				E60610400000000000000001 /* SSHPTYAttachReconnectInputFilterPumpIO.swift */,
 				C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */,
 				A76110010000000000000002 /* AgentHookNotificationPolicy.swift */,
@@ -8607,6 +8613,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F6357301A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift */,
 				C77070000000000000000007 /* SSHPTYAttachExitCodeClassifierTests.swift */,
 				0C4AD348F196FBBEE52D53A7 /* SSHPTYAttachReconnectInputFilterTests.swift */,
+				E1C0A11B0000000000000001 /* WelcomeLogoAnimationTests.swift */,
 				4F73A5C0BB93507E18261385 /* SSHStartupManualReconnectTests.swift */,
 				797800040000000000000002 /* SSHDeepSleepReattachTests.swift */,
 				8410A0010000000000000001 /* SSHForegroundAuthenticationMarkerCleanupTests.swift */,
@@ -11800,6 +11807,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D0F101000000000000000003 /* TerminalRawMode.swift in Sources */,
 				9009A0029009A0029009A001 /* TmuxCompatLaunchContextError.swift in Sources */,
 				DCFD2C3A4F04C00C62720EE5 /* VMMachineKind.swift in Sources */,
+				E1C0A11A0000000000000002 /* WelcomeLogoAnimation.swift in Sources */,
 				A6AC720A0000000000000001 /* WorkspaceLoadingArguments.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -12573,6 +12581,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C37800000000000000000003 /* VMDefaultCloudCommandTests.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */,
+						E1C0A11A0000000000000003 /* WelcomeLogoAnimation.swift in Sources */,
+						E1C0A11B0000000000000002 /* WelcomeLogoAnimationTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
 				A59170000000000000000001 /* WindowAppearanceSnapshotPaneBackgroundTests.swift in Sources */,
 				F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */,

--- a/cmuxTests/WelcomeLogoAnimationTests.swift
+++ b/cmuxTests/WelcomeLogoAnimationTests.swift
@@ -1,0 +1,187 @@
+import Foundation
+import Testing
+
+@Suite struct WelcomeLogoAnimationTests {
+    private let renderer = WelcomeLogoFrameRenderer(taglineColor: "\u{001B}[38;2;130;130;140m")
+
+    @Test func frameZeroIsTheCanonicalGradient() {
+        let rows = renderer.rows(frameIndex: 0)
+        #expect(rows.count == WelcomeLogoFrameRenderer.rowCount)
+        for (index, row) in rows.enumerated() {
+            #expect(row.hasPrefix(WelcomeLogoFrameRenderer.gradient[index].sgr + WelcomeLogoFrameRenderer.glyphs[index]))
+        }
+        #expect(rows[1].contains("\u{001B}[38;2;0;212;255mc\u{001B}[38;2;24;181;250mm\u{001B}[38;2;48;150;245mu\u{001B}[38;2;124;58;237mx"))
+        #expect(rows[3].contains("the open source terminal"))
+        #expect(rows[4].contains("built for coding agents"))
+    }
+
+    @Test func waveFlowsUpwardAndLoopsWithoutASeam() {
+        let palette = WelcomeLogoFrameRenderer.pingPongPalette
+        #expect(palette.count == 12)
+        #expect(palette.first == WelcomeLogoFrameRenderer.gradient.first)
+        #expect(palette[6] == WelcomeLogoFrameRenderer.gradient.last)
+        #expect(palette.last == WelcomeLogoFrameRenderer.gradient[1])
+
+        // Row 0 at frame 1 takes row 1's frame-0 color.
+        #expect(WelcomeLogoFrameRenderer.color(row: 0, frameIndex: 1) == WelcomeLogoFrameRenderer.color(row: 1, frameIndex: 0))
+        // A full cycle returns to the canonical gradient.
+        let cycle = WelcomeLogoFrameRenderer.cycleLength
+        #expect(renderer.rows(frameIndex: cycle) == renderer.rows(frameIndex: 0))
+        #expect(renderer.rows(frameIndex: 2 * cycle) == renderer.rows(frameIndex: 0))
+        #expect(renderer.rows(frameIndex: 1) != renderer.rows(frameIndex: 0))
+    }
+
+    @Test func staticTextIsIdenticalAcrossFrames() {
+        for frame in 0..<WelcomeLogoFrameRenderer.cycleLength {
+            for row in 0..<WelcomeLogoFrameRenderer.rowCount {
+                #expect(renderer.row(row, frameIndex: frame).hasSuffix(WelcomeLogoFrameRenderer.reset + renderer.trailer(row: row)))
+            }
+        }
+    }
+
+    @Test func repaintSequenceIsSelfContainedRelativeToTheSavedCursor() {
+        let rows = ["A", "B", "C"]
+        let sequence = WelcomeLogoAnimator.repaintSequence(rows: rows, linesAboveCursor: 10)
+        #expect(sequence.hasPrefix("\u{001B}7"))
+        #expect(sequence.hasSuffix("\u{001B}8"))
+        #expect(sequence.contains("\u{001B}8\u{001B}[10A\r\u{001B}[2KA"))
+        #expect(sequence.contains("\u{001B}8\u{001B}[9A\r\u{001B}[2KB"))
+        #expect(sequence.contains("\u{001B}8\u{001B}[8A\r\u{001B}[2KC"))
+        #expect(!sequence.contains("\n"))
+    }
+
+    @Test func shouldAnimateGates() {
+        let base = ["TERM": "xterm-256color"]
+        #expect(WelcomeLogoAnimator.shouldAnimate(environment: base, isTTY: true, terminalRows: 40, linesAboveCursor: 30))
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: base, isTTY: false, terminalRows: 40, linesAboveCursor: 30))
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: base, isTTY: true, terminalRows: nil, linesAboveCursor: 30))
+        // Logo top row scrolled off: 30 lines above the cursor need 31 rows.
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: base, isTTY: true, terminalRows: 30, linesAboveCursor: 30))
+        #expect(WelcomeLogoAnimator.shouldAnimate(environment: base, isTTY: true, terminalRows: 31, linesAboveCursor: 30))
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: ["TERM": "dumb"], isTTY: true, terminalRows: 40, linesAboveCursor: 30))
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: [:], isTTY: true, terminalRows: 40, linesAboveCursor: 30))
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: base.merging(["NO_COLOR": "1"]) { $1 }, isTTY: true, terminalRows: 40, linesAboveCursor: 30))
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: base.merging(["CI": "true"]) { $1 }, isTTY: true, terminalRows: 40, linesAboveCursor: 30))
+        #expect(!WelcomeLogoAnimator.shouldAnimate(environment: base.merging(["CMUX_WELCOME_ANIMATE": "0"]) { $1 }, isTTY: true, terminalRows: 40, linesAboveCursor: 30))
+        #expect(WelcomeLogoAnimator.shouldAnimate(environment: base.merging(["CMUX_WELCOME_ANIMATE": "1"]) { $1 }, isTTY: true, terminalRows: 40, linesAboveCursor: 30))
+    }
+
+    @Test func renderLoopWritesEveryFrameThenTheCanonicalFrame() {
+        let animator = WelcomeLogoAnimator(
+            renderer: renderer,
+            configuration: .init(frameCount: 5, frameInterval: 0.01, linesAboveCursor: 20)
+        )
+        var writes: [String] = []
+        var sleeps: [TimeInterval] = []
+        animator.renderLoop(
+            write: { writes.append($0); return true },
+            sleep: { sleeps.append($0) },
+            isCancelled: { false }
+        )
+        #expect(sleeps == Array(repeating: 0.01, count: 5))
+        #expect(writes.count == 6)
+        for frame in 1...5 {
+            #expect(writes[frame - 1] == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: frame), linesAboveCursor: 20))
+        }
+        #expect(writes.last == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: 0), linesAboveCursor: 20))
+    }
+
+    @Test func cancellationStopsEarlyButStillRestoresTheCanonicalFrame() {
+        let animator = WelcomeLogoAnimator(
+            renderer: renderer,
+            configuration: .init(frameCount: 50, frameInterval: 0.01, linesAboveCursor: 20)
+        )
+        var writes: [String] = []
+        var ticks = 0
+        animator.renderLoop(
+            write: { writes.append($0); return true },
+            sleep: { _ in ticks += 1 },
+            isCancelled: { ticks >= 3 }
+        )
+        #expect(ticks == 3)
+        // Frames 1 and 2 were painted, frame 3 was cancelled after its sleep.
+        #expect(writes.count == 3)
+        #expect(writes.last == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: 0), linesAboveCursor: 20))
+    }
+
+    @Test func writerFailureStopsWithoutFurtherWrites() {
+        let animator = WelcomeLogoAnimator(
+            renderer: renderer,
+            configuration: .init(frameCount: 10, frameInterval: 0.01, linesAboveCursor: 20)
+        )
+        var writes = 0
+        animator.renderLoop(
+            write: { _ in writes += 1; return writes < 2 },
+            sleep: { _ in },
+            isCancelled: { false }
+        )
+        #expect(writes == 2)
+    }
+
+    @Test func startRendersOnABackgroundThreadAndSignalsCompletion() {
+        let animator = WelcomeLogoAnimator(
+            renderer: renderer,
+            configuration: .init(frameCount: 3, frameInterval: 0.001, linesAboveCursor: 20)
+        )
+        let lock = NSLock()
+        var offMainWrites = 0
+        var totalWrites = 0
+        let handle = animator.start(
+            write: { _ in
+                lock.lock()
+                defer { lock.unlock() }
+                totalWrites += 1
+                if !Thread.isMainThread { offMainWrites += 1 }
+                return true
+            },
+            sleep: { Thread.sleep(forTimeInterval: $0) }
+        )
+        #expect(handle.wait(timeout: 5))
+        lock.lock()
+        defer { lock.unlock() }
+        #expect(totalWrites == 4)
+        #expect(offMainWrites == 4)
+    }
+
+    @Test func handleCancelStopsARunningAnimation() {
+        let animator = WelcomeLogoAnimator(
+            renderer: renderer,
+            configuration: .init(frameCount: 10_000, frameInterval: 0.001, linesAboveCursor: 20)
+        )
+        let lock = NSLock()
+        var writes = 0
+        let handle = animator.start(
+            write: { _ in
+                lock.lock()
+                writes += 1
+                lock.unlock()
+                return true
+            },
+            sleep: { Thread.sleep(forTimeInterval: $0) }
+        )
+        #expect(!handle.wait(timeout: 0.05))
+        handle.cancel()
+        #expect(handle.wait(timeout: 5))
+        lock.lock()
+        defer { lock.unlock() }
+        #expect(writes < 10_001)
+        #expect(writes >= 1)
+    }
+
+    @Test func writeAllWritesTheWholeStringToAPipe() throws {
+        var fds = [Int32](repeating: -1, count: 2)
+        #expect(pipe(&fds) == 0)
+        defer { close(fds[0]) }
+        let text = String(repeating: "x", count: 4096) + "\u{001B}[0m"
+        #expect(WelcomeLogoAnimator.writeAll(fd: fds[1], text))
+        close(fds[1])
+        var buffer = [UInt8](repeating: 0, count: 8192)
+        var received = Data()
+        while true {
+            let count = read(fds[0], &buffer, buffer.count)
+            if count <= 0 { break }
+            received.append(buffer, count: count)
+        }
+        #expect(received == Data(text.utf8))
+    }
+}

--- a/cmuxTests/WelcomeLogoAnimationTests.swift
+++ b/cmuxTests/WelcomeLogoAnimationTests.swift
@@ -8,46 +8,81 @@ import Testing
         let rows = renderer.rows(frameIndex: 0)
         #expect(rows.count == WelcomeLogoFrameRenderer.rowCount)
         for (index, row) in rows.enumerated() {
-            #expect(row.hasPrefix(WelcomeLogoFrameRenderer.gradient[index].sgr + WelcomeLogoFrameRenderer.glyphs[index]))
+            // One SGR, then the indented glyphs, exactly like the original static logo.
+            #expect(row.hasPrefix(WelcomeLogoFrameRenderer.gradient[index].sgr + WelcomeLogoFrameRenderer.glyphs[index] + WelcomeLogoFrameRenderer.reset))
         }
+        #expect(WelcomeLogoFrameRenderer.glyphs == ["  ::", "    ::::", "      ::::::", "        ::::::", "      ::::::", "    ::::", "  ::"])
         #expect(rows[1].contains("\u{001B}[38;2;0;212;255mc\u{001B}[38;2;24;181;250mm\u{001B}[38;2;48;150;245mu\u{001B}[38;2;124;58;237mx"))
         #expect(rows[3].contains("the open source terminal"))
         #expect(rows[4].contains("built for coding agents"))
     }
 
-    @Test func waveFlowsUpwardAndLoopsWithoutASeam() {
+    @Test func pulseTravelsLeftToRightAndLeavesTheLogoCanonical() {
+        let frames = WelcomeLogoFrameRenderer.frameCount
+        #expect(frames > 0)
+        #expect(renderer.rows(frameIndex: frames) == renderer.rows(frameIndex: 0))
+        #expect(renderer.rows(frameIndex: frames + 5) == renderer.rows(frameIndex: 0))
+
+        // Column 1 (row 0's single pair) is disturbed before column 6 (row 3's last pair).
+        func firstShiftedFrame(column: Int) -> Int? {
+            (1..<frames).first { WelcomeLogoFrameRenderer.paletteShift(pairColumn: column, frameIndex: $0) > 0 }
+        }
+        let leftStart = firstShiftedFrame(column: 1)
+        let rightStart = firstShiftedFrame(column: 6)
+        #expect(leftStart != nil && rightStart != nil)
+        #expect(leftStart! < rightStart!)
+
+        // At the pulse center the shift peaks at pulseWidth and falls off with distance.
+        let centerFrame = Int((Double(3 + WelcomeLogoFrameRenderer.pulseWidth) / WelcomeLogoFrameRenderer.pulseSpeed).rounded())
+        #expect(WelcomeLogoFrameRenderer.paletteShift(pairColumn: 3, frameIndex: centerFrame) == WelcomeLogoFrameRenderer.pulseWidth)
+        #expect(WelcomeLogoFrameRenderer.paletteShift(pairColumn: 5, frameIndex: centerFrame) == WelcomeLogoFrameRenderer.pulseWidth - 2)
+        #expect(WelcomeLogoFrameRenderer.paletteShift(pairColumn: 3 + WelcomeLogoFrameRenderer.pulseWidth, frameIndex: centerFrame) == 0)
+
+        // Every animated frame differs from the canonical one while the pulse is inside the logo.
+        #expect(renderer.rows(frameIndex: centerFrame) != renderer.rows(frameIndex: 0))
+    }
+
+    @Test func pingPongPaletteHasNoSeam() {
         let palette = WelcomeLogoFrameRenderer.pingPongPalette
         #expect(palette.count == 12)
         #expect(palette.first == WelcomeLogoFrameRenderer.gradient.first)
         #expect(palette[6] == WelcomeLogoFrameRenderer.gradient.last)
         #expect(palette.last == WelcomeLogoFrameRenderer.gradient[1])
+    }
 
-        // Row 0 at frame 1 takes row 1's frame-0 color.
-        #expect(WelcomeLogoFrameRenderer.color(row: 0, frameIndex: 1) == WelcomeLogoFrameRenderer.color(row: 1, frameIndex: 0))
-        // A full cycle returns to the canonical gradient.
-        let cycle = WelcomeLogoFrameRenderer.cycleLength
-        #expect(renderer.rows(frameIndex: cycle) == renderer.rows(frameIndex: 0))
-        #expect(renderer.rows(frameIndex: 2 * cycle) == renderer.rows(frameIndex: 0))
-        #expect(renderer.rows(frameIndex: 1) != renderer.rows(frameIndex: 0))
+    @Test func pairsInOneRowCanCarryDifferentColors() {
+        // Mid-pulse, row 2's three pairs sit at different distances from the center.
+        let centerFrame = Int((Double(3 + WelcomeLogoFrameRenderer.pulseWidth) / WelcomeLogoFrameRenderer.pulseSpeed).rounded())
+        let row = renderer.row(2, frameIndex: centerFrame)
+        let sgrCount = row.components(separatedBy: "\u{001B}[38;2;").count - 1
+        #expect(sgrCount == 3)
+        #expect(row.hasPrefix("\u{001B}[38;2;"))
+        #expect(row.hasSuffix(WelcomeLogoFrameRenderer.reset + renderer.trailer(row: 2)))
+        // Indent stays after the first SGR and before the first pair.
+        #expect(row.contains("m      ::"))
     }
 
     @Test func staticTextIsIdenticalAcrossFrames() {
-        for frame in 0..<WelcomeLogoFrameRenderer.cycleLength {
+        for frame in 0...WelcomeLogoFrameRenderer.frameCount {
             for row in 0..<WelcomeLogoFrameRenderer.rowCount {
                 #expect(renderer.row(row, frameIndex: frame).hasSuffix(WelcomeLogoFrameRenderer.reset + renderer.trailer(row: row)))
             }
         }
     }
 
-    @Test func repaintSequenceIsSelfContainedRelativeToTheSavedCursor() {
-        let rows = ["A", "B", "C"]
-        let sequence = WelcomeLogoAnimator.repaintSequence(rows: rows, linesAboveCursor: 10)
+    @Test func relativeRepaintSequenceIsSelfContainedRelativeToTheSavedCursor() {
+        let sequence = WelcomeLogoAnimator.repaintSequence(rows: ["A", "B", "C"], placement: .relative(linesAboveCursor: 10))
         #expect(sequence.hasPrefix("\u{001B}7"))
         #expect(sequence.hasSuffix("\u{001B}8"))
         #expect(sequence.contains("\u{001B}8\u{001B}[10A\r\u{001B}[2KA"))
         #expect(sequence.contains("\u{001B}8\u{001B}[9A\r\u{001B}[2KB"))
         #expect(sequence.contains("\u{001B}8\u{001B}[8A\r\u{001B}[2KC"))
         #expect(!sequence.contains("\n"))
+    }
+
+    @Test func absoluteRepaintSequenceAddressesRowsAndRestoresTheCursor() {
+        let sequence = WelcomeLogoAnimator.repaintSequence(rows: ["A", "B", "C"], placement: .absolute(topRow: 4))
+        #expect(sequence == "\u{001B}7\u{001B}[4;1H\u{001B}[2KA\u{001B}[5;1H\u{001B}[2KB\u{001B}[6;1H\u{001B}[2KC\u{001B}8")
     }
 
     @Test func shouldAnimateGates() {
@@ -66,10 +101,47 @@ import Testing
         #expect(WelcomeLogoAnimator.shouldAnimate(environment: base.merging(["CMUX_WELCOME_ANIMATE": "1"]) { $1 }, isTTY: true, terminalRows: 40, linesAboveCursor: 30))
     }
 
+    @Test func detachedPlacementNeedsRoomBelowTheCursor() {
+        // Cursor on row 40 of 50 with the logo starting 32 rows up.
+        #expect(WelcomeLogoAnimator.detachedPlacement(cursorRow: 40, linesAboveCursor: 32, terminalRows: 50) == .absolute(topRow: 8))
+        // Exactly at the scroll margin is still fine.
+        #expect(WelcomeLogoAnimator.detachedPlacement(cursorRow: 48, linesAboveCursor: 32, terminalRows: 50) == .absolute(topRow: 16))
+        // A prompt newline could scroll the logo: refuse.
+        #expect(WelcomeLogoAnimator.detachedPlacement(cursorRow: 49, linesAboveCursor: 32, terminalRows: 50) == nil)
+        #expect(WelcomeLogoAnimator.detachedPlacement(cursorRow: 50, linesAboveCursor: 32, terminalRows: 50) == nil)
+        // Logo top above the screen: refuse.
+        #expect(WelcomeLogoAnimator.detachedPlacement(cursorRow: 20, linesAboveCursor: 32, terminalRows: 50) == nil)
+    }
+
+    @Test func parsesCursorPositionReports() {
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("\u{001B}[34;1R".utf8)) == 34)
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("\u{001B}[7;120R".utf8)) == 7)
+        // Typeahead before the report is ignored.
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("ls\u{001B}[12;1R".utf8)) == 12)
+        // Incomplete reports are not a result yet.
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("\u{001B}[12;".utf8)) == nil)
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("\u{001B}[12;1".utf8)) == nil)
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("\u{001B}[".utf8)) == nil)
+        // Other CSI sequences are not reports.
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("\u{001B}[1;1H".utf8)) == nil)
+        #expect(WelcomeLogoAnimator.parseCursorReportRow(Array("\u{001B}[?1;2c".utf8)) == nil)
+    }
+
+    @Test func queryCursorRowReturnsNilWithoutATerminal() {
+        var fds = [Int32](repeating: -1, count: 2)
+        #expect(pipe(&fds) == 0)
+        defer {
+            close(fds[0])
+            close(fds[1])
+        }
+        #expect(WelcomeLogoAnimator.queryCursorRow(inputFD: fds[0], outputFD: fds[1], timeout: 0.05) == nil)
+    }
+
     @Test func renderLoopWritesEveryFrameThenTheCanonicalFrame() {
+        let placement = WelcomeLogoAnimator.Placement.relative(linesAboveCursor: 20)
         let animator = WelcomeLogoAnimator(
             renderer: renderer,
-            configuration: .init(frameCount: 5, frameInterval: 0.01, linesAboveCursor: 20)
+            configuration: .init(frameCount: 5, frameInterval: 0.01, placement: placement)
         )
         var writes: [String] = []
         var sleeps: [TimeInterval] = []
@@ -81,15 +153,24 @@ import Testing
         #expect(sleeps == Array(repeating: 0.01, count: 5))
         #expect(writes.count == 6)
         for frame in 1...5 {
-            #expect(writes[frame - 1] == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: frame), linesAboveCursor: 20))
+            #expect(writes[frame - 1] == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: frame), placement: placement))
         }
-        #expect(writes.last == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: 0), linesAboveCursor: 20))
+        #expect(writes.last == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: 0), placement: placement))
+    }
+
+    @Test func defaultConfigurationEndsOnTheCanonicalFrame() {
+        let configuration = WelcomeLogoAnimator.Configuration(placement: .absolute(topRow: 3))
+        #expect(configuration.frameCount == WelcomeLogoFrameRenderer.frameCount - 1)
+        #expect(configuration.duration < 1.5)
+        // The frame after the last animated one is canonical, so the final paint is seamless.
+        #expect(renderer.rows(frameIndex: configuration.frameCount + 1) == renderer.rows(frameIndex: 0))
     }
 
     @Test func cancellationStopsEarlyButStillRestoresTheCanonicalFrame() {
+        let placement = WelcomeLogoAnimator.Placement.absolute(topRow: 5)
         let animator = WelcomeLogoAnimator(
             renderer: renderer,
-            configuration: .init(frameCount: 50, frameInterval: 0.01, linesAboveCursor: 20)
+            configuration: .init(frameCount: 50, frameInterval: 0.01, placement: placement)
         )
         var writes: [String] = []
         var ticks = 0
@@ -101,13 +182,13 @@ import Testing
         #expect(ticks == 3)
         // Frames 1 and 2 were painted, frame 3 was cancelled after its sleep.
         #expect(writes.count == 3)
-        #expect(writes.last == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: 0), linesAboveCursor: 20))
+        #expect(writes.last == WelcomeLogoAnimator.repaintSequence(rows: renderer.rows(frameIndex: 0), placement: placement))
     }
 
     @Test func writerFailureStopsWithoutFurtherWrites() {
         let animator = WelcomeLogoAnimator(
             renderer: renderer,
-            configuration: .init(frameCount: 10, frameInterval: 0.01, linesAboveCursor: 20)
+            configuration: .init(frameCount: 10, frameInterval: 0.01, placement: .relative(linesAboveCursor: 20))
         )
         var writes = 0
         animator.renderLoop(
@@ -121,7 +202,7 @@ import Testing
     @Test func startRendersOnABackgroundThreadAndSignalsCompletion() {
         let animator = WelcomeLogoAnimator(
             renderer: renderer,
-            configuration: .init(frameCount: 3, frameInterval: 0.001, linesAboveCursor: 20)
+            configuration: .init(frameCount: 3, frameInterval: 0.001, placement: .relative(linesAboveCursor: 20))
         )
         let lock = NSLock()
         var offMainWrites = 0
@@ -146,7 +227,7 @@ import Testing
     @Test func handleCancelStopsARunningAnimation() {
         let animator = WelcomeLogoAnimator(
             renderer: renderer,
-            configuration: .init(frameCount: 10_000, frameInterval: 0.001, linesAboveCursor: 20)
+            configuration: .init(frameCount: 10_000, frameInterval: 0.001, placement: .relative(linesAboveCursor: 20))
         )
         let lock = NSLock()
         var writes = 0


### PR DESCRIPTION
`cmux welcome` prints the static screen, then animates the `::` logo in place without holding up the shell prompt.

Prompt first. After printing, the CLI asks the terminal for the cursor row (`DSR 6`), spawns `cmux __welcome-animate <topRow>` in its own session with stdout inherited, and exits. The shell prints its prompt immediately while the helper repaints the logo at absolute rows above it for about 1 s. The helper is refused when the cursor report does not arrive within 250 ms or when fewer than two spare rows remain below the cursor (a prompt newline could scroll the logo); then the CLI falls back to animating in-process from a render thread while it still owns the cursor.

Effect. A pulse enters from the left, shifts every `::` pair it covers along a 12-step cyan → purple → cyan ping-pong palette by an amount that peaks at the pulse center, and leaves on the right. 35 frames at 30 ms, ending on the canonical gradient. Each frame is one self-contained `write(2)`: save cursor, address each row (absolute `CSI row;1H` or relative `CSI nA` from the saved cursor), clear and rewrite, restore cursor. The terminal is consistent between frames whenever the process exits, and the cursor never moves from the user's point of view.

Skipped when stdout is not a TTY, `TERM` is unset or `dumb`, `NO_COLOR` or `CI` is set, `CMUX_WELCOME_ANIMATE=0`, or the terminal has too few rows to keep the logo's first row on screen. The static output is byte-identical to before.

Known limits. If the user runs a command whose output scrolls the screen during the ~1 s ripple, the remaining frames land on the wrong rows. Typeahead bytes that arrive before the cursor report are consumed by the query.

`WelcomeLogoFrameRenderer` (pure frame bytes) and `WelcomeLogoAnimator` (repaint sequences, gating, cursor report parsing and query, render loop with injected write/sleep/cancel, background thread handle, detached spawn) live in `CLI/WelcomeLogoAnimation.swift`, covered by `cmuxTests/WelcomeLogoAnimationTests`.

The cloud VM zshrc welcome (hardcoded `printf` lines in `freestyleInteractiveShellScript`) is unchanged.