### PR TITLE
web: resolve unoffered Cloud VM sizes to the plan machine instead of 400

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4307,7 +4307,7 @@ struct CMUXCLI {
     // `vm_image_config_error`.
     /// `--size` spellings → memory in MB. Every plan sells exactly the plan
     /// machine (5 vCPU / 20 GB / 200 GB), so 20g is the only preset; the
-    /// backend refuses other sizes with `vm_memory_unsupported`.
+    /// backend resolves any other size to the plan machine.
     private static let cloudVMSizeAliases: [String: Int] = [
         "20g": 20480, "20gb": 20480,
     ]

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -364,36 +364,26 @@ export async function POST(request: Request): Promise<Response> {
         });
 
         const maxMemoryMb = maxMemoryMbForPlan(entitlements.planId, process.env);
-        const memoryMb =
-          candidate.memoryMb === undefined
-            ? defaultMemoryMbForPlan(entitlements.planId, process.env)
-            : candidate.memoryMb as number;
-        if (memoryMb > maxMemoryMb) {
-          return vmErrorResponse({
-            error: "vm_memory_exceeds_plan",
-            status: 400,
-            message: "The requested Cloud VM size exceeds this plan's memory limit.",
-            action: `Choose a size at or below ${maxMemoryMb} MB, or upgrade the plan before retrying.`,
-            details: { requestedMemoryMb: memoryMb, maxMemoryMb, planId: entitlements.planId },
-          });
-        }
         const memoryOptionsMb = memoryOptionsMbForPlan(entitlements.planId, process.env);
-        if (!memoryOptionsMb.includes(memoryMb)) {
-          // The pricing page promises every machine is the plan machine, so a
-          // smaller request is refused rather than quietly under-delivered.
-          // The plan default is always accepted, so operator overrides cannot
-          // make an omitted size fail.
-          return vmErrorResponse({
-            error: "vm_memory_unsupported",
-            status: 400,
-            message: "The requested Cloud VM size is not offered.",
-            action: `Omit \`memoryMb\`, or choose one of: ${memoryOptionsMb.join(", ")} MB.`,
-            details: { requestedMemoryMb: memoryMb, memoryOptionsMb: [...memoryOptionsMb], planId: entitlements.planId },
-          });
-        }
+        const planMemoryMb = defaultMemoryMbForPlan(entitlements.planId, process.env);
+        const requestedMemoryMb = candidate.memoryMb as number | undefined;
+        // Every plan sells exactly the plan machine, so a size the plan does
+        // not offer resolves to that machine instead of failing the create.
+        // Clients ship their own size table and always trail the server: the
+        // 2026-09-02 pricing change (#11610) left every installed nightly
+        // sending its old 24 GB default and the server rejecting each create
+        // with `vm_memory_exceeds_plan` until the next nightly published. The
+        // server owns the machine spec, so a stale client must still get a
+        // machine; the mismatch is recorded on the span for Axiom.
+        const memoryMb =
+          requestedMemoryMb === undefined || memoryOptionsMb.includes(requestedMemoryMb)
+            ? requestedMemoryMb ?? planMemoryMb
+            : planMemoryMb;
         setSpanAttributes(span, {
           "cmux.vm.memory_mb": memoryMb,
           "cmux.vm.max_memory_mb": maxMemoryMb,
+          "cmux.vm.memory_requested_mb": requestedMemoryMb,
+          "cmux.vm.memory_coerced": requestedMemoryMb !== undefined && requestedMemoryMb !== memoryMb,
         });
 
         // Resolve provider/image only after the paid-plan boundary. A free or

--- a/web/tests/vm-route-auth.test.ts
+++ b/web/tests/vm-route-auth.test.ts
@@ -593,30 +593,42 @@ describe("VM REST auth", () => {
     expect(createVm).toHaveBeenCalledWith(expect.objectContaining({ memoryMb: 20480 }));
   });
 
-  test("rejects a memory size above the plan ceiling before the workflow", async () => {
+  test("resolves a legacy client's oversized memory request to the plan machine", async () => {
+    // Nightlies built before the 2026-09-02 pricing change send their old
+    // 24 GB default on every create; the server must still hand them the
+    // plan machine instead of failing every New Machine until they update.
     process.env.CMUX_VM_ALLOW_FREE_PROVISIONING = "1";
     getUser.mockResolvedValue(freePlanStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-legacy-size",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
 
     const response = await POST(
       new Request("https://cmux.test/api/vm", {
         method: "POST",
         headers: { origin: "https://cmux.test" },
-        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test", memoryMb: 32768 }),
+        body: JSON.stringify({ provider: "freestyle", image: "snapshot-test", memoryMb: 24576 }),
       }),
     );
 
-    expect(response.status).toBe(400);
-    const payload = await response.json();
-    expect(payload).toMatchObject({
-      error: "vm_memory_exceeds_plan",
-      details: { requestedMemoryMb: 32768, maxMemoryMb: 20480, planId: "free" },
-    });
-    expect(runVmWorkflow).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({ memoryMb: 20480 }));
   });
 
-  test("refuses a Cloud VM smaller than the plan machine", async () => {
+  test("resolves a memory request below the plan machine to the plan machine", async () => {
     process.env.CMUX_VM_ALLOW_FREE_PROVISIONING = "1";
     getUser.mockResolvedValue(freePlanStackUser());
+    runVmWorkflow.mockResolvedValue({
+      providerVmId: "provider-vm-small-size",
+      provider: "freestyle",
+      image: "snapshot-test",
+      imageVersion: null,
+      createdAt: 1_777_000_000_000,
+    });
 
     const response = await POST(
       new Request("https://cmux.test/api/vm", {
@@ -626,13 +638,8 @@ describe("VM REST auth", () => {
       }),
     );
 
-    expect(response.status).toBe(400);
-    const payload = await response.json();
-    expect(payload).toMatchObject({
-      error: "vm_memory_unsupported",
-      details: { requestedMemoryMb: 8192, memoryOptionsMb: [20480], planId: "free" },
-    });
-    expect(runVmWorkflow).not.toHaveBeenCalled();
+    expect(response.status).toBe(200);
+    expect(createVm).toHaveBeenCalledWith(expect.objectContaining({ memoryMb: 20480 }));
   });
 
   test("rejects malformed memory sizes before billing or provider work", async () => {


### PR DESCRIPTION
Every plan sells exactly the plan machine, so `POST /api/vm` now resolves a `memoryMb` the plan does not offer to that machine instead of returning `vm_memory_exceeds_plan` or `vm_memory_unsupported`.

Why: clients ship their own size table and always trail the server. The 2026-09-02 pricing change (https://github.com/manaflow-ai/cmux/pull/11610) lowered the plan machine to 20 GB on the server while the published nightly (c8ec44d, cut 43 minutes earlier) still sent its 24 GB default on every create, so every New Machine on that nightly failed with HTTP 400 until the next nightly published. PostHog `cloud_vm_provision` recorded 3 failures from 2 users at 11:45 UTC; Sentry never sees these because a 400 is a user fault.

The server owns the machine spec, so a stale client still gets a machine. The mismatch is stamped on the span (`cmux.vm.memory_requested_mb`, `cmux.vm.memory_coerced`) so Axiom can count stale clients. Malformed sizes (non-integer, below 512 MB) still fail with `invalid_request`.

Commit 1 adds the failing tests, commit 2 the fix. `bun test --isolate tests/vm-route-auth.test.ts`: 69 pass / 2 fail before, 71 pass after.

https://claude.ai/code/session_01HXVeowbRXQPeeveysv1Kw7

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11644"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790942472&installation_model_id=21920&pr_number=11644&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11644&signature=7d9b8eb2ea6c9a5f4664575b3dd52fd68a2d789bf159fe08f4ff6bc7879157d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`POST /api/vm` now resolves Cloud VM memory sizes the plan does not offer to the plan machine instead of rejecting the request with HTTP 400. Clients ship their own size tables and trail the server, so a stale client (like nightlies before the 2026-09-02 pricing change) was failing every New Machine with `vm_memory_exceeds_plan` or `vm_memory_unsupported`. The mismatch is stamped on the span (`cmux.vm.memory_requested_mb`, `cmux.vm.memory_coerced`) so Axiom can count stale clients. Malformed sizes (non-integer, below 512 MB) still fail with `invalid_request`.

<sup>Written for commit 259aeabce2c7c1a0300d6a789cda13219fb99276. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11644?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

