### PR TITLE
Send Durable Object errors to Sentry

### DIFF
--- a/workers/presence/README.md
+++ b/workers/presence/README.md
@@ -121,6 +121,14 @@ bunx wrangler secret put STACK_PROJECT_ID
 bunx wrangler secret put STACK_PUBLISHABLE_CLIENT_KEY
 ```
 
+Set `SENTRY_DSN` once for production and for each isolated dev Worker. The
+Worker sends application exceptions to this DSN using Sentry's envelope API;
+missing or unavailable telemetry never changes request behavior.
+
+```bash
+bunx wrangler secret put SENTRY_DSN
+```
+
 Optional plain var `STACK_API_URL` defaults to `https://api.stack-auth.com`.
 
 ### Dev/staging instance

--- a/workers/presence/src/controlPlaneDo.ts
+++ b/workers/presence/src/controlPlaneDo.ts
@@ -22,8 +22,9 @@ import {
   type CtlSocket,
   type CtlStorage,
 } from "./controlPlane";
+import { captureSentryException, type SentryEnv } from "./sentry";
 
-export interface ControlPlaneEnv {
+export interface ControlPlaneEnv extends SentryEnv {
   /** Vercel web API origin the DO proxies (dev/prod), e.g. https://cmux.com.
    * Same optional-with-production-default pattern as STACK_API_URL. */
   CMUX_WEB_BASE_URL?: string;
@@ -91,6 +92,13 @@ export class AccountControlPlane extends DurableObject<ControlPlaneEnv> {
           `control-plane upstream ${init.method} ${path} network failure`,
           String(error).slice(0, 300),
         );
+        await captureSentryException(this.env, "cloudflare-control-plane", error, {
+          durable_object: "AccountControlPlane",
+          operation: "upstream_fetch",
+          method: init.method,
+          path,
+          failure: "network",
+        });
         throw error;
       }
       // A connection-level failure throws out of fetch (the core's retry-once
@@ -103,6 +111,16 @@ export class AccountControlPlane extends DurableObject<ControlPlaneEnv> {
           `control-plane upstream ${init.method} ${path} -> ${response.status}`,
           JSON.stringify(json)?.slice(0, 300) ?? "<no body>",
         );
+        await captureSentryException(this.env, "cloudflare-control-plane", new Error(
+          `upstream ${init.method} ${path} returned ${response.status}`,
+        ), {
+          durable_object: "AccountControlPlane",
+          operation: "upstream_fetch",
+          method: init.method,
+          path,
+          status: response.status,
+          failure: "http",
+        });
       }
       return { status: response.status, json };
     },
@@ -111,6 +129,20 @@ export class AccountControlPlane extends DurableObject<ControlPlaneEnv> {
   });
 
   override async fetch(request: Request): Promise<Response> {
+    try {
+      return await this.handleFetch(request);
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-control-plane", error, {
+        durable_object: "AccountControlPlane",
+        operation: "fetch",
+        path: new URL(request.url).pathname,
+        method: request.method,
+      });
+      throw error;
+    }
+  }
+
+  private async handleFetch(request: Request): Promise<Response> {
     // Device revocation, forwarded by the worker with rebuilt headers after
     // Stack bearer verification. This DO instance IS the verified account
     // scope; the strict-parsed body carries only {endpointId, revoked}.
@@ -167,11 +199,27 @@ export class AccountControlPlane extends DurableObject<ControlPlaneEnv> {
   }
 
   override async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
-    await this.core.handleMessage(wrapSocket(ws), message);
+    try {
+      await this.core.handleMessage(wrapSocket(ws), message);
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-control-plane", error, {
+        durable_object: "AccountControlPlane",
+        operation: "websocket_message",
+      });
+      throw error;
+    }
   }
 
   override async webSocketClose(ws: WebSocket): Promise<void> {
-    await this.core.handleClose(wrapSocket(ws));
+    try {
+      await this.core.handleClose(wrapSocket(ws));
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-control-plane", error, {
+        durable_object: "AccountControlPlane",
+        operation: "websocket_close",
+      });
+      throw error;
+    }
     try {
       ws.close();
     } catch {
@@ -180,7 +228,15 @@ export class AccountControlPlane extends DurableObject<ControlPlaneEnv> {
   }
 
   override async alarm(): Promise<void> {
-    await this.core.handleAlarm();
+    try {
+      await this.core.handleAlarm();
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-control-plane", error, {
+        durable_object: "AccountControlPlane",
+        operation: "alarm",
+      });
+      throw error;
+    }
   }
 
   /** Pull the alarm earlier if `due` precedes the currently scheduled one

--- a/workers/presence/src/do.ts
+++ b/workers/presence/src/do.ts
@@ -80,6 +80,7 @@ import {
   type EnqueuePhoneReplyResult,
   type StoredPhoneReply,
 } from "./replies";
+import { captureSentryException, type SentryEnv } from "./sentry";
 
 const INSTANCE_PREFIX = "inst:";
 /** `owner:<deviceId>` -> Stack user id pinned on first heartbeat. Durable:
@@ -195,7 +196,7 @@ function ownerKey(deviceId: string): string {
   return `${OWNER_PREFIX}${deviceId}`;
 }
 
-export class TeamPresence extends DurableObject {
+export class TeamPresence extends DurableObject<SentryEnv> {
   /** Live SSE subscribers; in-memory only. An evicted DO drops the streams and
    * clients reconnect, which re-delivers a fresh snapshot. */
   private sseSubscribers = new Set<SseSubscriber>();
@@ -278,6 +279,11 @@ export class TeamPresence extends DurableObject {
         await this.syncOneDevice(beat.deviceId, now);
       } catch (err) {
         console.error("sync projection failed (heartbeat); presence unaffected", err);
+        await captureSentryException(this.env, userId, err, {
+          durable_object: "TeamPresence",
+          operation: "heartbeat_sync_projection",
+          team_id: teamId,
+        });
       }
     }
     await this.ensureAlarmFor(instance);
@@ -501,6 +507,20 @@ export class TeamPresence extends DurableObject {
   // ---- Subscribe transports (worker forwards the original Request) ----
 
   override async fetch(request: Request): Promise<Response> {
+    try {
+      return await this.handleFetch(request);
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-team-presence", error, {
+        durable_object: "TeamPresence",
+        operation: "fetch",
+        path: new URL(request.url).pathname,
+        method: request.method,
+      });
+      throw error;
+    }
+  }
+
+  private async handleFetch(request: Request): Promise<Response> {
     if (new URL(request.url).pathname === "/v1/connectivity/subscribe") {
       return this.subscribeConnectivity(request);
     }
@@ -639,6 +659,18 @@ export class TeamPresence extends DurableObject {
   // from an old client that never sends sync) is ignored, so this stays
   // backward-compatible with the one-way presence transport.
   override async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    try {
+      await this.handleWebSocketMessage(ws, message);
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-team-presence", error, {
+        durable_object: "TeamPresence",
+        operation: "websocket_message",
+      });
+      throw error;
+    }
+  }
+
+  private async handleWebSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
     if (wsExpiresAt(ws) <= Date.now()) return;
     // Connectivity invalidation channels are push-only.
     if (wsConnectivityAccountId(ws) !== null) return;
@@ -826,14 +858,29 @@ export class TeamPresence extends DurableObject {
   override async webSocketClose(ws: WebSocket): Promise<void> {
     try {
       ws.close();
-    } catch {
-      // already closed
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-team-presence", error, {
+        durable_object: "TeamPresence",
+        operation: "websocket_close",
+      });
     }
   }
 
   // ---- Alarm: timeout-offline transitions and pruning ----
 
   override async alarm(): Promise<void> {
+    try {
+      await this.handleAlarm();
+    } catch (error) {
+      await captureSentryException(this.env, "cloudflare-team-presence", error, {
+        durable_object: "TeamPresence",
+        operation: "alarm",
+      });
+      throw error;
+    }
+  }
+
+  private async handleAlarm(): Promise<void> {
     const now = Date.now();
     const all = await this.allEntries();
     const { expired, events } = expireInstances([...all.values()], now);
@@ -876,6 +923,10 @@ export class TeamPresence extends DurableObject {
       }
     } catch (err) {
       console.error("sync projection/GC failed (alarm); presence unaffected", err);
+      await captureSentryException(this.env, "cloudflare-team-presence", err, {
+        durable_object: "TeamPresence",
+        operation: "alarm_sync_projection",
+      });
     }
     this.closeExpiredSubscribers(now);
     const candidates = [nextAlarmTime([...all.values()]), this.nextSubscriberDeadline(), tombGc]

--- a/workers/presence/src/index.ts
+++ b/workers/presence/src/index.ts
@@ -50,6 +50,7 @@ import {
   parsePhoneReply,
   parsePhoneReplyAck,
 } from "./replies";
+import { captureSentryException } from "./sentry";
 
 export { TeamPresence, AccountControlPlane };
 
@@ -92,7 +93,7 @@ async function resolveTeamOr403(
   return { ok: true, teamId: team.teamId, user, stub };
 }
 
-export default {
+const worker = {
   async fetch(request: Request, env: Env): Promise<Response> {
     const url = new URL(request.url);
 
@@ -317,5 +318,21 @@ export default {
     }
 
     return json({ error: "not_found" }, 404);
+  },
+} satisfies ExportedHandler<Env>;
+
+export default {
+  async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+    try {
+      return await worker.fetch(request, env);
+    } catch (error) {
+      await captureSentryException(env, "cloudflare-worker", error, {
+        durable_object: "worker-router",
+        operation: "fetch",
+        path: new URL(request.url).pathname,
+        method: request.method,
+      });
+      return json({ error: "internal_error" }, 500);
+    }
   },
 } satisfies ExportedHandler<Env>;

--- a/workers/presence/src/sentry.ts
+++ b/workers/presence/src/sentry.ts
@@ -1,0 +1,81 @@
+export interface SentryEnv {
+  /** Sentry DSN provisioned as a Worker secret. */
+  SENTRY_DSN?: string;
+}
+
+function details(error: unknown): { type: string; message: string; stack?: string } {
+  if (error instanceof Error) {
+    return {
+      type: error.name || "Error",
+      message: error.message.slice(0, 2_000),
+      ...(error.stack ? { stack: error.stack.slice(0, 8_000) } : {}),
+    };
+  }
+  return { type: "UnknownError", message: String(error).slice(0, 2_000) };
+}
+
+function parseDsn(raw: string): { endpoint: string; publicKey: string } | null {
+  try {
+    const url = new URL(raw);
+    const projectId = url.pathname.replace(/^\/+|\/+$/g, "");
+    if (!url.username || !projectId || (url.protocol !== "https:" && url.protocol !== "http:")) {
+      return null;
+    }
+    return {
+      endpoint: `${url.origin}/api/${projectId}/envelope/`,
+      publicKey: decodeURIComponent(url.username),
+    };
+  } catch {
+    return null;
+  }
+}
+
+/** Sends an application exception to Sentry without an SDK dependency.
+ * Sentry's envelope protocol is stable and works in Cloudflare Workers.
+ * Delivery failures are swallowed so telemetry cannot change DO behavior. */
+export async function captureSentryException(
+  env: SentryEnv,
+  distinctId: string,
+  error: unknown,
+  context: Record<string, string | number | boolean | undefined>,
+  sentryFetch: typeof fetch = fetch,
+): Promise<void> {
+  const dsn = env.SENTRY_DSN ? parseDsn(env.SENTRY_DSN) : null;
+  if (!dsn) return;
+  const eventId = crypto.randomUUID().replace(/-/g, "");
+  const value = details(error);
+  const tags: Record<string, string> = { runtime: "cloudflare-worker" };
+  for (const [key, item] of Object.entries(context)) {
+    if (item !== undefined) tags[key] = String(item).slice(0, 200);
+  }
+  const event = {
+    event_id: eventId,
+    timestamp: Date.now() / 1_000,
+    platform: "javascript",
+    level: "error",
+    logger: "cmux-presence",
+    ...(distinctId ? { user: { id: distinctId.slice(0, 200) } } : {}),
+    tags,
+    exception: {
+      values: [{
+        type: value.type,
+        value: value.message,
+        ...(value.stack ? { stacktrace: { frames: [{ filename: "worker", function: value.stack }] } } : {}),
+      }],
+    },
+  };
+  const envelope = `${JSON.stringify({ event_id: eventId, sent_at: new Date().toISOString() })}\n` +
+    `${JSON.stringify({ type: "event" })}\n${JSON.stringify(event)}\n`;
+  try {
+    await sentryFetch(
+      `${dsn.endpoint}?sentry_version=7&sentry_key=${encodeURIComponent(dsn.publicKey)}&sentry_client=cmux-presence-worker/1.0`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/x-sentry-envelope" },
+        body: envelope,
+      },
+    );
+  } catch {
+    // Error reporting must never become a second production failure.
+  }
+}

--- a/workers/presence/test/sentry.test.ts
+++ b/workers/presence/test/sentry.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { captureSentryException } from "../src/sentry";
+
+describe("captureSentryException", () => {
+  test("emits a Sentry envelope with exception context", async () => {
+    let request: Request | undefined;
+    await captureSentryException(
+      { SENTRY_DSN: "https://public@example.test/42" },
+      "user-1",
+      new Error("upstream failed"),
+      { durable_object: "TeamPresence", operation: "alarm", team_id: "team-1" },
+      async (input, init) => {
+        request = new Request(input, init);
+        return new Response("ok", { status: 200 });
+      },
+    );
+
+    expect(request?.url).toContain("https://example.test/api/42/envelope/");
+    expect(request?.headers.get("content-type")).toBe("application/x-sentry-envelope");
+    const lines = (await request?.text())?.split("\n") ?? [];
+    const event = JSON.parse(lines[2]) as Record<string, any>;
+    expect(event.platform).toBe("javascript");
+    expect(event.user.id).toBe("user-1");
+    expect(event.exception.values[0].value).toBe("upstream failed");
+    expect(event.tags.operation).toBe("alarm");
+  });
+
+  test("swallows telemetry transport failures and missing DSNs", async () => {
+    await expect(captureSentryException({}, "user-1", "boom", {}, async () => {
+      throw new Error("sentry unavailable");
+    })).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
The presence Worker and Durable Objects had no Sentry transport.

This adds direct Sentry envelope delivery for worker-router, TeamPresence, and AccountControlPlane errors, covering fetch, WebSocket, alarm, upstream network, and upstream HTTP failure paths. Payloads contain bounded exception data and safe operation context. Delivery failures are swallowed.

Set the production and dev Worker secret with `bunx wrangler secret put SENTRY_DSN`.

Tests: `bun test` in `workers/presence`; `bunx tsc -p workers/presence/tsconfig.json --noEmit`; Wrangler dry-run.