### PR TITLE
fix(web): render the coderouter dashboard at request time

### DIFF
--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
+import { connection } from "next/server";
 import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
 import { Link } from "@/i18n/navigation";
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
@@ -74,6 +75,11 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
 }
 
 export default async function CoderouterOverviewPage({ params, searchParams }: PageProps) {
+  // Everything below depends on the live session. With cacheComponents, Next
+  // also runs this page during a prerender and a runtime prefetch, where
+  // headers() resolves but the Stack SDK's sync UUID generation aborts the
+  // render with blocking-prerender-crypto. Leave both before any of that work.
+  await connection();
   const [{ locale }, { team: teamParam }] = await Promise.all([params, searchParams]);
   const team = Array.isArray(teamParam) ? teamParam[0] : teamParam;
 

--- a/web/tests/dashboard-coderouter-page.test.tsx
+++ b/web/tests/dashboard-coderouter-page.test.tsx
@@ -23,6 +23,7 @@ let authorizedTeams: Array<{
   manageAccounts: true,
 }];
 const metricsTeamIds: string[] = [];
+const requestBoundaryEvents: string[] = [];
 
 mock.module("next-intl/server", () => ({
   getTranslations: async (input?: string | { namespace?: string }) =>
@@ -30,9 +31,16 @@ mock.module("next-intl/server", () => ({
   setRequestLocale: () => undefined,
 }));
 
+mock.module("next/server", () => ({
+  connection: async () => {
+    requestBoundaryEvents.push("connection");
+  },
+}));
+
 mock.module("next/headers", () => ({
-  headers: async () =>
-    new Headers(
+  headers: async () => {
+    requestBoundaryEvents.push("headers");
+    return new Headers(
       scopedTeamId
         ? {
           cookie: `cmux_coderouter_organization=${
@@ -40,7 +48,8 @@ mock.module("next/headers", () => ({
           }`,
         }
         : undefined,
-    ),
+    );
+  },
 }));
 
 mock.module("next/navigation", () => ({
@@ -68,6 +77,7 @@ mock.module("../app/lib/stack", () => ({
   isStackConfigured: () => true,
   getStackServerApp: () => ({
     getAuthJson: async () => {
+      requestBoundaryEvents.push("stack");
       if (!authJsonAvailable) throw new Error("Stack refresh unavailable");
       return { accessToken: "test-access-token" };
     },
@@ -83,7 +93,10 @@ mock.module("../services/vms/auth", () => ({
     if (!authorizationAvailable) throw authorizationFailure;
     return await operation(new AbortController().signal);
   },
-  verifySubrouterRequest: async () => ({ id: "user-1", selectedTeamId }),
+  verifySubrouterRequest: async () => {
+    requestBoundaryEvents.push("verify");
+    return { id: "user-1", selectedTeamId };
+  },
   SubrouterAuthorizationUnavailableError:
     TestSubrouterAuthorizationUnavailableError,
   isSubrouterAuthorizationError: (error: unknown) =>
@@ -160,6 +173,7 @@ describe("coderouter dashboard", () => {
     hostedControlConfigured = true;
     hostedExchangeCalls = 0;
     metricsTeamIds.length = 0;
+    requestBoundaryEvents.length = 0;
     selectedTeamId = "team-1";
     scopedTeamId = null;
     authorizedTeams = [{
@@ -168,6 +182,24 @@ describe("coderouter dashboard", () => {
       use: true,
       manageAccounts: true,
     }];
+  });
+
+  test("opts out of prerendering before reading request headers or Stack session state", async () => {
+    // With cacheComponents, Next runs this page during a prerender and a
+    // runtime prefetch, where headers() resolves but sync randomness (the
+    // Stack SDK's UUID generator) aborts with "blocking-prerender-crypto".
+    // connection() must be awaited before any of that work starts.
+    authorizationAvailable = true;
+
+    await CoderouterOverviewPage({
+      params: Promise.resolve({ locale: "en" }),
+      searchParams: Promise.resolve({}),
+    });
+
+    expect(requestBoundaryEvents[0]).toBe("connection");
+    expect(requestBoundaryEvents).toEqual(
+      ["connection", "headers", "verify", "stack"],
+    );
   });
 
   test("renders recovery UI when Stack authorization is unavailable", async () => {


### PR DESCRIPTION
Visiting \`/[locale]/dashboard/coderouter\` on Next 16.3 failed with:

\`\`\`
Route "/[locale]/dashboard/coderouter": Next.js encountered the unstable value \`crypto.getRandomValues()\` while prerendering.
\`\`\`

With \`cacheComponents\` and \`partialPrefetching\`, Next runs the page during a prerender and a runtime prefetch. \`headers()\` and \`searchParams\` resolve in the runtime prefetch, so the page continues into the Stack SDK, whose sync UUID generator calls \`crypto.getRandomValues()\` and aborts the render. \`instant = false\` does not stop that prefetch.

The page is per-request by design (session, team scope, hosted account list), so it now awaits \`connection()\` before any of that work, matching \`app/handler/[...stack]/page.tsx\` and \`app/vm/desktop/[id]/page.tsx\`.

Commit 1 adds a test that fails on main: it asserts \`connection()\` is awaited before \`headers()\`, request verification, and Stack session access. Commit 2 adds the fix.

Ran locally: \`bun test tests/dashboard-coderouter-page.test.tsx\` (10 pass), neighboring dashboard tests, \`tsgo --noEmit\`, eslint on both files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `/[locale]/dashboard/coderouter` failing on Next 16.3 when `cacheComponents` and `partialPrefetching` trigger a prerender. The page now awaits `connection()` before reading `headers()` or `searchParams`, so it renders at request time and avoids the Stack SDK's sync `crypto.getRandomValues()` abort. Adds a regression test asserting `connection()` is awaited before `headers()`, request verification, and Stack session access.

<sup>Written for commit 2014611bed5dc99c033277ea34d4d5e13324c525. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11632?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the Code Router dashboard’s loading behavior to prevent prerendering and runtime prefetch errors.
  * Ensured the page waits for the active session before loading request-specific dashboard data.

* **Tests**
  * Added coverage verifying the correct order of session, header, authentication, and data-loading operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->