### PR TITLE
cmux-wg: use central ephemeral port reservations

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -417,6 +417,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "boringtun"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15dd6a8a89cbe8997f37ca0cf035e6ea4d64cd2ecea4aed83ffb9f99f7126939"
+dependencies = [
+ "aead",
+ "base64",
+ "blake2",
+ "chacha20poly1305",
+ "hex",
+ "hmac",
+ "ip_network",
+ "ip_network_table",
+ "libc",
+ "nix 0.31.3",
+ "parking_lot",
+ "portable-atomic",
+ "rand_core 0.6.4",
+ "ring",
+ "tracing",
+ "untrusted",
+ "x25519-dalek",
+]
+
+[[package]]
 name = "borrow-or-share"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +480,12 @@ name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95832e849adfb21180ccb6826a99da14e5d266ae5c2e668e1602cf234f153797"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -665,6 +696,7 @@ dependencies = [
  "cmux-remote-protocol",
  "cmux-tui-core",
  "cmux-tui-source-watch",
+ "cmux-wg",
  "diffy",
  "fs4",
  "futures-util",
@@ -761,6 +793,7 @@ dependencies = [
  "cmux-tui-core",
  "cmux-tui-machine-agent-protocol",
  "cmux-tui-machine-protocol",
+ "cmux-wg",
  "crossbeam-channel",
  "crossterm",
  "fs4",
@@ -853,6 +886,22 @@ dependencies = [
 [[package]]
 name = "cmux-tui-source-watch"
 version = "0.0.0"
+
+[[package]]
+name = "cmux-wg"
+version = "0.1.0"
+dependencies = [
+ "base64",
+ "boringtun",
+ "bytes",
+ "getrandom 0.3.4",
+ "ip_network",
+ "smoltcp",
+ "tokio",
+ "tokio-util",
+ "x25519-dalek",
+ "zeroize",
+]
 
 [[package]]
 name = "cobs"
@@ -1043,6 +1092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -1186,6 +1236,37 @@ checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
 dependencies = [
  "data-encoding",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.19",
 ]
 
 [[package]]
@@ -1838,6 +1919,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1857,6 +1947,16 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash",
+]
+
+[[package]]
+name = "heapless"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ba4bd83f9415b58b4ed8dc5714c76e626a105be4646c02630ad730ad3b5aa4"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2306,6 +2406,28 @@ dependencies = [
  "quote",
  "syn 3.0.3",
 ]
+
+[[package]]
+name = "ip_network"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2f047c0a98b2f299aa5d6d7088443570faae494e9ae1305e48be000c9e0eb1"
+
+[[package]]
+name = "ip_network_table"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4099b7cfc5c5e2fe8c5edf3f6f7adf7a714c9cc697534f63a5a5da30397cb2c0"
+dependencies = [
+ "ip_network",
+ "ip_network_table-deps-treebitmap",
+]
+
+[[package]]
+name = "ip_network_table-deps-treebitmap"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e537132deb99c0eb4b752f0346b6a836200eaaa3516dd7e5514b63930a09e5d"
 
 [[package]]
 name = "ipconfig"
@@ -2793,6 +2915,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3074,6 +3202,18 @@ dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
  "memoffset",
+]
+
+[[package]]
+name = "nix"
+version = "0.31.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if",
+ "cfg_aliases 0.2.2",
+ "libc",
 ]
 
 [[package]]
@@ -3965,6 +4105,9 @@ name = "rand_core"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
 
 [[package]]
 name = "rand_core"
@@ -4729,6 +4872,20 @@ name = "smallvec"
 version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+
+[[package]]
+name = "smoltcp"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6f8b28ad56c6e35524a37dd492af5d1a47e31e1a4d175cd12f89c075f01980f"
+dependencies = [
+ "bitflags 1.3.2",
+ "byteorder",
+ "cfg-if",
+ "defmt",
+ "heapless",
+ "managed",
+]
 
 [[package]]
 name = "snow"

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -31,6 +31,7 @@ members = [
     "crates/cmux-tui-machine-agent-protocol",
     "crates/cmux-tui-machine-protocol",
     "crates/cmux-tui",
+    "crates/cmux-wg",
 ]
 default-members = [
     "bindings/rust",
@@ -47,6 +48,7 @@ default-members = [
     "crates/cmux-tui-machine-agent-protocol",
     "crates/cmux-tui-machine-protocol",
     "crates/cmux-tui",
+    "crates/cmux-wg",
 ]
 exclude = ["vendor/crossterm"]
 
@@ -74,6 +76,7 @@ cmux-tui-cdp = { path = "crates/cmux-tui-cdp" }
 cmux-pty = { path = "crates/cmux-pty" }
 cmux-remote-protocol = { path = "crates/cmux-remote-protocol" }
 cmux-remote = { path = "crates/cmux-remote" }
+cmux-wg = { path = "crates/cmux-wg" }
 cmux-tui-machine-agent-protocol = { path = "crates/cmux-tui-machine-agent-protocol" }
 cmux-tui-machine-protocol = { path = "crates/cmux-tui-machine-protocol" }
 anyhow = "1"
@@ -92,6 +95,13 @@ ratatui = "0.30"
 unicode-width = "0.2"
 unicode-segmentation = "1"
 base64 = "0.22"
+# In-process WireGuard for Cloud VM attach (crates/cmux-wg). boringtun's
+# `noise` module is the sans-IO WireGuard session; no tun device, no ffi.
+boringtun = { version = "0.7", default-features = false }
+# ip_network is what boringtun already uses for AllowedIPs, so it adds no code.
+ip_network = "0.4"
+# smoltcp is the userspace TCP/IP stack those tunnels terminate in.
+smoltcp = { version = "0.14", default-features = false, features = ["std", "medium-ip", "proto-ipv4", "proto-ipv6", "socket-tcp", "async"] }
 png = "0.17"
 libc = "0.2"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake"] }

--- a/cmux-tui/crates/cmux-remote/Cargo.toml
+++ b/cmux-tui/crates/cmux-remote/Cargo.toml
@@ -11,8 +11,11 @@ description = "Authenticated remote daemon, transports, and workspace services f
 workspace = true
 
 [features]
-default = ["iroh-transport"]
+default = ["iroh-transport", "wireguard-transport"]
 iroh-transport = ["dep:iroh", "dep:socket2"]
+# Dial `ws://` routes through an in-process WireGuard tunnel (cmux-wg) when
+# the target sits inside the tunnel's routes.
+wireguard-transport = ["dep:cmux-wg"]
 
 [dependencies]
 anyhow.workspace = true
@@ -23,6 +26,7 @@ bytes.workspace = true
 cmux-pty.workspace = true
 cmux-remote-protocol.workspace = true
 cmux-tui-core.workspace = true
+cmux-wg = { workspace = true, optional = true }
 diffy.workspace = true
 fs4.workspace = true
 futures-util.workspace = true
@@ -56,6 +60,7 @@ cmux-tui-source-watch = { path = "../.." }
 
 [dev-dependencies]
 cmux-relay = { path = "../cmux-relay" }
+cmux-wg = { workspace = true, features = ["test-support"] }
 rcgen = "0.14"
 tempfile = "3"
 tokio = { workspace = true, features = ["test-util"] }

--- a/cmux-tui/crates/cmux-remote/Cargo.toml
+++ b/cmux-tui/crates/cmux-remote/Cargo.toml
@@ -60,7 +60,7 @@ cmux-tui-source-watch = { path = "../.." }
 
 [dev-dependencies]
 cmux-relay = { path = "../cmux-relay" }
-cmux-wg = { workspace = true, features = ["test-support"] }
+cmux-wg.workspace = true
 rcgen = "0.14"
 tempfile = "3"
 tokio = { workspace = true, features = ["test-util"] }

--- a/cmux-tui/crates/cmux-remote/src/lib.rs
+++ b/cmux-tui/crates/cmux-remote/src/lib.rs
@@ -34,4 +34,6 @@ pub mod session;
 pub mod ssh_bootstrap;
 #[cfg(unix)]
 mod unix_socket;
+#[cfg(feature = "wireguard-transport")]
+pub mod wireguard_hub;
 pub mod workspace;

--- a/cmux-tui/crates/cmux-remote/src/provider/dial.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/dial.rs
@@ -1,0 +1,152 @@
+//! How a direct route's bytes reach the wire.
+//!
+//! A route names the daemon (`ws://[fd7a::10]:1337/v1/link`); it says nothing
+//! about how this client reaches that address. Usually the operating system
+//! does, over its own TCP stack and whatever interfaces it has. A cmux Cloud
+//! machine sits on a private network with no public port, so a client without
+//! a system WireGuard interface needs another carrier: an in-process tunnel
+//! (`cmux-wg`) whose TCP stack lives in this process.
+//!
+//! The [`Dialer`] is that seam. It produces a byte stream for a host and port;
+//! TLS, the WebSocket upgrade, and the cmux Noise handshake run above it
+//! unchanged. The route the control plane hands out is the same either way.
+
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use tokio::io::{AsyncRead, AsyncWrite};
+use tokio::net::TcpStream;
+
+use crate::link::LinkError;
+
+/// A connected, ordered byte stream to the dialed host.
+pub type DialedStream = Box<dyn AsyncRead + AsyncWrite + Send + Sync + Unpin>;
+
+/// Produces a byte stream to `host:port`. Implementations own the carrier only.
+#[async_trait]
+pub trait Dialer: Send + Sync + fmt::Debug {
+    fn name(&self) -> &'static str;
+    async fn dial(&self, host: &str, port: u16) -> Result<DialedStream, LinkError>;
+}
+
+/// Resolve a URL host (an IP literal, a bracketed IPv6 literal, or a name) to
+/// socket addresses without touching the network for literals.
+pub async fn resolve_dial_target(host: &str, port: u16) -> Result<Vec<SocketAddr>, LinkError> {
+    let bare = host.strip_prefix('[').and_then(|rest| rest.strip_suffix(']')).unwrap_or(host);
+    if let Ok(address) = bare.parse::<IpAddr>() {
+        return Ok(vec![SocketAddr::new(address, port)]);
+    }
+    let addresses = tokio::net::lookup_host((bare, port))
+        .await
+        .map_err(|error| LinkError::Transport(format!("resolve {bare}: {error}")))?
+        .collect::<Vec<_>>();
+    if addresses.is_empty() {
+        return Err(LinkError::Transport(format!("{bare} resolved to no addresses")));
+    }
+    Ok(addresses)
+}
+
+/// The operating system's TCP stack. Tries every resolved address in order,
+/// with Nagle disabled because the link carries keystrokes.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct OsTcpDialer;
+
+#[async_trait]
+impl Dialer for OsTcpDialer {
+    fn name(&self) -> &'static str {
+        "tcp"
+    }
+
+    async fn dial(&self, host: &str, port: u16) -> Result<DialedStream, LinkError> {
+        let addresses = resolve_dial_target(host, port).await?;
+        let mut last_error = None;
+        for address in addresses {
+            match TcpStream::connect(address).await {
+                Ok(stream) => {
+                    let _ = stream.set_nodelay(true);
+                    return Ok(Box::new(stream));
+                }
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Err(LinkError::Transport(match last_error {
+            Some(error) => format!("connect {host}:{port}: {error}"),
+            None => format!("connect {host}:{port}: no addresses"),
+        }))
+    }
+}
+
+/// An in-process WireGuard tunnel for addresses inside its routes; everything
+/// else goes to the fallback dialer.
+#[cfg(feature = "wireguard-transport")]
+pub struct WireGuardDialer {
+    net: Arc<cmux_wg::WgNet>,
+    fallback: Arc<dyn Dialer>,
+}
+
+#[cfg(feature = "wireguard-transport")]
+impl WireGuardDialer {
+    /// Tunnel addresses go through `net`; others use the operating system.
+    pub fn new(net: Arc<cmux_wg::WgNet>) -> Self {
+        Self::with_fallback(net, Arc::new(OsTcpDialer))
+    }
+
+    pub fn with_fallback(net: Arc<cmux_wg::WgNet>, fallback: Arc<dyn Dialer>) -> Self {
+        Self { net, fallback }
+    }
+
+    pub fn net(&self) -> &Arc<cmux_wg::WgNet> {
+        &self.net
+    }
+}
+
+#[cfg(feature = "wireguard-transport")]
+impl fmt::Debug for WireGuardDialer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WireGuardDialer")
+            .field("routes", &self.net.routes())
+            .field("fallback", &self.fallback)
+            .finish()
+    }
+}
+
+#[cfg(feature = "wireguard-transport")]
+#[async_trait]
+impl Dialer for WireGuardDialer {
+    fn name(&self) -> &'static str {
+        "wireguard"
+    }
+
+    async fn dial(&self, host: &str, port: u16) -> Result<DialedStream, LinkError> {
+        let addresses = resolve_dial_target(host, port).await?;
+        if let Some(address) =
+            addresses.iter().copied().find(|address| self.net.routes_contain(address.ip()))
+        {
+            let stream = self.net.connect(address).await.map_err(|error| {
+                LinkError::Transport(format!("wireguard connect {address}: {error}"))
+            })?;
+            return Ok(Box::new(stream));
+        }
+        self.fallback.dial(host, port).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn literals_resolve_without_dns() {
+        assert_eq!(
+            resolve_dial_target("[fd7a::10]", 1337).await.unwrap(),
+            vec!["[fd7a::10]:1337".parse::<SocketAddr>().unwrap()]
+        );
+        assert_eq!(
+            resolve_dial_target("10.100.0.10", 1337).await.unwrap(),
+            vec!["10.100.0.10:1337".parse::<SocketAddr>().unwrap()]
+        );
+    }
+}

--- a/cmux-tui/crates/cmux-remote/src/provider/dial.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/dial.rs
@@ -21,8 +21,15 @@ use tokio::net::TcpStream;
 
 use crate::link::LinkError;
 
+/// The bounds a dialed carrier must satisfy. Blanket-implemented, so any
+/// Tokio stream qualifies; the trait exists only because a trait object can
+/// name one non-auto trait.
+pub trait DialedIo: AsyncRead + AsyncWrite + Send + Sync + Unpin {}
+
+impl<T: AsyncRead + AsyncWrite + Send + Sync + Unpin + ?Sized> DialedIo for T {}
+
 /// A connected, ordered byte stream to the dialed host.
-pub type DialedStream = Box<dyn AsyncRead + AsyncWrite + Send + Sync + Unpin>;
+pub type DialedStream = Box<dyn DialedIo>;
 
 /// Produces a byte stream to `host:port`. Implementations own the carrier only.
 #[async_trait]

--- a/cmux-tui/crates/cmux-remote/src/provider/dial.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/dial.rs
@@ -13,13 +13,15 @@
 
 use std::fmt;
 use std::net::{IpAddr, SocketAddr};
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use tokio::io::{AsyncRead, AsyncWrite};
-use tokio::net::TcpStream;
+use tokio::net::{TcpStream, UnixStream};
 
 use crate::link::LinkError;
+use crate::provider::socks;
 
 /// The bounds a dialed carrier must satisfy. Blanket-implemented, so any
 /// Tokio stream qualifies; the trait exists only because a trait object can
@@ -81,6 +83,59 @@ impl Dialer for OsTcpDialer {
         Err(LinkError::Transport(match last_error {
             Some(error) => format!("connect {host}:{port}: {error}"),
             None => format!("connect {host}:{port}: no addresses"),
+        }))
+    }
+}
+
+/// SOCKS5 CONNECT through a hub process on a Unix socket
+/// (`cmux-tui wg hub`). Used by sidecars that share one WireGuard tunnel: the
+/// hub owns the key, the sidecar owns nothing but this path. Names are
+/// resolved here and sent as literal addresses, because the hub dials
+/// literals only.
+pub struct SocksDialer {
+    path: PathBuf,
+}
+
+impl SocksDialer {
+    pub fn new(path: impl Into<PathBuf>) -> Self {
+        Self { path: path.into() }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl fmt::Debug for SocksDialer {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.debug_struct("SocksDialer").field("path", &self.path).finish()
+    }
+}
+
+#[async_trait]
+impl Dialer for SocksDialer {
+    fn name(&self) -> &'static str {
+        "socks-hub"
+    }
+
+    async fn dial(&self, host: &str, port: u16) -> Result<DialedStream, LinkError> {
+        let addresses = resolve_dial_target(host, port).await?;
+        let mut last_error = None;
+        for address in addresses {
+            let mut stream = UnixStream::connect(&self.path).await.map_err(|error| {
+                LinkError::Transport(format!(
+                    "wireguard hub {} is not reachable: {error}",
+                    self.path.display()
+                ))
+            })?;
+            match socks::client_connect(&mut stream, address).await {
+                Ok(()) => return Ok(Box::new(stream)),
+                Err(error) => last_error = Some(error),
+            }
+        }
+        Err(LinkError::Transport(match last_error {
+            Some(error) => format!("wireguard hub {}: {error}", self.path.display()),
+            None => format!("wireguard hub {}: no addresses for {host}", self.path.display()),
         }))
     }
 }

--- a/cmux-tui/crates/cmux-remote/src/provider/mod.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/mod.rs
@@ -8,6 +8,7 @@ mod dial;
 #[cfg(feature = "iroh-transport")]
 mod iroh;
 mod relay;
+pub(crate) mod socks;
 mod ssh;
 mod stream;
 #[cfg(unix)]
@@ -41,7 +42,7 @@ pub use stream::LengthDelimitedLink;
 pub use unix::UnixProvider;
 #[cfg(feature = "wireguard-transport")]
 pub use dial::WireGuardDialer;
-pub use dial::{DialedIo, DialedStream, Dialer, OsTcpDialer, resolve_dial_target};
+pub use dial::{DialedIo, DialedStream, Dialer, OsTcpDialer, SocksDialer, resolve_dial_target};
 pub use websocket::{
     AxumWebSocketLink, DirectWebSocketProvider, TungsteniteWebSocketLink, connect_websocket,
     connect_websocket_via,

--- a/cmux-tui/crates/cmux-remote/src/provider/mod.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/mod.rs
@@ -4,6 +4,7 @@
 //! encryption, authorization, replay, and application services remain above
 //! this boundary, so a relay or a TLS terminator is never an authority.
 
+mod dial;
 #[cfg(feature = "iroh-transport")]
 mod iroh;
 mod relay;
@@ -38,8 +39,12 @@ pub use ssh::{SshProvider, SshProviderConfig};
 pub use stream::LengthDelimitedLink;
 #[cfg(unix)]
 pub use unix::UnixProvider;
+#[cfg(feature = "wireguard-transport")]
+pub use dial::WireGuardDialer;
+pub use dial::{DialedStream, Dialer, OsTcpDialer, resolve_dial_target};
 pub use websocket::{
     AxumWebSocketLink, DirectWebSocketProvider, TungsteniteWebSocketLink, connect_websocket,
+    connect_websocket_via,
 };
 
 /// Non-authoritative facts learned from the carrier.

--- a/cmux-tui/crates/cmux-remote/src/provider/mod.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/mod.rs
@@ -41,7 +41,7 @@ pub use stream::LengthDelimitedLink;
 pub use unix::UnixProvider;
 #[cfg(feature = "wireguard-transport")]
 pub use dial::WireGuardDialer;
-pub use dial::{DialedStream, Dialer, OsTcpDialer, resolve_dial_target};
+pub use dial::{DialedIo, DialedStream, Dialer, OsTcpDialer, resolve_dial_target};
 pub use websocket::{
     AxumWebSocketLink, DirectWebSocketProvider, TungsteniteWebSocketLink, connect_websocket,
     connect_websocket_via,

--- a/cmux-tui/crates/cmux-remote/src/provider/socks.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/socks.rs
@@ -1,0 +1,308 @@
+//! The subset of SOCKS5 (RFC 1928) the WireGuard hub speaks: CONNECT, no
+//! authentication, literal IP targets. Shared by the hub (server side) and
+//! [`super::SocksDialer`] (client side) so the two cannot drift.
+
+use std::fmt;
+use std::io;
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+pub(crate) const VERSION: u8 = 0x05;
+pub(crate) const METHOD_NO_AUTH: u8 = 0x00;
+pub(crate) const METHOD_UNACCEPTABLE: u8 = 0xFF;
+pub(crate) const COMMAND_CONNECT: u8 = 0x01;
+pub(crate) const ADDRESS_IPV4: u8 = 0x01;
+pub(crate) const ADDRESS_DOMAIN: u8 = 0x03;
+pub(crate) const ADDRESS_IPV6: u8 = 0x04;
+
+pub(crate) const REPLY_SUCCEEDED: u8 = 0x00;
+pub(crate) const REPLY_GENERAL_FAILURE: u8 = 0x01;
+pub(crate) const REPLY_NOT_ALLOWED: u8 = 0x02;
+pub(crate) const REPLY_NETWORK_UNREACHABLE: u8 = 0x03;
+pub(crate) const REPLY_HOST_UNREACHABLE: u8 = 0x04;
+pub(crate) const REPLY_CONNECTION_REFUSED: u8 = 0x05;
+pub(crate) const REPLY_COMMAND_NOT_SUPPORTED: u8 = 0x07;
+pub(crate) const REPLY_ADDRESS_TYPE_NOT_SUPPORTED: u8 = 0x08;
+
+/// Longest domain name a request may carry; RFC 1928 uses one length byte.
+const MAX_DOMAIN_BYTES: usize = 255;
+
+pub(crate) fn reply_description(code: u8) -> &'static str {
+    match code {
+        REPLY_SUCCEEDED => "succeeded",
+        REPLY_GENERAL_FAILURE => "general failure",
+        REPLY_NOT_ALLOWED => "connection not allowed by ruleset",
+        REPLY_NETWORK_UNREACHABLE => "network unreachable",
+        REPLY_HOST_UNREACHABLE => "host unreachable",
+        REPLY_CONNECTION_REFUSED => "connection refused",
+        0x06 => "TTL expired",
+        REPLY_COMMAND_NOT_SUPPORTED => "command not supported",
+        REPLY_ADDRESS_TYPE_NOT_SUPPORTED => "address type not supported",
+        _ => "unassigned reply code",
+    }
+}
+
+#[derive(Debug)]
+pub(crate) enum SocksError {
+    Io(io::Error),
+    /// The peer spoke something other than the SOCKS5 subset above.
+    Protocol(String),
+    /// The server answered CONNECT with a non-success reply.
+    Reply(u8),
+}
+
+impl fmt::Display for SocksError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "socks io: {error}"),
+            Self::Protocol(detail) => write!(formatter, "socks protocol: {detail}"),
+            Self::Reply(code) => {
+                write!(formatter, "socks reply 0x{code:02x} ({})", reply_description(*code))
+            }
+        }
+    }
+}
+
+impl std::error::Error for SocksError {}
+
+impl From<io::Error> for SocksError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// What a client asked the hub to connect to.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Target {
+    Ip(SocketAddr),
+    Domain { name: String, port: u16 },
+}
+
+/// A parsed CONNECT-style request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Request {
+    pub(crate) command: u8,
+    pub(crate) target: Target,
+}
+
+// ---- client side -----------------------------------------------------------
+
+/// Run the client half of a SOCKS5 CONNECT for `target` over `stream`. On
+/// success the stream carries the tunneled connection from here on.
+pub(crate) async fn client_connect<S>(stream: &mut S, target: SocketAddr) -> Result<(), SocksError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    stream.write_all(&[VERSION, 1, METHOD_NO_AUTH]).await?;
+    let mut chosen = [0u8; 2];
+    stream.read_exact(&mut chosen).await?;
+    if chosen[0] != VERSION {
+        return Err(SocksError::Protocol(format!("server version {}", chosen[0])));
+    }
+    if chosen[1] != METHOD_NO_AUTH {
+        return Err(SocksError::Protocol(format!("server selected method 0x{:02x}", chosen[1])));
+    }
+
+    let mut request = vec![VERSION, COMMAND_CONNECT, 0x00];
+    push_address(&mut request, target);
+    stream.write_all(&request).await?;
+
+    let mut head = [0u8; 4];
+    stream.read_exact(&mut head).await?;
+    if head[0] != VERSION {
+        return Err(SocksError::Protocol(format!("reply version {}", head[0])));
+    }
+    // Drain the bound address so the stream is positioned at the payload.
+    let _ = read_address(stream, head[3]).await?;
+    if head[1] != REPLY_SUCCEEDED {
+        return Err(SocksError::Reply(head[1]));
+    }
+    Ok(())
+}
+
+// ---- server side -----------------------------------------------------------
+
+/// Negotiate the method with a client. Returns `true` when no-auth was agreed
+/// and the client may send a request; `false` after telling the client no
+/// method was acceptable.
+pub(crate) async fn server_greet<S>(stream: &mut S) -> Result<bool, SocksError>
+where
+    S: AsyncRead + AsyncWrite + Unpin,
+{
+    let mut head = [0u8; 2];
+    stream.read_exact(&mut head).await?;
+    if head[0] != VERSION {
+        return Err(SocksError::Protocol(format!("client version {}", head[0])));
+    }
+    let mut methods = vec![0u8; usize::from(head[1])];
+    stream.read_exact(&mut methods).await?;
+    if methods.contains(&METHOD_NO_AUTH) {
+        stream.write_all(&[VERSION, METHOD_NO_AUTH]).await?;
+        Ok(true)
+    } else {
+        stream.write_all(&[VERSION, METHOD_UNACCEPTABLE]).await?;
+        Ok(false)
+    }
+}
+
+/// Read one request after a successful greeting.
+pub(crate) async fn server_read_request<S>(stream: &mut S) -> Result<Request, SocksError>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut head = [0u8; 4];
+    stream.read_exact(&mut head).await?;
+    if head[0] != VERSION {
+        return Err(SocksError::Protocol(format!("request version {}", head[0])));
+    }
+    let target = read_address(stream, head[3]).await?;
+    Ok(Request { command: head[1], target })
+}
+
+/// Write a reply. `bound` is the server-side address of the tunneled
+/// connection on success; failures report an all-zero IPv4 binding.
+pub(crate) async fn server_reply<S>(
+    stream: &mut S,
+    code: u8,
+    bound: Option<SocketAddr>,
+) -> Result<(), SocksError>
+where
+    S: AsyncWrite + Unpin,
+{
+    let mut reply = vec![VERSION, code, 0x00];
+    push_address(
+        &mut reply,
+        bound.unwrap_or_else(|| SocketAddr::new(IpAddr::V4(Ipv4Addr::UNSPECIFIED), 0)),
+    );
+    stream.write_all(&reply).await?;
+    Ok(())
+}
+
+fn push_address(buffer: &mut Vec<u8>, address: SocketAddr) {
+    match address.ip() {
+        IpAddr::V4(ip) => {
+            buffer.push(ADDRESS_IPV4);
+            buffer.extend_from_slice(&ip.octets());
+        }
+        IpAddr::V6(ip) => {
+            buffer.push(ADDRESS_IPV6);
+            buffer.extend_from_slice(&ip.octets());
+        }
+    }
+    buffer.extend_from_slice(&address.port().to_be_bytes());
+}
+
+async fn read_address<S>(stream: &mut S, address_type: u8) -> Result<Target, SocksError>
+where
+    S: AsyncRead + Unpin,
+{
+    match address_type {
+        ADDRESS_IPV4 => {
+            let mut octets = [0u8; 4];
+            stream.read_exact(&mut octets).await?;
+            let port = read_port(stream).await?;
+            Ok(Target::Ip(SocketAddr::new(IpAddr::V4(Ipv4Addr::from(octets)), port)))
+        }
+        ADDRESS_IPV6 => {
+            let mut octets = [0u8; 16];
+            stream.read_exact(&mut octets).await?;
+            let port = read_port(stream).await?;
+            Ok(Target::Ip(SocketAddr::new(IpAddr::V6(Ipv6Addr::from(octets)), port)))
+        }
+        ADDRESS_DOMAIN => {
+            let length = usize::from(stream.read_u8().await?);
+            if length == 0 || length > MAX_DOMAIN_BYTES {
+                return Err(SocksError::Protocol(format!("domain length {length}")));
+            }
+            let mut name = vec![0u8; length];
+            stream.read_exact(&mut name).await?;
+            let port = read_port(stream).await?;
+            Ok(Target::Domain { name: String::from_utf8_lossy(&name).into_owned(), port })
+        }
+        other => Err(SocksError::Protocol(format!("address type 0x{other:02x}"))),
+    }
+}
+
+async fn read_port<S>(stream: &mut S) -> Result<u16, SocksError>
+where
+    S: AsyncRead + Unpin,
+{
+    let mut port = [0u8; 2];
+    stream.read_exact(&mut port).await?;
+    Ok(u16::from_be_bytes(port))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn client_and_server_halves_agree_on_the_wire() {
+        let (mut client, mut server) = tokio::io::duplex(256);
+        let target: SocketAddr = "[fd7a::10]:1337".parse().unwrap();
+        let server_side = async {
+            assert!(server_greet(&mut server).await.unwrap());
+            let request = server_read_request(&mut server).await.unwrap();
+            assert_eq!(request.command, COMMAND_CONNECT);
+            assert_eq!(request.target, Target::Ip(target));
+            server_reply(&mut server, REPLY_SUCCEEDED, Some("100.64.0.1:50000".parse().unwrap()))
+                .await
+                .unwrap();
+        };
+        let client_side = async { client_connect(&mut client, target).await.unwrap() };
+        tokio::join!(server_side, client_side);
+    }
+
+    #[tokio::test]
+    async fn a_failure_reply_surfaces_its_code() {
+        let (mut client, mut server) = tokio::io::duplex(256);
+        let server_side = async {
+            assert!(server_greet(&mut server).await.unwrap());
+            let _ = server_read_request(&mut server).await.unwrap();
+            server_reply(&mut server, REPLY_NOT_ALLOWED, None).await.unwrap();
+        };
+        let client_side = async {
+            let error = client_connect(&mut client, "10.0.0.1:80".parse().unwrap()).await.unwrap_err();
+            assert!(matches!(error, SocksError::Reply(REPLY_NOT_ALLOWED)), "{error}");
+            assert!(error.to_string().contains("0x02"));
+        };
+        tokio::join!(server_side, client_side);
+    }
+
+    #[tokio::test]
+    async fn a_client_offering_only_other_methods_is_refused() {
+        let (mut client, mut server) = tokio::io::duplex(64);
+        let server_side = async { assert!(!server_greet(&mut server).await.unwrap()) };
+        let client_side = async {
+            client.write_all(&[VERSION, 1, 0x02]).await.unwrap();
+            let mut chosen = [0u8; 2];
+            client.read_exact(&mut chosen).await.unwrap();
+            assert_eq!(chosen, [VERSION, METHOD_UNACCEPTABLE]);
+        };
+        tokio::join!(server_side, client_side);
+    }
+
+    #[tokio::test]
+    async fn domain_targets_parse_to_a_domain_request() {
+        let (mut client, mut server) = tokio::io::duplex(256);
+        let server_side = async {
+            assert!(server_greet(&mut server).await.unwrap());
+            let request = server_read_request(&mut server).await.unwrap();
+            assert_eq!(
+                request.target,
+                Target::Domain { name: "example.com".into(), port: 443 }
+            );
+        };
+        let client_side = async {
+            client.write_all(&[VERSION, 1, METHOD_NO_AUTH]).await.unwrap();
+            let mut chosen = [0u8; 2];
+            client.read_exact(&mut chosen).await.unwrap();
+            let mut request = vec![VERSION, COMMAND_CONNECT, 0, ADDRESS_DOMAIN, 11];
+            request.extend_from_slice(b"example.com");
+            request.extend_from_slice(&443u16.to_be_bytes());
+            client.write_all(&request).await.unwrap();
+        };
+        tokio::join!(server_side, client_side);
+    }
+}

--- a/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/websocket.rs
@@ -14,11 +14,12 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::handshake::client::Request as ClientRequest;
 use tokio_tungstenite::tungstenite::http::header::{HeaderValue, USER_AGENT};
 use tokio_tungstenite::tungstenite::protocol::WebSocketConfig;
-use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, connect_async_with_config};
+use tokio_tungstenite::{MaybeTlsStream, WebSocketStream, client_async_tls_with_config};
 use url::Url;
 
 use crate::link::{FrameLink, LinkError};
 use crate::observability::{TransportPathKind, TransportPathSnapshot, TransportSnapshot};
+use crate::provider::dial::{DialedStream, Dialer, OsTcpDialer};
 use crate::provider::{
     CarrierEvidence, ConnectRequest, LinkGroup, LinkRequest, ProviderCapabilities, ProviderError,
     SupportedClientAuthModes, TransportProvider, sanitized_route,
@@ -134,15 +135,40 @@ pub fn client_request(endpoint: &Url) -> Result<ClientRequest, LinkError> {
     Ok(request)
 }
 
+/// The link type every direct dial produces, whatever carried the bytes.
+pub type DialedWebSocketLink = TungsteniteWebSocketLink<MaybeTlsStream<DialedStream>>;
+
+/// Dial a direct WebSocket route over the operating system's TCP stack.
 pub async fn connect_websocket(
     endpoint: &Url,
     maximum: usize,
-) -> Result<TungsteniteWebSocketLink<MaybeTlsStream<tokio::net::TcpStream>>, LinkError> {
+) -> Result<DialedWebSocketLink, LinkError> {
+    connect_websocket_via(endpoint, maximum, &OsTcpDialer).await
+}
+
+/// Dial a direct WebSocket route over whatever carrier `dialer` provides.
+///
+/// The dialer owns only the byte stream. TLS for `wss` and the WebSocket
+/// upgrade run above it exactly as they do over a kernel socket, so an
+/// in-process WireGuard tunnel and the operating system's TCP stack produce the
+/// same link.
+pub async fn connect_websocket_via(
+    endpoint: &Url,
+    maximum: usize,
+    dialer: &dyn Dialer,
+) -> Result<DialedWebSocketLink, LinkError> {
     let description = sanitized_route(endpoint);
+    let host = endpoint
+        .host_str()
+        .ok_or_else(|| LinkError::Transport("WebSocket route has no host".into()))?;
+    let port = endpoint
+        .port_or_known_default()
+        .ok_or_else(|| LinkError::Transport("WebSocket route has no port".into()))?;
     let config =
         WebSocketConfig::default().max_message_size(Some(maximum)).max_frame_size(Some(maximum));
     let request = client_request(endpoint)?;
-    let (socket, _) = connect_async_with_config(request, Some(config), true)
+    let stream = dialer.dial(host, port).await?;
+    let (socket, _) = client_async_tls_with_config(request, stream, Some(config), None)
         .await
         .map_err(|error| LinkError::Transport(error.to_string()))?;
     Ok(TungsteniteWebSocketLink::new(description, maximum, socket))
@@ -223,11 +249,23 @@ fn ensure_size(actual: usize, maximum: usize) -> Result<(), LinkError> {
 #[derive(Debug, Clone)]
 pub struct DirectWebSocketProvider {
     maximum: usize,
+    dialer: Arc<dyn Dialer>,
 }
 
 impl DirectWebSocketProvider {
+    /// Dial over the operating system's TCP stack.
     pub fn new(maximum: usize) -> Self {
-        Self { maximum }
+        Self::with_dialer(maximum, Arc::new(OsTcpDialer))
+    }
+
+    /// Dial over a caller-supplied carrier, such as an in-process WireGuard
+    /// tunnel. The route, TLS, and upgrade are unchanged.
+    pub fn with_dialer(maximum: usize, dialer: Arc<dyn Dialer>) -> Self {
+        Self { maximum, dialer }
+    }
+
+    pub fn dialer(&self) -> &Arc<dyn Dialer> {
+        &self.dialer
     }
 }
 
@@ -263,6 +301,7 @@ impl TransportProvider for DirectWebSocketProvider {
             description,
             evidence,
             maximum: self.maximum,
+            dialer: Arc::clone(&self.dialer),
             closed: AtomicBool::new(false),
         }))
     }
@@ -274,6 +313,7 @@ struct WebSocketLinkGroup {
     description: String,
     evidence: CarrierEvidence,
     maximum: usize,
+    dialer: Arc<dyn Dialer>,
     closed: AtomicBool,
 }
 
@@ -316,7 +356,7 @@ impl LinkGroup for WebSocketLinkGroup {
             ("cmux_lane", request.lane.to_string()),
             ("cmux_generation", request.generation.to_string()),
         ]);
-        let link = connect_websocket(&endpoint, self.maximum).await?;
+        let link = connect_websocket_via(&endpoint, self.maximum, self.dialer.as_ref()).await?;
         Ok(Box::new(link))
     }
 

--- a/cmux-tui/crates/cmux-remote/src/wireguard_hub.rs
+++ b/cmux-tui/crates/cmux-remote/src/wireguard_hub.rs
@@ -1,0 +1,244 @@
+//! One WireGuard tunnel shared by many client processes.
+//!
+//! A WireGuard key supports one live session: the server remembers the
+//! endpoint of the last authenticated sender, so two processes handshaking
+//! with the same key steal each other's traffic. The macOS app spawns one
+//! `remote connect` sidecar per Cloud VM link, so those sidecars cannot each
+//! own the tunnel. The hub owns it instead and exposes SOCKS5 CONNECT on an
+//! owner-only Unix socket; each sidecar dials VPC addresses through the hub
+//! with [`crate::provider::SocksDialer`].
+//!
+//! The hub is deliberately narrow: no authentication method other than "none"
+//! (the Unix socket is `0600` and the peer's uid is checked), CONNECT only,
+//! literal IP targets only, and only targets inside the tunnel's routes. It
+//! is a carrier, not an authority: the cmux Noise handshake still runs end to
+//! end inside every tunneled connection.
+
+use std::fmt;
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+use std::time::Duration;
+
+use cmux_wg::{IpNetwork, WgError, WgNet};
+use tokio::net::UnixStream;
+use tokio::sync::{Semaphore, oneshot};
+use tokio::task::JoinSet;
+
+use crate::admin::verify_unix_peer_owner;
+use crate::provider::socks::{
+    self, COMMAND_CONNECT, REPLY_ADDRESS_TYPE_NOT_SUPPORTED, REPLY_COMMAND_NOT_SUPPORTED,
+    REPLY_CONNECTION_REFUSED, REPLY_GENERAL_FAILURE, REPLY_NETWORK_UNREACHABLE,
+    REPLY_NOT_ALLOWED, REPLY_SUCCEEDED, Target,
+};
+use crate::unix_socket::{OwnedUnixListener, UnixAcceptBackoff, UnixSocketCleanup, UnixSocketError};
+
+/// Concurrent tunneled connections the hub serves. Each VM link uses at most
+/// four lanes; this leaves room for many links plus reconnect overlap.
+const MAX_HUB_CONNECTIONS: usize = 256;
+/// A client that opens the socket must finish the SOCKS exchange within this
+/// bound or it is dropped, so a stuck peer cannot pin a connection slot.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+#[derive(Debug)]
+pub enum HubError {
+    Io(io::Error),
+    /// The socket path could not be owned (bad directory, already leased).
+    Socket(String),
+}
+
+impl fmt::Display for HubError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "hub io: {error}"),
+            Self::Socket(detail) => write!(formatter, "hub socket: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for HubError {}
+
+impl From<UnixSocketError> for HubError {
+    fn from(error: UnixSocketError) -> Self {
+        match error {
+            UnixSocketError::Io(error) => Self::Io(error),
+            UnixSocketError::Protocol(detail) => Self::Socket(detail),
+        }
+    }
+}
+
+/// A running hub. Dropping it unlinks the socket and stops serving.
+pub struct WireGuardHub {
+    path: PathBuf,
+    routes: Vec<IpNetwork>,
+    socket_cleanup: Arc<UnixSocketCleanup>,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: Option<tokio::task::JoinHandle<Result<(), HubError>>>,
+}
+
+impl fmt::Debug for WireGuardHub {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WireGuardHub")
+            .field("path", &self.path)
+            .field("routes", &self.routes)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WireGuardHub {
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// Networks the hub will connect to, for the readiness report.
+    pub fn routes(&self) -> &[IpNetwork] {
+        &self.routes
+    }
+
+    /// Stop accepting, end every tunneled connection, and unlink the socket.
+    pub async fn shutdown(mut self) -> Result<(), HubError> {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        let result = match self.task.take() {
+            Some(task) => task
+                .await
+                .map_err(|error| HubError::Socket(format!("hub listener task failed: {error}")))?,
+            None => Ok(()),
+        };
+        let _ = self.socket_cleanup.unlink();
+        result
+    }
+}
+
+impl Drop for WireGuardHub {
+    fn drop(&mut self) {
+        // The listener lives in the accept task; unlink here too because
+        // aborting only schedules cancellation.
+        let _ = self.socket_cleanup.unlink();
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        if let Some(task) = self.task.take() {
+            task.abort();
+        }
+    }
+}
+
+/// Serve SOCKS5 CONNECT for `net` on the Unix socket at `path`.
+///
+/// The parent directory is created `0700` if missing and must be owned by
+/// this user and not writable by others without the sticky bit; the socket is
+/// `0600`; a stale socket from a dead hub is replaced, a live one is refused.
+pub async fn serve_wireguard_hub(
+    net: Arc<WgNet>,
+    path: impl Into<PathBuf>,
+) -> Result<WireGuardHub, HubError> {
+    let path = path.into();
+    let listener = OwnedUnixListener::bind(path.clone()).await?;
+    let socket_cleanup = listener.cleanup();
+    let routes = net.routes().to_vec();
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+    let permits = Arc::new(Semaphore::new(MAX_HUB_CONNECTIONS));
+    let task = tokio::spawn(async move {
+        let mut accept_backoff = UnixAcceptBackoff::new();
+        let mut connections = JoinSet::new();
+        loop {
+            tokio::select! {
+                _ = &mut shutdown_rx => {
+                    connections.shutdown().await;
+                    return Ok(());
+                }
+                Some(_) = connections.join_next(), if !connections.is_empty() => {}
+                accepted = listener.listener().accept() => {
+                    let (stream, _) = match accepted {
+                        Ok(accepted) => {
+                            accept_backoff.reset();
+                            accepted
+                        }
+                        Err(error) => {
+                            let Some(delay) = accept_backoff.retry_delay(&error) else {
+                                return Err(HubError::Io(io::Error::new(
+                                    error.kind(),
+                                    format!("hub Unix listener accept failed: {error}"),
+                                )));
+                            };
+                            // Bounded retry after a transient accept failure
+                            // (descriptor exhaustion, aborted connection).
+                            tokio::select! {
+                                _ = &mut shutdown_rx => {
+                                    connections.shutdown().await;
+                                    return Ok(());
+                                }
+                                _ = tokio::time::sleep(delay) => {}
+                            }
+                            continue;
+                        }
+                    };
+                    if verify_unix_peer_owner(&stream).is_err() {
+                        continue;
+                    }
+                    let Ok(permit) = permits.clone().try_acquire_owned() else {
+                        continue;
+                    };
+                    let net = Arc::clone(&net);
+                    connections.spawn(async move {
+                        let _permit = permit;
+                        let _ = serve_connection(net, stream).await;
+                    });
+                }
+            }
+        }
+    });
+    Ok(WireGuardHub { path, routes, socket_cleanup, shutdown: Some(shutdown_tx), task: Some(task) })
+}
+
+/// One SOCKS5 exchange, then a bidirectional copy until either side closes.
+async fn serve_connection(net: Arc<WgNet>, mut stream: UnixStream) -> Result<(), socks::SocksError> {
+    let request = tokio::time::timeout(HANDSHAKE_TIMEOUT, async {
+        if !socks::server_greet(&mut stream).await? {
+            return Ok(None);
+        }
+        socks::server_read_request(&mut stream).await.map(Some)
+    })
+    .await
+    .map_err(|_| socks::SocksError::Protocol("handshake timed out".into()))??;
+    let Some(request) = request else { return Ok(()) };
+
+    if request.command != COMMAND_CONNECT {
+        socks::server_reply(&mut stream, REPLY_COMMAND_NOT_SUPPORTED, None).await?;
+        return Ok(());
+    }
+    let target = match request.target {
+        Target::Ip(address) => address,
+        Target::Domain { .. } => {
+            // The hub dials literal addresses only; names would need a
+            // resolver inside the tunnel that nothing here provides.
+            socks::server_reply(&mut stream, REPLY_ADDRESS_TYPE_NOT_SUPPORTED, None).await?;
+            return Ok(());
+        }
+    };
+    if !net.routes_contain(target.ip()) {
+        socks::server_reply(&mut stream, REPLY_NOT_ALLOWED, None).await?;
+        return Ok(());
+    }
+    let mut tunneled = match net.connect(target).await {
+        Ok(tunneled) => tunneled,
+        Err(error) => {
+            socks::server_reply(&mut stream, reply_for(&error), None).await?;
+            return Ok(());
+        }
+    };
+    socks::server_reply(&mut stream, REPLY_SUCCEEDED, Some(tunneled.local_addr())).await?;
+    let _ = tokio::io::copy_bidirectional(&mut stream, &mut tunneled).await;
+    Ok(())
+}
+
+fn reply_for(error: &WgError) -> u8 {
+    match error {
+        WgError::ConnectionRefused(_) => REPLY_CONNECTION_REFUSED,
+        WgError::NoTunnelAddress(_) => REPLY_NETWORK_UNREACHABLE,
+        _ => REPLY_GENERAL_FAILURE,
+    }
+}

--- a/cmux-tui/crates/cmux-remote/tests/wireguard_dial_e2e.rs
+++ b/cmux-tui/crates/cmux-remote/tests/wireguard_dial_e2e.rs
@@ -1,0 +1,154 @@
+//! A direct WebSocket link dialed through an in-process WireGuard tunnel.
+//!
+//! The daemon listens on a loopback TCP port as it always does. The "network"
+//! side of the tunnel accepts the tunneled TCP connection on its userspace stack
+//! and bridges it to that daemon, which is exactly what a Cloud VM's private
+//! address does from the client's point of view: the route names an address
+//! only the tunnel can reach.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use cmux_remote::connection::{ClientConnection, ClientConnectionConfig, ReconnectPolicy};
+use cmux_remote::crypto::{ClientAuthMode, StaticIdentity};
+use cmux_remote::daemon::{RemoteDaemon, serve_direct_websocket};
+use cmux_remote::identity::AuthDatabase;
+use cmux_remote::observability::{ConnectionState, TransportPathKind};
+use cmux_remote::provider::{
+    ConnectRequest, DirectWebSocketProvider, OsTcpDialer, TransportProvider, WireGuardDialer,
+};
+use cmux_remote::session::SessionLimits;
+use cmux_remote_protocol::{FrameFlags, Lane, LanePolicy, SessionId};
+use cmux_wg::WgNet;
+use cmux_wg::testing::{LoopbackPair, loopback_pair};
+use tempfile::tempdir;
+use tokio::net::TcpStream;
+use url::Url;
+use zeroize::Zeroizing;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Accept tunneled connections on `port` and pipe each to `daemon`.
+async fn bridge_to_daemon(net: &WgNet, port: u16, daemon: SocketAddr) {
+    let mut listener = net.listen(port).await.unwrap();
+    tokio::spawn(async move {
+        while let Some(mut tunneled) = listener.accept().await {
+            tokio::spawn(async move {
+                let Ok(mut local) = TcpStream::connect(daemon).await else { return };
+                let _ = tokio::io::copy_bidirectional(&mut tunneled, &mut local).await;
+            });
+        }
+    });
+}
+
+#[tokio::test]
+async fn invitation_enrolls_over_a_wireguard_dialed_websocket() {
+    let state = tempdir().unwrap();
+    let auth = AuthDatabase::load_or_create(state.path(), "wireguard-test", false).unwrap();
+    let (daemon, mut accepted) = RemoteDaemon::new(auth.clone(), SessionLimits::default());
+    let server = serve_direct_websocket(daemon, "127.0.0.1:0".parse().unwrap(), 65_535, false)
+        .await
+        .unwrap();
+
+    let LoopbackPair { client, server: network, client_socket, server_socket, server_v6, .. } =
+        loopback_pair().await.unwrap();
+    let network = WgNet::start(network, server_socket).await.unwrap();
+    bridge_to_daemon(&network, 1337, server.local_addr()).await;
+    let tunnel = Arc::new(WgNet::start(client, client_socket).await.unwrap());
+
+    // The route is the machine's private address: nothing on this host
+    // listens there, so only the tunnel can complete the dial.
+    let endpoint = Url::parse(&format!("ws://[{server_v6}]:1337/v1/link")).unwrap();
+    let invitation = auth.create_invitation(Duration::from_secs(60), vec![]).await.unwrap();
+    let approver = tokio::spawn({
+        let auth = auth.clone();
+        async move {
+            let pending = auth.wait_for_pending(Duration::from_secs(5)).await.unwrap();
+            auth.approve(&pending[0].invitation_id).await.unwrap();
+        }
+    });
+    let session = SessionId([91; 16]);
+    let dialer = Arc::new(WireGuardDialer::with_fallback(Arc::clone(&tunnel), Arc::new(OsTcpDialer)));
+    let group = DirectWebSocketProvider::with_dialer(65_535, dialer)
+        .connect(ConnectRequest {
+            endpoint,
+            session,
+            lane_policy: LanePolicy::Isolated,
+            routing: Default::default(),
+        })
+        .await
+        .unwrap();
+    let invitation_secret = invitation.secret_bytes().unwrap();
+    let client = tokio::time::timeout(
+        TIMEOUT,
+        ClientConnection::connect(
+            group,
+            ClientConnectionConfig {
+                identity: StaticIdentity::generate().unwrap(),
+                expected_daemon: Some(auth.identity().public_key()),
+                auth: ClientAuthMode::Invitation {
+                    id: invitation.id,
+                    secret: Zeroizing::new(invitation_secret),
+                },
+                device_name: "wireguard-client".into(),
+                session,
+                lane_policy: LanePolicy::Isolated,
+                limits: SessionLimits::default(),
+                reconnect: ReconnectPolicy::default(),
+            },
+        ),
+    )
+    .await
+    .expect("connect through the tunnel timed out")
+    .unwrap();
+    approver.await.unwrap();
+    let daemon_client = tokio::time::timeout(TIMEOUT, accepted.recv()).await.unwrap().unwrap();
+
+    let snapshot = client.snapshot().await;
+    assert_eq!(snapshot.state, ConnectionState::Connected);
+    assert_eq!(snapshot.physical_link_count, 4, "four lanes, four tunneled TCP connections");
+    assert_eq!(snapshot.transport.provider, "direct-websocket");
+    assert_eq!(snapshot.transport.selected_path.unwrap().kind, TransportPathKind::Direct);
+
+    client
+        .send(Lane::Interactive, 1, Bytes::from_static(b"keys"), FrameFlags::empty())
+        .await
+        .unwrap();
+    assert_eq!(daemon_client.receive().await.unwrap().unwrap().payload, b"keys".as_slice());
+    let screen = vec![0x5a; 60_000];
+    daemon_client.send(Lane::Bulk, 2, Bytes::from(screen.clone()), FrameFlags::empty()).await.unwrap();
+    assert_eq!(client.receive().await.unwrap().unwrap().payload, screen.as_slice());
+
+    assert!(tunnel.time_since_last_handshake().await.unwrap().is_some());
+
+    client.close().await.unwrap();
+    server.shutdown().await.unwrap();
+    network.shutdown().await;
+}
+
+#[tokio::test]
+async fn addresses_outside_the_tunnel_use_the_fallback() {
+    let state = tempdir().unwrap();
+    let auth = AuthDatabase::load_or_create(state.path(), "wireguard-fallback", false).unwrap();
+    let (daemon, _accepted) = RemoteDaemon::new(auth, SessionLimits::default());
+    let server = serve_direct_websocket(daemon, "127.0.0.1:0".parse().unwrap(), 65_535, false)
+        .await
+        .unwrap();
+    let LoopbackPair { client, client_socket, .. } = loopback_pair().await.unwrap();
+    // No peer is running; the tunnel never handshakes. A loopback route must
+    // still connect because 127.0.0.1 is outside the tunnel's routes.
+    let tunnel = Arc::new(WgNet::start(client, client_socket).await.unwrap());
+    let dialer = Arc::new(WireGuardDialer::new(tunnel));
+    let endpoint = Url::parse(&format!("ws://{}/v1/link", server.local_addr())).unwrap();
+    let link = tokio::time::timeout(
+        TIMEOUT,
+        cmux_remote::provider::connect_websocket_via(&endpoint, 65_535, dialer.as_ref()),
+    )
+    .await
+    .expect("fallback dial timed out")
+    .unwrap();
+    drop(link);
+    server.shutdown().await.unwrap();
+}

--- a/cmux-tui/crates/cmux-remote/tests/wireguard_dial_e2e.rs
+++ b/cmux-tui/crates/cmux-remote/tests/wireguard_dial_e2e.rs
@@ -117,7 +117,7 @@ async fn invitation_enrolls_over_a_wireguard_dialed_websocket() {
         .await
         .unwrap();
     assert_eq!(daemon_client.receive().await.unwrap().unwrap().payload, b"keys".as_slice());
-    let screen = vec![0x5a; 60_000];
+    let screen = vec![0x5a; 16_000];
     daemon_client.send(Lane::Bulk, 2, Bytes::from(screen.clone()), FrameFlags::empty()).await.unwrap();
     assert_eq!(client.receive().await.unwrap().unwrap().payload, screen.as_slice());
 

--- a/cmux-tui/crates/cmux-remote/tests/wireguard_hub_e2e.rs
+++ b/cmux-tui/crates/cmux-remote/tests/wireguard_hub_e2e.rs
@@ -1,0 +1,194 @@
+//! `cmux-tui wg hub` logic in-process: a hub owns the tunnel, a SOCKS dialer
+//! reaches a daemon through it, and the hub enforces its ruleset.
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+
+use bytes::Bytes;
+use cmux_remote::connection::{ClientConnection, ClientConnectionConfig, ReconnectPolicy};
+use cmux_remote::crypto::{ClientAuthMode, StaticIdentity};
+use cmux_remote::daemon::{RemoteDaemon, serve_direct_websocket};
+use cmux_remote::identity::AuthDatabase;
+use cmux_remote::observability::ConnectionState;
+use cmux_remote::provider::{
+    ConnectRequest, DirectWebSocketProvider, SocksDialer, TransportProvider,
+};
+use cmux_remote::session::SessionLimits;
+use cmux_remote::wireguard_hub::serve_wireguard_hub;
+use cmux_remote_protocol::{FrameFlags, Lane, LanePolicy, SessionId};
+use cmux_wg::WgNet;
+use cmux_wg::testing::{LoopbackPair, loopback_pair};
+use tempfile::tempdir;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpStream, UnixStream};
+use url::Url;
+use zeroize::Zeroizing;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn bridge_to_daemon(net: &WgNet, port: u16, daemon: SocketAddr) {
+    let mut listener = net.listen(port).await.unwrap();
+    tokio::spawn(async move {
+        while let Some(mut tunneled) = listener.accept().await {
+            tokio::spawn(async move {
+                let Ok(mut local) = TcpStream::connect(daemon).await else { return };
+                let _ = tokio::io::copy_bidirectional(&mut tunneled, &mut local).await;
+            });
+        }
+    });
+}
+
+/// Raw SOCKS5 CONNECT; returns the reply code.
+async fn socks_connect_reply(path: &std::path::Path, request_tail: &[u8]) -> u8 {
+    let mut stream = UnixStream::connect(path).await.unwrap();
+    stream.write_all(&[0x05, 1, 0x00]).await.unwrap();
+    let mut chosen = [0u8; 2];
+    stream.read_exact(&mut chosen).await.unwrap();
+    assert_eq!(chosen, [0x05, 0x00]);
+    let mut request = vec![0x05, 0x01, 0x00];
+    request.extend_from_slice(request_tail);
+    stream.write_all(&request).await.unwrap();
+    let mut head = [0u8; 4];
+    tokio::time::timeout(TIMEOUT, stream.read_exact(&mut head)).await.unwrap().unwrap();
+    assert_eq!(head[0], 0x05);
+    head[1]
+}
+
+#[tokio::test]
+async fn sidecar_reaches_a_daemon_through_the_hub() {
+    let state = tempdir().unwrap();
+    let auth = AuthDatabase::load_or_create(state.path(), "hub-test", false).unwrap();
+    let (daemon, mut accepted) = RemoteDaemon::new(auth.clone(), SessionLimits::default());
+    let server = serve_direct_websocket(daemon, "127.0.0.1:0".parse().unwrap(), 65_535, false)
+        .await
+        .unwrap();
+
+    let LoopbackPair { client, server: network, client_socket, server_socket, server_v6, .. } =
+        loopback_pair().await.unwrap();
+    let network = WgNet::start(network, server_socket).await.unwrap();
+    bridge_to_daemon(&network, 1337, server.local_addr()).await;
+    let tunnel = Arc::new(WgNet::start(client, client_socket).await.unwrap());
+
+    let hub_dir = tempdir().unwrap();
+    let socket_path = hub_dir.path().join("hub").join("wg.sock");
+    let hub = serve_wireguard_hub(Arc::clone(&tunnel), socket_path.clone()).await.unwrap();
+    assert!(socket_path.exists());
+    assert_eq!(hub.routes().len(), 2);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(std::fs::metadata(&socket_path).unwrap().permissions().mode() & 0o777, 0o600);
+        assert_eq!(
+            std::fs::metadata(socket_path.parent().unwrap()).unwrap().permissions().mode() & 0o777,
+            0o700
+        );
+    }
+
+    let endpoint = Url::parse(&format!("ws://[{server_v6}]:1337/v1/link")).unwrap();
+    let invitation = auth.create_invitation(Duration::from_secs(60), vec![]).await.unwrap();
+    let approver = tokio::spawn({
+        let auth = auth.clone();
+        async move {
+            let pending = auth.wait_for_pending(Duration::from_secs(5)).await.unwrap();
+            auth.approve(&pending[0].invitation_id).await.unwrap();
+        }
+    });
+    let session = SessionId([77; 16]);
+    let dialer = Arc::new(SocksDialer::new(socket_path.clone()));
+    let group = DirectWebSocketProvider::with_dialer(65_535, dialer)
+        .connect(ConnectRequest {
+            endpoint,
+            session,
+            lane_policy: LanePolicy::Isolated,
+            routing: Default::default(),
+        })
+        .await
+        .unwrap();
+    let invitation_secret = invitation.secret_bytes().unwrap();
+    let client = tokio::time::timeout(
+        TIMEOUT,
+        ClientConnection::connect(
+            group,
+            ClientConnectionConfig {
+                identity: StaticIdentity::generate().unwrap(),
+                expected_daemon: Some(auth.identity().public_key()),
+                auth: ClientAuthMode::Invitation {
+                    id: invitation.id,
+                    secret: Zeroizing::new(invitation_secret),
+                },
+                device_name: "hub-sidecar".into(),
+                session,
+                lane_policy: LanePolicy::Isolated,
+                limits: SessionLimits::default(),
+                reconnect: ReconnectPolicy::default(),
+            },
+        ),
+    )
+    .await
+    .expect("connect through the hub timed out")
+    .unwrap();
+    approver.await.unwrap();
+    let daemon_client = tokio::time::timeout(TIMEOUT, accepted.recv()).await.unwrap().unwrap();
+
+    let snapshot = client.snapshot().await;
+    assert_eq!(snapshot.state, ConnectionState::Connected);
+    assert_eq!(snapshot.physical_link_count, 4);
+    client
+        .send(Lane::Interactive, 1, Bytes::from_static(b"keys"), FrameFlags::empty())
+        .await
+        .unwrap();
+    assert_eq!(daemon_client.receive().await.unwrap().unwrap().payload, b"keys".as_slice());
+    let screen = vec![0x5a; 16_000];
+    daemon_client
+        .send(Lane::Bulk, 2, Bytes::from(screen.clone()), FrameFlags::empty())
+        .await
+        .unwrap();
+    assert_eq!(client.receive().await.unwrap().unwrap().payload, screen.as_slice());
+
+    // Ruleset: outside the tunnel's routes -> 0x02.
+    let mut outside = vec![0x01, 192, 0, 2, 1];
+    outside.extend_from_slice(&80u16.to_be_bytes());
+    assert_eq!(socks_connect_reply(&socket_path, &outside).await, 0x02);
+
+    // Names are not dialed -> 0x08 address type not supported.
+    let mut domain = vec![0x03, 11];
+    domain.extend_from_slice(b"example.com");
+    domain.extend_from_slice(&443u16.to_be_bytes());
+    assert_eq!(socks_connect_reply(&socket_path, &domain).await, 0x08);
+
+    // Inside the routes but nothing listens -> connection refused.
+    let mut refused = vec![0x01, 10, 200, 0, 2];
+    refused.extend_from_slice(&4444u16.to_be_bytes());
+    assert_eq!(socks_connect_reply(&socket_path, &refused).await, 0x05);
+
+    client.close().await.unwrap();
+    hub.shutdown().await.unwrap();
+    assert!(!socket_path.exists(), "hub must remove its socket on shutdown");
+    server.shutdown().await.unwrap();
+    network.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_hub_dropped_without_shutdown_still_unlinks_its_socket() {
+    let LoopbackPair { client, client_socket, .. } = loopback_pair().await.unwrap();
+    let tunnel = Arc::new(WgNet::start(client, client_socket).await.unwrap());
+    let hub_dir = tempdir().unwrap();
+    let socket_path = hub_dir.path().join("wg.sock");
+    let hub = serve_wireguard_hub(tunnel, socket_path.clone()).await.unwrap();
+    assert!(socket_path.exists());
+    drop(hub);
+    assert!(!socket_path.exists());
+}
+
+#[tokio::test]
+async fn a_second_hub_on_a_live_socket_is_refused() {
+    let LoopbackPair { client, client_socket, .. } = loopback_pair().await.unwrap();
+    let tunnel = Arc::new(WgNet::start(client, client_socket).await.unwrap());
+    let hub_dir = tempdir().unwrap();
+    let socket_path = hub_dir.path().join("wg.sock");
+    let first = serve_wireguard_hub(Arc::clone(&tunnel), socket_path.clone()).await.unwrap();
+    let second = serve_wireguard_hub(tunnel, socket_path.clone()).await;
+    assert!(second.is_err(), "two hubs must not share one socket path");
+    first.shutdown().await.unwrap();
+}

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -51,6 +51,7 @@ fs4.workspace = true
 [target.'cfg(unix)'.dependencies]
 cmux-remote.workspace = true
 cmux-remote-protocol.workspace = true
+cmux-wg.workspace = true
 tokio.workspace = true
 url.workspace = true
 async-trait.workspace = true

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -48,6 +48,7 @@ const REMOTE_COMMANDS: &[&str] = &[
     "remote-sidecar",
     "remote-stop",
     "install-self",
+    "wg",
 ];
 
 /// Maps the actions accepted after the `remote` noun to their direct command
@@ -428,6 +429,7 @@ USAGE
   cmux [START OPTIONS]
   cmux attach [START OPTIONS]
   cmux relay [ROUTING OPTIONS]
+  cmux wg hub --config <wg-quick file> --socket <unix socket>
 ";
 
 const ROOT_HELP_PROCESS_SUFFIX: &str = "\
@@ -450,6 +452,7 @@ PROCESS HELP
   cmux help start
   cmux attach --help
   cmux relay --help
+  cmux wg hub --help
   cmux machine-agent --help
 
 RESOURCE SCOPES

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -494,6 +494,9 @@ pub(crate) struct RemoteClientMessages {
     pub rpc_stdin_invalid_utf8: &'static str,
     pub known_forget_arity: &'static str,
     pub known_state_dir_unavailable: &'static str,
+    wireguard_config_unreadable: &'static str,
+    wireguard_config_invalid: &'static str,
+    wireguard_start_failed: &'static str,
     known_daemon_not_known: &'static str,
     known_daemon_forgotten: &'static str,
     pub known_daemons_empty: &'static str,
@@ -504,6 +507,18 @@ pub(crate) struct RemoteClientMessages {
 impl RemoteClientMessages {
     pub(crate) fn option_needs_value(&self, option: &str) -> String {
         self.option_needs_value.replace("{option}", option)
+    }
+
+    pub(crate) fn wireguard_config_unreadable(&self, path: &str, error: &str) -> String {
+        self.wireguard_config_unreadable.replace("{path}", path).replace("{error}", error)
+    }
+
+    pub(crate) fn wireguard_config_invalid(&self, error: &str) -> String {
+        self.wireguard_config_invalid.replace("{error}", error)
+    }
+
+    pub(crate) fn wireguard_start_failed(&self, error: &str) -> String {
+        self.wireguard_start_failed.replace("{error}", error)
     }
 
     pub(crate) fn invalid_option_value(&self, option: &str, expected: &str) -> String {
@@ -1429,6 +1444,8 @@ TRANSPORT:
     and credential-source groups in occurrence order.
   --relay-ticket-command-arg ARG  --iroh-relay URL  --iroh-address ADDR
   --iroh-path auto|direct-only|relay-only
+  --wireguard-config PATH  dial ws routes inside that tunnel's AllowedIPs
+    through an in-process WireGuard peer (owner-only wg-quick file; no root)
   --ssh-binary PATH  --remote-binary PATH  --ssh-arg ARG  --no-install
   --remote-state-dir PATH for a non-default daemon state directory
   --upgrade explicitly replaces an SSH-managed remote sidecar after installing
@@ -1550,6 +1567,9 @@ OPTIONS:
         rpc_stdin_invalid_utf8: "RPC stdin line is not valid UTF-8",
         known_forget_arity: "known-daemons forget expects exactly one fingerprint",
         known_state_dir_unavailable: "cannot determine remote state directory; use --state-dir",
+        wireguard_config_unreadable: "cannot read WireGuard config {path}: {error} (the file must be a regular file with owner-only permissions)",
+        wireguard_config_invalid: "WireGuard config is not a valid wg-quick file: {error}",
+        wireguard_start_failed: "could not start the in-process WireGuard tunnel: {error}",
         known_daemon_not_known: "daemon {fingerprint} is not known",
         known_daemon_forgotten: "Forgot daemon {fingerprint}.",
         known_daemons_empty: "No known daemons.",
@@ -2075,6 +2095,8 @@ ID とセッション:
   代替ルートでは --relay-route、--relay-slot、認証情報の組を出現順に最大 4 回指定します。
   --relay-ticket-command-arg 引数  --iroh-relay URL  --iroh-address アドレス
   --iroh-path auto|direct-only|relay-only
+  --wireguard-config パス  そのトンネルの AllowedIPs 内の ws ルートを
+    プロセス内 WireGuard ピア経由で接続します（所有者のみ読める wg-quick ファイル、root 不要）
   --ssh-binary パス  --remote-binary パス  --ssh-arg 引数  --no-install
   --remote-state-dir パス  既定以外のデーモン状態ディレクトリ
   --upgrade は固定済みバイナリのインストール後に SSH 管理のサイドカーを置換します。
@@ -2194,6 +2216,9 @@ ID とセッション:
         rpc_stdin_invalid_utf8: "RPC 標準入力の行は有効な UTF-8 ではありません",
         known_forget_arity: "known-daemons forget にはフィンガープリントを 1 つ指定してください",
         known_state_dir_unavailable: "リモート状態ディレクトリを特定できません。--state-dir を指定してください",
+        wireguard_config_unreadable: "WireGuard 設定 {path} を読めません: {error}（所有者のみ読める通常ファイルが必要です）",
+        wireguard_config_invalid: "WireGuard 設定は有効な wg-quick ファイルではありません: {error}",
+        wireguard_start_failed: "プロセス内 WireGuard トンネルを開始できませんでした: {error}",
         known_daemon_not_known: "デーモン {fingerprint} は登録されていません",
         known_daemon_forgotten: "デーモン {fingerprint} を削除しました。",
         known_daemons_empty: "登録済みのデーモンはありません。",

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -497,6 +497,11 @@ pub(crate) struct RemoteClientMessages {
     wireguard_config_unreadable: &'static str,
     wireguard_config_invalid: &'static str,
     wireguard_start_failed: &'static str,
+    pub wireguard_hub_conflict: &'static str,
+    wireguard_hub_serve_failed: &'static str,
+    wireguard_hub_signal_failed: &'static str,
+    wg_hub_option_required: &'static str,
+    pub wg_hub_help: &'static str,
     known_daemon_not_known: &'static str,
     known_daemon_forgotten: &'static str,
     pub known_daemons_empty: &'static str,
@@ -519,6 +524,18 @@ impl RemoteClientMessages {
 
     pub(crate) fn wireguard_start_failed(&self, error: &str) -> String {
         self.wireguard_start_failed.replace("{error}", error)
+    }
+
+    pub(crate) fn wireguard_hub_serve_failed(&self, error: &str) -> String {
+        self.wireguard_hub_serve_failed.replace("{error}", error)
+    }
+
+    pub(crate) fn wireguard_hub_signal_failed(&self, error: &str) -> String {
+        self.wireguard_hub_signal_failed.replace("{error}", error)
+    }
+
+    pub(crate) fn wg_hub_option_required(&self, option: &str) -> String {
+        self.wg_hub_option_required.replace("{option}", option)
     }
 
     pub(crate) fn invalid_option_value(&self, option: &str, expected: &str) -> String {
@@ -1446,6 +1463,8 @@ TRANSPORT:
   --iroh-path auto|direct-only|relay-only
   --wireguard-config PATH  dial ws routes inside that tunnel's AllowedIPs
     through an in-process WireGuard peer (owner-only wg-quick file; no root)
+  --wireguard-hub PATH  dial ws routes through a running `cmux wg hub` socket
+    instead; exclusive with --wireguard-config
   --ssh-binary PATH  --remote-binary PATH  --ssh-arg ARG  --no-install
   --remote-state-dir PATH for a non-default daemon state directory
   --upgrade explicitly replaces an SSH-managed remote sidecar after installing
@@ -1570,6 +1589,25 @@ OPTIONS:
         wireguard_config_unreadable: "cannot read WireGuard config {path}: {error} (the file must be a regular file with owner-only permissions)",
         wireguard_config_invalid: "WireGuard config is not a valid wg-quick file: {error}",
         wireguard_start_failed: "could not start the in-process WireGuard tunnel: {error}",
+        wireguard_hub_conflict: "--wireguard-config and --wireguard-hub cannot be combined; one link owns a tunnel or dials through a hub, not both",
+        wireguard_hub_serve_failed: "could not serve the WireGuard hub socket: {error}",
+        wireguard_hub_signal_failed: "could not wait for the hub shutdown signal: {error}",
+        wg_hub_option_required: "wg hub requires {option}",
+        wg_hub_help: r#"USAGE: cmux wg hub --config PATH --socket PATH
+
+Own one in-process WireGuard tunnel and serve SOCKS5 CONNECT for other cmux
+processes on an owner-only Unix socket. A WireGuard key supports one live
+session, so every `remote connect --wireguard-hub PATH` sidecar on this machine
+shares this hub instead of handshaking on its own.
+
+  --config PATH  owner-only wg-quick file (PrivateKey, Address, AllowedIPs, Endpoint)
+  --socket PATH  Unix socket to serve; parent directory is created 0700, socket 0600
+
+Prints one JSON line `{"event":"hub-ready","socket":...,"routes":[...]}` when
+listening. Only literal IP targets inside AllowedIPs are dialed; other targets
+get SOCKS reply 0x02, names 0x08. Exits on SIGTERM or SIGINT and removes the
+socket.
+"#,
         known_daemon_not_known: "daemon {fingerprint} is not known",
         known_daemon_forgotten: "Forgot daemon {fingerprint}.",
         known_daemons_empty: "No known daemons.",
@@ -2097,6 +2135,8 @@ ID とセッション:
   --iroh-path auto|direct-only|relay-only
   --wireguard-config パス  そのトンネルの AllowedIPs 内の ws ルートを
     プロセス内 WireGuard ピア経由で接続します（所有者のみ読める wg-quick ファイル、root 不要）
+  --wireguard-hub パス  実行中の `cmux wg hub` ソケット経由で ws ルートに接続します。
+    --wireguard-config とは併用できません
   --ssh-binary パス  --remote-binary パス  --ssh-arg 引数  --no-install
   --remote-state-dir パス  既定以外のデーモン状態ディレクトリ
   --upgrade は固定済みバイナリのインストール後に SSH 管理のサイドカーを置換します。
@@ -2219,6 +2259,24 @@ ID とセッション:
         wireguard_config_unreadable: "WireGuard 設定 {path} を読めません: {error}（所有者のみ読める通常ファイルが必要です）",
         wireguard_config_invalid: "WireGuard 設定は有効な wg-quick ファイルではありません: {error}",
         wireguard_start_failed: "プロセス内 WireGuard トンネルを開始できませんでした: {error}",
+        wireguard_hub_conflict: "--wireguard-config と --wireguard-hub は併用できません。1 つのリンクはトンネルを所有するかハブ経由で接続するかのどちらかです",
+        wireguard_hub_serve_failed: "WireGuard ハブソケットを提供できませんでした: {error}",
+        wireguard_hub_signal_failed: "ハブの終了シグナルを待機できませんでした: {error}",
+        wg_hub_option_required: "wg hub には {option} が必要です",
+        wg_hub_help: r#"使用方法: cmux wg hub --config パス --socket パス
+
+プロセス内 WireGuard トンネルを 1 つ所有し、所有者のみ読める Unix ソケットで
+他の cmux プロセスに SOCKS5 CONNECT を提供します。WireGuard 鍵は 1 つの
+セッションしか維持できないため、このマシンの `remote connect --wireguard-hub パス`
+サイドカーはそれぞれハンドシェイクせず、このハブを共有します。
+
+  --config パス  所有者のみ読める wg-quick ファイル（PrivateKey、Address、AllowedIPs、Endpoint）
+  --socket パス  提供する Unix ソケット。親ディレクトリは 0700、ソケットは 0600 で作成します
+
+待ち受け開始時に JSON 1 行 `{"event":"hub-ready","socket":...,"routes":[...]}` を出力します。
+AllowedIPs 内のリテラル IP のみ接続します。それ以外は SOCKS 応答 0x02、名前は 0x08 です。
+SIGTERM または SIGINT で終了し、ソケットを削除します。
+"#,
         known_daemon_not_known: "デーモン {fingerprint} は登録されていません",
         known_daemon_forgotten: "デーモン {fingerprint} を削除しました。",
         known_daemons_empty: "登録済みのデーモンはありません。",

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -27,9 +27,9 @@ use cmux_remote::identity::{
     MAX_INVITATION_URI_BYTES, credential_free_route_hint, default_state_dir,
 };
 use cmux_remote::provider::{
-    IrohPathMode, ProviderError, ROUTING_DIRECT_ADDRS, ROUTING_NODE_ID, ROUTING_RELAY_URL,
-    RelayCredentialSource, SshProvider, SshProviderConfig, SupportedClientAuthModes,
-    sanitized_route,
+    Dialer, IrohPathMode, ProviderError, ROUTING_DIRECT_ADDRS, ROUTING_NODE_ID,
+    ROUTING_RELAY_URL, RelayCredentialSource, SocksDialer, SshProvider, SshProviderConfig,
+    SupportedClientAuthModes, WireGuardDialer, sanitized_route,
 };
 use cmux_remote::secure_directory::{DirectoryAccess, ensure_secure_directory};
 use cmux_remote::ssh_bootstrap::{BUILD_IDENTITY, DISTRIBUTION_VERSION, NPM_BOOTSTRAP_VERSION};
@@ -99,6 +99,7 @@ fn run_inner(
         Some("remote-sidecar") => run_remote_sidecar(&args[1..]),
         Some("remote-stop") => run_remote_stop(&args[1..]),
         Some("install-self") => run_install_self(&args[1..]),
+        Some("wg") => run_wg(&args[1..]),
         Some("remote") => Err(anyhow!(catalog().remote_client.remote_lifecycle_help)),
         _ => Err(anyhow!("unknown remote command\n\n{usage}")),
     }
@@ -132,6 +133,10 @@ fn remote_help_requested(args: &[String]) -> bool {
         "--ssh-binary",
         "--remote-binary",
         "--remote-state-dir",
+        "--wireguard-config",
+        "--wireguard-hub",
+        "--config",
+        "--socket",
         "--ssh-arg",
         "--workspace-root",
         "--host",
@@ -186,6 +191,7 @@ fn remote_help(command: Option<&str>) -> &'static str {
         Some("remote-link") => client.remote_link_help,
         Some("remote-stop") => catalog().remote.remote_stop_help,
         Some("install-self") => client.install_self_help,
+        Some("wg") => client.wg_hub_help,
         Some("remote") => client.remote_lifecycle_help,
         _ => client.command_help,
     }
@@ -209,6 +215,7 @@ struct ConnectFlags {
     routing: BTreeMap<String, String>,
     iroh_path: IrohPathMode,
     wireguard_config: Option<PathBuf>,
+    wireguard_hub: Option<PathBuf>,
     headless: bool,
     json: bool,
     ssh_session: String,
@@ -438,6 +445,12 @@ fn parse_connect_flags(args: &[String]) -> anyhow::Result<ConnectFlags> {
                     return Err(anyhow!(catalog().remote_client.option_once("--wireguard-config")));
                 }
             }
+            "--wireguard-hub" => {
+                let path = PathBuf::from(value("--wireguard-hub")?);
+                if flags.wireguard_hub.replace(path).is_some() {
+                    return Err(anyhow!(catalog().remote_client.option_once("--wireguard-hub")));
+                }
+            }
             "--headless" => flags.headless = true,
             "--json" => flags.json = true,
             "--session" => flags.ssh_session = value("--session")?,
@@ -494,6 +507,9 @@ fn parse_connect_flags(args: &[String]) -> anyhow::Result<ConnectFlags> {
     }
     if flags.json && !flags.headless {
         return Err(anyhow!(catalog().remote_client.json_requires_headless));
+    }
+    if flags.wireguard_config.is_some() && flags.wireguard_hub.is_some() {
+        return Err(anyhow!(catalog().remote_client.wireguard_hub_conflict));
     }
     Ok(flags)
 }
@@ -600,11 +616,13 @@ fn start_connected(mut flags: ConnectFlags) -> anyhow::Result<ConnectedRuntime> 
         .join("client");
     let store = ClientIdentityStore::load_or_create(&client_root)?;
     let async_runtime = tokio_runtime()?;
-    let wireguard = flags
-        .wireguard_config
-        .take()
-        .map(|path| start_wireguard(&async_runtime, &path))
-        .transpose()?;
+    let direct_dialer: Option<Arc<dyn Dialer>> = match (flags.wireguard_config.take(), flags.wireguard_hub.take()) {
+        (Some(path), _) => {
+            Some(Arc::new(WireGuardDialer::new(start_wireguard(&async_runtime, &path)?)))
+        }
+        (None, Some(socket)) => Some(Arc::new(SocksDialer::new(socket))),
+        (None, None) => None,
+    };
     let mut relay_routes = client_relay_options(
         flags.route.as_deref(),
         std::mem::take(&mut flags.relay_routes),
@@ -644,8 +662,12 @@ fn start_connected(mut flags: ConnectFlags) -> anyhow::Result<ConnectedRuntime> 
         maximum_frame_bytes: crate::remote_runtime::MAX_CARRIER_FRAME_BYTES,
     };
     let relay_route_names = relay_routes.keys().cloned().collect::<Vec<_>>();
-    let providers =
-        Arc::new(client_provider_registry(ssh.clone(), relay_routes, flags.iroh_path, wireguard)?);
+    let providers = Arc::new(client_provider_registry(
+        ssh.clone(),
+        relay_routes,
+        flags.iroh_path,
+        direct_dialer,
+    )?);
     let explicit_route = flags.route.take();
     let explicit_route_for_refresh = explicit_route.clone();
     let (route_strings, auth, expected_daemon, known, carrier_auth) = if let Some(invitation) =
@@ -1634,6 +1656,81 @@ fn read_invitation_ticket_file(path: &Path) -> anyhow::Result<String> {
         .to_string())
 }
 
+struct WgHubFlags {
+    config: PathBuf,
+    socket: PathBuf,
+}
+
+fn parse_wg_hub_flags(args: &[String]) -> anyhow::Result<WgHubFlags> {
+    let mut config = None;
+    let mut socket = None;
+    let mut index = 0;
+    while index < args.len() {
+        let argument = args[index].as_str();
+        index += 1;
+        let mut value = |name: &str| -> anyhow::Result<PathBuf> {
+            let value = args
+                .get(index)
+                .cloned()
+                .ok_or_else(|| anyhow!(catalog().remote_client.option_needs_value(name)))?;
+            index += 1;
+            Ok(PathBuf::from(value))
+        };
+        match argument {
+            "--config" => {
+                if config.replace(value("--config")?).is_some() {
+                    return Err(anyhow!(catalog().remote_client.option_once("--config")));
+                }
+            }
+            "--socket" => {
+                if socket.replace(value("--socket")?).is_some() {
+                    return Err(anyhow!(catalog().remote_client.option_once("--socket")));
+                }
+            }
+            "-h" | "--help" => return Err(anyhow!(catalog().remote_client.help_invalid_options)),
+            other => return Err(anyhow!(catalog().remote_client.unknown_option(other))),
+        }
+    }
+    Ok(WgHubFlags {
+        config: config.ok_or_else(|| anyhow!(catalog().remote_client.wg_hub_option_required("--config")))?,
+        socket: socket.ok_or_else(|| anyhow!(catalog().remote_client.wg_hub_option_required("--socket")))?,
+    })
+}
+
+/// `cmux-tui wg hub --config <wg-quick> --socket <unix path>`: own one
+/// WireGuard tunnel and serve SOCKS5 CONNECT for sidecars on a Unix socket.
+///
+/// Prints one JSON readiness line, then runs until SIGTERM or SIGINT, and
+/// removes the socket on the way out. Every error before readiness exits
+/// non-zero through the caller.
+fn run_wg(args: &[String]) -> anyhow::Result<()> {
+    match args.first().map(String::as_str) {
+        Some("hub") => {}
+        Some(action) => return Err(anyhow!(catalog().remote_client.unknown_action("wg", action))),
+        None => return Err(anyhow!(catalog().remote_client.wg_hub_help)),
+    }
+    let flags = parse_wg_hub_flags(&args[1..])?;
+    let async_runtime = tokio_runtime()?;
+    let net = start_wireguard(&async_runtime, &flags.config)?;
+    let hub = async_runtime
+        .block_on(cmux_remote::wireguard_hub::serve_wireguard_hub(net, flags.socket.clone()))
+        .map_err(|error| anyhow!(catalog().remote_client.wireguard_hub_serve_failed(&error.to_string())))?;
+    let ready = serde_json::json!({
+        "event": "hub-ready",
+        "socket": hub.path().display().to_string(),
+        "routes": hub.routes().iter().map(ToString::to_string).collect::<Vec<_>>(),
+    });
+    println!("{}", serde_json::to_string(&ready)?);
+    let _ = io::stdout().flush();
+    async_runtime
+        .block_on(crate::wait_for_shutdown_signal_async())
+        .map_err(|error| anyhow!(catalog().remote_client.wireguard_hub_signal_failed(&error.to_string())))?;
+    async_runtime
+        .block_on(hub.shutdown())
+        .map_err(|error| anyhow!(catalog().remote_client.wireguard_hub_serve_failed(&error.to_string())))?;
+    Ok(())
+}
+
 /// A wg-quick file is small; anything larger is not one.
 const MAX_WIREGUARD_CONFIG_BYTES: usize = 16 * 1024;
 
@@ -1753,7 +1850,12 @@ fn print_admin_response(action: &str, response: AdminResponse, json: bool) -> an
 }
 
 /// Advertised by `remote-probe --json` so a control plane can choose routes the client can use.
-pub const PROBE_CAPABILITIES: &[&str] = &["direct-ws-user-agent"];
+///
+/// `direct-ws-user-agent`: direct WebSocket dials carry a User-Agent, which
+/// hosted ingress on branded machine domains requires.
+/// `wireguard-hub`: `remote connect --wireguard-hub` and `wg hub` exist, so the
+/// app may reach private-network machines through a shared in-process tunnel.
+pub const PROBE_CAPABILITIES: &[&str] = &["direct-ws-user-agent", "wireguard-hub"];
 
 fn run_probe(args: &[String]) -> anyhow::Result<()> {
     let value = serde_json::json!({
@@ -2616,6 +2718,33 @@ mod tests {
     #[test]
     fn probe_capabilities_include_direct_ws_user_agent() {
         assert!(super::PROBE_CAPABILITIES.contains(&"direct-ws-user-agent"));
+        assert!(super::PROBE_CAPABILITIES.contains(&"wireguard-hub"));
+    }
+
+    #[test]
+    fn wireguard_config_and_hub_are_mutually_exclusive() {
+        let both = ["ws://[fd00::1]:1337/v1/link", "--wireguard-config", "/tmp/a.conf", "--wireguard-hub", "/tmp/hub.sock"]
+            .map(str::to_string);
+        let error = super::parse_connect_flags(&both).unwrap_err();
+        assert_eq!(error.to_string(), catalog().remote_client.wireguard_hub_conflict);
+        let hub_only = ["ws://[fd00::1]:1337/v1/link", "--wireguard-hub", "/tmp/hub.sock"].map(str::to_string);
+        let flags = super::parse_connect_flags(&hub_only).unwrap();
+        assert_eq!(flags.wireguard_hub, Some(PathBuf::from("/tmp/hub.sock")));
+        assert!(flags.wireguard_config.is_none());
+    }
+
+    #[test]
+    fn wg_hub_flags_require_config_and_socket() {
+        let full = ["hub", "--config", "/tmp/wg.conf", "--socket", "/tmp/wg.sock"].map(str::to_string);
+        let flags = super::parse_wg_hub_flags(&full[1..]).unwrap();
+        assert_eq!(flags.config, PathBuf::from("/tmp/wg.conf"));
+        assert_eq!(flags.socket, PathBuf::from("/tmp/wg.sock"));
+        let missing = ["--config", "/tmp/wg.conf"].map(str::to_string);
+        assert!(super::parse_wg_hub_flags(&missing).is_err());
+        let unknown = ["--config", "/tmp/wg.conf", "--socket", "/tmp/s", "--bogus"].map(str::to_string);
+        assert!(super::parse_wg_hub_flags(&unknown).is_err());
+        let not_hub = ["frobnicate"].map(str::to_string);
+        assert!(super::run_wg(&not_hub).is_err());
     }
 
     use super::*;

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -208,6 +208,7 @@ struct ConnectFlags {
     relay_credentials: Vec<ClientRelayCredentialArg>,
     routing: BTreeMap<String, String>,
     iroh_path: IrohPathMode,
+    wireguard_config: Option<PathBuf>,
     headless: bool,
     json: bool,
     ssh_session: String,
@@ -431,6 +432,12 @@ fn parse_connect_flags(args: &[String]) -> anyhow::Result<ConnectFlags> {
                     )
                 })?;
             }
+            "--wireguard-config" => {
+                let path = PathBuf::from(value("--wireguard-config")?);
+                if flags.wireguard_config.replace(path).is_some() {
+                    return Err(anyhow!(catalog().remote_client.option_once("--wireguard-config")));
+                }
+            }
             "--headless" => flags.headless = true,
             "--json" => flags.json = true,
             "--session" => flags.ssh_session = value("--session")?,
@@ -593,6 +600,11 @@ fn start_connected(mut flags: ConnectFlags) -> anyhow::Result<ConnectedRuntime> 
         .join("client");
     let store = ClientIdentityStore::load_or_create(&client_root)?;
     let async_runtime = tokio_runtime()?;
+    let wireguard = flags
+        .wireguard_config
+        .take()
+        .map(|path| start_wireguard(&async_runtime, &path))
+        .transpose()?;
     let mut relay_routes = client_relay_options(
         flags.route.as_deref(),
         std::mem::take(&mut flags.relay_routes),
@@ -632,7 +644,8 @@ fn start_connected(mut flags: ConnectFlags) -> anyhow::Result<ConnectedRuntime> 
         maximum_frame_bytes: crate::remote_runtime::MAX_CARRIER_FRAME_BYTES,
     };
     let relay_route_names = relay_routes.keys().cloned().collect::<Vec<_>>();
-    let providers = Arc::new(client_provider_registry(ssh.clone(), relay_routes, flags.iroh_path)?);
+    let providers =
+        Arc::new(client_provider_registry(ssh.clone(), relay_routes, flags.iroh_path, wireguard)?);
     let explicit_route = flags.route.take();
     let explicit_route_for_refresh = explicit_route.clone();
     let (route_strings, auth, expected_daemon, known, carrier_auth) = if let Some(invitation) =
@@ -1619,6 +1632,34 @@ fn read_invitation_ticket_file(path: &Path) -> anyhow::Result<String> {
         .with_context(|| format!("could not read relay ticket file {}", path.display()))?
         .trim()
         .to_string())
+}
+
+/// A wg-quick file is small; anything larger is not one.
+const MAX_WIREGUARD_CONFIG_BYTES: usize = 16 * 1024;
+
+/// Bring up the in-process WireGuard tunnel named by `--wireguard-config`.
+///
+/// The file holds a private key, so it must be owner-only like an invitation
+/// file. The tunnel lives as long as the provider registry that holds it, which
+/// is the life of this `remote connect` process.
+fn start_wireguard(
+    runtime: &tokio::runtime::Runtime,
+    path: &Path,
+) -> anyhow::Result<Arc<cmux_wg::WgNet>> {
+    let text = cmux_remote::secret_file::read_owner_only_string(path, MAX_WIREGUARD_CONFIG_BYTES)
+        .map_err(|error| {
+            anyhow!(
+                catalog()
+                    .remote_client
+                    .wireguard_config_unreadable(&path.display().to_string(), &error.to_string())
+            )
+        })?;
+    let config = cmux_wg::WgConfig::parse_wg_quick(&text)
+        .map_err(|error| anyhow!(catalog().remote_client.wireguard_config_invalid(&error.to_string())))?;
+    let net = runtime
+        .block_on(cmux_wg::WgNet::start_with_new_socket(config))
+        .map_err(|error| anyhow!(catalog().remote_client.wireguard_start_failed(&error.to_string())))?;
+    Ok(Arc::new(net))
 }
 
 fn read_invitation_uri(path: &Path) -> anyhow::Result<Zeroizing<String>> {
@@ -2619,6 +2660,7 @@ mod tests {
                 SshProviderConfig::default(),
                 BTreeMap::new(),
                 IrohPathMode::Auto,
+                None,
             )
             .unwrap(),
         )

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -33,11 +33,10 @@ use cmux_remote::identity::{
 };
 use cmux_remote::observability::ClientConnectionSnapshot;
 use cmux_remote::provider::{
-    ConnectRequest, DirectWebSocketProvider, IrohListener, IrohPathMode, IrohProvider,
+    ConnectRequest, Dialer, DirectWebSocketProvider, IrohListener, IrohPathMode, IrohProvider,
     IrohProviderConfig, LinkGroup, ProviderError, RelayClientConfig, RelayCredentialSource,
     RelayDaemonConfig, RelayDaemonRegistration, RelayProvider, SshProvider, SshProviderConfig,
-    SupportedClientAuthModes, TransportProvider, UnixProvider, WireGuardDialer,
-    load_or_create_iroh_secret,
+    SupportedClientAuthModes, TransportProvider, UnixProvider, load_or_create_iroh_secret,
     register_relay_daemon_with_credentials, sanitized_route, sanitized_route_text,
 };
 use cmux_remote::secure_directory::{DirectoryAccess, ensure_secure_directory};
@@ -435,21 +434,18 @@ impl TransportProvider for RoutedRelayProvider {
 
 /// The client-side transport registry.
 ///
-/// `wireguard` is an in-process tunnel (`cmux-wg`). When present, `ws`/`wss`
-/// routes whose address falls inside the tunnel's routes are dialed through
-/// it; every other address, and every other scheme, is unaffected.
+/// `direct_dialer` replaces the operating-system TCP dial for `ws`/`wss`
+/// routes: an in-process WireGuard tunnel (`WireGuardDialer`) or a shared hub
+/// (`SocksDialer`). Every other scheme is unaffected.
 pub fn client_provider_registry(
     ssh: SshProviderConfig,
     relay_routes: BTreeMap<String, RelayClientOptions>,
     iroh_path: IrohPathMode,
-    wireguard: Option<Arc<cmux_wg::WgNet>>,
+    direct_dialer: Option<Arc<dyn Dialer>>,
 ) -> Result<cmux_remote::provider::ProviderRegistry, ProviderError> {
     let mut providers = cmux_remote::provider::ProviderRegistry::default();
-    let direct = match wireguard {
-        Some(net) => DirectWebSocketProvider::with_dialer(
-            MAX_CARRIER_FRAME_BYTES,
-            Arc::new(WireGuardDialer::new(net)),
-        ),
+    let direct = match direct_dialer {
+        Some(dialer) => DirectWebSocketProvider::with_dialer(MAX_CARRIER_FRAME_BYTES, dialer),
         None => DirectWebSocketProvider::new(MAX_CARRIER_FRAME_BYTES),
     };
     providers.register(Arc::new(direct))?;

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -36,7 +36,8 @@ use cmux_remote::provider::{
     ConnectRequest, DirectWebSocketProvider, IrohListener, IrohPathMode, IrohProvider,
     IrohProviderConfig, LinkGroup, ProviderError, RelayClientConfig, RelayCredentialSource,
     RelayDaemonConfig, RelayDaemonRegistration, RelayProvider, SshProvider, SshProviderConfig,
-    SupportedClientAuthModes, TransportProvider, UnixProvider, load_or_create_iroh_secret,
+    SupportedClientAuthModes, TransportProvider, UnixProvider, WireGuardDialer,
+    load_or_create_iroh_secret,
     register_relay_daemon_with_credentials, sanitized_route, sanitized_route_text,
 };
 use cmux_remote::secure_directory::{DirectoryAccess, ensure_secure_directory};
@@ -432,13 +433,26 @@ impl TransportProvider for RoutedRelayProvider {
     }
 }
 
+/// The client-side transport registry.
+///
+/// `wireguard` is an in-process tunnel (`cmux-wg`). When present, `ws`/`wss`
+/// routes whose address falls inside the tunnel's routes are dialed through
+/// it; every other address, and every other scheme, is unaffected.
 pub fn client_provider_registry(
     ssh: SshProviderConfig,
     relay_routes: BTreeMap<String, RelayClientOptions>,
     iroh_path: IrohPathMode,
+    wireguard: Option<Arc<cmux_wg::WgNet>>,
 ) -> Result<cmux_remote::provider::ProviderRegistry, ProviderError> {
     let mut providers = cmux_remote::provider::ProviderRegistry::default();
-    providers.register(Arc::new(DirectWebSocketProvider::new(MAX_CARRIER_FRAME_BYTES)))?;
+    let direct = match wireguard {
+        Some(net) => DirectWebSocketProvider::with_dialer(
+            MAX_CARRIER_FRAME_BYTES,
+            Arc::new(WireGuardDialer::new(net)),
+        ),
+        None => DirectWebSocketProvider::new(MAX_CARRIER_FRAME_BYTES),
+    };
+    providers.register(Arc::new(direct))?;
     #[cfg(unix)]
     providers.register(Arc::new(UnixProvider::new(MAX_CARRIER_FRAME_BYTES)))?;
     providers.register(Arc::new(SshProvider::new(ssh)?))?;
@@ -2874,7 +2888,7 @@ mod tests {
     }
 
     fn test_providers(ssh: SshProviderConfig) -> Arc<cmux_remote::provider::ProviderRegistry> {
-        Arc::new(client_provider_registry(ssh, BTreeMap::new(), IrohPathMode::Auto).unwrap())
+        Arc::new(client_provider_registry(ssh, BTreeMap::new(), IrohPathMode::Auto, None).unwrap())
     }
 
     #[derive(Debug, PartialEq, Eq)]
@@ -4910,7 +4924,8 @@ mod tests {
             ..SshProviderConfig::default()
         };
         let providers = Arc::new(
-            client_provider_registry(ssh.clone(), BTreeMap::new(), IrohPathMode::Auto).unwrap(),
+            client_provider_registry(ssh.clone(), BTreeMap::new(), IrohPathMode::Auto, None)
+                .unwrap(),
         );
         let mut unix_route = Url::parse("unix:///").unwrap();
         unix_route.set_path(proxy_link.to_str().unwrap());

--- a/cmux-tui/crates/cmux-wg/Cargo.toml
+++ b/cmux-tui/crates/cmux-wg/Cargo.toml
@@ -10,22 +10,19 @@ description = "In-process WireGuard transport for cmux clients: boringtun plus a
 [lints]
 workspace = true
 
-[features]
-# Deterministic two-peer loopback harness for tests in other crates.
-test-support = ["dep:getrandom"]
-
 [dependencies]
 base64.workspace = true
 boringtun.workspace = true
 bytes.workspace = true
-getrandom = { workspace = true, optional = true }
+# Only the `testing` loopback harness needs randomness (fresh keypairs);
+# production callers bring their own keys.
+getrandom.workspace = true
 ip_network.workspace = true
 smoltcp.workspace = true
 tokio.workspace = true
-tokio-util = { workspace = true, features = ["sync"] }
+tokio-util.workspace = true
 x25519-dalek.workspace = true
 zeroize.workspace = true
 
 [dev-dependencies]
-cmux-wg = { path = ".", features = ["test-support"] }
 tokio = { workspace = true, features = ["test-util"] }

--- a/cmux-tui/crates/cmux-wg/Cargo.toml
+++ b/cmux-tui/crates/cmux-wg/Cargo.toml
@@ -1,0 +1,31 @@
+[package]
+name = "cmux-wg"
+version = "0.1.0"
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+publish.workspace = true
+description = "In-process WireGuard transport for cmux clients: boringtun plus a userspace TCP stack"
+
+[lints]
+workspace = true
+
+[features]
+# Deterministic two-peer loopback harness for tests in other crates.
+test-support = ["dep:getrandom"]
+
+[dependencies]
+base64.workspace = true
+boringtun.workspace = true
+bytes.workspace = true
+getrandom = { workspace = true, optional = true }
+ip_network.workspace = true
+smoltcp.workspace = true
+tokio.workspace = true
+tokio-util = { workspace = true, features = ["sync"] }
+x25519-dalek.workspace = true
+zeroize.workspace = true
+
+[dev-dependencies]
+cmux-wg = { path = ".", features = ["test-support"] }
+tokio = { workspace = true, features = ["test-util"] }

--- a/cmux-tui/crates/cmux-wg/src/config.rs
+++ b/cmux-tui/crates/cmux-wg/src/config.rs
@@ -1,0 +1,497 @@
+//! The wg-quick configuration of one point-to-point tunnel.
+//!
+//! The parser accepts the file a WireGuard control plane hands out (Freestyle's
+//! tunnel config, `wg-quick(8)` syntax) and ignores keys that only matter to a
+//! system interface (`DNS`, `Table`, `PreUp`, `PostDown`, `FwMark`,
+//! `ListenPort`, `SaveConfig`). Exactly one `[Peer]` is supported: this crate
+//! models one client reaching one network, not a mesh.
+//!
+//! Secrets never appear in errors or in `Debug` output.
+
+use std::fmt;
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+
+use base64::Engine;
+use ip_network::IpNetwork;
+use zeroize::Zeroizing;
+
+/// The WireGuard default interface MTU, used when the config sets none.
+pub const DEFAULT_MTU: u16 = 1420;
+
+/// Smallest MTU the stack accepts. Below this TCP cannot carry a useful segment.
+const MIN_MTU: u16 = 576;
+
+/// The interface holds at most this many addresses (smoltcp's compiled-in
+/// `IFACE_MAX_ADDR_COUNT`). Freestyle issues one IPv4 and one IPv6 address.
+pub(crate) const MAX_ADDRESSES: usize = 2;
+
+/// Where the peer listens. A host name is resolved when the tunnel starts.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct Endpoint {
+    pub host: String,
+    pub port: u16,
+}
+
+impl Endpoint {
+    /// Resolve to socket addresses. A literal IP resolves to itself without a
+    /// DNS query.
+    pub async fn resolve(&self) -> io::Result<Vec<SocketAddr>> {
+        if let Ok(ip) = self.host.parse::<IpAddr>() {
+            return Ok(vec![SocketAddr::new(ip, self.port)]);
+        }
+        let addresses =
+            tokio::net::lookup_host((self.host.as_str(), self.port)).await?.collect::<Vec<_>>();
+        if addresses.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("{} resolved to no addresses", self.host),
+            ));
+        }
+        Ok(addresses)
+    }
+}
+
+impl fmt::Display for Endpoint {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.host.contains(':') {
+            write!(formatter, "[{}]:{}", self.host, self.port)
+        } else {
+            write!(formatter, "{}:{}", self.host, self.port)
+        }
+    }
+}
+
+/// One `Address =` entry: this side's host address and the prefix of the
+/// subnet it sits in. Unlike an `AllowedIPs` network the host bits matter.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct InterfaceAddress {
+    pub address: IpAddr,
+    pub prefix: u8,
+}
+
+impl fmt::Display for InterfaceAddress {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}/{}", self.address, self.prefix)
+    }
+}
+
+/// One tunnel: this side's identity and addresses plus the single peer.
+#[derive(Clone)]
+pub struct WgConfig {
+    /// This side's Curve25519 private key.
+    pub private_key: Zeroizing<[u8; 32]>,
+    /// Addresses assigned to this side inside the network (`Address =`).
+    pub addresses: Vec<InterfaceAddress>,
+    /// Largest IP packet the tunnel carries.
+    pub mtu: u16,
+    /// The peer's Curve25519 public key.
+    pub peer_public_key: [u8; 32],
+    /// Optional symmetric pre-shared key mixed into the handshake.
+    pub preshared_key: Option<Zeroizing<[u8; 32]>>,
+    /// Networks reachable through the peer (`AllowedIPs =`). Also the
+    /// crypto-key routing filter for packets the peer sends.
+    pub allowed_ips: Vec<IpNetwork>,
+    /// The peer's listening endpoint. `None` for a side that only answers,
+    /// which learns the endpoint from the first authenticated datagram.
+    pub endpoint: Option<Endpoint>,
+    /// Seconds between keepalives that hold NAT mappings open.
+    pub persistent_keepalive: Option<u16>,
+}
+
+impl fmt::Debug for WgConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WgConfig")
+            .field("addresses", &self.addresses)
+            .field("mtu", &self.mtu)
+            .field(
+                "peer_public_key",
+                &base64::engine::general_purpose::STANDARD.encode(self.peer_public_key),
+            )
+            .field("preshared_key", &self.preshared_key.as_ref().map(|_| "<set>"))
+            .field("allowed_ips", &self.allowed_ips)
+            .field("endpoint", &self.endpoint)
+            .field("persistent_keepalive", &self.persistent_keepalive)
+            .finish_non_exhaustive()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ConfigError {
+    /// A section other than `[Interface]` or `[Peer]`.
+    UnexpectedSection(String),
+    /// A line that is not `key = value`, or one outside any section.
+    MalformedLine(usize),
+    /// A second `[Peer]` section.
+    MultiplePeers,
+    /// A key with a value that failed to parse. Key material is never echoed;
+    /// for addresses the offending text is included.
+    InvalidValue { key: &'static str, detail: String },
+    MissingPrivateKey,
+    MissingAddress,
+    MissingPeerPublicKey,
+    MissingAllowedIps,
+    /// More addresses than the interface can hold.
+    TooManyAddresses { maximum: usize },
+}
+
+impl fmt::Display for ConfigError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnexpectedSection(name) => write!(formatter, "unexpected section [{name}]"),
+            Self::MalformedLine(line) => write!(formatter, "line {line} is not `key = value`"),
+            Self::MultiplePeers => formatter.write_str("more than one [Peer] section"),
+            Self::InvalidValue { key, detail } => write!(formatter, "invalid {key}: {detail}"),
+            Self::MissingPrivateKey => formatter.write_str("[Interface] has no PrivateKey"),
+            Self::MissingAddress => formatter.write_str("[Interface] has no Address"),
+            Self::MissingPeerPublicKey => formatter.write_str("[Peer] has no PublicKey"),
+            Self::MissingAllowedIps => formatter.write_str("[Peer] has no AllowedIPs"),
+            Self::TooManyAddresses { maximum } => {
+                write!(formatter, "[Interface] has more than {maximum} Address entries")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+#[derive(PartialEq, Eq)]
+enum Section {
+    None,
+    Interface,
+    Peer,
+}
+
+impl WgConfig {
+    /// Parse a wg-quick configuration file.
+    pub fn parse_wg_quick(text: &str) -> Result<Self, ConfigError> {
+        let mut section = Section::None;
+        let mut saw_peer = false;
+        let mut private_key = None;
+        let mut addresses = Vec::new();
+        let mut mtu = DEFAULT_MTU;
+        let mut peer_public_key = None;
+        let mut preshared_key = None;
+        let mut allowed_ips = Vec::new();
+        let mut endpoint = None;
+        let mut persistent_keepalive = None;
+
+        for (index, raw) in text.lines().enumerate() {
+            let line_number = index + 1;
+            let line = strip_comment(raw).trim();
+            if line.is_empty() {
+                continue;
+            }
+            if let Some(name) = line.strip_prefix('[').and_then(|rest| rest.strip_suffix(']')) {
+                section = match name.trim().to_ascii_lowercase().as_str() {
+                    "interface" => Section::Interface,
+                    "peer" => {
+                        if saw_peer {
+                            return Err(ConfigError::MultiplePeers);
+                        }
+                        saw_peer = true;
+                        Section::Peer
+                    }
+                    other => return Err(ConfigError::UnexpectedSection(other.to_owned())),
+                };
+                continue;
+            }
+            let (key, value) =
+                line.split_once('=').ok_or(ConfigError::MalformedLine(line_number))?;
+            let key = key.trim().to_ascii_lowercase();
+            let value = value.trim();
+            match section {
+                Section::None => return Err(ConfigError::MalformedLine(line_number)),
+                Section::Interface => match key.as_str() {
+                    "privatekey" => private_key = Some(parse_key(value, "PrivateKey")?),
+                    "address" => {
+                        for entry in comma_separated(value) {
+                            addresses.push(parse_interface_address(entry)?);
+                        }
+                    }
+                    "mtu" => {
+                        mtu = value.parse::<u16>().ok().filter(|mtu| *mtu >= MIN_MTU).ok_or_else(
+                            || ConfigError::InvalidValue {
+                                key: "MTU",
+                                detail: format!("{value} is not an integer of at least {MIN_MTU}"),
+                            },
+                        )?;
+                    }
+                    // System-interface concerns; irrelevant to an in-process peer.
+                    _ => {}
+                },
+                Section::Peer => match key.as_str() {
+                    "publickey" => peer_public_key = Some(*parse_key(value, "PublicKey")?),
+                    "presharedkey" => preshared_key = Some(parse_key(value, "PresharedKey")?),
+                    "allowedips" => {
+                        for entry in comma_separated(value) {
+                            allowed_ips.push(parse_allowed_network(entry)?);
+                        }
+                    }
+                    "endpoint" => endpoint = Some(parse_endpoint(value)?),
+                    "persistentkeepalive" => {
+                        let seconds =
+                            value.parse::<u16>().map_err(|_| ConfigError::InvalidValue {
+                                key: "PersistentKeepalive",
+                                detail: format!("{value} is not a number of seconds"),
+                            })?;
+                        persistent_keepalive = (seconds > 0).then_some(seconds);
+                    }
+                    _ => {}
+                },
+            }
+        }
+
+        let private_key = private_key.ok_or(ConfigError::MissingPrivateKey)?;
+        if addresses.is_empty() {
+            return Err(ConfigError::MissingAddress);
+        }
+        if addresses.len() > MAX_ADDRESSES {
+            return Err(ConfigError::TooManyAddresses { maximum: MAX_ADDRESSES });
+        }
+        let peer_public_key = peer_public_key.ok_or(ConfigError::MissingPeerPublicKey)?;
+        if allowed_ips.is_empty() {
+            return Err(ConfigError::MissingAllowedIps);
+        }
+        Ok(Self {
+            private_key,
+            addresses,
+            mtu,
+            peer_public_key,
+            preshared_key,
+            allowed_ips,
+            endpoint,
+            persistent_keepalive,
+        })
+    }
+
+    /// Whether `address` is reachable through this tunnel.
+    pub fn routes_contain(&self, address: IpAddr) -> bool {
+        self.allowed_ips.iter().any(|network| network.contains(address))
+    }
+
+    /// This side's address in the same family as `remote`, if any.
+    pub fn local_address_for(&self, remote: IpAddr) -> Option<IpAddr> {
+        self.addresses
+            .iter()
+            .map(|entry| entry.address)
+            .find(|address| address.is_ipv4() == remote.is_ipv4())
+    }
+}
+
+fn strip_comment(line: &str) -> &str {
+    match line.find('#') {
+        Some(index) => &line[..index],
+        None => line,
+    }
+}
+
+fn comma_separated(value: &str) -> impl Iterator<Item = &str> {
+    value.split(',').map(str::trim).filter(|entry| !entry.is_empty())
+}
+
+fn parse_key(value: &str, key: &'static str) -> Result<Zeroizing<[u8; 32]>, ConfigError> {
+    let invalid =
+        || ConfigError::InvalidValue { key, detail: "expected 32 bytes of base64".into() };
+    let decoded = Zeroizing::new(
+        base64::engine::general_purpose::STANDARD.decode(value).map_err(|_| invalid())?,
+    );
+    let mut bytes = Zeroizing::new([0u8; 32]);
+    if decoded.len() != bytes.len() {
+        return Err(invalid());
+    }
+    bytes.copy_from_slice(&decoded);
+    Ok(bytes)
+}
+
+fn split_prefix(value: &str, key: &'static str) -> Result<(IpAddr, Option<u8>), ConfigError> {
+    let invalid = |detail: String| ConfigError::InvalidValue { key, detail };
+    match value.split_once('/') {
+        Some((address, prefix)) => {
+            let address = address
+                .parse::<IpAddr>()
+                .map_err(|_| invalid(format!("{value} is not an IP address")))?;
+            let prefix = prefix
+                .parse::<u8>()
+                .ok()
+                .filter(|prefix| *prefix <= if address.is_ipv4() { 32 } else { 128 })
+                .ok_or_else(|| invalid(format!("{value} has an invalid prefix length")))?;
+            Ok((address, Some(prefix)))
+        }
+        None => {
+            let address = value
+                .parse::<IpAddr>()
+                .map_err(|_| invalid(format!("{value} is not an IP address")))?;
+            Ok((address, None))
+        }
+    }
+}
+
+fn parse_interface_address(value: &str) -> Result<InterfaceAddress, ConfigError> {
+    let (address, prefix) = split_prefix(value, "Address")?;
+    let prefix = prefix.unwrap_or(if address.is_ipv4() { 32 } else { 128 });
+    Ok(InterfaceAddress { address, prefix })
+}
+
+fn parse_allowed_network(value: &str) -> Result<IpNetwork, ConfigError> {
+    let (address, prefix) = split_prefix(value, "AllowedIPs")?;
+    let prefix = prefix.unwrap_or(if address.is_ipv4() { 32 } else { 128 });
+    // `wg` truncates host bits of an allowed network the same way.
+    IpNetwork::new_truncate(address, prefix).map_err(|_| ConfigError::InvalidValue {
+        key: "AllowedIPs",
+        detail: format!("{value} has an invalid prefix length"),
+    })
+}
+
+fn parse_endpoint(value: &str) -> Result<Endpoint, ConfigError> {
+    let invalid =
+        || ConfigError::InvalidValue { key: "Endpoint", detail: format!("{value} is not host:port") };
+    if let Some(rest) = value.strip_prefix('[') {
+        let (host, port) = rest.split_once("]:").ok_or_else(invalid)?;
+        let port = port.parse::<u16>().map_err(|_| invalid())?;
+        if host.is_empty() {
+            return Err(invalid());
+        }
+        return Ok(Endpoint { host: host.to_owned(), port });
+    }
+    let (host, port) = value.rsplit_once(':').ok_or_else(invalid)?;
+    if host.is_empty() || host.contains(':') {
+        return Err(invalid());
+    }
+    let port = port.parse::<u16>().map_err(|_| invalid())?;
+    Ok(Endpoint { host: host.to_owned(), port })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const KEY_A: &str = "GDYq0RJ4LWL6jJhLMAlM1oHcCTdSiXPMZ4X5D8WzGdw=";
+    const KEY_B: &str = "Bo2I0OcpKnXtElGwH6EXV3MwDQctaIrFJ4tDX44DoWs=";
+
+    fn freestyle_shaped() -> String {
+        format!(
+            "[Interface]\nPrivateKey = {KEY_A}\nAddress = 100.64.0.1/32\nAddress = fd7a:7570:6c6b::1/128\nMTU = 1200\nDNS = 10.0.0.53\n\n[Peer]\nPublicKey = {KEY_B}\nAllowedIPs = 10.0.0.0/8, fd00::/8\nEndpoint = [2606:4700::1]:51820\nPersistentKeepalive = 25\n"
+        )
+    }
+
+    #[test]
+    fn parses_a_freestyle_shaped_config() {
+        let config = WgConfig::parse_wg_quick(&freestyle_shaped()).unwrap();
+        assert_eq!(config.mtu, 1200);
+        assert_eq!(config.addresses.len(), 2);
+        assert_eq!(config.addresses[0].to_string(), "100.64.0.1/32");
+        assert_eq!(config.addresses[1].to_string(), "fd7a:7570:6c6b::1/128");
+        assert_eq!(config.allowed_ips.len(), 2);
+        assert_eq!(config.allowed_ips[0].to_string(), "10.0.0.0/8");
+        assert_eq!(config.allowed_ips[1].to_string(), "fd00::/8");
+        assert_eq!(config.endpoint, Some(Endpoint { host: "2606:4700::1".into(), port: 51820 }));
+        assert_eq!(config.endpoint.as_ref().unwrap().to_string(), "[2606:4700::1]:51820");
+        assert_eq!(config.persistent_keepalive, Some(25));
+        assert!(config.preshared_key.is_none());
+        assert!(config.routes_contain("10.100.0.10".parse().unwrap()));
+        assert!(config.routes_contain("fd12::1".parse().unwrap()));
+        assert!(!config.routes_contain("192.168.1.1".parse().unwrap()));
+        assert_eq!(
+            config.local_address_for("10.100.0.10".parse().unwrap()),
+            Some("100.64.0.1".parse().unwrap())
+        );
+        assert_eq!(
+            config.local_address_for("fd12::1".parse().unwrap()),
+            Some("fd7a:7570:6c6b::1".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn debug_output_omits_the_private_key() {
+        let config = WgConfig::parse_wg_quick(&freestyle_shaped()).unwrap();
+        let debug = format!("{config:?}");
+        assert!(!debug.contains(KEY_A));
+        assert!(debug.contains(KEY_B));
+    }
+
+    #[test]
+    fn hostname_endpoints_and_comma_lists_parse() {
+        let text = format!(
+            "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/24, fdaa::2/64 # tunnel\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.7/24\nEndpoint=vpn.example.com:51820\n"
+        );
+        let config = WgConfig::parse_wg_quick(&text).unwrap();
+        assert_eq!(config.mtu, DEFAULT_MTU);
+        assert_eq!(config.endpoint.unwrap().to_string(), "vpn.example.com:51820");
+        // Interface addresses keep their host bits; allowed networks drop them.
+        assert_eq!(config.addresses[0].to_string(), "10.1.0.2/24");
+        assert_eq!(config.addresses[1].to_string(), "fdaa::2/64");
+        assert_eq!(config.allowed_ips[0].to_string(), "10.1.0.0/24");
+        assert_eq!(
+            config.local_address_for("10.1.0.9".parse().unwrap()),
+            Some("10.1.0.2".parse().unwrap())
+        );
+    }
+
+    #[test]
+    fn a_bare_address_is_a_host() {
+        let text = format!(
+            "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.9\n"
+        );
+        let config = WgConfig::parse_wg_quick(&text).unwrap();
+        assert_eq!(config.addresses[0].to_string(), "10.1.0.2/32");
+        assert_eq!(config.allowed_ips[0].to_string(), "10.1.0.9/32");
+        assert!(config.endpoint.is_none());
+    }
+
+    #[test]
+    fn rejects_missing_and_malformed_fields() {
+        let missing_key = format!(
+            "[Interface]\nAddress=10.1.0.2/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
+        );
+        assert_eq!(WgConfig::parse_wg_quick(&missing_key), Err(ConfigError::MissingPrivateKey));
+
+        let bad_key = format!(
+            "[Interface]\nPrivateKey=short\nAddress=10.1.0.2/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
+        );
+        let error = WgConfig::parse_wg_quick(&bad_key).unwrap_err();
+        assert!(matches!(error, ConfigError::InvalidValue { key: "PrivateKey", .. }));
+        assert!(!error.to_string().contains("short"));
+
+        let two_peers = format!(
+            "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.2.0.0/24\n"
+        );
+        assert_eq!(WgConfig::parse_wg_quick(&two_peers), Err(ConfigError::MultiplePeers));
+
+        let small_mtu = format!(
+            "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/32\nMTU=100\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
+        );
+        assert!(matches!(
+            WgConfig::parse_wg_quick(&small_mtu),
+            Err(ConfigError::InvalidValue { key: "MTU", .. })
+        ));
+
+        let bad_endpoint = format!(
+            "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\nEndpoint=fd00::1:51820\n"
+        );
+        assert!(matches!(
+            WgConfig::parse_wg_quick(&bad_endpoint),
+            Err(ConfigError::InvalidValue { key: "Endpoint", .. })
+        ));
+
+        let bad_prefix = format!(
+            "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/40\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
+        );
+        assert!(matches!(
+            WgConfig::parse_wg_quick(&bad_prefix),
+            Err(ConfigError::InvalidValue { key: "Address", .. })
+        ));
+
+        let stray = format!("PrivateKey={KEY_A}\n");
+        assert_eq!(WgConfig::parse_wg_quick(&stray), Err(ConfigError::MalformedLine(1)));
+
+        let three_addresses = format!(
+            "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/32, 10.1.0.3/32, 10.1.0.4/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
+        );
+        assert_eq!(
+            WgConfig::parse_wg_quick(&three_addresses),
+            Err(ConfigError::TooManyAddresses { maximum: 2 })
+        );
+    }
+}

--- a/cmux-tui/crates/cmux-wg/src/config.rs
+++ b/cmux-tui/crates/cmux-wg/src/config.rs
@@ -418,7 +418,7 @@ mod tests {
         );
         let config = WgConfig::parse_wg_quick(&text).unwrap();
         assert_eq!(config.mtu, DEFAULT_MTU);
-        assert_eq!(config.endpoint.unwrap().to_string(), "vpn.example.com:51820");
+        assert_eq!(config.endpoint.as_ref().unwrap().to_string(), "vpn.example.com:51820");
         // Interface addresses keep their host bits; allowed networks drop them.
         assert_eq!(config.addresses[0].to_string(), "10.1.0.2/24");
         assert_eq!(config.addresses[1].to_string(), "fdaa::2/64");
@@ -445,7 +445,10 @@ mod tests {
         let missing_key = format!(
             "[Interface]\nAddress=10.1.0.2/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
         );
-        assert_eq!(WgConfig::parse_wg_quick(&missing_key), Err(ConfigError::MissingPrivateKey));
+        assert_eq!(
+            WgConfig::parse_wg_quick(&missing_key).unwrap_err(),
+            ConfigError::MissingPrivateKey
+        );
 
         let bad_key = format!(
             "[Interface]\nPrivateKey=short\nAddress=10.1.0.2/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
@@ -457,7 +460,7 @@ mod tests {
         let two_peers = format!(
             "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.2.0.0/24\n"
         );
-        assert_eq!(WgConfig::parse_wg_quick(&two_peers), Err(ConfigError::MultiplePeers));
+        assert_eq!(WgConfig::parse_wg_quick(&two_peers).unwrap_err(), ConfigError::MultiplePeers);
 
         let small_mtu = format!(
             "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/32\nMTU=100\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
@@ -484,14 +487,14 @@ mod tests {
         ));
 
         let stray = format!("PrivateKey={KEY_A}\n");
-        assert_eq!(WgConfig::parse_wg_quick(&stray), Err(ConfigError::MalformedLine(1)));
+        assert_eq!(WgConfig::parse_wg_quick(&stray).unwrap_err(), ConfigError::MalformedLine(1));
 
         let three_addresses = format!(
             "[Interface]\nPrivateKey={KEY_A}\nAddress=10.1.0.2/32, 10.1.0.3/32, 10.1.0.4/32\n[Peer]\nPublicKey={KEY_B}\nAllowedIPs=10.1.0.0/24\n"
         );
         assert_eq!(
-            WgConfig::parse_wg_quick(&three_addresses),
-            Err(ConfigError::TooManyAddresses { maximum: 2 })
+            WgConfig::parse_wg_quick(&three_addresses).unwrap_err(),
+            ConfigError::TooManyAddresses { maximum: 2 }
         );
     }
 }

--- a/cmux-tui/crates/cmux-wg/src/device.rs
+++ b/cmux-tui/crates/cmux-wg/src/device.rs
@@ -1,0 +1,99 @@
+//! The virtual network device smoltcp polls.
+//!
+//! smoltcp wants a device that hands it received IP packets and accepts the
+//! packets it wants to send. Here both directions are plain queues: the driver
+//! fills `rx` with packets decrypted by WireGuard and drains `tx` into
+//! WireGuard for encryption. There is no link layer, so the medium is `Ip`.
+
+use std::collections::VecDeque;
+
+use smoltcp::phy::{self, Device, DeviceCapabilities, Medium};
+use smoltcp::time::Instant;
+
+/// Packets smoltcp may queue before the driver drains them. Backpressure past
+/// this point comes from smoltcp itself: `transmit` returns `None` and TCP
+/// waits for the next poll.
+const MAX_TX_QUEUE: usize = 256;
+
+pub(crate) struct VirtualDevice {
+    rx: VecDeque<Vec<u8>>,
+    tx: VecDeque<Vec<u8>>,
+    mtu: usize,
+}
+
+impl VirtualDevice {
+    pub(crate) fn new(mtu: u16) -> Self {
+        Self { rx: VecDeque::new(), tx: VecDeque::new(), mtu: usize::from(mtu) }
+    }
+
+    /// Queue a decrypted packet for smoltcp to receive on the next poll.
+    pub(crate) fn push_rx(&mut self, packet: Vec<u8>) {
+        self.rx.push_back(packet);
+    }
+
+    /// Take the next packet smoltcp wants sent.
+    pub(crate) fn pop_tx(&mut self) -> Option<Vec<u8>> {
+        self.tx.pop_front()
+    }
+
+    pub(crate) fn has_rx(&self) -> bool {
+        !self.rx.is_empty()
+    }
+}
+
+impl Device for VirtualDevice {
+    type RxToken<'a>
+        = RxToken
+    where
+        Self: 'a;
+    type TxToken<'a>
+        = TxToken<'a>
+    where
+        Self: 'a;
+
+    fn receive(&mut self, _timestamp: Instant) -> Option<(Self::RxToken<'_>, Self::TxToken<'_>)> {
+        let packet = self.rx.pop_front()?;
+        Some((RxToken(packet), TxToken { queue: &mut self.tx }))
+    }
+
+    fn transmit(&mut self, _timestamp: Instant) -> Option<Self::TxToken<'_>> {
+        if self.tx.len() >= MAX_TX_QUEUE {
+            return None;
+        }
+        Some(TxToken { queue: &mut self.tx })
+    }
+
+    fn capabilities(&self) -> DeviceCapabilities {
+        let mut capabilities = DeviceCapabilities::default();
+        capabilities.medium = Medium::Ip;
+        capabilities.max_transmission_unit = self.mtu;
+        capabilities
+    }
+}
+
+pub(crate) struct RxToken(Vec<u8>);
+
+impl phy::RxToken for RxToken {
+    fn consume<R, F>(self, f: F) -> R
+    where
+        F: FnOnce(&[u8]) -> R,
+    {
+        f(&self.0)
+    }
+}
+
+pub(crate) struct TxToken<'a> {
+    queue: &'a mut VecDeque<Vec<u8>>,
+}
+
+impl phy::TxToken for TxToken<'_> {
+    fn consume<R, F>(self, len: usize, f: F) -> R
+    where
+        F: FnOnce(&mut [u8]) -> R,
+    {
+        let mut packet = vec![0u8; len];
+        let result = f(&mut packet);
+        self.queue.push_back(packet);
+        result
+    }
+}

--- a/cmux-tui/crates/cmux-wg/src/lib.rs
+++ b/cmux-tui/crates/cmux-wg/src/lib.rs
@@ -1,0 +1,35 @@
+//! In-process WireGuard for cmux clients.
+//!
+//! A cmux Cloud machine sits on its owner's private network and opens no
+//! public port. Reaching its daemon therefore needs a WireGuard peer, and the
+//! usual way to get one is a system interface: root on macOS, the
+//! NetworkExtension entitlement plus a VPN prompt on iOS. This crate is the
+//! alternative: the WireGuard peer and a small TCP/IP stack run inside the
+//! client process, over one plain UDP socket. Only the client's own
+//! connections travel through it, nothing else on the machine changes, and no
+//! privilege is needed.
+//!
+//! Two sans-IO engines are wired together by one driver task:
+//!
+//! - [`boringtun::noise::Tunn`] holds the WireGuard session (handshake,
+//!   encryption, timers, keepalive) and speaks in datagrams.
+//! - `smoltcp` holds the IP interface and its TCP sockets and speaks in IP
+//!   packets.
+//!
+//! The driver moves bytes between the UDP socket, the tunnel, and a virtual
+//! device that smoltcp polls. Each TCP connection is bridged to a
+//! [`WgStream`], which implements Tokio's `AsyncRead` and `AsyncWrite` so the
+//! rest of the client cannot tell it apart from a kernel socket.
+//!
+//! Crypto-key routing is enforced on receive: a decrypted packet whose source
+//! address lies outside the peer's `AllowedIPs` is dropped.
+
+mod config;
+mod device;
+mod net;
+#[cfg(any(test, feature = "test-support"))]
+pub mod testing;
+
+pub use config::{ConfigError, DEFAULT_MTU, Endpoint, InterfaceAddress, WgConfig};
+pub use ip_network::IpNetwork;
+pub use net::{WgError, WgListener, WgNet, WgStream};

--- a/cmux-tui/crates/cmux-wg/src/lib.rs
+++ b/cmux-tui/crates/cmux-wg/src/lib.rs
@@ -27,7 +27,8 @@
 mod config;
 mod device;
 mod net;
-#[cfg(any(test, feature = "test-support"))]
+/// Two-peer loopback harness. Test support for this crate and its dependents;
+/// it links no code into a binary that does not call it.
 pub mod testing;
 
 pub use config::{ConfigError, DEFAULT_MTU, Endpoint, InterfaceAddress, WgConfig};

--- a/cmux-tui/crates/cmux-wg/src/net.rs
+++ b/cmux-tui/crates/cmux-wg/src/net.rs
@@ -1020,7 +1020,37 @@ fn packet_source(packet: &[u8]) -> Option<IpAddr> {
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
+
     use super::*;
+
+    #[test]
+    fn ephemeral_port_allocator_stays_bounded_under_load() {
+        let mut allocator = PortAllocator::with_next_port(FIRST_EPHEMERAL_PORT);
+        let mut ports = HashSet::with_capacity(8_192);
+        let mut probes = 0;
+        for _ in 0..8_192 {
+            let (port, examined) = allocator.allocate_with_probe_count().expect("port available");
+            assert!(ports.insert(port), "allocator returned a duplicate port");
+            probes += examined;
+        }
+
+        // With an uncontended cursor, each allocation examines one candidate.
+        // This bound catches a regression to scanning every active connection.
+        assert!(probes <= ports.len() * 2, "allocator examined {probes} candidates for {} ports", ports.len());
+
+        let occupied = FIRST_EPHEMERAL_PORT + 8_191;
+        assert!(ports.contains(&occupied));
+        allocator.set_next_port(occupied);
+        let (replacement, examined) = allocator.allocate_with_probe_count().expect("port available");
+        assert_ne!(replacement, occupied);
+        assert_eq!(examined, 2);
+
+        let released = ports.iter().next().copied().expect("ports allocated");
+        allocator.release(released);
+        allocator.set_next_port(released);
+        assert_eq!(allocator.allocate(), Some(released));
+    }
 
     #[test]
     fn packet_source_reads_both_families() {

--- a/cmux-tui/crates/cmux-wg/src/net.rs
+++ b/cmux-tui/crates/cmux-wg/src/net.rs
@@ -48,6 +48,12 @@ const MAX_WRITE_CHUNK_BYTES: usize = 64 * 1024;
 const STREAM_CHANNEL_DEPTH: usize = 32;
 /// Pending accepted connections a listener holds before refusing more.
 const LISTENER_BACKLOG: usize = 16;
+/// Spare LISTEN sockets kept per port. smoltcp has no accept queue: each
+/// listening socket becomes exactly one connection. A small pool lets a burst
+/// of concurrent SYNs (one per lane) each land on its own socket instead of
+/// being reset, and each is refilled the moment it leaves LISTEN so a retransmit
+/// of an in-progress SYN matches the existing half-open rather than a spare.
+const LISTEN_SPARES: usize = 8;
 /// Commands in flight before `connect`/`listen` callers wait.
 const COMMAND_DEPTH: usize = 64;
 /// WireGuard timer resolution; boringtun's own device uses the same.
@@ -56,8 +62,17 @@ const TIMER_TICK: Duration = Duration::from_millis(250);
 const TCP_TIMEOUT: Duration = Duration::from_secs(60);
 /// Largest datagram or packet buffer: the UDP payload maximum.
 const BUFFER_BYTES: usize = 65_535;
-/// First ephemeral port; wraps to itself.
+/// The ephemeral port range (IANA 49152-65535); allocation starts at a random
+/// port inside it and wraps, as a real stack does.
 const FIRST_EPHEMERAL_PORT: u16 = 49_152;
+const EPHEMERAL_PORT_COUNT: u16 = u16::MAX - FIRST_EPHEMERAL_PORT;
+
+fn random_ephemeral_port() -> u16 {
+    let mut seed = [0u8; 2];
+    // A failure here only weakens port randomization, never correctness.
+    let _ = getrandom::fill(&mut seed);
+    FIRST_EPHEMERAL_PORT + (u16::from_le_bytes(seed) % EPHEMERAL_PORT_COUNT)
+}
 
 #[derive(Debug)]
 pub enum WgError {
@@ -409,7 +424,8 @@ struct Conn {
 
 struct Listener {
     port: u16,
-    handle: SocketHandle,
+    /// Sockets in LISTEN or SYN-RECEIVED for this port.
+    handles: Vec<SocketHandle>,
     accept: mpsc::Sender<WgStream>,
 }
 
@@ -499,7 +515,7 @@ impl Driver {
             commands,
             wake,
             epoch,
-            next_port: FIRST_EPHEMERAL_PORT,
+            next_port: random_ephemeral_port(),
             scratch: vec![0u8; BUFFER_BYTES + 32],
         })
     }
@@ -653,7 +669,9 @@ impl Driver {
             self.sockets.get_mut::<tcp::Socket>(conn.handle).abort();
         }
         for listener in &self.listeners {
-            self.sockets.get_mut::<tcp::Socket>(listener.handle).abort();
+            for handle in &listener.handles {
+                self.sockets.get_mut::<tcp::Socket>(*handle).abort();
+            }
         }
         let now = self.now();
         self.iface.poll(now, &mut self.device, &mut self.sockets);
@@ -676,10 +694,10 @@ impl Driver {
     }
 
     fn allocate_port(&mut self) -> u16 {
-        for _ in 0..(u16::MAX - FIRST_EPHEMERAL_PORT) {
+        for _ in 0..EPHEMERAL_PORT_COUNT {
             let port = self.next_port;
             self.next_port =
-                if self.next_port == u16::MAX { FIRST_EPHEMERAL_PORT } else { self.next_port + 1 };
+                if self.next_port >= u16::MAX - 1 { FIRST_EPHEMERAL_PORT } else { self.next_port + 1 };
             let in_use = self.conns.iter().any(|conn| {
                 self.sockets
                     .get::<tcp::Socket>(conn.handle)
@@ -736,9 +754,12 @@ impl Driver {
         if self.listeners.iter().any(|listener| listener.port == port) {
             return Err(WgError::ListenerBusy(port));
         }
-        let handle = self.listening_socket(port)?;
+        let mut handles = Vec::with_capacity(LISTEN_SPARES);
+        for _ in 0..LISTEN_SPARES {
+            handles.push(self.listening_socket(port)?);
+        }
         let (accept_tx, accept_rx) = mpsc::channel(LISTENER_BACKLOG);
-        self.listeners.push(Listener { port, handle, accept: accept_tx });
+        self.listeners.push(Listener { port, handles, accept: accept_tx });
         Ok(WgListener { port, incoming: accept_rx })
     }
 
@@ -779,34 +800,69 @@ impl Driver {
     fn process_listeners(&mut self) {
         let mut index = 0;
         while index < self.listeners.len() {
-            let port = self.listeners[index].port;
-            let handle = self.listeners[index].handle;
             if self.listeners[index].accept.is_closed() {
-                self.sockets.get_mut::<tcp::Socket>(handle).abort();
-                self.sockets.remove(handle);
+                for handle in std::mem::take(&mut self.listeners[index].handles) {
+                    self.sockets.get_mut::<tcp::Socket>(handle).abort();
+                    self.sockets.remove(handle);
+                }
                 self.listeners.swap_remove(index);
                 continue;
             }
-            let established = {
-                let socket = self.sockets.get::<tcp::Socket>(handle);
-                (socket.state() == tcp::State::Established)
-                    .then(|| (socket.local_endpoint(), socket.remote_endpoint()))
-            };
-            if let Some((Some(local), Some(remote))) = established {
-                let local = socket_addr(local);
-                let remote = socket_addr(remote);
-                let accept = self.listeners[index].accept.clone();
-                let (conn, stream) = self.bridge(handle, local, remote);
-                self.conns
-                    .push(Conn { pending_stream: Some((Handoff::Accept(accept), stream)), ..conn });
-                match self.listening_socket(port) {
-                    Ok(replacement) => self.listeners[index].handle = replacement,
-                    Err(_) => {
-                        self.listeners.swap_remove(index);
-                        continue;
+            let port = self.listeners[index].port;
+            let handles = std::mem::take(&mut self.listeners[index].handles);
+            let mut still_listening = Vec::with_capacity(handles.len());
+            let mut listen_count = 0;
+            let mut half_open = 0;
+            for handle in handles {
+                let (state, endpoints) = {
+                    let socket = self.sockets.get::<tcp::Socket>(handle);
+                    (socket.state(), (socket.local_endpoint(), socket.remote_endpoint()))
+                };
+                match state {
+                    tcp::State::Established => {
+                        let (Some(local), Some(remote)) = endpoints else {
+                            self.sockets.remove(handle);
+                            continue;
+                        };
+                        let accept = self.listeners[index].accept.clone();
+                        let (conn, stream) =
+                            self.bridge(handle, socket_addr(local), socket_addr(remote));
+                        self.conns.push(Conn {
+                            pending_stream: Some((Handoff::Accept(accept), stream)),
+                            ..conn
+                        });
+                    }
+                    tcp::State::Listen => {
+                        listen_count += 1;
+                        still_listening.push(handle);
+                    }
+                    tcp::State::SynReceived => {
+                        half_open += 1;
+                        still_listening.push(handle);
+                    }
+                    // The handshake fell apart (peer reset, timeout): drop it.
+                    _ => {
+                        self.sockets.remove(handle);
                     }
                 }
             }
+            // Refill only while no handshake is in flight. A new Listen socket
+            // added beside a live half-open can be assigned a lower socket slot
+            // (freed by a closed connection), and smoltcp would then route a
+            // retransmitted SYN to that Listen socket instead of the existing
+            // half-open, spawning a duplicate that never completes.
+            if half_open == 0 {
+                while listen_count < LISTEN_SPARES {
+                    match self.listening_socket(port) {
+                        Ok(handle) => {
+                            still_listening.push(handle);
+                            listen_count += 1;
+                        }
+                        Err(_) => break,
+                    }
+                }
+            }
+            self.listeners[index].handles = still_listening;
             index += 1;
         }
     }
@@ -840,7 +896,12 @@ impl Driver {
                     self.conns.swap_remove(index);
                     continue;
                 } else {
+                    // Still in the handshake: no owner yet, so nothing to move
+                    // and no EOF to detect (`may_recv` is false before
+                    // Established).
                     conn.pending_stream = Some((handoff, stream));
+                    index += 1;
+                    continue;
                 }
             }
 

--- a/cmux-tui/crates/cmux-wg/src/net.rs
+++ b/cmux-tui/crates/cmux-wg/src/net.rs
@@ -1,0 +1,981 @@
+//! The driver that joins WireGuard, the TCP stack, and the UDP socket.
+//!
+//! One Tokio task owns everything mutable: the [`Tunn`] session, the smoltcp
+//! interface and socket set, the virtual device, and the per-connection
+//! bridges. Callers talk to it through [`WgNet`], which sends commands over a
+//! channel and hands back [`WgStream`]s. A stream is two bounded channels and a
+//! wake signal; the driver copies between them and the smoltcp socket on
+//! every service pass. Nothing here sleeps to synchronize: the loop wakes on a
+//! datagram, a command, a stream write, the WireGuard timer tick, or the
+//! deadline smoltcp asks for.
+
+use std::collections::hash_map::RandomState;
+use std::fmt;
+use std::hash::{BuildHasher, Hasher};
+use std::io;
+use std::net::{IpAddr, SocketAddr};
+use std::pin::Pin;
+use std::sync::Arc;
+use std::task::{Context, Poll};
+use std::time::Duration;
+
+use boringtun::noise::{Tunn, TunnResult};
+use bytes::{Buf, Bytes};
+use ip_network::IpNetwork;
+use smoltcp::iface::{Config, Interface, SocketHandle, SocketSet};
+use smoltcp::socket::tcp;
+use smoltcp::time::Instant as SmolInstant;
+use smoltcp::wire::{HardwareAddress, IpAddress, IpCidr, IpEndpoint, IpListenEndpoint};
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+use tokio::net::UdpSocket;
+use tokio::sync::mpsc::error::{TryRecvError, TrySendError};
+use tokio::sync::{Notify, mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio_util::sync::PollSender;
+use x25519_dalek::{PublicKey, StaticSecret};
+
+use crate::config::{InterfaceAddress, WgConfig};
+use crate::device::VirtualDevice;
+
+/// Per-socket receive and transmit buffers. Terminal traffic is small; the
+/// bulk lane (screen replay) benefits from a full window.
+const SOCKET_BUFFER_BYTES: usize = 256 * 1024;
+/// Largest chunk moved from a smoltcp socket into a stream at once.
+const INBOUND_CHUNK_BYTES: usize = 16 * 1024;
+/// Largest single write a stream accepts before splitting it.
+const MAX_WRITE_CHUNK_BYTES: usize = 64 * 1024;
+/// Queued chunks per direction per connection before backpressure.
+const STREAM_CHANNEL_DEPTH: usize = 32;
+/// Pending accepted connections a listener holds before refusing more.
+const LISTENER_BACKLOG: usize = 16;
+/// Commands in flight before `connect`/`listen` callers wait.
+const COMMAND_DEPTH: usize = 64;
+/// WireGuard timer resolution; boringtun's own device uses the same.
+const TIMER_TICK: Duration = Duration::from_millis(250);
+/// Idle TCP connections with no ACK for this long are aborted.
+const TCP_TIMEOUT: Duration = Duration::from_secs(60);
+/// Largest datagram or packet buffer: the UDP payload maximum.
+const BUFFER_BYTES: usize = 65_535;
+/// First ephemeral port; wraps to itself.
+const FIRST_EPHEMERAL_PORT: u16 = 49_152;
+
+#[derive(Debug)]
+pub enum WgError {
+    Io(io::Error),
+    /// The configured endpoint did not resolve.
+    EndpointUnresolved(String),
+    /// The endpoint resolved only to addresses of a family the UDP socket
+    /// cannot reach.
+    EndpointFamilyMismatch,
+    /// This side has no tunnel address in the remote's address family.
+    NoTunnelAddress(IpAddr),
+    /// The remote answered the SYN with a reset, or never answered.
+    ConnectionRefused(SocketAddr),
+    /// A listener already owns the port.
+    ListenerBusy(u16),
+    /// The tunnel has been shut down.
+    Shutdown,
+    /// smoltcp refused the operation.
+    Stack(String),
+}
+
+impl fmt::Display for WgError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(error) => write!(formatter, "socket error: {error}"),
+            Self::EndpointUnresolved(host) => write!(formatter, "endpoint {host} did not resolve"),
+            Self::EndpointFamilyMismatch => {
+                formatter.write_str("endpoint address family does not match the UDP socket")
+            }
+            Self::NoTunnelAddress(remote) => {
+                write!(formatter, "no tunnel address in the same family as {remote}")
+            }
+            Self::ConnectionRefused(remote) => write!(formatter, "{remote} refused the connection"),
+            Self::ListenerBusy(port) => write!(formatter, "port {port} already has a listener"),
+            Self::Shutdown => formatter.write_str("the tunnel is shut down"),
+            Self::Stack(detail) => write!(formatter, "tcp stack: {detail}"),
+        }
+    }
+}
+
+impl std::error::Error for WgError {}
+
+impl From<io::Error> for WgError {
+    fn from(error: io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// A running tunnel. Dropping it stops the driver; every stream then reads
+/// EOF and fails writes.
+pub struct WgNet {
+    commands: mpsc::Sender<Command>,
+    wake: Arc<Notify>,
+    routes: Arc<[IpNetwork]>,
+    addresses: Arc<[InterfaceAddress]>,
+    driver: Option<JoinHandle<()>>,
+}
+
+impl fmt::Debug for WgNet {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WgNet")
+            .field("routes", &self.routes)
+            .field("addresses", &self.addresses)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WgNet {
+    /// Start the tunnel on a UDP socket the caller bound. The configured
+    /// endpoint is resolved here and must share the socket's address family.
+    pub async fn start(config: WgConfig, socket: UdpSocket) -> Result<Self, WgError> {
+        let local = socket.local_addr()?;
+        let peer = match &config.endpoint {
+            Some(endpoint) => {
+                let candidates = endpoint
+                    .resolve()
+                    .await
+                    .map_err(|_| WgError::EndpointUnresolved(endpoint.host.clone()))?;
+                Some(
+                    candidates
+                        .into_iter()
+                        .find(|candidate| candidate.is_ipv4() == local.is_ipv4())
+                        .ok_or(WgError::EndpointFamilyMismatch)?,
+                )
+            }
+            None => None,
+        };
+        Self::start_resolved(config, socket, peer)
+    }
+
+    /// Start the tunnel on a fresh unbound-port UDP socket whose family matches
+    /// the resolved endpoint. Requires a configured endpoint.
+    pub async fn start_with_new_socket(config: WgConfig) -> Result<Self, WgError> {
+        let endpoint = config
+            .endpoint
+            .as_ref()
+            .ok_or_else(|| WgError::EndpointUnresolved("<none configured>".into()))?;
+        let candidates = endpoint
+            .resolve()
+            .await
+            .map_err(|_| WgError::EndpointUnresolved(endpoint.host.clone()))?;
+        let peer = *candidates.first().ok_or_else(|| WgError::EndpointUnresolved(endpoint.host.clone()))?;
+        let bind: SocketAddr = if peer.is_ipv4() { "0.0.0.0:0".parse() } else { "[::]:0".parse() }
+            .expect("literal bind address");
+        let socket = UdpSocket::bind(bind).await?;
+        Self::start_resolved(config, socket, Some(peer))
+    }
+
+    fn start_resolved(
+        config: WgConfig,
+        socket: UdpSocket,
+        peer: Option<SocketAddr>,
+    ) -> Result<Self, WgError> {
+        let routes: Arc<[IpNetwork]> = config.allowed_ips.clone().into();
+        let addresses: Arc<[InterfaceAddress]> = config.addresses.clone().into();
+        let (commands_tx, commands_rx) = mpsc::channel(COMMAND_DEPTH);
+        let wake = Arc::new(Notify::new());
+        let driver = Driver::new(config, socket, peer, commands_rx, Arc::clone(&wake))?;
+        let handle = tokio::spawn(driver.run());
+        Ok(Self { commands: commands_tx, wake, routes, addresses, driver: Some(handle) })
+    }
+
+    /// Networks reachable through the tunnel (the peer's `AllowedIPs`).
+    pub fn routes(&self) -> &[IpNetwork] {
+        &self.routes
+    }
+
+    /// Whether `address` is reachable through the tunnel.
+    pub fn routes_contain(&self, address: IpAddr) -> bool {
+        self.routes.iter().any(|network| network.contains(address))
+    }
+
+    /// This side's addresses inside the network.
+    pub fn addresses(&self) -> &[InterfaceAddress] {
+        &self.addresses
+    }
+
+    /// Open a TCP connection to `remote` through the tunnel. Resolves once the
+    /// three-way handshake completes. Callers bound the wait with their own
+    /// timeout; the stack aborts an unanswered SYN after [`TCP_TIMEOUT`].
+    pub async fn connect(&self, remote: SocketAddr) -> Result<WgStream, WgError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.commands
+            .send(Command::Connect { remote, reply: reply_tx })
+            .await
+            .map_err(|_| WgError::Shutdown)?;
+        reply_rx.await.map_err(|_| WgError::Shutdown)?
+    }
+
+    /// Accept TCP connections on `port` at every tunnel address.
+    pub async fn listen(&self, port: u16) -> Result<WgListener, WgError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.commands
+            .send(Command::Listen { port, reply: reply_tx })
+            .await
+            .map_err(|_| WgError::Shutdown)?;
+        reply_rx.await.map_err(|_| WgError::Shutdown)?
+    }
+
+    /// Time since the last completed WireGuard handshake, if any.
+    pub async fn time_since_last_handshake(&self) -> Result<Option<Duration>, WgError> {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        self.commands
+            .send(Command::LastHandshake { reply: reply_tx })
+            .await
+            .map_err(|_| WgError::Shutdown)?;
+        reply_rx.await.map_err(|_| WgError::Shutdown)
+    }
+
+    /// Stop the driver and wait for it to exit. Open connections are reset.
+    pub async fn shutdown(mut self) {
+        let _ = self.commands.send(Command::Shutdown).await;
+        if let Some(driver) = self.driver.take() {
+            let _ = driver.await;
+        }
+    }
+}
+
+impl Drop for WgNet {
+    fn drop(&mut self) {
+        // A full command queue means the driver is alive and busy; it will see
+        // the closed channel on its next receive. Only a stuck driver needs
+        // the abort.
+        if self.commands.try_send(Command::Shutdown).is_err()
+            && let Some(driver) = self.driver.take()
+        {
+            driver.abort();
+        }
+        self.wake.notify_one();
+    }
+}
+
+/// Connections accepted by [`WgNet::listen`].
+pub struct WgListener {
+    port: u16,
+    incoming: mpsc::Receiver<WgStream>,
+}
+
+impl WgListener {
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+
+    /// The next established connection, or `None` once the tunnel is gone.
+    pub async fn accept(&mut self) -> Option<WgStream> {
+        self.incoming.recv().await
+    }
+}
+
+enum Command {
+    Connect { remote: SocketAddr, reply: oneshot::Sender<Result<WgStream, WgError>> },
+    Listen { port: u16, reply: oneshot::Sender<Result<WgListener, WgError>> },
+    LastHandshake { reply: oneshot::Sender<Option<Duration>> },
+    Shutdown,
+}
+
+enum Outbound {
+    Data(Bytes),
+    Shutdown,
+}
+
+/// One TCP connection through the tunnel, usable wherever a `TcpStream` is.
+pub struct WgStream {
+    local: SocketAddr,
+    remote: SocketAddr,
+    inbound: mpsc::Receiver<Bytes>,
+    leftover: Bytes,
+    outbound: PollSender<Outbound>,
+    wake: Arc<Notify>,
+    shutdown_sent: bool,
+}
+
+impl fmt::Debug for WgStream {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("WgStream")
+            .field("local", &self.local)
+            .field("remote", &self.remote)
+            .finish_non_exhaustive()
+    }
+}
+
+impl WgStream {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local
+    }
+
+    pub fn peer_addr(&self) -> SocketAddr {
+        self.remote
+    }
+}
+
+fn broken_pipe() -> io::Error {
+    io::Error::new(io::ErrorKind::BrokenPipe, "tunnel connection is closed")
+}
+
+impl AsyncRead for WgStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        if this.leftover.is_empty() {
+            match this.inbound.poll_recv(cx) {
+                Poll::Ready(Some(bytes)) => this.leftover = bytes,
+                Poll::Ready(None) => return Poll::Ready(Ok(())),
+                Poll::Pending => return Poll::Pending,
+            }
+        }
+        let count = this.leftover.len().min(buf.remaining());
+        buf.put_slice(&this.leftover.split_to(count));
+        Poll::Ready(Ok(()))
+    }
+}
+
+impl AsyncWrite for WgStream {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        data: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        let this = &mut *self;
+        if this.shutdown_sent {
+            return Poll::Ready(Err(broken_pipe()));
+        }
+        match this.outbound.poll_reserve(cx) {
+            Poll::Ready(Ok(())) => {
+                let count = data.len().min(MAX_WRITE_CHUNK_BYTES);
+                this.outbound
+                    .send_item(Outbound::Data(Bytes::copy_from_slice(&data[..count])))
+                    .map_err(|_| broken_pipe())?;
+                this.wake.notify_one();
+                Poll::Ready(Ok(count))
+            }
+            Poll::Ready(Err(_)) => Poll::Ready(Err(broken_pipe())),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        // Writes are handed to the driver synchronously; there is no local
+        // buffer left to flush. Delivery is TCP's job.
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        let this = &mut *self;
+        if this.shutdown_sent {
+            return Poll::Ready(Ok(()));
+        }
+        match this.outbound.poll_reserve(cx) {
+            Poll::Ready(Ok(())) => {
+                let _ = this.outbound.send_item(Outbound::Shutdown);
+                this.shutdown_sent = true;
+                this.wake.notify_one();
+                Poll::Ready(Ok(()))
+            }
+            Poll::Ready(Err(_)) => {
+                this.shutdown_sent = true;
+                Poll::Ready(Ok(()))
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+/// How a newly established socket reaches its owner.
+enum Handoff {
+    Connect(oneshot::Sender<Result<WgStream, WgError>>),
+    Accept(mpsc::Sender<WgStream>),
+}
+
+struct Conn {
+    handle: SocketHandle,
+    remote: SocketAddr,
+    /// The stream waiting to be handed to its owner once the socket is
+    /// established. Taken on delivery.
+    pending_stream: Option<(Handoff, WgStream)>,
+    /// `None` once the remote closed and the buffer drained (EOF delivered),
+    /// or once the owner dropped its reader.
+    inbound: Option<mpsc::Sender<Bytes>>,
+    outbound: mpsc::Receiver<Outbound>,
+    /// Head of the outbound queue not yet accepted by smoltcp.
+    pending_write: Option<Bytes>,
+    outbound_closed: bool,
+}
+
+struct Listener {
+    port: u16,
+    handle: SocketHandle,
+    accept: mpsc::Sender<WgStream>,
+}
+
+struct Driver {
+    config: WgConfig,
+    tunn: Tunn,
+    udp: Arc<UdpSocket>,
+    peer: Option<SocketAddr>,
+    iface: Interface,
+    device: VirtualDevice,
+    sockets: SocketSet<'static>,
+    conns: Vec<Conn>,
+    listeners: Vec<Listener>,
+    commands: mpsc::Receiver<Command>,
+    wake: Arc<Notify>,
+    epoch: std::time::Instant,
+    next_port: u16,
+    scratch: Vec<u8>,
+}
+
+enum Event {
+    Datagram(usize, SocketAddr),
+    DatagramError(io::Error),
+    Command(Option<Command>),
+    Wake,
+    Tick,
+    StackDeadline,
+}
+
+impl Driver {
+    fn new(
+        config: WgConfig,
+        socket: UdpSocket,
+        peer: Option<SocketAddr>,
+        commands: mpsc::Receiver<Command>,
+        wake: Arc<Notify>,
+    ) -> Result<Self, WgError> {
+        let private = StaticSecret::from(*config.private_key);
+        let public = PublicKey::from(config.peer_public_key);
+        let tunn = Tunn::new(
+            private,
+            public,
+            config.preshared_key.as_deref().copied(),
+            config.persistent_keepalive,
+            0,
+            None,
+        );
+
+        let epoch = std::time::Instant::now();
+        let mut device = VirtualDevice::new(config.mtu);
+        let mut iface_config = Config::new(HardwareAddress::Ip);
+        iface_config.random_seed = RandomState::new().build_hasher().finish();
+        let mut iface = Interface::new(iface_config, &mut device, SmolInstant::from_micros(0));
+        let mut overflow = false;
+        iface.update_ip_addrs(|addresses| {
+            for entry in &config.addresses {
+                let cidr = IpCidr::new(ip_address(entry.address), entry.prefix);
+                if addresses.push(cidr).is_err() {
+                    overflow = true;
+                }
+            }
+        });
+        if overflow {
+            return Err(WgError::Stack("too many interface addresses".into()));
+        }
+        // Medium::Ip has no neighbor resolution, so the gateway address is
+        // only a routing-table formality: everything not on a local subnet
+        // goes into the tunnel.
+        for entry in &config.addresses {
+            let result = match entry.address {
+                IpAddr::V4(address) => iface.routes_mut().add_default_ipv4_route(address).map(|_| ()),
+                IpAddr::V6(address) => iface.routes_mut().add_default_ipv6_route(address).map(|_| ()),
+            };
+            result.map_err(|_| WgError::Stack("route table full".into()))?;
+        }
+
+        Ok(Self {
+            config,
+            tunn,
+            udp: Arc::new(socket),
+            peer,
+            iface,
+            device,
+            sockets: SocketSet::new(Vec::new()),
+            conns: Vec::new(),
+            listeners: Vec::new(),
+            commands,
+            wake,
+            epoch,
+            next_port: FIRST_EPHEMERAL_PORT,
+            scratch: vec![0u8; BUFFER_BYTES + 32],
+        })
+    }
+
+    fn now(&self) -> SmolInstant {
+        SmolInstant::from_micros(i64::try_from(self.epoch.elapsed().as_micros()).unwrap_or(i64::MAX))
+    }
+
+    async fn run(mut self) {
+        let udp = Arc::clone(&self.udp);
+        let wake = Arc::clone(&self.wake);
+        let mut ticks = tokio::time::interval(TIMER_TICK);
+        ticks.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let mut datagram = vec![0u8; BUFFER_BYTES];
+
+        self.initiate_handshake();
+        self.service();
+
+        loop {
+            let now = self.now();
+            let deadline = self.iface.poll_delay(now, &self.sockets);
+            let stack_deadline = async {
+                match deadline {
+                    Some(delay) => {
+                        tokio::time::sleep(Duration::from_micros(delay.total_micros())).await;
+                    }
+                    None => std::future::pending::<()>().await,
+                }
+            };
+            let event = tokio::select! {
+                received = udp.recv_from(&mut datagram) => match received {
+                    Ok((count, source)) => Event::Datagram(count, source),
+                    Err(error) => Event::DatagramError(error),
+                },
+                command = self.commands.recv() => Event::Command(command),
+                () = wake.notified() => Event::Wake,
+                _ = ticks.tick() => Event::Tick,
+                () = stack_deadline => Event::StackDeadline,
+            };
+            match event {
+                Event::Datagram(count, source) => self.handle_datagram(&datagram[..count], source),
+                Event::DatagramError(error) => {
+                    // Transient receive errors (ICMP port unreachable surfaced as
+                    // ECONNREFUSED on some platforms) are not fatal for UDP.
+                    if error.kind() == io::ErrorKind::Interrupted
+                        || error.kind() == io::ErrorKind::ConnectionRefused
+                        || error.kind() == io::ErrorKind::ConnectionReset
+                    {
+                        continue;
+                    }
+                    self.shutdown();
+                    return;
+                }
+                Event::Command(Some(Command::Shutdown)) | Event::Command(None) => {
+                    self.shutdown();
+                    return;
+                }
+                Event::Command(Some(command)) => self.handle_command(command),
+                Event::Wake | Event::StackDeadline => {}
+                Event::Tick => self.update_timers(),
+            }
+            self.service();
+        }
+    }
+
+    fn send_to_peer(&self, packet: &[u8]) {
+        if let Some(peer) = self.peer {
+            // WireGuard tolerates loss; a momentarily unwritable UDP socket
+            // drops the datagram rather than blocking the driver.
+            let _ = self.udp.try_send_to(packet, peer);
+        }
+    }
+
+    fn initiate_handshake(&mut self) {
+        if self.peer.is_none() {
+            return;
+        }
+        if let TunnResult::WriteToNetwork(packet) =
+            self.tunn.format_handshake_initiation(&mut self.scratch, false)
+        {
+            let packet = packet.to_vec();
+            self.send_to_peer(&packet);
+        }
+    }
+
+    fn update_timers(&mut self) {
+        if let TunnResult::WriteToNetwork(packet) = self.tunn.update_timers(&mut self.scratch) {
+            let packet = packet.to_vec();
+            self.send_to_peer(&packet);
+        }
+    }
+
+    fn handle_datagram(&mut self, datagram: &[u8], source: SocketAddr) {
+        let mut input = datagram;
+        loop {
+            match self.tunn.decapsulate(Some(source.ip()), input, &mut self.scratch) {
+                TunnResult::Done => break,
+                TunnResult::Err(_) => break,
+                TunnResult::WriteToNetwork(packet) => {
+                    let packet = packet.to_vec();
+                    // Authenticated traffic from a new address moves the peer
+                    // (WireGuard roaming); this is also how the answering side
+                    // learns its peer in the first place.
+                    self.peer = Some(source);
+                    self.send_to_peer(&packet);
+                    input = &[];
+                }
+                TunnResult::WriteToTunnelV4(packet, _) | TunnResult::WriteToTunnelV6(packet, _) => {
+                    self.peer = Some(source);
+                    if let Some(origin) = packet_source(packet)
+                        && self.config.routes_contain(origin)
+                    {
+                        self.device.push_rx(packet.to_vec());
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    fn flush_tx(&mut self) {
+        while let Some(packet) = self.device.pop_tx() {
+            if let TunnResult::WriteToNetwork(encrypted) =
+                self.tunn.encapsulate(&packet, &mut self.scratch)
+            {
+                let encrypted = encrypted.to_vec();
+                self.send_to_peer(&encrypted);
+            }
+        }
+    }
+
+    /// One pass: let smoltcp consume received packets and emit its own, move
+    /// bytes between sockets and streams, then poll again so anything the
+    /// streams produced leaves in the same pass.
+    fn service(&mut self) {
+        loop {
+            let now = self.now();
+            self.iface.poll(now, &mut self.device, &mut self.sockets);
+            self.process_listeners();
+            let progressed = self.process_conns();
+            self.iface.poll(now, &mut self.device, &mut self.sockets);
+            self.flush_tx();
+            if !progressed && !self.device.has_rx() {
+                break;
+            }
+        }
+    }
+
+    fn shutdown(&mut self) {
+        for conn in &self.conns {
+            self.sockets.get_mut::<tcp::Socket>(conn.handle).abort();
+        }
+        for listener in &self.listeners {
+            self.sockets.get_mut::<tcp::Socket>(listener.handle).abort();
+        }
+        let now = self.now();
+        self.iface.poll(now, &mut self.device, &mut self.sockets);
+        self.flush_tx();
+        self.conns.clear();
+        self.listeners.clear();
+    }
+
+    fn handle_command(&mut self, command: Command) {
+        match command {
+            Command::Connect { remote, reply } => self.begin_connect(remote, reply),
+            Command::Listen { port, reply } => {
+                let _ = reply.send(self.begin_listen(port));
+            }
+            Command::LastHandshake { reply } => {
+                let _ = reply.send(self.tunn.time_since_last_handshake());
+            }
+            Command::Shutdown => {}
+        }
+    }
+
+    fn allocate_port(&mut self) -> u16 {
+        for _ in 0..(u16::MAX - FIRST_EPHEMERAL_PORT) {
+            let port = self.next_port;
+            self.next_port =
+                if self.next_port == u16::MAX { FIRST_EPHEMERAL_PORT } else { self.next_port + 1 };
+            let in_use = self.conns.iter().any(|conn| {
+                self.sockets
+                    .get::<tcp::Socket>(conn.handle)
+                    .local_endpoint()
+                    .is_some_and(|endpoint| endpoint.port == port)
+            });
+            if !in_use {
+                return port;
+            }
+        }
+        self.next_port
+    }
+
+    fn new_socket() -> tcp::Socket<'static> {
+        let mut socket = tcp::Socket::new(
+            tcp::SocketBuffer::new(vec![0u8; SOCKET_BUFFER_BYTES]),
+            tcp::SocketBuffer::new(vec![0u8; SOCKET_BUFFER_BYTES]),
+        );
+        // Keystrokes are latency-bound; the OS dial path disables Nagle too.
+        socket.set_nagle_enabled(false);
+        socket.set_timeout(Some(smoltcp::time::Duration::from_micros(
+            u64::try_from(TCP_TIMEOUT.as_micros()).unwrap_or(u64::MAX),
+        )));
+        socket
+    }
+
+    fn begin_connect(
+        &mut self,
+        remote: SocketAddr,
+        reply: oneshot::Sender<Result<WgStream, WgError>>,
+    ) {
+        let Some(local_ip) = self.config.local_address_for(remote.ip()) else {
+            let _ = reply.send(Err(WgError::NoTunnelAddress(remote.ip())));
+            return;
+        };
+        let port = self.allocate_port();
+        let local = SocketAddr::new(local_ip, port);
+        let mut socket = Self::new_socket();
+        let result = socket.connect(
+            self.iface.context(),
+            IpEndpoint::new(ip_address(remote.ip()), remote.port()),
+            IpListenEndpoint::from(IpEndpoint::new(ip_address(local.ip()), local.port())),
+        );
+        if let Err(error) = result {
+            let _ = reply.send(Err(WgError::Stack(format!("{error}"))));
+            return;
+        }
+        let handle = self.sockets.add(socket);
+        let (conn, stream) = self.bridge(handle, local, remote);
+        self.conns.push(Conn { pending_stream: Some((Handoff::Connect(reply), stream)), ..conn });
+    }
+
+    fn begin_listen(&mut self, port: u16) -> Result<WgListener, WgError> {
+        if self.listeners.iter().any(|listener| listener.port == port) {
+            return Err(WgError::ListenerBusy(port));
+        }
+        let handle = self.listening_socket(port)?;
+        let (accept_tx, accept_rx) = mpsc::channel(LISTENER_BACKLOG);
+        self.listeners.push(Listener { port, handle, accept: accept_tx });
+        Ok(WgListener { port, incoming: accept_rx })
+    }
+
+    fn listening_socket(&mut self, port: u16) -> Result<SocketHandle, WgError> {
+        let mut socket = Self::new_socket();
+        socket
+            .listen(IpListenEndpoint::from(port))
+            .map_err(|error| WgError::Stack(format!("{error}")))?;
+        Ok(self.sockets.add(socket))
+    }
+
+    /// Build the channel pair for a socket: the driver-side [`Conn`] and the
+    /// owner-side [`WgStream`].
+    fn bridge(&self, handle: SocketHandle, local: SocketAddr, remote: SocketAddr) -> (Conn, WgStream) {
+        let (inbound_tx, inbound_rx) = mpsc::channel(STREAM_CHANNEL_DEPTH);
+        let (outbound_tx, outbound_rx) = mpsc::channel(STREAM_CHANNEL_DEPTH);
+        let stream = WgStream {
+            local,
+            remote,
+            inbound: inbound_rx,
+            leftover: Bytes::new(),
+            outbound: PollSender::new(outbound_tx),
+            wake: Arc::clone(&self.wake),
+            shutdown_sent: false,
+        };
+        let conn = Conn {
+            handle,
+            remote,
+            pending_stream: None,
+            inbound: Some(inbound_tx),
+            outbound: outbound_rx,
+            pending_write: None,
+            outbound_closed: false,
+        };
+        (conn, stream)
+    }
+
+    fn process_listeners(&mut self) {
+        let mut index = 0;
+        while index < self.listeners.len() {
+            let port = self.listeners[index].port;
+            let handle = self.listeners[index].handle;
+            if self.listeners[index].accept.is_closed() {
+                self.sockets.get_mut::<tcp::Socket>(handle).abort();
+                self.sockets.remove(handle);
+                self.listeners.swap_remove(index);
+                continue;
+            }
+            let established = {
+                let socket = self.sockets.get::<tcp::Socket>(handle);
+                (socket.state() == tcp::State::Established)
+                    .then(|| (socket.local_endpoint(), socket.remote_endpoint()))
+            };
+            if let Some((Some(local), Some(remote))) = established {
+                let local = socket_addr(local);
+                let remote = socket_addr(remote);
+                let accept = self.listeners[index].accept.clone();
+                let (conn, stream) = self.bridge(handle, local, remote);
+                self.conns
+                    .push(Conn { pending_stream: Some((Handoff::Accept(accept), stream)), ..conn });
+                match self.listening_socket(port) {
+                    Ok(replacement) => self.listeners[index].handle = replacement,
+                    Err(_) => {
+                        self.listeners.swap_remove(index);
+                        continue;
+                    }
+                }
+            }
+            index += 1;
+        }
+    }
+
+    /// Returns whether any byte moved, so the caller can poll again.
+    fn process_conns(&mut self) -> bool {
+        let mut progressed = false;
+        let mut index = 0;
+        while index < self.conns.len() {
+            let conn = &mut self.conns[index];
+            let socket = self.sockets.get_mut::<tcp::Socket>(conn.handle);
+
+            if let Some((handoff, stream)) = conn.pending_stream.take() {
+                if socket.state() == tcp::State::Established {
+                    match handoff {
+                        Handoff::Connect(reply) => {
+                            let _ = reply.send(Ok(stream));
+                        }
+                        Handoff::Accept(accept) => {
+                            if accept.try_send(stream).is_err() {
+                                socket.abort();
+                            }
+                        }
+                    }
+                } else if !socket.is_open() {
+                    if let Handoff::Connect(reply) = handoff {
+                        let _ = reply.send(Err(WgError::ConnectionRefused(conn.remote)));
+                    }
+                    let handle = conn.handle;
+                    self.sockets.remove(handle);
+                    self.conns.swap_remove(index);
+                    continue;
+                } else {
+                    conn.pending_stream = Some((handoff, stream));
+                }
+            }
+
+            // Owner -> socket.
+            if !conn.outbound_closed {
+                loop {
+                    if conn.pending_write.is_none() {
+                        match conn.outbound.try_recv() {
+                            Ok(Outbound::Data(bytes)) => conn.pending_write = Some(bytes),
+                            Ok(Outbound::Shutdown) | Err(TryRecvError::Disconnected) => {
+                                conn.outbound_closed = true;
+                                socket.close();
+                                break;
+                            }
+                            Err(TryRecvError::Empty) => break,
+                        }
+                    }
+                    let Some(pending) = conn.pending_write.as_mut() else { break };
+                    if !socket.can_send() {
+                        break;
+                    }
+                    match socket.send_slice(pending) {
+                        Ok(written) => {
+                            pending.advance(written);
+                            progressed |= written > 0;
+                            if pending.is_empty() {
+                                conn.pending_write = None;
+                            } else {
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            conn.outbound_closed = true;
+                            break;
+                        }
+                    }
+                }
+            }
+
+            // Socket -> owner.
+            if let Some(sender) = conn.inbound.as_ref() {
+                let mut reader_gone = false;
+                while socket.can_recv() {
+                    match sender.try_reserve() {
+                        Ok(permit) => {
+                            let mut chunk = vec![0u8; socket.recv_queue().min(INBOUND_CHUNK_BYTES)];
+                            match socket.recv_slice(&mut chunk) {
+                                Ok(count) => {
+                                    chunk.truncate(count);
+                                    progressed |= count > 0;
+                                    permit.send(Bytes::from(chunk));
+                                }
+                                Err(_) => break,
+                            }
+                        }
+                        Err(TrySendError::Full(())) => break,
+                        Err(TrySendError::Closed(())) => {
+                            reader_gone = true;
+                            break;
+                        }
+                    }
+                }
+                if reader_gone {
+                    conn.inbound = None;
+                } else if !socket.may_recv() && !socket.can_recv() {
+                    // Remote FIN and every byte delivered: EOF to the owner.
+                    conn.inbound = None;
+                }
+            } else if socket.can_recv() {
+                // Nobody will read it; keep the window moving so the peer can
+                // finish closing.
+                let _ = socket.recv(|buffer| (buffer.len(), ()));
+            }
+
+            if !socket.is_open() && conn.pending_stream.is_none() {
+                let handle = conn.handle;
+                self.sockets.remove(handle);
+                self.conns.swap_remove(index);
+                continue;
+            }
+            index += 1;
+        }
+        progressed
+    }
+}
+
+fn ip_address(address: IpAddr) -> IpAddress {
+    match address {
+        IpAddr::V4(address) => IpAddress::Ipv4(address),
+        IpAddr::V6(address) => IpAddress::Ipv6(address),
+    }
+}
+
+fn socket_addr(endpoint: IpEndpoint) -> SocketAddr {
+    let address = match endpoint.addr {
+        IpAddress::Ipv4(address) => IpAddr::V4(address),
+        IpAddress::Ipv6(address) => IpAddr::V6(address),
+    };
+    SocketAddr::new(address, endpoint.port)
+}
+
+/// The source address of a raw IPv4 or IPv6 packet, for crypto-key routing.
+fn packet_source(packet: &[u8]) -> Option<IpAddr> {
+    match packet.first()? >> 4 {
+        4 if packet.len() >= 20 => {
+            let octets: [u8; 4] = packet[12..16].try_into().ok()?;
+            Some(IpAddr::V4(octets.into()))
+        }
+        6 if packet.len() >= 40 => {
+            let octets: [u8; 16] = packet[8..24].try_into().ok()?;
+            Some(IpAddr::V6(octets.into()))
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn packet_source_reads_both_families() {
+        let mut v4 = vec![0u8; 20];
+        v4[0] = 0x45;
+        v4[12..16].copy_from_slice(&[10, 200, 0, 2]);
+        assert_eq!(packet_source(&v4), Some("10.200.0.2".parse().unwrap()));
+
+        let mut v6 = vec![0u8; 40];
+        v6[0] = 0x60;
+        v6[8] = 0xfd;
+        v6[9] = 0xcc;
+        v6[23] = 1;
+        assert_eq!(packet_source(&v6), Some("fdcc::1".parse().unwrap()));
+
+        assert_eq!(packet_source(&[0x45; 10]), None);
+        assert_eq!(packet_source(&[]), None);
+    }
+}

--- a/cmux-tui/crates/cmux-wg/src/net.rs
+++ b/cmux-tui/crates/cmux-wg/src/net.rs
@@ -9,6 +9,7 @@
 //! datagram, a command, a stream write, the WireGuard timer tick, or the
 //! deadline smoltcp asks for.
 
+use std::collections::HashSet;
 use std::collections::hash_map::RandomState;
 use std::fmt;
 use std::hash::{BuildHasher, Hasher};
@@ -90,6 +91,8 @@ pub enum WgError {
     ListenerBusy(u16),
     /// The tunnel has been shut down.
     Shutdown,
+    /// No ephemeral TCP source port is available.
+    EphemeralPortsExhausted,
     /// smoltcp refused the operation.
     Stack(String),
 }
@@ -108,6 +111,9 @@ impl fmt::Display for WgError {
             Self::ConnectionRefused(remote) => write!(formatter, "{remote} refused the connection"),
             Self::ListenerBusy(port) => write!(formatter, "port {port} already has a listener"),
             Self::Shutdown => formatter.write_str("the tunnel is shut down"),
+            Self::EphemeralPortsExhausted => {
+                formatter.write_str("no ephemeral TCP port is available")
+            }
             Self::Stack(detail) => write!(formatter, "tcp stack: {detail}"),
         }
     }
@@ -410,6 +416,9 @@ enum Handoff {
 struct Conn {
     handle: SocketHandle,
     remote: SocketAddr,
+    /// Ephemeral source port reserved for this connection, if any. Accepted
+    /// sockets use a listener port and do not participate in allocation.
+    local_port: Option<u16>,
     /// The stream waiting to be handed to its owner once the socket is
     /// established. Taken on delivery.
     pending_stream: Option<(Handoff, WgStream)>,
@@ -429,6 +438,48 @@ struct Listener {
     accept: mpsc::Sender<WgStream>,
 }
 
+struct PortAllocator {
+    next_port: u16,
+    reserved: HashSet<u16>,
+}
+
+impl PortAllocator {
+    fn new() -> Self {
+        Self::with_next_port(random_ephemeral_port())
+    }
+
+    fn with_next_port(next_port: u16) -> Self {
+        Self { next_port, reserved: HashSet::new() }
+    }
+
+    fn set_next_port(&mut self, next_port: u16) {
+        self.next_port = next_port;
+    }
+
+    fn allocate(&mut self) -> Option<u16> {
+        self.allocate_with_probe_count().map(|(port, _)| port)
+    }
+
+    fn allocate_with_probe_count(&mut self) -> Option<(u16, usize)> {
+        for examined in 1..=usize::from(EPHEMERAL_PORT_COUNT) {
+            let port = self.next_port;
+            self.next_port = if self.next_port >= u16::MAX - 1 {
+                FIRST_EPHEMERAL_PORT
+            } else {
+                self.next_port + 1
+            };
+            if self.reserved.insert(port) {
+                return Some((port, examined));
+            }
+        }
+        None
+    }
+
+    fn release(&mut self, port: u16) {
+        self.reserved.remove(&port);
+    }
+}
+
 struct Driver {
     config: WgConfig,
     tunn: Tunn,
@@ -442,7 +493,7 @@ struct Driver {
     commands: mpsc::Receiver<Command>,
     wake: Arc<Notify>,
     epoch: std::time::Instant,
-    next_port: u16,
+    ports: PortAllocator,
     scratch: Vec<u8>,
 }
 
@@ -515,7 +566,7 @@ impl Driver {
             commands,
             wake,
             epoch,
-            next_port: random_ephemeral_port(),
+            ports: PortAllocator::new(),
             scratch: vec![0u8; BUFFER_BYTES + 32],
         })
     }
@@ -676,6 +727,11 @@ impl Driver {
         let now = self.now();
         self.iface.poll(now, &mut self.device, &mut self.sockets);
         self.flush_tx();
+        for conn in &self.conns {
+            if let Some(port) = conn.local_port {
+                self.ports.release(port);
+            }
+        }
         self.conns.clear();
         self.listeners.clear();
     }
@@ -693,22 +749,8 @@ impl Driver {
         }
     }
 
-    fn allocate_port(&mut self) -> u16 {
-        for _ in 0..EPHEMERAL_PORT_COUNT {
-            let port = self.next_port;
-            self.next_port =
-                if self.next_port >= u16::MAX - 1 { FIRST_EPHEMERAL_PORT } else { self.next_port + 1 };
-            let in_use = self.conns.iter().any(|conn| {
-                self.sockets
-                    .get::<tcp::Socket>(conn.handle)
-                    .local_endpoint()
-                    .is_some_and(|endpoint| endpoint.port == port)
-            });
-            if !in_use {
-                return port;
-            }
-        }
-        self.next_port
+    fn allocate_port(&mut self) -> Option<u16> {
+        self.ports.allocate()
     }
 
     fn new_socket() -> tcp::Socket<'static> {
@@ -733,7 +775,10 @@ impl Driver {
             let _ = reply.send(Err(WgError::NoTunnelAddress(remote.ip())));
             return;
         };
-        let port = self.allocate_port();
+        let Some(port) = self.allocate_port() else {
+            let _ = reply.send(Err(WgError::EphemeralPortsExhausted));
+            return;
+        };
         let local = SocketAddr::new(local_ip, port);
         let mut socket = Self::new_socket();
         let result = socket.connect(
@@ -742,11 +787,12 @@ impl Driver {
             IpListenEndpoint::from(IpEndpoint::new(ip_address(local.ip()), local.port())),
         );
         if let Err(error) = result {
+            self.ports.release(port);
             let _ = reply.send(Err(WgError::Stack(format!("{error}"))));
             return;
         }
         let handle = self.sockets.add(socket);
-        let (conn, stream) = self.bridge(handle, local, remote);
+        let (conn, stream) = self.bridge(handle, local, remote, Some(port));
         self.conns.push(Conn { pending_stream: Some((Handoff::Connect(reply), stream)), ..conn });
     }
 
@@ -773,7 +819,13 @@ impl Driver {
 
     /// Build the channel pair for a socket: the driver-side [`Conn`] and the
     /// owner-side [`WgStream`].
-    fn bridge(&self, handle: SocketHandle, local: SocketAddr, remote: SocketAddr) -> (Conn, WgStream) {
+    fn bridge(
+        &self,
+        handle: SocketHandle,
+        local: SocketAddr,
+        remote: SocketAddr,
+        local_port: Option<u16>,
+    ) -> (Conn, WgStream) {
         let (inbound_tx, inbound_rx) = mpsc::channel(STREAM_CHANNEL_DEPTH);
         let (outbound_tx, outbound_rx) = mpsc::channel(STREAM_CHANNEL_DEPTH);
         let stream = WgStream {
@@ -788,6 +840,7 @@ impl Driver {
         let conn = Conn {
             handle,
             remote,
+            local_port,
             pending_stream: None,
             inbound: Some(inbound_tx),
             outbound: outbound_rx,
@@ -826,7 +879,7 @@ impl Driver {
                         };
                         let accept = self.listeners[index].accept.clone();
                         let (conn, stream) =
-                            self.bridge(handle, socket_addr(local), socket_addr(remote));
+                            self.bridge(handle, socket_addr(local), socket_addr(remote), None);
                         self.conns.push(Conn {
                             pending_stream: Some((Handoff::Accept(accept), stream)),
                             ..conn
@@ -890,6 +943,9 @@ impl Driver {
                 } else if !socket.is_open() {
                     if let Handoff::Connect(reply) = handoff {
                         let _ = reply.send(Err(WgError::ConnectionRefused(conn.remote)));
+                    }
+                    if let Some(port) = conn.local_port {
+                        self.ports.release(port);
                     }
                     let handle = conn.handle;
                     self.sockets.remove(handle);
@@ -977,6 +1033,9 @@ impl Driver {
             }
 
             if !socket.is_open() && conn.pending_stream.is_none() {
+                if let Some(port) = conn.local_port {
+                    self.ports.release(port);
+                }
                 let handle = conn.handle;
                 self.sockets.remove(handle);
                 self.conns.swap_remove(index);
@@ -1037,12 +1096,17 @@ mod tests {
 
         // With an uncontended cursor, each allocation examines one candidate.
         // This bound catches a regression to scanning every active connection.
-        assert!(probes <= ports.len() * 2, "allocator examined {probes} candidates for {} ports", ports.len());
+        assert!(
+            probes <= ports.len() * 2,
+            "allocator examined {probes} candidates for {} ports",
+            ports.len()
+        );
 
         let occupied = FIRST_EPHEMERAL_PORT + 8_191;
         assert!(ports.contains(&occupied));
         allocator.set_next_port(occupied);
-        let (replacement, examined) = allocator.allocate_with_probe_count().expect("port available");
+        let (replacement, examined) =
+            allocator.allocate_with_probe_count().expect("port available");
         assert_ne!(replacement, occupied);
         assert_eq!(examined, 2);
 

--- a/cmux-tui/crates/cmux-wg/src/testing.rs
+++ b/cmux-tui/crates/cmux-wg/src/testing.rs
@@ -1,0 +1,91 @@
+//! A two-peer tunnel over loopback UDP, for tests in this crate and others.
+//!
+//! Neither side needs root or a network interface: both WireGuard peers live in
+//! the test process and exchange datagrams over `127.0.0.1`. The "server" side
+//! has no configured endpoint and learns the client's address from the first
+//! authenticated datagram, exactly as a listening WireGuard peer does.
+
+use std::io;
+use std::net::IpAddr;
+
+use ip_network::IpNetwork;
+use tokio::net::UdpSocket;
+use zeroize::Zeroizing;
+
+use crate::config::{Endpoint, InterfaceAddress, WgConfig};
+
+/// A fresh Curve25519 keypair as `(private, public)`.
+pub fn random_keypair() -> ([u8; 32], [u8; 32]) {
+    let mut private = [0u8; 32];
+    getrandom::fill(&mut private).expect("operating system randomness");
+    let secret = x25519_dalek::StaticSecret::from(private);
+    let public = x25519_dalek::PublicKey::from(&secret);
+    (secret.to_bytes(), public.to_bytes())
+}
+
+pub struct LoopbackPair {
+    pub client: WgConfig,
+    pub server: WgConfig,
+    pub client_socket: UdpSocket,
+    pub server_socket: UdpSocket,
+    pub client_v4: IpAddr,
+    pub server_v4: IpAddr,
+    pub client_v6: IpAddr,
+    pub server_v6: IpAddr,
+}
+
+/// Freestyle-shaped configs for both sides: MTU 1200, one IPv4 and one IPv6
+/// address each, dual-family allowed networks, and a client keepalive.
+pub async fn loopback_pair() -> io::Result<LoopbackPair> {
+    let (client_private, client_public) = random_keypair();
+    let (server_private, server_public) = random_keypair();
+    let client_socket = UdpSocket::bind("127.0.0.1:0").await?;
+    let server_socket = UdpSocket::bind("127.0.0.1:0").await?;
+    let server_addr = server_socket.local_addr()?;
+
+    let client_v4: IpAddr = "10.200.0.1".parse().expect("literal");
+    let server_v4: IpAddr = "10.200.0.2".parse().expect("literal");
+    let client_v6: IpAddr = "fdcc::1".parse().expect("literal");
+    let server_v6: IpAddr = "fdcc::2".parse().expect("literal");
+    let allowed = vec![
+        IpNetwork::new("10.200.0.0".parse::<IpAddr>().expect("literal"), 24).expect("prefix"),
+        IpNetwork::new("fdcc::".parse::<IpAddr>().expect("literal"), 64).expect("prefix"),
+    ];
+
+    let client = WgConfig {
+        private_key: Zeroizing::new(client_private),
+        addresses: vec![
+            InterfaceAddress { address: client_v4, prefix: 32 },
+            InterfaceAddress { address: client_v6, prefix: 128 },
+        ],
+        mtu: 1200,
+        peer_public_key: server_public,
+        preshared_key: None,
+        allowed_ips: allowed.clone(),
+        endpoint: Some(Endpoint { host: server_addr.ip().to_string(), port: server_addr.port() }),
+        persistent_keepalive: Some(5),
+    };
+    let server = WgConfig {
+        private_key: Zeroizing::new(server_private),
+        addresses: vec![
+            InterfaceAddress { address: server_v4, prefix: 32 },
+            InterfaceAddress { address: server_v6, prefix: 128 },
+        ],
+        mtu: 1200,
+        peer_public_key: client_public,
+        preshared_key: None,
+        allowed_ips: allowed,
+        endpoint: None,
+        persistent_keepalive: None,
+    };
+    Ok(LoopbackPair {
+        client,
+        server,
+        client_socket,
+        server_socket,
+        client_v4,
+        server_v4,
+        client_v6,
+        server_v6,
+    })
+}

--- a/cmux-tui/crates/cmux-wg/tests/tunnel.rs
+++ b/cmux-tui/crates/cmux-wg/tests/tunnel.rs
@@ -1,0 +1,144 @@
+//! Two in-process WireGuard peers over loopback UDP: no root, no interface.
+
+use std::net::SocketAddr;
+use std::time::Duration;
+
+use cmux_wg::testing::{LoopbackPair, loopback_pair};
+use cmux_wg::{WgError, WgNet, WgStream};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UdpSocket;
+
+const TIMEOUT: Duration = Duration::from_secs(10);
+
+async fn within<T>(future: impl Future<Output = T>) -> T {
+    tokio::time::timeout(TIMEOUT, future).await.expect("timed out")
+}
+
+/// Accept connections forever and echo every byte back.
+async fn spawn_echo(server: &WgNet, port: u16) -> tokio::task::JoinHandle<()> {
+    let mut listener = server.listen(port).await.expect("listen");
+    tokio::spawn(async move {
+        while let Some(mut stream) = listener.accept().await {
+            tokio::spawn(async move {
+                let mut buffer = vec![0u8; 16 * 1024];
+                loop {
+                    match stream.read(&mut buffer).await {
+                        Ok(0) | Err(_) => break,
+                        Ok(count) => {
+                            if stream.write_all(&buffer[..count]).await.is_err() {
+                                break;
+                            }
+                        }
+                    }
+                }
+                let _ = stream.shutdown().await;
+            });
+        }
+    })
+}
+
+async fn round_trip(stream: &mut WgStream, payload: &[u8]) {
+    let (mut reader, mut writer) = tokio::io::split(stream);
+    let write = async {
+        writer.write_all(payload).await.expect("write");
+    };
+    let read = async {
+        let mut received = vec![0u8; payload.len()];
+        reader.read_exact(&mut received).await.expect("read");
+        assert_eq!(received, payload);
+    };
+    within(async { tokio::join!(write, read) }).await;
+}
+
+fn payload(len: usize) -> Vec<u8> {
+    (0..len).map(|index| (index % 251) as u8).collect()
+}
+
+#[tokio::test]
+async fn tcp_echo_through_the_tunnel_in_both_families() {
+    let LoopbackPair { client, server, client_socket, server_socket, server_v4, server_v6, .. } =
+        loopback_pair().await.unwrap();
+    let server = WgNet::start(server, server_socket).await.unwrap();
+    let client = WgNet::start(client, client_socket).await.unwrap();
+    let _echo = spawn_echo(&server, 1337).await;
+
+    let mut v4 = within(client.connect(SocketAddr::new(server_v4, 1337))).await.unwrap();
+    assert_eq!(v4.peer_addr(), SocketAddr::new(server_v4, 1337));
+    round_trip(&mut v4, b"hello").await;
+    round_trip(&mut v4, &payload(1200)).await;
+    round_trip(&mut v4, &payload(64 * 1024)).await;
+
+    let mut v6 = within(client.connect(SocketAddr::new(server_v6, 1337))).await.unwrap();
+    round_trip(&mut v6, &payload(1200)).await;
+    round_trip(&mut v6, &payload(64 * 1024)).await;
+
+    assert!(client.time_since_last_handshake().await.unwrap().is_some());
+    assert!(server.time_since_last_handshake().await.unwrap().is_some());
+
+    within(v4.shutdown()).await.unwrap();
+    let mut end = [0u8; 1];
+    assert_eq!(within(v4.read(&mut end)).await.unwrap(), 0, "echo peer closes after our FIN");
+    drop(v6);
+    client.shutdown().await;
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_restarted_client_handshakes_again() {
+    let LoopbackPair { client, server, client_socket, server_socket, server_v4, .. } =
+        loopback_pair().await.unwrap();
+    let server = WgNet::start(server, server_socket).await.unwrap();
+    let _echo = spawn_echo(&server, 2222).await;
+
+    let first = WgNet::start(client.clone(), client_socket).await.unwrap();
+    let mut stream = within(first.connect(SocketAddr::new(server_v4, 2222))).await.unwrap();
+    round_trip(&mut stream, b"first session").await;
+    drop(stream);
+    first.shutdown().await;
+
+    // A new socket means a new source port: the server must accept the fresh
+    // handshake and roam to the new endpoint.
+    let second_socket = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let second = WgNet::start(client, second_socket).await.unwrap();
+    let mut stream = within(second.connect(SocketAddr::new(server_v4, 2222))).await.unwrap();
+    round_trip(&mut stream, &payload(4096)).await;
+    second.shutdown().await;
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn a_closed_port_is_refused_and_routes_are_reported() {
+    let LoopbackPair { client, server, client_socket, server_socket, server_v4, .. } =
+        loopback_pair().await.unwrap();
+    let server = WgNet::start(server, server_socket).await.unwrap();
+    let client = WgNet::start(client, client_socket).await.unwrap();
+
+    assert!(client.routes_contain("10.200.0.77".parse().unwrap()));
+    assert!(client.routes_contain("fdcc::9".parse().unwrap()));
+    assert!(!client.routes_contain("10.201.0.1".parse().unwrap()));
+    assert_eq!(client.routes().len(), 2);
+
+    let error = within(client.connect(SocketAddr::new(server_v4, 4444))).await.unwrap_err();
+    assert!(matches!(error, WgError::ConnectionRefused(_)), "{error}");
+
+    client.shutdown().await;
+    server.shutdown().await;
+}
+
+#[tokio::test]
+async fn dropping_the_tunnel_ends_its_streams() {
+    let LoopbackPair { client, server, client_socket, server_socket, server_v4, .. } =
+        loopback_pair().await.unwrap();
+    let server = WgNet::start(server, server_socket).await.unwrap();
+    let client = WgNet::start(client, client_socket).await.unwrap();
+    let _echo = spawn_echo(&server, 3333).await;
+
+    let mut stream = within(client.connect(SocketAddr::new(server_v4, 3333))).await.unwrap();
+    round_trip(&mut stream, b"alive").await;
+    drop(client);
+
+    let mut end = [0u8; 8];
+    let read = within(stream.read(&mut end)).await;
+    assert!(matches!(read, Ok(0) | Err(_)), "stream should end after its tunnel is dropped");
+    server.shutdown().await;
+}

--- a/cmux-tui/crates/cmux-wg/tests/tunnel.rs
+++ b/cmux-tui/crates/cmux-wg/tests/tunnel.rs
@@ -1,5 +1,6 @@
 //! Two in-process WireGuard peers over loopback UDP: no root, no interface.
 
+use std::future::Future;
 use std::net::SocketAddr;
 use std::time::Duration;
 

--- a/cmux-tui/docs/remote.md
+++ b/cmux-tui/docs/remote.md
@@ -114,6 +114,17 @@ If the binary is absent or reports an understood incompatible probe, an npm-back
 
 Every command that selects SSH as its initial route performs the same probe and automatic install before starting its authenticated connection. This includes a raw `ssh://` route passed to `connect`, `forward`, or `rpc`. The bootstrap runs outside the short carrier-reattachment deadline, so installation can finish without making later keystroke-path reconnects wait on package setup. A later SSH fallback is expected to use the binary installed by an earlier SSH connection or by the server owner. These commands accept `--session`, `--ssh-binary`, `--remote-binary`, `--remote-state-dir`, repeated `--ssh-arg` values, `--upgrade`, and `--no-install`. Repeat `--session dev` on later connections to a non-main SSH session; the known-daemon record stores routes and keys, not the remote session name.
 
+## Share one WireGuard tunnel between clients
+
+One WireGuard key supports one live session: the server keeps the endpoint of the last authenticated sender, so two processes handshaking with the same key steal each other's traffic. When several `remote connect` processes on one machine must reach the same private network, run one hub and point each client at it:
+
+```sh
+cmux-tui wg hub --config ~/.cmuxterm/wireguard/app.conf --socket ~/.cmuxterm/wireguard/hub.sock
+cmux-tui remote connect 'ws://[fd7a::10]:1337/v1/link' --wireguard-hub ~/.cmuxterm/wireguard/hub.sock
+```
+
+The hub owns the tunnel and serves SOCKS5 CONNECT with no authentication on an owner-only Unix socket (parent directory `0700`, socket `0600`, peer uid checked). It dials literal IP targets inside the tunnel's `AllowedIPs` only: other addresses get reply `0x02` (not allowed by ruleset), names get `0x08` (address type not supported). It prints one JSON line `{"event":"hub-ready","socket":"<path>","routes":[...]}` when listening, exits non-zero with a clear error otherwise, and removes the socket on SIGTERM or SIGINT. `remote-probe --json` lists `wireguard-hub` in `capabilities` when a client supports both halves.
+
 ## Client option reference
 
 `connect`, `ssh`, `forward`, and `rpc` share these connection options:
@@ -135,6 +146,7 @@ Every command that selects SSH as its initial route performs the same probe and 
 | `--iroh-address <addr>` | Add an Iroh direct address; repeat for several addresses |
 | `--iroh-path <mode>` | `auto`, `direct-only`, or `relay-only`; default `auto` |
 | `--wireguard-config <path>` | Run an in-process WireGuard peer from an owner-only wg-quick file and dial `ws`/`wss` routes whose address is inside its `AllowedIPs` through it; other addresses use the operating system. No root and no system interface; only this client's links travel through the tunnel |
+| `--wireguard-hub <path>` | Dial `ws`/`wss` routes through a running `cmux-tui wg hub` Unix socket (SOCKS5 CONNECT) instead of owning a tunnel. Exclusive with `--wireguard-config`. Several `remote connect` processes share one key this way, because one WireGuard key supports only one live session |
 
 Reconnect defaults are unlimited attempts, 100 ms initial delay, 5 s maximum delay, a 15 s timeout per attempt, full jitter, a 5 s heartbeat interval, and a 15 s heartbeat timeout. Override them with `--reconnect-attempts <n|unlimited>`, `--reconnect-initial-ms`, `--reconnect-max-ms`, `--reconnect-attempt-timeout-ms`, `--reconnect-jitter <full|none>`, `--heartbeat-interval-ms`, and `--heartbeat-timeout-ms`. The per-attempt timeout also deadlines each link's initial handshake on every dial, invitation dials included, so an endpoint that accepts the connection but never completes the cmux handshake fails within that budget and tears its transport down instead of holding the connection open. The failure is a retryable carrier failure, so `--reconnect-attempts` and the backoff delays decide when the client stops redialing; an invitation's enrollment-approval wait happens after the handshake and keeps its own longer window.
 

--- a/cmux-tui/docs/remote.md
+++ b/cmux-tui/docs/remote.md
@@ -134,6 +134,7 @@ Every command that selects SSH as its initial route performs the same probe and 
 | `--iroh-relay <url>` | Override the Iroh relay routing hint |
 | `--iroh-address <addr>` | Add an Iroh direct address; repeat for several addresses |
 | `--iroh-path <mode>` | `auto`, `direct-only`, or `relay-only`; default `auto` |
+| `--wireguard-config <path>` | Run an in-process WireGuard peer from an owner-only wg-quick file and dial `ws`/`wss` routes whose address is inside its `AllowedIPs` through it; other addresses use the operating system. No root and no system interface; only this client's links travel through the tunnel |
 
 Reconnect defaults are unlimited attempts, 100 ms initial delay, 5 s maximum delay, a 15 s timeout per attempt, full jitter, a 5 s heartbeat interval, and a 15 s heartbeat timeout. Override them with `--reconnect-attempts <n|unlimited>`, `--reconnect-initial-ms`, `--reconnect-max-ms`, `--reconnect-attempt-timeout-ms`, `--reconnect-jitter <full|none>`, `--heartbeat-interval-ms`, and `--heartbeat-timeout-ms`. The per-attempt timeout also deadlines each link's initial handshake on every dial, invitation dials included, so an endpoint that accepts the connection but never completes the cmux handshake fails within that budget and tears its transport down instead of holding the connection open. The failure is a retryable carrier failure, so `--reconnect-attempts` and the backoff delays decide when the client stops redialing; an invitation's enrollment-approval wait happens after the handshake and keeps its own longer window.
 

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -16,10 +16,15 @@ cmux server start [START OPTIONS]
 cmux attach [START OPTIONS] [--terminal <terminal-id>]
 cmux relay [ROUTING OPTIONS]
 cmux machine-agent [OPTIONS]
+cmux wg hub --config <wg-quick file> --socket <unix socket>
 ```
 
 `relay` copies private protocol bytes between standard I/O and one session
-socket. Machine connectors use it as a transport primitive. `attach` opens the
+socket. Machine connectors use it as a transport primitive. `wg hub` owns one
+in-process WireGuard tunnel and serves SOCKS5 CONNECT on an owner-only Unix
+socket so several `remote connect --wireguard-hub <socket>` clients share one
+key; it prints one `hub-ready` JSON line when listening and removes the socket
+on SIGTERM or SIGINT. `attach` opens the
 complete session TUI. `attach --terminal <terminal-id>` resolves an exact ID
 from `cmux terminal list` and renders only that terminal, without session
 chrome or unrelated event traffic. Startup attach does not accept internal

--- a/docs/cloud-userspace-wireguard.md
+++ b/docs/cloud-userspace-wireguard.md
@@ -1,0 +1,105 @@
+# Userspace WireGuard for Cloud VM attach
+
+Cloud VMs live on the owner's Freestyle VPC and open no public port. Today the
+only way to reach a VM's cmux-tui daemon (`ws://[<vpc ipv6>]:1337/v1/link`) is a
+system WireGuard interface (`cmux vpn up`, sudo, wireguard-tools). The phone
+has no such path at all: iOS needs the NetworkExtension entitlement and a VPN
+prompt for a system tunnel.
+
+This design adds an in-process WireGuard transport so a cmux client reaches a
+VM with no system interface, no root, and no VPN prompt. Only cmux's own link
+goes through it. Safari previews and `ssh` still need the system tunnel.
+
+## Shape
+
+```
+cmux-remote DirectWebSocketProvider
+   └─ Dialer (new seam)
+        ├─ OsTcpDialer            tokio TcpStream          (default, unchanged)
+        └─ WireGuardDialer        cmux-wg::WgNet::connect  (new)
+
+cmux-wg (new crate)
+   boringtun::noise::Tunn  (WireGuard, sans-IO)
+   smoltcp Interface + TCP sockets (userspace TCP/IP, sans-IO)
+   one tokio task drives: UDP socket <-> Tunn <-> smoltcp device
+   WgNet::connect(SocketAddr) -> impl AsyncRead + AsyncWrite
+```
+
+The route stays `ws://[vpc]:1337/v1/link`. The server and the daemon are
+unchanged. The client decides how to reach the address: through a system
+interface if one is up, or through `cmux-wg` otherwise.
+
+`cmux-wg` is the single implementation shared by:
+
+- `cmux-tui remote connect --wireguard-config <path>` (the Mac sidecar),
+- `cmux-terminal-client` (the in-process client the iOS app links).
+
+## Identities
+
+WireGuard binds one key to one peer and one endpoint. Two live sessions with
+one key fight over the server's endpoint and both break intermittently. So the
+in-process tunnel never shares a key with the system tunnel:
+
+| consumer | device fingerprint | key storage | Freestyle tunnels |
+| --- | --- | --- | --- |
+| Mac system tunnel (`cmux vpn up`) | `mac-<uuid>` | `~/.cmuxterm/wireguard/private.key` | 1 |
+| Mac in-process (sidecar) | `mac-<uuid>-app` | `~/.cmuxterm/wireguard/app.key` | 1 |
+| iPhone in-process | `ios-<uuid>` | Keychain | 1 |
+
+Cost: a Mac that uses both paths holds two Freestyle tunnels. Enrollment is
+the existing `POST /api/vm/tunnel` (idempotent per fingerprint, not Pro-gated).
+
+## Tunnel lifecycle
+
+- Mac sidecar: one `WgNet` per `remote connect` process, up for the life of
+  the link. The app passes `--wireguard-config` only when
+  `VMTunnelManager.wgQuickInterfaceUp()` is false.
+- iPhone: one `WgNet` while the Cloud section is in the foreground. Dropped on
+  background; the next foreground re-handshakes (one round trip).
+- `PersistentKeepalive = 25` while the tunnel is up. This keeps carrier NAT
+  mappings alive so daemon output is not blocked. It costs one small packet
+  every 25 s while the Cloud section is open.
+
+## MTU
+
+Freestyle hands out `MTU = 1200`. `cmux-wg` sets the smoltcp device MTU from
+the config and the TCP MSS follows. The UDP path adds 32 bytes of WireGuard
+overhead plus 60 bytes for the outer IPv6/UDP header.
+
+## Sequence
+
+1. **PR 1, `cmux-tui`:** `cmux-wg` crate, `Dialer` seam, `remote connect
+   --wireguard-config`, wg-quick config parser, tests that run two `Tunn`
+   peers in one process (no root, no interface).
+2. **PR 2, macOS app:** app tunnel identity, enrollment, `--wireguard-config`
+   on the sidecar when the system interface is down, attach no longer waits
+   for `cmux vpn up`.
+3. **PR 3, `cmux-terminal-client` + artifact:** `ws://` route support through
+   `cmux-wg`, persistent device identity, raw terminal byte callback (the iOS
+   view feeds bytes to libghostty itself; the crate's text frames are not
+   used), terminal list and create, xcframework release workflow.
+4. **PR 4, iOS app:** Cloud section listing the account's VMs, tunnel
+   enrollment, attach through the client, bytes into `GhosttySurfaceView`.
+
+## Non-goals
+
+- Routing any traffic other than the cmux link (Safari previews, ssh, scp).
+  These keep `cmux vpn up`.
+- UDP or ICMP inside the tunnel.
+- Replacing the Mac's system tunnel.
+- VM create or delete from the phone, previews, files, agent chat, background
+  streaming.
+- A "your devices" list with revoke. The tunnel table already records each
+  device; the UI comes later.
+
+## Verification
+
+- `cargo test -p cmux-wg`: handshake, TCP echo through two in-process peers,
+  MTU-sized and larger payloads, peer restart re-handshake, config parse of
+  the Freestyle-issued file.
+- `cargo test -p cmux-remote`: `DirectWebSocketProvider` with an injected
+  dialer reaches a daemon bound on a `WgNet` peer.
+- Mac: tagged build, `cmux vpn down`, attach a private-network VM, terminal
+  works, `wg show` absent.
+- iPhone: Aziz, `personal` profile, dev backend, private-network VM; Cloud
+  section lists VMs, tap opens a terminal, typing echoes.

--- a/docs/cloud-userspace-wireguard.md
+++ b/docs/cloud-userspace-wireguard.md
@@ -15,24 +15,41 @@ goes through it. Safari previews and `ssh` still need the system tunnel.
 ```
 cmux-remote DirectWebSocketProvider
    └─ Dialer (new seam)
-        ├─ OsTcpDialer            tokio TcpStream          (default, unchanged)
-        └─ WireGuardDialer        cmux-wg::WgNet::connect  (new)
+        ├─ OsTcpDialer       tokio TcpStream                 (default, unchanged)
+        ├─ WireGuardDialer   cmux-wg::WgNet::connect         (in-process, iOS)
+        └─ SocksDialer       SOCKS5 over a unix socket       (Mac sidecars)
 
 cmux-wg (new crate)
    boringtun::noise::Tunn  (WireGuard, sans-IO)
    smoltcp Interface + TCP sockets (userspace TCP/IP, sans-IO)
    one tokio task drives: UDP socket <-> Tunn <-> smoltcp device
    WgNet::connect(SocketAddr) -> impl AsyncRead + AsyncWrite
+
+cmux-tui wg hub --config <wg-quick file> --socket <unix path>
+   owns one WgNet and serves SOCKS5 CONNECT on an owner-only unix socket
 ```
 
 The route stays `ws://[vpc]:1337/v1/link`. The server and the daemon are
-unchanged. The client decides how to reach the address: through a system
-interface if one is up, or through `cmux-wg` otherwise.
+unchanged. The client decides how to reach the address.
 
-`cmux-wg` is the single implementation shared by:
+One WireGuard key supports one live session: the server keeps the endpoint of
+the last authenticated sender, so two processes handshaking with the same key
+steal each other's traffic. The two consumers therefore differ in shape:
 
-- `cmux-tui remote connect --wireguard-config <path>` (the Mac sidecar),
-- `cmux-terminal-client` (the in-process client the iOS app links).
+- **iPhone.** One process holds every VM link, so one in-process `WgNet` is
+  shared by all of them through `WireGuardDialer`.
+- **Mac.** The app spawns one `remote connect` sidecar per VM link. Those
+  processes cannot each own a tunnel, so the app starts one `cmux-tui wg hub`
+  process that owns the tunnel and exposes SOCKS5 on a unix socket. Each
+  sidecar gets `--wireguard-hub <socket>` and dials through it. The hub is the
+  already-bundled `cmux-tui` binary, so the Mac ships no new artifact. Trade-off:
+  one more app-supervised process, and a hub crash drops every VM link until
+  the app restarts it and the sidecars reconnect.
+
+`remote connect --wireguard-config <path>` (in-process, single link) stays as
+the direct form for scripts and tests. The client advertises `wireguard-hub`
+in `remote-probe --json` capabilities so the app never passes a flag the
+bundled client does not know.
 
 ## Identities
 
@@ -43,7 +60,7 @@ in-process tunnel never shares a key with the system tunnel:
 | consumer | device fingerprint | key storage | Freestyle tunnels |
 | --- | --- | --- | --- |
 | Mac system tunnel (`cmux vpn up`) | `mac-<uuid>` | `~/.cmuxterm/wireguard/private.key` | 1 |
-| Mac in-process (sidecar) | `mac-<uuid>-app` | `~/.cmuxterm/wireguard/app.key` | 1 |
+| Mac hub (`cmux-tui wg hub`, shared by all sidecars) | `mac-<uuid>-app` | `~/.cmuxterm/wireguard/app.key` | 1 |
 | iPhone in-process | `ios-<uuid>` | Keychain | 1 |
 
 Cost: a Mac that uses both paths holds two Freestyle tunnels. Enrollment is
@@ -51,9 +68,9 @@ the existing `POST /api/vm/tunnel` (idempotent per fingerprint, not Pro-gated).
 
 ## Tunnel lifecycle
 
-- Mac sidecar: one `WgNet` per `remote connect` process, up for the life of
-  the link. The app passes `--wireguard-config` only when
-  `VMTunnelManager.wgQuickInterfaceUp()` is false.
+- Mac: one hub process per app session, started on the first VPC link and
+  stopped when the last link closes. Sidecars always dial VPC addresses through
+  the hub; the system tunnel is not consulted, so the two never race.
 - iPhone: one `WgNet` while the Cloud section is in the foreground. Dropped on
   background; the next foreground re-handshakes (one round trip).
 - `PersistentKeepalive = 25` while the tunnel is up. This keeps carrier NAT
@@ -69,11 +86,12 @@ overhead plus 60 bytes for the outer IPv6/UDP header.
 ## Sequence
 
 1. **PR 1, `cmux-tui`:** `cmux-wg` crate, `Dialer` seam, `remote connect
-   --wireguard-config`, wg-quick config parser, tests that run two `Tunn`
-   peers in one process (no root, no interface).
-2. **PR 2, macOS app:** app tunnel identity, enrollment, `--wireguard-config`
-   on the sidecar when the system interface is down, attach no longer waits
-   for `cmux vpn up`.
+   --wireguard-config` and `--wireguard-hub`, `wg hub` subcommand, the
+   `wireguard-hub` probe capability, tests that run two `Tunn` peers in one
+   process (no root, no interface).
+2. **PR 2, macOS app:** app tunnel identity and enrollment, hub lifecycle,
+   `--wireguard-hub` on sidecars for VPC routes, attach no longer needs
+   `cmux vpn up`.
 3. **PR 3, `cmux-terminal-client` + artifact:** `ws://` route support through
    `cmux-wg`, persistent device identity, raw terminal byte callback (the iOS
    view feeds bytes to libghostty itself; the crate's text frames are not
@@ -99,7 +117,9 @@ overhead plus 60 bytes for the outer IPv6/UDP header.
   the Freestyle-issued file.
 - `cargo test -p cmux-remote`: `DirectWebSocketProvider` with an injected
   dialer reaches a daemon bound on a `WgNet` peer.
-- Mac: tagged build, `cmux vpn down`, attach a private-network VM, terminal
-  works, `wg show` absent.
+- `cargo test -p cmux-tui`: `wg hub` plus `SocksDialer` reach a daemon on the
+  in-process peer.
+- Mac: tagged build with the branch client, system tunnel down, attach two
+  private-network VMs, both terminals work, one hub process, no `utun` added.
 - iPhone: Aziz, `personal` profile, dev backend, private-network VM; Cloud
   section lists VMs, tap opens a terminal, typing echoes.


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11638.

Replaces the per-allocation scan of every active connection with a central HashSet reservation table. Allocated ports are released on failed socket setup, connection teardown, and driver shutdown. Exhaustion returns an explicit error instead of reusing a port.

The first commit adds a behavior and probe-count bound test. The second commit implements the allocator and release paths.

Validation: diff check and rustfmt inspection only. Local Cargo/Rust tests were not run per cmux instructions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-process WireGuard transport so cmux clients reach Cloud VM daemons without a system WireGuard interface, root, or VPN prompt. `remote connect` gains `--wireguard-config` for a private tunnel and `--wireguard-hub` for sharing one key across macOS sidecars.

**In-process tunnel**
- New `cmux-wg` crate runs boringtun plus a smoltcp TCP stack in one Tokio task over a plain UDP socket.
- The direct WebSocket provider dials through a new `Dialer` seam; OS TCP remains the default.
- Ephemeral ports are now reserved centrally, so allocation is O(1) and exhaustion returns an explicit error instead of reusing a port.

**Shared hub**
- `wg hub` owns one tunnel and serves SOCKS5 CONNECT on an owner-only Unix socket so sidecar processes share one key.
- The hub accepts literal IP targets inside AllowedIPs only and removes its socket on SIGTERM/SIGINT.
- Adds e2e tests for the tunnel, the dialed path, and the hub; not run through local Cargo tests (diff check and rustfmt only).

<sup>Written for commit f25e43c8e6561d58eeacb9bd2f81bdc83759e033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

