### PR TITLE
Admin page: list every Pro user, team, and pending grant

### DIFF
--- a/web/app/[locale]/dashboard/admin/admin-pro-list.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-pro-list.tsx
@@ -1,0 +1,460 @@
+"use client";
+
+import { useFormatter, useTranslations } from "next-intl";
+import { useRef, useState } from "react";
+
+type GrantRecord = {
+  readonly plan: string | null;
+  readonly byUserId: string;
+  readonly byEmail: string | null;
+  readonly at: string;
+} | null;
+
+type Subscriber = {
+  readonly userId: string;
+  readonly email: string | null;
+  readonly subscriptionId: string;
+  readonly status: string;
+  readonly cancelAtPeriodEnd: boolean;
+  readonly currentPeriodEnd: string | null;
+};
+
+type TeamSubscription = {
+  readonly teamId: string;
+  readonly displayName: string | null;
+  readonly subscriptionId: string;
+  readonly status: string;
+  readonly seats: number | null;
+  readonly cancelAtPeriodEnd: boolean;
+  readonly currentPeriodEnd: string | null;
+};
+
+type PendingGrant = {
+  readonly id: string;
+  readonly email: string;
+  readonly plan: string;
+  readonly grantedByEmail: string | null;
+  readonly createdAt: string;
+};
+
+type UserGrant = {
+  readonly userId: string;
+  readonly email: string | null;
+  readonly emailVerified: boolean;
+  readonly plan: string;
+  readonly lastGrant: GrantRecord;
+};
+
+type TeamGrant = {
+  readonly teamId: string;
+  readonly displayName: string;
+  readonly plan: string;
+  readonly lastGrant: GrantRecord;
+};
+
+type Snapshot = {
+  readonly subscribers: readonly Subscriber[];
+  readonly teamSubscriptions: readonly TeamSubscription[];
+  readonly pendingGrants: readonly PendingGrant[];
+};
+
+type ScanState = {
+  readonly status: "idle" | "scanning" | "done" | "error";
+  readonly scanned: number;
+  readonly pages: number;
+  readonly message?: string;
+};
+
+type ListState =
+  | { readonly kind: "idle" }
+  | { readonly kind: "loading" }
+  | { readonly kind: "error"; readonly message: string }
+  | {
+      readonly kind: "loaded";
+      readonly snapshot: Snapshot;
+      readonly userGrants: readonly UserGrant[];
+      readonly teamGrants: readonly TeamGrant[];
+      readonly userScan: ScanState;
+      readonly teamScan: ScanState;
+      readonly loadedAt: string;
+    };
+
+type Translate = ReturnType<typeof useTranslations<"dashboard.admin">>;
+
+/** Hard stop so a runaway cursor cannot loop forever. */
+const MAX_SCAN_PAGES = 200;
+
+const buttonClass =
+  "border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background disabled:hover:text-foreground";
+
+export function AdminProList({ onPickQuery }: { onPickQuery?: (query: string) => void }) {
+  const t = useTranslations("dashboard.admin");
+  const [state, setState] = useState<ListState>({ kind: "idle" });
+  const runSeq = useRef(0);
+
+  async function load() {
+    const seq = ++runSeq.current;
+    setState({ kind: "loading" });
+    let response: Response;
+    try {
+      response = await fetch("/api/admin/pro-users", { headers: { accept: "application/json" } });
+    } catch {
+      if (seq === runSeq.current) setState({ kind: "error", message: t("errors.network") });
+      return;
+    }
+    if (seq !== runSeq.current) return;
+    if (!response.ok) {
+      setState({ kind: "error", message: errorMessage(t, response.status) });
+      return;
+    }
+    let snapshot: Snapshot;
+    try {
+      snapshot = (await response.json()) as Snapshot;
+    } catch {
+      if (seq === runSeq.current) setState({ kind: "error", message: t("errors.generic") });
+      return;
+    }
+    if (seq !== runSeq.current) return;
+    setState({
+      kind: "loaded",
+      snapshot: {
+        subscribers: snapshot.subscribers ?? [],
+        teamSubscriptions: snapshot.teamSubscriptions ?? [],
+        pendingGrants: snapshot.pendingGrants ?? [],
+      },
+      userGrants: [],
+      teamGrants: [],
+      userScan: { status: "scanning", scanned: 0, pages: 0 },
+      teamScan: { status: "scanning", scanned: 0, pages: 0 },
+      loadedAt: new Date().toISOString(),
+    });
+    // Manual grants need a directory walk; run both walks after the snapshot
+    // is on screen so the Stripe list is never blocked on them.
+    void walk("users", seq);
+    void walk("teams", seq);
+  }
+
+  async function walk(kind: "users" | "teams", seq: number) {
+    let cursor: string | null = null;
+    let pages = 0;
+    let scanned = 0;
+    while (pages < MAX_SCAN_PAGES) {
+      if (seq !== runSeq.current) return;
+      const params = new URLSearchParams({ kind });
+      if (cursor) params.set("cursor", cursor);
+      let response: Response;
+      try {
+        response = await fetch(`/api/admin/pro-users/scan?${params}`, { headers: { accept: "application/json" } });
+      } catch {
+        patchScan(kind, { status: "error", scanned, pages, message: t("errors.network") });
+        return;
+      }
+      if (seq !== runSeq.current) return;
+      if (!response.ok) {
+        patchScan(kind, { status: "error", scanned, pages, message: errorMessage(t, response.status) });
+        return;
+      }
+      let page: { rows: unknown[]; scanned: number; nextCursor: string | null };
+      try {
+        page = (await response.json()) as typeof page;
+      } catch {
+        patchScan(kind, { status: "error", scanned, pages, message: t("errors.generic") });
+        return;
+      }
+      if (seq !== runSeq.current) return;
+      const nextPages = pages + 1;
+      const nextScanned = scanned + page.scanned;
+      const rows = page.rows;
+      setState((current) => {
+        if (current.kind !== "loaded") return current;
+        return kind === "users"
+          ? { ...current, userGrants: [...current.userGrants, ...(rows as UserGrant[])], userScan: { status: "scanning", scanned: nextScanned, pages: nextPages } }
+          : { ...current, teamGrants: [...current.teamGrants, ...(rows as TeamGrant[])], teamScan: { status: "scanning", scanned: nextScanned, pages: nextPages } };
+      });
+      pages = nextPages;
+      scanned = nextScanned;
+      cursor = page.nextCursor;
+      if (!cursor) break;
+    }
+    patchScan(kind, {
+      status: pages >= MAX_SCAN_PAGES && cursor ? "error" : "done",
+      scanned,
+      pages,
+      message: pages >= MAX_SCAN_PAGES && cursor ? t("list.scanTruncated") : undefined,
+    });
+  }
+
+  function patchScan(kind: "users" | "teams", scan: ScanState) {
+    setState((current) => {
+      if (current.kind !== "loaded") return current;
+      return kind === "users" ? { ...current, userScan: scan } : { ...current, teamScan: scan };
+    });
+  }
+
+  return (
+    <section className="border border-border p-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <h2 className="text-sm font-medium">{t("list.title")}</h2>
+          <p className="mt-1 max-w-2xl text-muted">{t("list.description")}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={state.kind === "loading"}
+          className={buttonClass}
+        >
+          {state.kind === "loading"
+            ? t("list.loading")
+            : state.kind === "loaded"
+              ? t("list.reload")
+              : t("list.load")}
+        </button>
+      </div>
+
+      {state.kind === "error" ? (
+        <p className="mt-3 border border-border p-3 text-sm text-muted" role="alert">{state.message}</p>
+      ) : null}
+
+      {state.kind === "loaded" ? (
+        <LoadedList t={t} state={state} onPickQuery={onPickQuery} />
+      ) : null}
+    </section>
+  );
+}
+
+function LoadedList({
+  t,
+  state,
+  onPickQuery,
+}: {
+  t: Translate;
+  state: Extract<ListState, { kind: "loaded" }>;
+  onPickQuery?: (query: string) => void;
+}) {
+  const format = useFormatter();
+  const { snapshot, userGrants, teamGrants, userScan, teamScan } = state;
+  const totalUsers = snapshot.subscribers.length + userGrants.length;
+  const totalTeams = snapshot.teamSubscriptions.length + teamGrants.length;
+  return (
+    <div className="mt-3 space-y-4">
+      <div className="flex flex-wrap gap-2 text-xs">
+        <Stat label={t("list.stats.proUsers")} value={String(totalUsers)} />
+        <Stat label={t("list.stats.subscribers")} value={String(snapshot.subscribers.length)} />
+        <Stat label={t("list.stats.userGrants")} value={String(userGrants.length)} pending={userScan.status === "scanning"} />
+        <Stat label={t("list.stats.teams")} value={String(totalTeams)} pending={teamScan.status === "scanning"} />
+        <Stat label={t("list.stats.pending")} value={String(snapshot.pendingGrants.length)} />
+      </div>
+
+      <ScanNote t={t} scan={userScan} label={t("list.scanUsers")} />
+      <ScanNote t={t} scan={teamScan} label={t("list.scanTeams")} />
+
+      <Block title={t("list.sections.subscribers", { count: snapshot.subscribers.length })}>
+        {snapshot.subscribers.length === 0 ? (
+          <Empty text={t("list.empty")} />
+        ) : (
+          <table className="w-full min-w-[40rem] text-left text-xs">
+            <thead className="border-b border-border text-muted">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.email")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.stripe")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("list.periodEnd")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("list.userId")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {snapshot.subscribers.map((row) => (
+                <tr key={row.subscriptionId} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 font-mono text-foreground">
+                    <PickButton value={row.email ?? row.userId} label={row.email ?? t("results.noEmail")} onPickQuery={onPickQuery} />
+                  </td>
+                  <td className="px-3 py-2 text-muted">
+                    {row.status}{row.cancelAtPeriodEnd ? ` · ${t("results.cancelling")}` : ""}
+                  </td>
+                  <td className="px-3 py-2 text-muted">{row.currentPeriodEnd ? formatTime(format, row.currentPeriodEnd) : "—"}</td>
+                  <td className="px-3 py-2 font-mono text-[10px] text-muted">{row.userId}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Block>
+
+      <Block title={t("list.sections.userGrants", { count: userGrants.length })}>
+        {userGrants.length === 0 ? (
+          <Empty text={userScan.status === "scanning" ? t("list.scanning") : t("list.empty")} />
+        ) : (
+          <table className="w-full min-w-[40rem] text-left text-xs">
+            <thead className="border-b border-border text-muted">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.email")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.plan")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.grant")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("list.userId")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {userGrants.map((row) => (
+                <tr key={row.userId} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 font-mono text-foreground">
+                    <PickButton value={row.email ?? row.userId} label={row.email ?? t("results.noEmail")} onPickQuery={onPickQuery} />
+                    <span className="ml-2 text-muted">{row.emailVerified ? t("results.verified") : t("results.unverified")}</span>
+                  </td>
+                  <td className="px-3 py-2 text-muted">{row.plan}</td>
+                  <td className="px-3 py-2 text-muted">
+                    {row.lastGrant
+                      ? t("grant.by", { who: row.lastGrant.byEmail ?? row.lastGrant.byUserId, when: formatTime(format, row.lastGrant.at) })
+                      : t("grant.none")}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-[10px] text-muted">{row.userId}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Block>
+
+      <Block title={t("list.sections.teams", { count: totalTeams })}>
+        {totalTeams === 0 ? (
+          <Empty text={teamScan.status === "scanning" ? t("list.scanning") : t("list.empty")} />
+        ) : (
+          <table className="w-full min-w-[40rem] text-left text-xs">
+            <thead className="border-b border-border text-muted">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.team")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("list.source")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("list.detail")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("list.teamId")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {snapshot.teamSubscriptions.map((row) => (
+                <tr key={`sub-${row.subscriptionId}`} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 text-foreground">
+                    <PickButton value={row.displayName ?? row.teamId} label={row.displayName ?? row.teamId} onPickQuery={onPickQuery} />
+                  </td>
+                  <td className="px-3 py-2 text-muted">{t("list.sourceStripe")}</td>
+                  <td className="px-3 py-2 text-muted">
+                    {row.status}{row.cancelAtPeriodEnd ? ` · ${t("results.cancelling")}` : ""}
+                    {row.seats !== null ? ` · ${t("list.seats", { count: row.seats })}` : ""}
+                    {row.currentPeriodEnd ? ` · ${formatTime(format, row.currentPeriodEnd)}` : ""}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-[10px] text-muted">{row.teamId}</td>
+                </tr>
+              ))}
+              {teamGrants.map((row) => (
+                <tr key={`grant-${row.teamId}`} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 text-foreground">
+                    <PickButton value={row.displayName} label={row.displayName} onPickQuery={onPickQuery} />
+                  </td>
+                  <td className="px-3 py-2 text-muted">{t("list.sourceGrant")}</td>
+                  <td className="px-3 py-2 text-muted">
+                    {row.plan}
+                    {row.lastGrant ? ` · ${t("grant.by", { who: row.lastGrant.byEmail ?? row.lastGrant.byUserId, when: formatTime(format, row.lastGrant.at) })}` : ""}
+                  </td>
+                  <td className="px-3 py-2 font-mono text-[10px] text-muted">{row.teamId}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Block>
+
+      <Block title={t("list.sections.pending", { count: snapshot.pendingGrants.length })}>
+        {snapshot.pendingGrants.length === 0 ? (
+          <Empty text={t("list.empty")} />
+        ) : (
+          <table className="w-full min-w-[36rem] text-left text-xs">
+            <thead className="border-b border-border text-muted">
+              <tr>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.email")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.plan")}</th>
+                <th scope="col" className="px-3 py-2 font-medium">{t("results.grant")}</th>
+              </tr>
+            </thead>
+            <tbody>
+              {snapshot.pendingGrants.map((row) => (
+                <tr key={row.id} className="border-b border-border last:border-b-0">
+                  <td className="px-3 py-2 font-mono text-foreground">
+                    <PickButton value={row.email} label={row.email} onPickQuery={onPickQuery} />
+                  </td>
+                  <td className="px-3 py-2 text-muted">{row.plan}</td>
+                  <td className="px-3 py-2 text-muted">
+                    {t("grant.by", { who: row.grantedByEmail ?? "?", when: formatTime(format, row.createdAt) })}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </Block>
+    </div>
+  );
+}
+
+function Stat({ label, value, pending }: { label: string; value: string; pending?: boolean }) {
+  return (
+    <div className="border border-border px-2.5 py-1.5">
+      <div className="text-[10px] uppercase tracking-wide text-muted">{label}</div>
+      <div className="font-mono text-sm text-foreground">{value}{pending ? "…" : ""}</div>
+    </div>
+  );
+}
+
+function ScanNote({ t, scan, label }: { t: Translate; scan: ScanState; label: string }) {
+  if (scan.status === "idle") return null;
+  const text = scan.status === "scanning"
+    ? t("list.scanProgress", { label, scanned: scan.scanned })
+    : scan.status === "done"
+      ? t("list.scanDone", { label, scanned: scan.scanned })
+      : `${t("list.scanFailed", { label, scanned: scan.scanned })} ${scan.message ?? ""}`;
+  return (
+    <p className="text-xs text-muted" role={scan.status === "error" ? "alert" : undefined}>{text}</p>
+  );
+}
+
+function Block({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div>
+      <h3 className="mb-1 text-xs font-semibold text-foreground">{title}</h3>
+      <div className="overflow-x-auto border border-border">{children}</div>
+    </div>
+  );
+}
+
+function Empty({ text }: { text: string }) {
+  return <p className="p-3 text-xs text-muted">{text}</p>;
+}
+
+function PickButton({
+  value,
+  label,
+  onPickQuery,
+}: {
+  value: string;
+  label: string;
+  onPickQuery?: (query: string) => void;
+}) {
+  if (!onPickQuery) return <>{label}</>;
+  return (
+    <button
+      type="button"
+      onClick={() => onPickQuery(value)}
+      className="underline decoration-dotted underline-offset-2 hover:decoration-solid focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground"
+    >
+      {label}
+    </button>
+  );
+}
+
+function formatTime(format: ReturnType<typeof useFormatter>, iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  return format.dateTime(date, { dateStyle: "medium" });
+}
+
+function errorMessage(t: Translate, status: number): string {
+  if (status === 401 || status === 403) return t("errors.forbidden");
+  if (status === 503) return t("errors.billing");
+  return t("errors.generic");
+}

--- a/web/app/[locale]/dashboard/admin/admin-pro-panel.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-pro-panel.tsx
@@ -5,6 +5,7 @@ import { useFormatter, useTranslations } from "next-intl";
 import { useId, useRef, useState, type ReactNode } from "react";
 
 import { Modal } from "../../components/modal";
+import { AdminProList } from "./admin-pro-list";
 
 type GrantRecord = {
   readonly plan: string | null;
@@ -381,6 +382,15 @@ export function AdminProPanel() {
           </table>
         </ResultSection>
       ) : null}
+
+      <AdminProList
+        onPickQuery={(value) => {
+          setQuery(value);
+          setNotice(null);
+          void runSearch(value);
+          if (typeof window !== "undefined") window.scrollTo({ top: 0, behavior: "smooth" });
+        }}
+      />
 
       <ConfirmDialog
         t={t}

--- a/web/app/api/admin/pro-users/route.ts
+++ b/web/app/api/admin/pro-users/route.ts
@@ -1,0 +1,39 @@
+import { NextRequest } from "next/server";
+
+import {
+  listAllPendingEmailGrants,
+  listStripeProSubscribers,
+  listStripeTeamSubscriptions,
+  type ProListSnapshot,
+} from "../../../../services/admin/proList";
+import { isMissingGrantsTableError } from "../../../../services/admin/proGrants";
+import { adminJsonResponse, requireAdmin } from "../../../../services/admin/routeAuth";
+
+/**
+ * GET /api/admin/pro-users — every active Stripe Pro subscriber and Team
+ * subscription (from the local Stripe mirror) plus open pending email grants.
+ * Manual grants come from /api/admin/pro-users/scan, page by page.
+ */
+export async function GET(request: NextRequest) {
+  const gate = await requireAdmin(request);
+  if (!gate.ok) return gate.response;
+
+  let snapshot: ProListSnapshot;
+  try {
+    const [subscribers, teamSubscriptions, pendingGrants] = await Promise.all([
+      listStripeProSubscribers(),
+      listStripeTeamSubscriptions(),
+      listAllPendingEmailGrants().catch((error: unknown) => {
+        if (isMissingGrantsTableError(error)) return [];
+        throw error;
+      }),
+    ]);
+    snapshot = { subscribers, teamSubscriptions, pendingGrants };
+  } catch (error) {
+    if (error instanceof Error && /DATABASE_URL is required/.test(error.message)) {
+      return adminJsonResponse({ error: "database_unavailable" }, 503);
+    }
+    throw error;
+  }
+  return adminJsonResponse(snapshot);
+}

--- a/web/app/api/admin/pro-users/scan/route.ts
+++ b/web/app/api/admin/pro-users/scan/route.ts
@@ -1,0 +1,29 @@
+import { NextRequest } from "next/server";
+
+import {
+  isValidScanCursor,
+  scanManualTeamGrants,
+  scanManualUserGrants,
+} from "../../../../../services/admin/proList";
+import { adminJsonResponse, requireAdmin } from "../../../../../services/admin/routeAuth";
+
+/**
+ * GET /api/admin/pro-users/scan?kind=users|teams[&cursor=...] — one page of
+ * the Stack directory filtered to paid manual overrides. The page walks the
+ * cursor until it is null.
+ */
+export async function GET(request: NextRequest) {
+  const gate = await requireAdmin(request);
+  if (!gate.ok) return gate.response;
+
+  const kind = request.nextUrl.searchParams.get("kind");
+  const rawCursor = request.nextUrl.searchParams.get("cursor");
+  const cursor = rawCursor === null || rawCursor === "" ? null : rawCursor;
+  if ((kind !== "users" && kind !== "teams") || (cursor !== null && !isValidScanCursor(cursor))) {
+    return adminJsonResponse({ error: "invalid_query" }, 400);
+  }
+  const page = kind === "users"
+    ? await scanManualUserGrants(cursor)
+    : await scanManualTeamGrants(cursor);
+  return adminJsonResponse({ kind, ...page });
+}

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -388,6 +388,42 @@
         "conflict": "Another change to this account is in progress, or the email matches several accounts.",
         "billing": "Billing is not available right now.",
         "generic": "The request failed. Try again shortly."
+      },
+      "list": {
+        "title": "All Pro users",
+        "description": "Every account with Pro access and why: active Stripe subscriptions from the billing mirror, manual grants found by walking the account directory, and grants waiting for a first sign-in.",
+        "load": "Load list",
+        "reload": "Reload",
+        "loading": "Loading…",
+        "stats": {
+          "proUsers": "Pro users",
+          "subscribers": "Stripe subscribers",
+          "userGrants": "Manual grants",
+          "teams": "Teams",
+          "pending": "Pending grants"
+        },
+        "scanUsers": "accounts",
+        "scanTeams": "teams",
+        "scanProgress": "Scanning {label} for manual grants… {scanned} checked.",
+        "scanDone": "Scanned {scanned} {label} for manual grants.",
+        "scanFailed": "Scan of {label} stopped after {scanned}.",
+        "scanTruncated": "Reached the page limit before the end of the directory.",
+        "scanning": "Scanning…",
+        "empty": "None.",
+        "sections": {
+          "subscribers": "Stripe Pro subscribers ({count})",
+          "userGrants": "Manual user grants ({count})",
+          "teams": "Teams with Team access ({count})",
+          "pending": "Pending email grants ({count})"
+        },
+        "periodEnd": "Period end",
+        "userId": "User id",
+        "teamId": "Team id",
+        "source": "Source",
+        "detail": "Detail",
+        "sourceStripe": "Stripe subscription",
+        "sourceGrant": "Manual grant",
+        "seats": "{count, plural, =1 {1 seat} other {# seats}}"
       }
     },
     "aiAccounts": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -388,6 +388,42 @@
         "conflict": "このアカウントへの別の変更が進行中か、メールが複数のアカウントに一致します。",
         "billing": "請求機能は現在利用できません。",
         "generic": "リクエストに失敗しました。しばらくしてからお試しください。"
+      },
+      "list": {
+        "title": "すべての Pro ユーザー",
+        "description": "Pro アクセスを持つすべてのアカウントとその理由: 請求ミラーの有効な Stripe サブスクリプション、アカウント一覧を走査して見つけた手動付与、初回サインイン待ちの付与。",
+        "load": "一覧を読み込む",
+        "reload": "再読み込み",
+        "loading": "読み込み中…",
+        "stats": {
+          "proUsers": "Pro ユーザー",
+          "subscribers": "Stripe 契約者",
+          "userGrants": "手動付与",
+          "teams": "チーム",
+          "pending": "保留中の付与"
+        },
+        "scanUsers": "アカウント",
+        "scanTeams": "チーム",
+        "scanProgress": "手動付与を探して{label}を走査中… {scanned} 件確認。",
+        "scanDone": "{scanned} 件の{label}を走査しました。",
+        "scanFailed": "{label}の走査は {scanned} 件で停止しました。",
+        "scanTruncated": "一覧の終端に達する前にページ上限に達しました。",
+        "scanning": "走査中…",
+        "empty": "なし。",
+        "sections": {
+          "subscribers": "Stripe Pro 契約者 ({count})",
+          "userGrants": "手動付与ユーザー ({count})",
+          "teams": "Team アクセスを持つチーム ({count})",
+          "pending": "保留中のメール付与 ({count})"
+        },
+        "periodEnd": "期間終了",
+        "userId": "ユーザー ID",
+        "teamId": "チーム ID",
+        "source": "ソース",
+        "detail": "詳細",
+        "sourceStripe": "Stripe サブスクリプション",
+        "sourceGrant": "手動付与",
+        "seats": "{count} シート"
       }
     },
     "aiAccounts": {

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -1,0 +1,276 @@
+// The complete Pro roster for the admin page.
+//
+// Two sources, listed separately so an admin can see why an account is Pro:
+// - Stripe: active user and team subscription rows, joined to the recorded
+//   customer email (no Stack calls).
+// - Manual grants: `cmuxVmPlan` overrides on Stack users and teams. Stack has
+//   no metadata filter, so these are found by paging through all accounts in
+//   bounded pages that the page walks one request at a time.
+
+import { and, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { adminPlanGrants, stripeCustomers, stripeSubscriptions } from "../../db/schema";
+import { getStackServerApp } from "../../app/lib/stack";
+import {
+  ACTIVE_STRIPE_PRO_STATUSES,
+  PRO_PLAN_ID,
+  TEAM_PLAN_ID,
+  isPaidPlanId,
+  manualVmPlanOverride,
+} from "../billing/pro";
+import {
+  grantRecordFromServerMetadata,
+  type AdminPendingGrantRow,
+  type AdminPlanGrantRecord,
+  type AdminStackTeam,
+  type AdminStackUser,
+} from "./proGrants";
+
+export const PRO_LIST_SCAN_PAGE_SIZE = 100;
+export const PRO_LIST_MAX_ROWS = 5000;
+
+export type StripeProSubscriber = {
+  readonly userId: string;
+  readonly email: string | null;
+  readonly subscriptionId: string;
+  readonly status: string;
+  readonly cancelAtPeriodEnd: boolean;
+  readonly currentPeriodEnd: string | null;
+};
+
+export type StripeTeamSubscription = {
+  readonly teamId: string;
+  readonly displayName: string | null;
+  readonly subscriptionId: string;
+  readonly status: string;
+  readonly seats: number | null;
+  readonly cancelAtPeriodEnd: boolean;
+  readonly currentPeriodEnd: string | null;
+};
+
+export type ManualUserGrant = {
+  readonly userId: string;
+  readonly email: string | null;
+  readonly emailVerified: boolean;
+  readonly plan: string;
+  readonly lastGrant: AdminPlanGrantRecord | null;
+};
+
+export type ManualTeamGrant = {
+  readonly teamId: string;
+  readonly displayName: string;
+  readonly plan: string;
+  readonly lastGrant: AdminPlanGrantRecord | null;
+};
+
+export type ProListSnapshot = {
+  readonly subscribers: readonly StripeProSubscriber[];
+  readonly teamSubscriptions: readonly StripeTeamSubscription[];
+  readonly pendingGrants: readonly AdminPendingGrantRow[];
+};
+
+export type ProListScanPage<Row> = {
+  readonly rows: readonly Row[];
+  readonly scanned: number;
+  readonly nextCursor: string | null;
+};
+
+export type ProListDb = Pick<ReturnType<typeof cloudDb>, "select">;
+
+export type ProListStackApp = {
+  getTeam(teamId: string): Promise<Pick<AdminStackTeam, "id" | "displayName"> | null>;
+  listUsers(options: {
+    cursor?: string;
+    limit?: number;
+    includeAnonymous?: boolean;
+    includeRestricted?: boolean;
+  }): Promise<readonly AdminStackUser[] & { readonly nextCursor?: string | null }>;
+  listTeams(options: {
+    cursor?: string;
+    limit?: number;
+  }): Promise<readonly AdminStackTeam[] & { readonly nextCursor?: string | null }>;
+};
+
+/** Every account with an active Stripe Pro row, newest period first, one row per user. */
+export async function listStripeProSubscribers(
+  options: { readonly db?: ProListDb } = {},
+): Promise<StripeProSubscriber[]> {
+  const db = options.db ?? cloudDb();
+  const rows = await db
+    .select({
+      userId: stripeSubscriptions.stackUserId,
+      subscriptionId: stripeSubscriptions.id,
+      status: stripeSubscriptions.status,
+      cancelAtPeriodEnd: stripeSubscriptions.cancelAtPeriodEnd,
+      currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+      email: stripeCustomers.email,
+    })
+    .from(stripeSubscriptions)
+    .leftJoin(stripeCustomers, eq(stripeSubscriptions.customerId, stripeCustomers.id))
+    .where(
+      and(
+        isNull(stripeSubscriptions.stackTeamId),
+        eq(stripeSubscriptions.scope, "user"),
+        eq(stripeSubscriptions.plan, PRO_PLAN_ID),
+        inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+      ),
+    )
+    .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
+    .limit(PRO_LIST_MAX_ROWS);
+  const seen = new Set<string>();
+  const out: StripeProSubscriber[] = [];
+  for (const row of rows) {
+    if (seen.has(row.userId)) continue;
+    seen.add(row.userId);
+    out.push({
+      userId: row.userId,
+      email: row.email ?? null,
+      subscriptionId: row.subscriptionId,
+      status: row.status,
+      cancelAtPeriodEnd: Boolean(row.cancelAtPeriodEnd),
+      currentPeriodEnd: row.currentPeriodEnd ? row.currentPeriodEnd.toISOString() : null,
+    });
+  }
+  return out;
+}
+
+/** Every team with an active Stripe Team row, with its Stack display name when reachable. */
+export async function listStripeTeamSubscriptions(
+  options: { readonly db?: ProListDb; readonly app?: ProListStackApp } = {},
+): Promise<StripeTeamSubscription[]> {
+  const db = options.db ?? cloudDb();
+  const app = options.app ?? defaultProListStackApp();
+  const rows = await db
+    .select({
+      teamId: stripeSubscriptions.stackTeamId,
+      subscriptionId: stripeSubscriptions.id,
+      status: stripeSubscriptions.status,
+      seats: stripeSubscriptions.seats,
+      cancelAtPeriodEnd: stripeSubscriptions.cancelAtPeriodEnd,
+      currentPeriodEnd: stripeSubscriptions.currentPeriodEnd,
+    })
+    .from(stripeSubscriptions)
+    .where(
+      and(
+        isNotNull(stripeSubscriptions.stackTeamId),
+        eq(stripeSubscriptions.scope, "team"),
+        eq(stripeSubscriptions.plan, TEAM_PLAN_ID),
+        inArray(stripeSubscriptions.status, ACTIVE_STRIPE_PRO_STATUSES),
+      ),
+    )
+    .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
+    .limit(PRO_LIST_MAX_ROWS);
+  const seen = new Set<string>();
+  const unique = rows.filter((row) => {
+    if (!row.teamId || seen.has(row.teamId)) return false;
+    seen.add(row.teamId);
+    return true;
+  });
+  return await Promise.all(
+    unique.map(async (row) => {
+      const team = await app.getTeam(row.teamId!).catch(() => null);
+      return {
+        teamId: row.teamId!,
+        displayName: team?.displayName ?? null,
+        subscriptionId: row.subscriptionId,
+        status: row.status,
+        seats: row.seats ?? null,
+        cancelAtPeriodEnd: Boolean(row.cancelAtPeriodEnd),
+        currentPeriodEnd: row.currentPeriodEnd ? row.currentPeriodEnd.toISOString() : null,
+      };
+    }),
+  );
+}
+
+/** Every open pending email grant, newest first. */
+export async function listAllPendingEmailGrants(
+  options: { readonly db?: ProListDb } = {},
+): Promise<AdminPendingGrantRow[]> {
+  const db = options.db ?? cloudDb();
+  const rows = await db
+    .select({
+      id: adminPlanGrants.id,
+      email: adminPlanGrants.email,
+      plan: adminPlanGrants.plan,
+      grantedByEmail: adminPlanGrants.grantedByEmail,
+      createdAt: adminPlanGrants.createdAt,
+    })
+    .from(adminPlanGrants)
+    .where(and(isNull(adminPlanGrants.appliedAt), isNull(adminPlanGrants.revokedAt)))
+    .orderBy(desc(adminPlanGrants.createdAt))
+    .limit(PRO_LIST_MAX_ROWS);
+  return rows.map((row) => ({
+    id: row.id,
+    email: row.email,
+    plan: row.plan,
+    grantedByEmail: row.grantedByEmail ?? null,
+    createdAt: row.createdAt.toISOString(),
+  }));
+}
+
+/** One page of the Stack user directory, keeping only accounts with a paid manual override. */
+export async function scanManualUserGrants(
+  cursor: string | null,
+  options: { readonly app?: ProListStackApp; readonly pageSize?: number } = {},
+): Promise<ProListScanPage<ManualUserGrant>> {
+  const app = options.app ?? defaultProListStackApp();
+  const users = await app.listUsers({
+    cursor: cursor ?? undefined,
+    limit: options.pageSize ?? PRO_LIST_SCAN_PAGE_SIZE,
+    includeAnonymous: false,
+    includeRestricted: true,
+  });
+  const rows: ManualUserGrant[] = [];
+  for (const user of users) {
+    if (user.isAnonymous) continue;
+    const plan = manualVmPlanOverride(user.clientReadOnlyMetadata);
+    if (!isPaidPlanId(plan)) continue;
+    rows.push({
+      userId: user.id,
+      email: user.primaryEmail ?? null,
+      emailVerified: user.primaryEmailVerified === true,
+      plan: plan!,
+      lastGrant: grantRecordFromServerMetadata(user.serverMetadata),
+    });
+  }
+  return { rows, scanned: users.length, nextCursor: users.nextCursor ?? null };
+}
+
+/** One page of the Stack team directory, keeping only teams with a paid manual override. */
+export async function scanManualTeamGrants(
+  cursor: string | null,
+  options: { readonly app?: ProListStackApp; readonly pageSize?: number } = {},
+): Promise<ProListScanPage<ManualTeamGrant>> {
+  const app = options.app ?? defaultProListStackApp();
+  const teams = await app.listTeams({
+    cursor: cursor ?? undefined,
+    limit: options.pageSize ?? PRO_LIST_SCAN_PAGE_SIZE,
+  });
+  const rows: ManualTeamGrant[] = [];
+  for (const team of teams) {
+    const plan = manualVmPlanOverride(team.clientReadOnlyMetadata);
+    if (!isPaidPlanId(plan)) continue;
+    rows.push({
+      teamId: team.id,
+      displayName: team.displayName,
+      plan: plan!,
+      lastGrant: grantRecordFromServerMetadata(team.serverMetadata),
+    });
+  }
+  return { rows, scanned: teams.length, nextCursor: teams.nextCursor ?? null };
+}
+
+/** Opaque Stack cursors are short tokens; refuse anything that looks like injection or garbage. */
+export function isValidScanCursor(value: string): boolean {
+  return value.length > 0 && value.length <= 512 && /^[A-Za-z0-9_.:=+/-]+$/.test(value);
+}
+
+function defaultProListStackApp(): ProListStackApp {
+  const app = getStackServerApp();
+  return {
+    getTeam: (teamId) => app.getTeam(teamId),
+    listUsers: (options) => app.listUsers(options),
+    listTeams: (options) => app.listTeams(options),
+  };
+}

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  isValidScanCursor,
+  listAllPendingEmailGrants,
+  listStripeProSubscribers,
+  listStripeTeamSubscriptions,
+  scanManualTeamGrants,
+  scanManualUserGrants,
+  type ProListDb,
+  type ProListStackApp,
+} from "../services/admin/proList";
+import { adminPlanGrants, stripeSubscriptions } from "../db/schema";
+
+/** Chainable select double: from(table) picks the row set; joins/where/order are ignored. */
+function fakeDb(rowsByTable: Map<unknown, unknown[]>): ProListDb {
+  return {
+    select: () => ({
+      from: (table: unknown) => {
+        const rows = rowsByTable.get(table) ?? [];
+        const chain = {
+          leftJoin: () => chain,
+          where: () => chain,
+          orderBy: () => chain,
+          limit: async () => rows,
+        };
+        return chain;
+      },
+    }),
+  } as unknown as ProListDb;
+}
+
+function fakeApp(input: {
+  users?: Array<Record<string, unknown>>;
+  teams?: Array<Record<string, unknown>>;
+  pageSize?: number;
+}): ProListStackApp & { calls: unknown[] } {
+  const calls: unknown[] = [];
+  const page = <T,>(all: T[], options: { cursor?: string; limit?: number }) => {
+    const start = options.cursor ? Number(options.cursor) : 0;
+    const limit = options.limit ?? 100;
+    const slice = all.slice(start, start + limit);
+    const next = start + limit < all.length ? String(start + limit) : null;
+    return Object.assign(slice, { nextCursor: next });
+  };
+  return {
+    calls,
+    async getTeam(teamId) {
+      const team = (input.teams ?? []).find((candidate) => candidate.id === teamId);
+      return team ? { id: teamId, displayName: String(team.displayName) } : null;
+    },
+    async listUsers(options) {
+      calls.push({ kind: "users", ...options });
+      return page(input.users ?? [], options) as never;
+    },
+    async listTeams(options) {
+      calls.push({ kind: "teams", ...options });
+      return page(input.teams ?? [], options) as never;
+    },
+  };
+}
+
+describe("Pro roster", () => {
+  test("lists one Stripe subscriber per user with the customer email", async () => {
+    const db = fakeDb(new Map([[stripeSubscriptions, [
+      { userId: "u1", subscriptionId: "sub_new", status: "active", cancelAtPeriodEnd: false, currentPeriodEnd: new Date("2026-10-01T00:00:00Z"), email: "pat@example.com" },
+      { userId: "u1", subscriptionId: "sub_old", status: "past_due", cancelAtPeriodEnd: true, currentPeriodEnd: new Date("2026-09-01T00:00:00Z"), email: "pat@example.com" },
+      { userId: "u2", subscriptionId: "sub_2", status: "trialing", cancelAtPeriodEnd: false, currentPeriodEnd: null, email: null },
+    ]]]));
+    const rows = await listStripeProSubscribers({ db });
+    expect(rows).toEqual([
+      { userId: "u1", email: "pat@example.com", subscriptionId: "sub_new", status: "active", cancelAtPeriodEnd: false, currentPeriodEnd: "2026-10-01T00:00:00.000Z" },
+      { userId: "u2", email: null, subscriptionId: "sub_2", status: "trialing", cancelAtPeriodEnd: false, currentPeriodEnd: null },
+    ]);
+  });
+
+  test("lists team subscriptions with the Stack display name when reachable", async () => {
+    const db = fakeDb(new Map([[stripeSubscriptions, [
+      { teamId: "t1", subscriptionId: "sub_t1", status: "active", seats: 5, cancelAtPeriodEnd: false, currentPeriodEnd: null },
+      { teamId: "t1", subscriptionId: "sub_t1_dup", status: "active", seats: 5, cancelAtPeriodEnd: false, currentPeriodEnd: null },
+      { teamId: "t9", subscriptionId: "sub_t9", status: "active", seats: null, cancelAtPeriodEnd: true, currentPeriodEnd: null },
+    ]]]));
+    const app = fakeApp({ teams: [{ id: "t1", displayName: "Acme" }] });
+    const rows = await listStripeTeamSubscriptions({ db, app });
+    expect(rows.map((row) => [row.teamId, row.displayName, row.seats, row.cancelAtPeriodEnd])).toEqual([
+      ["t1", "Acme", 5, false],
+      ["t9", null, null, true],
+    ]);
+  });
+
+  test("lists open pending grants", async () => {
+    const db = fakeDb(new Map([[adminPlanGrants, [
+      { id: "g1", email: "a@example.com", plan: "pro", grantedByEmail: "lawrence@manaflow.ai", createdAt: new Date("2026-09-02T00:00:00Z") },
+    ]]]));
+    expect(await listAllPendingEmailGrants({ db })).toEqual([
+      { id: "g1", email: "a@example.com", plan: "pro", grantedByEmail: "lawrence@manaflow.ai", createdAt: "2026-09-02T00:00:00.000Z" },
+    ]);
+  });
+
+  test("scans the user directory page by page and keeps only paid manual overrides", async () => {
+    const users = [
+      { id: "u1", primaryEmail: "a@example.com", primaryEmailVerified: true, isAnonymous: false, clientReadOnlyMetadata: { cmuxVmPlan: "pro" }, serverMetadata: { cmuxAdminPlanGrant: { plan: "pro", byUserId: "admin-1", byEmail: "lawrence@manaflow.ai", at: "2026-09-02T00:00:00.000Z" } } },
+      { id: "u2", primaryEmail: "b@example.com", primaryEmailVerified: true, isAnonymous: false, clientReadOnlyMetadata: { cmuxPlan: "pro" }, serverMetadata: {} },
+      { id: "u3", primaryEmail: "c@example.com", primaryEmailVerified: false, isAnonymous: false, clientReadOnlyMetadata: { cmuxVmPlan: "free" }, serverMetadata: {} },
+      { id: "u4", primaryEmail: "d@example.com", primaryEmailVerified: false, isAnonymous: false, clientReadOnlyMetadata: { cmuxVmPlan: "Founders" }, serverMetadata: {} },
+      { id: "u5", primaryEmail: "anon@example.com", primaryEmailVerified: true, isAnonymous: true, clientReadOnlyMetadata: { cmuxVmPlan: "pro" }, serverMetadata: {} },
+    ];
+    const app = fakeApp({ users });
+    const first = await scanManualUserGrants(null, { app, pageSize: 3 });
+    expect(first.scanned).toBe(3);
+    expect(first.nextCursor).toBe("3");
+    expect(first.rows.map((row) => [row.userId, row.plan, row.lastGrant?.byEmail ?? null])).toEqual([["u1", "pro", "lawrence@manaflow.ai"]]);
+    const second = await scanManualUserGrants(first.nextCursor, { app, pageSize: 3 });
+    expect(second.scanned).toBe(2);
+    expect(second.nextCursor).toBeNull();
+    expect(second.rows.map((row) => [row.userId, row.plan, row.emailVerified])).toEqual([["u4", "founders", false]]);
+    expect(app.calls).toEqual([
+      { kind: "users", cursor: undefined, limit: 3, includeAnonymous: false, includeRestricted: true },
+      { kind: "users", cursor: "3", limit: 3, includeAnonymous: false, includeRestricted: true },
+    ]);
+  });
+
+  test("scans teams for paid manual overrides", async () => {
+    const app = fakeApp({ teams: [
+      { id: "t1", displayName: "Acme", clientReadOnlyMetadata: { cmuxVmPlan: "team" }, serverMetadata: {} },
+      { id: "t2", displayName: "Free", clientReadOnlyMetadata: { cmuxPlan: "team" }, serverMetadata: {} },
+    ] });
+    const page = await scanManualTeamGrants(null, { app });
+    expect(page.rows.map((row) => [row.teamId, row.plan])).toEqual([["t1", "team"]]);
+    expect(page.nextCursor).toBeNull();
+  });
+
+  test("isValidScanCursor accepts opaque tokens and rejects junk", () => {
+    expect(isValidScanCursor("abc123")).toBe(true);
+    expect(isValidScanCursor("eyJhIjoxfQ==")).toBe(true);
+    expect(isValidScanCursor("")).toBe(false);
+    expect(isValidScanCursor("a b")).toBe(false);
+    expect(isValidScanCursor("<script>")).toBe(false);
+    expect(isValidScanCursor("x".repeat(600))).toBe(false);
+  });
+});

--- a/web/tests/admin-users-route.test.ts
+++ b/web/tests/admin-users-route.test.ts
@@ -112,6 +112,7 @@ mock.module("../app/lib/stack", () => ({
 let pendingGrantRows: Array<Record<string, unknown>> = [];
 let grantsTableMissing = false;
 let subscriptionRows: Array<{ id: string }> = [];
+let subscriptionListRows: Array<Record<string, unknown>> = [];
 let subscriptionUpdates: Array<Record<string, unknown>> = [];
 const stripeSubscriptionUpdate = mock(async (id: unknown, params: unknown) => ({
   id,
@@ -127,6 +128,13 @@ function adminDbMock() {
   const base = {
       select: () => ({
         from: (table: unknown) => ({
+          leftJoin: () => ({
+            where: () => ({
+              orderBy: () => ({
+                limit: async () => (table === stripeSubscriptions ? subscriptionListRows : []),
+              }),
+            }),
+          }),
           where: () => ({
             limit: async () => (table === stripeSubscriptions ? [] : []),
             orderBy: () => ({
@@ -205,6 +213,8 @@ const { POST: POST_EMAIL_GRANTS, DELETE: DELETE_EMAIL_GRANTS } = await import(
   "../app/api/admin/email-grants/route"
 );
 const { POST: POST_SUBSCRIPTIONS } = await import("../app/api/admin/subscriptions/route");
+const { GET: GET_PRO_USERS } = await import("../app/api/admin/pro-users/route");
+const { GET: GET_PRO_SCAN } = await import("../app/api/admin/pro-users/scan/route");
 
 const adminUser = () =>
   stackUser({ id: "admin-1", primaryEmail: "lawrence@manaflow.ai" });
@@ -522,5 +532,51 @@ describe("admin subscriptions route", () => {
     currentUser = stackUser({ id: "user", primaryEmail: "pat@example.com" });
     expect((await POST_SUBSCRIPTIONS(postRequest({ scope: "user", ownerId: "u1", action: "cancel" }, {}, "/api/admin/subscriptions"))).status).toBe(403);
     expect(stripeSubscriptionUpdate).not.toHaveBeenCalled();
+  });
+});
+
+describe("admin pro-users routes", () => {
+  beforeEach(() => {
+    currentUser = adminUser();
+    subscriptionListRows = [
+      { userId: "u1", subscriptionId: "sub_1", status: "active", cancelAtPeriodEnd: false, currentPeriodEnd: null, email: "pat@example.com" },
+    ];
+    directory = [stackUser({ id: "u9", primaryEmail: "granted@example.com", clientReadOnlyMetadata: { cmuxVmPlan: "pro" } })];
+    listUsers.mockClear();
+  });
+
+  test("the roster and the scan are admin-only and never cacheable", async () => {
+    for (const user of [
+      null,
+      stackUser({ id: "user", primaryEmail: "pat@example.com" }),
+      stackUser({ id: "impostor", primaryEmail: "x@manaflow.ai", primaryEmailVerified: false }),
+      stackUser({ id: "anon", primaryEmail: "a@cmux.com", isAnonymous: true }),
+    ]) {
+      currentUser = user;
+      const expected = user === null || user.isAnonymous ? 401 : 403;
+      expect((await GET_PRO_USERS(new NextRequest("https://cmux.com/api/admin/pro-users"))).status).toBe(expected);
+      expect((await GET_PRO_SCAN(new NextRequest("https://cmux.com/api/admin/pro-users/scan?kind=users"))).status).toBe(expected);
+    }
+    expect(listUsers).not.toHaveBeenCalled();
+    currentUser = adminUser();
+    const response = await GET_PRO_USERS(new NextRequest("https://cmux.com/api/admin/pro-users"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const body = (await response.json()) as { subscribers: Array<Record<string, unknown>> };
+    expect(body.subscribers).toEqual([
+      { userId: "u1", email: "pat@example.com", subscriptionId: "sub_1", status: "active", cancelAtPeriodEnd: false, currentPeriodEnd: null },
+    ]);
+  });
+
+  test("the scan validates its query and returns paid manual overrides", async () => {
+    expect((await GET_PRO_SCAN(new NextRequest("https://cmux.com/api/admin/pro-users/scan"))).status).toBe(400);
+    expect((await GET_PRO_SCAN(new NextRequest("https://cmux.com/api/admin/pro-users/scan?kind=nope"))).status).toBe(400);
+    expect((await GET_PRO_SCAN(new NextRequest("https://cmux.com/api/admin/pro-users/scan?kind=users&cursor=a%20b"))).status).toBe(400);
+    const response = await GET_PRO_SCAN(new NextRequest("https://cmux.com/api/admin/pro-users/scan?kind=users"));
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const body = (await response.json()) as { rows: Array<Record<string, unknown>>; nextCursor: string | null };
+    expect(body.rows.map((row) => [row.userId, row.plan])).toEqual([["u9", "pro"]]);
+    expect(body.nextCursor).toBeNull();
   });
 });


### PR DESCRIPTION
Adds an "All Pro users" section to `/dashboard/admin`, behind the same verified `cmux.com` / `manaflow.ai` / `manaflow.com` gate as the rest of the page (404 on the page, 401/403 on the API before any lookup, `cache-control: no-store`).

`/api/admin/pro-users` returns every active Stripe Pro subscriber and Team subscription from the local billing mirror (one row per owner, with the recorded customer email, period end, and cancel state) plus open pending email grants. `/api/admin/pro-users/scan?kind=users|teams` walks the Stack directory one bounded page at a time and keeps accounts with a paid manual `cmuxVmPlan` grant, since Stack has no metadata filter. The page loads the Stripe roster first, then streams both scans with progress counts and a page cap, and any row can be clicked to fill the search box for grant or downgrade actions.

Tests: `tests/admin-pro-list.test.ts` (roster and scan service) and gate, validation, and no-store cases in `tests/admin-users-route.test.ts`.

https://claude.ai/code/session_01PrCfEysHKCZFpXcqeRiPHL

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11645"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790942529&installation_model_id=21920&pr_number=11645&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11645&signature=ab7d5905b3ff970508bd97898cc213fa0591fb94474c97a92170313ca845b97a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an "All Pro users" section to `/dashboard/admin` so admins can see every account with Pro access and why, from both Stripe subscriptions and manual grants.

- `GET /api/admin/pro-users` returns active Stripe Pro subscribers, Team subscriptions, and pending email grants from the billing mirror.
- `GET /api/admin/pro-users/scan?kind=users|teams` pages through the Stack directory to find manual `cmuxVmPlan` grants.
- The page loads the Stripe roster first, then streams both directory scans with progress counts and a page cap.
- Clicking any row fills the search box for grant or downgrade actions.
- All responses are `no-store`; non-admins get 401 or 403 before any lookup.

<sup>Written for commit 22e3c7bd43f8273dac93373361f5ec92a93d4985. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

