### PR TITLE
perf(cmux-tui): resolve resource selectors without the registry lock

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2007,6 +2007,7 @@ pub struct Mux {
     /// registry, then state.
     workspace_registry: SignaledMutex<WorkspaceRegistry>,
     session_public_id: SessionPublicId,
+    machine_public_id: crate::resource::MachinePublicId,
     state: Mutex<State>,
     subscribers: MuxEventBroadcaster,
     config_reload: Mutex<ConfigReloadState>,
@@ -2182,14 +2183,16 @@ impl Mux {
         target: crate::ResourceTarget,
         selectors: &crate::ResourceSelectors,
     ) -> Result<crate::ResolvedResourcePath, ResourceError> {
-        let registry = self.workspace_registry.lock().unwrap();
+        // Session and machine identity never change for the life of a mux, so
+        // selector resolution must not queue behind the registry mutex, which
+        // the journal writer holds across every fsync.
         let state = self.state.lock().unwrap();
         resolve_resource_selectors(
             &state,
             ResourceSelectorContext {
-                machine_id: registry.machine_id(),
+                machine_id: &self.machine_public_id,
                 machine_name: None,
-                session_id: registry.session_id(),
+                session_id: &self.session_public_id,
                 session_name: &self.session,
             },
             target,
@@ -2373,6 +2376,7 @@ impl Mux {
         } = restore_public_projections(&state, registry.public_projections()?)?;
         let journal_producers = registry.journal_producer_manifests()?;
         let session_public_id = registry.session_id().clone();
+        let machine_public_id = registry.machine_id().clone();
         let journal_kernel = crate::journal_kernel::JournalKernel::new(
             registry.session_journal_database_path(),
             &journal_producers,
@@ -2386,6 +2390,7 @@ impl Mux {
         let mux = Arc::new(Mux {
             workspace_registry: SignaledMutex::new(registry),
             session_public_id,
+            machine_public_id,
             state: Mutex::new(state),
             subscribers: MuxEventBroadcaster::default(),
             config_reload: Mutex::new(ConfigReloadState::default()),


### PR DESCRIPTION
Every resource request first resolved its session path under the workspace registry mutex, only to read the machine and session ids. The journal writer holds that mutex across each fullfsync, so with many agents firing hooks at once every connection thread queued behind the writer before it could enqueue its event, batches stayed tiny, and throughput plateaued near 45 events/s with connection timeouts at 96 clients.

Both ids are fixed for the life of a mux. This caches the machine id next to the already cached session id and resolves selectors under the state lock only. No change to durability or commit ordering.

Measured on a headless daemon with 16 live terminals so every hook also commits its projection (dev build, same Mac, blocking helper so the number is server latency):

| clients | main p50 | PR p50 | main throughput | PR throughput |
| --- | --- | --- | --- | --- |
| 1 | 32 ms | 35 ms | 29/s | 28/s |
| 16 | 307 ms | 185 ms | 43/s | 75/s |
| 48 | 1174 ms | 621 ms | 32/s | 59/s |

Timeouts at 48 clients: 2 on main, 0 here. The remaining ceiling is the per-event projection commit, which still pays its own fullfsync under the registry lock; folding it into the writer batch is a separate change.

https://claude.ai/code/session_01QLoqLLRPs23FHHYTjzrzqb

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11630"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790934677&installation_model_id=21920&pr_number=11630&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11630&signature=4d447921be0e1ce4869785144621e86f3d7c101e2af3db1cee42c9e400c2c388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resource selector resolution no longer waits on the workspace registry mutex; it uses cached machine and session IDs under the state lock instead. This lets requests enqueue while the journal writer performs fullfsyncs, improving concurrent hook latency and throughput without changing durability or commit ordering.

**Performance**

- With 16 clients, p50 latency fell from 307 ms to 185 ms and throughput increased from 43 to 75 events/s.
- With 48 clients, p50 latency fell from 1174 ms to 621 ms and throughput increased from 32 to 59 events/s, with no timeouts.
- Per-event projection commits remain a separate bottleneck because they still perform fullfsyncs under the registry lock.

<sup>Written for commit 586a2a68a252d1d2f687e55168f51de2ca7618ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11630?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

