### PR TITLE
ci: add cmux-terminal-client xcframework release workflow

### DIFF
--- a/.github/workflows/cmux-terminal-client-xcframework.yml
+++ b/.github/workflows/cmux-terminal-client-xcframework.yml
@@ -121,26 +121,77 @@ jobs:
           done
 
       - name: Assemble xcframework
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         shell: bash
         run: |
           set -euo pipefail
-          headers="$(mktemp -d)/include"
-          mkdir -p "$headers"
-          cp cmux-tui/crates/cmux-terminal-client/include/cmux_terminal_client.h "$headers/"
-          cat > "$headers/module.modulemap" <<'MAP'
-          module CmuxTerminalClientFFI {
-              header "cmux_terminal_client.h"
+          # Each slice ships as a static framework, not a bare library. Xcode
+          # copies every bare-library slice's Headers/module.modulemap to the
+          # same Build/Products/<config>/include/module.modulemap, and the app
+          # already links GhosttyKit.xcframework that way, so two bare-library
+          # xcframeworks collide ("Multiple commands produce"). A framework
+          # carries its module map under Modules/ and nothing collides. The
+          # xcframework Info.plist is written here rather than by
+          # `xcodebuild -create-xcframework` so the layout is exactly the one
+          # the iOS app link was verified against.
+          lib=cmux-tui/target
+          header=cmux-tui/crates/cmux-terminal-client/include/cmux_terminal_client.h
+          xcf="$RUNNER_TEMP/xcframework/CmuxTerminalClient.xcframework"
+          rm -rf "$RUNNER_TEMP/xcframework"
+          mkdir -p "$xcf"
+          short_version="${VERSION%%+*}"
+          entries=""
+          add_slice() {
+            local target="$1" slice="$2" platform="$3" supported="$4" minos="$5" variant="$6"
+            local fw="$xcf/$slice/CmuxTerminalClientFFI.framework"
+            mkdir -p "$fw/Headers" "$fw/Modules"
+            cp "$lib/$target/release/libcmux_terminal_client.a" "$fw/CmuxTerminalClientFFI"
+            cp "$header" "$fw/Headers/"
+            cat > "$fw/Modules/module.modulemap" <<'MAP'
+          framework module CmuxTerminalClientFFI {
+              umbrella header "cmux_terminal_client.h"
               export *
+              module * { export * }
           }
           MAP
+            local variant_key=""
+            if [[ -n "$variant" ]]; then
+              variant_key="<key>SupportedPlatformVariant</key><string>$variant</string>"
+            fi
+            cat > "$fw/Info.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>CFBundleDevelopmentRegion</key><string>en</string>
+            <key>CFBundleExecutable</key><string>CmuxTerminalClientFFI</string>
+            <key>CFBundleIdentifier</key><string>com.cmuxterm.CmuxTerminalClientFFI</string>
+            <key>CFBundleInfoDictionaryVersion</key><string>6.0</string>
+            <key>CFBundleName</key><string>CmuxTerminalClientFFI</string>
+            <key>CFBundlePackageType</key><string>FMWK</string>
+            <key>CFBundleShortVersionString</key><string>$short_version</string>
+            <key>CFBundleVersion</key><string>1</string>
+            <key>CFBundleSupportedPlatforms</key><array><string>$supported</string></array>
+            <key>MinimumOSVersion</key><string>$minos</string>
+          </dict></plist>
+          PLIST
+            plutil -lint "$fw/Info.plist"
+            entries+="<dict><key>BinaryPath</key><string>CmuxTerminalClientFFI.framework/CmuxTerminalClientFFI</string><key>LibraryIdentifier</key><string>$slice</string><key>LibraryPath</key><string>CmuxTerminalClientFFI.framework</string><key>SupportedArchitectures</key><array><string>arm64</string></array><key>SupportedPlatform</key><string>$platform</string>$variant_key</dict>"
+          }
+          add_slice aarch64-apple-ios ios-arm64 ios iPhoneOS 18.0 ""
+          add_slice aarch64-apple-ios-sim ios-arm64-simulator ios iPhoneSimulator 18.0 simulator
+          add_slice aarch64-apple-darwin macos-arm64 macos MacOSX 14.0 ""
+          cat > "$xcf/Info.plist" <<PLIST
+          <?xml version="1.0" encoding="UTF-8"?>
+          <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+          <plist version="1.0"><dict>
+            <key>AvailableLibraries</key><array>$entries</array>
+            <key>CFBundlePackageType</key><string>XFWK</string>
+            <key>XCFrameworkFormatVersion</key><string>1.0</string>
+          </dict></plist>
+          PLIST
+          plutil -lint "$xcf/Info.plist"
           out="$RUNNER_TEMP/xcframework"
-          mkdir -p "$out"
-          lib=cmux-tui/target
-          xcodebuild -create-xcframework \
-            -library "$lib/aarch64-apple-ios/release/libcmux_terminal_client.a" -headers "$headers" \
-            -library "$lib/aarch64-apple-ios-sim/release/libcmux_terminal_client.a" -headers "$headers" \
-            -library "$lib/aarch64-apple-darwin/release/libcmux_terminal_client.a" -headers "$headers" \
-            -output "$out/CmuxTerminalClient.xcframework"
           (cd "$out" && ditto -c -k --keepParent CmuxTerminalClient.xcframework CmuxTerminalClient.xcframework.zip)
           checksum="$(swift package compute-checksum "$out/CmuxTerminalClient.xcframework.zip")"
           printf '%s\n' "$checksum" > "$out/CmuxTerminalClient.xcframework.zip.sha256"
@@ -182,7 +233,7 @@ jobs:
         run: |
           set -euo pipefail
           checksum="$(cat assets/CmuxTerminalClient.xcframework.zip.sha256)"
-          notes="cmux-terminal-client $VERSION as CmuxTerminalClient.xcframework (iOS arm64, iOS simulator arm64, macOS arm64). Source ${SOURCE_SHA}. SwiftPM binaryTarget checksum: ${checksum}"
+          notes="cmux-terminal-client $VERSION as CmuxTerminalClient.xcframework (static frameworks: iOS arm64, iOS simulator arm64, macOS arm64). Source ${SOURCE_SHA}. SwiftPM binaryTarget checksum: ${checksum}"
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release upload "$TAG" assets/CmuxTerminalClient.xcframework.zip assets/CmuxTerminalClient.xcframework.zip.sha256 assets/SHA256SUMS --clobber
           else

--- a/.github/workflows/cmux-terminal-client-xcframework.yml
+++ b/.github/workflows/cmux-terminal-client-xcframework.yml
@@ -1,0 +1,176 @@
+# Builds the cmux-terminal-client static library for iOS devices, the iOS
+# simulator, and macOS, bundles them as CmuxTerminalClient.xcframework, and
+# attaches the zip plus its SwiftPM checksum to a GitHub release tagged
+# cmux-terminal-client-v<crate version>[+<short sha>]. Manual dispatch only;
+# the Swift package at Packages/Shared/CmuxTerminalClient pins one release by
+# tag and checksum. Nothing here touches files.cmux.com.
+name: cmux-terminal-client xcframework
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Commit or branch to build (defaults to the dispatched ref)"
+        required: false
+        default: ""
+        type: string
+      macos_runner:
+        description: "macOS runner label override"
+        required: false
+        default: ""
+        type: string
+
+concurrency:
+  group: cmux-terminal-client-xcframework-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions: {}
+
+jobs:
+  build:
+    name: build xcframework
+    runs-on: ${{ inputs.macos_runner != '' && inputs.macos_runner || vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Checkout dispatched ref
+        if: inputs.ref == ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Checkout requested ref
+        if: inputs.ref != ''
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.ref }}
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Resolve Ghostty Zig version
+        id: ghostty-zig-version
+        shell: bash
+        run: |
+          version="$(bash ./scripts/ghostty-zig-version.sh)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: ${{ steps.ghostty-zig-version.outputs.version }}
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Install Apple targets
+        shell: bash
+        run: rustup target add aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin
+
+      - name: Resolve version
+        id: version
+        shell: bash
+        run: |
+          set -euo pipefail
+          crate_version="$(python3 - <<'PY'
+          import re, pathlib
+          text = pathlib.Path("cmux-tui/crates/cmux-terminal-client/Cargo.toml").read_text()
+          print(re.search(r'^version\s*=\s*"([^"]+)"', text, re.M).group(1))
+          PY
+          )"
+          short_sha="$(git rev-parse --short=12 HEAD)"
+          if [[ "$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)" == "main" ]]; then
+            version="$crate_version"
+          else
+            version="${crate_version}+${short_sha}"
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "tag=cmux-terminal-client-v$version" >> "$GITHUB_OUTPUT"
+
+      - name: Build static libraries
+        working-directory: cmux-tui
+        shell: bash
+        run: |
+          set -euo pipefail
+          unset CMUX_GHOSTTY_SRC
+          for target in aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin; do
+            cargo build -p cmux-terminal-client --release --locked --target "$target"
+            test -f "target/$target/release/libcmux_terminal_client.a"
+          done
+
+      - name: Assemble xcframework
+        shell: bash
+        run: |
+          set -euo pipefail
+          headers="$(mktemp -d)/include"
+          mkdir -p "$headers"
+          cp cmux-tui/crates/cmux-terminal-client/include/cmux_terminal_client.h "$headers/"
+          cat > "$headers/module.modulemap" <<'MAP'
+          module CmuxTerminalClientFFI {
+              header "cmux_terminal_client.h"
+              export *
+          }
+          MAP
+          out="$RUNNER_TEMP/xcframework"
+          mkdir -p "$out"
+          lib=cmux-tui/target
+          xcodebuild -create-xcframework \
+            -library "$lib/aarch64-apple-ios/release/libcmux_terminal_client.a" -headers "$headers" \
+            -library "$lib/aarch64-apple-ios-sim/release/libcmux_terminal_client.a" -headers "$headers" \
+            -library "$lib/aarch64-apple-darwin/release/libcmux_terminal_client.a" -headers "$headers" \
+            -output "$out/CmuxTerminalClient.xcframework"
+          (cd "$out" && ditto -c -k --keepParent CmuxTerminalClient.xcframework CmuxTerminalClient.xcframework.zip)
+          checksum="$(swift package compute-checksum "$out/CmuxTerminalClient.xcframework.zip")"
+          printf '%s\n' "$checksum" > "$out/CmuxTerminalClient.xcframework.zip.sha256"
+          printf '%s  %s\n' "$(shasum -a 256 "$out/CmuxTerminalClient.xcframework.zip" | cut -d' ' -f1)" CmuxTerminalClient.xcframework.zip > "$out/SHA256SUMS"
+          echo "swiftpm checksum: $checksum"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: CmuxTerminalClient.xcframework
+          path: |
+            ${{ runner.temp }}/xcframework/CmuxTerminalClient.xcframework.zip
+            ${{ runner.temp }}/xcframework/CmuxTerminalClient.xcframework.zip.sha256
+            ${{ runner.temp }}/xcframework/SHA256SUMS
+          if-no-files-found: error
+
+  release:
+    name: publish release
+    needs: build
+    runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - name: Download build artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: CmuxTerminalClient.xcframework
+          path: assets
+
+      - name: Create or update release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.build.outputs.tag }}
+          VERSION: ${{ needs.build.outputs.version }}
+          SOURCE_SHA: ${{ github.sha }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          checksum="$(cat assets/CmuxTerminalClient.xcframework.zip.sha256)"
+          notes="cmux-terminal-client $VERSION as CmuxTerminalClient.xcframework (iOS arm64, iOS simulator arm64, macOS arm64). Source ${SOURCE_SHA}. SwiftPM binaryTarget checksum: ${checksum}"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release upload "$TAG" assets/CmuxTerminalClient.xcframework.zip assets/CmuxTerminalClient.xcframework.zip.sha256 assets/SHA256SUMS --clobber
+          else
+            gh release create "$TAG" assets/CmuxTerminalClient.xcframework.zip assets/CmuxTerminalClient.xcframework.zip.sha256 assets/SHA256SUMS \
+              --target "$SOURCE_SHA" --title "$TAG" --notes "$notes" --prerelease
+          fi
+          echo "release: https://github.com/$GH_REPO/releases/tag/$TAG"
+          echo "checksum: $checksum"

--- a/.github/workflows/cmux-terminal-client-xcframework.yml
+++ b/.github/workflows/cmux-terminal-client-xcframework.yml
@@ -103,6 +103,10 @@ jobs:
           # the Apple slices as ordinary machine code instead.
           CARGO_PROFILE_RELEASE_LTO: "off"
           RUSTFLAGS: "-C embed-bitcode=no"
+          # cc-built C objects (sqlite3, blake3, ring) must carry the same
+          # minimum OS as the app, or ld warns about every one of them.
+          IPHONEOS_DEPLOYMENT_TARGET: "18.0"
+          MACOSX_DEPLOYMENT_TARGET: "14.0"
         run: |
           set -euo pipefail
           unset CMUX_GHOSTTY_SRC
@@ -197,6 +201,47 @@ jobs:
           printf '%s\n' "$checksum" > "$out/CmuxTerminalClient.xcframework.zip.sha256"
           printf '%s  %s\n' "$(shasum -a 256 "$out/CmuxTerminalClient.xcframework.zip" | cut -d' ' -f1)" CmuxTerminalClient.xcframework.zip > "$out/SHA256SUMS"
           echo "swiftpm checksum: $checksum"
+
+      - name: Smoke-link each slice
+        shell: bash
+        run: |
+          set -euo pipefail
+          # Prove every slice links into a real program with only the system
+          # frameworks the Swift package declares. A C file that takes the
+          # address of every exported cmux_* symbol (list taken from the
+          # archive itself, so a new export is covered automatically) is
+          # compiled against the framework header and linked per platform.
+          xcf="$RUNNER_TEMP/xcframework/CmuxTerminalClient.xcframework"
+          work="$RUNNER_TEMP/smoke"
+          mkdir -p "$work"
+          frameworks=(-framework CmuxTerminalClientFFI -framework Network -framework CoreFoundation -framework Security -framework SystemConfiguration)
+          smoke_link() {
+            local slice="$1" sdk="$2" triple="$3"
+            local dir="$xcf/$slice"
+            local lib="$dir/CmuxTerminalClientFFI.framework/CmuxTerminalClientFFI"
+            local src="$work/smoke-$slice.c"
+            {
+              echo '#include <CmuxTerminalClientFFI/cmux_terminal_client.h>'
+              echo '#include <stdio.h>'
+              echo 'int main(void) { const void *p[] = {'
+              nm -g "$lib" 2>/dev/null | awk '$2 == "T" && $3 ~ /^_cmux_/ { print "  (const void *)&" substr($3, 2) "," }' | sort -u
+              printf '%s\n' '  0 }; printf("%p\n", p[0]); return 0; }'
+            } > "$src"
+            local count
+            count="$(grep -c '(const void \*)&cmux_' "$src")"
+            echo "$slice: $count exported symbols referenced"
+            [[ "$count" -ge 1 ]]
+            xcrun --sdk "$sdk" clang -target "$triple" \
+              -isysroot "$(xcrun --sdk "$sdk" --show-sdk-path)" \
+              -F "$dir" "${frameworks[@]}" \
+              -o "$work/smoke-$slice" "$src"
+            echo "$slice: linked"
+          }
+          smoke_link ios-arm64 iphoneos arm64-apple-ios18.0
+          smoke_link ios-arm64-simulator iphonesimulator arm64-apple-ios18.0-simulator
+          smoke_link macos-arm64 macosx arm64-apple-macos14.0
+          "$work/smoke-macos-arm64" >/dev/null
+          echo "macos-arm64: smoke binary ran"
 
       - name: Upload build artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2

--- a/.github/workflows/cmux-terminal-client-xcframework.yml
+++ b/.github/workflows/cmux-terminal-client-xcframework.yml
@@ -95,12 +95,29 @@ jobs:
       - name: Build static libraries
         working-directory: cmux-tui
         shell: bash
+        env:
+          # The workspace release profile uses thin LTO, which leaves the
+          # staticlib's objects as LLVM bitcode. Apple's nm and ld (LLVM 17)
+          # cannot read bitcode from a newer rustc ("Unknown attribute kind"),
+          # so the archive would build green and fail to link in Xcode. Build
+          # the Apple slices as ordinary machine code instead.
+          CARGO_PROFILE_RELEASE_LTO: "off"
+          RUSTFLAGS: "-C embed-bitcode=no"
         run: |
           set -euo pipefail
           unset CMUX_GHOSTTY_SRC
           for target in aarch64-apple-ios aarch64-apple-ios-sim aarch64-apple-darwin; do
             cargo build -p cmux-terminal-client --release --locked --target "$target"
-            test -f "target/$target/release/libcmux_terminal_client.a"
+            lib="target/$target/release/libcmux_terminal_client.a"
+            test -f "$lib"
+            # Apple's nm must see the exported C symbols as real text symbols;
+            # bitcode-only objects show none.
+            exported="$(nm -g "$lib" 2>/dev/null | grep -c ' T _cmux_' || true)"
+            echo "$target: $exported exported _cmux_ symbols"
+            if [[ "$exported" -lt 1 ]]; then
+              echo "::error::$lib exports no _cmux_ text symbols; the archive is not linkable by Apple tools" >&2
+              exit 1
+            fi
           done
 
       - name: Assemble xcframework

--- a/.github/workflows/cmux-terminal-client-xcframework.yml
+++ b/.github/workflows/cmux-terminal-client-xcframework.yml
@@ -224,7 +224,11 @@ jobs:
               echo '#include <CmuxTerminalClientFFI/cmux_terminal_client.h>'
               echo '#include <stdio.h>'
               echo 'int main(void) { const void *p[] = {'
-              nm -g "$lib" 2>/dev/null | awk '$2 == "T" && $3 ~ /^_cmux_/ { print "  (const void *)&" substr($3, 2) "," }' | sort -u
+              # Apple nm exits 1 on the Rust sysroot members (newer LLVM
+              # bitcode) even though it lists every machine-code symbol, so
+              # its status is ignored; the count check below still fails an
+              # archive that exports nothing.
+              { nm -g "$lib" 2>/dev/null || true; } | awk '$2 == "T" && $3 ~ /^_cmux_/ { print "  (const void *)&" substr($3, 2) "," }' | sort -u
               printf '%s\n' '  0 }; printf("%p\n", p[0]); return 0; }'
             } > "$src"
             local count


### PR DESCRIPTION
Dispatch-only workflow that builds the cmux-terminal-client staticlib for aarch64-apple-ios, aarch64-apple-ios-sim, and aarch64-apple-darwin from a given ref, packages CmuxTerminalClient.xcframework, and uploads the zip plus SwiftPM checksum as a GitHub release asset. It never writes to files.cmux.com.

GitHub only dispatches workflows that exist on the default branch, so this file lands first. The client that it packages is https://github.com/manaflow-ai/cmux/pull/11658 (PR 3 of docs/cloud-userspace-wireguard.md in https://github.com/manaflow-ai/cmux/pull/11638). actionlint and tests/check_ghostty_zig_workflows.py pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a manual dispatch workflow that builds `cmux-terminal-client` for iOS device, iOS simulator, and macOS, packages `CmuxTerminalClient.xcframework`, and uploads it with a SwiftPM checksum as a GitHub release asset. It never writes to files.cmux.com, and it lands on `main` first because GitHub only dispatches workflows that exist on the default branch.

- Apple slices are built without LTO, and the job fails if any archive exports no `_cmux_` text symbols so Xcode can link them.
- Each slice is packaged as a static framework so its module map doesn't collide with the app's existing GhosttyKit xcframework.
- C objects are built at the app's minimums (iOS 18.0, macOS 14.0), and every slice is smoke-linked against the system frameworks the Swift package declares.

<sup>Written for commit 419fe5d9c5fb704de807f959fc8c3e6517f54b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manually triggered release workflow for building the terminal client as an Apple XCFramework.
  * Publishes device, simulator, and macOS builds in downloadable release packages.
  * Supports releases from selected source revisions, including prerelease builds where applicable.
  * Provides SHA-256 checksums and Swift Package Manager checksum data for verifying downloads.
  * Validates exported symbols and confirms compatibility with required Apple system frameworks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->