### PR TITLE
fix(relay): own the grep pattern before spawning the runner task

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1745,7 +1745,8 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             };
             let raw =
                 args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
-            let pattern = args.get("pattern").and_then(Value::as_str).unwrap_or_default().to_owned();
+            let pattern =
+                args.get("pattern").and_then(Value::as_str).unwrap_or_default().to_owned();
             if pattern.is_empty() {
                 return fail("failed", "grep: pattern is required");
             }

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1745,7 +1745,7 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             };
             let raw =
                 args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
-            let pattern = args.get("pattern").and_then(Value::as_str).unwrap_or_default();
+            let pattern = args.get("pattern").and_then(Value::as_str).unwrap_or_default().to_owned();
             if pattern.is_empty() {
                 return fail("failed", "grep: pattern is required");
             }
@@ -1803,7 +1803,7 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                             "--exclude-dir=.git".to_owned(),
                             "--exclude-dir=node_modules".to_owned(),
                             "-e".to_owned(),
-                            pattern.to_owned(),
+                            pattern,
                             "--".to_owned(),
                             process_path,
                         ],


### PR DESCRIPTION
chatmux-relay has not compiled on main since https://github.com/manaflow-ai/cmux/pull/11568 merged: the grep arm's spawned task captured `pattern`, a `&str` borrowed from the request frame, so the `'static` future held a borrow of `frame` and `empty_args` (E0597 at the `unwrap_or(&empty_args)` binding, E0521 at the `tokio::spawn`). Every cmux-tui.yml job failed at build on main, for example https://github.com/manaflow-ai/cmux/actions/runs/33616280724, and the open follow-up https://github.com/manaflow-ai/cmux/pull/11629 fails the same way (https://github.com/manaflow-ai/cmux/actions/runs/33618595740).

Fix: own the pattern as a `String` before the spawn and move it into the argv. Two lines, no behavior change.

Hosted focused run on this head, all green (Linux, macOS, MSRV 1.91, aarch64 release build): https://github.com/manaflow-ai/cmux/actions/runs/33619939294

https://github.com/manaflow-ai/cmux/pull/11629 touches the same block and will need `origin/main` merged in after this lands.

https://claude.ai/code/session_01AvkeWizggvvUAngHyB7JUQ


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `chatmux-relay` not compiling on main by owning the grep pattern as a `String` before the spawned task runs.

- The task no longer borrows from the request frame, resolving the E0597/E0521 errors.  
- No behavior change; the grep argv now moves the owned pattern instead of cloning it.

<sup>Written for commit ee1f7bae9f84d4a3453e29e1f90239bd6303926e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

