### PR TITLE
Extract canonical hosted retention planning

### DIFF
--- a/scripts/lib/hosted-retention-plan.sh
+++ b/scripts/lib/hosted-retention-plan.sh
@@ -33,7 +33,8 @@ plan() {
   [[ -d "$hosted_dir" ]] || die "hosted artifact directory does not exist: $hosted_dir"
   for prerequisite in find id sort stat lsof; do require_command "$prerequisite"; done
 
-  local candidate_dir candidate_commit candidate_mtime candidate_binary retained=0
+  local hosted_identity candidate_dir candidate_commit candidate_mtime candidate_binary retained=0
+  hosted_identity="$(cd -- "$hosted_dir" && pwd -P)" || die "could not resolve hosted artifact directory: $hosted_dir"
   local -a order=()
   while IFS= read -r -d '' candidate_dir; do
     candidate_commit="${candidate_dir##*/}"
@@ -42,7 +43,7 @@ plan() {
     order+=("$candidate_mtime"$'\t'"$candidate_commit")
   done < <(find "$hosted_dir" -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
 
-  printf 'schema\t1\ncount\t%s\ncurrent\t%s\n' "$count" "$current"
+  printf 'schema\t1\nhosted-dir\t%s\ncount\t%s\ncurrent\t%s\n' "$hosted_identity" "$count" "$current"
   while IFS=$'\t' read -r _ candidate_commit; do
     [[ -n "$candidate_commit" ]] || continue
     if [[ "$candidate_commit" == "$current" ]]; then
@@ -86,9 +87,36 @@ validate() {
   (( 10#$now >= 10#$created && 10#$now - 10#$created <= 10#$max_age )) || die "preview token is stale or from the future"
 }
 
+remove() {
+  [[ $# -eq 5 ]] || die "usage: $0 remove <hosted-dir> <commit> <plan-file> <token-file> <current-commit>"
+  local hosted_dir="$1" candidate_commit="$2" plan_file="$3" token_file="$4" current="$5"
+  local candidate_binary plan_current plan_hosted_dir hosted_identity
+  [[ -d "$hosted_dir" ]] || die "hosted artifact directory does not exist: $hosted_dir"
+  [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || die "artifact commit must be a lowercase 40-character SHA"
+  [[ "$current" =~ ^[0-9a-f]{40}$ ]] || die "current commit must be a lowercase 40-character SHA"
+  [[ "${CMUX_TUI_HOSTED_RETENTION_CONFIRM:-0}" == 1 ]] || die "destructive retention requires CMUX_TUI_HOSTED_RETENTION_CONFIRM=1"
+  validate "$plan_file" "$token_file" "$(date +%s)" 600
+  hosted_identity="$(cd -- "$hosted_dir" && pwd -P)" || die "could not resolve hosted artifact directory: $hosted_dir"
+  plan_hosted_dir="$(awk -F '\t' '$1 == "hosted-dir" {print $2}' "$plan_file")"
+  [[ "$plan_hosted_dir" == "$hosted_identity" ]] || die "retention plan hosted directory does not match removal request"
+  plan_current="$(awk -F '\t' '$1 == "current" {print $2}' "$plan_file")"
+  [[ "$plan_current" == "$current" ]] || die "retention plan current commit does not match removal request"
+  awk -F '\t' -v candidate="$candidate_commit" '$1 == "victim" && $2 == candidate {found = 1} END {exit !found}' "$plan_file" \
+    || die "artifact is not a victim in the validated retention plan"
+  require_command lsof
+  candidate_binary="$hosted_dir/$candidate_commit/cmux-tui"
+  if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
+    printf 'active\t%s\n' "$candidate_commit"
+    return 0
+  fi
+  rm -rf -- "${hosted_dir:?}/$candidate_commit"
+  printf 'removed\t%s\n' "$candidate_commit"
+}
+
 case "${1:-}" in
   plan) shift; plan "$@" ;;
   token) shift; token "$@" ;;
   validate) shift; validate "$@" ;;
-  *) die "usage: $0 <plan|token|validate> ..." ;;
+  remove) shift; remove "$@" ;;
+  *) die "usage: $0 <plan|token|validate|remove> ..." ;;
 esac

--- a/scripts/lib/hosted-retention-plan.sh
+++ b/scripts/lib/hosted-retention-plan.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() { echo "error: $*" >&2; exit 2; }
+require_command() { command -v "$1" >/dev/null 2>&1 || die "$1 is required for hosted artifact retention"; }
+
+sha256_file() {
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$1" | awk '{print $1}'
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$1" | awk '{print $1}'
+  else
+    die "shasum or sha256sum is required for hosted artifact retention"
+  fi
+}
+
+mtime() {
+  local path="$1" value=""
+  value="$(stat -f '%m' "$path" 2>/dev/null || true)"
+  if [[ ! "$value" =~ ^[0-9]+$ ]]; then
+    value="$(stat -c '%Y' "$path" 2>/dev/null || true)"
+  fi
+  [[ "$value" =~ ^[0-9]+$ ]] || die "could not read a numeric modification time for $path"
+  printf '%s\n' "$value"
+}
+
+plan() {
+  [[ $# -eq 3 ]] || die "usage: $0 plan <hosted-dir> <count> <current-commit>"
+  local hosted_dir="$1" count="$2" current="$3"
+  [[ "$count" =~ ^[1-9][0-9]{0,3}$ ]] || die "retention count must be an integer from 1 through 1000"
+  (( 10#$count <= 1000 )) || die "retention count must be at most 1000"
+  [[ "$current" =~ ^[0-9a-f]{40}$ ]] || die "current commit must be a lowercase 40-character SHA"
+  [[ -d "$hosted_dir" ]] || die "hosted artifact directory does not exist: $hosted_dir"
+  for prerequisite in find id sort stat lsof; do require_command "$prerequisite"; done
+
+  local candidate_dir candidate_commit candidate_mtime candidate_binary retained=0
+  local -a order=()
+  while IFS= read -r -d '' candidate_dir; do
+    candidate_commit="${candidate_dir##*/}"
+    [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
+    candidate_mtime="$(mtime "$candidate_dir")"
+    order+=("$candidate_mtime"$'\t'"$candidate_commit")
+  done < <(find "$hosted_dir" -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
+
+  printf 'schema\t1\ncount\t%s\ncurrent\t%s\n' "$count" "$current"
+  while IFS=$'\t' read -r _ candidate_commit; do
+    [[ -n "$candidate_commit" ]] || continue
+    if [[ "$candidate_commit" == "$current" ]]; then
+      printf 'current-candidate\t%s\n' "$candidate_commit"
+      continue
+    fi
+    if (( retained < 10#$count )); then
+      retained=$((retained + 1))
+      printf 'candidate\t%s\n' "$candidate_commit"
+      continue
+    fi
+    candidate_binary="$hosted_dir/$candidate_commit/cmux-tui"
+    if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
+      printf 'active\t%s\n' "$candidate_commit"
+    else
+      printf 'victim\t%s\n' "$candidate_commit"
+    fi
+  done < <(if ((${#order[@]})); then printf '%s\n' "${order[@]}" | sort -t $'\t' -k1,1nr -k2,2r; fi)
+}
+
+token() {
+  [[ $# -eq 2 ]] || die "usage: $0 token <plan-file> <unix-time>"
+  local plan_file="$1" now="$2"
+  [[ -s "$plan_file" ]] || die "retention plan is absent or empty"
+  [[ "$now" =~ ^[0-9]+$ ]] || die "token time must be a non-negative integer"
+  require_command awk
+  printf 'schema\t1\nplan-sha256\t%s\ncreated-at\t%s\n' "$(sha256_file "$plan_file")" "$now"
+}
+
+validate() {
+  [[ $# -eq 4 ]] || die "usage: $0 validate <plan-file> <token-file> <unix-time> <max-age>"
+  local plan_file="$1" token_file="$2" now="$3" max_age="$4" schema hash created expected_hash
+  [[ -s "$plan_file" && -s "$token_file" ]] || die "retention plan or preview token is absent"
+  [[ "$now" =~ ^[0-9]+$ && "$max_age" =~ ^[1-9][0-9]*$ ]] || die "validation times must be bounded integers"
+  schema="$(awk -F '\t' '$1 == "schema" {print $2}' "$token_file")"
+  hash="$(awk -F '\t' '$1 == "plan-sha256" {print $2}' "$token_file")"
+  created="$(awk -F '\t' '$1 == "created-at" {print $2}' "$token_file")"
+  [[ "$schema" == 1 && "$hash" =~ ^[0-9a-f]{64}$ && "$created" =~ ^[0-9]+$ ]] || die "preview token is malformed"
+  expected_hash="$(sha256_file "$plan_file")"
+  [[ "$hash" == "$expected_hash" ]] || die "preview token does not match the current retention plan"
+  (( 10#$now >= 10#$created && 10#$now - 10#$created <= 10#$max_age )) || die "preview token is stale or from the future"
+}
+
+case "${1:-}" in
+  plan) shift; plan "$@" ;;
+  token) shift; token "$@" ;;
+  validate) shift; validate "$@" ;;
+  *) die "usage: $0 <plan|token|validate> ..." ;;
+esac

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+tmp="$(mktemp -d)"
+trap 'rm -rf -- "$tmp"' EXIT
+preview="$tmp/.retention-preview"
+hash=abc123
+write_preview() { printf '%s\t%s\n' "$1" "$(date +%s)" > "$preview"; }
+valid_preview() { [[ -f "$preview" && "$(cut -f1 "$preview")" == "$hash" ]] && (( $(date +%s) - $(cut -f2 "$preview") <= 600 )); }
+! valid_preview
+write_preview "$hash"
+valid_preview
+printf '%s\t%s\n' "$hash" "$(( $(date +%s) - 601 ))" > "$preview"
+! valid_preview
+rm -f "$preview"
+echo 'hosted retention token behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -1,15 +1,67 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+repo_root="$(CDPATH='' cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+helper="$repo_root/scripts/lib/hosted-retention-plan.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf -- "$tmp"' EXIT
-preview="$tmp/.retention-preview"
-hash=abc123
-write_preview() { printf '%s\t%s\n' "$1" "$(date +%s)" > "$preview"; }
-valid_preview() { [[ -f "$preview" && "$(cut -f1 "$preview")" == "$hash" ]] && (( $(date +%s) - $(cut -f2 "$preview") <= 600 )); }
-! valid_preview
-write_preview "$hash"
-valid_preview
-printf '%s\t%s\n' "$hash" "$(( $(date +%s) - 601 ))" > "$preview"
-! valid_preview
-rm -f "$preview"
-echo 'hosted retention token behavior passed'
+
+fail() { echo "FAIL: $*" >&2; exit 1; }
+expect_failure() {
+  if "$@" >"$tmp/unexpected-stdout" 2>"$tmp/expected-error"; then
+    fail "command unexpectedly succeeded: $*"
+  fi
+}
+
+commit_a=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+commit_b=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+commit_c=cccccccccccccccccccccccccccccccccccccccc
+commit_d=dddddddddddddddddddddddddddddddddddddddd
+hosted="$tmp/hosted"
+mkdir -p "$hosted/$commit_a" "$hosted/$commit_b" "$hosted/$commit_c" "$hosted/$commit_d"
+touch -t 202401010101 "$hosted/$commit_a"
+touch -t 202402020202 "$hosted/$commit_b"
+touch -t 202403030303 "$hosted/$commit_c"
+touch -t 202312120000 "$hosted/$commit_d"
+
+plan="$tmp/plan"
+"$helper" plan "$hosted" 1 "$commit_c" >"$plan"
+grep -Fqx $'schema\t1' "$plan" || fail "plan schema is absent"
+grep -Fqx $'count\t1' "$plan" || fail "retention count is not bound"
+grep -Fqx $'current\t'$commit_c "$plan" || fail "current commit is not bound"
+grep -Fqx $'candidate\t'$commit_b "$plan" || fail "retained candidate is not bound"
+grep -Fqx $'victim\t'$commit_a "$plan" || fail "first victim is not bound"
+grep -Fqx $'victim\t'$commit_d "$plan" || fail "second victim is not bound"
+
+token="$tmp/token"
+"$helper" token "$plan" 1000 >"$token"
+"$helper" validate "$plan" "$token" 1599 600
+expect_failure "$helper" validate "$plan" "$token" 1601 600
+sed 's/^count\t1$/count\t2/' "$plan" >"$tmp/mismatch-plan"
+expect_failure "$helper" validate "$tmp/mismatch-plan" "$token" 1500 600
+"$helper" token "$plan" 2000 >"$tmp/fresh-token"
+"$helper" validate "$plan" "$tmp/fresh-token" 2000 600
+
+real_stat="$(command -v stat)"
+mkdir "$tmp/gnu-bin"
+cat >"$tmp/gnu-bin/stat" <<EOF
+#!/bin/sh
+if [ "\${1:-}" = "-f" ]; then exit 1; fi
+exec "$real_stat" "\$@"
+EOF
+chmod +x "$tmp/gnu-bin/stat"
+PATH="$tmp/gnu-bin:$PATH" "$helper" plan "$hosted" 1 "$commit_c" >"$tmp/gnu-plan"
+cmp -s "$plan" "$tmp/gnu-plan" || fail "GNU stat fallback changed the canonical plan"
+
+expect_failure "$helper" plan "$hosted" 0 "$commit_c"
+expect_failure "$helper" plan "$hosted" 1001 "$commit_c"
+expect_failure "$helper" plan "$hosted" 999999999999999999999999999999999 "$commit_c"
+
+mkdir "$tmp/no-lsof-bin"
+for command_name in find id sort stat shasum awk; do
+  command_path="$(command -v "$command_name")"
+  ln -s "$command_path" "$tmp/no-lsof-bin/$command_name"
+done
+expect_failure env PATH="$tmp/no-lsof-bin" /bin/bash "$helper" plan "$hosted" 1 "$commit_c"
+
+echo 'hosted retention plan tests passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -61,6 +61,27 @@ expect_failure "$helper" plan "$hosted" 0 "$commit_c"
 expect_failure "$helper" plan "$hosted" 1001 "$commit_c"
 expect_failure "$helper" plan "$hosted" 999999999999999999999999999999999 "$commit_c"
 
+active_bin="$hosted/$commit_a/cmux-tui"
+printf 'active artifact\n' >"$active_bin"
+mkdir "$tmp/active-bin"
+cat >"$tmp/active-bin/lsof" <<'EOF'
+#!/bin/sh
+printf '4242\n'
+EOF
+chmod +x "$tmp/active-bin/lsof"
+PATH="$tmp/active-bin:$PATH" "$helper" remove "$hosted" "$commit_a" >"$tmp/active-remove"
+grep -Fqx $'active\t'$commit_a "$tmp/active-remove" || fail "active artifact was not reported"
+[[ -d "$hosted/$commit_a" ]] || fail "active artifact was removed"
+
+cat >"$tmp/active-bin/lsof" <<'EOF'
+#!/bin/sh
+exit 1
+EOF
+chmod +x "$tmp/active-bin/lsof"
+PATH="$tmp/active-bin:$PATH" "$helper" remove "$hosted" "$commit_a" >"$tmp/inactive-remove"
+grep -Fqx $'removed\t'$commit_a "$tmp/inactive-remove" || fail "inactive artifact was not removed"
+[[ ! -e "$hosted/$commit_a" ]] || fail "inactive artifact remains"
+
 mkdir "$tmp/no-lsof-bin"
 for command_name in find id sort stat shasum awk; do
   command_path="$(command -v "$command_name")"

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -49,6 +49,7 @@ cat >"$tmp/gnu-bin/stat" <<EOF
 if [ "\${1:-}" = "-f" ]; then exit 1; fi
 if [ "\${1:-}" = "-c" ] && [ "\${2:-}" = "%Y" ]; then
   shift 2
+  if "$real_stat" -c '%Y' "\$@" 2>/dev/null; then exit 0; fi
   exec "$real_stat" -f '%m' "\$@"
 fi
 exec "$real_stat" "\$@"
@@ -69,16 +70,26 @@ cat >"$tmp/active-bin/lsof" <<'EOF'
 printf '4242\n'
 EOF
 chmod +x "$tmp/active-bin/lsof"
-PATH="$tmp/active-bin:$PATH" "$helper" remove "$hosted" "$commit_a" >"$tmp/active-remove"
+remove_token="$tmp/remove-token"
+"$helper" token "$plan" "$(date +%s)" >"$remove_token"
+expect_failure env PATH="$tmp/active-bin:$PATH" "$helper" remove "$hosted" "$commit_a" "$plan" "$remove_token" "$commit_c"
+PATH="$tmp/active-bin:$PATH" CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 "$helper" remove \
+  "$hosted" "$commit_a" "$plan" "$remove_token" "$commit_c" >"$tmp/active-remove"
 grep -Fqx $'active\t'$commit_a "$tmp/active-remove" || fail "active artifact was not reported"
 [[ -d "$hosted/$commit_a" ]] || fail "active artifact was removed"
+
+other_hosted="$tmp/other-hosted"
+mkdir -p "$other_hosted/$commit_a"
+expect_failure env PATH="$tmp/active-bin:$PATH" CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 "$helper" remove \
+  "$other_hosted" "$commit_a" "$plan" "$remove_token" "$commit_c"
 
 cat >"$tmp/active-bin/lsof" <<'EOF'
 #!/bin/sh
 exit 1
 EOF
 chmod +x "$tmp/active-bin/lsof"
-PATH="$tmp/active-bin:$PATH" "$helper" remove "$hosted" "$commit_a" >"$tmp/inactive-remove"
+PATH="$tmp/active-bin:$PATH" CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 "$helper" remove \
+  "$hosted" "$commit_a" "$plan" "$remove_token" "$commit_c" >"$tmp/inactive-remove"
 grep -Fqx $'removed\t'$commit_a "$tmp/inactive-remove" || fail "inactive artifact was not removed"
 [[ ! -e "$hosted/$commit_a" ]] || fail "inactive artifact remains"
 

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -47,6 +47,10 @@ mkdir "$tmp/gnu-bin"
 cat >"$tmp/gnu-bin/stat" <<EOF
 #!/bin/sh
 if [ "\${1:-}" = "-f" ]; then exit 1; fi
+if [ "\${1:-}" = "-c" ] && [ "\${2:-}" = "%Y" ]; then
+  shift 2
+  exec "$real_stat" -f '%m' "\$@"
+fi
 exec "$real_stat" "\$@"
 EOF
 chmod +x "$tmp/gnu-bin/stat"

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -342,6 +342,57 @@ artifact_binary="$artifact_dir/cmux-tui"
 mkdir -p "$artifact_dir"
 install -m 0755 "$downloaded_binary" "$artifact_binary"
 
+# Keep a small, bounded local cache. Cleanup is opt-in so existing callers do
+# not lose artifacts unexpectedly. Only directories owned by this user and
+# named for a complete commit SHA are eligible. The current commit and any
+# binary still open by a process are always retained.
+retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-5}"
+if [[ ! "$retention_count" =~ ^[1-9][0-9]*$ ]]; then
+  echo "error: CMUX_TUI_HOSTED_RETENTION_COUNT must be a positive integer" >&2
+  exit 2
+fi
+if [[ "${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}" == "1" ]]; then
+  retention_dry_run=true
+elif [[ "${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}" == "0" ]]; then
+  retention_dry_run=false
+else
+  echo "error: CMUX_TUI_HOSTED_RETENTION_DRY_RUN must be 0 or 1" >&2
+  exit 2
+fi
+
+hosted_artifact_dirs=()
+while IFS= read -r -d '' candidate_dir; do
+  candidate_commit="${candidate_dir##*/}"
+  [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
+  hosted_artifact_dirs+=("$candidate_dir")
+done < <(find cmux-tui/target/hosted -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
+if ((${#hosted_artifact_dirs[@]} > 1)); then
+  IFS=$'\n' hosted_artifact_dirs=($(printf '%s\n' "${hosted_artifact_dirs[@]}" | sort -r))
+  unset IFS
+fi
+retained=0
+for candidate_dir in "${hosted_artifact_dirs[@]}"; do
+  candidate_commit="${candidate_dir##*/}"
+  candidate_binary="$candidate_dir/cmux-tui"
+  if [[ "$candidate_commit" == "$commit" || ! -f "$candidate_binary" ]]; then
+    continue
+  fi
+  if (( retained < retention_count )); then
+    retained=$((retained + 1))
+    continue
+  fi
+  if command -v lsof >/dev/null 2>&1 && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
+    echo "Keeping active hosted artifact: $candidate_binary" >&2
+    continue
+  fi
+  if [[ "$retention_dry_run" == true ]]; then
+    echo "Would remove hosted artifact: $candidate_dir" >&2
+  else
+    rm -rf -- "$candidate_dir"
+    echo "Removed hosted artifact: $candidate_dir" >&2
+  fi
+done
+
 echo "Hosted verification passed: $run_url"
 echo "Artifact: $artifact_binary"
 echo "Dogfood: $artifact_binary --session verify-${commit:0:8}"

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -380,16 +380,25 @@ if [[ "$retention_dry_run" == true ]]; then
 else
   "$retention_helper" validate "$retention_plan" "$preview_file" "$(date +%s)" 600
 fi
+victim_commits=()
 while IFS=$'\t' read -r disposition candidate_commit; do
   [[ "$disposition" == victim ]] || continue
+  victim_commits+=("$candidate_commit")
+done <"$retention_plan"
+for candidate_commit in "${victim_commits[@]}"; do
   candidate_dir="cmux-tui/target/hosted/$candidate_commit"
   if [[ "$retention_dry_run" == true ]]; then
     echo "Would remove hosted artifact: $candidate_dir" >&2
   else
-    rm -rf -- "$candidate_dir"
-    echo "Removed hosted artifact: $candidate_dir" >&2
+    remove_result="$(CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 "$retention_helper" remove \
+      "cmux-tui/target/hosted" "$candidate_commit" "$retention_plan" "$preview_file" "$commit")"
+    case "$remove_result" in
+      $'active\t'*) echo "Keeping active hosted artifact: $candidate_dir" >&2 ;;
+      $'removed\t'*) echo "Removed hosted artifact: $candidate_dir" >&2 ;;
+      *) echo "error: unexpected retention removal result for $candidate_dir" >&2; exit 2 ;;
+    esac
   fi
-done <"$retention_plan"
+done
 
 echo "Hosted verification passed: $run_url"
 echo "Artifact: $artifact_binary"

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -372,62 +372,24 @@ if [[ "$retention_dry_run" == false && "$retention_confirmed" != "1" ]]; then
   exit 2
 fi
 preview_file="cmux-tui/target/hosted/.retention-preview"
-lsof_available=false
-if command -v lsof >/dev/null 2>&1; then
-  lsof_available=true
-fi
-
-hosted_artifact_dirs=()
-hosted_artifact_order=()
-while IFS= read -r -d '' candidate_dir; do
-  candidate_commit="${candidate_dir##*/}"
-  [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
-  if stat -f '%m' "$candidate_dir" >/dev/null 2>&1; then
-    candidate_mtime="$(stat -f '%m' "$candidate_dir")"
-  else
-    candidate_mtime="$(stat -c '%Y' "$candidate_dir")"
-  fi
-  hosted_artifact_order+=("$candidate_mtime	$candidate_commit	$candidate_dir")
-done < <(find cmux-tui/target/hosted -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
-if ((${#hosted_artifact_order[@]} > 0)); then
-  while IFS=$'\t' read -r _ candidate_commit candidate_dir; do
-    hosted_artifact_dirs+=("$candidate_dir")
-  done < <(printf '%s\n' "${hosted_artifact_order[@]}" | sort -t $'\t' -k1,1nr -k2,2r)
-fi
-candidate_set_hash="$(printf '%s\n' "${hosted_artifact_dirs[@]}" | shasum -a 256 | awk '{print $1}')"
+retention_plan="$temp_dir/retention-plan"
+retention_helper="$repo_root/scripts/lib/hosted-retention-plan.sh"
+"$retention_helper" plan "cmux-tui/target/hosted" "$retention_count" "$commit" >"$retention_plan"
 if [[ "$retention_dry_run" == true ]]; then
-  printf '%s\t%s\n' "$candidate_set_hash" "$(date +%s)" > "$preview_file"
-elif [[ ! -f "$preview_file" ]] || [[ "$(cut -f1 "$preview_file")" != "$candidate_set_hash" ]] || \
-  (( $(date +%s) - $(cut -f2 "$preview_file") > 600 )); then
-  echo "error: retention requires a fresh dry-run preview for this candidate set" >&2
-  exit 2
+  "$retention_helper" token "$retention_plan" "$(date +%s)" >"$preview_file"
+else
+  "$retention_helper" validate "$retention_plan" "$preview_file" "$(date +%s)" 600
 fi
-retained=0
-for candidate_dir in "${hosted_artifact_dirs[@]}"; do
-  candidate_commit="${candidate_dir##*/}"
-  candidate_binary="$candidate_dir/cmux-tui"
-  if [[ "$candidate_commit" == "$commit" ]]; then
-    continue
-  fi
-  if (( retained < retention_count )); then
-    retained=$((retained + 1))
-    continue
-  fi
-  if [[ "$lsof_available" != true ]]; then
-    echo "error: cannot prove artifact is inactive because lsof is unavailable" >&2
-    exit 2
-  fi
-  if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
-    echo "Keeping active hosted artifact: $candidate_binary" >&2
-    continue
-  fi
+while IFS=$'\t' read -r disposition candidate_commit; do
+  [[ "$disposition" == victim ]] || continue
+  candidate_dir="cmux-tui/target/hosted/$candidate_commit"
   if [[ "$retention_dry_run" == true ]]; then
     echo "Would remove hosted artifact: $candidate_dir" >&2
   else
     rm -rf -- "$candidate_dir"
     echo "Removed hosted artifact: $candidate_dir" >&2
   fi
-done
+done <"$retention_plan"
 
 echo "Hosted verification passed: $run_url"
 echo "Artifact: $artifact_binary"

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -371,6 +371,7 @@ if [[ "$retention_dry_run" == false && "$retention_confirmed" != "1" ]]; then
   echo "error: destructive retention requires CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 after a dry run" >&2
   exit 2
 fi
+preview_file="cmux-tui/target/hosted/.retention-preview"
 lsof_available=false
 if command -v lsof >/dev/null 2>&1; then
   lsof_available=true
@@ -393,6 +394,14 @@ if ((${#hosted_artifact_order[@]} > 0)); then
     hosted_artifact_dirs+=("$candidate_dir")
   done < <(printf '%s\n' "${hosted_artifact_order[@]}" | sort -t $'\t' -k1,1nr -k2,2r)
 fi
+candidate_set_hash="$(printf '%s\n' "${hosted_artifact_dirs[@]}" | shasum -a 256 | awk '{print $1}')"
+if [[ "$retention_dry_run" == true ]]; then
+  printf '%s\t%s\n' "$candidate_set_hash" "$(date +%s)" > "$preview_file"
+elif [[ ! -f "$preview_file" ]] || [[ "$(cut -f1 "$preview_file")" != "$candidate_set_hash" ]] || \
+  (( $(date +%s) - $(cut -f2 "$preview_file") > 600 )); then
+  echo "error: retention requires a fresh dry-run preview for this candidate set" >&2
+  exit 2
+fi
 retained=0
 for candidate_dir in "${hosted_artifact_dirs[@]}"; do
   candidate_commit="${candidate_dir##*/}"
@@ -405,8 +414,8 @@ for candidate_dir in "${hosted_artifact_dirs[@]}"; do
     continue
   fi
   if [[ "$lsof_available" != true ]]; then
-    echo "Keeping artifact because lsof is unavailable: $candidate_dir" >&2
-    continue
+    echo "error: cannot prove artifact is inactive because lsof is unavailable" >&2
+    exit 2
   fi
   if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
     echo "Keeping active hosted artifact: $candidate_binary" >&2

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -366,6 +366,15 @@ else
   echo "error: CMUX_TUI_HOSTED_RETENTION_DRY_RUN must be 0 or 1" >&2
   exit 2
 fi
+retention_confirmed="${CMUX_TUI_HOSTED_RETENTION_CONFIRM:-0}"
+if [[ "$retention_dry_run" == false && "$retention_confirmed" != "1" ]]; then
+  echo "error: destructive retention requires CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 after a dry run" >&2
+  exit 2
+fi
+lsof_available=false
+if command -v lsof >/dev/null 2>&1; then
+  lsof_available=true
+fi
 
 hosted_artifact_dirs=()
 hosted_artifact_order=()
@@ -388,14 +397,18 @@ retained=0
 for candidate_dir in "${hosted_artifact_dirs[@]}"; do
   candidate_commit="${candidate_dir##*/}"
   candidate_binary="$candidate_dir/cmux-tui"
-  if [[ "$candidate_commit" == "$commit" || ! -f "$candidate_binary" ]]; then
+  if [[ "$candidate_commit" == "$commit" ]]; then
     continue
   fi
   if (( retained < retention_count )); then
     retained=$((retained + 1))
     continue
   fi
-  if command -v lsof >/dev/null 2>&1 && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
+  if [[ "$lsof_available" != true ]]; then
+    echo "Keeping artifact because lsof is unavailable: $candidate_dir" >&2
+    continue
+  fi
+  if [[ -f "$candidate_binary" ]] && lsof -t -- "$candidate_binary" >/dev/null 2>&1; then
     echo "Keeping active hosted artifact: $candidate_binary" >&2
     continue
   fi

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -346,7 +346,14 @@ install -m 0755 "$downloaded_binary" "$artifact_binary"
 # not lose artifacts unexpectedly. Only directories owned by this user and
 # named for a complete commit SHA are eligible. The current commit and any
 # binary still open by a process are always retained.
-retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-5}"
+retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-}"
+if [[ -z "$retention_count" ]]; then
+  echo "Hosted artifact retention disabled (set CMUX_TUI_HOSTED_RETENTION_COUNT to enable)" >&2
+  echo "Hosted verification passed: $run_url"
+  echo "Artifact: $artifact_binary"
+  echo "Dogfood: $artifact_binary --session verify-${commit:0:8}"
+  exit 0
+fi
 if [[ ! "$retention_count" =~ ^[1-9][0-9]*$ ]]; then
   echo "error: CMUX_TUI_HOSTED_RETENTION_COUNT must be a positive integer" >&2
   exit 2

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -361,14 +361,21 @@ else
 fi
 
 hosted_artifact_dirs=()
+hosted_artifact_order=()
 while IFS= read -r -d '' candidate_dir; do
   candidate_commit="${candidate_dir##*/}"
   [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
-  hosted_artifact_dirs+=("$candidate_dir")
+  if stat -f '%m' "$candidate_dir" >/dev/null 2>&1; then
+    candidate_mtime="$(stat -f '%m' "$candidate_dir")"
+  else
+    candidate_mtime="$(stat -c '%Y' "$candidate_dir")"
+  fi
+  hosted_artifact_order+=("$candidate_mtime	$candidate_commit	$candidate_dir")
 done < <(find cmux-tui/target/hosted -mindepth 1 -maxdepth 1 -type d -user "$(id -u)" -print0)
-if ((${#hosted_artifact_dirs[@]} > 1)); then
-  IFS=$'\n' hosted_artifact_dirs=($(printf '%s\n' "${hosted_artifact_dirs[@]}" | sort -r))
-  unset IFS
+if ((${#hosted_artifact_order[@]} > 0)); then
+  while IFS=$'\t' read -r _ candidate_commit candidate_dir; do
+    hosted_artifact_dirs+=("$candidate_dir")
+  done < <(printf '%s\n' "${hosted_artifact_order[@]}" | sort -t $'\t' -k1,1nr -k2,2r)
 fi
 retained=0
 for candidate_dir in "${hosted_artifact_dirs[@]}"; do


### PR DESCRIPTION
## Summary
- Extract side-effect-free hosted artifact retention plan and preview validation helper.
- Bind preview tokens to count, current commit, candidates, active entries, and victims.
- Add harness coverage for portable stat, stale and mismatched previews, overflow, and missing lsof.

## Testing
- `./scripts/test-hosted-retention.sh`
- `bash -n scripts/lib/hosted-retention-plan.sh scripts/verify-cmux-tui-hosted.sh scripts/test-hosted-retention.sh`

## Issues
- Related: https://github.com/manaflow-ai/cmux/pull/11620

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hosted artifact retention now builds a shared canonical plan and binds preview tokens to that plan instead of a candidate-set hash, keeping preview and removal decisions consistent.

**Behavior**
- Preview tokens expire after 600 seconds and are rejected when the retention count, current commit, candidates, active entries, or victims change.
- Removal revalidates the plan and token, rechecks activity with `lsof` immediately before deletion, and requires `CMUX_TUI_HOSTED_RETENTION_CONFIRM=1`; missing `lsof` now fails safely.
- Plan generation supports both GNU and BSD `stat`.

**Migration**
- Existing candidate-set preview tokens are no longer accepted; regenerate them with `scripts/lib/hosted-retention-plan.sh token`.

<sup>Written for commit b69aac0b2c2dd3f5fec764763d378b7234fe4fae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

