### PR TITLE
cloud: one devbox snapshot per Freestyle size; the plan's memory picks the size

### DIFF
--- a/web/app/api/vm/base/routeShared.ts
+++ b/web/app/api/vm/base/routeShared.ts
@@ -1,4 +1,5 @@
 import type { AuthedUser } from "../../../../services/vms/auth";
+import { defaultMemoryMbForPlan } from "../../../../services/vms/entitlements";
 import { assertVmCreateEnabled } from "../../../../services/vms/config";
 import { defaultProviderId, isProviderId, type ProviderId } from "../../../../services/vms/drivers";
 import {
@@ -59,7 +60,10 @@ export async function runBaseRoute(input: {
   let imageSelection;
   try {
     assertVmCreateEnabled(provider);
-    imageSelection = resolveVmImage(provider, parsed.body.image, process.env, { kind: parsed.body.kind });
+    imageSelection = resolveVmImage(provider, parsed.body.image, process.env, {
+      kind: parsed.body.kind,
+      memoryMb: defaultMemoryMbForPlan(entitlements.planId, process.env),
+    });
   } catch (err) {
     if (isVmCreateDisabledError(err)) {
       return vmErrorResponse({

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -161,7 +161,9 @@ export async function GET(request: Request): Promise<Response> {
           ),
           // Kinds a client may request (and the image each resolves to) for the
           // default provider, so a "new machine" dialog offers only kinds that work.
-          imageKinds: listVmImageKinds(defaultProviderId()),
+          imageKinds: listVmImageKinds(defaultProviderId(), process.env, {
+            memoryMb: defaultMemoryMbForPlan(listEntitlements.planId, process.env),
+          }),
         }
         : undefined;
       return jsonResponse({ vms, limits });
@@ -396,7 +398,9 @@ export async function POST(request: Request): Promise<Response> {
         let imageSelection;
         try {
           assertVmCreateEnabled(provider);
-          imageSelection = resolveVmImage(provider, body.image, process.env, { kind: body.kind });
+          // The plan's memory picks the snapshot size (one snapshot per size on
+          // Freestyle), so the machine boots at its shape with nothing to resize.
+          imageSelection = resolveVmImage(provider, body.image, process.env, { kind: body.kind, memoryMb });
         } catch (err) {
           if (isVmCreateDisabledError(err)) {
             return vmErrorResponse({
@@ -521,6 +525,7 @@ export async function POST(request: Request): Promise<Response> {
           image: created.image,
           imageVersion: created.imageVersion,
           kind: imageSelection.kind,
+          ...(imageSelection.size ? { size: imageSelection.size } : {}),
           createdAt: created.createdAt,
         });
       }

--- a/web/scripts/build-devbox-freestyle.ts
+++ b/web/scripts/build-devbox-freestyle.ts
@@ -36,9 +36,11 @@
  * onto the new snapshot (the old holder keeps its data under its id);
  * without it a collision leaves the new snapshot slugless.
  *
- * Builder VM: freestyle/ubuntu (4 vCPU / 8 GiB / 32 GB). VMs always boot at
- * their snapshot's size and resizing is grow-only, so this is the shape every
- * cmux Cloud machine gets. CMUX_FREESTYLE_BUILDER_SNAPSHOT overrides it.
+ * Builder VM: freestyle/ubuntu-sm (2 vCPU / 4 GiB / 16 GB), the floor of
+ * Freestyle's size ladder. VMs boot at their snapshot's size and resizing is
+ * grow-only, so the bake happens once at the smallest shape and
+ * derive-devbox-sizes.ts turns it into one snapshot per ladder size.
+ * CMUX_FREESTYLE_BUILDER_SNAPSHOT overrides the base.
  * Outbound-only firewall; deleted whatever happens (unless --keep-builder).
  *
  * Daemon contract: the session daemon is cmux-tui, same as every other
@@ -107,7 +109,7 @@ const BUILD_ENV = {
 const WORK_USER = "ubuntu";
 const WORK_HOME = `/home/${WORK_USER}`;
 
-const builderSnapshot = process.env.CMUX_FREESTYLE_BUILDER_SNAPSHOT?.trim() || "freestyle/ubuntu";
+const builderSnapshot = process.env.CMUX_FREESTYLE_BUILDER_SNAPSHOT?.trim() || "freestyle/ubuntu-sm";
 const { vm, vmId } = await fs.vms.create({
   snapshotId: builderSnapshot,
   displayName: `cmux-devbox-builder ${slug}`,

--- a/web/scripts/derive-devbox-sizes.ts
+++ b/web/scripts/derive-devbox-sizes.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env bun
+/**
+ * Derive sized snapshots from one baked devbox snapshot.
+ *
+ * A Freestyle VM boots at its snapshot's size and resize is grow-only, so the
+ * bake happens once on the smallest ladder shape and every larger size is
+ * "boot the master, resize to the ladder row, snapshot, delete". Each derived
+ * snapshot then boots straight into its shape: no account-level size
+ * override, nothing to grow at create.
+ *
+ * Usage:
+ *   FREESTYLE_API_KEY=... bun scripts/derive-devbox-sizes.ts <master-snapshot-id> <slug-prefix>
+ *       [--sizes sm,md,lg,xl,2xl] [--out <json>] [--replace-slug]
+ *
+ * Prints one line per size and a final JSON `{ sizes: { <name>: { imageId, slug, size } } }`
+ * (also written to --out). Every derived VM is booted once more from its own
+ * snapshot and checked (nproc, memory, root filesystem, the cmux-tui-daemon
+ * and cmux-desktop units) before its id is reported; a failed check aborts.
+ *
+ * The master must be at or below every requested size (bake on
+ * freestyle/ubuntu-sm for the full ladder). `sm` is the master itself when
+ * the master already has that shape, so it is recorded without a second
+ * snapshot.
+ */
+import { Freestyle } from "freestyle";
+import { writeFileSync } from "node:fs";
+import {
+  VM_IMAGE_SIZE_NAMES,
+  isVmImageSizeName,
+  vmImageSize,
+  type VmImageSize,
+  type VmImageSizeName,
+} from "../services/vms/images/sizes";
+import { argValue, hasFlag } from "./devbox-image-common";
+
+const apiKey = process.env.FREESTYLE_API_KEY;
+const stackToken = process.env.FREESTYLE_STACK_ACCESS_TOKEN;
+const teamId = process.env.FREESTYLE_TEAM_ID;
+const baseUrl = process.env.FREESTYLE_API_URL?.trim() || undefined;
+const fs = (() => {
+  if (apiKey) return new Freestyle({ apiKey, baseUrl });
+  if (stackToken && teamId) return new Freestyle({ stackAccessToken: stackToken, teamId, baseUrl });
+  throw new Error("set FREESTYLE_API_KEY, or FREESTYLE_STACK_ACCESS_TOKEN + FREESTYLE_TEAM_ID");
+})();
+
+const master = process.argv[2];
+const slugPrefix = process.argv[3];
+if (!master || master.startsWith("--") || !slugPrefix || slugPrefix.startsWith("--")) {
+  throw new Error("usage: bun scripts/derive-devbox-sizes.ts <master-snapshot-id> <slug-prefix> [--sizes sm,md,lg,xl,2xl] [--out <json>] [--replace-slug]");
+}
+const requested = (argValue("--sizes") ?? VM_IMAGE_SIZE_NAMES.join(",")).split(",").map((s) => s.trim()).filter(Boolean);
+for (const name of requested) {
+  if (!isVmImageSizeName(name)) throw new Error(`--sizes: unknown size ${name}; expected ${VM_IMAGE_SIZE_NAMES.join(", ")}`);
+}
+const sizes = requested as VmImageSizeName[];
+const replaceSlug = hasFlag("--replace-slug");
+
+const FIREWALL = { rules: [{ action: "allow" as const, source: {}, destination: { public: true } }] };
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+type Exec = { exec: (options: { command: string; timeoutMs?: number; linuxUser?: string }) => Promise<{ stdout?: string | null; stderr?: string | null; statusCode?: number | null }> };
+async function sh(vm: Exec, command: string, timeoutMs = 120_000): Promise<{ code: number; out: string }> {
+  const r = await vm.exec({ command, timeoutMs, linuxUser: "root" });
+  return { code: r.statusCode ?? 124, out: `${r.stdout ?? ""}${r.stderr ?? ""}`.trim() };
+}
+
+/** What the guest sees; disk is the root filesystem after the grow. */
+async function measure(vm: Exec): Promise<{ cpu: number; memoryMb: number; rootMb: number; units: string }> {
+  const r = await sh(vm, "echo cpu=$(nproc); echo mem=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo); echo root=$(df -BM --output=size / | tail -1 | tr -dc 0-9); echo units=$(systemctl is-active cmux-tui-daemon cmux-desktop 2>/dev/null | tr '\\n' ',')");
+  const get = (key: string) => r.out.match(new RegExp(`${key}=([^\\n]*)`))?.[1] ?? "";
+  return { cpu: Number(get("cpu")), memoryMb: Number(get("mem")), rootMb: Number(get("root")), units: get("units") };
+}
+
+/** Guest memory is a little under the allocation (kernel reservations); the root fs a little under the disk. */
+function fits(actual: { cpu: number; memoryMb: number; rootMb: number }, size: VmImageSize): string | null {
+  if (actual.cpu < size.cpu) return `cpu ${actual.cpu} < ${size.cpu}`;
+  if (actual.memoryMb < size.memoryMb * 0.9) return `memory ${actual.memoryMb} MiB < ${size.memoryMb} MiB`;
+  if (actual.rootMb < size.storageMb * 0.85) return `root fs ${actual.rootMb} MiB < ${size.storageMb} MiB (disk not grown?)`;
+  return null;
+}
+
+async function assignSlug(snapshotId: string, slug: string): Promise<string | null> {
+  try {
+    await fs.vms.snapshots.update(snapshotId, { slug });
+    return slug;
+  } catch (error) {
+    if (!replaceSlug) {
+      console.warn(`  slug ${slug} not assigned (${String(error).slice(0, 120)}); pass --replace-slug to move it`);
+      return null;
+    }
+    const { snapshots } = await fs.vms.snapshots.list();
+    const holder = snapshots.find((candidate) => candidate.slug === slug && candidate.id !== snapshotId);
+    if (!holder) throw error;
+    await fs.vms.snapshots.update(holder.id, { slug: "" });
+    await fs.vms.snapshots.update(snapshotId, { slug });
+    return slug;
+  }
+}
+
+const result: Record<string, { imageId: string; slug: string | null; size: VmImageSize; measured: unknown }> = {};
+
+// The master's own shape, so a size it already has is recorded without a copy.
+const probe = await fs.vms.create({ snapshotId: master, displayName: `${slugPrefix} size-probe`, firewall: FIREWALL });
+const masterShape = await measure(probe.vm);
+await probe.vm.delete();
+console.log(`master ${master}: ${masterShape.cpu} vCPU, ${masterShape.memoryMb} MiB, root ${masterShape.rootMb} MiB`);
+
+for (const name of sizes) {
+  const size = vmImageSize(name);
+  const slug = name === "md" ? slugPrefix : `${slugPrefix}-${name}`;
+  const t0 = Date.now();
+  let imageId: string;
+
+  if (masterShape.cpu === size.cpu && Math.abs(masterShape.memoryMb - size.memoryMb) < size.memoryMb * 0.1 && masterShape.rootMb >= size.storageMb * 0.85) {
+    imageId = master;
+    console.log(`${name}: master already has this shape; reusing ${master}`);
+  } else {
+    if (masterShape.cpu > size.cpu || masterShape.memoryMb > size.memoryMb) {
+      throw new Error(`${name}: master (${masterShape.cpu} vCPU, ${masterShape.memoryMb} MiB) is larger than the target; resize is grow-only, bake on a smaller base`);
+    }
+    const { vm, vmId } = await fs.vms.create({ snapshotId: master, displayName: `${slugPrefix} derive ${name}`, firewall: FIREWALL });
+    try {
+      await vm.resize({ cpu: size.cpu, memory: size.memoryMb, storage: size.storageMb });
+      // The disk grows in place while the guest runs; wait for the root fs to
+      // reflect it, then let the daemon units settle before the snapshot.
+      let grown: Awaited<ReturnType<typeof measure>> | null = null;
+      for (let i = 0; i < 30; i += 1) {
+        const m = await measure(vm);
+        if (!fits(m, size)) { grown = m; break; }
+        await sleep(2000);
+      }
+      if (!grown) {
+        const m = await measure(vm);
+        throw new Error(`${name}: resize did not take: ${fits(m, size)} (${JSON.stringify(m)})`);
+      }
+      await sh(vm, "sync");
+      const snap = await vm.snapshot({ displayName: `cmux devbox ${slug} (${size.cpu} vCPU · ${size.memoryMb} MiB · ${size.storageMb} MiB)` });
+      if (!snap.snapshotId) throw new Error(`${name}: snapshot response carried no id`);
+      imageId = snap.snapshotId;
+    } finally {
+      await vm.delete().catch(() => {});
+    }
+  }
+
+  // Boot the derived snapshot itself: the shape must survive the round trip.
+  const check = await fs.vms.create({ snapshotId: imageId, displayName: `${slugPrefix} verify ${name}`, firewall: FIREWALL });
+  let measured: Awaited<ReturnType<typeof measure>>;
+  try {
+    measured = await measure(check.vm);
+    const problem = fits(measured, size);
+    if (problem) throw new Error(`${name}: derived snapshot ${imageId} boots wrong: ${problem}`);
+    if (!measured.units.includes("active")) throw new Error(`${name}: units not active after boot: ${measured.units}`);
+  } finally {
+    await check.vm.delete().catch(() => {});
+  }
+
+  const assigned = imageId === master ? null : await assignSlug(imageId, slug);
+  result[name] = { imageId, slug: assigned, size, measured };
+  console.log(`${name}: ${imageId} (${measured.cpu} vCPU, ${measured.memoryMb} MiB, root ${measured.rootMb} MiB, units ${measured.units}) ${((Date.now() - t0) / 1000).toFixed(0)}s`);
+}
+
+const out = { master, sizes: result };
+console.log(JSON.stringify(out, null, 2));
+const outPath = argValue("--out");
+if (outPath) writeFileSync(outPath, `${JSON.stringify(out, null, 2)}\n`);

--- a/web/scripts/derive-devbox-sizes.ts
+++ b/web/scripts/derive-devbox-sizes.ts
@@ -118,7 +118,7 @@ for (const name of sizes) {
     if (masterShape.cpu > size.cpu || masterShape.memoryMb > size.memoryMb) {
       throw new Error(`${name}: master (${masterShape.cpu} vCPU, ${masterShape.memoryMb} MiB) is larger than the target; resize is grow-only, bake on a smaller base`);
     }
-    const { vm, vmId } = await fs.vms.create({ snapshotId: master, displayName: `${slugPrefix} derive ${name}`, firewall: FIREWALL });
+    const { vm } = await fs.vms.create({ snapshotId: master, displayName: `${slugPrefix} derive ${name}`, firewall: FIREWALL });
     try {
       await vm.resize({ cpu: size.cpu, memory: size.memoryMb, storage: size.storageMb });
       // The disk grows in place while the guest runs; wait for the root fs to

--- a/web/scripts/devbox-image-common.ts
+++ b/web/scripts/devbox-image-common.ts
@@ -14,6 +14,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { vmImageSizeRank, type VmImageSizeName } from "../services/vms/images/sizes";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const webRoot = path.resolve(__dirname, "..");
@@ -192,6 +193,12 @@ export function bakeMetadata(
 
 export type DevboxProvider = "freestyle";
 export type DevboxImageKind = "desktop" | "base";
+export type DevboxImageSize = {
+  name: VmImageSizeName;
+  cpu: number;
+  memoryMb: number;
+  storageMb: number;
+};
 
 /** One `images[]` row of services/vms/images/manifest.json, as the bake scripts emit it. */
 export type DevboxManifestEntry = {
@@ -204,6 +211,8 @@ export type DevboxManifestEntry = {
   defaultForLocalDev?: boolean;
   kind?: DevboxImageKind;
   defaultForKind?: boolean;
+  /** The shape this snapshot boots at (Freestyle ladder). Size-less entries are pre-ladder bakes. */
+  size?: DevboxImageSize;
   cmuxdRemoteCommit: string;
   /** The cmux commit whose devbox definition produced this image. */
   repoCommit?: string;
@@ -298,16 +307,26 @@ export function writeImageManifest(manifest: DevboxImageManifest, file = imageMa
 export type PromoteImageOptions = {
   /** Kinds this image serves. Each gets its own entry flagged `defaultForKind`. */
   readonly kinds: readonly DevboxImageKind[];
+  /**
+   * Sized snapshots derived from the bake (derive-devbox-sizes.ts): one
+   * manifest entry per kind and size, each the default for that kind+size.
+   * Omitted: a single size-less entry per kind (a pre-ladder bake).
+   */
+  readonly sizes?: readonly { readonly imageId: string; readonly size: DevboxImageSize }[];
   /** Human-readable validation summary appended to `notes`. */
   readonly validationNotes?: string;
 };
 
+function sizeKey(entry: Pick<DevboxManifestEntry, "size">): string {
+  return entry.size?.name ?? "";
+}
+
 /**
  * Appends a verified image to the manifest as the default for every kind in
- * `kinds`, demoting the provider's previous defaults for those kinds. Pure:
- * returns a new manifest and never mutates the input. Existing entries are
- * only ever flag-flipped, never removed, so rollback stays a one-line
- * manifest change.
+ * `kinds` (and every size in `sizes`), demoting the provider's previous
+ * defaults for those kind+size pairs. Pure: returns a new manifest and never
+ * mutates the input. Existing entries are only ever flag-flipped, never
+ * removed, so rollback stays a one-line manifest change.
  */
 export function promoteImageManifestEntry(
   manifest: DevboxImageManifest,
@@ -324,32 +343,51 @@ export function promoteImageManifestEntry(
     throw new Error(`refusing to promote ${entry.imageId}: no kinds given`);
   }
   const kinds = [...new Set(options.kinds)];
+  const variants: Array<{ imageId: string; size?: DevboxImageSize }> =
+    options.sizes && options.sizes.length > 0
+      ? [...options.sizes].sort((a, b) => vmImageSizeRank(a.size.name) - vmImageSizeRank(b.size.name))
+      : [{ imageId: entry.imageId }];
   for (const kind of kinds) {
-    const clash = manifest.images.find((candidate) =>
-      candidate.provider === entry.provider &&
-      candidate.imageId === entry.imageId &&
-      (candidate.kind ?? "base") === kind
-    );
-    if (clash) {
-      throw new Error(
-        `refusing to promote ${entry.provider} ${entry.imageId}: already listed as ${clash.version} (${kind})`,
+    for (const variant of variants) {
+      const clash = manifest.images.find((candidate) =>
+        candidate.provider === entry.provider &&
+        candidate.imageId === variant.imageId &&
+        (candidate.kind ?? "base") === kind &&
+        sizeKey(candidate) === (variant.size?.name ?? "")
       );
+      if (clash) {
+        throw new Error(
+          `refusing to promote ${entry.provider} ${variant.imageId}: already listed as ${clash.version} (${kind}${variant.size ? `, ${variant.size.name}` : ""})`,
+        );
+      }
     }
   }
+  const promotedSizes = new Set(variants.map((variant) => variant.size?.name ?? ""));
   const demoted = manifest.images.map((candidate) => {
     if (candidate.provider !== entry.provider) return candidate;
     const next: DevboxManifestEntry = { ...candidate };
-    if (next.defaultForKind && kinds.includes(next.kind ?? "base")) next.defaultForKind = false;
+    // A sized promotion demotes the provider's size-less defaults too: the
+    // ladder replaces the single-shape image, not just one row of it.
+    const sameSize = promotedSizes.has(sizeKey(next)) || (sizeKey(next) === "" && promotedSizes.size > 0);
+    if (next.defaultForKind && kinds.includes(next.kind ?? "base") && sameSize) next.defaultForKind = false;
     return next;
   });
   const notes = [entry.notes, options.validationNotes].filter(Boolean).join(" ");
-  const promoted = kinds.map((kind): DevboxManifestEntry => ({
-    ...entry,
-    version: kinds.length > 1 && kind !== kinds[0] ? `${entry.version}-${kind}` : entry.version,
-    kind,
-    defaultForKind: true,
-    ...(notes ? { notes } : {}),
-  }));
+  const promoted: DevboxManifestEntry[] = [];
+  for (const kind of kinds) {
+    for (const variant of variants) {
+      const suffix = [variant.size ? variant.size.name : "", kind !== kinds[0] ? kind : ""].filter(Boolean).join("-");
+      promoted.push({
+        ...entry,
+        version: suffix ? `${entry.version}-${suffix}` : entry.version,
+        imageId: variant.imageId,
+        kind,
+        defaultForKind: true,
+        ...(variant.size ? { size: variant.size } : {}),
+        ...(notes ? { notes } : {}),
+      });
+    }
+  }
   return { schemaVersion: manifest.schemaVersion, images: [...demoted, ...promoted] };
 }
 
@@ -370,17 +408,33 @@ export function imageManifestProblems(manifest: DevboxImageManifest): string[] {
     if (entry.kind !== undefined && entry.kind !== "desktop" && entry.kind !== "base") {
       problems.push(`${entry.version}: kind ${String(entry.kind)} is not desktop|base`);
     }
+    if (entry.size !== undefined) {
+      const { name, cpu, memoryMb, storageMb } = entry.size;
+      if (vmImageSizeRank(name) < 0) problems.push(`${entry.version}: size ${String(name)} is not on the ladder`);
+      if (![cpu, memoryMb, storageMb].every((n) => Number.isInteger(n) && n > 0)) {
+        problems.push(`${entry.version}: size ${String(name)} needs positive integer cpu/memoryMb/storageMb`);
+      }
+    }
     if (entry.defaultForKind) {
       if (entry.validationStatus !== "passed") {
         problems.push(`${entry.version}: defaultForKind but validationStatus is ${entry.validationStatus}`);
       }
-      const key = `${entry.provider}/${entry.kind ?? "base"}`;
+      const key = `${entry.provider}/${entry.kind ?? "base"}${entry.size ? `/${entry.size.name}` : ""}`;
       defaults.set(key, [...(defaults.get(key) ?? []), entry]);
     }
   }
   const versions = manifest.images.map((entry) => `${entry.provider}/${entry.version}`);
   for (const dup of versions.filter((v, i) => versions.indexOf(v) !== i)) {
     problems.push(`${dup}: version listed more than once`);
+  }
+  const shapesByKind = new Map<string, Set<string>>();
+  for (const entry of manifest.images) {
+    if (!entry.defaultForKind) continue;
+    const key = `${entry.provider}/${entry.kind ?? "base"}`;
+    shapesByKind.set(key, new Set([...(shapesByKind.get(key) ?? []), entry.size ? "sized" : "size-less"]));
+  }
+  for (const [key, shapes] of shapesByKind) {
+    if (shapes.size > 1) problems.push(`${key}: defaults mix sized and size-less entries`);
   }
   for (const [key, entries] of defaults) {
     if (entries.length > 1) {

--- a/web/scripts/promote-devbox-image.ts
+++ b/web/scripts/promote-devbox-image.ts
@@ -14,6 +14,13 @@
  *   --image     promote an already-baked image (still verified) instead of baking.
  *   --bake-result <json>  adopt a bake script's --out file (its manifest entry
  *               and image id) instead of baking; still verified.
+ *   --sizes     ladder sizes to derive from the verified bake (default
+ *               sm,md,lg,xl,2xl; "none" records a single size-less entry):
+ *               derive-devbox-sizes.ts boots the bake, resizes, snapshots and
+ *               re-boots each one; the manifest gets one entry per kind and
+ *               size, each the default for that kind+size. The bake must be
+ *               on the smallest requested size (the default builder is
+ *               freestyle/ubuntu-sm).
  *   --kinds     machine kinds the image serves; each gets a manifest entry
  *               flagged defaultForKind (default: desktop,base for a desktop
  *               bake, base for --no-desktop). A desktop image is a superset
@@ -38,6 +45,7 @@ import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { VM_IMAGE_SIZE_NAMES, isVmImageSizeName, type VmImageSize } from "../services/vms/images/sizes";
 import {
   argValue,
   bakeMetadata,
@@ -76,6 +84,11 @@ if (kinds.includes("desktop") && !withDesktop) {
 }
 const pointerSlug = argValue("--pointer-slug") ?? "cmux-devbox";
 const skipVerify = hasFlag("--skip-verify");
+const sizesArg = argValue("--sizes") ?? VM_IMAGE_SIZE_NAMES.join(",");
+const sizeNames = sizesArg === "none" ? [] : sizesArg.split(",").map((name) => name.trim()).filter(Boolean);
+for (const name of sizeNames) {
+  if (!isVmImageSizeName(name)) throw new Error(`--sizes: unknown size ${name}; expected ${VM_IMAGE_SIZE_NAMES.join(", ")} or none`);
+}
 const dryRun = hasFlag("--dry-run");
 const existingImage = argValue("--image");
 const tag = defaultBakeTag();
@@ -157,11 +170,34 @@ if (skipVerify) {
     (withDesktop ? " (toolchain, agent pins, daemon contract, desktop on 5901/6901)." : " (toolchain, agent pins, daemon contract).");
 }
 
+// 2b. Sizes: derive the ladder from the verified bake, each booted and checked.
+let sizes: Array<{ imageId: string; size: VmImageSize }> | undefined;
+if (!skipVerify && sizeNames.length > 0) {
+  const sizesOut = path.join(workDir, "sizes.json");
+  const deriveStatus = run("derive sizes", [
+    "scripts/derive-devbox-sizes.ts",
+    imageId,
+    argValue("--pointer-slug") ?? "cmux-devbox",
+    "--sizes",
+    sizeNames.join(","),
+    "--out",
+    sizesOut,
+    ...(hasFlag("--replace-slug") ? ["--replace-slug"] : []),
+  ]);
+  if (deriveStatus !== 0) {
+    console.error(`derive sizes failed (exit ${deriveStatus}); nothing promoted`);
+    process.exit(deriveStatus);
+  }
+  const derived = JSON.parse(readFileSync(sizesOut, "utf8")) as { sizes: Record<string, { imageId: string; size: VmImageSize }> };
+  sizes = Object.values(derived.sizes).map((row) => ({ imageId: row.imageId, size: row.size }));
+  validationNotes += ` Sizes derived and re-booted by derive-devbox-sizes.ts: ${sizes.map((row) => `${row.size.name}=${row.imageId}`).join(", ")}.`;
+}
+
 // 3. Manifest: append and flip defaults (pure edit), then re-check invariants.
 const manifest = readImageManifest();
 const next = skipVerify
   ? { ...manifest, images: [...manifest.images, { ...entry, kind: kinds[0], notes: [entry.notes, validationNotes].filter(Boolean).join(" ") }] }
-  : promoteImageManifestEntry(manifest, entry, { kinds, validationNotes });
+  : promoteImageManifestEntry(manifest, entry, { kinds, sizes, validationNotes });
 const problems = imageManifestProblems(next);
 if (problems.length > 0) {
   throw new Error(`refusing to write an inconsistent manifest:\n  ${problems.join("\n  ")}`);
@@ -175,9 +211,10 @@ if (dryRun) {
   console.log(`wrote ${imageManifestPath} (+${added.length} entries)`);
 }
 
-// 4. Pointer slug: a readable "current" handle on the platform.
+// 4. Pointer slug: a readable "current" handle on the platform. With sizes,
+// derive-devbox-sizes.ts already named each snapshot `<pointer>[-<size>]`.
 let pointer: string | null = null;
-if (!dryRun && !skipVerify && pointerSlug !== "none") {
+if (!dryRun && !skipVerify && pointerSlug !== "none" && !sizes) {
   const { Freestyle } = await import("freestyle");
   const fs = new Freestyle({ baseUrl: process.env.FREESTYLE_API_URL?.trim() || undefined });
   try {
@@ -200,6 +237,7 @@ const result = {
   imageId,
   kinds,
   versions: added.map((row) => row.version),
+  sizes: sizes?.map((row) => row.size.name) ?? [],
   validationStatus: entry.validationStatus,
   pointerSlug: pointer,
   manifest: dryRun ? null : imageManifestPath,

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -79,9 +79,12 @@ Image policy:
 
 - Clients request a machine **kind** (`kind: "desktop" | "base"` on `POST /api/vm`,
   `POST /api/vm/base/open`, and `POST /api/vm/base/reset`) rather than pinning an image id. With
-  no `image`, the resolver serves the manifest entry flagged `kind` + `defaultForKind` (a body with
-  neither `image` nor `kind` gets the `base` default) and otherwise fails closed with
-  `vm_image_config_error`. `image` still wins when present, but a client-requested `image` must be
+  no `image`, the resolver serves the manifest entry flagged `kind` + `defaultForKind` at the
+  plan's **size** (a body with neither `image` nor `kind` gets the `base` default) and otherwise
+  fails closed with `vm_image_config_error`. Sizes are Freestyle's ladder (`sm` … `2xl`,
+  `services/vms/images/sizes.ts`): one snapshot per size, and the smallest whose memory covers
+  the plan's `defaultMemoryMbForPlan` is served, so machines boot at their shape and the driver
+  never resizes. Create responses and `limits.imageKinds` carry the `size`. `image` still wins when present, but a client-requested `image` must be
   in the manifest (or `CMUX_VM_ALLOW_UNMANIFESTED_IMAGES=1`, which local dev implies). Responses
   and `GET /api/vm` entries echo `kind`; `GET /api/vm` `limits.imageKinds` lists the kinds the
   default provider can serve and the image each resolves to.

--- a/web/services/vms/images/devbox/README.md
+++ b/web/services/vms/images/devbox/README.md
@@ -68,33 +68,63 @@ VM's IPv6 address, so the listener must be dual-stack).
 Shells spawned by the daemon get the bash devshell (ble.sh ghost text,
 half-life prompt, seeded history) through the `/etc/bash.bashrc` chain.
 
-## Promote: bake, verify, record (one command)
+## Sizes: one bake, one snapshot per size
+
+A Freestyle VM boots at its snapshot's size and resize is grow-only, so the
+bake happens once on the ladder floor (`freestyle/ubuntu-sm`, 2 vCPU / 4 GiB /
+16 GB) and `derive-devbox-sizes.ts` turns it into one snapshot per size:
+boot the bake, `vm.resize`, snapshot, delete, then boot the derived snapshot
+once more and check `nproc`, memory, the grown root filesystem and the
+daemon/desktop units. Sizes are Freestyle's own ladder
+(`web/services/vms/images/sizes.ts`, verbatim from freestyle-vms
+`catalog/snapshots.json`), so every cmux machine is a shape Freestyle already
+bills and caps:
+
+| name | vCPU | memory | disk | Freestyle base |
+|---|---|---|---|---|
+| `sm` | 2 | 4 GiB | 16 GB | `freestyle/ubuntu-sm` |
+| `md` | 4 | 8 GiB | 32 GB | `freestyle/ubuntu` |
+| `lg` | 8 | 16 GiB | 64 GB | `freestyle/ubuntu-lg` |
+| `xl` | 16 | 32 GiB | 128 GB | `freestyle/ubuntu-xl` |
+| `2xl` | 32 | 64 GiB | 128 GB | `freestyle/ubuntu-2xl` |
+
+The manifest records one entry per kind and size (`size: { name, cpu,
+memoryMb, storageMb }`), each the default for its kind+size. The resolver
+picks the smallest size whose memory covers the plan's `memoryMb`
+(`defaultMemoryMbForPlan`; today's paid default of 24 GiB lands on `xl`), so
+the driver never resizes at create and nothing has to grow at boot. Snapshot
+slugs are `cmux-devbox-<size>` (`cmux-devbox` for `md`).
+
+## Promote: bake, verify, derive sizes, record (one command)
 
 The checked-in manifest (`web/services/vms/images/manifest.json`) is the
 only source of truth for the image users get: the resolver serves the entry
-flagged `defaultForKind`, in local dev and every deployed runtime alike, and
-no env var selects or overrides it. `promote-devbox-image.ts` is the only
-sanctioned writer:
+flagged `defaultForKind` for the requested kind and the plan's size, in local
+dev and every deployed runtime alike, and no env var selects or overrides
+it. `promote-devbox-image.ts` is the only sanctioned writer:
 
 ```bash
 # from web/, with the Freestyle key in env
-FREESTYLE_API_KEY=... bun run devbox:promote -- freestyle
-FREESTYLE_API_KEY=... bun run devbox:promote -- freestyle --image sh-…   # verify + record an existing snapshot
+FREESTYLE_API_KEY=... bun run devbox:promote -- freestyle                     # bake -> verify -> sm,md,lg,xl,2xl -> manifest
+FREESTYLE_API_KEY=... bun run devbox:promote -- freestyle --sizes lg,xl       # a subset of the ladder
+FREESTYLE_API_KEY=... bun run devbox:promote -- freestyle --sizes none        # one size-less entry (pre-ladder behaviour)
+FREESTYLE_API_KEY=... bun run devbox:promote -- freestyle --image sh-…        # verify + derive + record an existing bake
 ```
 
 Snapshots are account-scoped: promote under the Freestyle account the
-deployment's `FREESTYLE_API_KEY` belongs to, or the recorded id is
+deployment's `FREESTYLE_API_KEY` belongs to, or the recorded ids are
 unreachable from production.
 
 It runs the stale-checkout preflight (`CMUX_BAKE_ALLOW_BRANCH=1` for
 deliberate branch bakes), the bake, then `verify-devbox-image.ts`; only a
-passing verify writes the manifest, appending one entry per kind flagged
-`defaultForKind` while demoting the provider's previous defaults. Existing
-entries are never removed, so rollback is a manifest revert. It also moves the
-`cmux-devbox` snapshot slug onto the new id as a dashboard convenience;
-production boots from the immutable `sh-…` id, never the slug. The last
-stdout line is `IMAGE_ID <id>`; `--out <json>` writes the summary.
-Commit the manifest diff in a PR; merging it is the promotion.
+passing verify derives the sizes and writes the manifest, appending one
+entry per kind and size flagged `defaultForKind` while demoting the
+provider's previous defaults for those kind+size pairs (a sized promotion
+also demotes size-less defaults: the ladder replaces the single-shape
+image). Existing entries are never removed, so rollback is a manifest
+revert. The last stdout line is `IMAGE_ID <id>` (the bake); `--out <json>`
+writes the summary with every derived id. Commit the manifest diff in a PR;
+merging it is the promotion.
 
 ## Bake and verify by hand
 

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -124,6 +124,286 @@
       "validationStatus": "passed",
       "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Baked on the Freestyle team of the contributor (no-limits), not on cmux's account: snapshots are account-scoped, so this id is a validated reference bake, not a default. Re-bake with `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to promote the desktop devbox.",
       "defaultForKind": false
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-sm",
+      "imageId": "sh-e1e5b47ac1504e7f979a3060e1834a38",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-md",
+      "imageId": "sh-98a58b6f006a4868b7998cd1e7a0792f",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-lg",
+      "imageId": "sh-ca009fee35c84a6aa65b065fb0b5ff41",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-xl",
+      "imageId": "sh-f9d58fa1c57d402f97aa8f1d466a6f6e",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-2xl",
+      "imageId": "sh-3059b5db998342b2aca5e6b893cf1f70",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-sm-base",
+      "imageId": "sh-e1e5b47ac1504e7f979a3060e1834a38",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-md-base",
+      "imageId": "sh-98a58b6f006a4868b7998cd1e7a0792f",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-lg-base",
+      "imageId": "sh-ca009fee35c84a6aa65b065fb0b5ff41",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-xl-base",
+      "imageId": "sh-f9d58fa1c57d402f97aa8f1d466a6f6e",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260902i-2xl-base",
+      "imageId": "sh-3059b5db998342b2aca5e6b893cf1f70",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "70ae784694d7a10e02c41e2a10848c5db2a2100a",
+      "builtAt": "2026-09-02T12:39:06.404Z",
+      "builderScriptVersion": "62d061ed781b2b3eee6bcb0e9e7c6662f37572ff49b3981d4d97fe04999c5d39",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; cmux-tui transport. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-e1e5b47ac1504e7f979a3060e1834a38, md=sh-98a58b6f006a4868b7998cd1e7a0792f, lg=sh-ca009fee35c84a6aa65b065fb0b5ff41, xl=sh-f9d58fa1c57d402f97aa8f1d466a6f6e, 2xl=sh-3059b5db998342b2aca5e6b893cf1f70. Baked on the contributor's Freestyle team (no-limits), not on cmux's account: snapshots are account-scoped, so these are validated reference bakes, not defaults. Re-run `bun run devbox:promote -- freestyle` under cmux's FREESTYLE_API_KEY to get the sized ladder as the defaults.",
+      "defaultForKind": false,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
     }
   ]
 }

--- a/web/services/vms/images/resolver.ts
+++ b/web/services/vms/images/resolver.ts
@@ -2,6 +2,13 @@ import type { ProviderId } from "../drivers";
 import { allowUnmanifestedImages, type VmRuntimeEnv } from "../config";
 import { VmImageConfigError, type VmImageSource } from "../errors";
 import manifest from "./manifest.json";
+import {
+  isVmImageSizeName,
+  pickVmImageSizeForMemory,
+  vmImageSizeRank,
+  type VmImageSize,
+  type VmImageSizeName,
+} from "./sizes";
 
 /**
  * What a machine is for. Clients ask for a kind instead of pinning an image id so
@@ -16,6 +23,14 @@ export function isVmImageKind(value: unknown): value is VmImageKind {
   return typeof value === "string" && (VM_IMAGE_KINDS as readonly string[]).includes(value);
 }
 
+/** A manifest entry's machine shape: one snapshot per size on Freestyle. */
+export type VmImageManifestSize = {
+  readonly name: VmImageSizeName;
+  readonly cpu: number;
+  readonly memoryMb: number;
+  readonly storageMb: number;
+};
+
 export type VmImageManifestEntry = {
   readonly provider: ProviderId;
   readonly version: string;
@@ -26,8 +41,13 @@ export type VmImageManifestEntry = {
   readonly defaultForLocalDev?: boolean;
   /** Which machine kind this image serves. Missing means "base" unless the id says otherwise. */
   readonly kind?: VmImageKind;
-  /** The image served for `kind` when the client does not name one. Exactly one per provider and kind. */
+  /**
+   * The image served for `kind` (and `size`, when the entry has one) when the
+   * client does not name an image. Exactly one per provider, kind and size.
+   */
   readonly defaultForKind?: boolean;
+  /** The shape this snapshot boots at. Entries without one are size-less (pre-ladder bakes). */
+  readonly size?: VmImageManifestSize;
   readonly cmuxdRemoteCommit: string;
   /** The cmux commit whose devbox definition produced this image. */
   readonly repoCommit?: string;
@@ -44,10 +64,17 @@ export type VmImageSelection = {
   readonly imageVersion: string | null;
   readonly manifestEntry: VmImageManifestEntry | null;
   readonly kind: VmImageKind;
+  /** The shape the machine boots at, when the manifest knows it. */
+  readonly size: VmImageManifestSize | null;
 };
 
 export type VmImageResolveOptions = {
   readonly kind?: VmImageKind;
+  /**
+   * The plan's machine memory in MiB. Picks the smallest ladder size that has
+   * at least this much; omitted means the smallest size the manifest offers.
+   */
+  readonly memoryMb?: number;
 };
 
 const typedManifest = manifest as {
@@ -88,11 +115,37 @@ export function findVmImageManifestEntry(
   return matches[0] ?? null;
 }
 
-/** The manifest entry flagged `defaultForKind` for `kind`, if the provider has one. */
-export function findVmImageKindDefault(provider: ProviderId, kind: VmImageKind): VmImageManifestEntry | null {
-  return typedManifest.images.find((entry) =>
-    entry.provider === provider && (entry.kind ?? "base") === kind && entry.defaultForKind === true
-  ) ?? null;
+/** Every entry flagged `defaultForKind` for `kind`, smallest size first (size-less entries last). */
+export function listVmImageKindDefaults(provider: ProviderId, kind: VmImageKind): VmImageManifestEntry[] {
+  return typedManifest.images
+    .filter((entry) =>
+      entry.provider === provider && (entry.kind ?? "base") === kind && entry.defaultForKind === true
+    )
+    .sort((a, b) => sizeRank(a) - sizeRank(b));
+}
+
+function sizeRank(entry: VmImageManifestEntry): number {
+  return entry.size && isVmImageSizeName(entry.size.name) ? vmImageSizeRank(entry.size.name) : Number.MAX_SAFE_INTEGER;
+}
+
+/**
+ * The manifest default for `kind` at the plan's size: the smallest sized
+ * default with at least `memoryMb` of memory. With no `memoryMb`, the smallest
+ * sized default. A provider whose defaults carry no sizes (a pre-ladder bake)
+ * serves its size-less default for every request.
+ */
+export function findVmImageKindDefault(
+  provider: ProviderId,
+  kind: VmImageKind,
+  memoryMb?: number,
+): VmImageManifestEntry | null {
+  const defaults = listVmImageKindDefaults(provider, kind);
+  const sized = defaults.filter((entry) => entry.size !== undefined);
+  if (sized.length === 0) return defaults[0] ?? null;
+  if (memoryMb === undefined) return sized[0] ?? null;
+  const wanted = pickVmImageSizeForMemory(memoryMb);
+  if (!wanted) return null;
+  return sized.find((entry) => vmImageSizeRank(entry.size!.name) >= vmImageSizeRank(wanted.name)) ?? null;
 }
 
 /**
@@ -110,24 +163,33 @@ export function vmImageKindFor(provider: ProviderId, image: string): VmImageKind
 }
 
 /**
- * The image each kind would resolve to for `provider`.
- * Kinds with no manifest default are omitted, so clients can offer only kinds that work.
+ * The image each kind would resolve to for `provider` at `memoryMb` (or the
+ * smallest size). Kinds with no manifest default are omitted, so clients can
+ * offer only kinds that work.
  */
 export function listVmImageKinds(
   provider: ProviderId,
   env: VmRuntimeEnv = process.env,
-): Array<{ kind: VmImageKind; image: string }> {
-  const kinds: Array<{ kind: VmImageKind; image: string }> = [];
+  options: { readonly memoryMb?: number } = {},
+): Array<{ kind: VmImageKind; image: string; size?: VmImageManifestSize }> {
+  const kinds: Array<{ kind: VmImageKind; image: string; size?: VmImageManifestSize }> = [];
   for (const kind of VM_IMAGE_KINDS) {
     try {
-      const selection = resolveVmImage(provider, undefined, env, { kind });
-      kinds.push({ kind, image: selection.image });
+      const selection = resolveVmImage(provider, undefined, env, { kind, memoryMb: options.memoryMb });
+      kinds.push({ kind, image: selection.image, ...(selection.size ? { size: selection.size } : {}) });
     } catch (err) {
       if (err instanceof VmImageConfigError) continue;
       throw err;
     }
   }
   return kinds;
+}
+
+/** The sizes a provider's manifest defaults offer for `kind`, ladder order. */
+export function listVmImageSizes(provider: ProviderId, kind: VmImageKind): VmImageManifestSize[] {
+  return listVmImageKindDefaults(provider, kind)
+    .map((entry) => entry.size)
+    .filter((size): size is VmImageManifestSize => size !== undefined);
 }
 
 /**
@@ -159,7 +221,8 @@ export function inferVmProviderForImage(requestedImage: string | undefined): Pro
  *     images are allowed, which they are outside deployed runtimes or with
  *     CMUX_VM_ALLOW_UNMANIFESTED_IMAGES=1);
  *  2. the manifest entry flagged `defaultForKind` for the requested kind
- *     (`base` when the client did not ask for a kind).
+ *     (`base` when the client did not ask for a kind) at the plan's size:
+ *     the smallest sized default with at least `memoryMb` of memory.
  * Rollback is a manifest change (revert the promotion PR) and a deploy.
  */
 export function resolveVmImage(
@@ -185,15 +248,19 @@ export function resolveVmImage(
   }
 
   const effectiveKind = kind ?? "base";
-  const kindDefault = findVmImageKindDefault(provider, effectiveKind);
+  const kindDefault = findVmImageKindDefault(provider, effectiveKind, options.memoryMb);
   if (kindDefault) return selectionFromEntry(kindDefault);
 
+  const sizes = listVmImageSizes(provider, effectiveKind);
+  const reason = sizes.length > 0 && options.memoryMb !== undefined
+    ? `no ${effectiveKind} image size fits ${options.memoryMb} MiB for ${provider}: the manifest offers ${sizes.map((size) => `${size.name} (${size.memoryMb} MiB)`).join(", ")}`
+    : `no ${effectiveKind} image is recorded as the manifest default for ${provider}: promote one (bun run devbox:promote -- ${provider})`;
   throw new VmImageConfigError({
     provider,
     kind: effectiveKind,
     source: "default",
     allowedImages: listVmImageIds(provider),
-    reason: `no ${effectiveKind} image is recorded as the manifest default for ${provider}: promote one (bun run devbox:promote -- ${provider})`,
+    reason,
   });
 }
 
@@ -226,6 +293,7 @@ function resolveRequested(
       imageVersion: null,
       manifestEntry: null,
       kind: kind ?? deriveVmImageKind(null, image),
+      size: null,
     };
   }
 
@@ -319,5 +387,8 @@ function selectionFromEntry(entry: VmImageManifestEntry): VmImageSelection {
     imageVersion: entry.version,
     manifestEntry: entry,
     kind: deriveVmImageKind(entry, entry.imageId),
+    size: entry.size ?? null,
   };
 }
+
+export type { VmImageSize, VmImageSizeName };

--- a/web/services/vms/images/sizes.ts
+++ b/web/services/vms/images/sizes.ts
@@ -1,0 +1,59 @@
+/**
+ * Machine sizes: Freestyle's t-shirt ladder, verbatim from
+ * `freestyle-vms/catalog/snapshots.json` (the file that seeds both its dev and
+ * production platforms). A Freestyle VM always boots at its snapshot's size,
+ * so cmux keeps one snapshot per size, derived from a single bake by
+ * resize + snapshot (`scripts/derive-devbox-sizes.ts`). Freestyle pins these
+ * shapes to its plan caps (Free `md`, Hobby `lg`, Pro `2xl`), and a size a
+ * plan cannot boot is simply not creatable by it, so inventing shapes
+ * outside the ladder buys nothing.
+ *
+ * `md` is Freestyle's bare default slug (`freestyle/ubuntu`); the others keep
+ * Freestyle's suffixes.
+ */
+export type VmImageSizeName = "sm" | "md" | "lg" | "xl" | "2xl";
+
+export type VmImageSize = {
+  readonly name: VmImageSizeName;
+  readonly cpu: number;
+  /** MiB, the unit the Freestyle API and cmux's plan knobs both use. */
+  readonly memoryMb: number;
+  /** MiB (a "64 GB" disk is 65536, matching how Freestyle counts). */
+  readonly storageMb: number;
+  /** The Freestyle base snapshot with this exact shape. */
+  readonly freestyleBase: string;
+};
+
+export const VM_IMAGE_SIZES: readonly VmImageSize[] = [
+  { name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384, freestyleBase: "freestyle/ubuntu-sm" },
+  { name: "md", cpu: 4, memoryMb: 8192, storageMb: 32768, freestyleBase: "freestyle/ubuntu" },
+  { name: "lg", cpu: 8, memoryMb: 16384, storageMb: 65536, freestyleBase: "freestyle/ubuntu-lg" },
+  { name: "xl", cpu: 16, memoryMb: 32768, storageMb: 131072, freestyleBase: "freestyle/ubuntu-xl" },
+  { name: "2xl", cpu: 32, memoryMb: 65536, storageMb: 131072, freestyleBase: "freestyle/ubuntu-2xl" },
+];
+
+export const VM_IMAGE_SIZE_NAMES: readonly VmImageSizeName[] = VM_IMAGE_SIZES.map((size) => size.name);
+
+export function isVmImageSizeName(value: unknown): value is VmImageSizeName {
+  return typeof value === "string" && (VM_IMAGE_SIZE_NAMES as readonly string[]).includes(value);
+}
+
+export function vmImageSize(name: VmImageSizeName): VmImageSize {
+  const size = VM_IMAGE_SIZES.find((candidate) => candidate.name === name);
+  if (!size) throw new Error(`unknown machine size ${name}`);
+  return size;
+}
+
+/** Ladder order, so "smallest that fits" is a plain scan. */
+export function vmImageSizeRank(name: VmImageSizeName): number {
+  return VM_IMAGE_SIZE_NAMES.indexOf(name);
+}
+
+/**
+ * The smallest ladder size whose memory is at least `memoryMb` (the plan's
+ * size), or null when the request is above the ladder. cmux's plan knobs are
+ * expressed in memory only; vCPU and disk follow the ladder row.
+ */
+export function pickVmImageSizeForMemory(memoryMb: number): VmImageSize | null {
+  return VM_IMAGE_SIZES.find((size) => size.memoryMb >= memoryMb) ?? null;
+}

--- a/web/tests/vm-image-sizes.test.ts
+++ b/web/tests/vm-image-sizes.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, test } from "bun:test";
+import {
+  VM_IMAGE_SIZES,
+  VM_IMAGE_SIZE_NAMES,
+  pickVmImageSizeForMemory,
+  vmImageSize,
+  vmImageSizeRank,
+} from "../services/vms/images/sizes";
+import {
+  imageManifestProblems,
+  promoteImageManifestEntry,
+  type DevboxImageManifest,
+  type DevboxManifestEntry,
+} from "../scripts/devbox-image-common";
+
+// Machine sizes are Freestyle's t-shirt ladder (freestyle-vms
+// catalog/snapshots.json), one cmux snapshot per size, picked by the plan's
+// memory. These pin the ladder and the per-size promotion semantics.
+
+const entry = (overrides: Partial<DevboxManifestEntry> = {}): DevboxManifestEntry => ({
+  provider: "freestyle",
+  version: "freestyle-cmux-devbox-test",
+  imageId: "sh-master",
+  envVar: "FREESTYLE_SANDBOX_SNAPSHOT",
+  cmuxdRemoteCommit: "none-cmux-tui",
+  builtAt: "2026-09-02T00:00:00.000Z",
+  builderScriptVersion: "deadbeef",
+  agentToolResolvedVersions: {},
+  validationStatus: "passed",
+  notes: "epoch test",
+  ...overrides,
+});
+
+describe("size ladder", () => {
+  test("mirrors Freestyle's catalog exactly, smallest first", () => {
+    expect(VM_IMAGE_SIZE_NAMES).toEqual(["sm", "md", "lg", "xl", "2xl"]);
+    expect(VM_IMAGE_SIZES.map((s) => [s.name, s.cpu, s.memoryMb, s.storageMb, s.freestyleBase])).toEqual([
+      ["sm", 2, 4096, 16384, "freestyle/ubuntu-sm"],
+      ["md", 4, 8192, 32768, "freestyle/ubuntu"],
+      ["lg", 8, 16384, 65536, "freestyle/ubuntu-lg"],
+      ["xl", 16, 32768, 131072, "freestyle/ubuntu-xl"],
+      ["2xl", 32, 65536, 131072, "freestyle/ubuntu-2xl"],
+    ]);
+    // Grow-only resize means the ladder must be monotonic in every dimension
+    // except disk between xl and 2xl, which Freestyle keeps equal.
+    for (let i = 1; i < VM_IMAGE_SIZES.length; i += 1) {
+      expect(VM_IMAGE_SIZES[i].cpu).toBeGreaterThan(VM_IMAGE_SIZES[i - 1].cpu);
+      expect(VM_IMAGE_SIZES[i].memoryMb).toBeGreaterThan(VM_IMAGE_SIZES[i - 1].memoryMb);
+      expect(VM_IMAGE_SIZES[i].storageMb).toBeGreaterThanOrEqual(VM_IMAGE_SIZES[i - 1].storageMb);
+    }
+    expect(vmImageSizeRank("lg")).toBe(2);
+    expect(vmImageSize("xl").memoryMb).toBe(32768);
+  });
+
+  test("the plan's memory picks the smallest size that fits", () => {
+    // cmux's plan knobs are memory-only; vCPU and disk follow the row.
+    expect(pickVmImageSizeForMemory(512)?.name).toBe("sm");
+    expect(pickVmImageSizeForMemory(4096)?.name).toBe("sm");
+    expect(pickVmImageSizeForMemory(4097)?.name).toBe("md");
+    // cmux's paid default (24 GiB) is between lg and xl: it gets xl.
+    expect(pickVmImageSizeForMemory(24576)?.name).toBe("xl");
+    expect(pickVmImageSizeForMemory(32768)?.name).toBe("xl");
+    expect(pickVmImageSizeForMemory(65536)?.name).toBe("2xl");
+    expect(pickVmImageSizeForMemory(65537)).toBeNull();
+  });
+});
+
+describe("promoteImageManifestEntry with sizes", () => {
+  const sizes = [
+    { imageId: "sh-lg", size: { ...vmImageSize("lg") } },
+    { imageId: "sh-sm", size: { ...vmImageSize("sm") } },
+    { imageId: "sh-xl", size: { ...vmImageSize("xl") } },
+  ];
+  const base: DevboxImageManifest = {
+    schemaVersion: 1,
+    images: [
+      // A pre-ladder, size-less default: the sized promotion replaces it.
+      entry({ version: "freestyle-old", imageId: "sh-old", kind: "base", defaultForKind: true }),
+      // An old desktop default: not this promotion's kind, untouched.
+      entry({ version: "freestyle-old-desktop", imageId: "sh-old-d", kind: "desktop", defaultForKind: true }),
+    ],
+  };
+
+  test("writes one entry per kind and size, ladder order, and demotes the size-less default", () => {
+    const next = promoteImageManifestEntry(base, entry(), { kinds: ["base"], sizes, validationNotes: "ok" });
+    expect(imageManifestProblems(next)).toEqual([]);
+    expect(next.images[0]).toMatchObject({ version: "freestyle-old", defaultForKind: false });
+    expect(next.images[1]).toMatchObject({ version: "freestyle-old-desktop", defaultForKind: true });
+    expect(next.images.slice(2).map((e) => [e.version, e.imageId, e.kind, e.size?.name, e.defaultForKind])).toEqual([
+      ["freestyle-cmux-devbox-test-sm", "sh-sm", "base", "sm", true],
+      ["freestyle-cmux-devbox-test-lg", "sh-lg", "base", "lg", true],
+      ["freestyle-cmux-devbox-test-xl", "sh-xl", "base", "xl", true],
+    ]);
+    expect(next.images[2].size).toEqual({ name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384, freestyleBase: "freestyle/ubuntu-sm" });
+    expect(next.images[2].notes).toBe("epoch test ok");
+  });
+
+  test("two kinds times three sizes is six entries, desktop versions suffixed", () => {
+    const next = promoteImageManifestEntry(base, entry(), { kinds: ["desktop", "base"], sizes });
+    expect(imageManifestProblems(next)).toEqual([]);
+    expect(next.images.slice(2).map((e) => e.version)).toEqual([
+      "freestyle-cmux-devbox-test-sm",
+      "freestyle-cmux-devbox-test-lg",
+      "freestyle-cmux-devbox-test-xl",
+      "freestyle-cmux-devbox-test-sm-base",
+      "freestyle-cmux-devbox-test-lg-base",
+      "freestyle-cmux-devbox-test-xl-base",
+    ]);
+    expect(next.images[1]).toMatchObject({ version: "freestyle-old-desktop", defaultForKind: false });
+  });
+
+  test("a second sized promotion demotes only the same kind+size rows", () => {
+    const first = promoteImageManifestEntry(base, entry(), { kinds: ["base"], sizes });
+    const next = promoteImageManifestEntry(
+      first,
+      entry({ version: "freestyle-cmux-devbox-next", imageId: "sh-master-2" }),
+      { kinds: ["base"], sizes: [{ imageId: "sh-lg-2", size: { ...vmImageSize("lg") } }] },
+    );
+    expect(imageManifestProblems(next)).toEqual([]);
+    const defaults = next.images.filter((e) => e.defaultForKind && (e.kind ?? "base") === "base").map((e) => [e.size?.name, e.imageId]);
+    expect(defaults).toEqual([["sm", "sh-sm"], ["xl", "sh-xl"], ["lg", "sh-lg-2"]]);
+  });
+
+  test("refuses to list the same image twice for a kind+size", () => {
+    const first = promoteImageManifestEntry(base, entry(), { kinds: ["base"], sizes });
+    expect(() => promoteImageManifestEntry(first, entry(), { kinds: ["base"], sizes })).toThrow(/already listed .* \(base, sm\)/);
+  });
+});
+
+describe("imageManifestProblems with sizes", () => {
+  test("flags mixed sized and size-less defaults, off-ladder sizes, and duplicate size defaults", () => {
+    const bad: DevboxImageManifest = {
+      schemaVersion: 1,
+      images: [
+        entry({ version: "a", imageId: "sh-a", kind: "base", defaultForKind: true }),
+        entry({ version: "b", imageId: "sh-b", kind: "base", defaultForKind: true, size: { ...vmImageSize("lg") } }),
+        entry({ version: "c", imageId: "sh-c", kind: "base", defaultForKind: true, size: { ...vmImageSize("lg") } }),
+        entry({ version: "d", imageId: "sh-d", kind: "base", size: { name: "huge" as never, cpu: 1, memoryMb: 1, storageMb: 1 } }),
+      ],
+    };
+    const problems = imageManifestProblems(bad);
+    expect(problems).toEqual(expect.arrayContaining([
+      expect.stringContaining("freestyle/base: defaults mix sized and size-less entries"),
+      expect.stringContaining("freestyle/base/lg: 2 entries flagged defaultForKind"),
+      expect.stringContaining("d: size huge is not on the ladder"),
+    ]));
+  });
+});


### PR DESCRIPTION
## Summary

Follow-up to #11601. A Freestyle VM boots at its snapshot's size and resize is grow-only, so cmux keeps **one snapshot per size**, derived from a single bake, and the resolver picks the size from the plan. The driver never resizes at create, nothing grows at boot, and no account-level size override on Freestyle's side is needed.

Sizes are Freestyle's own ladder, verbatim from `freestyle-vms/catalog/snapshots.json` (the file that seeds its dev and production platforms), so every cmux machine is a shape Freestyle already bills and caps:

| name | vCPU | memory | disk | Freestyle base |
|---|---|---|---|---|
| `sm` | 2 | 4 GiB | 16 GB | `freestyle/ubuntu-sm` |
| `md` | 4 | 8 GiB | 32 GB | `freestyle/ubuntu` |
| `lg` | 8 | 16 GiB | 64 GB | `freestyle/ubuntu-lg` |
| `xl` | 16 | 32 GiB | 128 GB | `freestyle/ubuntu-xl` |
| `2xl` | 32 | 64 GiB | 128 GB | `freestyle/ubuntu-2xl` |

## Why

Today's production machines come up at 5 vCPU / 20 GB / 197 GB, a shape that is not on Freestyle's ladder and that nothing in cmux requests: `drivers/freestyle.ts` never reads the `memoryMb` the route computes (paid default 24 GiB), so the size is whatever Freestyle's account default says. If that default changes, every machine silently becomes 2 vCPU / 4 GiB / 16 GB (the snapshot's bake size). This PR makes size cmux's decision, recorded in the manifest.

## What changes

- **`services/vms/images/sizes.ts`**: the ladder and `pickVmImageSizeForMemory` (smallest size whose memory covers the plan's `memoryMb`; 24 GiB lands on `xl`).
- **Manifest entries carry `size {name, cpu, memoryMb, storageMb}`**, one entry per kind and size, each the default for that kind+size. Invariants: one default per provider/kind/size, ladder-only sizes, no mixing sized and size-less defaults for a kind.
- **Resolver**: `resolveVmImage(..., { kind, memoryMb })` serves the smallest sized default that fits; a provider whose defaults are size-less (a pre-ladder bake, i.e. today's `…20260902c`) keeps serving them for every request, so nothing changes until a sized ladder is promoted. `POST /api/vm` and the base open/reset routes pass `defaultMemoryMbForPlan`; create responses and `limits.imageKinds` carry `size`.
- **`scripts/derive-devbox-sizes.ts`**: boot the bake, `vm.resize` to a ladder row, snapshot, delete; then boot the derived snapshot and check `nproc`, memory, the grown root filesystem and the `cmux-tui-daemon` / `cmux-desktop` units. About 5-15 s per size.
- **`promote-devbox-image.ts --sizes`** (default the full ladder; `none` keeps the old single-entry behaviour) runs the derive after verify and records every size in one manifest diff. The bake now defaults to `freestyle/ubuntu-sm`, the ladder floor.
- Slugs: `cmux-devbox-<size>` (`cmux-devbox` for `md`).

## Manifest in this PR

The ladder was baked, verified and derived for real (all five sizes booted at their shape with both units active) and is recorded as **validated, non-default reference entries** (`freestyle-cmux-devbox-20260902i-*`). They live on the contributor's Freestyle account, and snapshots are account-scoped, so cmux's own `…20260902c` stays the default. To switch production to the ladder:

```
cd web && FREESTYLE_API_KEY=<cmux's key> bun run devbox:promote -- freestyle
```

and merge the manifest diff. That also retires the account-level size override on Freestyle's side.

## Verification
- `bun test tests/vm-*.test.ts tests/cloud-vm-*.test.ts`: every file green on its own (new: `tests/vm-image-sizes.test.ts`). Running the whole directory in one process trips eight `VM REST auth` tests on current main too (mock state leaking between files), unrelated to this PR; `bun test tests/vm-route-auth.test.ts` alone is 71/71 on both.
- `tsc --noEmit` clean; `eslint` clean on the touched scripts.
- Live on the public platform: bake on `ubuntu-sm`, verify (all checks), derive `sm,md,lg,xl,2xl`, each re-booted and measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013M6fLnbEMj9WSDsCQS9z3C

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11664"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790945352&installation_model_id=21920&pr_number=11664&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11664&signature=395c7c3c81b971b89bd490ce03857884c04d6e122035576cb1d74e8f0d2f3fa6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives Freestyle devbox machines a real size ladder. Previously every machine booted at Freestyle's account default (5 vCPU / 20 GB / 197 GB, off their ladder), and a default change would silently shrink all machines to 2 vCPU / 4 GiB / 16 GB; now the plan's memory picks a size from Freestyle's own ladder (`sm`/`md`/`lg`/`xl`/`2xl`), with one snapshot per size derived from a single bake and the size recorded in the manifest.

**Migration**
- `FREESTYLE_SANDBOX_SNAPSHOT` is no longer read; `web/services/vms/images/manifest.json` is the only image source of truth, in local dev and deployed runtimes alike.
- To put the ladder in production, run `cd web && FREESTYLE_API_KEY=<cmux's key> bun run devbox:promote -- freestyle` and merge the manifest diff; this retires the account-level size override on Freestyle's side.

**Image pipeline**
- Manifest entries now carry `size`; the resolver serves the smallest sized default whose memory covers the plan's `memoryMb`, and size-less entries keep serving as before.
- New `derive-devbox-sizes.ts` and `promote-devbox-image.ts --sizes` produce one snapshot per ladder size; each derived snapshot is re-booted and checked (nproc, memory, root filesystem, units) before recording.
- The bake defaults to `freestyle/ubuntu-sm` and adds a desktop layer (TigerVNC + noVNC on 6901, pinned ports); create responses and `limits.imageKinds` now carry `size`.

<sup>Written for commit d46caff4c73e1e21d5b884b08bdd16300a70a435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11664?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * VM images now automatically match the smallest available size that meets the plan’s memory requirements.
  * VM creation and image listings now show the resolved image size when available.
  * Added support for multiple Freestyle devbox sizes, from small through 2XL, with corresponding image variants.

* **Bug Fixes**
  * Improved image selection to prevent plans from receiving undersized VM images.
  * Added validation for duplicate, unsupported, or inconsistent image-size configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->