### PR TITLE
cloud: let Cloud VMs notify the owning Mac over the private network

### DIFF
--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -101,6 +101,8 @@ extension CMUXCLI {
             detail = String(localized: "cli.vpn.notifications.reason.noMachines", defaultValue: "you have no Cloud machines")
         case "network_metadata_missing":
             detail = String(localized: "cli.vpn.notifications.reason.metadata", defaultValue: "network details missing; run `cmux vpn up` to re-enroll")
+        case "inventory_pending":
+            detail = String(localized: "cli.vpn.notifications.reason.inventoryPending", defaultValue: "checking sign-in and machines, run `cmux vpn notifications status` again")
         case "cloud_unreachable":
             let format = String(localized: "cli.vpn.notifications.reason.cloudUnreachable", defaultValue: "cloud service unreachable: %@")
             detail = String(format: format, (response["last_error"] as? String) ?? reason)

--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -40,9 +40,74 @@ extension CMUXCLI {
             try runVPNRevoke(client: client, jsonOutput: jsonOutput)
         case "hosts":
             try runVPNHostsSync(client: client, jsonOutput: jsonOutput)
+        case "notifications":
+            try runVPNNotifications(Array(commandArgs.dropFirst()), client: client, jsonOutput: jsonOutput)
         default:
-            throw CLIError(message: "Usage: cmux vpn <up|down|status|revoke|hosts>")
+            throw CLIError(message: "Usage: cmux vpn <up|down|status|revoke|hosts|notifications>")
         }
+    }
+
+    /// `cmux vpn notifications [on|off|status]` — whether this Mac accepts
+    /// notifications from its Cloud VMs over the tunnel (default off).
+    private func runVPNNotifications(_ args: [String], client: SocketClient, jsonOutput: Bool) throws {
+        let sub = args.first?.lowercased() ?? "status"
+        let response: [String: Any]
+        switch sub {
+        case "on", "off":
+            response = try client.sendV2(
+                method: "vm.host_notifications_set",
+                params: ["enabled": sub == "on"],
+                responseTimeout: 30
+            )
+        case "status":
+            response = try client.sendV2(method: "vm.host_status", responseTimeout: 30)
+        default:
+            throw CLIError(message: "Usage: cmux vpn notifications <on|off|status>")
+        }
+        if jsonOutput {
+            print(jsonString(response))
+            return
+        }
+        printVMHostStatus(response)
+    }
+
+    /// Human summary of `vm.host_status`.
+    private func printVMHostStatus(_ response: [String: Any]) {
+        let enabled = (response["enabled"] as? Bool) ?? false
+        let listening = (response["listening"] as? Bool) ?? false
+        if !enabled {
+            print(String(
+                localized: "cli.vpn.notifications.off",
+                defaultValue: "Notifications from machines: off. Turn on with `cmux vpn notifications on` or in Settings > Cloud."
+            ))
+            return
+        }
+        if listening, let endpoint = response["machine_endpoint"] as? String {
+            let format = String(localized: "cli.vpn.notifications.listening", defaultValue: "Notifications from machines: on, listening at %@")
+            print(String(format: format, endpoint))
+            let machines = (response["machine_count"] as? Int) ?? 0
+            let machinesFormat = String(localized: "cli.vpn.notifications.machines", defaultValue: "Machines: %d")
+            print(String(format: machinesFormat, machines))
+            return
+        }
+        let reason = (response["off_reason"] as? String) ?? "unknown"
+        let detail: String
+        switch reason {
+        case "signed_out":
+            detail = String(localized: "cli.vpn.notifications.reason.signedOut", defaultValue: "not signed in")
+        case "tunnel_down":
+            detail = String(localized: "cli.vpn.notifications.reason.tunnelDown", defaultValue: "tunnel is down; run `cmux vpn up`")
+        case "no_machines":
+            detail = String(localized: "cli.vpn.notifications.reason.noMachines", defaultValue: "you have no Cloud machines")
+        case "network_metadata_missing":
+            detail = String(localized: "cli.vpn.notifications.reason.metadata", defaultValue: "network details missing; run `cmux vpn up` to re-enroll")
+        case "bind_failed":
+            detail = (response["last_error"] as? String) ?? reason
+        default:
+            detail = reason
+        }
+        let format = String(localized: "cli.vpn.notifications.waiting", defaultValue: "Notifications from machines: on, not listening (%@)")
+        print(String(format: format, detail))
     }
 
     private func runVPNUp(client: SocketClient, jsonOutput: Bool) throws {
@@ -229,6 +294,9 @@ extension CMUXCLI {
         }
         let backendFormat = String(localized: "cli.vpn.status.backend", defaultValue: "Backend: %@")
         print(String(format: backendFormat, neAvailable ? "app-managed (NetworkExtension)" : "wg-quick"))
+        if let hostStatus = try? client.sendV2(method: "vm.host_status", responseTimeout: 30) {
+            printVMHostStatus(hostStatus)
+        }
         if !neAvailable, Self.firstExecutable(Self.wgQuickCandidates) == nil {
             print(String(
                 localized: "cli.vpn.status.wgQuickMissing",

--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -101,6 +101,9 @@ extension CMUXCLI {
             detail = String(localized: "cli.vpn.notifications.reason.noMachines", defaultValue: "you have no Cloud machines")
         case "network_metadata_missing":
             detail = String(localized: "cli.vpn.notifications.reason.metadata", defaultValue: "network details missing; run `cmux vpn up` to re-enroll")
+        case "cloud_unreachable":
+            let format = String(localized: "cli.vpn.notifications.reason.cloudUnreachable", defaultValue: "cloud service unreachable: %@")
+            detail = String(format: format, (response["last_error"] as? String) ?? reason)
         case "bind_failed":
             detail = (response["last_error"] as? String) ?? reason
         default:

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -18469,7 +18469,7 @@ struct CMUXCLI {
             """
         case "vpn":
             return """
-            Usage: cmux vpn <up|down|status|revoke|hosts>
+            Usage: cmux vpn <up|down|status|revoke|hosts|notifications>
 
             The WireGuard tunnel between this Mac and your private Cloud VM
             network. Cloud machines have no public ports, so `cmux vm` attach,
@@ -18479,7 +18479,8 @@ struct CMUXCLI {
                     internal hostnames. Uses wg-quick and prompts for sudo;
                     install with `brew install wireguard-tools`.
             down    Take the tunnel down. Enrollment is kept.
-            status  Show tunnel state, config path, and backend.
+            status  Show tunnel state, config path, backend, and whether
+                    machines may notify this Mac.
             revoke  Take the tunnel down, unenroll this Mac, and clear its
                     internal hostnames. The server deletes its side, so the
                     saved config stops working.
@@ -18488,6 +18489,13 @@ struct CMUXCLI {
                     http://<name>.internal:<port> resolves system-wide.
                     `up` already runs this; call it again after `cmux vm new`
                     to pick up a machine created since.
+            notifications <on|off|status>
+                    Let your machines send notifications, titles, and agent
+                    status to this Mac over the tunnel (default off). While on,
+                    the app listens only on its tunnel addresses, only while
+                    you own at least one machine, and admits only the
+                    notification verbs from machines holding the token it
+                    minted for them.
 
             The cmux app writes the config to ~/.cmuxterm/wireguard/cmux.conf
             with the private key generated on this Mac; the key never leaves it.

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/CloudMachinesCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/CloudMachinesCatalogSection.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Cloud Machines settings: what the user's Cloud VMs may do to this Mac.
+public struct CloudMachinesCatalogSection: SettingCatalogSection {
+    /// Let Cloud VMs send notifications, titles, and agent status to this Mac
+    /// over the private Cloud VM network. Off by default. While on, the app
+    /// listens on its own tunnel addresses only, and only while the account
+    /// owns at least one machine; machines receive a per-machine token the
+    /// Mac minted, and only the notification and telemetry verbs are admitted.
+    public let hostNotifications = DefaultsKey<Bool>(
+        id: "cloud.vmHostNotifications.enabled",
+        defaultValue: false,
+        userDefaultsKey: "cloud.vmHostNotifications.enabled"
+    )
+
+    public init() {}
+}

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SettingCatalog.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SettingCatalog.swift
@@ -44,6 +44,7 @@ public struct SettingCatalog: SettingCatalogSection {
     public let fileEditor = FileEditorCatalogSection()
     /// Settings for Mobile pairing and sync.
     public let mobile = MobileCatalogSection()
+    public let cloudMachines = CloudMachinesCatalogSection()
     public let betaFeatures = BetaFeaturesCatalogSection()
     /// Settings for custom (user/agent-authored) sidebars (the `customSidebars.*` keys).
     public let customSidebars = CustomSidebarsCatalogSection()

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -302,6 +302,19 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .customSidebars, id: "enabled", title: String(localized: "settings.customSidebars.enabled", defaultValue: "Show Custom Sidebars"), synonyms: "custom sidebars enable show vibe swift json interpreted picker beta"),
             .init(section: .customSidebars, id: "renderer", title: String(localized: "settings.customSidebars.renderer", defaultValue: "Renderer"), synonyms: "customSidebars.renderer renderer in-process in app remote worker isolated process hover focus typing input"),
 
+            // Cloud Machines
+            .init(
+                section: .cloudMachines,
+                id: "host-notifications",
+                title: String(localized: "settings.cloudMachines.hostNotifications.title", defaultValue: "Notifications from machines"),
+                detailText: [
+                    String(localized: "settings.cloudMachines.hostNotifications.subtitleOn", defaultValue: "Your machines can send notifications, titles, and agent status to this Mac over your private Cloud VM network while the tunnel is up."),
+                    String(localized: "settings.cloudMachines.hostNotifications.subtitleOff", defaultValue: "This Mac accepts nothing from your machines. Turn on to let agents in Cloud VMs notify you here."),
+                ].joined(separator: " "),
+                paths: ["cloud.vmHostNotifications.enabled"],
+                synonyms: "cloud machines vm notifications hooks agent tunnel wireguard vpn listener private network"
+            ),
+
             // Beta
             .init(section: .betaFeatures, id: "feed", title: "Feed", synonyms: "feed right sidebar agent decisions permissions questions approval beta unstable"),
             .init(section: .betaFeatures, id: "dock", title: "Dock", synonyms: "dock right sidebar terminal controls tui beta unstable"),

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -466,7 +466,7 @@ public struct SettingsWindowRoot: View {
         MobileSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)
             .id(anchorID(for: .mobile))
 
-        CloudMachinesSection(hostActions: hostActions)
+        CloudMachinesSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)
             .id(anchorID(for: .cloudMachines))
 
         IrohNetworkingSection(hostActions: hostActions)

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/CloudMachinesSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/CloudMachinesSection.swift
@@ -1,3 +1,5 @@
+import CmuxFoundation
+import CmuxSettings
 import SwiftUI
 
 /// **Cloud Machines** section — the plan card for persistent cloud VMs.
@@ -10,9 +12,11 @@ public struct CloudMachinesSection: View {
     private let hostActions: SettingsHostActions
     @State private var plan: CloudMachinesPlanSummary?
     @State private var hasLoaded = false
+    @State private var hostNotifications: DefaultsValueModel<Bool>
 
-    public init(hostActions: SettingsHostActions) {
+    public init(defaultsStore: UserDefaultsSettingsStore, catalog: SettingCatalog, hostActions: SettingsHostActions) {
         self.hostActions = hostActions
+        _hostNotifications = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.cloudMachines.hostNotifications))
     }
 
     public var body: some View {
@@ -26,13 +30,17 @@ public struct CloudMachinesSection: View {
                     planRow
                     Divider().padding(.horizontal, 14)
                     panelRow
+                    Divider().padding(.horizontal, 14)
+                    hostNotificationsRow
                 }
             }
             .settingsSearchAnchors([
                 "setting:cloudMachines:plan",
                 "setting:cloudMachines:open-panel",
+                "setting:cloudMachines:host-notifications",
             ])
             .task {
+                hostNotifications.startObserving()
                 plan = await hostActions.cloudMachinesPlanSummary()
                 hasLoaded = true
             }
@@ -80,6 +88,23 @@ public struct CloudMachinesSection: View {
         .padding(.horizontal, 14)
         .padding(.vertical, 10)
         .id("setting:cloudMachines:open-panel")
+    }
+
+    @ViewBuilder
+    private var hostNotificationsRow: some View {
+        SettingsCardRow(
+            configurationReview: .json("cloud.vmHostNotifications.enabled"),
+            searchAnchorID: "setting:cloudMachines:host-notifications",
+            String(localized: "settings.cloudMachines.hostNotifications.title", defaultValue: "Notifications from machines"),
+            subtitle: hostNotifications.current
+                ? String(localized: "settings.cloudMachines.hostNotifications.subtitleOn", defaultValue: "Your machines can send notifications, titles, and agent status to this Mac over your private Cloud VM network while the tunnel is up.")
+                : String(localized: "settings.cloudMachines.hostNotifications.subtitleOff", defaultValue: "This Mac accepts nothing from your machines. Turn on to let agents in Cloud VMs notify you here.")
+        ) {
+            Toggle("", isOn: Binding(get: { hostNotifications.current }, set: { hostNotifications.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsCloudMachinesHostNotificationsToggle")
+        }
     }
 
     private var planSubtitle: String {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -103,6 +103,23 @@
         }
       }
     },
+    "cli.vpn.notifications.reason.inventoryPending": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "checking sign-in and machines, run `cmux vpn notifications status` again"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインインとマシンを確認中です。もう一度 `cmux vpn notifications status` を実行してください"
+          }
+        }
+      }
+    },
     "cli.vpn.notifications.reason.signedOut": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,193 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "cli.vpn.notifications.listening": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications from machines: on, listening at %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシンからの通知: オン、%@ で待ち受け中"
+          }
+        }
+      }
+    },
+    "cli.vpn.notifications.machines": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Machines: %d"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシン数: %d"
+          }
+        }
+      }
+    },
+    "cli.vpn.notifications.off": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications from machines: off. Turn on with `cmux vpn notifications on` or in Settings > Cloud."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシンからの通知: オフ。`cmux vpn notifications on` または 設定 > Cloud でオンにできます。"
+          }
+        }
+      }
+    },
+    "cli.vpn.notifications.reason.metadata": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "network details missing; run `cmux vpn up` to re-enroll"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ネットワーク情報がありません。`cmux vpn up` で再登録してください"
+          }
+        }
+      }
+    },
+    "cli.vpn.notifications.reason.noMachines": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "you have no Cloud machines"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cloud マシンがありません"
+          }
+        }
+      }
+    },
+    "cli.vpn.notifications.reason.signedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "not signed in"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サインインしていません"
+          }
+        }
+      }
+    },
+    "cli.vpn.notifications.reason.tunnelDown": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "tunnel is down; run `cmux vpn up`"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トンネルが停止中です。`cmux vpn up` を実行してください"
+          }
+        }
+      }
+    },
+    "cli.vpn.notifications.waiting": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications from machines: on, not listening (%@)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシンからの通知: オン、待ち受けなし（%@）"
+          }
+        }
+      }
+    },
+    "settings.cloudMachines.hostNotifications.subtitleOff": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Mac accepts nothing from your machines. Turn on to let agents in Cloud VMs notify you here."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac はマシンから何も受け付けません。オンにすると Cloud VM 内のエージェントがここに通知できます。"
+          }
+        }
+      }
+    },
+    "settings.cloudMachines.hostNotifications.subtitleOn": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Your machines can send notifications, titles, and agent status to this Mac over your private Cloud VM network while the tunnel is up."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "トンネル接続中、マシンはプライベート Cloud VM ネットワーク経由でこの Mac に通知、タイトル、エージェント状態を送信できます。"
+          }
+        }
+      }
+    },
+    "settings.cloudMachines.hostNotifications.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Notifications from machines"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "マシンからの通知"
+          }
+        }
+      }
+    },
     "socket.error.unknownMethod": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -86,6 +86,23 @@
         }
       }
     },
+    "cli.vpn.notifications.reason.cloudUnreachable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cloud service unreachable: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "クラウドサービスに接続できません: %@"
+          }
+        }
+      }
+    },
     "cli.vpn.notifications.reason.signedOut": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate+CloudVMWorkspaces.swift
+++ b/Sources/AppDelegate+CloudVMWorkspaces.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+extension AppDelegate {
+    /// Every open workspace bound to Cloud VM `vmID` through
+    /// `workspace.cloud_vm_bind`, across all main windows. The Cloud VM host
+    /// gate uses this set to scope what a machine may address: nothing
+    /// outside these workspaces is reachable from that machine.
+    func workspaces(boundToCloudVM vmID: String) -> [Workspace] {
+        var managers: [TabManager] = mainWindowContexts.values.map(\.tabManager)
+        if let tabManager, !managers.contains(where: { $0 === tabManager }) {
+            managers.append(tabManager)
+        }
+        var seen = Set<UUID>()
+        var result: [Workspace] = []
+        for manager in managers {
+            for workspace in manager.tabs where workspace.cloudVMBinding?.vmID == vmID {
+                guard seen.insert(workspace.id).inserted else { continue }
+                result.append(workspace)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8129,6 +8129,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 source: "bootstrapInitialMainWindow.\(debugSource)"
             )
             MobileHostService.shared.start()
+            VMHostListenerCoordinator.shared.start()
         }
         guard !didBootstrapInitialMainWindow else { return windowId }
 

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -62,6 +62,38 @@ actor CloudMachineLinkManager {
         self.paths = paths
         self.clientURL = clientURL
         self.hostThemeColors = hostThemeColors
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            VMHostListenerCoordinator.shared.register(linkManager: self)
+        }
+    }
+
+    /// The host listener (re)started: every connected machine gets the new
+    /// endpoint. Fire-and-forget like the theme push.
+    func redeliverHostEndpoints() async {
+        for (machineID, link) in links {
+            guard await link.isConnected else { continue }
+            Task { await VMHostListenerCoordinator.shared.deliverEndpoint(machineID: machineID) }
+        }
+    }
+
+    /// Install the host-forward journal hook on `machineID`'s daemon over its
+    /// link. Returns nil on success, else the failure text. A machine whose
+    /// daemon predates journal hooks fails here and simply never forwards.
+    func registerHostForwardHook(machineID: String) async -> String? {
+        guard let link = links[machineID], let connected = await link.connected else {
+            return "no link to \(machineID)"
+        }
+        let arguments = CloudTuiCommandLine.putJournalHookArguments(
+            socketPath: connected.socketPath,
+            manifestJSON: VMHostForwardHook.manifestJSON()
+        )
+        do {
+            _ = try await link.run(arguments: arguments)
+            return nil
+        } catch {
+            return CloudMachineLink.errorText(error)
+        }
     }
 
     var hasClient: Bool { clientURL != nil }
@@ -114,6 +146,10 @@ actor CloudMachineLinkManager {
             cmuxDebugLog("cloud.link.connected machine=\(machineID) socket=\(connected.socketPath)")
             #endif
             pushHostTheme(machineID: machineID, socketPath: connected.socketPath)
+            // Hand the machine this Mac's notification endpoint (no-op while the
+            // host listener is off). Fire-and-forget: a failed delivery must not
+            // fail the connect that just succeeded.
+            Task { await VMHostListenerCoordinator.shared.machineDidLink(machineID) }
             return connected
         } catch {
             let text = CloudMachineLink.errorText(error)

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -212,6 +212,14 @@ struct CloudTuiCommandLine: Sendable {
             .joined(separator: " ")
     }
 
+    /// `session current journal hook put --manifest-json <json>`: install or
+    /// re-affirm a journal hook on the machine's daemon (spec
+    /// `session.journal.hook.put`). Re-putting an identical manifest is a
+    /// no-op; a changed manifest needs a higher `manifest_version`.
+    static func putJournalHookArguments(socketPath: String, manifestJSON: String) -> [String] {
+        ["--socket", socketPath, "--json", "session", "current", "journal", "hook", "put", "--manifest-json", manifestJSON]
+    }
+
     static func shellQuote(_ value: String) -> String {
         if value.isEmpty { return "''" }
         if value.range(of: "^[A-Za-z0-9_./:@%+=,-]+$", options: .regularExpression) != nil {

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -686,6 +686,11 @@ final class MachinesPanelViewModel: ObservableObject {
                 snapshots[index].stats = previous[snapshots[index].id] ?? nil
             }
             machines = snapshots
+            NotificationCenter.default.post(
+                name: .cmuxCloudVMInventoryDidChange,
+                object: nil,
+                userInfo: ["count": snapshots.count]
+            )
             lastLimits = page.limits
             scheduleFreeAccessTransition()
             refreshStats()

--- a/Sources/Cloud/VMClientSocketCommands.swift
+++ b/Sources/Cloud/VMClientSocketCommands.swift
@@ -259,6 +259,22 @@ extension TerminalController {
                     "network_extension_available": VMTunnelManager.networkExtensionAvailable(),
                 ]
             }
+        case "vm.host_status":
+            // Read-only: whether this Mac currently accepts notifications from
+            // its Cloud VMs, and why not when it doesn't.
+            return v2VmCall(id: id) {
+                await MainActor.run { VMHostListenerCoordinator.shared.statusPayload() }
+            }
+        case "vm.host_notifications_set":
+            guard let enabled = params["enabled"] as? Bool else {
+                return v2Error(id: id, code: "invalid_params", message: "vm.host_notifications_set requires `enabled` (true|false).")
+            }
+            return v2VmCall(id: id) {
+                await MainActor.run {
+                    VMHostListenerCoordinator.shared.setEnabled(enabled)
+                    return VMHostListenerCoordinator.shared.statusPayload()
+                }
+            }
         case "vm.tunnel_revoke":
             // Unenrolls this Mac server-side and removes the local config so a
             // later `cmux vpn up` re-enrolls from scratch.
@@ -267,6 +283,8 @@ extension TerminalController {
                 let fingerprint = try manager.deviceFingerprint()
                 try await VMClient.shared.revokeTunnel(deviceFingerprint: fingerprint)
                 try? FileManager.default.removeItem(at: manager.configURL)
+                try? FileManager.default.removeItem(at: manager.networkMetadataURL)
+                VMHostListenerCoordinator.tokens.removeAll()
                 return ["revoked": true]
             }
         case "vm.ssh_info":

--- a/Sources/Cloud/VMHostAccessPolicy.swift
+++ b/Sources/Cloud/VMHostAccessPolicy.swift
@@ -1,0 +1,152 @@
+import Foundation
+
+/// What a Cloud VM may ask of this Mac over the private-network listener,
+/// and how a caller proves it is one of the user's own machines.
+///
+/// The listener is reachable only through the user's WireGuard tunnel into
+/// their private Cloud VM network (`VMHostListenerCoordinator`), so the peers
+/// that can reach it at all are the user's machines and the user's other
+/// tunnels. This policy narrows that further:
+///
+/// - the peer address must sit inside the network's own CIDRs,
+/// - every request must carry the per-machine token this Mac minted and
+///   delivered to that machine (`VMHostTokenStore`),
+/// - only the telemetry and attention verbs below are admitted, and every
+///   workspace or surface selector in a request must belong to a workspace
+///   bound to the calling machine (`workspace.cloud_vm_bind`).
+///
+/// Nothing here types, focuses, navigates, reads Mac state, or reaches the
+/// cloud control plane. A compromised guest can spam its own owner's
+/// notifications and nothing else.
+enum VMHostAccessPolicy {
+    /// Request parameter carrying the machine token. Stripped before dispatch.
+    static let tokenParamKey = "_cmux_vm_host_token"
+
+    /// Longest request line the listener buffers before dropping the client.
+    /// Hook payloads are small; agents in a guest run arbitrary code, so the
+    /// cap is deliberately far below the local socket's limit.
+    static let maxRequestLineBytes = 64 * 1024
+
+    /// Verbs a machine may call. Fire-and-forget telemetry and attention, plus
+    /// the Feed bridge (`feed.push`) which holds the request for the human's
+    /// decision. Mirrors the ssh remote relay's allow-list minus everything
+    /// that reads Mac state or has nothing to do without an ssh channel.
+    static let allowedMethods: Set<String> = [
+        "system.ping",
+        "system.capabilities",
+        "notification.create",
+        "notification.create_for_target",
+        "agent.resolve_delivery_target",
+        "surface.report_tty",
+        "surface.report_pwd",
+        "surface.report_git_branch",
+        "surface.clear_git_branch",
+        "surface.report_shell_state",
+        "workspace.set_auto_title",
+        "workspace.status.set",
+        "feed.push",
+    ]
+
+    /// Verbs that must name a workspace explicitly. A machine never lands on
+    /// whatever the user happens to be looking at.
+    static let workspaceRequiredMethods: Set<String> = [
+        "notification.create",
+        "notification.create_for_target",
+        "surface.report_tty",
+        "surface.report_pwd",
+        "surface.report_git_branch",
+        "surface.clear_git_branch",
+        "surface.report_shell_state",
+        "workspace.set_auto_title",
+        "workspace.status.set",
+        "feed.push",
+    ]
+
+    /// Verbs that must also name a surface.
+    static let surfaceRequiredMethods: Set<String> = [
+        "notification.create_for_target",
+        "surface.report_tty",
+        "surface.report_pwd",
+        "surface.report_git_branch",
+        "surface.clear_git_branch",
+        "surface.report_shell_state",
+    ]
+
+    // MARK: - Source addresses
+
+    /// Whether `peer` (a numeric IPv4 or IPv6 address) lies inside any of the
+    /// network CIDRs. IPv4-mapped IPv6 peers (`::ffff:10.1.2.3`) are compared
+    /// as IPv4. Anything unparsable is denied.
+    static func sourceIsAllowed(peer: String, networkCIDRs: [String]) -> Bool {
+        guard let peerBytes = addressBytes(peer) else { return false }
+        for cidr in networkCIDRs {
+            guard let (network, prefix) = parseCIDR(cidr), network.count == peerBytes.count else { continue }
+            if matches(peerBytes, network: network, prefixLength: prefix) { return true }
+        }
+        return false
+    }
+
+    /// `"10.16.0.0/24"` → (address bytes, prefix length). A bare address is a
+    /// full-length prefix.
+    static func parseCIDR(_ cidr: String) -> ([UInt8], Int)? {
+        let trimmed = cidr.trimmingCharacters(in: .whitespacesAndNewlines)
+        let parts = trimmed.split(separator: "/", maxSplits: 1).map(String.init)
+        guard let first = parts.first, let bytes = addressBytes(first) else { return nil }
+        let maxPrefix = bytes.count * 8
+        guard parts.count == 2 else { return (bytes, maxPrefix) }
+        guard let prefix = Int(parts[1]), (0...maxPrefix).contains(prefix) else { return nil }
+        return (bytes, prefix)
+    }
+
+    /// Numeric address → raw bytes (4 for IPv4, 16 for IPv6). IPv4-mapped
+    /// IPv6 collapses to its 4 IPv4 bytes so one CIDR list covers both socket
+    /// families. Zone suffixes (`fe80::1%utun4`) are dropped before parsing.
+    static func addressBytes(_ address: String) -> [UInt8]? {
+        var text = address.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let zone = text.firstIndex(of: "%") { text = String(text[..<zone]) }
+        if text.hasPrefix("["), text.hasSuffix("]") { text = String(text.dropFirst().dropLast()) }
+        var v4 = in_addr()
+        if inet_pton(AF_INET, text, &v4) == 1 {
+            return withUnsafeBytes(of: &v4.s_addr) { Array($0) }
+        }
+        var v6 = in6_addr()
+        if inet_pton(AF_INET6, text, &v6) == 1 {
+            let bytes = withUnsafeBytes(of: &v6) { Array($0) }
+            // ::ffff:a.b.c.d
+            if bytes[0..<10].allSatisfy({ $0 == 0 }), bytes[10] == 0xff, bytes[11] == 0xff {
+                return Array(bytes[12..<16])
+            }
+            return bytes
+        }
+        return nil
+    }
+
+    private static func matches(_ address: [UInt8], network: [UInt8], prefixLength: Int) -> Bool {
+        var remaining = prefixLength
+        for index in 0..<address.count {
+            if remaining <= 0 { return true }
+            let bits = min(8, remaining)
+            let mask: UInt8 = bits == 8 ? 0xff : UInt8(0xff << (8 - bits) & 0xff)
+            if (address[index] & mask) != (network[index] & mask) { return false }
+            remaining -= bits
+        }
+        return true
+    }
+
+    // MARK: - Tokens
+
+    /// Constant-time equality for tokens. Length differences still return
+    /// false, but through the same number of byte comparisons.
+    static func tokensMatch(_ presented: String, _ expected: String) -> Bool {
+        let a = Array(presented.utf8)
+        let b = Array(expected.utf8)
+        var difference: UInt8 = a.count == b.count ? 0 : 1
+        let length = max(a.count, b.count)
+        for index in 0..<length {
+            let x = index < a.count ? a[index] : 0
+            let y = index < b.count ? b[index] : 0
+            difference |= x ^ y
+        }
+        return difference == 0
+    }
+}

--- a/Sources/Cloud/VMHostForwardHook.swift
+++ b/Sources/Cloud/VMHostForwardHook.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// The journal hook this Mac registers on each Cloud machine's cmux-tui daemon
+/// so agent events in the machine reach this Mac. The guest side is
+/// `cmux-tui host-forward` (`cmux-tui/crates/cmux-tui/src/host_forward.rs`),
+/// which reads `/etc/cmux/host.env` (written by `VMHostListenerCoordinator`)
+/// and dials the listener with the machine's token. Both sides must agree on
+/// this manifest; the guest validates it on `session.journal.hook.put`.
+enum VMHostForwardHook {
+    static let hookID = "cmux_host_forward"
+    static let manifestVersion = 1
+    /// Where the daemon image links the cmux-tui binary (`cmuxTuiDaemon.ts`).
+    static let guestBinaryPath = "/usr/local/bin/cmux-tui"
+    /// Same vocabulary as the guest's `FORWARDED_KINDS`.
+    static let forwardedKinds = [
+        "agent.turn.started",
+        "agent.turn.completed",
+        "agent.approval.requested",
+        "agent.question.requested",
+        "agent.plan_review.requested",
+        "agent.error.reported",
+        "agent.session.ended",
+    ]
+
+    static func manifest(binaryPath: String = guestBinaryPath) -> [String: Any] {
+        [
+            "hook_id": hookID,
+            "manifest_version": manifestVersion,
+            "filter": ["kinds": forwardedKinds],
+            "exec": ["argv": [binaryPath, "host-forward"], "timeout_ms": 15_000, "max_parallel": 2],
+            "delivery": ["start": "tail", "retry": ["max_attempts": 3, "backoff_ms": 2_000]],
+            "permissions": ["journal.read"],
+        ]
+    }
+
+    static func manifestJSON(binaryPath: String = guestBinaryPath) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: manifest(binaryPath: binaryPath), options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
+    }
+}

--- a/Sources/Cloud/VMHostListener.swift
+++ b/Sources/Cloud/VMHostListener.swift
@@ -1,0 +1,227 @@
+import Darwin
+import Foundation
+import os
+
+/// A TCP listener bound to specific local addresses — the Mac's own
+/// addresses on its WireGuard tunnel into the private Cloud VM network.
+///
+/// Binding to those exact addresses (never `0.0.0.0`) means the port exists
+/// only while the tunnel does: when the utun goes away the sockets fail
+/// closed, and nothing on the LAN or loopback can reach the listener at all.
+/// Accepted descriptors are handed to `onAccept` together with the peer's
+/// numeric address; the caller owns the descriptor from then on.
+final class VMHostListener: @unchecked Sendable {
+    struct BoundAddress: Sendable, Equatable {
+        let address: String
+        let port: UInt16
+    }
+
+    enum ListenerError: Error, CustomStringConvertible {
+        case unsupportedAddress(String)
+        case socketFailed(String, Int32)
+        case bindFailed(String, Int32)
+        case listenFailed(String, Int32)
+
+        var description: String {
+            switch self {
+            case .unsupportedAddress(let address): return "unsupported listener address \(address)"
+            case .socketFailed(let address, let code): return "socket(\(address)) failed: \(String(cString: strerror(code)))"
+            case .bindFailed(let address, let code): return "bind(\(address)) failed: \(String(cString: strerror(code)))"
+            case .listenFailed(let address, let code): return "listen(\(address)) failed: \(String(cString: strerror(code)))"
+            }
+        }
+    }
+
+    private struct Bound {
+        let socket: Int32
+        let source: DispatchSourceRead
+        let address: BoundAddress
+    }
+
+    private let queue = DispatchQueue(label: "dev.cmux.vm-host-listener", qos: .utility)
+    private let state = OSAllocatedUnfairLock<[Bound]>(initialState: [])
+    private let onAccept: @Sendable (_ socket: Int32, _ peerAddress: String) -> Void
+
+    init(onAccept: @escaping @Sendable (_ socket: Int32, _ peerAddress: String) -> Void) {
+        self.onAccept = onAccept
+    }
+
+    deinit { stop() }
+
+    var boundAddresses: [BoundAddress] {
+        state.withLock { $0.map(\.address) }
+    }
+
+    var isListening: Bool {
+        state.withLock { !$0.isEmpty }
+    }
+
+    /// Bind and listen on every address. `port` 0 lets the kernel pick a port
+    /// on the first address, which is then reused for the rest so one port
+    /// number describes the listener. Throws (and binds nothing) if any
+    /// address fails.
+    func start(addresses: [String], port requestedPort: UInt16) throws {
+        stop()
+        // Bind everything first so a failure binds nothing and no dispatch
+        // source is ever created for a descriptor that will be closed (a
+        // suspended source must not be released).
+        var sockets: [(fd: Int32, address: BoundAddress)] = []
+        var port = requestedPort
+        do {
+            for address in addresses {
+                let socketFD = try Self.listen(address: address, port: port)
+                let actualPort = try Self.localPort(of: socketFD, address: address)
+                if port == 0 { port = actualPort }
+                sockets.append((socketFD, BoundAddress(address: address, port: actualPort)))
+            }
+        } catch {
+            for entry in sockets { close(entry.fd) }
+            throw error
+        }
+        var bound: [Bound] = []
+        for entry in sockets {
+            let socketFD = entry.fd
+            let source = DispatchSource.makeReadSource(fileDescriptor: socketFD, queue: queue)
+            source.setEventHandler { [weak self] in
+                self?.drainAccepts(listener: socketFD)
+            }
+            source.setCancelHandler {
+                close(socketFD)
+            }
+            bound.append(Bound(socket: socketFD, source: source, address: entry.address))
+        }
+        state.withLock { $0 = bound }
+        for entry in bound { entry.source.resume() }
+    }
+
+    func stop() {
+        let bound = state.withLock { current -> [Bound] in
+            let snapshot = current
+            current = []
+            return snapshot
+        }
+        // Cancel closes the descriptor (cancel handler); a source that never
+        // resumed must be resumed first or it is leaked.
+        for entry in bound { entry.source.cancel() }
+    }
+
+    // MARK: - internals
+
+    private func drainAccepts(listener: Int32) {
+        while true {
+            var storage = sockaddr_storage()
+            var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
+            let client = withUnsafeMutablePointer(to: &storage) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { accept(listener, $0, &length) }
+            }
+            guard client >= 0 else {
+                let code = errno
+                if code == EINTR || code == ECONNABORTED { continue }
+                return // EAGAIN or a fatal error; the read source fires again when ready
+            }
+            // Accepted sockets inherit O_NONBLOCK on macOS; the async line
+            // reader expects a blocking descriptor like the Unix socket path.
+            let flags = fcntl(client, F_GETFL)
+            if flags >= 0 { _ = fcntl(client, F_SETFL, flags & ~O_NONBLOCK) }
+            var noSigPipe: Int32 = 1
+            _ = setsockopt(client, SOL_SOCKET, SO_NOSIGPIPE, &noSigPipe, socklen_t(MemoryLayout<Int32>.size))
+            let peer = withUnsafePointer(to: &storage) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { Self.numericAddress($0) }
+            } ?? ""
+            onAccept(client, peer)
+        }
+    }
+
+    private static func listen(address: String, port: UInt16) throws -> Int32 {
+        guard let bytes = VMHostAccessPolicy.addressBytes(address) else {
+            throw ListenerError.unsupportedAddress(address)
+        }
+        let family = bytes.count == 4 ? AF_INET : AF_INET6
+        let fd = socket(family, SOCK_STREAM, 0)
+        guard fd >= 0 else { throw ListenerError.socketFailed(address, errno) }
+        var one: Int32 = 1
+        _ = setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, &one, socklen_t(MemoryLayout<Int32>.size))
+        _ = setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, &one, socklen_t(MemoryLayout<Int32>.size))
+        let flags = fcntl(fd, F_GETFL)
+        if flags >= 0 { _ = fcntl(fd, F_SETFL, flags | O_NONBLOCK) }
+        _ = fcntl(fd, F_SETFD, FD_CLOEXEC)
+
+        let bindResult: Int32
+        if family == AF_INET {
+            var addr = sockaddr_in()
+            addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+            addr.sin_family = sa_family_t(AF_INET)
+            addr.sin_port = port.bigEndian
+            _ = inet_pton(AF_INET, address, &addr.sin_addr)
+            bindResult = withUnsafePointer(to: &addr) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+                }
+            }
+        } else {
+            var addr = sockaddr_in6()
+            addr.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.size)
+            addr.sin6_family = sa_family_t(AF_INET6)
+            addr.sin6_port = port.bigEndian
+            var text = address
+            if let zone = text.firstIndex(of: "%") { text = String(text[..<zone]) }
+            _ = inet_pton(AF_INET6, text, &addr.sin6_addr)
+            var v6Only: Int32 = 1
+            _ = setsockopt(fd, IPPROTO_IPV6, IPV6_V6ONLY, &v6Only, socklen_t(MemoryLayout<Int32>.size))
+            bindResult = withUnsafePointer(to: &addr) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                    Darwin.bind(fd, $0, socklen_t(MemoryLayout<sockaddr_in6>.size))
+                }
+            }
+        }
+        guard bindResult == 0 else {
+            let code = errno
+            close(fd)
+            throw ListenerError.bindFailed(address, code)
+        }
+        guard Darwin.listen(fd, 16) == 0 else {
+            let code = errno
+            close(fd)
+            throw ListenerError.listenFailed(address, code)
+        }
+        return fd
+    }
+
+    private static func localPort(of fd: Int32, address: String) throws -> UInt16 {
+        var storage = sockaddr_storage()
+        var length = socklen_t(MemoryLayout<sockaddr_storage>.size)
+        let result = withUnsafeMutablePointer(to: &storage) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(fd, $0, &length) }
+        }
+        guard result == 0 else { throw ListenerError.bindFailed(address, errno) }
+        switch Int32(storage.ss_family) {
+        case AF_INET:
+            return withUnsafePointer(to: &storage) { pointer in
+                pointer.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { UInt16(bigEndian: $0.pointee.sin_port) }
+            }
+        case AF_INET6:
+            return withUnsafePointer(to: &storage) { pointer in
+                pointer.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { UInt16(bigEndian: $0.pointee.sin6_port) }
+            }
+        default:
+            throw ListenerError.unsupportedAddress(address)
+        }
+    }
+
+    static func numericAddress(_ sa: UnsafePointer<sockaddr>) -> String? {
+        switch Int32(sa.pointee.sa_family) {
+        case AF_INET:
+            var addr = sa.withMemoryRebound(to: sockaddr_in.self, capacity: 1) { $0.pointee.sin_addr }
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            guard inet_ntop(AF_INET, &addr, &buffer, socklen_t(INET_ADDRSTRLEN)) != nil else { return nil }
+            return String(cString: buffer)
+        case AF_INET6:
+            var addr = sa.withMemoryRebound(to: sockaddr_in6.self, capacity: 1) { $0.pointee.sin6_addr }
+            var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            guard inet_ntop(AF_INET6, &addr, &buffer, socklen_t(INET6_ADDRSTRLEN)) != nil else { return nil }
+            return String(cString: buffer).lowercased()
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/Cloud/VMHostListenerCoordinator.swift
+++ b/Sources/Cloud/VMHostListenerCoordinator.swift
@@ -86,6 +86,9 @@ final class VMHostListenerCoordinator {
     private var refreshTask: Task<Void, Never>?
     private var deliveredEndpoints: [String: String] = [:]
     private var linkManagers: [WeakLinkManager] = []
+    /// One metadata refresh per tunnel-up episode; reset when the utun goes away.
+    private var metadataRefresh: Task<Void, Never>?
+    private var metadataRefreshAttempted = false
     private(set) var status = Status()
     private var started = false
 
@@ -158,6 +161,10 @@ final class VMHostListenerCoordinator {
     func setEnabled(_ enabled: Bool) {
         defaults.set(enabled, forKey: Self.settingsKey)
         reconcile(source: "setEnabled")
+        // Sign-in and inventory are learned asynchronously; a user who turns
+        // the feature on right after launch should not see a stale "not
+        // signed in" until some other surface refreshes the machine list.
+        if enabled { scheduleInventoryRefresh(source: "setEnabled") }
     }
 
     /// A link to `machineID` just connected: the account owns at least this
@@ -338,6 +345,7 @@ final class VMHostListenerCoordinator {
         let metadata = manager.loadNetworkMetadata()
         status.enabled = isEnabled
         status.tunnelUp = !live.isEmpty
+        if live.isEmpty { metadataRefreshAttempted = false }
         status.machineFacingAddresses = metadata?.machineFacingAddresses ?? []
         status.networkCIDRs = metadata?.networkCIDRs ?? []
         status.tokenCount = Self.tokens.count
@@ -354,6 +362,7 @@ final class VMHostListenerCoordinator {
         case .on:
             guard !status.machineFacingAddresses.isEmpty, !status.networkCIDRs.isEmpty else {
                 stopListener(reason: "network_metadata_missing")
+                refreshNetworkMetadataOnce()
                 return
             }
             let current = listener?.boundAddresses.map(\.address) ?? []
@@ -367,6 +376,25 @@ final class VMHostListenerCoordinator {
         #if DEBUG
         cmuxDebugLog("vmhost.reconcile source=\(source) desired=\(desired) listening=\(status.listening) port=\(status.port)")
         #endif
+    }
+
+    /// `network.json` is missing while the tunnel is up: a Mac enrolled before
+    /// the file existed. Re-ask the control plane once (idempotent enrollment,
+    /// config untouched) and reconcile again when it lands.
+    private func refreshNetworkMetadataOnce() {
+        guard !metadataRefreshAttempted, metadataRefresh == nil, let client = VMClient.shared else { return }
+        metadataRefreshAttempted = true
+        metadataRefresh = Task { @MainActor [weak self] in
+            guard let self else { return }
+            defer { self.metadataRefresh = nil }
+            do {
+                _ = try await self.manager.refreshNetworkMetadata(client: client)
+                self.reconcile(source: "metadataRefresh")
+            } catch {
+                self.status.lastError = "network metadata: \(error.localizedDescription)"
+                self.publish()
+            }
+        }
     }
 
     private func startListener(addresses: [String]) {

--- a/Sources/Cloud/VMHostListenerCoordinator.swift
+++ b/Sources/Cloud/VMHostListenerCoordinator.swift
@@ -1,0 +1,432 @@
+import CmuxSettings
+import Foundation
+import Network
+
+extension Notification.Name {
+    /// Posted by whoever refreshes the machine list (`MachinesPanelViewModel`)
+    /// with `userInfo["count"]` = number of machines the account owns, so the
+    /// host listener can follow inventory without polling.
+    static let cmuxCloudVMInventoryDidChange = Notification.Name("cmux.cloudVM.inventoryDidChange")
+    /// Posted by `VMHostListenerCoordinator` after any status change.
+    static let cmuxCloudVMHostListenerStatusDidChange = Notification.Name("cmux.cloudVM.hostListenerStatusDidChange")
+}
+
+/// Owns the listener Cloud VMs use to reach this Mac, and the four facts that
+/// decide whether it exists at all:
+///
+/// 1. the user turned **Notifications from machines** on (default off),
+/// 2. the account is signed in,
+/// 3. the WireGuard tunnel into the private Cloud VM network is up, and
+/// 4. the account owns at least one machine.
+///
+/// All four must hold for the listener to be bound. When any one stops
+/// holding — the toggle flips, sign-out, the utun disappears, the last
+/// machine is destroyed — the listener closes in the same event. No timers:
+/// the toggle arrives through `UserDefaults`, sign-out through
+/// `.cmuxCloudVMAccessDidEnd`, interface changes through `NWPathMonitor`,
+/// and inventory through `.cmuxCloudVMInventoryDidChange` plus machine create
+/// completions and link connects.
+///
+/// The listener binds only the tunnel's own interface addresses, never a
+/// wildcard, so nothing on the LAN or loopback can reach it. Each accepted
+/// connection is handed to `TerminalController.spawnVMHostClientHandler`,
+/// which applies `VMHostAccessPolicy`.
+@MainActor
+final class VMHostListenerCoordinator {
+    static let shared = VMHostListenerCoordinator()
+
+    /// Off-main readable so the socket worker lanes can map tokens to
+    /// machines without a main-actor hop.
+    nonisolated static let tokens = VMHostTokenStore()
+
+    static let settingsKey = CloudMachinesCatalogSection().hostNotifications.userDefaultsKey
+    /// The chosen port is remembered so machines keep a valid endpoint across
+    /// relaunches; 0 means "not chosen yet".
+    static let portDefaultsKey = "cloud.vmHostNotifications.port"
+
+    struct Status: Sendable, Equatable {
+        var enabled = false
+        var signedIn = false
+        var tunnelUp = false
+        var machineCount = 0
+        var listening = false
+        var port: UInt16 = 0
+        var boundAddresses: [String] = []
+        var machineFacingAddresses: [String] = []
+        var networkCIDRs: [String] = []
+        var tokenCount = 0
+        var lastError: String?
+        var offReason: String?
+    }
+
+    enum DesiredState: Equatable {
+        case on
+        case off(reason: String)
+    }
+
+    /// The whole lifecycle rule in one testable function.
+    nonisolated static func desiredState(
+        enabled: Bool,
+        signedIn: Bool,
+        liveTunnelAddresses: [String],
+        machineCount: Int
+    ) -> DesiredState {
+        guard enabled else { return .off(reason: "disabled") }
+        guard signedIn else { return .off(reason: "signed_out") }
+        guard !liveTunnelAddresses.isEmpty else { return .off(reason: "tunnel_down") }
+        guard machineCount > 0 else { return .off(reason: "no_machines") }
+        return .on
+    }
+
+    private let manager: VMTunnelManager
+    private let defaults: UserDefaults
+    private var listener: VMHostListener?
+    private var pathMonitor: NWPathMonitor?
+    private var observers: [NSObjectProtocol] = []
+    private var refreshTask: Task<Void, Never>?
+    private var deliveredEndpoints: [String: String] = [:]
+    private var linkManagers: [WeakLinkManager] = []
+    private(set) var status = Status()
+    private var started = false
+
+    private struct WeakLinkManager {
+        weak var value: CloudMachineLinkManager?
+    }
+
+    /// Link managers register so a listener that (re)starts can push the new
+    /// endpoint to machines that are already connected.
+    func register(linkManager: CloudMachineLinkManager) {
+        linkManagers.removeAll { $0.value == nil || $0.value === linkManager }
+        linkManagers.append(WeakLinkManager(value: linkManager))
+    }
+
+    init(manager: VMTunnelManager = VMTunnelManager(), defaults: UserDefaults = .standard) {
+        self.manager = manager
+        self.defaults = defaults
+    }
+
+    // MARK: - lifecycle
+
+    func start() {
+        guard !started else { return }
+        started = true
+        let center = NotificationCenter.default
+        observers.append(center.addObserver(forName: UserDefaults.didChangeNotification, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.reconcile(source: "defaults") }
+        })
+        observers.append(center.addObserver(forName: .cmuxCloudVMAccessDidEnd, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.accessDidEnd() }
+        })
+        observers.append(center.addObserver(forName: .cmuxCloudVMInventoryDidChange, object: nil, queue: .main) { [weak self] note in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                if let count = note.userInfo?["count"] as? Int {
+                    self.status.signedIn = true
+                    self.status.machineCount = count
+                    self.reconcile(source: "inventory")
+                } else {
+                    self.scheduleInventoryRefresh(source: "inventory")
+                }
+            }
+        })
+        observers.append(center.addObserver(forName: MachineCreateCoordinator.didChangeNotification, object: nil, queue: .main) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.scheduleInventoryRefresh(source: "machineCreate") }
+        })
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { [weak self] _ in
+            Task { @MainActor [weak self] in self?.reconcile(source: "path") }
+        }
+        monitor.start(queue: DispatchQueue(label: "dev.cmux.vm-host-listener.path", qos: .utility))
+        pathMonitor = monitor
+        scheduleInventoryRefresh(source: "start")
+    }
+
+    func stop() {
+        for observer in observers { NotificationCenter.default.removeObserver(observer) }
+        observers = []
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        refreshTask?.cancel()
+        stopListener(reason: "stopped")
+        started = false
+    }
+
+    var isEnabled: Bool {
+        defaults.object(forKey: Self.settingsKey) == nil ? false : defaults.bool(forKey: Self.settingsKey)
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        defaults.set(enabled, forKey: Self.settingsKey)
+        reconcile(source: "setEnabled")
+    }
+
+    /// A link to `machineID` just connected: the account owns at least this
+    /// machine, and it is the moment to hand it this Mac's endpoint.
+    func machineDidLink(_ machineID: String) async {
+        if status.machineCount == 0 {
+            status.machineCount = 1
+            status.signedIn = true
+        }
+        reconcile(source: "link")
+        await deliverEndpoint(machineID: machineID)
+    }
+
+    /// The cmux-tui workspace bound to a Cloud VM changed (`workspace.cloud_vm_bind`):
+    /// the machine's env file names that workspace, so redeliver it.
+    func bindingDidChange(vmID: String) async {
+        deliveredEndpoints[vmID] = nil
+        await deliverEndpoint(machineID: vmID)
+    }
+
+    /// The Mac workspace a machine's notifications land in: the base cloud
+    /// workspace when one is bound, else the first bound workspace.
+    func boundWorkspaceID(for machineID: String) -> UUID? {
+        let bound = AppDelegate.shared?.workspaces(boundToCloudVM: machineID) ?? []
+        return (bound.first { $0.cloudVMBinding?.isBase == true } ?? bound.first)?.id
+    }
+
+    /// Write this Mac's endpoint, the machine's token, and the bound workspace
+    /// into the machine at `/etc/cmux/host.env`, then register the
+    /// `host-forward` journal hook on its daemon. Idempotent per (machine,
+    /// payload). Only runs while listening: a machine is never handed an
+    /// endpoint that does not exist.
+    func deliverEndpoint(machineID: String) async {
+        guard status.listening, let endpoint = machineEndpointString() else { return }
+        let token = Self.tokens.token(for: machineID)
+        let payload = Self.envPayload(
+            endpoint: endpoint,
+            token: token,
+            workspaceID: boundWorkspaceID(for: machineID)?.uuidString
+        )
+        guard deliveredEndpoints[machineID] != payload else { return }
+        guard let client = VMClient.shared else { return }
+        let command = Self.deliverCommand(payload: payload)
+        do {
+            let result = try await client.exec(id: machineID, command: command, timeoutMs: 20_000)
+            guard result.exitCode == 0 else {
+                status.lastError = "deliver to \(machineID) exited \(result.exitCode): \(result.stderr.trimmingCharacters(in: .whitespacesAndNewlines))"
+                publish()
+                return
+            }
+            deliveredEndpoints[machineID] = payload
+            #if DEBUG
+            cmuxDebugLog("vmhost.deliver machine=\(machineID) endpoint=\(endpoint)")
+            #endif
+        } catch {
+            status.lastError = "deliver to \(machineID): \(error.localizedDescription)"
+            publish()
+            return
+        }
+        for box in linkManagers {
+            guard let manager = box.value else { continue }
+            if let failure = await manager.registerHostForwardHook(machineID: machineID) {
+                #if DEBUG
+                cmuxDebugLog("vmhost.hook machine=\(machineID) failed=\(failure)")
+                #endif
+                status.lastError = "hook on \(machineID): \(failure)"
+                publish()
+            }
+        }
+    }
+
+    /// Tell every machine that was handed an endpoint that it is gone: an env
+    /// file with an empty endpoint makes `host-forward` exit without dialing.
+    /// Fire-and-forget; a machine that is unreachable simply retries against a
+    /// closed port until its own attempts run out.
+    private func withdrawEndpoints(from machineIDs: [String]) {
+        guard !machineIDs.isEmpty, let client = VMClient.shared else { return }
+        let command = Self.deliverCommand(payload: Self.envPayload(endpoint: nil, token: "", workspaceID: nil))
+        Task {
+            for machineID in machineIDs {
+                _ = try? await client.exec(id: machineID, command: command, timeoutMs: 20_000)
+            }
+        }
+    }
+
+    /// The env file body. Keys the guest reads: `CMUX_HOST_ENDPOINT` (empty =
+    /// forwarding off), `CMUX_HOST_TOKEN`, `CMUX_HOST_WORKSPACE_ID`.
+    nonisolated static func envPayload(endpoint: String?, token: String, workspaceID: String?) -> String {
+        "CMUX_HOST_ENDPOINT=\(endpoint ?? "")\nCMUX_HOST_TOKEN=\(token)\nCMUX_HOST_WORKSPACE_ID=\(workspaceID ?? "")\n"
+    }
+
+    /// The shell command that installs the env file as root, replacing it
+    /// atomically. World-readable on purpose: the daemon drops to the `cmux`
+    /// user and runs the hook with an empty environment, so the hook must be
+    /// able to open the file itself. Inside the machine every process already
+    /// belongs to the owner; the token guards the network, not the guest.
+    nonisolated static func deliverCommand(payload: String) -> String {
+        let encoded = Data(payload.utf8).base64EncodedString()
+        return "sudo -n sh -c 'umask 022; mkdir -p /etc/cmux; printf %s \(encoded) | base64 -d > /etc/cmux/host.env.tmp && chmod 0644 /etc/cmux/host.env.tmp && mv -f /etc/cmux/host.env.tmp /etc/cmux/host.env'"
+    }
+
+    /// `host:port` (IPv6 bracketed) machines dial, or nil when the network
+    /// metadata is missing or the listener is down.
+    func machineEndpointString() -> String? {
+        guard status.listening, status.port != 0,
+              let address = status.machineFacingAddresses.first else { return nil }
+        return address.contains(":") ? "[\(address)]:\(status.port)" : "\(address):\(status.port)"
+    }
+
+    /// Network CIDRs a caller must sit inside; read by the connection handler.
+    nonisolated static func networkCIDRs(manager: VMTunnelManager = VMTunnelManager()) -> [String] {
+        manager.loadNetworkMetadata()?.networkCIDRs ?? []
+    }
+
+    func statusPayload() -> [String: Any] {
+        let s = status
+        return [
+            "enabled": s.enabled,
+            "signed_in": s.signedIn,
+            "tunnel_up": s.tunnelUp,
+            "machine_count": s.machineCount,
+            "listening": s.listening,
+            "port": Int(s.port),
+            "bound_addresses": s.boundAddresses,
+            "machine_endpoint": machineEndpointString() ?? NSNull(),
+            "network_cidrs": s.networkCIDRs,
+            "token_count": s.tokenCount,
+            "off_reason": s.offReason ?? NSNull(),
+            "last_error": s.lastError ?? NSNull(),
+            "allowed_methods": VMHostAccessPolicy.allowedMethods.sorted(),
+        ]
+    }
+
+    // MARK: - internals
+
+    private func accessDidEnd() {
+        status.signedIn = false
+        status.machineCount = 0
+        deliveredEndpoints = [:]
+        Self.tokens.removeAll()
+        reconcile(source: "accessDidEnd")
+    }
+
+    private func scheduleInventoryRefresh(source: String) {
+        refreshTask?.cancel()
+        refreshTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            guard let client = VMClient.shared else {
+                self.status.signedIn = false
+                self.status.machineCount = 0
+                self.reconcile(source: source)
+                return
+            }
+            do {
+                let machines = try await client.list()
+                guard !Task.isCancelled else { return }
+                self.status.signedIn = true
+                self.status.machineCount = machines.count
+                Self.tokens.retain(vmIDs: Set(machines.map(\.id)))
+                let ids = Set(machines.map(\.id))
+                self.deliveredEndpoints = self.deliveredEndpoints.filter { ids.contains($0.key) }
+            } catch let error as VMClientError {
+                if case .notSignedIn = error {
+                    self.status.signedIn = false
+                    self.status.machineCount = 0
+                } else {
+                    self.status.lastError = error.localizedDescription
+                }
+            } catch {
+                self.status.lastError = error.localizedDescription
+            }
+            self.reconcile(source: source)
+        }
+    }
+
+    private func reconcile(source: String) {
+        let live = manager.liveInterfaceAddresses()
+        let metadata = manager.loadNetworkMetadata()
+        status.enabled = isEnabled
+        status.tunnelUp = !live.isEmpty
+        status.machineFacingAddresses = metadata?.machineFacingAddresses ?? []
+        status.networkCIDRs = metadata?.networkCIDRs ?? []
+        status.tokenCount = Self.tokens.count
+
+        let desired = Self.desiredState(
+            enabled: status.enabled,
+            signedIn: status.signedIn,
+            liveTunnelAddresses: live,
+            machineCount: status.machineCount
+        )
+        switch desired {
+        case .off(let reason):
+            stopListener(reason: reason)
+        case .on:
+            guard !status.machineFacingAddresses.isEmpty, !status.networkCIDRs.isEmpty else {
+                stopListener(reason: "network_metadata_missing")
+                return
+            }
+            let current = listener?.boundAddresses.map(\.address) ?? []
+            if listener?.isListening == true, Set(current) == Set(live) {
+                status.offReason = nil
+                publish()
+                return
+            }
+            startListener(addresses: live)
+        }
+        #if DEBUG
+        cmuxDebugLog("vmhost.reconcile source=\(source) desired=\(desired) listening=\(status.listening) port=\(status.port)")
+        #endif
+    }
+
+    private func startListener(addresses: [String]) {
+        listener?.stop()
+        let cidrs = status.networkCIDRs
+        let listener = VMHostListener { socket, peer in
+            let context = TerminalController.VMHostConnectionContext(peerAddress: peer, networkCIDRs: cidrs)
+            Task { @MainActor in
+                await TerminalController.shared.spawnVMHostClientHandler(socket: socket, context: context)
+            }
+        }
+        let remembered = UInt16(clamping: defaults.integer(forKey: Self.portDefaultsKey))
+        do {
+            do {
+                try listener.start(addresses: addresses, port: remembered)
+            } catch where remembered != 0 {
+                // The remembered port is taken; pick a fresh one and remember it.
+                try listener.start(addresses: addresses, port: 0)
+            }
+            self.listener = listener
+            let port = listener.boundAddresses.first?.port ?? 0
+            if port != remembered { defaults.set(Int(port), forKey: Self.portDefaultsKey) }
+            status.listening = true
+            status.port = port
+            status.boundAddresses = listener.boundAddresses.map(\.address)
+            status.offReason = nil
+            status.lastError = nil
+            publish()
+            // Machines already linked need the (possibly new) endpoint.
+            deliveredEndpoints = [:]
+            for box in linkManagers {
+                guard let manager = box.value else { continue }
+                Task { await manager.redeliverHostEndpoints() }
+            }
+            linkManagers.removeAll { $0.value == nil }
+        } catch {
+            self.listener = nil
+            status.listening = false
+            status.port = 0
+            status.boundAddresses = []
+            status.lastError = "listener: \(error)"
+            status.offReason = "bind_failed"
+            publish()
+        }
+    }
+
+    private func stopListener(reason: String) {
+        let wasListening = status.listening
+        if wasListening { withdrawEndpoints(from: Array(deliveredEndpoints.keys)) }
+        listener?.stop()
+        listener = nil
+        status.listening = false
+        status.port = 0
+        status.boundAddresses = []
+        status.offReason = reason
+        deliveredEndpoints = [:]
+        if wasListening || status.offReason != reason { publish() }
+    }
+
+    private func publish() {
+        NotificationCenter.default.post(name: .cmuxCloudVMHostListenerStatusDidChange, object: self)
+    }
+}

--- a/Sources/Cloud/VMHostListenerCoordinator.swift
+++ b/Sources/Cloud/VMHostListenerCoordinator.swift
@@ -55,6 +55,9 @@ final class VMHostListenerCoordinator {
         var machineFacingAddresses: [String] = []
         var networkCIDRs: [String] = []
         var tokenCount = 0
+        /// Whether sign-in and machine inventory have been learned at least
+        /// once this session; until then "signed_out" is a guess.
+        var inventoryKnown = false
         var lastError: String?
         var offReason: String?
     }
@@ -315,6 +318,7 @@ final class VMHostListenerCoordinator {
             guard let client = VMClient.shared else {
                 self.status.signedIn = false
                 self.status.machineCount = 0
+                self.status.inventoryKnown = true
                 self.reconcile(source: source)
                 return
             }
@@ -322,6 +326,8 @@ final class VMHostListenerCoordinator {
                 let machines = try await client.list()
                 guard !Task.isCancelled else { return }
                 self.status.signedIn = true
+                self.status.inventoryKnown = true
+                self.status.lastError = nil
                 self.status.machineCount = machines.count
                 Self.tokens.retain(vmIDs: Set(machines.map(\.id)))
                 let ids = Set(machines.map(\.id))
@@ -330,8 +336,11 @@ final class VMHostListenerCoordinator {
                 if case .notSignedIn = error {
                     self.status.signedIn = false
                     self.status.machineCount = 0
+                    self.status.inventoryKnown = true
                 } else {
-                    self.status.lastError = error.localizedDescription
+                    // Backend unreachable or erroring: keep what we knew and
+                    // surface the error instead of claiming "signed out".
+                    self.status.lastError = error.description
                 }
             } catch {
                 self.status.lastError = error.localizedDescription
@@ -357,7 +366,10 @@ final class VMHostListenerCoordinator {
             machineCount: status.machineCount
         )
         switch desired {
-        case .off(let reason):
+        case .off(var reason):
+            if reason == "signed_out", !status.inventoryKnown, status.lastError != nil {
+                reason = "cloud_unreachable"
+            }
             stopListener(reason: reason)
         case .on:
             guard !status.machineFacingAddresses.isEmpty, !status.networkCIDRs.isEmpty else {

--- a/Sources/Cloud/VMHostListenerCoordinator.swift
+++ b/Sources/Cloud/VMHostListenerCoordinator.swift
@@ -332,7 +332,11 @@ final class VMHostListenerCoordinator {
                 Self.tokens.retain(vmIDs: Set(machines.map(\.id)))
                 let ids = Set(machines.map(\.id))
                 self.deliveredEndpoints = self.deliveredEndpoints.filter { ids.contains($0.key) }
+            } catch is CancellationError {
+                // Superseded by a newer refresh; that one reports.
+                return
             } catch let error as VMClientError {
+                guard !Task.isCancelled else { return }
                 if case .notSignedIn = error {
                     self.status.signedIn = false
                     self.status.machineCount = 0
@@ -343,6 +347,8 @@ final class VMHostListenerCoordinator {
                     self.status.lastError = error.description
                 }
             } catch {
+                guard !Task.isCancelled else { return }
+                if (error as? URLError)?.code == .cancelled { return }
                 self.status.lastError = error.localizedDescription
             }
             self.reconcile(source: source)
@@ -367,8 +373,10 @@ final class VMHostListenerCoordinator {
         )
         switch desired {
         case .off(var reason):
-            if reason == "signed_out", !status.inventoryKnown, status.lastError != nil {
-                reason = "cloud_unreachable"
+            if reason == "signed_out", !status.inventoryKnown {
+                // Nothing learned yet: either the first fetch is still in
+                // flight or it failed. Never claim "signed out" on a guess.
+                reason = status.lastError == nil ? "inventory_pending" : "cloud_unreachable"
             }
             stopListener(reason: reason)
         case .on:

--- a/Sources/Cloud/VMHostTokenStore.swift
+++ b/Sources/Cloud/VMHostTokenStore.swift
@@ -1,0 +1,126 @@
+import Foundation
+import Security
+import os
+
+/// Per-machine bearer tokens for the Cloud VM host listener.
+///
+/// This Mac mints one token per machine, delivers it into the machine over
+/// the link it already holds (`CloudMachineLinkManager`), and later maps a
+/// presented token back to the machine that may use it. Tokens are stored in
+/// `~/.cmuxterm/vm-host/tokens.json` (0600, directory 0700) — the same trust
+/// model as the WireGuard private key next door — so a relaunch keeps
+/// accepting the tokens machines already hold instead of forcing a redeliver.
+final class VMHostTokenStore: @unchecked Sendable {
+    private let lock = OSAllocatedUnfairLock<[String: String]>(initialState: [:])
+    private let fileURL: URL
+    private let directoryURL: URL
+    private let loaded = OSAllocatedUnfairLock(initialState: false)
+
+    init(home: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)) {
+        directoryURL = home.appendingPathComponent(".cmuxterm", isDirectory: true)
+            .appendingPathComponent("vm-host", isDirectory: true)
+        fileURL = directoryURL.appendingPathComponent("tokens.json", isDirectory: false)
+    }
+
+    /// The token for `vmID`, minted on first use. 32 random bytes, base64url.
+    func token(for vmID: String) -> String {
+        loadIfNeeded()
+        return lock.withLock { tokens in
+            if let existing = tokens[vmID] { return existing }
+            let minted = Self.mintToken()
+            tokens[vmID] = minted
+            persist(tokens)
+            return minted
+        }
+    }
+
+    /// The machine a presented token belongs to, or nil. Scans every entry so
+    /// timing does not reveal which prefix matched.
+    func vmID(forToken presented: String) -> String? {
+        loadIfNeeded()
+        return lock.withLock { tokens in
+            var match: String?
+            for (vmID, token) in tokens where VMHostAccessPolicy.tokensMatch(presented, token) {
+                match = vmID
+            }
+            return match
+        }
+    }
+
+    func remove(vmID: String) {
+        loadIfNeeded()
+        lock.withLock { tokens in
+            guard tokens.removeValue(forKey: vmID) != nil else { return }
+            persist(tokens)
+        }
+    }
+
+    /// Drop every token; used on sign-out and tunnel revoke so a later account
+    /// never inherits a previous one's machines.
+    func removeAll() {
+        loaded.withLock { $0 = true }
+        lock.withLock { tokens in
+            tokens = [:]
+            persist(tokens)
+        }
+    }
+
+    /// Keep only the machines the account still owns.
+    func retain(vmIDs: Set<String>) {
+        loadIfNeeded()
+        lock.withLock { tokens in
+            let before = tokens.count
+            tokens = tokens.filter { vmIDs.contains($0.key) }
+            if tokens.count != before { persist(tokens) }
+        }
+    }
+
+    var count: Int {
+        loadIfNeeded()
+        return lock.withLock { $0.count }
+    }
+
+    // MARK: - internals
+
+    static func mintToken() -> String {
+        var bytes = [UInt8](repeating: 0, count: 32)
+        let status = SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes)
+        precondition(status == errSecSuccess, "SecRandomCopyBytes failed: \(status)")
+        return Data(bytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    private func loadIfNeeded() {
+        let alreadyLoaded = loaded.withLock { flag -> Bool in
+            if flag { return true }
+            flag = true
+            return false
+        }
+        guard !alreadyLoaded else { return }
+        guard let data = try? Data(contentsOf: fileURL),
+              let decoded = try? JSONDecoder().decode([String: String].self, from: data) else { return }
+        lock.withLock { tokens in
+            if tokens.isEmpty { tokens = decoded }
+        }
+    }
+
+    /// Called with the lock held.
+    private func persist(_ tokens: [String: String]) {
+        do {
+            try FileManager.default.createDirectory(
+                at: directoryURL,
+                withIntermediateDirectories: true,
+                attributes: [.posixPermissions: 0o700]
+            )
+            let data = try JSONEncoder().encode(tokens)
+            try data.write(to: fileURL, options: [.atomic])
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: fileURL.path)
+        } catch {
+            #if DEBUG
+            cmuxDebugLog("vmhost.tokens.persistFailed error=\(error.localizedDescription)")
+            #endif
+        }
+    }
+}

--- a/Sources/Cloud/VMTunnelManager.swift
+++ b/Sources/Cloud/VMTunnelManager.swift
@@ -223,6 +223,31 @@ struct VMTunnelManager: Sendable {
         return try? JSONDecoder().decode(NetworkMetadata.self, from: data)
     }
 
+    /// Fetch this device's network addresses from the control plane and write
+    /// `network.json` without touching the WireGuard config. Enrollment is
+    /// idempotent per device fingerprint and public key, so a Mac that
+    /// enrolled before `network.json` existed (or lost the file) learns its
+    /// addresses again with the tunnel left running and no sudo prompt.
+    func refreshNetworkMetadata(client: VMClient) async throws -> NetworkMetadata {
+        let keys = try keypair()
+        let fingerprint = try deviceFingerprint()
+        let endpoint = try await client.enrollTunnel(
+            clientPublicKey: keys.publicKey,
+            deviceFingerprint: fingerprint,
+            deviceName: CloudTuiClientPaths.deviceName()
+        )
+        let metadata = NetworkMetadata(
+            tunnelId: endpoint.tunnelId,
+            addressV4: endpoint.addressV4,
+            addressV6: endpoint.addressV6,
+            networkCidr: endpoint.networkCidr,
+            networkCidrV6: endpoint.networkCidrV6
+        )
+        try ensureStateDir()
+        try writeNetworkMetadata(metadata)
+        return metadata
+    }
+
     func writeNetworkMetadata(_ metadata: NetworkMetadata) throws {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]

--- a/Sources/Cloud/VMTunnelManager.swift
+++ b/Sources/Cloud/VMTunnelManager.swift
@@ -69,6 +69,33 @@ struct VMTunnelManager: Sendable {
     var privateKeyURL: URL { stateDir.appendingPathComponent("private.key", isDirectory: false) }
     var deviceIDURL: URL { stateDir.appendingPathComponent("device-id", isDirectory: false) }
     var configURL: URL { stateDir.appendingPathComponent("\(Self.interfaceName).conf", isDirectory: false) }
+    /// The network facts the control plane returned at enrollment that the
+    /// config file does not carry: this Mac's address on the network and the
+    /// network's CIDRs. The host listener needs them to tell machines where
+    /// to call and to admit only callers from inside the network.
+    var networkMetadataURL: URL { stateDir.appendingPathComponent("network.json", isDirectory: false) }
+
+    /// `PersistentKeepalive` written into `[Peer]`. The platform config omits
+    /// it; without a keepalive the gateway's NAT mapping for this Mac expires
+    /// while idle and a *machine-initiated* connection (a notification) has no
+    /// path back until the Mac next sends something.
+    static let persistentKeepaliveSeconds = 25
+
+    struct NetworkMetadata: Codable, Sendable, Equatable {
+        let tunnelId: String
+        let addressV4: String?
+        let addressV6: String?
+        let networkCidr: String?
+        let networkCidrV6: String?
+
+        /// The CIDRs a caller must sit inside to be one of the user's machines
+        /// or tunnels. Empty when the control plane reported none.
+        var networkCIDRs: [String] { [networkCidr, networkCidrV6].compactMap { $0 } }
+
+        /// The addresses machines dial to reach this Mac; IPv6 first because
+        /// the daemon side prefers it, matching `freestyleCmuxRemoteRoute`.
+        var machineFacingAddresses: [String] { [addressV6, addressV4].compactMap { $0 } }
+    }
 
     /// wg-quick(8) records the created utun's name here — but on macOS the
     /// file is root-only (0400), so liveness detection must not depend on it;
@@ -143,6 +170,13 @@ struct VMTunnelManager: Sendable {
         let config = try Self.completedConfig(endpoint.clientConfig, privateKey: keys.privateKey)
         try ensureStateDir()
         try write(config, to: configURL)
+        try writeNetworkMetadata(NetworkMetadata(
+            tunnelId: endpoint.tunnelId,
+            addressV4: endpoint.addressV4,
+            addressV6: endpoint.addressV6,
+            networkCidr: endpoint.networkCidr,
+            networkCidrV6: endpoint.networkCidrV6
+        ))
         return LocalTunnelState(
             endpoint: endpoint,
             configPath: configURL.path,
@@ -159,21 +193,44 @@ struct VMTunnelManager: Sendable {
     /// unique to the tunnel, so a match is the tunnel and nothing else. A
     /// future NetworkExtension tunnel reports through NEVPNStatus instead.
     func wgQuickInterfaceUp() -> Bool {
-        guard let config = try? String(contentsOf: configURL, encoding: .utf8) else { return false }
+        !liveInterfaceAddresses().isEmpty
+    }
+
+    /// The tunnel's own `[Interface] Address`es that some interface currently
+    /// holds — the exact local addresses a listener may bind so it exists only
+    /// while the tunnel does. Empty when the tunnel is down or unconfigured.
+    func liveInterfaceAddresses() -> [String] {
+        guard let config = try? String(contentsOf: configURL, encoding: .utf8) else { return [] }
         let expected = Self.interfaceAddresses(in: config)
-        guard !expected.isEmpty else { return false }
+        guard !expected.isEmpty else { return [] }
         var addrs: UnsafeMutablePointer<ifaddrs>?
-        guard getifaddrs(&addrs) == 0 else { return false }
+        guard getifaddrs(&addrs) == 0 else { return [] }
         defer { freeifaddrs(addrs) }
+        var live: [String] = []
         var cursor = addrs
         while let current = cursor {
             if let sa = current.pointee.ifa_addr, let address = Self.numericAddress(sa),
-               expected.contains(address) {
-                return true
+               expected.contains(address), !live.contains(address) {
+                live.append(address)
             }
             cursor = current.pointee.ifa_next
         }
-        return false
+        return live
+    }
+
+    func loadNetworkMetadata() -> NetworkMetadata? {
+        guard let data = try? Data(contentsOf: networkMetadataURL) else { return nil }
+        return try? JSONDecoder().decode(NetworkMetadata.self, from: data)
+    }
+
+    func writeNetworkMetadata(_ metadata: NetworkMetadata) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(metadata)
+        guard let text = String(data: data, encoding: .utf8) else {
+            throw TunnelError.keyStorageFailed("could not encode network metadata")
+        }
+        try write(text, to: networkMetadataURL)
     }
 
     /// The `Address =` values in a wg-quick config's `[Interface]` section,
@@ -217,8 +274,9 @@ struct VMTunnelManager: Sendable {
         }
     }
 
-    /// Fill the blank `PrivateKey` line the server left in the config.
-    /// The server-issued config is otherwise complete and final.
+    /// Fill the blank `PrivateKey` line the server left in the config and add
+    /// the `[Peer]` keepalive (see `persistentKeepaliveSeconds`). The
+    /// server-issued config is otherwise complete and final.
     static func completedConfig(_ config: String, privateKey: String) throws -> String {
         var lines = config.components(separatedBy: "\n")
         if let index = lines.firstIndex(where: { line in
@@ -226,16 +284,36 @@ struct VMTunnelManager: Sendable {
             return trimmed.lowercased().hasPrefix("privatekey")
         }) {
             lines[index] = "PrivateKey = \(privateKey)"
-            return lines.joined(separator: "\n")
+        } else {
+            // No PrivateKey line at all: insert directly under [Interface].
+            guard let interfaceIndex = lines.firstIndex(where: {
+                $0.trimmingCharacters(in: .whitespaces).lowercased() == "[interface]"
+            }) else {
+                throw TunnelError.configMalformed("no [Interface] section in server config")
+            }
+            lines.insert("PrivateKey = \(privateKey)", at: interfaceIndex + 1)
         }
-        // No PrivateKey line at all: insert directly under [Interface].
-        guard let interfaceIndex = lines.firstIndex(where: {
-            $0.trimmingCharacters(in: .whitespaces).lowercased() == "[interface]"
-        }) else {
-            throw TunnelError.configMalformed("no [Interface] section in server config")
+        return withPersistentKeepalive(lines).joined(separator: "\n")
+    }
+
+    /// Ensure the `[Peer]` section carries `PersistentKeepalive`. A value the
+    /// server already set is left alone; a config with no `[Peer]` section is
+    /// returned unchanged (it is not a usable tunnel either way).
+    static func withPersistentKeepalive(_ lines: [String]) -> [String] {
+        let trimmedLower = lines.map { $0.trimmingCharacters(in: .whitespaces).lowercased() }
+        guard let peerIndex = trimmedLower.firstIndex(of: "[peer]") else { return lines }
+        let peerEnd = trimmedLower[(peerIndex + 1)...].firstIndex(where: { $0.hasPrefix("[") }) ?? lines.count
+        let alreadySet = trimmedLower[(peerIndex + 1)..<peerEnd].contains { $0.hasPrefix("persistentkeepalive") }
+        guard !alreadySet else { return lines }
+        var result = lines
+        // Insert after the last non-empty line of the [Peer] section so a
+        // trailing blank line stays trailing.
+        var insertAt = peerEnd
+        while insertAt > peerIndex + 1, result[insertAt - 1].trimmingCharacters(in: .whitespaces).isEmpty {
+            insertAt -= 1
         }
-        lines.insert("PrivateKey = \(privateKey)", at: interfaceIndex + 1)
-        return lines.joined(separator: "\n")
+        result.insert("PersistentKeepalive = \(persistentKeepaliveSeconds)", at: insertAt)
+        return result
     }
 
     private func ensureStateDir() throws {

--- a/Sources/TerminalController+RemoteRelayAuthorization.swift
+++ b/Sources/TerminalController+RemoteRelayAuthorization.swift
@@ -75,7 +75,7 @@ extension TerminalController {
         "notification.create_for_target",
     ]
 
-    private nonisolated static let remoteRelayWorkspaceSelectorKeys: Set<String> = [
+    nonisolated static let remoteRelayWorkspaceSelectorKeys: Set<String> = [
         "workspace_id",
         "preferred_workspace_id",
         "selected_workspace_id",
@@ -87,9 +87,9 @@ extension TerminalController {
         "_cmux_remote_workspace_id",
     ]
 
-    private nonisolated static let remoteRelayWorkspaceArrayKeys: Set<String> = ["workspace_ids"]
+    nonisolated static let remoteRelayWorkspaceArrayKeys: Set<String> = ["workspace_ids"]
 
-    private nonisolated static let remoteRelaySurfaceSelectorKeys: Set<String> = [
+    nonisolated static let remoteRelaySurfaceSelectorKeys: Set<String> = [
         "panel_id",
         "surface_id",
         "preferred_panel_id",
@@ -104,7 +104,7 @@ extension TerminalController {
         "after_surface_id",
     ]
 
-    private nonisolated static let remoteRelaySurfaceArrayKeys: Set<String> = ["panel_ids", "surface_ids"]
+    nonisolated static let remoteRelaySurfaceArrayKeys: Set<String> = ["panel_ids", "surface_ids"]
 
     /// Authorizes relay metadata before execution-policy routing.  Ordinary
     /// local socket requests have no generic relay MAC and pass through
@@ -271,12 +271,12 @@ extension TerminalController {
         )
     }
 
-    private struct RemoteRelaySelectorValidation {
+    struct RemoteRelaySelectorValidation {
         let code: String
         let message: String
     }
 
-    private nonisolated static func containsTopLevelSelector(
+    nonisolated static func containsTopLevelSelector(
         _ params: [String: Any],
         keys: Set<String>
     ) -> Bool {
@@ -289,6 +289,18 @@ extension TerminalController {
     private nonisolated static func validateRemoteRelaySelectors(
         _ params: [String: Any],
         ownerWorkspaceID: UUID,
+        surfaceIDs: Set<UUID>
+    ) -> RemoteRelaySelectorValidation? {
+        validateRelaySelectors(params, ownerWorkspaceIDs: [ownerWorkspaceID], surfaceIDs: surfaceIDs)
+    }
+
+    /// Every workspace selector must name one of `ownerWorkspaceIDs` and every
+    /// surface selector one of `surfaceIDs`, at any nesting depth. Shared by
+    /// the ssh relay gate (one owner workspace) and the Cloud VM host gate
+    /// (every workspace bound to the calling machine).
+    nonisolated static func validateRelaySelectors(
+        _ params: [String: Any],
+        ownerWorkspaceIDs: Set<UUID>,
         surfaceIDs: Set<UUID>
     ) -> RemoteRelaySelectorValidation? {
         func validate(_ value: Any, key: String?) -> RemoteRelaySelectorValidation? {
@@ -326,7 +338,7 @@ extension TerminalController {
                     message: "Relay selector is invalid"
                 )
             }
-            if remoteRelayWorkspaceSelectorKeys.contains(key), id != ownerWorkspaceID {
+            if remoteRelayWorkspaceSelectorKeys.contains(key), !ownerWorkspaceIDs.contains(id) {
                 return RemoteRelaySelectorValidation(
                     code: "remote_relay_workspace_denied",
                     message: "Relay request targets a different workspace"

--- a/Sources/TerminalController+VMHostClient.swift
+++ b/Sources/TerminalController+VMHostClient.swift
@@ -1,0 +1,186 @@
+import CmuxControlSocket
+import Foundation
+
+/// Connections from Cloud VMs over the private-network listener
+/// (`VMHostListenerCoordinator`). Same wire protocol as the local control
+/// socket, but a different trust model: the peer is a machine the user owns,
+/// not a process on this Mac, so the local same-UID and password gates do not
+/// apply and `VMHostAccessPolicy` does instead.
+extension TerminalController {
+    struct VMHostConnectionContext: Sendable {
+        let peerAddress: String
+        let networkCIDRs: [String]
+    }
+
+    /// Admit one accepted machine connection to the bounded worker pool.
+    nonisolated func spawnVMHostClientHandler(socket clientSocket: Int32, context: VMHostConnectionContext) async {
+        guard VMHostAccessPolicy.sourceIsAllowed(peer: context.peerAddress, networkCIDRs: context.networkCIDRs) else {
+            #if DEBUG
+            cmuxDebugLog("vmhost.connection.denied peer=\(context.peerAddress) reason=source")
+            #endif
+            close(clientSocket)
+            return
+        }
+        let submission = await socketClientWorkerPool.submit { [weak self] in
+            guard let self else {
+                close(clientSocket)
+                return
+            }
+            await self.handleVMHostClientAsync(clientSocket, context: context)
+        } onDrop: {
+            close(clientSocket)
+        }
+        _ = submission
+    }
+
+    private nonisolated func handleVMHostClientAsync(_ socket: Int32, context: VMHostConnectionContext) async {
+        defer {
+            shutdown(socket, SHUT_RDWR)
+            close(socket)
+        }
+        let lineReader = ControlClientAsyncLineReader(
+            socket: socket,
+            maximumBufferedBytes: VMHostAccessPolicy.maxRequestLineBytes
+        )
+        let writer = ControlClientAsyncWriter(socket: socket)
+        let rateLimiter = ControlClientRateLimiter()
+        defer {
+            lineReader.cancel()
+            writer.cancel()
+        }
+        while let line = await lineReader.nextLine(shouldContinueReading: { true }) {
+            let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else { continue }
+            guard trimmed.hasPrefix("{") else {
+                // v1 text commands carry no token and are never admitted.
+                _ = await writer.writeAll(Data((Self.socketClientAccessDeniedResponse + "\n").utf8))
+                return
+            }
+            let request: ControlRequest
+            switch Self.v2Parser.request(fromLine: trimmed) {
+            case .failure(let parseError):
+                guard await writer.writeAll(Data((Self.v2Encoder.response(for: parseError) + "\n").utf8)) else { return }
+                continue
+            case .success(let parsed):
+                request = parsed
+            }
+            let authorization = authorizeVMHostRequest(request, context: context)
+            if let errorResponse = authorization.errorResponse {
+                guard await writer.writeAll(Data((errorResponse + "\n").utf8)) else { return }
+                continue
+            }
+            if case .limited(let retryAfterMilliseconds) = await rateLimiter.admit(method: request.method) {
+                let response = v2Error(
+                    id: request.id?.foundationObject,
+                    code: "rate_limited",
+                    message: "Too many requests; retry after \(retryAfterMilliseconds) ms"
+                )
+                guard await writer.writeAll(Data((response + "\n").utf8)) else { return }
+                continue
+            }
+            guard let sanitizedLine = Self.vmHostRequestLine(authorization.request) else {
+                let response = v2Error(id: request.id?.foundationObject, code: "invalid_params", message: "Request could not be re-encoded")
+                guard await writer.writeAll(Data((response + "\n").utf8)) else { return }
+                continue
+            }
+            let response = await processCommandUsingSocketExecutionPolicyAsync(sanitizedLine)
+            if let response {
+                guard await writer.writeAll(Data((response + "\n").utf8)) else { return }
+            }
+        }
+    }
+
+    /// Re-encode a sanitized request as one JSON line for the shared v2
+    /// dispatcher. The token parameter has already been removed.
+    nonisolated static func vmHostRequestLine(_ request: ControlRequest) -> String? {
+        var object: [String: Any] = [
+            "method": request.method,
+            "params": request.params.mapValues(\.foundationObject),
+        ]
+        if let id = request.id?.foundationObject { object["id"] = id }
+        guard JSONSerialization.isValidJSONObject(object),
+              let data = try? JSONSerialization.data(withJSONObject: object, options: [.sortedKeys]),
+              let line = String(data: data, encoding: .utf8) else { return nil }
+        return line
+    }
+
+    private struct VMHostAuthorizationSnapshot: Sendable {
+        let workspaceIDs: Set<UUID>
+        let surfaceIDs: Set<UUID>
+    }
+
+    /// The Cloud VM host gate. A request must carry a token this Mac minted
+    /// for a machine, name only an allowed verb, and name only workspaces and
+    /// surfaces bound to that machine. Returns the request with the token
+    /// stripped, or an encoded error.
+    nonisolated func authorizeVMHostRequest(
+        _ request: ControlRequest,
+        context: VMHostConnectionContext
+    ) -> RemoteRelayAuthorizationResult {
+        let foundationParams = request.params.mapValues(\.foundationObject)
+        guard let token = foundationParams[VMHostAccessPolicy.tokenParamKey] as? String, !token.isEmpty else {
+            return deniedVMHostRequest(request, code: "vm_host_authentication_required", message: "Machine token is missing")
+        }
+        guard let vmID = VMHostListenerCoordinator.tokens.vmID(forToken: token) else {
+            return deniedVMHostRequest(request, code: "vm_host_authentication_failed", message: "Machine token is not recognized")
+        }
+        guard VMHostAccessPolicy.allowedMethods.contains(request.method) else {
+            return deniedVMHostRequest(request, code: "vm_host_method_denied", message: "Method is not permitted from a machine")
+        }
+
+        let snapshot: VMHostAuthorizationSnapshot = v2MainSync(commandKey: request.method) {
+            var workspaceIDs = Set<UUID>()
+            var surfaceIDs = Set<UUID>()
+            for workspace in AppDelegate.shared?.workspaces(boundToCloudVM: vmID) ?? [] {
+                workspaceIDs.insert(workspace.id)
+                surfaceIDs.formUnion(workspace.panels.keys)
+                surfaceIDs.formUnion(workspace.surfaceIdToPanelId.keys.map(\.uuid))
+            }
+            return VMHostAuthorizationSnapshot(workspaceIDs: workspaceIDs, surfaceIDs: surfaceIDs)
+        }
+        guard !snapshot.workspaceIDs.isEmpty || !Self.vmHostMethodNeedsAWorkspace(request.method) else {
+            return deniedVMHostRequest(request, code: "vm_host_workspace_denied", message: "No workspace is bound to this machine")
+        }
+        if let failure = Self.validateRelaySelectors(
+            foundationParams,
+            ownerWorkspaceIDs: snapshot.workspaceIDs,
+            surfaceIDs: snapshot.surfaceIDs
+        ) {
+            return deniedVMHostRequest(request, code: failure.code.replacingOccurrences(of: "remote_relay", with: "vm_host"), message: failure.message)
+        }
+        let hasWorkspaceSelector = Self.containsTopLevelSelector(foundationParams, keys: Self.remoteRelayWorkspaceSelectorKeys)
+        let hasSurfaceSelector = Self.containsTopLevelSelector(foundationParams, keys: Self.remoteRelaySurfaceSelectorKeys)
+        if VMHostAccessPolicy.workspaceRequiredMethods.contains(request.method), !hasWorkspaceSelector {
+            return deniedVMHostRequest(request, code: "vm_host_workspace_denied", message: "Method requires an explicit workspace selector")
+        }
+        if VMHostAccessPolicy.surfaceRequiredMethods.contains(request.method), !hasSurfaceSelector {
+            return deniedVMHostRequest(request, code: "vm_host_surface_denied", message: "Method requires an explicit surface selector")
+        }
+        if request.method == "agent.resolve_delivery_target" {
+            guard foundationParams["pid"] == nil,
+                  foundationParams["pid_resolution"] == nil,
+                  foundationParams["tty_name"] is String,
+                  (foundationParams["tty_resolution"] as? String) == "reported_tty" else {
+                return deniedVMHostRequest(request, code: "vm_host_method_denied", message: "Delivery resolution requires the reported TTY path")
+            }
+        }
+
+        var sanitizedParams = request.params
+        sanitizedParams.removeValue(forKey: VMHostAccessPolicy.tokenParamKey)
+        return RemoteRelayAuthorizationResult(
+            request: ControlRequest(id: request.id, method: request.method, params: sanitizedParams),
+            errorResponse: nil
+        )
+    }
+
+    private nonisolated static func vmHostMethodNeedsAWorkspace(_ method: String) -> Bool {
+        VMHostAccessPolicy.workspaceRequiredMethods.contains(method)
+    }
+
+    private nonisolated func deniedVMHostRequest(_ request: ControlRequest, code: String, message: String) -> RemoteRelayAuthorizationResult {
+        RemoteRelayAuthorizationResult(
+            request: request,
+            errorResponse: ControlResponseEncoder().error(id: request.id, code: code, message: message)
+        )
+    }
+}

--- a/Sources/TerminalController+WorkspaceCreate.swift
+++ b/Sources/TerminalController+WorkspaceCreate.swift
@@ -259,6 +259,7 @@ extension TerminalController {
         }
         let isBase = v2Bool(params, "base") ?? false
         workspace.cloudVMBinding = WorkspaceCloudVMBinding(vmID: vmID, isBase: isBase)
+        Task { @MainActor in await VMHostListenerCoordinator.shared.bindingDidChange(vmID: vmID) }
         return .ok([
             "workspace_id": workspaceId.uuidString,
             "workspace_ref": v2Ref(kind: .workspace, uuid: workspaceId),

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -182,7 +182,7 @@ class TerminalController {
     private nonisolated let socketConnectionsTask: Task<Void, Never>
     /// Bounded async connection admission. The pool owns task lifetimes; an
     /// admitted connection owns its descriptor until its async handler exits.
-    private nonisolated let socketClientWorkerPool = ControlClientWorkerPool(
+    nonisolated let socketClientWorkerPool = ControlClientWorkerPool(
         maximumConcurrentJobs: 32,
         maximumPendingJobs: 64
     )

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -157,6 +157,7 @@ pub fn run(args: &[String], startup_usage: &str) -> i32 {
                 command::run_provider_authority(global, authority)
             }
             CommandPlan::RawCommand(command) => raw::run(global, command),
+            CommandPlan::HostForward(plan) => command::run_host_forward(global, plan),
         },
         Err(failure) => {
             let message = if matches!(failure.output, OutputMode::Quiet | OutputMode::Human) {
@@ -416,6 +417,7 @@ fn scope_help_for(
         "pairing" => Cow::Borrowed(PAIRING_HELP),
         "projection" => Cow::Borrowed(PROJECTION_HELP),
         "provider" => Cow::Borrowed(PROVIDER_HELP),
+        "host-forward" => Cow::Borrowed(HOST_FORWARD_HELP),
         "raw" => Cow::Borrowed(RAW_HELP),
         _ => Cow::Owned(root_help(&catalog.local_server)),
     }
@@ -661,6 +663,23 @@ const PROVIDER_HELP: &str = "\
 USAGE
   cmux --socket <path> provider authority install
     --generation <decimal> --authority-file <root-private-path>
+";
+
+const HOST_FORWARD_HELP: &str = "\
+Usage: cmux host-forward [--env-file <path>] [--print-manifest <guest cmux-tui path>]
+
+Journal hook command for cmux Cloud machines. The Mac that owns this machine
+writes /etc/cmux/host.env (CMUX_HOST_ENDPOINT, CMUX_HOST_TOKEN,
+CMUX_HOST_WORKSPACE_ID) and registers a journal hook whose argv is this
+command. The daemon runs it once per agent.* event with the hook envelope on
+stdin; it forwards the event to the Mac as workspace.status.set and
+notification.create. Exit 0 means delivered or nothing to do; exit 1 means
+the Mac was unreachable and the dispatcher should retry.
+
+  --env-file <path>          Read the endpoint file from <path> instead of
+                             /etc/cmux/host.env.
+  --print-manifest <binary>  Print the journal hook manifest that runs
+                             <binary> host-forward, and exit.
 ";
 
 const RAW_HELP: &str = "\

--- a/cmux-tui/crates/cmux-tui/src/cli/command.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/command.rs
@@ -24,6 +24,7 @@ pub(super) enum CommandPlan {
     Plugin(PluginPlan),
     ProviderAuthority(ProviderAuthorityPlan),
     RawCommand(super::raw::RawCommandPlan),
+    HostForward(crate::host_forward::Plan),
 }
 
 #[derive(Clone, Debug)]
@@ -171,6 +172,7 @@ pub(super) fn parse(args: &[String]) -> Result<CommandPlan, UsageError> {
         "projection" => parse_projection(&tokens.words[1..], &mut selectors, &mut tokens.flags)?,
         "provider" => parse_provider(&tokens.words[1..], &mut selectors, &mut tokens.flags)?,
         "raw" => parse_raw(&tokens.words[1..], &mut tokens.flags)?,
+        "host-forward" => parse_host_forward(&tokens.words[1..], &mut tokens.flags)?,
         value => return Err(super::unknown_scope(value)),
     };
     tokens.flags.reject_remaining()?;
@@ -1649,6 +1651,22 @@ fn parse_provider(
     }
 }
 
+/// `host-forward [--env-file <path>] [--print-manifest <guest cmux-tui path>]`:
+/// the journal hook command a cmux Cloud machine's owner Mac registers. It
+/// reads one hook envelope from stdin and forwards it to the Mac; see
+/// `crate::host_forward`.
+fn parse_host_forward(words: &[String], flags: &mut Flags) -> Result<CommandPlan, UsageError> {
+    if !words.is_empty() {
+        return Err(UsageError::new("host-forward takes no positional arguments"));
+    }
+    let env_file = flags.take("env-file").map(std::path::PathBuf::from);
+    let print_manifest = flags.take("print-manifest");
+    if print_manifest.as_deref().is_some_and(|binary| !std::path::Path::new(binary).is_absolute()) {
+        return Err(UsageError::new("--print-manifest needs the absolute guest path of cmux-tui"));
+    }
+    Ok(CommandPlan::HostForward(crate::host_forward::Plan { env_file, print_manifest }))
+}
+
 fn parse_raw(words: &[String], flags: &mut Flags) -> Result<CommandPlan, UsageError> {
     let refs = strs(words);
     if refs.as_slice() == ["command"] {
@@ -2705,6 +2723,22 @@ pub(super) fn run_provider_authority(global: GlobalArgs, plan: ProviderAuthority
             output,
             1,
         )
+    }
+}
+
+pub(super) fn run_host_forward(global: GlobalArgs, plan: crate::host_forward::Plan) -> i32 {
+    match crate::host_forward::run(&plan) {
+        Ok(value) => super::wire::print_local_success(&value, global.output),
+        Err(error) => {
+            // Exit 1 is the dispatcher's retry signal: the Mac was unreachable
+            // or the envelope was unusable.
+            let error = json!({
+                "code": "local.host_forward",
+                "message": format!("{error:#}"),
+                "retryable": true,
+            });
+            super::wire::print_local_error(&error, global.output, 1)
+        }
     }
 }
 
@@ -3792,6 +3826,26 @@ mod tests {
             ]))
             .is_err()
         );
+    }
+
+    #[test]
+    fn host_forward_parses_flags_and_rejects_positionals() {
+        let plan = parse(&strings(&["host-forward"])).unwrap();
+        let CommandPlan::HostForward(plan) = plan else { panic!("expected host-forward plan") };
+        assert_eq!(plan, crate::host_forward::Plan { env_file: None, print_manifest: None });
+        let plan = parse(&strings(&[
+            "host-forward",
+            "--env-file",
+            "/tmp/host.env",
+            "--print-manifest",
+            "/usr/local/bin/cmux-tui",
+        ]))
+        .unwrap();
+        let CommandPlan::HostForward(plan) = plan else { panic!("expected host-forward plan") };
+        assert_eq!(plan.env_file.as_deref(), Some(std::path::Path::new("/tmp/host.env")));
+        assert_eq!(plan.print_manifest.as_deref(), Some("/usr/local/bin/cmux-tui"));
+        assert!(parse(&strings(&["host-forward", "extra"])).is_err());
+        assert!(parse(&strings(&["host-forward", "--print-manifest", "cmux-tui"])).is_err());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/host_forward.rs
+++ b/cmux-tui/crates/cmux-tui/src/host_forward.rs
@@ -1,0 +1,470 @@
+//! Forward agent journal events from this machine to the Mac that owns it.
+//!
+//! On a cmux Cloud machine the owner's Mac listens on its private-network
+//! address for notifications (`VMHostListenerCoordinator` in the Mac app). It
+//! writes `/etc/cmux/host.env` here (`CMUX_HOST_ENDPOINT`, `CMUX_HOST_TOKEN`,
+//! `CMUX_HOST_WORKSPACE_ID`) and registers a journal hook on this daemon whose
+//! argv is `cmux-tui host-forward`. The dispatcher runs that command once per
+//! matching `agent.*` event, with the hook envelope on stdin and an empty
+//! environment, so everything this command needs comes from the env file and
+//! stdin.
+//!
+//! Each event becomes the Mac's own control-socket verbs: `workspace.status.set`
+//! moves the bound workspace's status lane, and `notification.create` raises a
+//! notification when the agent finished or needs the human. Requests carry the
+//! per-machine token the Mac minted; the Mac admits only these verbs from a
+//! machine and only for workspaces bound to it.
+//!
+//! Exit status is the retry contract with the dispatcher: 0 means delivered or
+//! nothing to do (the Mac turned forwarding off, or the Mac answered with a
+//! definitive error that a retry cannot fix); 1 means the Mac was unreachable,
+//! so the dispatcher retries with its backoff.
+
+use std::fs;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::net::{SocketAddr, TcpStream};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use anyhow::{Context, anyhow, bail};
+use serde_json::{Map, Value, json};
+
+/// Where the Mac installs the endpoint file on a machine.
+pub(crate) const DEFAULT_ENV_PATH: &str = "/etc/cmux/host.env";
+/// The journal hook id the Mac registers for this command.
+pub(crate) const HOOK_ID: &str = "cmux_host_forward";
+/// The Mac-side parameter that carries the machine token.
+const TOKEN_PARAM: &str = "_cmux_vm_host_token";
+/// Longest hook envelope this command reads before refusing it.
+const MAX_ENVELOPE_BYTES: u64 = 1024 * 1024;
+/// Longest notification body sent to the Mac.
+const MAX_BODY_CHARS: usize = 500;
+const CONNECT_TIMEOUT: Duration = Duration::from_secs(4);
+const IO_TIMEOUT: Duration = Duration::from_secs(6);
+const MAX_RESPONSE_BYTES: usize = 64 * 1024;
+
+/// Journal event kinds the hook subscribes to. Mirrors the agent status
+/// reducer's vocabulary (`agent_state_for_hook_kind` in cmux-tui-core).
+pub(crate) const FORWARDED_KINDS: [&str; 7] = [
+    "agent.turn.started",
+    "agent.turn.completed",
+    "agent.approval.requested",
+    "agent.question.requested",
+    "agent.plan_review.requested",
+    "agent.error.reported",
+    "agent.session.ended",
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Plan {
+    pub env_file: Option<PathBuf>,
+    pub print_manifest: Option<String>,
+}
+
+/// The endpoint file the Mac wrote. An empty or missing endpoint means the
+/// Mac has forwarding off; that is not an error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct HostEnv {
+    pub endpoint: Option<String>,
+    pub token: String,
+    pub workspace_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Request {
+    pub method: &'static str,
+    pub params: Map<String, Value>,
+}
+
+/// The manifest the Mac puts on a machine's daemon. `binary` is the guest path
+/// of cmux-tui (argv[0] must be absolute).
+pub(crate) fn hook_manifest(binary: &str) -> Value {
+    json!({
+        "hook_id": HOOK_ID,
+        "manifest_version": 1,
+        "filter": { "kinds": FORWARDED_KINDS },
+        "exec": { "argv": [binary, "host-forward"], "timeout_ms": 15_000, "max_parallel": 2 },
+        "delivery": { "start": "tail", "retry": { "max_attempts": 3, "backoff_ms": 2_000 } },
+        "permissions": ["journal.read"],
+    })
+}
+
+pub(crate) fn parse_host_env(text: &str) -> anyhow::Result<HostEnv> {
+    let mut endpoint = None;
+    let mut token = None;
+    let mut workspace_id = None;
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let Some((key, value)) = line.split_once('=') else {
+            bail!("host env line has no '=': {line:?}");
+        };
+        let value = value.trim().trim_matches('"').trim_matches('\'').to_string();
+        let value = (!value.is_empty()).then_some(value);
+        match key.trim() {
+            "CMUX_HOST_ENDPOINT" => endpoint = value,
+            "CMUX_HOST_TOKEN" => token = value,
+            "CMUX_HOST_WORKSPACE_ID" => workspace_id = value,
+            _ => {}
+        }
+    }
+    Ok(HostEnv { endpoint, token: token.unwrap_or_default(), workspace_id })
+}
+
+/// Human name for a hook adapter id (`payload.adapter`).
+fn agent_display_name(adapter: &str) -> String {
+    match adapter {
+        "claude-code" | "claude" => "Claude Code".into(),
+        "codex" => "Codex".into(),
+        "cursor" => "Cursor".into(),
+        "gemini" => "Gemini".into(),
+        "grok" => "Grok".into(),
+        "opencode" => "OpenCode".into(),
+        "pi" => "Pi".into(),
+        "hermes" => "Hermes".into(),
+        "" => "Agent".into(),
+        other => other.to_string(),
+    }
+}
+
+fn truncate_chars(text: &str, limit: usize) -> String {
+    let mut out: String = text.chars().take(limit).collect();
+    if out.len() < text.len() {
+        out.push('…');
+    }
+    out
+}
+
+/// Turn one hook envelope into Mac requests. Pure, so the mapping is testable
+/// without a socket. Unknown kinds produce no requests.
+pub(crate) fn plan_requests(envelope: &Value, env: &HostEnv) -> anyhow::Result<Vec<Request>> {
+    let event = envelope.get("event").ok_or_else(|| anyhow!("hook envelope has no event"))?;
+    let kind = event.get("kind").and_then(Value::as_str).unwrap_or_default();
+    let payload = event.get("payload").cloned().unwrap_or(Value::Null);
+    let adapter = payload.get("adapter").and_then(Value::as_str).unwrap_or_default();
+    let normalized = payload.get("normalized").cloned().unwrap_or(Value::Null);
+    let message = normalized
+        .get("message")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|text| !text.is_empty())
+        .map(|text| truncate_chars(text, MAX_BODY_CHARS));
+    let agent = agent_display_name(adapter);
+
+    let (status, notification): (Option<&str>, Option<(String, String)>) = match kind {
+        "agent.turn.started" => (Some("working"), None),
+        "agent.turn.completed" => (
+            Some("review"),
+            Some((format!("{agent} finished"), message.clone().unwrap_or_else(|| "Turn completed".into()))),
+        ),
+        "agent.approval.requested" => (
+            Some("needs-attention"),
+            Some((format!("{agent} needs approval"), message.clone().unwrap_or_else(|| "Waiting for your approval".into()))),
+        ),
+        "agent.question.requested" => (
+            Some("needs-attention"),
+            Some((format!("{agent} asked a question"), message.clone().unwrap_or_else(|| "Waiting for your answer".into()))),
+        ),
+        "agent.plan_review.requested" => (
+            Some("needs-attention"),
+            Some((format!("{agent} wants a plan review"), message.clone().unwrap_or_else(|| "Waiting for your review".into()))),
+        ),
+        "agent.error.reported" => (
+            Some("needs-attention"),
+            Some((format!("{agent} reported an error"), message.clone().unwrap_or_else(|| "The agent hit an error".into()))),
+        ),
+        // The session is gone: hand the lane back to the Mac's own inference.
+        "agent.session.ended" => (Some("auto"), None),
+        _ => (None, None),
+    };
+
+    let mut requests = Vec::new();
+    let base = |env: &HostEnv| -> Map<String, Value> {
+        let mut params = Map::new();
+        params.insert(TOKEN_PARAM.into(), Value::String(env.token.clone()));
+        if let Some(workspace) = &env.workspace_id {
+            params.insert("workspace_id".into(), Value::String(workspace.clone()));
+        }
+        params
+    };
+    if let Some(status) = status {
+        let mut params = base(env);
+        params.insert("status".into(), Value::String(status.into()));
+        requests.push(Request { method: "workspace.status.set", params });
+    }
+    if let Some((title, body)) = notification {
+        let mut params = base(env);
+        params.insert("title".into(), Value::String(title));
+        params.insert("body".into(), Value::String(body));
+        requests.push(Request { method: "notification.create", params });
+    }
+    Ok(requests)
+}
+
+/// One response line from the Mac, already parsed.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Delivered {
+    Ok,
+    /// The Mac answered with an error. Retrying the same request cannot help.
+    Rejected { code: String, message: String },
+}
+
+fn parse_endpoint(endpoint: &str) -> anyhow::Result<SocketAddr> {
+    endpoint
+        .parse::<SocketAddr>()
+        .with_context(|| format!("CMUX_HOST_ENDPOINT {endpoint:?} is not host:port"))
+}
+
+/// Send every request on one connection, one JSON line each, and read one
+/// response line per request. A transport error is returned as `Err` so the
+/// caller can exit non-zero and let the dispatcher retry.
+pub(crate) fn deliver(endpoint: &str, requests: &[Request]) -> anyhow::Result<Vec<Delivered>> {
+    let address = parse_endpoint(endpoint)?;
+    let stream = TcpStream::connect_timeout(&address, CONNECT_TIMEOUT)
+        .with_context(|| format!("connect to Mac at {endpoint}"))?;
+    stream.set_read_timeout(Some(IO_TIMEOUT))?;
+    stream.set_write_timeout(Some(IO_TIMEOUT))?;
+    let mut writer = stream.try_clone()?;
+    let mut reader = BufReader::new(stream);
+    let mut outcomes = Vec::with_capacity(requests.len());
+    for (index, request) in requests.iter().enumerate() {
+        let line = json!({
+            "id": format!("host-forward-{}", index + 1),
+            "method": request.method,
+            "params": request.params,
+        });
+        let mut bytes = serde_json::to_vec(&line)?;
+        bytes.push(b'\n');
+        writer.write_all(&bytes).context("write request to Mac")?;
+        writer.flush()?;
+        let mut response = Vec::new();
+        let read = (&mut reader)
+            .take(MAX_RESPONSE_BYTES as u64)
+            .read_until(b'\n', &mut response)
+            .context("read response from Mac")?;
+        if read == 0 {
+            bail!("Mac closed the connection before answering");
+        }
+        let value: Value = serde_json::from_slice(&response).context("parse Mac response")?;
+        let ok = value.get("ok").and_then(Value::as_bool).unwrap_or(false);
+        if ok {
+            outcomes.push(Delivered::Ok);
+        } else {
+            let error = value.get("error").cloned().unwrap_or(Value::Null);
+            outcomes.push(Delivered::Rejected {
+                code: error.get("code").and_then(Value::as_str).unwrap_or("unknown").to_string(),
+                message: error.get("message").and_then(Value::as_str).unwrap_or_default().to_string(),
+            });
+        }
+    }
+    Ok(outcomes)
+}
+
+fn read_envelope(mut input: impl Read) -> anyhow::Result<Value> {
+    let mut bytes = Vec::new();
+    input.by_ref().take(MAX_ENVELOPE_BYTES + 1).read_to_end(&mut bytes)?;
+    anyhow::ensure!(bytes.len() as u64 <= MAX_ENVELOPE_BYTES, "hook envelope exceeds {MAX_ENVELOPE_BYTES} bytes");
+    serde_json::from_slice(&bytes).context("hook envelope is not JSON")
+}
+
+/// Outcome of one run, printed as the command's JSON result.
+pub(crate) fn run_with(env_path: &Path, input: impl Read) -> anyhow::Result<Value> {
+    let env = match fs::read_to_string(env_path) {
+        Ok(text) => parse_host_env(&text)?,
+        Err(error) if error.kind() == io::ErrorKind::NotFound => {
+            return Ok(json!({ "forwarded": false, "reason": "no_host_env" }));
+        }
+        Err(error) => return Err(error).with_context(|| format!("read {}", env_path.display())),
+    };
+    let Some(endpoint) = env.endpoint.clone() else {
+        return Ok(json!({ "forwarded": false, "reason": "forwarding_off" }));
+    };
+    if env.token.is_empty() {
+        return Ok(json!({ "forwarded": false, "reason": "no_token" }));
+    }
+    let envelope = read_envelope(input)?;
+    let requests = plan_requests(&envelope, &env)?;
+    if requests.is_empty() {
+        return Ok(json!({ "forwarded": false, "reason": "kind_not_forwarded" }));
+    }
+    let outcomes = deliver(&endpoint, &requests)?;
+    let rejected: Vec<Value> = outcomes
+        .iter()
+        .zip(requests.iter())
+        .filter_map(|(outcome, request)| match outcome {
+            Delivered::Ok => None,
+            Delivered::Rejected { code, message } => {
+                Some(json!({ "method": request.method, "code": code, "message": message }))
+            }
+        })
+        .collect();
+    Ok(json!({
+        "forwarded": true,
+        "endpoint": endpoint,
+        "requests": requests.iter().map(|request| request.method).collect::<Vec<_>>(),
+        "rejected": rejected,
+    }))
+}
+
+pub(crate) fn run(plan: &Plan) -> anyhow::Result<Value> {
+    if let Some(binary) = &plan.print_manifest {
+        return Ok(hook_manifest(binary));
+    }
+    let path = plan.env_file.clone().unwrap_or_else(|| PathBuf::from(DEFAULT_ENV_PATH));
+    run_with(&path, io::stdin().lock())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+    use std::net::TcpListener;
+    use std::thread;
+
+    fn env() -> HostEnv {
+        HostEnv {
+            endpoint: Some("127.0.0.1:1".into()),
+            token: "tok".into(),
+            workspace_id: Some("11111111-2222-3333-4444-555555555555".into()),
+        }
+    }
+
+    fn envelope(kind: &str, adapter: &str, message: Option<&str>) -> Value {
+        let mut normalized = Map::new();
+        if let Some(message) = message {
+            normalized.insert("message".into(), Value::String(message.into()));
+        }
+        json!({
+            "protocol_version": 1,
+            "delivery": { "hook_id": HOOK_ID, "manifest_version": 1, "attempt": 1 },
+            "event": {
+                "kind": kind,
+                "subjects": [{ "kind": "terminal", "id": "term_1" }],
+                "payload": { "adapter": adapter, "normalized": normalized },
+            }
+        })
+    }
+
+    #[test]
+    fn parses_env_file_and_treats_empty_endpoint_as_off() {
+        let parsed = parse_host_env(
+            "# written by the Mac\nCMUX_HOST_ENDPOINT=[fd00::1]:4321\nCMUX_HOST_TOKEN=\"abc\"\nCMUX_HOST_WORKSPACE_ID=ws\n",
+        )
+        .unwrap();
+        assert_eq!(
+            parsed,
+            HostEnv { endpoint: Some("[fd00::1]:4321".into()), token: "abc".into(), workspace_id: Some("ws".into()) }
+        );
+        let off = parse_host_env("CMUX_HOST_ENDPOINT=\nCMUX_HOST_TOKEN=abc\n").unwrap();
+        assert_eq!(off.endpoint, None);
+        assert!(parse_host_env("garbage").is_err());
+    }
+
+    #[test]
+    fn turn_completed_sets_review_and_notifies_with_message() {
+        let requests = plan_requests(&envelope("agent.turn.completed", "claude-code", Some("Done: 3 files")), &env()).unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(requests[0].method, "workspace.status.set");
+        assert_eq!(requests[0].params["status"], "review");
+        assert_eq!(requests[0].params[TOKEN_PARAM], "tok");
+        assert_eq!(requests[0].params["workspace_id"], "11111111-2222-3333-4444-555555555555");
+        assert_eq!(requests[1].method, "notification.create");
+        assert_eq!(requests[1].params["title"], "Claude Code finished");
+        assert_eq!(requests[1].params["body"], "Done: 3 files");
+        assert_eq!(requests[1].params[TOKEN_PARAM], "tok");
+    }
+
+    #[test]
+    fn attention_kinds_set_needs_attention_and_notify() {
+        for kind in ["agent.approval.requested", "agent.question.requested", "agent.plan_review.requested", "agent.error.reported"] {
+            let requests = plan_requests(&envelope(kind, "codex", None), &env()).unwrap();
+            assert_eq!(requests[0].params["status"], "needs-attention", "{kind}");
+            assert_eq!(requests[1].method, "notification.create", "{kind}");
+            assert!(requests[1].params["title"].as_str().unwrap().starts_with("Codex "), "{kind}");
+        }
+    }
+
+    #[test]
+    fn turn_started_only_moves_the_lane_and_session_end_releases_it() {
+        let started = plan_requests(&envelope("agent.turn.started", "codex", None), &env()).unwrap();
+        assert_eq!(started.len(), 1);
+        assert_eq!(started[0].params["status"], "working");
+        let ended = plan_requests(&envelope("agent.session.ended", "codex", None), &env()).unwrap();
+        assert_eq!(ended.len(), 1);
+        assert_eq!(ended[0].params["status"], "auto");
+        assert!(plan_requests(&envelope("agent.tool.started", "codex", None), &env()).unwrap().is_empty());
+    }
+
+    #[test]
+    fn manifest_is_a_valid_journal_hook_manifest() {
+        let manifest: cmux_tui_core::JournalHookManifest =
+            serde_json::from_value(hook_manifest("/usr/local/bin/cmux-tui")).unwrap();
+        assert_eq!(manifest.hook_id, HOOK_ID);
+        assert_eq!(manifest.exec.argv, vec!["/usr/local/bin/cmux-tui", "host-forward"]);
+        assert_eq!(manifest.filter.kinds, FORWARDED_KINDS.iter().map(|kind| kind.to_string()).collect::<Vec<_>>());
+        assert_eq!(manifest.delivery.start, "tail");
+        assert!(manifest.permissions.iter().any(|permission| permission == "journal.read"));
+    }
+
+    #[test]
+    fn deliver_sends_one_line_per_request_and_reads_each_reply() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = thread::spawn(move || {
+            let (stream, _) = listener.accept().unwrap();
+            let mut reader = BufReader::new(stream.try_clone().unwrap());
+            let mut writer = stream;
+            let mut lines = Vec::new();
+            for index in 0..2 {
+                let mut line = String::new();
+                reader.read_line(&mut line).unwrap();
+                let request: Value = serde_json::from_str(&line).unwrap();
+                lines.push(request.clone());
+                let reply = if index == 0 {
+                    json!({ "id": request["id"], "ok": true, "result": {} })
+                } else {
+                    json!({ "id": request["id"], "ok": false, "error": { "code": "vm_host_workspace_denied", "message": "nope" } })
+                };
+                writer.write_all(format!("{reply}\n").as_bytes()).unwrap();
+            }
+            lines
+        });
+        let env = HostEnv { endpoint: Some(address.to_string()), ..env() };
+        let requests = plan_requests(&envelope("agent.turn.completed", "codex", None), &env).unwrap();
+        let outcomes = deliver(&address.to_string(), &requests).unwrap();
+        assert_eq!(outcomes[0], Delivered::Ok);
+        assert_eq!(
+            outcomes[1],
+            Delivered::Rejected { code: "vm_host_workspace_denied".into(), message: "nope".into() }
+        );
+        let received = server.join().unwrap();
+        assert_eq!(received[0]["method"], "workspace.status.set");
+        assert_eq!(received[0]["params"][TOKEN_PARAM], "tok");
+        assert_eq!(received[1]["method"], "notification.create");
+    }
+
+    #[test]
+    fn run_with_reports_off_without_dialing() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("host.env");
+        fs::write(&path, "CMUX_HOST_ENDPOINT=\nCMUX_HOST_TOKEN=tok\n").unwrap();
+        let result = run_with(&path, Cursor::new(b"{}".to_vec())).unwrap();
+        assert_eq!(result["reason"], "forwarding_off");
+        let missing = run_with(&dir.path().join("absent"), Cursor::new(b"{}".to_vec())).unwrap();
+        assert_eq!(missing["reason"], "no_host_env");
+    }
+
+    #[test]
+    fn unreachable_mac_is_a_transport_error() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        drop(listener);
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("host.env");
+        fs::write(&path, format!("CMUX_HOST_ENDPOINT={address}\nCMUX_HOST_TOKEN=tok\nCMUX_HOST_WORKSPACE_ID=ws\n")).unwrap();
+        let body = serde_json::to_vec(&envelope("agent.turn.completed", "codex", None)).unwrap();
+        assert!(run_with(&path, Cursor::new(body)).is_err());
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -15,6 +15,7 @@ mod cli;
 mod client_log;
 mod config;
 mod host_colors;
+mod host_forward;
 mod keys;
 mod layout_undo;
 mod local_owner;

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -192,6 +192,7 @@
 		D35A00000000000000000001 /* AppDelegate+BrowserDesignMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000001 /* AppDelegate+BrowserDesignMode.swift */; };
 		C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */; };
 		C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */; };
+		DB80299BF82825C46A26B2AB /* AppDelegate+CloudVMWorkspaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47050CA96AF13CB8F97DC453 /* AppDelegate+CloudVMWorkspaces.swift */; };
 		C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */; };
 		C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */; };
 		C65930010000000000000003 /* AppDelegate+CrashSessionSnapshotRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65930010000000000000004 /* AppDelegate+CrashSessionSnapshotRemoval.swift */; };
@@ -2578,6 +2579,7 @@
 		A79840030000000000000002 /* TerminalController+SocketConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = A79840030000000000000001 /* TerminalController+SocketConfiguration.swift */; };
 		C79470020000000000000001 /* TerminalController+SocketListenerRearm.swift in Sources */ = {isa = PBXBuildFile; fileRef = C79470020000000000000002 /* TerminalController+SocketListenerRearm.swift */; };
 		C0DE00000000000000000F01 /* TerminalController+SSHSessionAttachContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000F02 /* TerminalController+SSHSessionAttachContext.swift */; };
+		C0C1F30DE88A9A325ECF98B1 /* TerminalController+VMHostClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D74322C3F24505A6AB1AB691 /* TerminalController+VMHostClient.swift */; };
 		D6212D0C00000000000000D3 /* TerminalController+WindowDockBrowserRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */; };
 		9065A0010000000000000001 /* TerminalController+WindowScreenshotCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9065A0010000000000000002 /* TerminalController+WindowScreenshotCapture.swift */; };
 		C0DE00000000000000000C84 /* TerminalController+WorkspaceCreate.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C83 /* TerminalController+WorkspaceCreate.swift */; };
@@ -2821,6 +2823,13 @@
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
 		ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */; };
 		C37800000000000000000003 /* VMDefaultCloudCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */; };
+		46E3DB5C8D261C66BC020263 /* VMHostAccessPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13FE8B9B44E2648AE4419C9E /* VMHostAccessPolicy.swift */; };
+		9B50DA449CF06ABCE471163E /* VMHostAccessPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BE50AF04C498FFF2202A7F2 /* VMHostAccessPolicyTests.swift */; };
+		A8DEDCAFFCBFD1DCB8216FF3 /* VMHostForwardHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 016DF587228A94B4088EA1B1 /* VMHostForwardHook.swift */; };
+		19B45F112CB53F80118C21A5 /* VMHostListener.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647416BF315E986E30A0533A /* VMHostListener.swift */; };
+		9EF4117770379FC13599369F /* VMHostListenerCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FADDF7CB075EEDBE7BB9D641 /* VMHostListenerCoordinator.swift */; };
+		72BF88CF8CDC94DD6F345EBF /* VMHostListenerCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E4B7729AC069F8621C1B1AC /* VMHostListenerCoordinatorTests.swift */; };
+		E3B5035FA60D42C65C795155 /* VMHostTokenStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05F5F48E0E7688F84A3E1B6B /* VMHostTokenStore.swift */; };
 		DCFD2C3A4F04C00C62720EE5 /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
 		F1C699902D31503EE3D492DF /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
@@ -3308,6 +3317,7 @@
 		D35B00000000000000000001 /* AppDelegate+BrowserDesignMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+BrowserDesignMode.swift"; sourceTree = "<group>"; };
 		C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CanvasShortcutRouting.swift"; sourceTree = "<group>"; };
 		C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ClosedItemHistory.swift"; sourceTree = "<group>"; };
+		47050CA96AF13CB8F97DC453 /* AppDelegate+CloudVMWorkspaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CloudVMWorkspaces.swift"; sourceTree = "<group>"; };
 		C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxNavigationDeepLinks.swift"; sourceTree = "<group>"; };
 		C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxSSHURL.swift"; sourceTree = "<group>"; };
 		C65930010000000000000004 /* AppDelegate+CrashSessionSnapshotRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CrashSessionSnapshotRemoval.swift"; sourceTree = "<group>"; };
@@ -5595,6 +5605,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		A79840030000000000000001 /* TerminalController+SocketConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SocketConfiguration.swift"; sourceTree = "<group>"; };
 		C79470020000000000000002 /* TerminalController+SocketListenerRearm.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SocketListenerRearm.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000F02 /* TerminalController+SSHSessionAttachContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+SSHSessionAttachContext.swift"; sourceTree = "<group>"; };
+		D74322C3F24505A6AB1AB691 /* TerminalController+VMHostClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+VMHostClient.swift"; sourceTree = "<group>"; };
 		D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+WindowDockBrowserRouting.swift"; sourceTree = "<group>"; };
 		9065A0010000000000000002 /* TerminalController+WindowScreenshotCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+WindowScreenshotCapture.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C83 /* TerminalController+WorkspaceCreate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+WorkspaceCreate.swift"; sourceTree = "<group>"; };
@@ -5838,6 +5849,13 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
 		9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientSocketCommands.swift; sourceTree = "<group>"; };
 		C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMDefaultCloudCommandTests.swift; sourceTree = "<group>"; };
+		13FE8B9B44E2648AE4419C9E /* VMHostAccessPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMHostAccessPolicy.swift; sourceTree = "<group>"; };
+		0BE50AF04C498FFF2202A7F2 /* VMHostAccessPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMHostAccessPolicyTests.swift; sourceTree = "<group>"; };
+		016DF587228A94B4088EA1B1 /* VMHostForwardHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMHostForwardHook.swift; sourceTree = "<group>"; };
+		647416BF315E986E30A0533A /* VMHostListener.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMHostListener.swift; sourceTree = "<group>"; };
+		FADDF7CB075EEDBE7BB9D641 /* VMHostListenerCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMHostListenerCoordinator.swift; sourceTree = "<group>"; };
+		5E4B7729AC069F8621C1B1AC /* VMHostListenerCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMHostListenerCoordinatorTests.swift; sourceTree = "<group>"; };
+		05F5F48E0E7688F84A3E1B6B /* VMHostTokenStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMHostTokenStore.swift; sourceTree = "<group>"; };
 		6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMMachineKind.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
 		03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelManager.swift; sourceTree = "<group>"; };
@@ -6518,6 +6536,11 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D1F0A00100000000000000B4 /* PresenceSettings.swift */,
 				9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */,
 				03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */,
+				FADDF7CB075EEDBE7BB9D641 /* VMHostListenerCoordinator.swift */,
+				647416BF315E986E30A0533A /* VMHostListener.swift */,
+				05F5F48E0E7688F84A3E1B6B /* VMHostTokenStore.swift */,
+				13FE8B9B44E2648AE4419C9E /* VMHostAccessPolicy.swift */,
+				016DF587228A94B4088EA1B1 /* VMHostForwardHook.swift */,
 				D9143D900F124494A55F859F /* CloudMachinesFeature.swift */,
 				08610D114C8CF23877176D7E /* MachinesPanelView.swift */,
 				68672B3C63D4E348AFA4DEF7 /* MachinesPanelViewModel.swift */,
@@ -7151,6 +7174,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				E30780000000000000000011 /* SSHPTYAttachStartupCommandBuilder.swift */,
 				EE30D5000000000000000001 /* RemoteDaemonStrings+App.swift */,
 				A19F4C0D0000000000000001 /* TerminalController+RemoteRelayAuthorization.swift */,
+				D74322C3F24505A6AB1AB691 /* TerminalController+VMHostClient.swift */,
 				EE30D5000000000000000003 /* WorkspaceRemoteRelayCommandRewriter.swift */,
 				EE30D6000000000000000001 /* WorkspaceRemoteSessionHostAdapter.swift */,
 				EE30D6000000000000000003 /* WorkspaceRemoteSessionBuildInfo.swift */,
@@ -7227,6 +7251,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F90070010000000000000002 /* WorkspaceSurfaceOwnershipTarget.swift */,
 				A5001417 /* WorkspaceContentView.swift */,
 				5C0728FF0C3B4FF2925CA071 /* AppDelegate+ManagedPolicy.swift */,
+				47050CA96AF13CB8F97DC453 /* AppDelegate+CloudVMWorkspaces.swift */,
 				CFDB146929E340BE89407AC1 /* ManagedPolicyEnforcementObserver.swift */,
 				111A8E6117014894B1DB6998 /* BrowserAvailabilityManagedPolicy.swift */,
 				E30760030000000000000001 /* TmuxOverlayExperimentSettings.swift */,
@@ -8625,6 +8650,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */,
 				A5C017000000000000000010 /* AccountSignInModelTests.swift */,
 				74A47FAD328D6669A5B40CE3 /* VMTunnelManagerTests.swift */,
+				5E4B7729AC069F8621C1B1AC /* VMHostListenerCoordinatorTests.swift */,
+				0BE50AF04C498FFF2202A7F2 /* VMHostAccessPolicyTests.swift */,
 				A9126001C5E7F90123456789 /* ReopenLastClosedTests.swift */,
 				F17A5F020000000000000002 /* FocusedPanelFlashShortcutTests.swift */,
 				F5588001A1B2C3D4E5F60718 /* AppDelegateOptionDigitShortcutRoutingTests.swift */,
@@ -9877,6 +9904,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D35A00000000000000000001 /* AppDelegate+BrowserDesignMode.swift in Sources */,
 				C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */,
 				C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */,
+				DB80299BF82825C46A26B2AB /* AppDelegate+CloudVMWorkspaces.swift in Sources */,
 				C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */,
 				C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */,
 				C65930010000000000000003 /* AppDelegate+CrashSessionSnapshotRemoval.swift in Sources */,
@@ -11369,6 +11397,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A79840030000000000000002 /* TerminalController+SocketConfiguration.swift in Sources */,
 				C79470020000000000000001 /* TerminalController+SocketListenerRearm.swift in Sources */,
 				C0DE00000000000000000F01 /* TerminalController+SSHSessionAttachContext.swift in Sources */,
+				C0C1F30DE88A9A325ECF98B1 /* TerminalController+VMHostClient.swift in Sources */,
 				D6212D0C00000000000000D3 /* TerminalController+WindowDockBrowserRouting.swift in Sources */,
 				9065A0010000000000000001 /* TerminalController+WindowScreenshotCapture.swift in Sources */,
 				C0DE00000000000000000C84 /* TerminalController+WorkspaceCreate.swift in Sources */,
@@ -11552,6 +11581,11 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A28B087F0000000000000005 /* ViewerNavigationKeyRouter.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
+				46E3DB5C8D261C66BC020263 /* VMHostAccessPolicy.swift in Sources */,
+				A8DEDCAFFCBFD1DCB8216FF3 /* VMHostForwardHook.swift in Sources */,
+				19B45F112CB53F80118C21A5 /* VMHostListener.swift in Sources */,
+				9EF4117770379FC13599369F /* VMHostListenerCoordinator.swift in Sources */,
+				E3B5035FA60D42C65C795155 /* VMHostTokenStore.swift in Sources */,
 				F1C699902D31503EE3D492DF /* VMMachineKind.swift in Sources */,
 				B43AFCE7099305905825EA0A /* VMTunnelManager.swift in Sources */,
 				A500120C /* WindowAccessor.swift in Sources */,
@@ -12647,6 +12681,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				992300019923000199230006 /* VaultRestoreRelaunchPersistenceTests.swift in Sources */,
 				A3340002A3340002A3340002 /* ViewerNavigationTests.swift in Sources */,
 				C37800000000000000000003 /* VMDefaultCloudCommandTests.swift in Sources */,
+				9B50DA449CF06ABCE471163E /* VMHostAccessPolicyTests.swift in Sources */,
+				72BF88CF8CDC94DD6F345EBF /* VMHostListenerCoordinatorTests.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,

--- a/cmuxTests/VMHostAccessPolicyTests.swift
+++ b/cmuxTests/VMHostAccessPolicyTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// What a Cloud VM may do to this Mac over the private-network listener: only
+/// callers from inside the network, only with a token this Mac minted, only
+/// the notification and telemetry verbs.
+@Suite
+struct VMHostAccessPolicyTests {
+    @Test
+    func sourceInsideNetworkCIDRsIsAllowed() {
+        let cidrs = ["10.16.204.0/24", "fd53:9585:5690::/64"]
+        #expect(VMHostAccessPolicy.sourceIsAllowed(peer: "10.16.204.3", networkCIDRs: cidrs))
+        #expect(VMHostAccessPolicy.sourceIsAllowed(peer: "fd53:9585:5690::3", networkCIDRs: cidrs))
+        // IPv4-mapped IPv6 peer on a dual-stack accept path.
+        #expect(VMHostAccessPolicy.sourceIsAllowed(peer: "::ffff:10.16.204.7", networkCIDRs: cidrs))
+    }
+
+    @Test
+    func sourceOutsideNetworkIsDenied() {
+        let cidrs = ["10.16.204.0/24", "fd53:9585:5690::/64"]
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "10.16.205.3", networkCIDRs: cidrs))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "127.0.0.1", networkCIDRs: cidrs))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "100.64.0.1", networkCIDRs: cidrs))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "fd53:9585:5691::3", networkCIDRs: cidrs))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "::1", networkCIDRs: cidrs))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "not-an-address", networkCIDRs: cidrs))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "10.16.204.3", networkCIDRs: []))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "10.16.204.3", networkCIDRs: ["garbage/99"]))
+    }
+
+    @Test
+    func cidrParsingHandlesPrefixesAndBareAddresses() throws {
+        let (network, prefix) = try #require(VMHostAccessPolicy.parseCIDR("10.40.0.0/24"))
+        #expect(network == [10, 40, 0, 0])
+        #expect(prefix == 24)
+        let (bare, barePrefix) = try #require(VMHostAccessPolicy.parseCIDR("10.40.0.9"))
+        #expect(bare == [10, 40, 0, 9])
+        #expect(barePrefix == 32)
+        #expect(VMHostAccessPolicy.parseCIDR("10.40.0.0/33") == nil)
+        #expect(VMHostAccessPolicy.parseCIDR("fd00::/129") == nil)
+        #expect(VMHostAccessPolicy.parseCIDR("") == nil)
+    }
+
+    @Test
+    func nonOctetAlignedPrefixMatchesOnlyInsideTheBlock() {
+        #expect(VMHostAccessPolicy.sourceIsAllowed(peer: "10.16.193.7", networkCIDRs: ["10.16.192.0/22"]))
+        #expect(!VMHostAccessPolicy.sourceIsAllowed(peer: "10.16.196.1", networkCIDRs: ["10.16.192.0/22"]))
+    }
+
+    @Test
+    func tokensCompareExactly() {
+        #expect(VMHostAccessPolicy.tokensMatch("abc123", "abc123"))
+        #expect(!VMHostAccessPolicy.tokensMatch("abc123", "abc124"))
+        #expect(!VMHostAccessPolicy.tokensMatch("abc12", "abc123"))
+        #expect(!VMHostAccessPolicy.tokensMatch("", "abc123"))
+    }
+
+    @Test
+    func allowListHoldsOnlyTelemetryAndAttentionVerbs() {
+        let allowed = VMHostAccessPolicy.allowedMethods
+        #expect(allowed.contains("notification.create"))
+        #expect(allowed.contains("feed.push"))
+        #expect(allowed.contains("surface.report_pwd"))
+        for denied in [
+            "surface.send_text", "surface.send_key", "surface.read_text", "surface.list",
+            "workspace.create", "workspace.select", "workspace.list", "notification.list",
+            "notification.open", "notification.jump_to_unread", "notification.dismiss",
+            "vm.destroy", "vm.exec", "browser.navigate", "window.focus", "system.tree", "feed.list",
+        ] {
+            #expect(!allowed.contains(denied), "\(denied) must not be callable from a machine")
+        }
+        #expect(VMHostAccessPolicy.workspaceRequiredMethods.isSubset(of: allowed))
+        #expect(VMHostAccessPolicy.surfaceRequiredMethods.isSubset(of: VMHostAccessPolicy.workspaceRequiredMethods))
+    }
+
+    @Test
+    func tokenStoreMintsOncePersistsAndMapsBack() throws {
+        let home = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vmhost-tokens-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: home) }
+
+        let store = VMHostTokenStore(home: home)
+        let token = store.token(for: "vm-a")
+        #expect(token.count >= 40)
+        #expect(store.token(for: "vm-a") == token)
+        #expect(store.vmID(forToken: token) == "vm-a")
+        #expect(store.vmID(forToken: token + "x") == nil)
+        #expect(store.token(for: "vm-b") != token)
+
+        // A fresh store over the same home reads the persisted tokens.
+        let reloaded = VMHostTokenStore(home: home)
+        #expect(reloaded.vmID(forToken: token) == "vm-a")
+        #expect(reloaded.count == 2)
+
+        let file = home.appendingPathComponent(".cmuxterm/vm-host/tokens.json")
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+        #expect((attributes[.posixPermissions] as? Int) == 0o600)
+
+        reloaded.retain(vmIDs: ["vm-b"])
+        #expect(reloaded.vmID(forToken: token) == nil)
+        reloaded.removeAll()
+        #expect(reloaded.count == 0)
+    }
+}

--- a/cmuxTests/VMHostListenerCoordinatorTests.swift
+++ b/cmuxTests/VMHostListenerCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import CmuxControlSocket
 import Foundation
 import Testing
 

--- a/cmuxTests/VMHostListenerCoordinatorTests.swift
+++ b/cmuxTests/VMHostListenerCoordinatorTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// The listener Cloud VMs use to reach this Mac exists only while all four
+/// facts hold: enabled, signed in, tunnel up, at least one machine.
+@Suite
+struct VMHostListenerCoordinatorTests {
+    private let live = ["100.64.0.1", "fd7a:7570:6c6b::1"]
+
+    @Test
+    func listenerIsOnOnlyWhenEveryConditionHolds() {
+        #expect(VMHostListenerCoordinator.desiredState(enabled: true, signedIn: true, liveTunnelAddresses: live, machineCount: 1) == .on)
+        #expect(VMHostListenerCoordinator.desiredState(enabled: true, signedIn: true, liveTunnelAddresses: live, machineCount: 12) == .on)
+    }
+
+    @Test
+    func defaultOffAndEveryMissingConditionTurnsItOff() {
+        #expect(VMHostListenerCoordinator.desiredState(enabled: false, signedIn: true, liveTunnelAddresses: live, machineCount: 1) == .off(reason: "disabled"))
+        #expect(VMHostListenerCoordinator.desiredState(enabled: true, signedIn: false, liveTunnelAddresses: live, machineCount: 1) == .off(reason: "signed_out"))
+        #expect(VMHostListenerCoordinator.desiredState(enabled: true, signedIn: true, liveTunnelAddresses: [], machineCount: 1) == .off(reason: "tunnel_down"))
+        #expect(VMHostListenerCoordinator.desiredState(enabled: true, signedIn: true, liveTunnelAddresses: live, machineCount: 0) == .off(reason: "no_machines"))
+        // Disabled wins over everything else, so the toggle alone is a full off switch.
+        #expect(VMHostListenerCoordinator.desiredState(enabled: false, signedIn: false, liveTunnelAddresses: [], machineCount: 0) == .off(reason: "disabled"))
+    }
+
+    @Test
+    func settingDefaultsToOff() {
+        let suite = "cmux-vmhost-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defer { defaults.removePersistentDomain(forName: suite) }
+        #expect(defaults.object(forKey: VMHostListenerCoordinator.settingsKey) == nil)
+        #expect(VMHostListenerCoordinator.settingsKey == "cloud.vmHostNotifications.enabled")
+    }
+
+    @Test
+    func deliverCommandInstallsDaemonReadableEnvFileAtomically() throws {
+        let payload = VMHostListenerCoordinator.envPayload(
+            endpoint: "[fd53::2]:41234", token: "abc", workspaceID: "11111111-2222-3333-4444-555555555555"
+        )
+        #expect(payload == "CMUX_HOST_ENDPOINT=[fd53::2]:41234\nCMUX_HOST_TOKEN=abc\nCMUX_HOST_WORKSPACE_ID=11111111-2222-3333-4444-555555555555\n")
+        // Withdrawal keeps the file but empties the endpoint, which the guest reads as "off".
+        #expect(VMHostListenerCoordinator.envPayload(endpoint: nil, token: "", workspaceID: nil).hasPrefix("CMUX_HOST_ENDPOINT=\n"))
+        let command = VMHostListenerCoordinator.deliverCommand(payload: payload)
+        // The daemon drops to the `cmux` user and runs hooks with an empty
+        // environment, so the file must be readable by that user.
+        #expect(command.hasPrefix("sudo -n sh -c 'umask 022;"))
+        #expect(command.contains("chmod 0644 /etc/cmux/host.env.tmp && mv -f /etc/cmux/host.env.tmp /etc/cmux/host.env"))
+        // The payload travels base64-encoded so no shell metacharacter in a
+        // token or address can escape the quoting.
+        let encoded = Data(payload.utf8).base64EncodedString()
+        #expect(command.contains(encoded))
+        #expect(!command.contains("abc\n"))
+    }
+
+    @Test
+    func hostForwardHookManifestMatchesTheGuestContract() throws {
+        let manifest = VMHostForwardHook.manifest()
+        #expect(manifest["hook_id"] as? String == "cmux_host_forward")
+        let exec = manifest["exec"] as? [String: Any]
+        #expect(exec?["argv"] as? [String] == ["/usr/local/bin/cmux-tui", "host-forward"])
+        let filter = manifest["filter"] as? [String: Any]
+        #expect(filter?["kinds"] as? [String] == VMHostForwardHook.forwardedKinds)
+        #expect(VMHostForwardHook.forwardedKinds.contains("agent.turn.completed"))
+        #expect(manifest["permissions"] as? [String] == ["journal.read"])
+        let arguments = CloudTuiCommandLine.putJournalHookArguments(socketPath: "/tmp/link.sock", manifestJSON: VMHostForwardHook.manifestJSON())
+        #expect(arguments.prefix(9) == ["--socket", "/tmp/link.sock", "--json", "session", "current", "journal", "hook", "put", "--manifest-json"])
+        let decoded = try JSONSerialization.jsonObject(with: Data(arguments[9].utf8)) as? [String: Any]
+        #expect(decoded?["manifest_version"] as? Int == 1)
+    }
+
+    @Test
+    func listenerBindsOnlyTheGivenAddressAndReportsThePeer() async throws {
+        let accepted = AcceptRecorder()
+        let listener = VMHostListener { socket, peer in
+            close(socket)
+            accepted.record(peer)
+        }
+        defer { listener.stop() }
+        try listener.start(addresses: ["127.0.0.1"], port: 0)
+        let bound = try #require(listener.boundAddresses.first)
+        #expect(bound.address == "127.0.0.1")
+        #expect(bound.port != 0)
+
+        // Connect over loopback; the accept callback sees the loopback peer.
+        let fd = socket(AF_INET, SOCK_STREAM, 0)
+        defer { close(fd) }
+        var addr = sockaddr_in()
+        addr.sin_len = UInt8(MemoryLayout<sockaddr_in>.size)
+        addr.sin_family = sa_family_t(AF_INET)
+        addr.sin_port = bound.port.bigEndian
+        _ = inet_pton(AF_INET, "127.0.0.1", &addr.sin_addr)
+        let result = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) {
+                connect(fd, $0, socklen_t(MemoryLayout<sockaddr_in>.size))
+            }
+        }
+        #expect(result == 0)
+        let peer = await accepted.first(timeout: .seconds(5))
+        #expect(peer == "127.0.0.1")
+
+        listener.stop()
+        #expect(!listener.isListening)
+        #expect(listener.boundAddresses.isEmpty)
+    }
+
+    @Test
+    func requestLineDropsNothingButIsStableJSON() throws {
+        let request = ControlRequest(
+            id: .string("r1"),
+            method: "notification.create",
+            params: ["title": .string("Done"), "workspace_id": .string("11111111-1111-1111-1111-111111111111")]
+        )
+        let line = try #require(TerminalController.vmHostRequestLine(request))
+        let object = try #require(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+        #expect(object["id"] as? String == "r1")
+        #expect(object["method"] as? String == "notification.create")
+        #expect((object["params"] as? [String: Any])?["title"] as? String == "Done")
+        #expect(!line.contains("\n"))
+    }
+}
+
+/// Collects peers from the listener's accept callback across threads.
+private final class AcceptRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var peers: [String] = []
+    private var continuation: CheckedContinuation<String, Never>?
+
+    func record(_ peer: String) {
+        lock.lock()
+        peers.append(peer)
+        let waiter = continuation
+        continuation = nil
+        lock.unlock()
+        waiter?.resume(returning: peer)
+    }
+
+    func first(timeout: Duration) async -> String? {
+        lock.lock()
+        if let existing = peers.first {
+            lock.unlock()
+            return existing
+        }
+        lock.unlock()
+        return await withTaskGroup(of: String?.self) { group in
+            group.addTask {
+                await withCheckedContinuation { (continuation: CheckedContinuation<String, Never>) in
+                    self.lock.lock()
+                    if let existing = self.peers.first {
+                        self.lock.unlock()
+                        continuation.resume(returning: existing)
+                        return
+                    }
+                    self.continuation = continuation
+                    self.lock.unlock()
+                }
+            }
+            group.addTask {
+                try? await Task.sleep(for: timeout)
+                return nil
+            }
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
+    }
+}

--- a/cmuxTests/VMTunnelManagerTests.swift
+++ b/cmuxTests/VMTunnelManagerTests.swift
@@ -140,4 +140,72 @@ struct VMTunnelManagerTests {
         """.write(to: manager.configURL, atomically: true, encoding: .utf8)
         #expect(manager.wgQuickInterfaceUp() == true)
     }
+
+    @Test
+    func completedConfigAddsPeerKeepaliveOnce() throws {
+        let server = """
+        [Interface]
+        PrivateKey =
+        Address = 100.64.0.1/32
+        MTU = 1380
+
+        [Peer]
+        PublicKey = abc
+        AllowedIPs = 10.0.0.0/8, fd00::/8
+        Endpoint = tun.example:51820
+        """
+        let completed = try VMTunnelManager.completedConfig(server, privateKey: "KEY")
+        let lines = completed.components(separatedBy: "\n").map { $0.trimmingCharacters(in: .whitespaces) }
+        #expect(lines.filter { $0.hasPrefix("PersistentKeepalive") }.count == 1)
+        let peerIndex = try #require(lines.firstIndex(of: "[Peer]"))
+        let keepaliveIndex = try #require(lines.firstIndex(of: "PersistentKeepalive = \(VMTunnelManager.persistentKeepaliveSeconds)"))
+        #expect(keepaliveIndex > peerIndex)
+        // Re-completing an already-complete config does not duplicate it.
+        let again = try VMTunnelManager.completedConfig(completed, privateKey: "KEY")
+        #expect(again.components(separatedBy: "PersistentKeepalive").count == 2)
+    }
+
+    @Test
+    func completedConfigKeepsAServerProvidedKeepalive() throws {
+        let server = """
+        [Interface]
+        PrivateKey =
+        Address = 100.64.0.1/32
+
+        [Peer]
+        PublicKey = abc
+        PersistentKeepalive = 15
+        """
+        let completed = try VMTunnelManager.completedConfig(server, privateKey: "KEY")
+        #expect(completed.contains("PersistentKeepalive = 15"))
+        #expect(!completed.contains("PersistentKeepalive = 25"))
+    }
+
+    @Test
+    func networkMetadataRoundTripsWithRestrictedPermissions() throws {
+        let home = try temporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        let manager = VMTunnelManager(home: home)
+        #expect(manager.loadNetworkMetadata() == nil)
+        let metadata = VMTunnelManager.NetworkMetadata(
+            tunnelId: "tun-1",
+            addressV4: "10.16.204.2",
+            addressV6: "fd53:9585:5690::2",
+            networkCidr: "10.16.204.0/24",
+            networkCidrV6: "fd53:9585:5690::/64"
+        )
+        try manager.writeNetworkMetadata(metadata)
+        #expect(manager.loadNetworkMetadata() == metadata)
+        #expect(metadata.networkCIDRs == ["10.16.204.0/24", "fd53:9585:5690::/64"])
+        #expect(metadata.machineFacingAddresses == ["fd53:9585:5690::2", "10.16.204.2"])
+        let attributes = try FileManager.default.attributesOfItem(atPath: manager.networkMetadataURL.path)
+        #expect((attributes[.posixPermissions] as? Int) == 0o600)
+    }
+
+    @Test
+    func liveInterfaceAddressesIsEmptyWithoutAConfig() throws {
+        let home = try temporaryHome()
+        defer { try? FileManager.default.removeItem(at: home) }
+        #expect(VMTunnelManager(home: home).liveInterfaceAddresses().isEmpty)
+    }
 }

--- a/docs/cloud-cmux-tui-daemon.md
+++ b/docs/cloud-cmux-tui-daemon.md
@@ -287,3 +287,42 @@ over the same catalog (`vm.tree` is the catalog restricted to cloud machines;
 `vm.desktop_open` projects `<id>/display/display:1`; `vm.port_open` projects
 `<id>/browser/port:<n>`, registering the port first when the probe has not
 seen it). CLI: `cmux surface ls|open|new-terminal` and `cmux vm tree|open`.
+
+## Machine to Mac notifications (2026-09-02)
+
+Machines have no public ports and, until now, no path back to the Mac: agent
+hooks in a machine wrote to the machine's own cmux-tui journal and nothing on
+the Mac read it. The reverse path reuses the private network the Mac already
+joins over WireGuard (`cmux vpn up`), so it needs no new Freestyle feature and
+no public listener anywhere.
+
+Mac side (`Sources/Cloud/VMHostListener*.swift`, `VMHostAccessPolicy.swift`,
+`TerminalController+VMHostClient.swift`). Off by default; Settings > Cloud
+"Notifications from machines" or `cmux vpn notifications on` turns it on. While
+on, signed in, the tunnel is up, and the account owns at least one machine, the
+app binds a TCP listener on its tunnel addresses only, never a wildcard, so the
+port stops existing when the utun goes away. Every accepted connection must
+come from the network's own CIDRs, carry the per-machine token the Mac minted
+(`_cmux_vm_host_token`, kept in `~/.cmuxterm/vm-host/tokens.json`, 0600, in the
+clear because the Mac re-delivers it on every rebind), call only the notification and status verbs in
+`VMHostAccessPolicy.allowedMethods`, and name only workspaces bound to that
+machine through `workspace.cloud_vm_bind`. The same wire protocol as the local
+control socket; a different gate.
+
+Machine side. When a link connects while the listener is up, the Mac writes
+`/etc/cmux/host.env` into the machine (`CMUX_HOST_ENDPOINT`, `CMUX_HOST_TOKEN`,
+`CMUX_HOST_WORKSPACE_ID`, world-readable because the daemon runs hooks as the
+`cmux` user with an empty environment) and puts a journal hook on the daemon
+over the link (`session current journal hook put`). The hook runs
+`/usr/local/bin/cmux-tui host-forward` once per `agent.*` event listed in
+`VMHostForwardHook.forwardedKinds`. `host-forward` reads the envelope on stdin,
+maps it to `workspace.status.set` (working / needs-attention / review, and
+`auto` when the session ends) plus `notification.create` when the agent
+finished or needs the human, and delivers both to the Mac with the token. Exit 1
+means the Mac was unreachable and the dispatcher retries; a Mac-side error
+response exits 0 because a retry cannot fix it. Turning the feature off rewrites
+the env file with an empty endpoint, which `host-forward` reads as "off".
+
+Not covered yet: OSC 9 terminal notifications from guest processes, surface
+level verbs (the guest does not know Mac surface ids), and a Mac that is offline
+when the event fires (needs the control plane).


### PR DESCRIPTION
Machines have no public ports and no path back to the Mac, so agent hooks inside a Cloud VM never reached the Mac's notifications. This adds the reverse path over the WireGuard private network the Mac already joins (`cmux vpn up`, https://github.com/manaflow-ai/cmux/pull/11602), with no new Freestyle feature and no public listener.

Mac side. Off by default; Settings > Cloud "Notifications from machines" or `cmux vpn notifications on`. While on, signed in, tunnel up, and at least one machine owned, the app binds TCP on its tunnel addresses only (never a wildcard), so the port disappears with the utun. Each request must come from the network CIDRs, carry the per-machine token the Mac minted, use one of the notification/status verbs in `VMHostAccessPolicy.allowedMethods`, and name only workspaces bound to that machine. Same wire protocol as the local control socket, different gate (`TerminalController+VMHostClient.swift`).

Machine side. On link connect the Mac writes `/etc/cmux/host.env` (endpoint, token, bound workspace) and puts a journal hook on the daemon over the link. The hook runs `cmux-tui host-forward` per `agent.*` event, which maps the event to `workspace.status.set` and `notification.create` on the Mac. Exit 1 = Mac unreachable, dispatcher retries. Turning the feature off rewrites the env file with an empty endpoint.

Tests: `VMHostAccessPolicyTests`, `VMHostListenerCoordinatorTests` (Swift Testing), `host_forward` unit tests in cmux-tui (9 pass on a Blacksmith testbox, clippy clean for touched files).

Not covered: OSC 9 notifications from guest processes, surface-level verbs, and an offline Mac. See `docs/cloud-cmux-tui-daemon.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11641"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790942276&installation_model_id=21920&pr_number=11641&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11641&signature=7cf16be677c8f100de512732de709563d5ab5f7a285b05471a970bc64e742208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lets Cloud VMs notify the owning Mac over the private WireGuard network, so VM agent notifications and status reach the Mac. Previously machines had no public ports and no path back; the Mac now listens only on its tunnel addresses, and the feature is off by default (Settings > Cloud or `cmux vpn notifications on`).

- Listener runs only while enabled, signed in, tunnel up, and the account owns at least one machine.
- Enabling refreshes the machine inventory, and missing tunnel network metadata self-heals by re-asking the control plane once per tunnel-up episode, writing only `network.json`.
- An unreachable Cloud service now surfaces as `cloud_unreachable` with the error text in the CLI and `vm.host_status`, instead of a misleading "not signed in"; cancelled fetches stay silent, and until the first fetch lands the status reads "still checking".
- Requests must come from network CIDRs, carry a per-machine token, use allow-listed verbs, and target only workspaces bound to that machine.
- Each linked machine gets `/etc/cmux/host.env` and a journal hook that runs `cmux-tui host-forward`, mapping `agent.*` events to `workspace.status.set` and `notification.create`; turning the feature off rewrites the env file with an empty endpoint.
- Not covered: OSC 9 notifications from guest processes, surface-level verbs, and an offline Mac.

<sup>Written for commit 0ba128c06c0f5efb337254e342f216c088eab278. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

