### PR TITLE
fix(relay): reap cancelled grep children

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2383,6 +2383,49 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn cancelled_grep_reaps_child_before_releasing_capacity() {
+        let root = scratch("grep-cancel");
+        let bin = root.join("bin");
+        std::fs::create_dir(&bin).unwrap();
+        let grep = bin.join("grep");
+        std::fs::write(
+            &grep,
+            "#!/bin/sh\n: > \"$CMUX_GREP_STARTED\"\ntrap 'exit 0' TERM INT HUP\nwhile :; do sleep 1; done\n",
+        )
+        .unwrap();
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(&grep, std::fs::Permissions::from_mode(0o755)).unwrap();
+        let started = root.join("started");
+        let roots = vec![root.display().to_string()];
+        let mut context = ctx("supervised", Some(roots.clone()), root.clone());
+        context.env = HashMap::from([
+            ("PATH".to_owned(), format!("{}:/bin:/usr/bin", bin.display())),
+            ("CMUX_GREP_STARTED".to_owned(), started.display().to_string()),
+        ]);
+        let frame = json!({ "verb": "grep", "actionId": "grep-cancel", "allowedRoots": roots,
+                            "args": { "path": ".", "pattern": "needle" }, "timeoutMs": 10000 });
+        let action = Box::pin(perform_action(&frame, &context));
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while !started.exists() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("grep child must start");
+        assert_eq!(context.file_slots.available_permits(), MAX_BLOCKING_FILE_ACTIONS - 1);
+        drop(action);
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while context.file_slots.available_permits() != MAX_BLOCKING_FILE_ACTIONS {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled grep must reap its child before releasing capacity");
+        std::fs::remove_dir_all(&root).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn symlinks_cannot_escape_allowed_roots() {
         let root = scratch("symlink");
         let outside = scratch("outside");

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -981,6 +981,16 @@ enum RunOutcome {
     Failed { message: String },
 }
 
+struct CancelOnDrop(Option<tokio_util::sync::CancellationToken>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if let Some(token) = self.0.take() {
+            token.cancel();
+        }
+    }
+}
+
 #[cfg(unix)]
 struct ProcessGroupGuard {
     pid: Option<u32>,
@@ -1010,6 +1020,7 @@ async fn run_spec(
     cwd_fd: Option<ScopedCwdFd>,
     timeout_ms: u64,
     env: &HashMap<String, String>,
+    cancellation: Option<tokio_util::sync::CancellationToken>,
 ) -> RunOutcome {
     use tokio::io::AsyncReadExt as _;
     let mut command = match &spec {
@@ -1082,6 +1093,7 @@ async fn run_spec(
     let mut stderr = child.stderr.take();
     let mut output: Vec<u8> = Vec::new();
     let mut timed_out = false;
+    let mut cancelled = false;
     let deadline = tokio::time::sleep(std::time::Duration::from_millis(timeout_ms));
     tokio::pin!(deadline);
     let mut stdout_buf = [0_u8; 8_192];
@@ -1105,6 +1117,23 @@ async fn run_spec(
             break;
         }
         tokio::select! {
+            () = async {
+                match cancellation.as_ref() {
+                    Some(token) => token.cancelled().await,
+                    None => std::future::pending().await,
+                }
+            }, if !cancelled => {
+                cancelled = true;
+                #[cfg(unix)]
+                if !signal_process_tree(pid, false) {
+                    let _ = child.start_kill();
+                }
+                #[cfg(not(unix))]
+                signal_process_tree(pid, false);
+                kill_deadline = Some(Box::pin(tokio::time::sleep(
+                    std::time::Duration::from_millis(250),
+                )));
+            }
             read = async {
                 match stdout.as_mut() {
                     Some(stream) => stream.read(&mut stdout_buf).await,
@@ -1259,6 +1288,9 @@ async fn run_spec(
     }
     if timed_out {
         return RunOutcome::TimedOut;
+    }
+    if cancelled {
+        return RunOutcome::Failed { message: "process cancelled".to_owned() };
     }
     let text = String::from_utf8_lossy(&output);
     RunOutcome::Done { exit_code: exited.unwrap_or(0), output: text.into_owned() }
@@ -1789,7 +1821,9 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             };
             #[cfg(not(unix))]
             let command_cwd_fd = None;
-            let outcome = tokio::spawn(async move {
+            let grep_cancellation = tokio_util::sync::CancellationToken::new();
+            let mut cancel_on_drop = CancelOnDrop(Some(grep_cancellation.clone()));
+            let grep_task = tokio::spawn(async move {
                 let _file_permit = file_permit;
                 #[cfg(unix)]
                 let _path_guard = _path_guard;
@@ -1812,11 +1846,14 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                     command_cwd_fd,
                     timeout_ms,
                     &env,
+                    Some(grep_cancellation),
                 )
                 .await
-            })
-            .await
-            .unwrap_or(RunOutcome::Failed { message: "process failed to start".to_owned() });
+            });
+            let outcome = grep_task
+                .await
+                .unwrap_or(RunOutcome::Failed { message: "process failed to start".to_owned() });
+            cancel_on_drop.0 = None;
             run_reply(version, &action_id, outcome, args.get("limit"), Some(200), timeout_ms)
         }
         "find" => {
@@ -1886,6 +1923,7 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                 command_cwd_fd,
                 timeout_ms,
                 &env,
+                None,
             )
             .await;
             run_reply(version, &action_id, outcome, args.get("limit"), Some(500), timeout_ms)
@@ -1927,6 +1965,7 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                 scoped_cwd_fd,
                 timeout_ms,
                 &env,
+                None,
             )
             .await;
             run_reply(version, &action_id, outcome, None, None, timeout_ms)
@@ -2530,7 +2569,7 @@ mod tests {
         let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
         let outcome = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env),
+            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env, None),
         )
         .await
         .expect("timeout cleanup must not wait for a descendant pipe");


### PR DESCRIPTION
Follow-up to #11568.

When a connection cancels a grep request, keep the shared file-action permit and descriptor guards owned by the child task. Propagate cancellation into the bounded process runner, terminate the process group, wait for cleanup, then release capacity. Add a deterministic regression test proving capacity is restored only after child cleanup.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11629"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790934600&installation_model_id=21920&pr_number=11629&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11629&signature=fe69b60a6b0418be54f16d7f197d67f5a841710dae5fe1dc1ebbc1c2bbfeee94"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cancelled relay file actions (grep, find, exec) so child processes are terminated and reaped instead of running until timeout.

**Bug Fixes**

- Cancellation fires when the action task is dropped or aborted, and cancelled runs report `process cancelled`.
- Capacity and descriptor guards stay held until the child is reaped.
- On Unix, signals the process group first with fallback to the direct child; on Windows, waits on the job handle and kills the child directly when assignment fails.
- A detached reaper quarantines failed waits, retries up to three times, then runs a bounded blocking wait.
- Adds a Unix regression test proving the grep child is gone before capacity is restored.

<sup>Written for commit 47eceb64ce65006b96b6e7a64ef3f7077814110b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11629?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cancellation handling for grep, find, and exec operations.
  - Cancelled operations now terminate associated processes more reliably, including fallback termination when needed.
  - Child processes are reaped before related resources are released.
  - Cancelled runs now report a clear “process cancelled” failure message.
  - Added bounded cleanup to prevent cancelled operations from waiting indefinitely or leaving background work running.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->