### PR TITLE
cmux-tui: avoid roster worker self-join during Mux drop

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -19103,6 +19103,36 @@ mod tests {
         Mux::new_for_test("test", SurfaceOptions::default())
     }
 
+    #[test]
+    fn mux_drop_from_roster_worker_does_not_self_join() {
+        let mux = test_mux();
+        let weak = Arc::downgrade(&mux);
+        let (ready_sender, ready_receiver) = std::sync::mpsc::sync_channel(0);
+        let (release_sender, release_receiver) = std::sync::mpsc::sync_channel(0);
+        let (result_sender, result_receiver) = std::sync::mpsc::sync_channel(0);
+        let worker = std::thread::spawn(move || {
+            let worker_mux = weak.upgrade().expect("test mux stays alive for the worker");
+            ready_sender.send(()).unwrap();
+            release_receiver.recv().unwrap();
+            let dropped = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                drop(worker_mux);
+            }))
+            .is_ok();
+            result_sender.send(dropped).unwrap();
+        });
+        *mux.agent_roster_fold_worker_handle.lock().unwrap() = Some(worker);
+
+        ready_receiver.recv().unwrap();
+        // Dropping the last external owner leaves the worker-owned Arc as the
+        // owner that runs Mux::drop after it releases its shutdown gate.
+        drop(mux);
+        release_sender.send(()).unwrap();
+        assert!(
+            result_receiver.recv_timeout(Duration::from_secs(1)).unwrap_or(false),
+            "dropping Mux from its roster worker must not panic while joining itself"
+        );
+    }
+
     /// Direct registry appends stage a pending hook receipt by design. Tests
     /// that exercise only journal replay use this helper to model the paired
     /// projection having already committed, without invoking the live report

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -6202,9 +6202,34 @@ impl Mux {
             && !self.agent_roster_fold_worker_running.load(Ordering::Acquire)
         {
             if let Some(handle) = self.agent_roster_fold_worker_handle.lock().unwrap().take() {
-                let _ = handle.join();
+                Self::join_agent_roster_fold_worker(handle);
             }
         }
+    }
+
+    /// A worker can be the last owner of its mux. In that case dropping the
+    /// mux runs this cleanup on the worker itself, and joining its own handle
+    /// would deadlock or panic. Hand the join to a short-lived reaper so the
+    /// worker still gets joined after it finishes unwinding the mux.
+    fn join_agent_roster_fold_worker(handle: std::thread::JoinHandle<()>) {
+        if handle.thread().id() == std::thread::current().id() {
+            let spawn = std::thread::Builder::new().name("agent-roster-fold-reaper".into()).spawn(
+                move || {
+                    if handle.join().is_err() {
+                        eprintln!(
+                            "cmux-tui: agent roster fold worker panicked during self-join handoff"
+                        );
+                    }
+                },
+            );
+            if let Err(error) = spawn {
+                eprintln!(
+                    "cmux-tui: hand off agent roster fold worker self-join to reaper failed: {error}"
+                );
+            }
+            return;
+        }
+        let _ = handle.join();
     }
 
     fn run_agent_roster_fold_worker(mux: Weak<Self>, signal: Arc<JournalEventSignal>) {
@@ -18007,7 +18032,7 @@ impl Drop for Mux {
         if let Ok(handle) = self.agent_roster_fold_worker_handle.get_mut()
             && let Some(handle) = handle.take()
         {
-            let _ = handle.join();
+            Self::join_agent_roster_fold_worker(handle);
         }
         self.finalize_terminal_journal("mux drop");
         self.journal_kernel.shutdown();


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/11002.

Mux::drop can run on the roster worker when its Arc is the last owner. Joining the retained worker handle from that thread can deadlock or panic. This adds a test-first regression and hands self-join to a short-lived reaper thread; other callers still join synchronously.

Commits: test 878b9ddf95, fix 1f8685dfb4.

Checks: rustfmt --edition 2024 --check; git diff --check. Cargo/Rust tests were not run on the local Mac per cmux-tui policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790942681&installation_model_id=21920&pr_number=11646&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11646&signature=b515a9182c14f61eaf3c6ce83cbe756dee70cd5a42d7e7b92097e4e19d9eadfd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a deadlock when `Mux::drop` runs on the roster worker thread because it holds the last `Arc`. The old code would join its own handle from that thread and deadlock or panic; now the self-join is handed to a short-lived reaper thread, and other callers still join synchronously.

**Bug Fixes**
- Adds a regression test for dropping a `Mux` from its own roster worker.

<sup>Written for commit 1f8685dfb49a0301514822b477783b7440bb1df3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

