### PR TITLE
Test and bound Cloud client bootstrap retries

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -127992,40 +127992,6 @@
         }
       }
     },
-    "machines.notConfigured.subtitle": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Restart cmux. If this continues, reinstall or update the app."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "cmux を再起動してください。問題が続く場合は、アプリを再インストールまたはアップデートしてください。"
-          }
-        }
-      }
-    },
-    "machines.notConfigured.title": {
-      "extractionState": "manual",
-      "localizations": {
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "Cloud is not configured"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "クラウドが設定されていません"
-          }
-        }
-      }
-    },
     "machines.unavailable.stale": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -127992,6 +127992,40 @@
         }
       }
     },
+    "machines.notConfigured.subtitle": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Restart cmux. If this continues, reinstall or update the app."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux を再起動してください。問題が続く場合は、アプリを再インストールまたはアップデートしてください。"
+          }
+        }
+      }
+    },
+    "machines.notConfigured.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud is not configured"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドが設定されていません"
+          }
+        }
+      }
+    },
     "machines.unavailable.stale": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -127975,6 +127975,23 @@
         }
       }
     },
+    "machines.loading.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading Cloud Machines…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドマシンを読み込み中…"
+          }
+        }
+      }
+    },
     "machines.unavailable.stale": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -466,8 +466,6 @@ struct MachinesPanelView: View {
                     sessionRejectedState
                 case .requiresPro:
                     requiresProState
-                case .notConfigured:
-                    notConfiguredState
                 case .unreachable:
                     unreachableState
                 }
@@ -529,25 +527,6 @@ struct MachinesPanelView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("CloudMachinesEmptyState")
-    }
-
-    @ViewBuilder
-    private var notConfiguredState: some View {
-        Image(systemName: "exclamationmark.cloud")
-            .font(.system(size: 26, weight: .light))
-            .foregroundColor(.secondary.opacity(0.55))
-        Text(String(localized: "machines.notConfigured.title", defaultValue: "Cloud is not configured"))
-            .cmuxFont(size: 13, weight: .semibold)
-            .foregroundColor(.primary.opacity(0.85))
-        Text(String(
-            localized: "machines.notConfigured.subtitle",
-            defaultValue: "Restart cmux. If this continues, reinstall or update the app."
-        ))
-        .cmuxFont(size: 12)
-        .foregroundColor(.secondary)
-        .multilineTextAlignment(.center)
-        .padding(.horizontal, 24)
-        .accessibilityIdentifier("CloudMachinesNotConfiguredView")
     }
 
     /// Free plans: "Upgrade to use more than 1 machine" — the ceiling plus the

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -466,6 +466,8 @@ struct MachinesPanelView: View {
                     sessionRejectedState
                 case .requiresPro:
                     requiresProState
+                case .notConfigured:
+                    notConfiguredState
                 case .unreachable:
                     unreachableState
                 }
@@ -527,6 +529,25 @@ struct MachinesPanelView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .accessibilityIdentifier("CloudMachinesEmptyState")
+    }
+
+    @ViewBuilder
+    private var notConfiguredState: some View {
+        Image(systemName: "exclamationmark.cloud")
+            .font(.system(size: 26, weight: .light))
+            .foregroundColor(.secondary.opacity(0.55))
+        Text(String(localized: "machines.notConfigured.title", defaultValue: "Cloud is not configured"))
+            .cmuxFont(size: 13, weight: .semibold)
+            .foregroundColor(.primary.opacity(0.85))
+        Text(String(
+            localized: "machines.notConfigured.subtitle",
+            defaultValue: "Restart cmux. If this continues, reinstall or update the app."
+        ))
+        .cmuxFont(size: 12)
+        .foregroundColor(.secondary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 24)
+        .accessibilityIdentifier("CloudMachinesNotConfiguredView")
     }
 
     /// Free plans: "Upgrade to use more than 1 machine" — the ceiling plus the

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -511,8 +511,17 @@ struct MachinesPanelView: View {
                         .foregroundColor(.secondary.opacity(0.7))
                 }
             } else {
-                ProgressView()
-                    .controlSize(.small)
+                VStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(String(
+                        localized: "machines.loading.title",
+                        defaultValue: "Loading Cloud Machines…"
+                    ))
+                    .cmuxFont(size: 13)
+                    .foregroundColor(.secondary)
+                }
+                .accessibilityIdentifier("CloudMachinesLoadingState")
             }
             Spacer()
         }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -330,24 +330,6 @@ enum MachineSnapshotBuilder {
 /// through this store.
 @MainActor
 final class MachinesPanelViewModel: ObservableObject {
-    /// Retries a short-lived Cloud client bootstrap race without an unbounded loop.
-    struct CloudClientBootstrapRetry {
-        let maxRetries: Int
-
-        init(maxRetries: Int) {
-            self.maxRetries = max(0, maxRetries)
-        }
-
-        func run(attempt: () async -> Bool) async -> Bool {
-            for retry in 0...maxRetries {
-                if await attempt() { return true }
-                guard !Task.isCancelled, retry < maxRetries else { return false }
-                await Task.yield()
-            }
-            return false
-        }
-    }
-
     @Published private(set) var machines: [MachineSnapshot] = []
     @Published private(set) var plan: MachinePlanSnapshot?
     @Published private(set) var isLoading = false
@@ -592,7 +574,6 @@ final class MachinesPanelViewModel: ObservableObject {
     /// real machine now, not on the next 45 s sweep.
     private var refreshRequestedWhileLoading = false
     private var refreshGeneration = 0
-    private static let maxClientBootstrapRetries = 3
 
     func refresh() {
         guard refreshTask == nil else {
@@ -612,23 +593,7 @@ final class MachinesPanelViewModel: ObservableObject {
                     }
                 }
             }
-            let loaded = await CloudClientBootstrapRetry(maxRetries: Self.maxClientBootstrapRetries).run { [weak self] in
-                guard !Task.isCancelled, let self else { return true }
-                return await self.performRefresh()
-            }
-            guard !Task.isCancelled, let self else { return }
-            if !loaded {
-                // A bounded bootstrap timeout is still a transient readiness
-                // failure. Keep the retry-first state so a slow, valid setup
-                // is never reported as permanently misconfigured.
-                self.lastErrorDescription = String(
-                    localized: "machines.unavailable.title",
-                    defaultValue: "Cloud is unreachable"
-                )
-                self.listProblem = .unreachable
-                self.isLoading = false
-                self.hasLoadedOnce = true
-            }
+            await self?.performRefresh()
         }
     }
 
@@ -686,6 +651,7 @@ final class MachinesPanelViewModel: ObservableObject {
     /// notification observer so a signed-out panel can never render a stale
     /// fleet while SwiftUI is catching up with the auth projection.
     func resetForAuthTransition() {
+        refreshGeneration += 1
         refreshTask?.cancel()
         refreshTask = nil
         refreshRequestedWhileLoading = false
@@ -710,14 +676,21 @@ final class MachinesPanelViewModel: ObservableObject {
         isLoading = false
     }
 
-    private func performRefresh() async -> Bool {
-        guard !Task.isCancelled else { return true }
+    private func performRefresh() async {
+        guard !Task.isCancelled else { return }
         guard let client = VMClient.shared else {
-            return false
+            lastErrorDescription = String(
+                localized: "machines.unavailable.title",
+                defaultValue: "Cloud is unreachable"
+            )
+            listProblem = .unreachable
+            isLoading = false
+            hasLoadedOnce = true
+            return
         }
         do {
             let page = try await client.listPage()
-            guard !Task.isCancelled else { return true }
+            guard !Task.isCancelled else { return }
             let previous = Dictionary(uniqueKeysWithValues: machines.map { ($0.id, $0.stats) })
             let freeAccessWindowDays = page.limits?.freeAccessWindowDays ?? 0
             self.freeAccessWindowDays = freeAccessWindowDays
@@ -748,7 +721,7 @@ final class MachinesPanelViewModel: ObservableObject {
                 listProblem = nil
                 hasLoadedOnce = false
                 isLoading = false
-                return true
+                return
             }
             lastErrorDescription = String(describing: error)
             listProblem = Self.classifyListFailure(error)
@@ -756,9 +729,8 @@ final class MachinesPanelViewModel: ObservableObject {
             lastErrorDescription = String(describing: error)
             listProblem = .unreachable
         }
-        guard !Task.isCancelled else { return true }
+        guard !Task.isCancelled else { return }
         isLoading = false
         hasLoadedOnce = true
-        return true
     }
 }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -364,8 +364,6 @@ final class MachinesPanelViewModel: ObservableObject {
         case sessionRejected
         /// HTTP 402: the plan gates Cloud access.
         case requiresPro
-        /// The app composition root did not install the Cloud client.
-        case notConfigured
         /// Everything else — retrying may help.
         case unreachable
     }
@@ -710,17 +708,6 @@ final class MachinesPanelViewModel: ObservableObject {
         listProblem = nil
         hasLoadedOnce = false
         isLoading = false
-    }
-
-    /// Completes a load when the composition root did not install the Cloud runtime.
-    func completeMissingClientLoad() {
-        lastErrorDescription = String(
-            localized: "machines.notConfigured.title",
-            defaultValue: "Cloud is not configured"
-        )
-        listProblem = .notConfigured
-        isLoading = false
-        hasLoadedOnce = true
     }
 
     private func performRefresh() async -> Bool {

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -328,22 +328,16 @@ enum MachineSnapshotBuilder {
 @MainActor
 struct CloudClientBootstrapRetry {
     let maxRetries: Int
-    let retryDelay: Duration
 
-    init(maxRetries: Int, retryDelay: Duration = .milliseconds(100)) {
+    init(maxRetries: Int) {
         self.maxRetries = max(0, maxRetries)
-        self.retryDelay = retryDelay
     }
 
     func run(attempt: () async -> Bool) async -> Bool {
         for retry in 0...maxRetries {
             if await attempt() { return true }
             guard !Task.isCancelled, retry < maxRetries else { return false }
-            do {
-                try await Task.sleep(for: retryDelay)
-            } catch {
-                return false
-            }
+            await Task.yield()
         }
         return false
     }
@@ -601,9 +595,7 @@ final class MachinesPanelViewModel: ObservableObject {
     /// real machine now, not on the next 45 s sweep.
     private var refreshRequestedWhileLoading = false
     private var refreshGeneration = 0
-    // Allow several seconds for auth restoration and client construction, while
-    // keeping the loading state bounded if composition really failed.
-    private static let maxClientBootstrapRetries = 50
+    private static let maxClientBootstrapRetries = 3
 
     func refresh() {
         guard refreshTask == nil else {
@@ -629,7 +621,16 @@ final class MachinesPanelViewModel: ObservableObject {
             }
             guard !Task.isCancelled, let self else { return }
             if !loaded {
-                self.completeMissingClientLoad()
+                // A bounded bootstrap timeout is still a transient readiness
+                // failure. Keep the retry-first state so a slow, valid setup
+                // is never reported as permanently misconfigured.
+                self.lastErrorDescription = String(
+                    localized: "machines.unavailable.title",
+                    defaultValue: "Cloud is unreachable"
+                )
+                self.listProblem = .unreachable
+                self.isLoading = false
+                self.hasLoadedOnce = true
             }
         }
     }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -615,12 +615,12 @@ final class MachinesPanelViewModel: ObservableObject {
         let generation = refreshGeneration
         refreshTask = Task { [weak self] in
             defer {
-                guard let self, self.refreshGeneration == generation else { return }
-                self.refreshTask = nil
-                guard !Task.isCancelled else { return }
-                if self.refreshRequestedWhileLoading {
-                    self.refreshRequestedWhileLoading = false
-                    self.refresh()
+                if let self, self.refreshGeneration == generation {
+                    self.refreshTask = nil
+                    if !Task.isCancelled, self.refreshRequestedWhileLoading {
+                        self.refreshRequestedWhileLoading = false
+                        self.refresh()
+                    }
                 }
             }
             let loaded = await CloudClientBootstrapRetry(maxRetries: Self.maxClientBootstrapRetries).run { [weak self] in

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -671,7 +671,16 @@ final class MachinesPanelViewModel: ObservableObject {
 
     private func performRefresh() async {
         guard let client = VMClient.shared else {
+            // A signed-in panel can briefly outlive the client during bootstrap.
+            // Treat that as a completed, retryable load so the UI cannot remain
+            // blank behind an endless spinner.
+            lastErrorDescription = String(
+                localized: "machines.unavailable.title",
+                defaultValue: "Cloud is unreachable"
+            )
+            listProblem = .unreachable
             isLoading = false
+            hasLoadedOnce = true
             return
         }
         do {

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -709,6 +709,7 @@ final class MachinesPanelViewModel: ObservableObject {
             lastErrorDescription = nil
             listProblem = nil
         } catch let error as VMClientError {
+            guard !Task.isCancelled else { return }
             if case .notSignedIn = error {
                 // A request can race sign-out before the auth observation or
                 // notification arrives. Clear the authoritative-looking
@@ -726,6 +727,7 @@ final class MachinesPanelViewModel: ObservableObject {
             lastErrorDescription = String(describing: error)
             listProblem = Self.classifyListFailure(error)
         } catch {
+            guard !Task.isCancelled else { return }
             lastErrorDescription = String(describing: error)
             listProblem = .unreachable
         }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -402,6 +402,8 @@ final class MachinesPanelViewModel: ObservableObject {
     }
 
     private var refreshTask: Task<Void, Never>?
+    private var clientBootstrapRetryCount = 0
+    private static let maxClientBootstrapRetries = 3
     private var pollTask: Task<Void, Never>?
     private var statsTask: Task<Void, Never>?
     /// One-shot timer armed at the exact next free-access transition (a
@@ -580,9 +582,17 @@ final class MachinesPanelViewModel: ObservableObject {
             return
         }
         isLoading = true
+        clientBootstrapRetryCount = 0
         refreshTask = Task { [weak self] in
-            await self?.performRefresh()
             guard let self else { return }
+            await self.performRefresh()
+            if !Task.isCancelled, !self.hasLoadedOnce, self.clientBootstrapRetryCount < Self.maxClientBootstrapRetries {
+                self.clientBootstrapRetryCount += 1
+                self.refreshTask = nil
+                await Task.yield()
+                self.refresh()
+                return
+            }
             self.refreshTask = nil
             if self.refreshRequestedWhileLoading {
                 self.refreshRequestedWhileLoading = false
@@ -674,13 +684,6 @@ final class MachinesPanelViewModel: ObservableObject {
             // A signed-in panel can briefly outlive the client during bootstrap.
             // Treat that as a completed, retryable load so the UI cannot remain
             // blank behind an endless spinner.
-            lastErrorDescription = String(
-                localized: "machines.unavailable.title",
-                defaultValue: "Cloud is unreachable"
-            )
-            listProblem = .unreachable
-            isLoading = false
-            hasLoadedOnce = true
             return
         }
         do {

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -324,22 +324,6 @@ enum MachineSnapshotBuilder {
     }
 }
 
-/// Runs the bounded retry phase while the signed-in Cloud client is still bootstrapping.
-@MainActor
-enum CloudClientBootstrapRetry {
-    static func run(
-        maxRetries: Int,
-        attempt: () async -> Bool
-    ) async -> Bool {
-        for retry in 0...maxRetries {
-            if await attempt() { return true }
-            guard !Task.isCancelled, retry < maxRetries else { return false }
-            await Task.yield()
-        }
-        return false
-    }
-}
-
 /// Loads the machine fleet for the right-sidebar Machines tab. Refreshes on
 /// demand plus a slow poll while the panel is visible; machine mutations go
 /// through the shared Cloud VM action path (`CloudVMActionLauncher`), never
@@ -362,6 +346,8 @@ final class MachinesPanelViewModel: ObservableObject {
         case sessionRejected
         /// HTTP 402: the plan gates Cloud access.
         case requiresPro
+        /// The app composition root did not install the Cloud client.
+        case notConfigured
         /// Everything else — retrying may help.
         case unreachable
     }
@@ -418,7 +404,6 @@ final class MachinesPanelViewModel: ObservableObject {
     }
 
     private var refreshTask: Task<Void, Never>?
-    private static let maxClientBootstrapRetries = 3
     private var pollTask: Task<Void, Never>?
     private var statsTask: Task<Void, Never>?
     /// One-shot timer armed at the exact next free-access transition (a
@@ -599,18 +584,7 @@ final class MachinesPanelViewModel: ObservableObject {
         isLoading = true
         refreshTask = Task { [weak self] in
             guard let self else { return }
-            let loaded = await CloudClientBootstrapRetry.run(maxRetries: Self.maxClientBootstrapRetries) {
-                await self.performRefresh()
-            }
-            if !loaded, !Task.isCancelled {
-                self.lastErrorDescription = String(
-                    localized: "machines.unavailable.title",
-                    defaultValue: "Cloud is unreachable"
-                )
-                self.listProblem = .unreachable
-                self.isLoading = false
-                self.hasLoadedOnce = true
-            }
+            await self.performRefresh()
             self.refreshTask = nil
             if self.refreshRequestedWhileLoading {
                 self.refreshRequestedWhileLoading = false
@@ -697,13 +671,21 @@ final class MachinesPanelViewModel: ObservableObject {
         isLoading = false
     }
 
-    /// Returns false only when the client has not finished bootstrapping yet.
-    private func performRefresh() async -> Bool {
+    /// Completes a load when the composition root did not install the Cloud runtime.
+    func completeMissingClientLoad() {
+        lastErrorDescription = String(
+            localized: "machines.notConfigured.title",
+            defaultValue: "Cloud is not configured"
+        )
+        listProblem = .notConfigured
+        isLoading = false
+        hasLoadedOnce = true
+    }
+
+    private func performRefresh() async {
         guard let client = VMClient.shared else {
-            // A signed-in panel can briefly outlive the client during bootstrap.
-            // Treat that as a completed, retryable load so the UI cannot remain
-            // blank behind an endless spinner.
-            return false
+            completeMissingClientLoad()
+            return
         }
         do {
             let page = try await client.listPage()
@@ -737,7 +719,7 @@ final class MachinesPanelViewModel: ObservableObject {
                 listProblem = nil
                 hasLoadedOnce = false
                 isLoading = false
-                return true
+                return
             }
             lastErrorDescription = String(describing: error)
             listProblem = Self.classifyListFailure(error)
@@ -747,6 +729,5 @@ final class MachinesPanelViewModel: ObservableObject {
         }
         isLoading = false
         hasLoadedOnce = true
-        return true
     }
 }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -594,6 +594,7 @@ final class MachinesPanelViewModel: ObservableObject {
     /// create that lands mid-poll must still replace its pending row with the
     /// real machine now, not on the next 45 s sweep.
     private var refreshRequestedWhileLoading = false
+    private var refreshGeneration = 0
     private static let maxClientBootstrapRetries = 3
 
     func refresh() {
@@ -602,7 +603,18 @@ final class MachinesPanelViewModel: ObservableObject {
             return
         }
         isLoading = true
+        refreshGeneration += 1
+        let generation = refreshGeneration
         refreshTask = Task { [weak self] in
+            defer {
+                guard let self, self.refreshGeneration == generation else { return }
+                self.refreshTask = nil
+                guard !Task.isCancelled else { return }
+                if self.refreshRequestedWhileLoading {
+                    self.refreshRequestedWhileLoading = false
+                    self.refresh()
+                }
+            }
             let loaded = await CloudClientBootstrapRetry(maxRetries: Self.maxClientBootstrapRetries).run { [weak self] in
                 guard !Task.isCancelled, let self else { return true }
                 return await self.performRefresh()
@@ -610,11 +622,6 @@ final class MachinesPanelViewModel: ObservableObject {
             guard !Task.isCancelled, let self else { return }
             if !loaded {
                 self.completeMissingClientLoad()
-            }
-            self.refreshTask = nil
-            if self.refreshRequestedWhileLoading {
-                self.refreshRequestedWhileLoading = false
-                self.refresh()
             }
         }
     }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -328,16 +328,22 @@ enum MachineSnapshotBuilder {
 @MainActor
 struct CloudClientBootstrapRetry {
     let maxRetries: Int
+    let retryDelay: Duration
 
-    init(maxRetries: Int) {
+    init(maxRetries: Int, retryDelay: Duration = .milliseconds(100)) {
         self.maxRetries = max(0, maxRetries)
+        self.retryDelay = retryDelay
     }
 
     func run(attempt: () async -> Bool) async -> Bool {
         for retry in 0...maxRetries {
             if await attempt() { return true }
             guard !Task.isCancelled, retry < maxRetries else { return false }
-            await Task.yield()
+            do {
+                try await Task.sleep(for: retryDelay)
+            } catch {
+                return false
+            }
         }
         return false
     }
@@ -595,7 +601,9 @@ final class MachinesPanelViewModel: ObservableObject {
     /// real machine now, not on the next 45 s sweep.
     private var refreshRequestedWhileLoading = false
     private var refreshGeneration = 0
-    private static let maxClientBootstrapRetries = 3
+    // Allow several seconds for auth restoration and client construction, while
+    // keeping the loading state bounded if composition really failed.
+    private static let maxClientBootstrapRetries = 50
 
     func refresh() {
         guard refreshTask == nil else {

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -324,6 +324,22 @@ enum MachineSnapshotBuilder {
     }
 }
 
+/// Runs the bounded retry phase while the signed-in Cloud client is still bootstrapping.
+@MainActor
+enum CloudClientBootstrapRetry {
+    static func run(
+        maxRetries: Int,
+        attempt: () async -> Bool
+    ) async -> Bool {
+        for retry in 0...maxRetries {
+            if await attempt() { return true }
+            guard !Task.isCancelled, retry < maxRetries else { return false }
+            await Task.yield()
+        }
+        return false
+    }
+}
+
 /// Loads the machine fleet for the right-sidebar Machines tab. Refreshes on
 /// demand plus a slow poll while the panel is visible; machine mutations go
 /// through the shared Cloud VM action path (`CloudVMActionLauncher`), never
@@ -402,7 +418,6 @@ final class MachinesPanelViewModel: ObservableObject {
     }
 
     private var refreshTask: Task<Void, Never>?
-    private var clientBootstrapRetryCount = 0
     private static let maxClientBootstrapRetries = 3
     private var pollTask: Task<Void, Never>?
     private var statsTask: Task<Void, Never>?
@@ -582,16 +597,19 @@ final class MachinesPanelViewModel: ObservableObject {
             return
         }
         isLoading = true
-        clientBootstrapRetryCount = 0
         refreshTask = Task { [weak self] in
             guard let self else { return }
-            await self.performRefresh()
-            if !Task.isCancelled, !self.hasLoadedOnce, self.clientBootstrapRetryCount < Self.maxClientBootstrapRetries {
-                self.clientBootstrapRetryCount += 1
-                self.refreshTask = nil
-                await Task.yield()
-                self.refresh()
-                return
+            let loaded = await CloudClientBootstrapRetry.run(maxRetries: Self.maxClientBootstrapRetries) {
+                await self.performRefresh()
+            }
+            if !loaded, !Task.isCancelled {
+                self.lastErrorDescription = String(
+                    localized: "machines.unavailable.title",
+                    defaultValue: "Cloud is unreachable"
+                )
+                self.listProblem = .unreachable
+                self.isLoading = false
+                self.hasLoadedOnce = true
             }
             self.refreshTask = nil
             if self.refreshRequestedWhileLoading {
@@ -679,12 +697,13 @@ final class MachinesPanelViewModel: ObservableObject {
         isLoading = false
     }
 
-    private func performRefresh() async {
+    /// Returns false only when the client has not finished bootstrapping yet.
+    private func performRefresh() async -> Bool {
         guard let client = VMClient.shared else {
             // A signed-in panel can briefly outlive the client during bootstrap.
             // Treat that as a completed, retryable load so the UI cannot remain
             // blank behind an endless spinner.
-            return
+            return false
         }
         do {
             let page = try await client.listPage()
@@ -718,7 +737,7 @@ final class MachinesPanelViewModel: ObservableObject {
                 listProblem = nil
                 hasLoadedOnce = false
                 isLoading = false
-                return
+                return true
             }
             lastErrorDescription = String(describing: error)
             listProblem = Self.classifyListFailure(error)
@@ -728,5 +747,6 @@ final class MachinesPanelViewModel: ObservableObject {
         }
         isLoading = false
         hasLoadedOnce = true
+        return true
     }
 }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -324,31 +324,30 @@ enum MachineSnapshotBuilder {
     }
 }
 
-/// Retries a short-lived Cloud client bootstrap race without an unbounded loop.
-@MainActor
-struct CloudClientBootstrapRetry {
-    let maxRetries: Int
-
-    init(maxRetries: Int) {
-        self.maxRetries = max(0, maxRetries)
-    }
-
-    func run(attempt: () async -> Bool) async -> Bool {
-        for retry in 0...maxRetries {
-            if await attempt() { return true }
-            guard !Task.isCancelled, retry < maxRetries else { return false }
-            await Task.yield()
-        }
-        return false
-    }
-}
-
 /// Loads the machine fleet for the right-sidebar Machines tab. Refreshes on
 /// demand plus a slow poll while the panel is visible; machine mutations go
 /// through the shared Cloud VM action path (`CloudVMActionLauncher`), never
 /// through this store.
 @MainActor
 final class MachinesPanelViewModel: ObservableObject {
+    /// Retries a short-lived Cloud client bootstrap race without an unbounded loop.
+    struct CloudClientBootstrapRetry {
+        let maxRetries: Int
+
+        init(maxRetries: Int) {
+            self.maxRetries = max(0, maxRetries)
+        }
+
+        func run(attempt: () async -> Bool) async -> Bool {
+            for retry in 0...maxRetries {
+                if await attempt() { return true }
+                guard !Task.isCancelled, retry < maxRetries else { return false }
+                await Task.yield()
+            }
+            return false
+        }
+    }
+
     @Published private(set) var machines: [MachineSnapshot] = []
     @Published private(set) var plan: MachinePlanSnapshot?
     @Published private(set) var isLoading = false

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -583,8 +583,8 @@ final class MachinesPanelViewModel: ObservableObject {
         }
         isLoading = true
         refreshTask = Task { [weak self] in
-            guard let self else { return }
-            await self.performRefresh()
+            await self?.performRefresh()
+            guard !Task.isCancelled, let self else { return }
             self.refreshTask = nil
             if self.refreshRequestedWhileLoading {
                 self.refreshRequestedWhileLoading = false

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -324,6 +324,25 @@ enum MachineSnapshotBuilder {
     }
 }
 
+/// Retries a short-lived Cloud client bootstrap race without an unbounded loop.
+@MainActor
+struct CloudClientBootstrapRetry {
+    let maxRetries: Int
+
+    init(maxRetries: Int) {
+        self.maxRetries = max(0, maxRetries)
+    }
+
+    func run(attempt: () async -> Bool) async -> Bool {
+        for retry in 0...maxRetries {
+            if await attempt() { return true }
+            guard !Task.isCancelled, retry < maxRetries else { return false }
+            await Task.yield()
+        }
+        return false
+    }
+}
+
 /// Loads the machine fleet for the right-sidebar Machines tab. Refreshes on
 /// demand plus a slow poll while the panel is visible; machine mutations go
 /// through the shared Cloud VM action path (`CloudVMActionLauncher`), never
@@ -575,6 +594,7 @@ final class MachinesPanelViewModel: ObservableObject {
     /// create that lands mid-poll must still replace its pending row with the
     /// real machine now, not on the next 45 s sweep.
     private var refreshRequestedWhileLoading = false
+    private static let maxClientBootstrapRetries = 3
 
     func refresh() {
         guard refreshTask == nil else {
@@ -583,8 +603,14 @@ final class MachinesPanelViewModel: ObservableObject {
         }
         isLoading = true
         refreshTask = Task { [weak self] in
-            await self?.performRefresh()
+            let loaded = await CloudClientBootstrapRetry(maxRetries: Self.maxClientBootstrapRetries).run { [weak self] in
+                guard !Task.isCancelled, let self else { return true }
+                return await self.performRefresh()
+            }
             guard !Task.isCancelled, let self else { return }
+            if !loaded {
+                self.completeMissingClientLoad()
+            }
             self.refreshTask = nil
             if self.refreshRequestedWhileLoading {
                 self.refreshRequestedWhileLoading = false
@@ -682,13 +708,14 @@ final class MachinesPanelViewModel: ObservableObject {
         hasLoadedOnce = true
     }
 
-    private func performRefresh() async {
+    private func performRefresh() async -> Bool {
+        guard !Task.isCancelled else { return true }
         guard let client = VMClient.shared else {
-            completeMissingClientLoad()
-            return
+            return false
         }
         do {
             let page = try await client.listPage()
+            guard !Task.isCancelled else { return true }
             let previous = Dictionary(uniqueKeysWithValues: machines.map { ($0.id, $0.stats) })
             let freeAccessWindowDays = page.limits?.freeAccessWindowDays ?? 0
             self.freeAccessWindowDays = freeAccessWindowDays
@@ -719,7 +746,7 @@ final class MachinesPanelViewModel: ObservableObject {
                 listProblem = nil
                 hasLoadedOnce = false
                 isLoading = false
-                return
+                return true
             }
             lastErrorDescription = String(describing: error)
             listProblem = Self.classifyListFailure(error)
@@ -727,7 +754,9 @@ final class MachinesPanelViewModel: ObservableObject {
             lastErrorDescription = String(describing: error)
             listProblem = .unreachable
         }
+        guard !Task.isCancelled else { return true }
         isLoading = false
         hasLoadedOnce = true
+        return true
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1474,6 +1474,7 @@
 		7F874952678AC9761AE53902 /* MachineCreateOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA7AB7C9143F6869E3ED0E95 /* MachineCreateOperation.swift */; };
 		EC5494EFC3A45E0D2EAF7CD3 /* MachineCreateRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DE6021305BAAE21622C5DFD /* MachineCreateRequest.swift */; };
 		E692C1AAEBB6F25FC0A733ED /* MachineCreateRowActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45500183C33186986F073F0B /* MachineCreateRowActions.swift */; };
+		C4B700010000000000000001 /* MachinesPanelClientBootstrapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4B700020000000000000001 /* MachinesPanelClientBootstrapTests.swift */; };
 		7690848956F4C55873F767F6 /* MachinesPanelModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 78F49DA9F80DC43173341410 /* MachinesPanelModelTests.swift */; };
 		98E6802001D61AC24F2ABB09 /* MachinesPanelUncappedPlanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A986C3063FCE5F28AA10ACA /* MachinesPanelUncappedPlanTests.swift */; };
 		E879C292A2D38E3DDBCB004D /* MachinesPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08610D114C8CF23877176D7E /* MachinesPanelView.swift */; };
@@ -4508,6 +4509,7 @@
 		FA7AB7C9143F6869E3ED0E95 /* MachineCreateOperation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachineCreateOperation.swift; sourceTree = "<group>"; };
 		5DE6021305BAAE21622C5DFD /* MachineCreateRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachineCreateRequest.swift; sourceTree = "<group>"; };
 		45500183C33186986F073F0B /* MachineCreateRowActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachineCreateRowActions.swift; sourceTree = "<group>"; };
+		C4B700020000000000000001 /* MachinesPanelClientBootstrapTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachinesPanelClientBootstrapTests.swift; sourceTree = "<group>"; };
 		78F49DA9F80DC43173341410 /* MachinesPanelModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachinesPanelModelTests.swift; sourceTree = "<group>"; };
 		9A986C3063FCE5F28AA10ACA /* MachinesPanelUncappedPlanTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachinesPanelUncappedPlanTests.swift; sourceTree = "<group>"; };
 		08610D114C8CF23877176D7E /* MachinesPanelView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MachinesPanelView.swift; sourceTree = "<group>"; };
@@ -8944,6 +8946,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				6042B0016042B0016042B001 /* ShortcutHintModifierPolicyTests.swift */,
 				C3408A000000000000000004 /* RightSidebarCommandPaletteTests.swift */,
 				78F49DA9F80DC43173341410 /* MachinesPanelModelTests.swift */,
+				C4B700020000000000000001 /* MachinesPanelClientBootstrapTests.swift */,
 				763D217526D3832668F47568 /* CloudAgentSkillLauncherTests.swift */,
 				5130177E80C2A18E09DBBBC4 /* NewMachineModelTests.swift */,
 				E56499DF099E405122930472 /* MachineCreateCoordinatorTests.swift */,
@@ -12326,6 +12329,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				9492CAFE0000000000000002 /* LastTerminalChildExitRecoveryTests.swift in Sources */,
 				540A9F26DCDFD0C16B257D6F /* LocalSurfaceProviderTests.swift in Sources */,
 				484A89A4B4AA08EF63E0DB51 /* MachineCreateCoordinatorTests.swift in Sources */,
+				C4B700010000000000000001 /* MachinesPanelClientBootstrapTests.swift in Sources */,
 				7690848956F4C55873F767F6 /* MachinesPanelModelTests.swift in Sources */,
 				98E6802001D61AC24F2ABB09 /* MachinesPanelUncappedPlanTests.swift in Sources */,
 				A7C0F0010000000000000002 /* MacPairedMacBackupPublisherScopeTests.swift in Sources */,

--- a/cmuxTests/MachinesPanelClientBootstrapTests.swift
+++ b/cmuxTests/MachinesPanelClientBootstrapTests.swift
@@ -1,0 +1,22 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Cloud machines client bootstrap")
+struct MachinesPanelClientBootstrapTests {
+    @Test("Auth teardown clears refresh ownership and loading state")
+    @MainActor
+    func authTeardownClearsRefreshState() {
+        let model = MachinesPanelViewModel()
+
+        model.resetForAuthTransition()
+
+        #expect(!model.isLoading)
+        #expect(!model.hasLoadedOnce)
+        #expect(model.listProblem == nil)
+    }
+}

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -999,19 +999,6 @@ struct MachinesPanelClientBootstrapTests {
         #expect(attempts == 3)
     }
 
-    @Test("A missing configured client completes loading with a truthful problem")
-    @MainActor
-    func missingClientCompletesLoading() {
-        let model = MachinesPanelViewModel()
-
-        model.completeMissingClientLoad()
-
-        #expect(!model.isLoading)
-        #expect(model.hasLoadedOnce)
-        #expect(model.listProblem == .notConfigured)
-        #expect(model.lastErrorDescription?.isEmpty == false)
-    }
-
     @Test("Auth teardown clears refresh ownership and loading state")
     @MainActor
     func authTeardownClearsRefreshState() {

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -985,6 +985,17 @@ struct MachinesPanelClientBootstrapTests {
         #expect(model.listProblem == .notConfigured)
         #expect(model.lastErrorDescription?.isEmpty == false)
     }
+
+    @Test("Auth teardown clears refresh ownership and loading state")
+    @MainActor
+    func authTeardownClearsRefreshState() {
+        let model = MachinesPanelViewModel()
+
+        model.resetForAuthTransition()
+
+        #expect(!model.isLoading)
+        #expect(!model.hasLoadedOnce)
+    }
 }
 
 @Suite("Cloud machines paid-plan classification")

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -973,32 +973,6 @@ struct MachinesPanelListProblemTests {
 
 @Suite("Cloud machines client bootstrap")
 struct MachinesPanelClientBootstrapTests {
-    @Test("A missing client retries only through the bounded bootstrap budget")
-    func missingClientUsesBoundedRetryBudget() async {
-        var attempts = 0
-
-        let loaded = await MachinesPanelViewModel.CloudClientBootstrapRetry(maxRetries: 3).run {
-            attempts += 1
-            return false
-        }
-
-        #expect(!loaded)
-        #expect(attempts == 4)
-    }
-
-    @Test("A client that appears during bootstrap completes immediately")
-    func clientAppearsDuringBootstrap() async {
-        var attempts = 0
-
-        let loaded = await MachinesPanelViewModel.CloudClientBootstrapRetry(maxRetries: 3).run {
-            attempts += 1
-            return attempts == 3
-        }
-
-        #expect(loaded)
-        #expect(attempts == 3)
-    }
-
     @Test("Auth teardown clears refresh ownership and loading state")
     @MainActor
     func authTeardownClearsRefreshState() {

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -971,21 +971,6 @@ struct MachinesPanelListProblemTests {
     }
 }
 
-@Suite("Cloud machines client bootstrap")
-struct MachinesPanelClientBootstrapTests {
-    @Test("Auth teardown clears refresh ownership and loading state")
-    @MainActor
-    func authTeardownClearsRefreshState() {
-        let model = MachinesPanelViewModel()
-
-        model.resetForAuthTransition()
-
-        #expect(!model.isLoading)
-        #expect(!model.hasLoadedOnce)
-        #expect(model.listProblem == nil)
-    }
-}
-
 @Suite("Cloud machines paid-plan classification")
 struct MachinesPanelPaidPlanTests {
     @Test("Only plans the backend accepts for provisioning are paid", arguments: [

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -977,7 +977,7 @@ struct MachinesPanelClientBootstrapTests {
     func missingClientUsesBoundedRetryBudget() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry(maxRetries: 3, retryDelay: .zero).run {
+        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
             attempts += 1
             return false
         }
@@ -990,7 +990,7 @@ struct MachinesPanelClientBootstrapTests {
     func clientAppearsDuringBootstrap() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry(maxRetries: 3, retryDelay: .zero).run {
+        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
             attempts += 1
             return attempts == 3
         }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -982,6 +982,7 @@ struct MachinesPanelClientBootstrapTests {
 
         #expect(!model.isLoading)
         #expect(!model.hasLoadedOnce)
+        #expect(model.listProblem == nil)
     }
 }
 

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -973,32 +973,17 @@ struct MachinesPanelListProblemTests {
 
 @Suite("Cloud machines client bootstrap")
 struct MachinesPanelClientBootstrapTests {
-    @Test("A missing client retries only through the bounded bootstrap budget")
+    @Test("A missing configured client completes loading with a truthful problem")
     @MainActor
-    func missingClientUsesBoundedRetryBudget() async {
-        var attempts = 0
+    func missingClientCompletesLoading() {
+        let model = MachinesPanelViewModel()
 
-        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
-            attempts += 1
-            return false
-        }
+        model.completeMissingClientLoad()
 
-        #expect(!loaded)
-        #expect(attempts == 4)
-    }
-
-    @Test("A client that appears during bootstrap completes immediately")
-    @MainActor
-    func clientAppearsDuringBootstrap() async {
-        var attempts = 0
-
-        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
-            attempts += 1
-            return attempts == 3
-        }
-
-        #expect(loaded)
-        #expect(attempts == 3)
+        #expect(!model.isLoading)
+        #expect(model.hasLoadedOnce)
+        #expect(model.listProblem == .notConfigured)
+        #expect(model.lastErrorDescription?.isEmpty == false)
     }
 }
 

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -974,6 +974,7 @@ struct MachinesPanelListProblemTests {
 @Suite("Cloud machines client bootstrap")
 struct MachinesPanelClientBootstrapTests {
     @Test("A missing client retries only through the bounded bootstrap budget")
+    @MainActor
     func missingClientUsesBoundedRetryBudget() async {
         var attempts = 0
 
@@ -987,6 +988,7 @@ struct MachinesPanelClientBootstrapTests {
     }
 
     @Test("A client that appears during bootstrap completes immediately")
+    @MainActor
     func clientAppearsDuringBootstrap() async {
         var attempts = 0
 

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -971,6 +971,35 @@ struct MachinesPanelListProblemTests {
     }
 }
 
+@Suite("Cloud machines client bootstrap")
+struct MachinesPanelClientBootstrapTests {
+    @Test("A missing client retries only through the bounded bootstrap budget")
+    func missingClientUsesBoundedRetryBudget() async {
+        var attempts = 0
+
+        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
+            attempts += 1
+            return false
+        }
+
+        #expect(!loaded)
+        #expect(attempts == 4)
+    }
+
+    @Test("A client that appears during bootstrap completes immediately")
+    func clientAppearsDuringBootstrap() async {
+        var attempts = 0
+
+        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
+            attempts += 1
+            return attempts == 3
+        }
+
+        #expect(loaded)
+        #expect(attempts == 3)
+    }
+}
+
 @Suite("Cloud machines paid-plan classification")
 struct MachinesPanelPaidPlanTests {
     @Test("Only plans the backend accepts for provisioning are paid", arguments: [

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -973,6 +973,32 @@ struct MachinesPanelListProblemTests {
 
 @Suite("Cloud machines client bootstrap")
 struct MachinesPanelClientBootstrapTests {
+    @Test("A missing client retries only through the bounded bootstrap budget")
+    func missingClientUsesBoundedRetryBudget() async {
+        var attempts = 0
+
+        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
+            attempts += 1
+            return false
+        }
+
+        #expect(!loaded)
+        #expect(attempts == 4)
+    }
+
+    @Test("A client that appears during bootstrap completes immediately")
+    func clientAppearsDuringBootstrap() async {
+        var attempts = 0
+
+        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
+            attempts += 1
+            return attempts == 3
+        }
+
+        #expect(loaded)
+        #expect(attempts == 3)
+    }
+
     @Test("A missing configured client completes loading with a truthful problem")
     @MainActor
     func missingClientCompletesLoading() {

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -977,7 +977,7 @@ struct MachinesPanelClientBootstrapTests {
     func missingClientUsesBoundedRetryBudget() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
+        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
             attempts += 1
             return false
         }
@@ -990,7 +990,7 @@ struct MachinesPanelClientBootstrapTests {
     func clientAppearsDuringBootstrap() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry.run(maxRetries: 3) {
+        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
             attempts += 1
             return attempts == 3
         }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -977,7 +977,7 @@ struct MachinesPanelClientBootstrapTests {
     func missingClientUsesBoundedRetryBudget() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
+        let loaded = await CloudClientBootstrapRetry(maxRetries: 3, retryDelay: .zero).run {
             attempts += 1
             return false
         }
@@ -990,7 +990,7 @@ struct MachinesPanelClientBootstrapTests {
     func clientAppearsDuringBootstrap() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
+        let loaded = await CloudClientBootstrapRetry(maxRetries: 3, retryDelay: .zero).run {
             attempts += 1
             return attempts == 3
         }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -977,7 +977,7 @@ struct MachinesPanelClientBootstrapTests {
     func missingClientUsesBoundedRetryBudget() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
+        let loaded = await MachinesPanelViewModel.CloudClientBootstrapRetry(maxRetries: 3).run {
             attempts += 1
             return false
         }
@@ -990,7 +990,7 @@ struct MachinesPanelClientBootstrapTests {
     func clientAppearsDuringBootstrap() async {
         var attempts = 0
 
-        let loaded = await CloudClientBootstrapRetry(maxRetries: 3).run {
+        let loaded = await MachinesPanelViewModel.CloudClientBootstrapRetry(maxRetries: 3).run {
             attempts += 1
             return attempts == 3
         }


### PR DESCRIPTION
## Summary
- add deterministic behavior tests for missing and late Cloud client bootstrap
- replace recursive refresh retries with one bounded async retry loop
- show the retryable unavailable state after the retry budget is exhausted

## Testing
- `swiftc -parse Sources/Cloud/MachinesPanelViewModel.swift cmuxTests/MachinesPanelModelTests.swift`
- `git diff --check`
- local Xcode tests were not run, per repository policy

## Context
- Follow-up to https://github.com/manaflow-ai/cmux/pull/11618

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11631"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790934732&installation_model_id=21920&pr_number=11631&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11631&signature=d091de12e86feb2ee933c3ffd0c7e62ae4d6926d963d323b6b4ce67da1c14e7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloud Machines hanging in the loading state when the Cloud client is unavailable by showing the unreachable state instead. Refresh cleanup uses a generation counter so canceled or stale tasks cannot overwrite newer refresh state or surface errors after teardown.

- Fails closed to the unreachable state when the Cloud client is missing.
- Adds a progress indicator, localized loading label, and accessibility identifier with English and Japanese translations.
- Tests that auth teardown clears loading, refresh, and list problem state.

<sup>Written for commit 74829b10106985c1920fba1054364a2db3d06227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11631?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer Cloud Machines loading feedback with a progress indicator and localized loading message.
  * Added English and Japanese translations for the loading message.
* **Bug Fixes**
  * Cloud Machines now show an unreachable error when Cloud is unavailable instead of remaining in a loading state.
  * Refresh handling now avoids stale results and correctly responds to cancelled or superseded requests.
* **Tests**
  * Added coverage for resetting loading and error states during authentication transitions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->