### PR TITLE
Admin Pro roster: bounded team lookups, truncation flag, scan sequence guard

### DIFF
--- a/web/app/[locale]/dashboard/admin/admin-pro-list.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-pro-list.tsx
@@ -56,6 +56,11 @@ type Snapshot = {
   readonly subscribers: readonly Subscriber[];
   readonly teamSubscriptions: readonly TeamSubscription[];
   readonly pendingGrants: readonly PendingGrant[];
+  readonly truncated: {
+    readonly subscribers: boolean;
+    readonly teamSubscriptions: boolean;
+    readonly pendingGrants: boolean;
+  };
 };
 
 type ScanState = {
@@ -121,6 +126,11 @@ export function AdminProList({ onPickQuery }: { onPickQuery?: (query: string) =>
         subscribers: snapshot.subscribers ?? [],
         teamSubscriptions: snapshot.teamSubscriptions ?? [],
         pendingGrants: snapshot.pendingGrants ?? [],
+        truncated: {
+          subscribers: snapshot.truncated?.subscribers === true,
+          teamSubscriptions: snapshot.truncated?.teamSubscriptions === true,
+          pendingGrants: snapshot.truncated?.pendingGrants === true,
+        },
       },
       userGrants: [],
       teamGrants: [],
@@ -146,19 +156,19 @@ export function AdminProList({ onPickQuery }: { onPickQuery?: (query: string) =>
       try {
         response = await fetch(`/api/admin/pro-users/scan?${params}`, { headers: { accept: "application/json" } });
       } catch {
-        patchScan(kind, { status: "error", scanned, pages, message: t("errors.network") });
+        patchScan(kind, seq, { status: "error", scanned, pages, message: t("errors.network") });
         return;
       }
       if (seq !== runSeq.current) return;
       if (!response.ok) {
-        patchScan(kind, { status: "error", scanned, pages, message: errorMessage(t, response.status) });
+        patchScan(kind, seq, { status: "error", scanned, pages, message: errorMessage(t, response.status) });
         return;
       }
       let page: { rows: unknown[]; scanned: number; nextCursor: string | null };
       try {
         page = (await response.json()) as typeof page;
       } catch {
-        patchScan(kind, { status: "error", scanned, pages, message: t("errors.generic") });
+        patchScan(kind, seq, { status: "error", scanned, pages, message: t("errors.generic") });
         return;
       }
       if (seq !== runSeq.current) return;
@@ -176,7 +186,7 @@ export function AdminProList({ onPickQuery }: { onPickQuery?: (query: string) =>
       cursor = page.nextCursor;
       if (!cursor) break;
     }
-    patchScan(kind, {
+    patchScan(kind, seq, {
       status: pages >= MAX_SCAN_PAGES && cursor ? "error" : "done",
       scanned,
       pages,
@@ -184,7 +194,10 @@ export function AdminProList({ onPickQuery }: { onPickQuery?: (query: string) =>
     });
   }
 
-  function patchScan(kind: "users" | "teams", scan: ScanState) {
+  // Only the run that started this scan may update it; a reload starts a new
+  // sequence and results from the old fetches are dropped.
+  function patchScan(kind: "users" | "teams", seq: number, scan: ScanState) {
+    if (seq !== runSeq.current) return;
     setState((current) => {
       if (current.kind !== "loaded") return current;
       return kind === "users" ? { ...current, userScan: scan } : { ...current, teamScan: scan };
@@ -248,6 +261,9 @@ function LoadedList({
 
       <ScanNote t={t} scan={userScan} label={t("list.scanUsers")} />
       <ScanNote t={t} scan={teamScan} label={t("list.scanTeams")} />
+      {snapshot.truncated.subscribers || snapshot.truncated.teamSubscriptions || snapshot.truncated.pendingGrants ? (
+        <p className="border border-border p-2 text-xs text-muted" role="alert">{t("list.truncated")}</p>
+      ) : null}
 
       <Block title={t("list.sections.subscribers", { count: snapshot.subscribers.length })}>
         {snapshot.subscribers.length === 0 ? (

--- a/web/app/api/admin/pro-users/route.ts
+++ b/web/app/api/admin/pro-users/route.ts
@@ -24,11 +24,20 @@ export async function GET(request: NextRequest) {
       listStripeProSubscribers(),
       listStripeTeamSubscriptions(),
       listAllPendingEmailGrants().catch((error: unknown) => {
-        if (isMissingGrantsTableError(error)) return [];
+        if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
         throw error;
       }),
     ]);
-    snapshot = { subscribers, teamSubscriptions, pendingGrants };
+    snapshot = {
+      subscribers: subscribers.rows,
+      teamSubscriptions: teamSubscriptions.rows,
+      pendingGrants: pendingGrants.rows,
+      truncated: {
+        subscribers: subscribers.truncated,
+        teamSubscriptions: teamSubscriptions.truncated,
+        pendingGrants: pendingGrants.truncated,
+      },
+    };
   } catch (error) {
     if (error instanceof Error && /DATABASE_URL is required/.test(error.message)) {
       return adminJsonResponse({ error: "database_unavailable" }, 503);

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -423,7 +423,8 @@
         "detail": "Detail",
         "sourceStripe": "Stripe subscription",
         "sourceGrant": "Manual grant",
-        "seats": "{count, plural, =1 {1 seat} other {# seats}}"
+        "seats": "{count, plural, =1 {1 seat} other {# seats}}",
+        "truncated": "This list is capped at 5,000 rows per source and some rows are not shown. Use search for anything missing."
       }
     },
     "aiAccounts": {

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -423,7 +423,8 @@
         "detail": "詳細",
         "sourceStripe": "Stripe サブスクリプション",
         "sourceGrant": "手動付与",
-        "seats": "{count} シート"
+        "seats": "{count} シート",
+        "truncated": "この一覧はソースごとに 5,000 行までに制限されており、一部の行は表示されていません。見つからないものは検索してください。"
       }
     },
     "aiAccounts": {

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -29,6 +29,8 @@ import {
 
 export const PRO_LIST_SCAN_PAGE_SIZE = 100;
 export const PRO_LIST_MAX_ROWS = 5000;
+/** Stack lookups issued at once while resolving team display names. */
+export const PRO_LIST_TEAM_LOOKUP_CONCURRENCY = 8;
 
 export type StripeProSubscriber = {
   readonly userId: string;
@@ -64,10 +66,22 @@ export type ManualTeamGrant = {
   readonly lastGrant: AdminPlanGrantRecord | null;
 };
 
+/** A list plus whether the hard row cap cut it off. */
+export type CappedList<Row> = {
+  readonly rows: readonly Row[];
+  /** True when more rows exist than PRO_LIST_MAX_ROWS; the UI must say so. */
+  readonly truncated: boolean;
+};
+
 export type ProListSnapshot = {
   readonly subscribers: readonly StripeProSubscriber[];
   readonly teamSubscriptions: readonly StripeTeamSubscription[];
   readonly pendingGrants: readonly AdminPendingGrantRow[];
+  readonly truncated: {
+    readonly subscribers: boolean;
+    readonly teamSubscriptions: boolean;
+    readonly pendingGrants: boolean;
+  };
 };
 
 export type ProListScanPage<Row> = {
@@ -95,9 +109,9 @@ export type ProListStackApp = {
 /** Every account with an active Stripe Pro row, newest period first, one row per user. */
 export async function listStripeProSubscribers(
   options: { readonly db?: ProListDb } = {},
-): Promise<StripeProSubscriber[]> {
+): Promise<CappedList<StripeProSubscriber>> {
   const db = options.db ?? cloudDb();
-  const rows = await db
+  const fetched = await db
     .select({
       userId: stripeSubscriptions.stackUserId,
       subscriptionId: stripeSubscriptions.id,
@@ -117,7 +131,9 @@ export async function listStripeProSubscribers(
       ),
     )
     .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
-    .limit(PRO_LIST_MAX_ROWS);
+    .limit(PRO_LIST_MAX_ROWS + 1);
+  const truncated = fetched.length > PRO_LIST_MAX_ROWS;
+  const rows = fetched.slice(0, PRO_LIST_MAX_ROWS);
   const seen = new Set<string>();
   const out: StripeProSubscriber[] = [];
   for (const row of rows) {
@@ -132,16 +148,24 @@ export async function listStripeProSubscribers(
       currentPeriodEnd: row.currentPeriodEnd ? row.currentPeriodEnd.toISOString() : null,
     });
   }
-  return out;
+  return { rows: out, truncated };
 }
 
-/** Every team with an active Stripe Team row, with its Stack display name when reachable. */
+/**
+ * Every team with an active Stripe Team row, with its Stack display name
+ * when reachable. Name lookups run a few at a time so a large roster cannot
+ * open thousands of Stack requests at once.
+ */
 export async function listStripeTeamSubscriptions(
-  options: { readonly db?: ProListDb; readonly app?: ProListStackApp } = {},
-): Promise<StripeTeamSubscription[]> {
+  options: {
+    readonly db?: ProListDb;
+    readonly app?: ProListStackApp;
+    readonly concurrency?: number;
+  } = {},
+): Promise<CappedList<StripeTeamSubscription>> {
   const db = options.db ?? cloudDb();
   const app = options.app ?? defaultProListStackApp();
-  const rows = await db
+  const fetched = await db
     .select({
       teamId: stripeSubscriptions.stackTeamId,
       subscriptionId: stripeSubscriptions.id,
@@ -160,15 +184,19 @@ export async function listStripeTeamSubscriptions(
       ),
     )
     .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
-    .limit(PRO_LIST_MAX_ROWS);
+    .limit(PRO_LIST_MAX_ROWS + 1);
+  const truncated = fetched.length > PRO_LIST_MAX_ROWS;
+  const rows = fetched.slice(0, PRO_LIST_MAX_ROWS);
   const seen = new Set<string>();
   const unique = rows.filter((row) => {
     if (!row.teamId || seen.has(row.teamId)) return false;
     seen.add(row.teamId);
     return true;
   });
-  return await Promise.all(
-    unique.map(async (row) => {
+  const resolved = await mapWithConcurrency(
+    unique,
+    options.concurrency ?? PRO_LIST_TEAM_LOOKUP_CONCURRENCY,
+    async (row): Promise<StripeTeamSubscription> => {
       const team = await app.getTeam(row.teamId!).catch(() => null);
       return {
         teamId: row.teamId!,
@@ -179,16 +207,35 @@ export async function listStripeTeamSubscriptions(
         cancelAtPeriodEnd: Boolean(row.cancelAtPeriodEnd),
         currentPeriodEnd: row.currentPeriodEnd ? row.currentPeriodEnd.toISOString() : null,
       };
-    }),
+    },
   );
+  return { rows: resolved, truncated };
+}
+
+/** Runs `work` over `items` with at most `limit` in flight, preserving order. */
+export async function mapWithConcurrency<Item, Result>(
+  items: readonly Item[],
+  limit: number,
+  work: (item: Item) => Promise<Result>,
+): Promise<Result[]> {
+  const results: Result[] = new Array(items.length);
+  let next = 0;
+  const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
+    while (next < items.length) {
+      const index = next++;
+      results[index] = await work(items[index]!);
+    }
+  });
+  await Promise.all(workers);
+  return results;
 }
 
 /** Every open pending email grant, newest first. */
 export async function listAllPendingEmailGrants(
   options: { readonly db?: ProListDb } = {},
-): Promise<AdminPendingGrantRow[]> {
+): Promise<CappedList<AdminPendingGrantRow>> {
   const db = options.db ?? cloudDb();
-  const rows = await db
+  const fetched = await db
     .select({
       id: adminPlanGrants.id,
       email: adminPlanGrants.email,
@@ -199,14 +246,17 @@ export async function listAllPendingEmailGrants(
     .from(adminPlanGrants)
     .where(and(isNull(adminPlanGrants.appliedAt), isNull(adminPlanGrants.revokedAt)))
     .orderBy(desc(adminPlanGrants.createdAt))
-    .limit(PRO_LIST_MAX_ROWS);
-  return rows.map((row) => ({
-    id: row.id,
-    email: row.email,
-    plan: row.plan,
-    grantedByEmail: row.grantedByEmail ?? null,
-    createdAt: row.createdAt.toISOString(),
-  }));
+    .limit(PRO_LIST_MAX_ROWS + 1);
+  return {
+    truncated: fetched.length > PRO_LIST_MAX_ROWS,
+    rows: fetched.slice(0, PRO_LIST_MAX_ROWS).map((row) => ({
+      id: row.id,
+      email: row.email,
+      plan: row.plan,
+      grantedByEmail: row.grantedByEmail ?? null,
+      createdAt: row.createdAt.toISOString(),
+    })),
+  };
 }
 
 /** One page of the Stack user directory, keeping only accounts with a paid manual override. */

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import {
   isValidScanCursor,
   listAllPendingEmailGrants,
+  mapWithConcurrency,
+  PRO_LIST_MAX_ROWS,
   listStripeProSubscribers,
   listStripeTeamSubscriptions,
   scanManualTeamGrants,
@@ -67,7 +69,8 @@ describe("Pro roster", () => {
       { userId: "u1", subscriptionId: "sub_old", status: "past_due", cancelAtPeriodEnd: true, currentPeriodEnd: new Date("2026-09-01T00:00:00Z"), email: "pat@example.com" },
       { userId: "u2", subscriptionId: "sub_2", status: "trialing", cancelAtPeriodEnd: false, currentPeriodEnd: null, email: null },
     ]]]));
-    const rows = await listStripeProSubscribers({ db });
+    const { rows, truncated } = await listStripeProSubscribers({ db });
+    expect(truncated).toBe(false);
     expect(rows).toEqual([
       { userId: "u1", email: "pat@example.com", subscriptionId: "sub_new", status: "active", cancelAtPeriodEnd: false, currentPeriodEnd: "2026-10-01T00:00:00.000Z" },
       { userId: "u2", email: null, subscriptionId: "sub_2", status: "trialing", cancelAtPeriodEnd: false, currentPeriodEnd: null },
@@ -81,7 +84,7 @@ describe("Pro roster", () => {
       { teamId: "t9", subscriptionId: "sub_t9", status: "active", seats: null, cancelAtPeriodEnd: true, currentPeriodEnd: null },
     ]]]));
     const app = fakeApp({ teams: [{ id: "t1", displayName: "Acme" }] });
-    const rows = await listStripeTeamSubscriptions({ db, app });
+    const { rows } = await listStripeTeamSubscriptions({ db, app });
     expect(rows.map((row) => [row.teamId, row.displayName, row.seats, row.cancelAtPeriodEnd])).toEqual([
       ["t1", "Acme", 5, false],
       ["t9", null, null, true],
@@ -92,9 +95,12 @@ describe("Pro roster", () => {
     const db = fakeDb(new Map([[adminPlanGrants, [
       { id: "g1", email: "a@example.com", plan: "pro", grantedByEmail: "lawrence@manaflow.ai", createdAt: new Date("2026-09-02T00:00:00Z") },
     ]]]));
-    expect(await listAllPendingEmailGrants({ db })).toEqual([
-      { id: "g1", email: "a@example.com", plan: "pro", grantedByEmail: "lawrence@manaflow.ai", createdAt: "2026-09-02T00:00:00.000Z" },
-    ]);
+    expect(await listAllPendingEmailGrants({ db })).toEqual({
+      truncated: false,
+      rows: [
+        { id: "g1", email: "a@example.com", plan: "pro", grantedByEmail: "lawrence@manaflow.ai", createdAt: "2026-09-02T00:00:00.000Z" },
+      ],
+    });
   });
 
   test("scans the user directory page by page and keeps only paid manual overrides", async () => {
@@ -128,6 +134,36 @@ describe("Pro roster", () => {
     const page = await scanManualTeamGrants(null, { app });
     expect(page.rows.map((row) => [row.teamId, row.plan])).toEqual([["t1", "team"]]);
     expect(page.nextCursor).toBeNull();
+  });
+
+  test("reports truncation when a source exceeds the row cap", async () => {
+    const many = Array.from({ length: PRO_LIST_MAX_ROWS + 1 }, (_, i) => ({
+      userId: `u${i}`, subscriptionId: `sub_${i}`, status: "active", cancelAtPeriodEnd: false, currentPeriodEnd: null, email: null,
+    }));
+    const { rows, truncated } = await listStripeProSubscribers({ db: fakeDb(new Map([[stripeSubscriptions, many]])) });
+    expect(truncated).toBe(true);
+    expect(rows).toHaveLength(PRO_LIST_MAX_ROWS);
+  });
+
+  test("team name lookups run with bounded concurrency", async () => {
+    const subs = Array.from({ length: 20 }, (_, i) => ({
+      teamId: `t${i}`, subscriptionId: `sub_${i}`, status: "active", seats: 1, cancelAtPeriodEnd: false, currentPeriodEnd: null,
+    }));
+    let inFlight = 0; let peak = 0;
+    const app: ProListStackApp = {
+      async getTeam(teamId) {
+        inFlight += 1; peak = Math.max(peak, inFlight);
+        await new Promise((resolve) => setTimeout(resolve, 2));
+        inFlight -= 1;
+        return { id: teamId, displayName: `Team ${teamId}` };
+      },
+      listUsers: async () => Object.assign([], { nextCursor: null }) as never,
+      listTeams: async () => Object.assign([], { nextCursor: null }) as never,
+    };
+    const { rows } = await listStripeTeamSubscriptions({ db: fakeDb(new Map([[stripeSubscriptions, subs]])), app, concurrency: 4 });
+    expect(rows.map((row) => row.displayName)).toEqual(subs.map((sub) => `Team ${sub.teamId}`));
+    expect(peak).toBeLessThanOrEqual(4);
+    expect(await mapWithConcurrency([], 3, async () => 1)).toEqual([]);
   });
 
   test("isValidScanCursor accepts opaque tokens and rejects junk", () => {

--- a/web/tests/admin-users-route.test.ts
+++ b/web/tests/admin-users-route.test.ts
@@ -562,10 +562,11 @@ describe("admin pro-users routes", () => {
     const response = await GET_PRO_USERS(new NextRequest("https://cmux.com/api/admin/pro-users"));
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
-    const body = (await response.json()) as { subscribers: Array<Record<string, unknown>> };
+    const body = (await response.json()) as { subscribers: Array<Record<string, unknown>>; truncated: Record<string, boolean> };
     expect(body.subscribers).toEqual([
       { userId: "u1", email: "pat@example.com", subscriptionId: "sub_1", status: "active", cancelAtPeriodEnd: false, currentPeriodEnd: null },
     ]);
+    expect(body.truncated).toEqual({ subscribers: false, teamSubscriptions: false, pendingGrants: false });
   });
 
   test("the scan validates its query and returns paid manual overrides", async () => {


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11645 from the local review gate that finished after the merge.

- Team display-name lookups for Stripe Team subscriptions run eight at a time instead of one Stack request per row all at once.
- Each roster source (Stripe subscribers, Team subscriptions, pending grants) fetches one row past the 5,000 cap and returns a `truncated` flag; the page shows a notice instead of presenting a capped list as complete.
- Directory-scan error paths are guarded by the run sequence, so a request from a superseded reload cannot mark the new run as failed.

Tests added for truncation, bounded concurrency, and the snapshot shape.

https://claude.ai/code/session_01PrCfEysHKCZFpXcqeRiPHL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Admin Pro roster so capped lists are no longer shown as complete and stale scan failures can't clobber a newer run.

- Team display-name lookups now run eight at a time instead of one Stack request per row all at once.
- Each roster source fetches one row past the 5,000-row cap and returns a `truncated` flag; the admin API exposes it per source and the page shows a notice when any source is cut off.
- Scan error paths check the run sequence before updating state, so a superseded reload is ignored.
- Adds tests for truncation, bounded concurrency, and the snapshot shape.

<sup>Written for commit 4a9e22c5ef4b6890d1c0e9c41544528fe69048d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

