### PR TITLE
Pricing cards: one action height, no duplicate "Current plan" button

### DIFF
--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -23,7 +23,6 @@ import {
 } from "../../../i18n/locale-availability";
 import {
   CurrentPlanBadge,
-  DisabledButton,
   FeatureList,
   PlanCard,
   PricingCompareTable,
@@ -205,19 +204,14 @@ export default async function PricingPage({
                 ) : null
               }
             >
-              {snapshot.isPro ? (
-                <div className="space-y-2">
-                  <DisabledButton>{t("currentPlan")}</DisabledButton>
-                  <SecondaryLink href="/api/billing/portal">
-                    {t("manageBilling")}
-                  </SecondaryLink>
-                </div>
-              ) : canManageBilling ? (
+              {/* The badge already says "Current plan"; the one action a
+                  subscriber has here is billing. */}
+              {snapshot.isPro || canManageBilling ? (
                 <SecondaryLink href="/api/billing/portal">
                   {t("manageBilling")}
                 </SecondaryLink>
               ) : (
-                <ProCtaLink checkoutHrefs={proCheckoutHrefs} size="compact">
+                <ProCtaLink checkoutHrefs={proCheckoutHrefs}>
                   {t("pro.cta")}
                 </ProCtaLink>
               )}
@@ -245,7 +239,6 @@ export default async function PricingPage({
                 hrefs={teamCheckoutHrefs}
                 location="pricing_page"
                 plan="team"
-                size="compact"
               >
                 {t("team.cta")}
               </PricingCheckoutButton>
@@ -303,9 +296,7 @@ export default async function PricingPage({
                   </PrimaryLink>
                 ),
                 pro: (
-                  snapshot.isPro ? (
-                    <DisabledButton size="compact">{t("currentPlan")}</DisabledButton>
-                  ) : canManageBilling ? (
+                  snapshot.isPro || canManageBilling ? (
                     <SecondaryLink href="/api/billing/portal" size="compact">
                       {t("manageBilling")}
                     </SecondaryLink>

--- a/web/app/app-pricing/page.tsx
+++ b/web/app/app-pricing/page.tsx
@@ -187,14 +187,15 @@ export default async function AppPricingPage({
                 }
               >
                 {snapshot.isPro ? (
-                  <div className="space-y-2">
+                  // The badge already says "Current plan"; the one action a
+                  // subscriber has here is billing, unless payments are gated.
+                  appStorePaymentGated ? (
                     <DisabledButton>{pricing.currentPlan}</DisabledButton>
-                    {appStorePaymentGated ? null : (
-                      <SecondaryLink href="/api/billing/portal">
-                        {pricing.manageBilling}
-                      </SecondaryLink>
-                    )}
-                  </div>
+                  ) : (
+                    <SecondaryLink href="/api/billing/portal">
+                      {pricing.manageBilling}
+                    </SecondaryLink>
+                  )
                 ) : appStorePaymentGated ? (
                   <DisabledButton>{pricing.billingUnavailable}</DisabledButton>
                 ) : canManageBilling ? (

--- a/web/tests/app-pricing-page.test.tsx
+++ b/web/tests/app-pricing-page.test.tsx
@@ -276,6 +276,7 @@ describe("app pricing page", () => {
     expect(html).toContain('href="/api/billing/portal"');
     expect(html).toContain("Manage billing");
     expect(html).toContain("Current plan");
+    expect(html).not.toMatch(/<button[^>]*disabled[^>]*>Current plan<\/button>/);
   });
 
   for (const [name, params, message] of [

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -136,7 +136,7 @@ describe("localized pricing page", () => {
     }
   });
 
-  test("defaults public pricing to annual billing with compact paid-plan CTAs", async () => {
+  test("defaults public pricing to annual billing; card CTAs are full size, compare-header CTAs compact", async () => {
     const element = await PricingPage({ params: Promise.resolve({ locale: "en" }) });
     const html = renderToStaticMarkup(element);
 
@@ -157,6 +157,14 @@ describe("localized pricing page", () => {
     );
     expect(html).toMatch(
       /href="\/api\/billing\/checkout\?plan=team[^"]*interval=year"[^>]*class="[^"]*px-3 py-1\.5 text-xs[^"]*"[^>]*><span>Get Teams/,
+    );
+    // Every plan card's primary action shares one height (the Team card was
+    // the only compact one).
+    expect(html).toMatch(
+      /href="\/api\/billing\/checkout\?plan=pro[^"]*interval=year"[^>]*class="[^"]*px-5 py-2\.5 text-\[15px\][^"]*"[^>]*><span>Get Pro/,
+    );
+    expect(html).toMatch(
+      /href="\/api\/billing\/checkout\?plan=team[^"]*interval=year"[^>]*class="[^"]*px-5 py-2\.5 text-\[15px\][^"]*"[^>]*><span>Get Teams/,
     );
     expect(html).toContain('<p class="mt-5 text-sm font-medium">Includes:</p>');
     expect(html).not.toContain('style="min-height:4rem"');
@@ -199,6 +207,9 @@ describe("localized pricing page", () => {
     expect(html).toContain('href="/api/billing/portal"');
     expect(html).toContain("Manage billing");
     expect(html).toContain("Current plan");
+    // The badge says "Current plan"; no disabled button repeats it above
+    // Manage billing in the card.
+    expect(html).not.toMatch(/<button[^>]*disabled[^>]*>Current plan<\/button>/);
   });
 
   test("renders the annual price and sends annual checkout intent", async () => {


### PR DESCRIPTION
The Team card CTA was compact while its neighbors were full size, so "Get Teams" rendered shorter. Every plan card action is full size now; the sticky compare header stays compact.

A Pro subscriber saw a disabled "Current plan" button stacked above "Manage billing" although the card badge already says "Current plan". The card (and the compare-header cell) now show "Manage billing" alone; in App Store distribution mode, where the portal is hidden, the disabled button remains as the only affordance.

https://claude.ai/code/session_01YKXxKXemYnpAhSyZ4uaVhF

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes all pricing card CTAs full size and removes the duplicate "Current plan" button for Pro subscribers.

- The Team card's CTA was the only compact one; now all card actions share the same height. The sticky compare header stays compact.
- Pro subscribers' cards and compare-header cells now show only "Manage billing" since the badge already says "Current plan." The disabled button remains only in App Store distribution mode where the billing portal is hidden.

<sup>Written for commit 493bd3ab8a6445b8aaffe563a48fab1e165eadcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

