### PR TITLE
fix(relay): own the grep pattern before spawning the runner task

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1745,7 +1745,8 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             };
             let raw =
                 args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
-            let pattern = args.get("pattern").and_then(Value::as_str).unwrap_or_default().to_owned();
+            let pattern =
+                args.get("pattern").and_then(Value::as_str).unwrap_or_default().to_owned();
             if pattern.is_empty() {
                 return fail("failed", "grep: pattern is required");
             }

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1745,7 +1745,7 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             };
             let raw =
                 args.get("path").and_then(Value::as_str).filter(|p| !p.is_empty()).unwrap_or(".");
-            let pattern = args.get("pattern").and_then(Value::as_str).unwrap_or_default();
+            let pattern = args.get("pattern").and_then(Value::as_str).unwrap_or_default().to_owned();
             if pattern.is_empty() {
                 return fail("failed", "grep: pattern is required");
             }
@@ -1803,7 +1803,7 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                             "--exclude-dir=.git".to_owned(),
                             "--exclude-dir=node_modules".to_owned(),
                             "-e".to_owned(),
-                            pattern.to_owned(),
+                            pattern,
                             "--".to_owned(),
                             process_path,
                         ],


### PR DESCRIPTION
Same two-line fix as https://github.com/manaflow-ai/cmux/pull/11634, recreated on current main because GitHub stopped updating that PR's head and mergeability. chatmux-relay has not compiled on main since https://github.com/manaflow-ai/cmux/pull/11568 (E0597/E0521 at the grep spawn). Focused hosted run on the original head, all green: https://github.com/manaflow-ai/cmux/actions/runs/33619939294

https://claude.ai/code/session_01AvkeWizggvvUAngHyB7JUQ

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a compile error in `chatmux-relay` where the grep action borrowed the pattern from the request frame, causing a lifetime error when the run was moved into `tokio::spawn`. The pattern is now cloned into an owned `String` before the spawn. No behavior change.

<sup>Written for commit eeee401532a0829c88b4881ea1ebbce594f2d637. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

