### PR TITLE
cmux-wg: enforce AllowedIPs for direct outbound connects

### DIFF
--- a/cmux-tui/crates/cmux-wg/src/net.rs
+++ b/cmux-tui/crates/cmux-wg/src/net.rs
@@ -734,6 +734,10 @@ impl Driver {
         remote: SocketAddr,
         reply: oneshot::Sender<Result<WgStream, WgError>>,
     ) {
+        if !self.config.routes_contain(remote.ip()) {
+            let _ = reply.send(Err(WgError::RouteNotAllowed(remote.ip())));
+            return;
+        }
         let Some(local_ip) = self.config.local_address_for(remote.ip()) else {
             let _ = reply.send(Err(WgError::NoTunnelAddress(remote.ip())));
             return;

--- a/cmux-tui/crates/cmux-wg/src/net.rs
+++ b/cmux-tui/crates/cmux-wg/src/net.rs
@@ -86,6 +86,8 @@ pub enum WgError {
     NoTunnelAddress(IpAddr),
     /// The remote answered the SYN with a reset, or never answered.
     ConnectionRefused(SocketAddr),
+    /// The destination is outside the peer's configured `AllowedIPs`.
+    RouteNotAllowed(IpAddr),
     /// A listener already owns the port.
     ListenerBusy(u16),
     /// The tunnel has been shut down.
@@ -106,6 +108,9 @@ impl fmt::Display for WgError {
                 write!(formatter, "no tunnel address in the same family as {remote}")
             }
             Self::ConnectionRefused(remote) => write!(formatter, "{remote} refused the connection"),
+            Self::RouteNotAllowed(remote) => {
+                write!(formatter, "destination {remote} is outside the tunnel routes")
+            }
             Self::ListenerBusy(port) => write!(formatter, "port {port} already has a listener"),
             Self::Shutdown => formatter.write_str("the tunnel is shut down"),
             Self::Stack(detail) => write!(formatter, "tcp stack: {detail}"),

--- a/cmux-tui/crates/cmux-wg/tests/tunnel.rs
+++ b/cmux-tui/crates/cmux-wg/tests/tunnel.rs
@@ -126,6 +126,24 @@ async fn a_closed_port_is_refused_and_routes_are_reported() {
 }
 
 #[tokio::test]
+async fn outbound_connect_rejects_target_outside_allowed_ips() {
+    let LoopbackPair { client, server, client_socket, server_socket, .. } =
+        loopback_pair().await.unwrap();
+    let server = WgNet::start(server, server_socket).await.unwrap();
+    let client = WgNet::start(client, client_socket).await.unwrap();
+    let target = SocketAddr::new("10.201.0.1".parse().unwrap(), 1337);
+
+    let error = within(client.connect(target)).await.unwrap_err();
+    assert!(
+        matches!(error, WgError::RouteNotAllowed(address) if address == target.ip()),
+        "{error}"
+    );
+
+    client.shutdown().await;
+    server.shutdown().await;
+}
+
+#[tokio::test]
 async fn dropping_the_tunnel_ends_its_streams() {
     let LoopbackPair { client, server, client_socket, server_socket, server_v4, .. } =
         loopback_pair().await.unwrap();


### PR DESCRIPTION
## Summary

- reject direct `WgNet::connect` targets outside the peer's configured `AllowedIPs`
- add a behavior test covering a same-family target outside the route set

`WgNet::begin_connect` is the shared driver path for the public outbound API, so the check applies even when callers do not use the SOCKS hub's preflight. WireGuard's cryptokey routing associates peer keys with allowed IPs and uses destination matching for outbound encryption: https://www.wireguard.com/

Stacked on PR #11638 (`feat-ios-userspace-wireguard`, head `2963d70bbccb584bf2dfc270b2222cfc0f454583`). Do not merge until that PR lands.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces WireGuard's AllowedIPs on direct outbound connects in `cmux-wg`, so `WgNet::connect` now rejects destinations outside the peer's configured routes with a new `RouteNotAllowed` error instead of attempting the connection.

- Adds `WgError::RouteNotAllowed` to report rejected destinations.
- Adds a test covering a same-family target outside the allowed routes.

<sup>Written for commit b2add3e2bb7eaaef4ccc346f646442cca38f13ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

