### PR TITLE
fix(tui): normalize legacy terminal exit receipts

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -2930,7 +2930,6 @@ impl Mux {
                 &terminal_id,
                 TerminalLifecycle::Adopting,
                 Some(&record.incarnation),
-                None,
             ) {
                 let current =
                     self.workspace_registry.lock().unwrap().terminal_record(&terminal_id)?;
@@ -3330,7 +3329,6 @@ impl Mux {
                                 &terminal_id,
                                 TerminalLifecycle::Adopting,
                                 Some(&record.incarnation),
-                                None,
                             )
                             .is_err()
                         {
@@ -6295,7 +6293,6 @@ impl Mux {
         terminal_id: &str,
         lifecycle: TerminalLifecycle,
         incarnation: Option<&str>,
-        exit: Option<Value>,
     ) -> anyhow::Result<(RegistryTerminal, u64)> {
         anyhow::ensure!(
             lifecycle != TerminalLifecycle::Exited,
@@ -6309,7 +6306,7 @@ impl Mux {
             terminal_id,
             lifecycle,
             incarnation,
-            exit,
+            None,
         )?;
         self.emit_terminal_registry_changed(&registry, result.1);
         Ok(result)
@@ -6858,17 +6855,13 @@ impl Mux {
                 match self.reconcile_surface_cell_pixels_for_publish(&surface) {
                     Ok(lifecycle) => lifecycle,
                     Err(error) => {
-                        let _ = self.transition_terminal_lifecycle(
-                            "terminal-exited",
-                            "terminal-cell-pixel-reconcile-failed",
+                        let _ = self.persist_terminal_exit(
                             &terminal_hex,
-                            TerminalLifecycle::Exited,
                             Some(&identity.incarnation),
-                            Some(serde_json::json!({
-                                "reason":"cell-pixel-reconcile-failed",
-                                "error":error.to_string(),
-                                "ready_revision":ready_revision,
-                            })),
+                            &TerminalExit::unknown(format!(
+                                "cell-pixel-reconcile-failed at terminal revision \
+                                 {ready_revision}: {error}"
+                            )),
                         );
                         surface.kill();
                         return Err(error);
@@ -27680,7 +27673,6 @@ mod tests {
             TERMINAL,
             TerminalLifecycle::Adopting,
             Some(INCARNATION),
-            None,
         )
         .unwrap();
         assert!(mux.terminal_host_connection_lost(PENDING_SURFACE, &identity));
@@ -27781,7 +27773,6 @@ mod tests {
             TERMINAL,
             TerminalLifecycle::Running,
             Some(INCARNATION),
-            None,
         )
         .unwrap();
 

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -1706,6 +1706,8 @@ type KittyImageBudgetOperationHook =
     Arc<dyn Fn(&Arc<Surface>, KittyGraphicsLimits, Instant) -> anyhow::Result<()> + Send + Sync>;
 #[cfg(test)]
 type TerminalSpawnAfterCellPixelSnapshotHook = Arc<dyn Fn(bool) + Send + Sync>;
+#[cfg(test)]
+type TerminalSpawnBeforeCellPixelReconcileHook = Arc<dyn Fn(&Arc<Surface>) + Send + Sync>;
 
 type CellPixelSurfaceResult = (SurfaceId, (u16, u16), anyhow::Result<Option<u64>>, bool);
 
@@ -2048,6 +2050,9 @@ pub struct Mux {
     #[cfg(test)]
     terminal_spawn_after_cell_pixel_snapshot:
         Mutex<Option<TerminalSpawnAfterCellPixelSnapshotHook>>,
+    #[cfg(test)]
+    terminal_spawn_before_cell_pixel_reconcile:
+        Mutex<Option<TerminalSpawnBeforeCellPixelReconcileHook>>,
     #[cfg(test)]
     terminal_create_after_terminal_reservation: Mutex<Option<TerminalReservationHook>>,
     pending_terminal_hosts: Mutex<HashMap<SurfaceId, TerminalHostIdentity>>,
@@ -2417,6 +2422,8 @@ impl Mux {
             terminal_create_after_workspace_reservation: Mutex::new(None),
             #[cfg(test)]
             terminal_spawn_after_cell_pixel_snapshot: Mutex::new(None),
+            #[cfg(test)]
+            terminal_spawn_before_cell_pixel_reconcile: Mutex::new(None),
             #[cfg(test)]
             terminal_create_after_terminal_reservation: Mutex::new(None),
             pending_terminal_hosts: Mutex::new(HashMap::new()),
@@ -6964,6 +6971,12 @@ impl Mux {
                     }
                 };
                 self.emit_terminal_registry_changed(&registry, revision);
+            }
+            #[cfg(test)]
+            if let Some(hook) =
+                self.terminal_spawn_before_cell_pixel_reconcile.lock().unwrap().clone()
+            {
+                hook(&surface);
             }
             let cell_pixel_lifecycle =
                 match self.reconcile_surface_cell_pixels_for_publish(&surface) {
@@ -20020,6 +20033,93 @@ mod tests {
         assert_eq!(*observed_unlocked.lock().unwrap(), vec![true]);
         assert_eq!(mux.cell_pixel_size(), (9, 18));
         assert_eq!(surface.test_cell_pixel_size(), (9, 18));
+    }
+
+    fn spawn_terminal_with_cell_pixel_failure(
+        mux: &Arc<Mux>,
+        fail_exit_persistence: bool,
+    ) -> (String, anyhow::Result<Arc<Surface>>) {
+        *mux.terminal_spawn_after_cell_pixel_snapshot.lock().unwrap() = Some(Arc::new({
+            let mux = Arc::downgrade(mux);
+            move |unlocked| {
+                assert!(unlocked, "terminal spawn retained the cell-pixel lifecycle lock");
+                mux.upgrade().unwrap().set_cell_pixel_size(9, 18);
+            }
+        }));
+        *mux.terminal_spawn_before_cell_pixel_reconcile.lock().unwrap() = Some(Arc::new({
+            let mux = Arc::downgrade(mux);
+            move |surface| {
+                surface.fail_next_test_master_resize();
+                if fail_exit_persistence {
+                    mux.upgrade()
+                        .unwrap()
+                        .workspace_registry
+                        .lock()
+                        .unwrap()
+                        .set_terminal_exit_failure(true)
+                        .unwrap();
+                }
+            }
+        }));
+        let workspace =
+            mux.create_empty_workspace(Some("cell-pixel-failure".into()), None, None).unwrap();
+        let terminal_id = TerminalId::random().unwrap();
+        let terminal_hex = terminal_id.to_hex();
+        let reservation = TerminalReservationRequest {
+            terminal_id,
+            mutation: WorkspaceMutation::new("cell-pixel-failure", "test").unwrap(),
+            fingerprint: serde_json::json!({"test":"cell-pixel-failure"}),
+            expected_generation: None,
+            expected_revision: None,
+            on_exit: TerminalOnExit::Close,
+        };
+        let result = mux.spawn_surface_in_workspace_reserved(
+            &workspace.key,
+            None,
+            Some((80, 24)),
+            None,
+            reservation,
+        );
+        (terminal_hex, result)
+    }
+
+    #[test]
+    fn terminal_spawn_cell_pixel_failure_uses_stable_exit_reason() {
+        let mux = test_mux();
+        let (terminal_id, result) = spawn_terminal_with_cell_pixel_failure(&mux, false);
+
+        let error = result.expect_err("injected cell-pixel failure must abort terminal creation");
+        assert!(format!("{error:#}").contains("injected PTY master resize failure"));
+        let exited = mux
+            .workspace_registry
+            .lock()
+            .unwrap()
+            .terminal_record(&terminal_id)
+            .unwrap()
+            .unwrap()
+            .exit
+            .unwrap();
+        assert_eq!(
+            exited["outcome"],
+            serde_json::json!({
+                "kind":"unknown",
+                "reason":"cell-pixel-reconcile-failed",
+            })
+        );
+        assert!(!exited.to_string().contains("injected PTY master resize failure"));
+    }
+
+    #[test]
+    fn terminal_spawn_cell_pixel_failure_propagates_exit_persistence_error() {
+        let mux = test_mux();
+        let (_, result) = spawn_terminal_with_cell_pixel_failure(&mux, true);
+
+        let error = result.expect_err("injected persistence failure must abort terminal creation");
+        assert!(
+            format!("{error:#}")
+                .contains("could not persist terminal exit after cell-pixel reconciliation failed"),
+            "unexpected terminal creation error: {error:#}"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -6707,6 +6707,27 @@ impl Mux {
         self.spawn_surface_with(cwd, command, size, Some(workspace_key), Some(reservation))
     }
 
+    fn persist_terminal_cell_pixel_reconcile_failure(
+        &self,
+        terminal_id: &str,
+        incarnation: Option<&str>,
+        error: &anyhow::Error,
+    ) -> anyhow::Result<()> {
+        let detail = format!("{error:#}");
+        eprintln!(
+            "cmux-tui: terminal {terminal_id} cell-pixel reconciliation failed before \
+             publication: {}",
+            detail.escape_debug()
+        );
+        self.persist_terminal_exit(
+            terminal_id,
+            incarnation,
+            &TerminalExit::unknown("cell-pixel-reconcile-failed"),
+        )
+        .context("could not persist terminal exit after cell-pixel reconciliation failed")?;
+        Ok(())
+    }
+
     fn spawn_surface_with(
         self: &Arc<Self>,
         cwd: Option<String>,
@@ -6837,7 +6858,7 @@ impl Mux {
                 surface.kill();
                 anyhow::bail!("terminal host changed registry-reserved identity");
             }
-            let ready_revision = {
+            {
                 let mut registry = self.workspace_registry.lock().unwrap();
                 let ready = commit_terminal_lifecycle(
                     &mut registry,
@@ -6856,21 +6877,18 @@ impl Mux {
                     }
                 };
                 self.emit_terminal_registry_changed(&registry, ready_revision);
-                ready_revision
-            };
+            }
             let cell_pixel_lifecycle =
                 match self.reconcile_surface_cell_pixels_for_publish(&surface) {
                     Ok(lifecycle) => lifecycle,
                     Err(error) => {
-                        let _ = self.persist_terminal_exit(
+                        let persistence = self.persist_terminal_cell_pixel_reconcile_failure(
                             &terminal_hex,
                             Some(&identity.incarnation),
-                            &TerminalExit::unknown(format!(
-                                "cell-pixel-reconcile-failed at terminal revision \
-                                 {ready_revision}: {error}"
-                            )),
+                            &error,
                         );
                         surface.kill();
+                        persistence?;
                         return Err(error);
                     }
                 };
@@ -6982,12 +7000,13 @@ impl Mux {
                 match self.reconcile_surface_cell_pixels_for_publish(&surface) {
                     Ok(lifecycle) => lifecycle,
                     Err(error) => {
-                        let _ = self.persist_terminal_exit(
+                        let persistence = self.persist_terminal_cell_pixel_reconcile_failure(
                             &terminal_hex,
                             Some(&incarnation),
-                            &TerminalExit::unknown(format!("cell-pixel-reconcile-failed: {error}")),
+                            &error,
                         );
                         surface.kill();
+                        persistence?;
                         return Err(error);
                     }
                 };

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -98,7 +98,8 @@ pub(crate) use session_journal::{SessionJournalReader, unix_epoch_ms};
 // one branch. Version 12 scopes receipts by origin. Version 13 adds immutable
 // binary content to journal rows. Version 14 gives resource API frontend
 // projections one owned envelope instead of storing anonymous projection JSON.
-const SCHEMA_VERSION: i64 = 14;
+// Version 15 normalizes legacy terminal exits to the exact public receipt shape.
+const SCHEMA_VERSION: i64 = 15;
 pub(crate) const RESOURCE_API_FRONTEND_PROJECTION_SCHEMA_VERSION: u32 = 2;
 const RESOURCE_EFFECT_PEPPER_SCHEMA_VERSION: i64 = 7;
 const MAX_ID_LEN: usize = 128;
@@ -2413,13 +2414,14 @@ impl WorkspaceRegistry {
                 require_resource_effect_pepper_id(&tx, &resource_effect_pepper_id)?;
                 tx.commit()?;
             }
-            Some(9..=13) => {
+            Some(9..=14) => {
                 let tx = connection.unchecked_transaction()?;
                 create_workspace_schema(&tx)?;
                 create_terminal_schema(&tx)?;
                 create_resource_schema(&tx)?;
                 create_resource_effect_schema(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 tx.execute(
                     "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
                     [SCHEMA_VERSION.to_string()],
@@ -2444,6 +2446,7 @@ impl WorkspaceRegistry {
                 backfill_workspace_public_ids(&tx)?;
                 migrate_resource_agent_projections(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 require_resource_effect_pepper_id(&tx, &resource_effect_pepper_id)?;
                 tx.execute(
                     "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
@@ -2469,6 +2472,7 @@ impl WorkspaceRegistry {
                 backfill_workspace_public_ids(&tx)?;
                 migrate_resource_agent_projections(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 migrate_resource_effect_pepper(&tx, &resource_effect_pepper_id)?;
                 tx.commit()?;
             }
@@ -2490,6 +2494,7 @@ impl WorkspaceRegistry {
                 backfill_workspace_public_ids(&tx)?;
                 migrate_resource_agent_projections(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 require_resource_effect_pepper_id(&tx, &resource_effect_pepper_id)?;
                 tx.execute(
                     "UPDATE meta SET value = ?1 WHERE key = 'schema_version'",
@@ -2506,6 +2511,7 @@ impl WorkspaceRegistry {
                 ensure_session_public_id(&tx)?;
                 migrate_resource_agent_projections(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 migrate_resource_effect_pepper(&tx, &resource_effect_pepper_id)?;
                 tx.commit()?;
             }
@@ -2519,6 +2525,7 @@ impl WorkspaceRegistry {
                 ensure_session_public_id(&tx)?;
                 migrate_resource_agent_projections(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 migrate_resource_effect_pepper(&tx, &resource_effect_pepper_id)?;
                 tx.commit()?;
             }
@@ -2533,6 +2540,7 @@ impl WorkspaceRegistry {
                 ensure_session_public_id(&tx)?;
                 migrate_resource_agent_projections(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 migrate_resource_effect_pepper(&tx, &resource_effect_pepper_id)?;
                 tx.commit()?;
             }
@@ -2555,6 +2563,7 @@ impl WorkspaceRegistry {
                 backfill_workspace_public_ids(&tx)?;
                 migrate_resource_agent_projections(&tx)?;
                 normalize_journal_multiview_schema(&tx)?;
+                terminal_exit_store::migrate_legacy_terminal_exit_receipts(&tx)?;
                 migrate_resource_effect_pepper(&tx, &resource_effect_pepper_id)?;
                 tx.commit()?;
             }
@@ -4697,7 +4706,10 @@ fn validate_terminal(terminal: &RegistryTerminal) -> anyhow::Result<()> {
         }
         _ => {}
     }
-    if terminal.lifecycle != TerminalLifecycle::Exited && terminal.exit.is_some() {
+    if terminal.lifecycle == TerminalLifecycle::Exited {
+        let exit = terminal.exit.as_ref().context("exited terminal requires exit metadata")?;
+        terminal_exit_store::validate_terminal_exit_receipt(exit)?;
+    } else if terminal.exit.is_some() {
         anyhow::bail!("only an exited terminal can carry exit metadata");
     }
     Ok(())

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
-use rusqlite::{OptionalExtension, params};
+use rusqlite::{OptionalExtension, Transaction, params};
+use serde::Deserialize;
 use serde_json::{Value, json};
 
 use super::resource_store::validate_resource_patch;
@@ -9,7 +10,85 @@ use super::{
     session_journal::append_resource_journal_record, transaction_resource_revision,
     transaction_terminal_revision, validate_terminal_transition,
 };
-use crate::terminal_host_protocol::TerminalExit;
+use crate::resource::WireDecimal;
+use crate::terminal_host_protocol::{TerminalExit, TerminalExitOutcome};
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DurableTerminalExitReceipt {
+    outcome: TerminalExitOutcome,
+    exited_at: WireDecimal,
+    revision: WireDecimal,
+}
+
+pub(super) fn validate_terminal_exit_receipt(value: &Value) -> anyhow::Result<()> {
+    let DurableTerminalExitReceipt { outcome, exited_at, revision } =
+        serde_json::from_value(value.clone()).context("terminal exit receipt is invalid")?;
+    let _validated_revision = revision.get();
+    anyhow::ensure!(
+        TerminalExit { outcome, exited_at_ms: exited_at.get() }.is_valid(),
+        "terminal exit receipt outcome is invalid"
+    );
+    Ok(())
+}
+
+fn legacy_terminal_exit_reason(value: &Value) -> anyhow::Result<String> {
+    let present =
+        |key: &str| value.get(key).and_then(Value::as_str).filter(|value| !value.trim().is_empty());
+    Ok(match (present("reason"), present("error")) {
+        (Some(reason), Some(error)) if reason != error => format!("{reason}: {error}"),
+        (Some(reason), _) => reason.to_string(),
+        (None, Some(error)) => error.to_string(),
+        (None, None) => format!("legacy-terminal-exit: {}", canonical_json(value)?),
+    })
+}
+
+pub(super) fn migrate_legacy_terminal_exit_receipts(
+    transaction: &Transaction<'_>,
+) -> anyhow::Result<()> {
+    // Legacy rows recorded neither an exit timestamp nor a resource revision.
+    // Anchor the converted receipt to the upgrade observation and current head.
+    let resource_revision = super::meta_value(transaction, "resource_revision")?
+        .map(|value| value.parse::<u64>().context("resource revision is invalid"))
+        .transpose()?
+        .unwrap_or(0);
+    let terminals = {
+        let mut statement = transaction.prepare(
+            "SELECT terminal_id, exit_json
+             FROM terminal_hosts
+             WHERE lifecycle = 'exited'
+                OR (lifecycle = 'tombstoned' AND exit_json IS NOT NULL)
+             ORDER BY terminal_id",
+        )?;
+        let rows = statement.query_map([], |row| {
+            Ok((row.get::<_, String>(0)?, row.get::<_, Option<String>>(1)?))
+        })?;
+        rows.collect::<rusqlite::Result<Vec<_>>>()?
+    };
+    for (terminal_id, stored) in terminals {
+        let legacy = stored
+            .as_deref()
+            .map(serde_json::from_str::<Value>)
+            .transpose()
+            .with_context(|| format!("terminal {terminal_id} exit metadata is invalid JSON"))?
+            .unwrap_or(Value::Null);
+        if validate_terminal_exit_receipt(&legacy).is_ok() {
+            continue;
+        }
+        let observed = TerminalExit::unknown(legacy_terminal_exit_reason(&legacy)?);
+        let receipt = json!({
+            "outcome": observed.outcome,
+            "exited_at": observed.exited_at_ms.to_string(),
+            "revision": resource_revision.to_string(),
+        });
+        validate_terminal_exit_receipt(&receipt)?;
+        transaction.execute(
+            "UPDATE terminal_hosts SET exit_json = ?1 WHERE terminal_id = ?2",
+            params![canonical_json(&receipt)?, terminal_id],
+        )?;
+    }
+    Ok(())
+}
 
 impl WorkspaceRegistry {
     /// Latch one authoritative process exit into both registry timelines.

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
@@ -309,4 +309,18 @@ impl WorkspaceRegistry {
         tx.commit()?;
         Ok((terminal, next_terminal_revision, next_resource_revision, false))
     }
+
+    #[cfg(test)]
+    pub(crate) fn set_terminal_exit_failure(&self, enabled: bool) -> anyhow::Result<()> {
+        if enabled {
+            self.connection.execute_batch(
+                "CREATE TEMP TRIGGER cmux_test_fail_terminal_exit
+                 BEFORE INSERT ON terminal_mutations
+                 BEGIN SELECT RAISE(ABORT, 'forced terminal exit failure'); END;",
+            )?;
+        } else {
+            self.connection.execute_batch("DROP TRIGGER IF EXISTS cmux_test_fail_terminal_exit")?;
+        }
+        Ok(())
+    }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/terminal_exit_store.rs
@@ -227,10 +227,6 @@ impl WorkspaceRegistry {
             apply_resource_patch(&tx, patch, sqlite_resource_revision)?;
         }
 
-        if let Some((patch, _)) = topology {
-            apply_resource_patch(&tx, patch, sqlite_resource_revision)?;
-        }
-
         tx.execute(
             "UPDATE terminal_hosts
              SET incarnation = ?1, lifecycle = 'exited', exit_json = ?2,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/tests.rs
@@ -3478,9 +3478,29 @@ fn first_exit_metadata_wins_and_exited_ids_cannot_be_relaunched() {
         )
         .unwrap();
 
+    let mut malformed_exit = launching.clone();
+    malformed_exit.lifecycle = TerminalLifecycle::Exited;
+    malformed_exit.exit = Some(json!({"reason":"legacy-writer"}));
+    let error = registry
+        .commit_terminal(
+            &WorkspaceMutation::new("malformed-exit", "daemon").unwrap(),
+            &json!({"op":"terminal-exited","terminal_id":TERMINAL_ONE}),
+            None,
+            Some(1),
+            "terminal-exited",
+            &malformed_exit,
+            &json!({"terminal_id":TERMINAL_ONE}),
+        )
+        .unwrap_err();
+    assert!(error.to_string().contains("terminal exit receipt is invalid"));
+
     let mut first_exit = launching.clone();
     first_exit.lifecycle = TerminalLifecycle::Exited;
-    first_exit.exit = Some(json!({"reason":"first-observer","status":17}));
+    first_exit.exit = Some(json!({
+        "outcome":{"kind":"unknown","reason":"first-observer"},
+        "exited_at":"17",
+        "revision":"1",
+    }));
     let first = registry
         .commit_terminal(
             &WorkspaceMutation::new("exit-one", "daemon").unwrap(),
@@ -3495,7 +3515,11 @@ fn first_exit_metadata_wins_and_exited_ids_cannot_be_relaunched() {
     assert_eq!(first.revision, 2);
 
     let mut late_exit = first_exit.clone();
-    late_exit.exit = Some(json!({"reason":"late-observer","status":99}));
+    late_exit.exit = Some(json!({
+        "outcome":{"kind":"unknown","reason":"late-observer"},
+        "exited_at":"99",
+        "revision":"2",
+    }));
     let duplicate = registry
         .commit_terminal(
             &WorkspaceMutation::new("exit-two", "daemon").unwrap(),
@@ -3675,6 +3699,59 @@ fn registries_created_before_on_exit_gain_the_column_with_close_default() {
         TerminalOnExit::Keep
     );
     drop(registry);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn schema_14_legacy_terminal_exit_metadata_migrates_to_exact_receipt() {
+    let root = temp_root("legacy-terminal-exit-migration");
+    {
+        let mut registry = WorkspaceRegistry::open(&root, "session").unwrap();
+        commit_terminal_topology(&mut registry, "legacy-terminal-exit");
+        let legacy_exit = json!({
+            "reason":"launch-failed",
+            "error":"terminal-host connection reset",
+        });
+        registry
+            .connection
+            .execute(
+                "UPDATE terminal_hosts
+                 SET lifecycle = 'exited', exit_json = ?1
+                 WHERE terminal_id = ?2",
+                params![canonical_json(&legacy_exit).unwrap(), TERMINAL_ONE],
+            )
+            .unwrap();
+        registry
+            .connection
+            .execute("UPDATE meta SET value = '14' WHERE key = 'schema_version'", [])
+            .unwrap();
+    }
+
+    let registry = WorkspaceRegistry::open(&root, "session").unwrap();
+    assert_eq!(
+        required_meta(&registry.connection, "schema_version").unwrap(),
+        SCHEMA_VERSION.to_string()
+    );
+    let terminal = registry.terminal_record(TERMINAL_ONE).unwrap().unwrap();
+    let exit = terminal.exit.unwrap();
+    assert_eq!(exit["outcome"]["kind"], "unknown");
+    assert_eq!(exit["outcome"]["reason"], "launch-failed: terminal-host connection reset");
+    assert!(exit["exited_at"].as_str().unwrap().parse::<u64>().is_ok());
+    assert_eq!(exit["revision"], registry.resource_revision().unwrap().to_string());
+    let stored: String = registry
+        .connection
+        .query_row(
+            "SELECT exit_json FROM terminal_hosts WHERE terminal_id = ?1",
+            [TERMINAL_ONE],
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(serde_json::from_str::<Value>(&stored).unwrap(), exit);
+    drop(registry);
+
+    let reopened = WorkspaceRegistry::open(&root, "session").unwrap();
+    assert_eq!(reopened.terminal_record(TERMINAL_ONE).unwrap().unwrap().exit, Some(exit));
+    drop(reopened);
     fs::remove_dir_all(root).unwrap();
 }
 
@@ -4793,7 +4870,10 @@ fn schema_thirteen_wraps_legacy_resource_api_frontend_projections() {
     }
 
     let migrated = WorkspaceRegistry::open(&root, "session").unwrap();
-    assert_eq!(required_meta(&migrated.connection, "schema_version").unwrap(), "14");
+    assert_eq!(
+        required_meta(&migrated.connection, "schema_version").unwrap(),
+        SCHEMA_VERSION.to_string()
+    );
     let projections = migrated.public_projections().unwrap().frontend_projections;
     assert_eq!(projections.len(), 1);
     assert_eq!(projections[0].schema_version, 2);


### PR DESCRIPTION
## Summary

- Migrate schema 1-14 registries to schema 15, converting legacy exited-terminal metadata to the exact public receipt shape: `{ outcome, exited_at, revision }`.
- Preserve useful legacy `reason` / `error` diagnostics as an `unknown` outcome; already-canonical receipts remain byte-equivalent JSON values.
- Reject malformed exit receipts on new registry writes and prevent generic lifecycle transitions from bypassing the durable public exit latch.
- Route cell-pixel reconciliation failures through that latch, propagate persistence errors, and keep detailed diagnostics out of durable/public receipts.

Current main serializes legacy values such as `{ "reason": "launch-failed" }` from schema-14 registries into `terminal.list`, then rejects its own response against the embedded catalog with `validation.invalid`. The legacy format did not record a timestamp or public resource revision, so migration anchors those fields to the upgrade observation and current resource head.

Related lifecycle audit: #10998.

## Testing

- `cargo fmt --all -- --check`
- `cargo test -p cmux-tui-core terminal_exit -- --nocapture` — 6 passed
- `cargo test -p cmux-tui-core terminal_spawn_cell_pixel_failure -- --nocapture` — 2 passed
- Red/green commits: schema migration `e487da4afe` → `4903d7d495`; spawn failure handling `7613c7e114` → `eb1fa8ceff`.
- `cargo clippy -p cmux-tui-core --all-targets` — completed; existing main warnings only
- Real server/CLI smoke: created and exited a disposable terminal, rewrote its stored schema to 14 and `exit_json` to `{ "reason": "legacy launch failure" }`, reopened with this branch, and verified `cmux --json terminal list` succeeded with:

  ```json
  {"exit":{"exited_at":"1788350589414","outcome":{"kind":"unknown","reason":"legacy launch failure"},"revision":"2"},"lifecycle":"exited"}
  ```

- Broad baseline comparison:
  - `cmux-tui-core`: the patch introduced no new failures; every non-passing case matched unmodified `origin/main` (the known current-schema SQLite counter test was filtered on the patch run).
  - `cmux-tui`: patch and unmodified `origin/main` both reported 1,546 passed and the same 25 environment-sensitive failures.

## Demo Video

Not applicable; protocol/storage correction with CLI smoke evidence above.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes terminal exit receipts so registries on schema 14 or older no longer return `validation.invalid` when listing terminals. These registries migrate to schema 15, converting legacy exit metadata into the canonical `{ outcome, exited_at, revision }` shape and preserving old reason/error diagnostics as an `unknown` outcome.

**Migration**
- Migrated receipts anchor `exited_at` to the upgrade time and `revision` to the current resource head.
- Already-canonical receipts are left byte-for-byte unchanged.

**Bug Fixes**
- New writes reject exit receipts that don't match the canonical shape.
- Generic lifecycle transitions no longer bypass the durable exit latch; the cell-pixel reconciliation failure writer uses it with a stable reason and propagates persistence errors.
- The exit latch applies terminal topology once instead of twice.

<sup>Written for commit eb1fa8ceff898174f57aba7d3de51876846592ea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal exit handling with durable, validated exit receipts.
  * Standardized legacy terminal exit metadata during workspace migration.
  * Ensured exited terminals include valid exit details and preserved the first recorded exit.
  * Improved compatibility when reopening workspaces created with earlier versions.
  * Recorded a consistent exit reason when terminal display reconciliation fails.
  * Improved reporting when exit information cannot be persisted.

* **Tests**
  * Added coverage for invalid receipts, legacy metadata migration, exit protection, and persistence failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->