### PR TITLE
web: answer Stack Auth throttles on iroh routes with 429, add a Stack throttle circuit

### DIFF
--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -4,6 +4,7 @@ import type * as Layer from "effect/Layer";
 import { after } from "next/server";
 import { env } from "../../app/env";
 import { unauthorized, verifyRequest, type AuthedUser } from "../vms/auth";
+import { authProviderErrorResponse } from "../vms/authErrors";
 import { enforceBrowserMutationProtection, jsonResponse } from "../vms/routeHelpers";
 import { irohExpectedError } from "./errors";
 import {
@@ -48,8 +49,13 @@ export async function handleIrohRoute(
   let user: AuthedUser | null;
   try {
     user = await verify(request, { allowCookie: false });
-  } catch {
-    return jsonResponse({ error: "unauthorized" }, 401);
+  } catch (error) {
+    // A Stack Auth throttle or outage is not the caller's fault. Answering 401
+    // told every host that its credentials were rejected, and the irx host
+    // retries a 401 every few seconds with the same tokens, which kept Stack's
+    // project-wide limit exhausted for every other route. 429 + Retry-After
+    // (or 503) lets clients honor the broker cooldown instead.
+    return authProviderErrorResponse(error, `iroh.${operation}.auth`);
   }
   if (!user) return unauthorized();
   const clientNamespace = request.headers.get("x-cmux-app-namespace") ?? "legacy";

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -516,6 +516,9 @@ export async function verifyRequest(
         options.subrouterAuthorizationSignal,
       );
     } catch (error) {
+      // The circuit's own fast-fail must not count as a new upstream throttle,
+      // or steady retry traffic would hold the circuit open forever.
+      if (error instanceof StackAuthRateLimitedError) throw error;
       if (cacheable && hasAuthRateLimitSignal(error)) throw recordStackThrottle(error);
       throw error;
     }

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -512,7 +512,7 @@ export async function verifyRequest(
         options.subrouterAuthorizationSignal,
       );
     } catch (error) {
-      if (hasAuthRateLimitSignal(error)) throw recordStackThrottle(error);
+      if (cacheable && hasAuthRateLimitSignal(error)) throw recordStackThrottle(error);
       throw error;
     }
     if (user) {

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -504,11 +504,15 @@ export async function verifyRequest(
     }
     // Subrouter calls carry their own deadline and error classes; only the
     // cacheable native path (device registry, iroh broker, relay) is gated.
-    if (cacheable) assertStackNotThrottled();
+    // The check runs inside the operation so it is evaluated when the call
+    // actually starts, not when it was queued behind the concurrency limiter.
     let user: Awaited<ReturnType<typeof stackServerApp.getUser>>;
     try {
       user = await stackAuthorizationCall(
-        () => stackServerApp.getUser({ tokenStore: tokens }),
+        () => {
+          if (cacheable) assertStackNotThrottled();
+          return stackServerApp.getUser({ tokenStore: tokens });
+        },
         options.subrouterAuthorizationSignal,
       );
     } catch (error) {

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -2,6 +2,7 @@ import { createHash } from "node:crypto";
 import { eq } from "drizzle-orm";
 import type { Team } from "@stackframe/stack";
 import { getStackServerApp, isStackConfigured } from "../../app/lib/stack";
+import { hasAuthRateLimitSignal } from "./authErrors";
 import { cloudDb } from "../../db/client";
 import { accountDeletionTombstones } from "../../db/schema";
 import {
@@ -52,6 +53,15 @@ export class SubrouterAuthorizationTimeoutError extends Error {
 
 export class SubrouterAuthorizationUnavailableError extends Error {
   override readonly name = "SubrouterAuthorizationUnavailableError";
+}
+
+/**
+ * Stack Auth rejected (or is presumed to be rejecting) verification with a
+ * project-wide throttle. The message keeps the "rate limited" wording that
+ * `authProviderErrorResponse` and `relayAuthenticationError` detect.
+ */
+export class StackAuthRateLimitedError extends Error {
+  override readonly name = "StackAuthRateLimitedError";
 }
 
 export type NativeStackTokens = {
@@ -180,6 +190,34 @@ export function invalidateNativeAuthCacheForTokens(tokens: NativeStackTokens): v
   for (const [key, entry] of nativeAuthCache) {
     if (entry.tokenFingerprint === fingerprint) nativeAuthCache.delete(key);
   }
+}
+
+// Stack throttles per project, not per caller. Once one native verification is
+// throttled, every other native verification from this instance fails the same
+// way for the next few seconds, and the Stack SDK retries each of those calls
+// against three hosts before giving up. Fail fast during that window so a
+// throttled window costs one upstream call per instance instead of multiplying
+// the load that caused the throttle. Successful verifications still come from
+// the positive cache above; the cookie path is interactive and is never gated.
+const STACK_THROTTLE_CIRCUIT_MS = 10_000;
+let stackThrottledUntil = 0;
+
+function assertStackNotThrottled(): void {
+  const remainingMs = stackThrottledUntil - Date.now();
+  if (remainingMs <= 0) return;
+  throw new StackAuthRateLimitedError(
+    `Stack Auth rate limited; circuit open for ${Math.ceil(remainingMs / 1_000)}s`,
+  );
+}
+
+function recordStackThrottle(cause: unknown): StackAuthRateLimitedError {
+  stackThrottledUntil = Date.now() + STACK_THROTTLE_CIRCUIT_MS;
+  return new StackAuthRateLimitedError("Stack Auth rate limited", { cause });
+}
+
+/** Test hook: close the Stack throttle circuit between cases. */
+export function clearStackThrottleCircuitForTests(): void {
+  stackThrottledUntil = 0;
 }
 
 let activeStackAuthorizationCalls = 0;
@@ -464,10 +502,19 @@ export async function verifyRequest(
       const cached = readNativeAuthCache(cacheKey);
       if (cached) return cached;
     }
-    const user = await stackAuthorizationCall(
-      () => stackServerApp.getUser({ tokenStore: tokens }),
-      options.subrouterAuthorizationSignal,
-    );
+    // Subrouter calls carry their own deadline and error classes; only the
+    // cacheable native path (device registry, iroh broker, relay) is gated.
+    if (cacheable) assertStackNotThrottled();
+    let user: Awaited<ReturnType<typeof stackServerApp.getUser>>;
+    try {
+      user = await stackAuthorizationCall(
+        () => stackServerApp.getUser({ tokenStore: tokens }),
+        options.subrouterAuthorizationSignal,
+      );
+    } catch (error) {
+      if (hasAuthRateLimitSignal(error)) throw recordStackThrottle(error);
+      throw error;
+    }
     if (user) {
       const authed = await authedUserFromStackUser(user, options);
       if (authed && cacheKey) {

--- a/web/services/vms/authErrors.ts
+++ b/web/services/vms/authErrors.ts
@@ -34,7 +34,7 @@ export function authProviderErrorResponse(
   );
 }
 
-function hasAuthRateLimitSignal(
+export function hasAuthRateLimitSignal(
   value: unknown,
   state: { readonly seen: Set<object>; count: number } = {
     seen: new Set<object>(),

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -192,6 +192,48 @@ describe("Iroh route boundary", () => {
     expect(called).toBe(false);
   });
 
+  test("maps a Stack Auth throttle to 429 with Retry-After instead of 401", async () => {
+    let called = false;
+    const response = await handleIrohRoute(
+      authedPost("/api/devices/iroh/register", {}),
+      "register",
+      {
+        verify: async () => {
+          throw new AggregateError([
+            new Error("Rate limited, no retry-after header received"),
+          ]);
+        },
+        broker: broker({
+          register: () => {
+            called = true;
+            return Effect.succeed({});
+          },
+        }),
+      },
+    );
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(await response.json()).toEqual({ error: "rate_limited" });
+    expect(called).toBe(false);
+  });
+
+  test("maps other Stack Auth provider failures to 503 instead of 401", async () => {
+    const response = await handleIrohRoute(
+      authedPost("/api/devices/iroh/challenge", {}),
+      "challenge",
+      {
+        verify: async () => {
+          throw new Error("Stack Auth unreachable");
+        },
+        broker: broker(),
+      },
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "authentication_unavailable" });
+  });
+
   test("rejects malformed discovery cursors before broker work", async () => {
     let brokerCalled = false;
     const response = await handleIrohRoute(

--- a/web/tests/vm-auth-cache.test.ts
+++ b/web/tests/vm-auth-cache.test.ts
@@ -166,6 +166,22 @@ describe("Stack Auth throttle circuit", () => {
     expect(getUser).toHaveBeenCalledTimes(2);
   });
 
+  test("requests rejected by the open circuit do not extend it", async () => {
+    setSystemTime(BASE + 30_000);
+    failStackOnce(new AggregateError([
+      new Error("Rate limited, no retry-after header received"),
+    ]));
+    await expect(verifyRequest(nativeRequest("extend-1"))).rejects.toThrow(/rate limited/i);
+
+    setSystemTime(BASE + 30_000 + 9_000);
+    await expect(verifyRequest(nativeRequest("extend-2"))).rejects.toThrow(/rate limited/i);
+
+    setSystemTime(BASE + 30_000 + 10_001);
+    const user = await verifyRequest(nativeRequest("extend-3"));
+    expect(user?.id).toBe("user-1");
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+
   test("a non-throttle Stack failure does not open the circuit", async () => {
     setSystemTime(BASE + 60_000);
     failStackOnce(new Error("Stack Auth unreachable"));

--- a/web/tests/vm-auth-cache.test.ts
+++ b/web/tests/vm-auth-cache.test.ts
@@ -19,6 +19,7 @@ mock.module("../app/lib/stack", () => ({
 const {
   verifyRequest,
   clearNativeAuthCacheForTests,
+  clearStackThrottleCircuitForTests,
   invalidateNativeAuthCacheForTokens,
 } = await import("../services/vms/auth");
 
@@ -44,6 +45,7 @@ const originalTtl = process.env.CMUX_VM_AUTH_CACHE_TTL_MS;
 
 beforeEach(() => {
   clearNativeAuthCacheForTests();
+  clearStackThrottleCircuitForTests();
   getUser.mockClear();
   getUser.mockResolvedValue(fakeStackUser);
   delete process.env.CMUX_VM_AUTH_CACHE_TTL_MS;

--- a/web/tests/vm-auth-cache.test.ts
+++ b/web/tests/vm-auth-cache.test.ts
@@ -176,6 +176,18 @@ describe("Stack Auth throttle circuit", () => {
     expect(getUser).toHaveBeenCalledTimes(2);
   });
 
+  test("a subrouter-path throttle does not open the native circuit", async () => {
+    setSystemTime(BASE + 180_000);
+    failStackOnce(new Error("Rate limited, no retry-after header received"));
+
+    await expect(verifyRequest(nativeRequest("subrouter-1"), {
+      subrouterAuthorizationSignal: new AbortController().signal,
+    })).rejects.toThrow(/rate limited/i);
+    const user = await verifyRequest(nativeRequest("native-after-subrouter"));
+    expect(user?.id).toBe("user-1");
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+
   test("cookie verification is never short-circuited by a native throttle", async () => {
     setSystemTime(BASE + 120_000);
     failStackOnce(new AggregateError([

--- a/web/tests/vm-auth-cache.test.ts
+++ b/web/tests/vm-auth-cache.test.ts
@@ -131,3 +131,61 @@ describe("native auth verification cache", () => {
     expect(getUser).toHaveBeenCalledTimes(2);
   });
 });
+
+
+// bun's MockFunction typing in this tree lacks the *Once variants; the
+// devices-route test uses the same cast.
+function failStackOnce(error: unknown): void {
+  (getUser as unknown as {
+    mockImplementationOnce(implementation: () => Promise<never>): void;
+  }).mockImplementationOnce(async () => {
+    throw error;
+  });
+}
+
+describe("Stack Auth throttle circuit", () => {
+  // Fake clocks far in the future so an opened circuit can never leak into
+  // the cache tests above, which run at epoch 0.
+  const BASE = 4_000_000_000_000;
+
+  test("a Stack throttle opens a short circuit so native retries stop hitting Stack", async () => {
+    setSystemTime(BASE);
+    failStackOnce(new AggregateError([
+        new Error("Rate limited, no retry-after header received"),
+      ]));
+
+    await expect(verifyRequest(nativeRequest("throttled-1"))).rejects.toThrow(/rate limited/i);
+    await expect(verifyRequest(nativeRequest("throttled-2"))).rejects.toThrow(/rate limited/i);
+    expect(getUser).toHaveBeenCalledTimes(1);
+
+    setSystemTime(BASE + 10_001);
+    const user = await verifyRequest(nativeRequest("throttled-2"));
+    expect(user?.id).toBe("user-1");
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+
+  test("a non-throttle Stack failure does not open the circuit", async () => {
+    setSystemTime(BASE + 60_000);
+    failStackOnce(new Error("Stack Auth unreachable"));
+
+    await expect(verifyRequest(nativeRequest("plain-1"))).rejects.toThrow("Stack Auth unreachable");
+    const user = await verifyRequest(nativeRequest("plain-2"));
+    expect(user?.id).toBe("user-1");
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+
+  test("cookie verification is never short-circuited by a native throttle", async () => {
+    setSystemTime(BASE + 120_000);
+    failStackOnce(new AggregateError([
+        new Error("Rate limited, no retry-after header received"),
+      ]));
+    await expect(verifyRequest(nativeRequest("throttled-3"))).rejects.toThrow(/rate limited/i);
+
+    const cookieRequest = new Request("https://cmux.test/api/vm", {
+      headers: { cookie: "stack-session=abc" },
+    });
+    const user = await verifyRequest(cookieRequest);
+    expect(user?.id).toBe("user-1");
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Production has been in a Stack Auth rate-limit storm for at least 48 hours. Clicking Get Pro on nightly redirected to `/pricing?billing=error` because checkout's `getUser` hit Stack while Stack was returning 429 (Vercel log at 09:49 UTC: `Rate limited while sending request to https://api.stack-auth.com/api/v1/users/me`).

Volume source: stable 0.64.22 Macs (user agent `cmux/102`) drive `/api/devices/iroh/{challenge,register,endpoint-attestations}` at roughly 140 requests/s, a full challenge + register + attestation cycle on every iroh `networkChanged`/`recovered` event with no de-duplication. https://github.com/manaflow-ai/cmux/pull/9350 (2026-08-08) fixed that on main but no app release has shipped since v0.64.22 (2026-08-03). Every one of those requests verifies with Stack `users/me` (30 s positive cache per instance only), which keeps the project-wide limit exhausted.

Amplifier on the server: `handleIrohRoute` turned every verification failure, including a Stack 429, into `401 unauthorized`. Hosts treat 401 as rejected credentials and retry (irx on nightly every ~5 s, https://github.com/manaflow-ai/cmux/issues/11192; 0.64.22 on a 2 s to 120 s ladder), so the throttle never cleared and every Stack-backed route failed at random.

Changes:
- `handleIrohRoute` maps provider failures through `authProviderErrorResponse`, the mapper `/api/devices` already uses: 429 + `Retry-After: 60` for throttles, 503 otherwise. Mac and iOS clients already honor the broker cooldown on 429.
- `verifyRequest` opens a 10 s circuit after a Stack throttle on the cacheable native path, so a throttled window costs one upstream call per instance instead of the Stack SDK's multi-host retry loop per request. Cookie and subrouter paths are not gated.

Commit 1 adds the failing tests; commit 2 adds the fix. Focused suites pass: `iroh-route-handler`, `vm-auth-cache`, `devices-route`, `relay-token-route`. `bun run typecheck` and eslint clean.

Not in this PR: ship a stable release with #9350 so the fleet stops re-registering on every network event; verify the Stack access-token JWT locally on broker routes so device traffic stops reaching `users/me`; make the irx host honor Retry-After instead of a fixed 5 s sleep.