### PR TITLE
ci: report ignored-only focused filters

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -489,7 +489,7 @@ jobs:
           ignored_listing="$RUNNER_TEMP/cmux-tui-focused-ignored-list.txt"
           cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored > "$ignored_listing"
           grep -E ': test$' "$ignored_listing" | sort > "$ignored_names" || [[ "$?" -eq 1 ]]
-          if [[ -s "$normal_names" && -s "$ignored_names" ]] && cmp -s "$normal_names" "$ignored_names"; then
+          if [[ ! -s "$normal_names" && -s "$ignored_names" ]]; then
             echo "::error::test_filter '$TEST_FILTER' matches only ignored tests" >&2
             exit 1
           fi


### PR DESCRIPTION
Focused cmux-tui verification currently reports a generic no-tests error when a filter selects only #[ignore] tests. Make the branch explicit by checking the ignored listing when the runnable listing is empty, so skipped matches are visible and cannot produce a false-green focused run.

No Rust build run locally per policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the focused cmux-tui verification to report an explicit error when a filter matches only ignored tests, instead of a generic no-tests error.

<sup>Written for commit 2efa2d8d6c2f3a48baf62052b864c3f34e6216ae. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

