### PR TITLE
fix(cmux-tui): keep active tab aligned after malformed tab filtering

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -436,6 +436,8 @@ fn parse_layout(value: &Value) -> Option<Node> {
 }
 
 fn parse_pane(value: &Value) -> Option<PaneView> {
+    let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let mut active_tab = raw_active_tab;
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
         resource_id: value
@@ -444,15 +446,16 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
             .and_then(|value| PanePublicId::parse(value.to_string()).ok()),
         short_id: value.get("short_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
         name: value.get("name").and_then(|v| v.as_str()).map(|s| s.to_string()),
-        active_tab: value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
         focused_at: value.get("focused_at").and_then(|v| v.as_u64()).unwrap_or(0),
         tabs: value
             .get("tabs")
             .and_then(|v| v.as_array())
             .map(|tabs| {
+                let mut compact_index = 0;
                 tabs.iter()
-                    .filter_map(|tab| {
-                        Some(TabView {
+                    .enumerate()
+                    .filter_map(|(raw_index, tab)| {
+                        let parsed = Some(TabView {
                             surface: tab.get("surface")?.as_u64()?,
                             public_id: tab
                                 .get("tab_resource_id")
@@ -504,11 +507,17 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                                 .and_then(Value::as_bool)
                                 .unwrap_or(false),
                             notification: tab.get("notification").and_then(parse_notification),
-                        })
+                        })?;
+                        if raw_index == raw_active_tab {
+                            active_tab = compact_index;
+                        }
+                        compact_index += 1;
+                        Some(parsed)
                     })
                     .collect()
             })
             .unwrap_or_default(),
+        active_tab,
     })
 }
 

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -954,6 +954,23 @@ mod tests {
     }
 
     #[test]
+    fn pane_parser_reindexes_active_tab_after_dropping_malformed_tabs() {
+        let pane = parse_pane(&json!({
+            "id": 3,
+            "active_tab": 1,
+            "tabs": [
+                {"title": "malformed"},
+                {"surface": 5, "title": "active"}
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(pane.tabs.len(), 1);
+        assert_eq!(pane.active_tab, 0);
+        assert_eq!(pane.active_surface(), Some(5));
+    }
+
+    #[test]
     fn tree_parser_defaults_and_preserves_pane_revision() {
         assert_eq!(parse_tree(&json!({"workspaces": []})).pane_revision, None);
         assert_eq!(


### PR DESCRIPTION
Summary:
- preserve the active tab selection when malformed tab records are removed during tree parsing
- track the raw active position with enumerate and assign its compact parsed index

Regression coverage is in the first commit; the repair is in the second commit.

Checks:
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/session/tree.rs
- git diff --check origin/main...HEAD
- Cargo/Xcode not run per cmux-tui instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11637"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790938933&installation_model_id=21920&pr_number=11637&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11637&signature=cb1b2ad36b712e2ceef79e4db30a847ee8c69ec6f4c89616bc9f894404cc3ca6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `cmux-tui` pane parser so the active tab index stays aligned when malformed tab records are dropped during tree parsing. Previously the active tab pointed to the raw position in the unfiltered list, which could select the wrong tab after filtering; now it reindexes to the compacted parsed list. Includes a regression test covering a malformed first tab.

<sup>Written for commit e23e77cbd5d39e89d54bca07a11c99731c65938d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

