### PR TITLE
Fix notification hook descriptor inheritance

### DIFF
--- a/Sources/TerminalNotificationPolicy.swift
+++ b/Sources/TerminalNotificationPolicy.swift
@@ -629,7 +629,9 @@ private final class NotificationHookProcessRun: @unchecked Sendable {
         var attributes: posix_spawnattr_t?
         try throwIfPOSIXError(posix_spawnattr_init(&attributes), operation: "initialize spawn attributes")
         defer { posix_spawnattr_destroy(&attributes) }
-        let flags = Int16(POSIX_SPAWN_SETPGROUP)
+        // Keep unrelated app descriptors out of hooks. The dup2 actions above
+        // preserve the hook's standard streams.
+        let flags = Int16(POSIX_SPAWN_SETPGROUP | POSIX_SPAWN_CLOEXEC_DEFAULT)
         try throwIfPOSIXError(posix_spawnattr_setflags(&attributes, flags), operation: "set spawn flags")
         try throwIfPOSIXError(posix_spawnattr_setpgroup(&attributes, 0), operation: "set process group")
         let arguments = ["/bin/sh", "-c", hook.command]

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 import AppKit
+import Darwin
 import SwiftUI
+import Testing
 import UniformTypeIdentifiers
 import WebKit
 import ObjectiveC.runtime
@@ -32,6 +34,47 @@ private final class NotificationHookEvaluationResultBox: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return stored
+    }
+}
+
+@Suite("Notification hook process isolation")
+struct NotificationHookProcessIsolationTests {
+    @Test
+    func hookDoesNotInheritUnrelatedParentFileDescriptor() async throws {
+        var unrelatedPipe = [Int32](repeating: -1, count: 2)
+        try #require(Darwin.pipe(&unrelatedPipe) == 0)
+        defer {
+            for descriptor in unrelatedPipe where descriptor >= 0 {
+                Darwin.close(descriptor)
+            }
+        }
+        let unrelatedDescriptor = try #require(unrelatedPipe.first)
+        try #require(unrelatedDescriptor > STDERR_FILENO)
+
+        let request = TerminalNotificationPolicyRequest(
+            tabId: UUID(),
+            surfaceId: nil,
+            title: "Title",
+            subtitle: "",
+            body: "Body",
+            cwd: FileManager.default.temporaryDirectory.path,
+            isAppFocused: false,
+            isFocusedPanel: false
+        )
+        let hook = CmuxResolvedNotificationHook(
+            id: "descriptor-isolation",
+            command: "if [ -e /dev/fd/\(unrelatedDescriptor) ]; then printf '{\"notification\":{\"body\":\"inherited\"}}'; else cat; fi",
+            timeoutSeconds: 5,
+            sourcePath: "/tmp/cmux.json",
+            cwd: FileManager.default.temporaryDirectory.path
+        )
+
+        let result = await TerminalNotificationPolicyEngine.evaluate(
+            request: request,
+            hooks: [hook]
+        )
+        let envelope = try result.get()
+        #expect(envelope.notification.body == "Body")
     }
 }
 


### PR DESCRIPTION
## Summary

- Close unrelated parent file descriptors when cmux spawns a notification policy hook.
- Preserve the hook's stdin, stdout, and stderr through the existing `dup2` actions.
- Add a regression test that opens an unrelated pipe in the app process and verifies that the hook cannot see it.
- This prevents inherited pipe writers from keeping hook stdin open. Those stalls caused 20-second hook timeouts, hook-failure alerts, and fail-open desktop approval banners.

## Testing

- Regression protocol: `94338a40f1` contains the test only. The equivalent pre-rebase test-only commit returned `"inherited"` instead of the original notification body.
- `CMUX_SKIP_ZIG_BUILD=1 xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -derivedDataPath /tmp/cmux-notification-fd-clean-derived -only-testing:cmuxTests/NotificationHookProcessIsolationTests -only-testing:cmuxTests/TerminalNotificationPolicyEngineTests`
- Result: 16 policy engine tests passed. The Swift Testing regression test also passed. There were no failures.
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag notification-fd --launch`
- Result: the exact branch head built and launched. The tagged socket responded to `list-workspaces`.
- Manual runtime probe on the equivalent pre-rebase fix head: a synthetic Codex permission event completed its policy hook with `desktop=0` and no hook timeout or hook-failure alert.
- Local build note: the repository's Diff Sidecar artifact verifier exits early when `dwarfdump` returns its normal no-DWARF status. I applied `|| true` only in the local clean worktree during builds, then removed it. That unrelated workaround is not in this PR.
- Localization audit: no user-facing strings changed.

## Demo Video

This change has no visible UI state to record. The tagged runtime probe verified the behavior through the notification policy log.

- Video URL or attachment: Not applicable.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification hook process isolation by preventing unrelated application file descriptors from being inherited.
  - Notification hooks now receive only the intended standard input, output, and error streams, reducing the risk of unintended resource access and improving reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->