### PR TITLE
fix(test): make scoped attach killer mutable

### DIFF
--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -2708,7 +2708,7 @@ impl CapturingPtyChild {
 
     fn wait_for_exit(&mut self, timeout: Duration) -> Option<cmux_pty::ExitStatus> {
         let mut child = self.child.take().expect("scoped attach child already waited");
-        let killer = child.clone_killer();
+        let mut killer = child.clone_killer();
         let (sender, receiver) = mpsc::sync_channel(1);
         std::thread::spawn(move || {
             let _ = sender.send(child.wait());


### PR DESCRIPTION
Fixes the compile error introduced by merged PR #11492.

`clone_killer()` returns a killer whose `kill()` method requires mutable access. Declare the local as `mut` so the scoped attach lifecycle test compiles on hosted Linux and macOS runners.

Validation:
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/tests/cli.rs`
- `git diff --check`
- No local Cargo/Rust tests run by policy.

Closes the hosted compile failure reported for #11492.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790942421&installation_model_id=21920&pr_number=11643&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11643&signature=fe0a30b85b8dc75594c1b7741ba868fcecdf7eff7e11b5caac30b3fe842f1f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the scoped attach lifecycle test so it compiles on hosted Linux and macOS runners. `clone_killer()` returns a killer whose `kill()` method requires mutable access, so the local is now declared `mut`.

<sup>Written for commit 65c0c60f435d5e3c7166ede93e3c7764f023796d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

