### PR TITLE
Index live terminal scrollback in global search

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -125153,6 +125153,23 @@
         }
       }
     },
+    "globalSearch.kind.terminal": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナル"
+          }
+        }
+      }
+    },
     "globalSearch.kind.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -659,6 +659,7 @@ final class TerminalPanel: Panel, ObservableObject {
 
     func close() {
         isClosingPanel = true
+        GlobalSearchCoordinator.shared.purgePanel(id: id)
         AgentHibernationController.shared.discardTrackingStateForClosedPanel(
             workspaceId: workspaceId,
             panelId: id

--- a/Sources/Search/AppDelegate+GlobalSearch.swift
+++ b/Sources/Search/AppDelegate+GlobalSearch.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxTerminal
 import Foundation
 
 extension AppDelegate {
@@ -187,6 +188,8 @@ extension AppDelegate {
                 applyBrowserInlineSearch(query: query, hit: hit, to: browserPanel)
             } else if let markdownPanel = workspace.markdownPanel(for: panelID) {
                 applyMarkdownInlineSearch(query: query, hit: hit, to: markdownPanel)
+            } else if hit.kind == .terminal, let terminalPanel = workspace.terminalPanel(for: panelID) {
+                applyTerminalInlineSearch(query: query, hit: hit, to: terminalPanel)
             }
         }
     }
@@ -203,6 +206,14 @@ extension AppDelegate {
     private func applyMarkdownInlineSearch(query: String, hit: SearchIndexHit, to panel: MarkdownPanel) {
         guard let needle = GlobalSearchInlineSearch.needle(for: query, hit: hit) else { return }
         panel.applySearchNeedle(needle)
+    }
+
+    /// Opens the surface find bar on the needle, the same entry point Cmd+F
+    /// uses. Ghostty searches screen and history on its own thread, scrolls to
+    /// the match and highlights it.
+    private func applyTerminalInlineSearch(query: String, hit: SearchIndexHit, to panel: TerminalPanel) {
+        guard let needle = GlobalSearchInlineSearch.needle(for: query, hit: hit) else { return }
+        _ = startOrFocusTerminalSearch(panel.surface, initialNeedle: needle)
     }
 }
 

--- a/Sources/Search/GlobalSearchDocuments.swift
+++ b/Sources/Search/GlobalSearchDocuments.swift
@@ -2,6 +2,13 @@ import Foundation
 
 enum GlobalSearchIndexingLimits {
     static let maxIndexedTextCharacters = 400_000
+    /// Mirrors `SessionPersistencePolicy.maxScrollbackLinesPerTerminal`: the
+    /// same bound session snapshots use when they persist terminal scrollback.
+    static let maxTerminalCaptureRows = 4000
+    /// Byte ceiling for the VT reconstruction Ghostty formats for those rows.
+    /// Generous against escape sequences while keeping one capture bounded;
+    /// the scrollback itself defaults to 50 MB (`GhosttyConfig.scrollbackLimit`).
+    static let maxTerminalCaptureVTBytes = 1_500_000
 }
 
 @MainActor
@@ -34,7 +41,9 @@ enum GlobalSearchDocuments {
             kind = .browser
         case .markdown:
             kind = .markdown
-        case .terminal, .filePreview, .rightSidebarTool, .customSidebar, .agentSession, .project,
+        case .terminal:
+            kind = .terminal
+        case .filePreview, .rightSidebarTool, .customSidebar, .agentSession, .project,
              .extensionBrowser, .simulator, .workspaceTodo, .notifications, .cloudVMLoading, .mobilePairing, .accountSignIn:
             kind = .title
         }
@@ -89,6 +98,23 @@ enum GlobalSearchDocuments {
             location: panel.filePath,
             anchor: panel.filePath,
             text: text
+        )
+    }
+
+    static func terminalDocument(for context: GlobalSearchPanelContext, text: String) -> SearchIndexDocument? {
+        let capped = cappedText(text)
+        guard !capped.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return nil }
+
+        return SearchIndexDocument(
+            id: SearchIndexDocument.panelStableID(panelID: context.panelID, kind: .terminal),
+            windowID: context.windowID,
+            workspaceID: context.workspaceID,
+            panelID: context.panelID,
+            kind: .terminal,
+            title: context.panelTitle,
+            location: context.location,
+            anchor: "terminal",
+            text: capped
         )
     }
 

--- a/Sources/Search/GlobalSearchPaletteModel.swift
+++ b/Sources/Search/GlobalSearchPaletteModel.swift
@@ -1,0 +1,200 @@
+import CmuxFoundation
+import Foundation
+
+/// Search state and per-open lifecycle for the global search palette.
+///
+/// The popover retains its SwiftUI content view across shows, so `onAppear` /
+/// `onDisappear` fire only around the first open and cannot drive per-open
+/// work (#7445). `MenubarSearchPopover` calls `prepareForOpen()` /
+/// `handleDidClose()` from the AppKit show/close path instead; the SwiftUI
+/// view is a renderer bound to this model.
+@MainActor
+final class GlobalSearchPaletteModel: ObservableObject {
+    /// The palette's outward dependencies, injectable for tests.
+    struct Client {
+        var refreshLiveIndex: () async -> Void
+        var search: (String) async -> [SearchIndexHit]
+        var browseOpenPanels: (Int) -> [SearchIndexHit]
+        var activate: (SearchIndexHit, String) -> Void
+        var dismissPalette: () -> Void
+        var isPaletteVisible: () -> Bool
+    }
+
+    @Published var query = ""
+    @Published private(set) var results: [GlobalSearchResultRow] = []
+    @Published var selectedIndex = 0
+    @Published private(set) var isSearching = false
+    /// Bumped on every popover open so the view can re-run per-open work
+    /// (focusing the search field) that `onAppear` no longer covers.
+    @Published private(set) var openGeneration = 0
+
+    private let client: Client
+    private let searchDebounceDelay: Duration
+    private let browseResultLimit = 20
+    private var searchGeneration = 0
+    private let searchDebounceScheduler = MainActorDeferredActionScheduler()
+    private let tasks = MainActorTaskStore<String>()
+
+    init(client: Client, searchDebounceDelay: Duration = .milliseconds(80)) {
+        self.client = client
+        self.searchDebounceDelay = searchDebounceDelay
+    }
+
+    func prepareForOpen() {
+        openGeneration += 1
+        cancelSearchWork()
+        query = ""
+        selectedIndex = 0
+        isSearching = false
+        reloadBrowseResults()
+        tasks.replaceOnMainActor("refresh") { [weak self] in
+            guard let self else { return }
+            await self.client.refreshLiveIndex()
+            guard !Task.isCancelled else { return }
+            self.scheduleSearch(self.query)
+        }
+    }
+
+    func handleDidClose() {
+        tasks.cancel("refresh")
+        cancelSearchWork()
+    }
+
+    func queryDidChange(_ newValue: String) {
+        scheduleSearch(newValue)
+    }
+
+    func openSelectedResult() {
+        openResult(at: selectedIndex)
+    }
+
+    func openResult(at index: Int) {
+        guard results.indices.contains(index) else { return }
+        let row = results[index]
+        client.activate(row.hit, row.query)
+    }
+
+    func handleKeyEvent(_ event: GlobalSearchKeyEvent) -> Bool {
+        guard client.isPaletteVisible() else { return false }
+
+        let flags = event.modifierFlags
+        if flags.contains(.command),
+           !flags.contains(.option),
+           !flags.contains(.control),
+           let rawDigit = event.charactersIgnoringModifiers,
+           let digit = Int(rawDigit),
+           (1...9).contains(digit) {
+            openResult(at: digit - 1)
+            return true
+        }
+
+        switch event.keyCode {
+        case 53:
+            client.dismissPalette()
+            return true
+        case 126 where flags.isDisjoint(with: [.command, .shift, .option, .control]):
+            selectedIndex = max(0, selectedIndex - 1)
+            return true
+        case 125 where flags.isDisjoint(with: [.command, .shift, .option, .control]):
+            selectedIndex = min(max(results.count - 1, 0), selectedIndex + 1)
+            return true
+        case 36, 76:
+            openSelectedResult()
+            return true
+        default:
+            if flags.contains(.command),
+               !flags.contains(.option),
+               !flags.contains(.control) {
+                return !event.queryOwnsEditingShortcut && !isSystemCommand(event)
+            }
+            return false
+        }
+    }
+
+    private func isSystemCommand(_ event: GlobalSearchKeyEvent) -> Bool {
+        guard let characters = event.charactersIgnoringModifiers?.lowercased() else { return false }
+        return ["h", "m", "q", "w", ","].contains(characters)
+    }
+
+    private func scheduleSearch(_ nextQuery: String) {
+        cancelSearchWork()
+        searchGeneration += 1
+        let generation = searchGeneration
+        let trimmed = nextQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            isSearching = false
+            reloadBrowseResults()
+            return
+        }
+
+        isSearching = true
+
+        searchDebounceScheduler.schedule(after: searchDebounceDelay) { [weak self] in
+            guard let self, self.searchGeneration == generation else { return }
+            self.tasks.replaceOnMainActor("search") { [weak self] in
+                guard let self, self.searchGeneration == generation, !Task.isCancelled else { return }
+                let hits = await self.client.search(trimmed)
+                guard self.searchGeneration == generation, !Task.isCancelled else { return }
+                self.results = hits.enumerated().map { offset, hit in
+                    GlobalSearchResultRow(hit: hit, query: trimmed, index: offset)
+                }
+                self.selectedIndex = min(self.selectedIndex, max(self.results.count - 1, 0))
+                self.isSearching = false
+            }
+        }
+    }
+
+    private func cancelSearchWork() {
+        searchDebounceScheduler.cancel()
+        tasks.cancel("search")
+    }
+
+    private func reloadBrowseResults() {
+        let hits = client.browseOpenPanels(browseResultLimit)
+        results = hits.enumerated().map { offset, hit in
+            GlobalSearchResultRow(hit: hit, query: "", index: offset)
+        }
+        selectedIndex = 0
+    }
+}
+
+struct GlobalSearchResultRow: Identifiable, Equatable {
+    let hit: SearchIndexHit
+    let query: String
+    let index: Int
+
+    var id: String { hit.id }
+
+    var title: String {
+        let trimmed = hit.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty
+            ? String(localized: "globalSearch.untitled", defaultValue: "Untitled")
+            : trimmed
+    }
+
+    var location: String {
+        hit.location.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    var snippet: String {
+        let trimmed = hit.snippet.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? title : trimmed
+    }
+
+    var shortcutLabel: String? {
+        index < 9 ? "⌘\(index + 1)" : nil
+    }
+
+    var systemImageName: String {
+        switch hit.kind {
+        case .browser:
+            return "globe"
+        case .markdown:
+            return "doc.richtext"
+        case .terminal:
+            return "terminal"
+        case .title:
+            return "rectangle.stack"
+        }
+    }
+}

--- a/Sources/Search/GlobalSearchPanelCaptureManager.swift
+++ b/Sources/Search/GlobalSearchPanelCaptureManager.swift
@@ -13,6 +13,9 @@ final class GlobalSearchPanelCaptureManager {
     private var markdownCaptureTimers: [UUID: DispatchSourceTimer] = [:]
     private var markdownCaptureTasks: [UUID: Task<Void, Never>] = [:]
     private var markdownCaptureTaskIDs: [UUID: UUID] = [:]
+    /// Last indexed scrollback fingerprint per terminal panel, to skip
+    /// unchanged re-captures across palette opens.
+    private var terminalCaptureFingerprints: [UUID: UInt64] = [:]
 
     init(
         indexProvider: @escaping () async -> SearchIndex?,
@@ -38,6 +41,8 @@ final class GlobalSearchPanelCaptureManager {
             }
         } else if let browserPanel = context.panel as? BrowserPanel {
             captureBrowserPanel(browserPanel)
+        } else if let terminalPanel = context.panel as? TerminalPanel {
+            await indexTerminalPanel(terminalPanel, context: context, index: index)
         }
     }
 
@@ -162,6 +167,7 @@ final class GlobalSearchPanelCaptureManager {
     func cancelCaptures(forPanelID panelID: UUID) {
         cancelBrowserCapture(forPanelID: panelID)
         cancelMarkdownCapture(forPanelID: panelID)
+        terminalCaptureFingerprints[panelID] = nil
     }
 
     private func cancelBrowserCapture(forPanelID panelID: UUID) {
@@ -188,6 +194,64 @@ final class GlobalSearchPanelCaptureManager {
         timer.schedule(deadline: .now() + .milliseconds(milliseconds), leeway: .milliseconds(25))
         timer.setEventHandler(handler: handler)
         return timer
+    }
+
+    /// Indexes a live terminal's scrollback.
+    ///
+    /// Reads through `boundedScreenTailVT`: Ghostty applies the row and byte
+    /// bounds before anything crosses the FFI, and the read itself runs on the
+    /// teardown coordinator, so a 50 MB scrollback (the configured default)
+    /// never lands on the main actor — the failure mode issue #5757 fixed for
+    /// `surface.read_text`. Sanitizing and hashing then run off-main too.
+    private func indexTerminalPanel(
+        _ panel: TerminalPanel,
+        context: GlobalSearchPanelContext,
+        index: SearchIndex
+    ) async {
+        let panelID = context.panelID
+        let capturedVT = await panel.surface.boundedScreenTailVT(
+            maxRows: GlobalSearchIndexingLimits.maxTerminalCaptureRows,
+            maxBytes: GlobalSearchIndexingLimits.maxTerminalCaptureVTBytes
+        )
+        guard !Task.isCancelled else { return }
+        guard let capturedVT else {
+            // No snapshot available (hibernated or torn down): keep whatever is
+            // indexed, since the hit still routes to the panel. close() purges.
+            return
+        }
+
+        let prepared = await Task.detached(priority: .utility) {
+            let text = GlobalSearchTerminalText.strippedVT(capturedVT)
+            return (text: text, fingerprint: GlobalSearchTerminalText.fingerprint(text))
+        }.value
+        guard !Task.isCancelled else { return }
+        guard terminalCaptureFingerprints[panelID] != prepared.fingerprint else { return }
+
+        guard let document = GlobalSearchDocuments.terminalDocument(for: context, text: prepared.text) else {
+            terminalCaptureFingerprints[panelID] = nil
+            await purgeTerminalDocument(forPanelID: panelID, index: index)
+            return
+        }
+
+        do {
+            try await index.upsert(document)
+            terminalCaptureFingerprints[panelID] = prepared.fingerprint
+        } catch {
+#if DEBUG
+            cmuxDebugLog("globalSearch.terminal.upsert failed panel=\(panelID.uuidString.prefix(5)) error=\(error.localizedDescription)")
+#endif
+        }
+    }
+
+    private func purgeTerminalDocument(forPanelID panelID: UUID, index: SearchIndex) async {
+        let documentID = SearchIndexDocument.panelStableID(panelID: panelID, kind: .terminal)
+        do {
+            try await index.deleteDocument(id: documentID)
+        } catch {
+#if DEBUG
+            cmuxDebugLog("globalSearch.terminal.purge failed panel=\(panelID.uuidString.prefix(5)) error=\(error.localizedDescription)")
+#endif
+        }
     }
 
     private func purgeMarkdownDocument(forPanelID panelID: UUID, index: SearchIndex) async {

--- a/Sources/Search/GlobalSearchTerminalText.swift
+++ b/Sources/Search/GlobalSearchTerminalText.swift
@@ -1,0 +1,89 @@
+import Foundation
+
+/// Text preparation for indexing terminal scrollback.
+///
+/// The bounded screen tail arrives as a VT reconstruction: it carries the
+/// styling escape sequences Ghostty emits to redraw those rows. Those bytes
+/// are noise for full-text search — they inflate the document, tokenize into
+/// junk, and surface inside result snippets — so they are removed before the
+/// text reaches the index.
+enum GlobalSearchTerminalText {
+    /// Strips VT escape sequences, leaving printable text, newlines and tabs.
+    nonisolated static func strippedVT(_ text: String) -> String {
+        guard text.contains("\u{1B}") || text.unicodeScalars.contains(where: isStrippableControl) else {
+            return text
+        }
+
+        var output = String.UnicodeScalarView()
+        output.reserveCapacity(text.unicodeScalars.count)
+        var iterator = text.unicodeScalars.makeIterator()
+        var pending: Unicode.Scalar? = nil
+
+        while let scalar = pending ?? iterator.next() {
+            pending = nil
+            guard scalar == "\u{1B}" else {
+                if !isStrippableControl(scalar) {
+                    output.append(scalar)
+                }
+                continue
+            }
+
+            guard let introducer = iterator.next() else { break }
+            switch introducer {
+            case "[":
+                // CSI: parameter and intermediate bytes, then a final byte in 0x40...0x7E.
+                while let next = iterator.next() {
+                    if (0x40...0x7E).contains(next.value) { break }
+                }
+            case "]", "P", "X", "^", "_":
+                // OSC/DCS/SOS/PM/APC run until BEL or the ST sequence (ESC \).
+                while let next = iterator.next() {
+                    if next == "\u{07}" { break }
+                    if next == "\u{1B}" {
+                        if let terminator = iterator.next(), terminator != "\\" {
+                            // Not ST: hand the scalar back so it starts a new sequence.
+                            pending = terminator == "\u{1B}" ? terminator : nil
+                        }
+                        break
+                    }
+                }
+            default:
+                // Everything else is ESC + zero or more intermediate bytes
+                // (0x20...0x2F) + one final byte, so `ESC ( B` (charset
+                // designation) consumes the designator while `ESC =` ends at
+                // the introducer. A nested ESC starts a fresh sequence.
+                if introducer == "\u{1B}" {
+                    pending = introducer
+                } else if (0x20...0x2F).contains(introducer.value) {
+                    while let next = iterator.next() {
+                        if next == "\u{1B}" {
+                            pending = next
+                            break
+                        }
+                        if !(0x20...0x2F).contains(next.value) { break }
+                    }
+                }
+            }
+        }
+
+        return String(output)
+    }
+
+    /// FNV-1a over the scrollback, used to skip re-indexing unchanged panels.
+    ///
+    /// `Hasher` is seeded per process, which is fine in memory but makes the
+    /// value untestable; this stays deterministic.
+    nonisolated static func fingerprint(_ text: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in text.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x1000_0000_01b3
+        }
+        return hash
+    }
+
+    private nonisolated static func isStrippableControl(_ scalar: Unicode.Scalar) -> Bool {
+        guard scalar.value < 0x20 || scalar.value == 0x7F else { return false }
+        return scalar != "\n" && scalar != "\t"
+    }
+}

--- a/Sources/Search/MenubarSearchPopover.swift
+++ b/Sources/Search/MenubarSearchPopover.swift
@@ -4,7 +4,6 @@ import SwiftUI
 
 @MainActor
 final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
-    private unowned let coordinator: GlobalSearchCoordinator
     private let popover = NSPopover()
     private let model: GlobalSearchPaletteModel
     private var keyMonitor: Any?
@@ -14,7 +13,6 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
     }
 
     init(coordinator: GlobalSearchCoordinator) {
-        self.coordinator = coordinator
         self.model = GlobalSearchPaletteModel(client: .init(
             refreshLiveIndex: { [unowned coordinator] in await coordinator.refreshLiveIndex() },
             search: { [unowned coordinator] query in await coordinator.search(query: query) },
@@ -29,11 +27,7 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
         popover.contentSize = NSSize(width: 720, height: 460)
         popover.delegate = self
         popover.contentViewController = NSHostingController(
-            rootView: GlobalSearchPaletteView(
-                model: model,
-                onOpen: { [weak self] in self?.prepareModelForOpen() },
-                onClose: { [weak self] in self?.handleModelDidClose() }
-            )
+            rootView: GlobalSearchPaletteView(model: model)
         )
     }
 
@@ -52,6 +46,11 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
             popover.performClose(nil)
         }
         dismissalHandler = onDismiss
+        // The hosting controller retains its content view across shows, so
+        // SwiftUI onAppear only fires for the first open. Drive the per-open
+        // lifecycle (state reset, live re-index, key monitor) from here (#7445).
+        model.prepareForOpen()
+        installKeyMonitorIfNeeded()
         popover.show(relativeTo: button.bounds, of: button, preferredEdge: .minY)
     }
 
@@ -60,19 +59,11 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
     }
 
     func popoverDidClose(_ notification: Notification) {
+        removeKeyMonitor()
+        model.handleDidClose()
         let handler = dismissalHandler
         dismissalHandler = nil
         handler?()
-    }
-
-    func prepareModelForOpen() {
-        model.prepareForOpen()
-        installKeyMonitorIfNeeded()
-    }
-
-    func handleModelDidClose() {
-        removeKeyMonitor()
-        model.handleDidClose()
     }
 
     private func installKeyMonitorIfNeeded() {
@@ -108,8 +99,6 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
 
 private struct GlobalSearchPaletteView: View {
     @ObservedObject var model: GlobalSearchPaletteModel
-    let onOpen: () -> Void
-    let onClose: () -> Void
     @FocusState private var searchFieldFocused: Bool
 
     var body: some View {
@@ -168,10 +157,6 @@ private struct GlobalSearchPaletteView: View {
         .background(.regularMaterial)
         .onAppear {
             searchFieldFocused = true
-            onOpen()
-        }
-        .onDisappear {
-            onClose()
         }
         .onChange(of: model.openGeneration) { _, _ in
             searchFieldFocused = true

--- a/Sources/Search/MenubarSearchPopover.swift
+++ b/Sources/Search/MenubarSearchPopover.swift
@@ -6,6 +6,8 @@ import SwiftUI
 final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
     private unowned let coordinator: GlobalSearchCoordinator
     private let popover = NSPopover()
+    private let model: GlobalSearchPaletteModel
+    private var keyMonitor: Any?
 
     var isShown: Bool {
         popover.isShown
@@ -13,13 +15,25 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
 
     init(coordinator: GlobalSearchCoordinator) {
         self.coordinator = coordinator
+        self.model = GlobalSearchPaletteModel(client: .init(
+            refreshLiveIndex: { [unowned coordinator] in await coordinator.refreshLiveIndex() },
+            search: { [unowned coordinator] query in await coordinator.search(query: query) },
+            browseOpenPanels: { [unowned coordinator] limit in coordinator.browseOpenPanels(limit: limit) },
+            activate: { [unowned coordinator] hit, query in coordinator.activate(hit, query: query) },
+            dismissPalette: { [unowned coordinator] in coordinator.dismissPalette() },
+            isPaletteVisible: { [unowned coordinator] in coordinator.isPaletteVisible() }
+        ))
         super.init()
         popover.behavior = .transient
         popover.animates = true
         popover.contentSize = NSSize(width: 720, height: 460)
         popover.delegate = self
         popover.contentViewController = NSHostingController(
-            rootView: GlobalSearchPaletteView(coordinator: coordinator)
+            rootView: GlobalSearchPaletteView(
+                model: model,
+                onOpen: { [weak self] in self?.prepareModelForOpen() },
+                onClose: { [weak self] in self?.handleModelDidClose() }
+            )
         )
     }
 
@@ -50,154 +64,20 @@ final class MenubarSearchPopover: NSObject, NSPopoverDelegate {
         dismissalHandler = nil
         handler?()
     }
-}
 
-private struct GlobalSearchPaletteView: View {
-    let coordinator: GlobalSearchCoordinator
-
-    @State private var query = ""
-    @State private var results: [GlobalSearchResultRow] = []
-    @State private var selectedIndex = 0
-    @State private var isSearching = false
-    @State private var searchGeneration = 0
-    @State private var searchDebounceScheduler = MainActorDeferredActionScheduler()
-    @State private var tasks = MainActorTaskStore<String>()
-    @State private var keyMonitor: Any?
-    @FocusState private var searchFieldFocused: Bool
-
-    private let searchDebounceDelay: Duration = .milliseconds(80)
-    private let browseResultLimit = 20
-
-    var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                Image(systemName: "magnifyingglass")
-                    .cmuxFont(size: 15, weight: .semibold)
-                    .foregroundStyle(.secondary)
-                TextField(
-                    String(
-                        localized: "globalSearch.palette.placeholder",
-                        defaultValue: "Search all windows, panels, browser tabs..."
-                    ),
-                    text: $query
-                )
-                .textFieldStyle(.plain)
-                .cmuxFont(size: 18, weight: .regular)
-                .focused($searchFieldFocused)
-            }
-            .padding(.horizontal, 18)
-            .frame(height: 56)
-
-            Divider()
-
-            if results.isEmpty {
-                GlobalSearchEmptyStateView(
-                    title: query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                        ? String(localized: "globalSearch.empty.noOpenPanels", defaultValue: "No open panels")
-                        : String(localized: "globalSearch.empty.noResults", defaultValue: "No results")
-                )
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else {
-                ScrollView {
-                    LazyVStack(spacing: 0) {
-                        ForEach(results) { row in
-                            GlobalSearchResultRowView(
-                                row: row,
-                                isSelected: selectedIndex == row.index,
-                                action: {
-                                    selectedIndex = row.index
-                                    openSelectedResult()
-                                }
-                            )
-                            .onHover { hovering in
-                                if hovering {
-                                    selectedIndex = row.index
-                                }
-                            }
-                        }
-                    }
-                    .padding(.vertical, 6)
-                }
-            }
-        }
-        .frame(width: 720, height: 460)
-        .background(.regularMaterial)
-        .onAppear {
-            searchFieldFocused = true
-            installKeyMonitorIfNeeded()
-            resetResultsForPopoverOpen()
-            tasks.replaceOnMainActor("refresh") {
-                await coordinator.refreshLiveIndex()
-                guard !Task.isCancelled else { return }
-                scheduleSearch(query)
-            }
-        }
-        .onDisappear {
-            removeKeyMonitor()
-            tasks.cancel("refresh")
-            cancelSearchWork()
-        }
-        .onChange(of: query) { _, newValue in
-            scheduleSearch(newValue)
-        }
+    func prepareModelForOpen() {
+        model.prepareForOpen()
+        installKeyMonitorIfNeeded()
     }
 
-    private func scheduleSearch(_ nextQuery: String) {
-        cancelSearchWork()
-        searchGeneration += 1
-        let generation = searchGeneration
-        let trimmed = nextQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else {
-            isSearching = false
-            reloadBrowseResults()
-            return
-        }
-
-        isSearching = true
-
-        searchDebounceScheduler.schedule(after: searchDebounceDelay) {
-            guard searchGeneration == generation else { return }
-            tasks.replaceOnMainActor("search") {
-                guard searchGeneration == generation, !Task.isCancelled else { return }
-                let hits = await coordinator.search(query: trimmed)
-                guard searchGeneration == generation, !Task.isCancelled else { return }
-                results = hits.enumerated().map { offset, hit in
-                    GlobalSearchResultRow(hit: hit, query: trimmed, index: offset)
-                }
-                selectedIndex = min(selectedIndex, max(results.count - 1, 0))
-                isSearching = false
-            }
-        }
-    }
-
-    private func cancelSearchWork() {
-        searchDebounceScheduler.cancel()
-        tasks.cancel("search")
-    }
-
-    private func resetResultsForPopoverOpen() {
-        selectedIndex = 0
-        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed.isEmpty {
-            reloadBrowseResults()
-            isSearching = false
-        } else {
-            results = []
-            isSearching = true
-        }
-    }
-
-    private func reloadBrowseResults() {
-        let hits = coordinator.browseOpenPanels(limit: browseResultLimit)
-        results = hits.enumerated().map { offset, hit in
-            GlobalSearchResultRow(hit: hit, query: "", index: offset)
-        }
-        selectedIndex = 0
+    func handleModelDidClose() {
+        removeKeyMonitor()
+        model.handleDidClose()
     }
 
     private func installKeyMonitorIfNeeded() {
         guard keyMonitor == nil else { return }
-        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+        keyMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak model] event in
             let keyEvent = GlobalSearchKeyEvent(event)
             let route = MainActor.assumeIsolated {
                 AppDelegate.shared?
@@ -211,7 +91,7 @@ private struct GlobalSearchPaletteView: View {
                 return event
             case .notApplicable:
                 let consumed = MainActor.assumeIsolated {
-                    handleKeyEvent(keyEvent)
+                    model?.handleKeyEvent(keyEvent) ?? false
                 }
                 return consumed ? nil : event
             }
@@ -224,57 +104,81 @@ private struct GlobalSearchPaletteView: View {
             self.keyMonitor = nil
         }
     }
+}
 
-    private func handleKeyEvent(_ event: GlobalSearchKeyEvent) -> Bool {
-        guard coordinator.isPaletteVisible() else { return false }
+private struct GlobalSearchPaletteView: View {
+    @ObservedObject var model: GlobalSearchPaletteModel
+    let onOpen: () -> Void
+    let onClose: () -> Void
+    @FocusState private var searchFieldFocused: Bool
 
-        let flags = event.modifierFlags
-        if flags.contains(.command),
-           !flags.contains(.option),
-           !flags.contains(.control),
-           let rawDigit = event.charactersIgnoringModifiers,
-           let digit = Int(rawDigit),
-           (1...9).contains(digit) {
-            openResult(at: digit - 1)
-            return true
-        }
-
-        switch event.keyCode {
-        case 53:
-            coordinator.dismissPalette()
-            return true
-        case 126 where flags.isDisjoint(with: [.command, .shift, .option, .control]):
-            selectedIndex = max(0, selectedIndex - 1)
-            return true
-        case 125 where flags.isDisjoint(with: [.command, .shift, .option, .control]):
-            selectedIndex = min(max(results.count - 1, 0), selectedIndex + 1)
-            return true
-        case 36, 76:
-            openSelectedResult()
-            return true
-        default:
-            if flags.contains(.command),
-               !flags.contains(.option),
-               !flags.contains(.control) {
-                return !event.queryOwnsEditingShortcut && !isSystemCommand(event)
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: 10) {
+                Image(systemName: "magnifyingglass")
+                    .cmuxFont(size: 15, weight: .semibold)
+                    .foregroundStyle(.secondary)
+                TextField(
+                    String(
+                        localized: "globalSearch.palette.placeholder",
+                        defaultValue: "Search all windows, panels, browser tabs..."
+                    ),
+                    text: $model.query
+                )
+                .textFieldStyle(.plain)
+                .cmuxFont(size: 18, weight: .regular)
+                .focused($searchFieldFocused)
             }
-            return false
+            .padding(.horizontal, 18)
+            .frame(height: 56)
+
+            Divider()
+
+            if model.results.isEmpty {
+                GlobalSearchEmptyStateView(
+                    title: model.query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                        ? String(localized: "globalSearch.empty.noOpenPanels", defaultValue: "No open panels")
+                        : String(localized: "globalSearch.empty.noResults", defaultValue: "No results")
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(model.results) { row in
+                            GlobalSearchResultRowView(
+                                row: row,
+                                isSelected: model.selectedIndex == row.index,
+                                action: {
+                                    model.selectedIndex = row.index
+                                    model.openSelectedResult()
+                                }
+                            )
+                            .onHover { hovering in
+                                if hovering {
+                                    model.selectedIndex = row.index
+                                }
+                            }
+                        }
+                    }
+                    .padding(.vertical, 6)
+                }
+            }
         }
-    }
-
-    private func isSystemCommand(_ event: GlobalSearchKeyEvent) -> Bool {
-        guard let characters = event.charactersIgnoringModifiers?.lowercased() else { return false }
-        return ["h", "m", "q", "w", ","].contains(characters)
-    }
-
-    private func openSelectedResult() {
-        openResult(at: selectedIndex)
-    }
-
-    private func openResult(at index: Int) {
-        guard results.indices.contains(index) else { return }
-        let row = results[index]
-        coordinator.activate(row.hit, query: row.query)
+        .frame(width: 720, height: 460)
+        .background(.regularMaterial)
+        .onAppear {
+            searchFieldFocused = true
+            onOpen()
+        }
+        .onDisappear {
+            onClose()
+        }
+        .onChange(of: model.openGeneration) { _, _ in
+            searchFieldFocused = true
+        }
+        .onChange(of: model.query) { _, newValue in
+            model.queryDidChange(newValue)
+        }
     }
 }
 
@@ -305,45 +209,6 @@ private struct GlobalSearchEmptyStateView: View {
         Text(title)
             .cmuxFont(size: 14, weight: .medium)
             .foregroundStyle(.secondary)
-    }
-}
-
-private struct GlobalSearchResultRow: Identifiable, Equatable {
-    let hit: SearchIndexHit
-    let query: String
-    let index: Int
-
-    var id: String { hit.id }
-
-    var title: String {
-        let trimmed = hit.title.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty
-            ? String(localized: "globalSearch.untitled", defaultValue: "Untitled")
-            : trimmed
-    }
-
-    var location: String {
-        hit.location.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-
-    var snippet: String {
-        let trimmed = hit.snippet.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? title : trimmed
-    }
-
-    var shortcutLabel: String? {
-        index < 9 ? "⌘\(index + 1)" : nil
-    }
-
-    var systemImageName: String {
-        switch hit.kind {
-        case .browser:
-            return "globe"
-        case .markdown:
-            return "doc.richtext"
-        case .title:
-            return "rectangle.stack"
-        }
     }
 }
 

--- a/Sources/Search/SearchIndex.swift
+++ b/Sources/Search/SearchIndex.swift
@@ -4,6 +4,7 @@ import SQLite3
 enum GlobalSearchKind: String, Codable, Sendable {
     case browser
     case markdown
+    case terminal
     case title
 
     var localizedLabel: String {
@@ -12,6 +13,8 @@ enum GlobalSearchKind: String, Codable, Sendable {
             return String(localized: "globalSearch.kind.browser", defaultValue: "Browser")
         case .markdown:
             return String(localized: "globalSearch.kind.markdown", defaultValue: "Markdown")
+        case .terminal:
+            return String(localized: "globalSearch.kind.terminal", defaultValue: "Terminal")
         case .title:
             return String(localized: "globalSearch.kind.title", defaultValue: "Title")
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1384,6 +1384,8 @@
 		3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */; };
 		8561A0018561A0018561A001 /* GlobalSearchInputOwnershipTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0018561B0018561B001 /* GlobalSearchInputOwnershipTests.swift */; };
 		8561A0058561A0058561A005 /* GlobalSearchKeyEvent+QueryEditing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0058561B0058561B005 /* GlobalSearchKeyEvent+QueryEditing.swift */; };
+		3865A0133865A0133865A013 /* GlobalSearchPaletteModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0133865B0133865B013 /* GlobalSearchPaletteModel.swift */; };
+		3865A0113865A0113865A011 /* GlobalSearchPaletteModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0113865B0113865B011 /* GlobalSearchPaletteModelTests.swift */; };
 		3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */; };
 		D5AAB5856FF095F610EB565A /* GlobalSearchShortcutBehaviorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5AAB5856FF095F610EB565B /* GlobalSearchShortcutBehaviorTests.swift */; };
 		8561A0068561A0068561A006 /* GlobalSearchShortcutPersistencePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0068561B0068561B006 /* GlobalSearchShortcutPersistencePolicyTests.swift */; };
@@ -4418,6 +4420,8 @@
 		3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchDocuments.swift; sourceTree = "<group>"; };
 		8561B0018561B0018561B001 /* GlobalSearchInputOwnershipTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchInputOwnershipTests.swift; sourceTree = "<group>"; };
 		8561B0058561B0058561B005 /* GlobalSearchKeyEvent+QueryEditing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Search/GlobalSearchKeyEvent+QueryEditing.swift"; sourceTree = "<group>"; };
+		3865B0133865B0133865B013 /* GlobalSearchPaletteModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchPaletteModel.swift; sourceTree = "<group>"; };
+		3865B0113865B0113865B011 /* GlobalSearchPaletteModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchPaletteModelTests.swift; sourceTree = "<group>"; };
 		3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchPanelCaptureManager.swift; sourceTree = "<group>"; };
 		D5AAB5856FF095F610EB565B /* GlobalSearchShortcutBehaviorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutBehaviorTests.swift; sourceTree = "<group>"; };
 		8561B0068561B0068561B006 /* GlobalSearchShortcutPersistencePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutPersistencePolicyTests.swift; sourceTree = "<group>"; };
@@ -7701,6 +7705,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */,
 				3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */,
 				3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */,
+				3865B0133865B0133865B013 /* GlobalSearchPaletteModel.swift */,
 				8561B0058561B0058561B005 /* GlobalSearchKeyEvent+QueryEditing.swift */,
 				3865B0033865B0033865B003 /* MenubarSearchPopover.swift */,
 				D10786DB0000000000000002 /* DeferredBrowserPanel.swift */,
@@ -8619,6 +8624,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F54100A1A1B2C3D4E5F60718 /* RestorableAgentSessionStalePIDTests.swift */,
 				F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */,
 				3865B0043865B0043865B004 /* SearchIndexTests.swift */,
+				3865B0113865B0113865B011 /* GlobalSearchPaletteModelTests.swift */,
 				F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */,
 				F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */,
 				FA100001A1B2C3D4E5F60718 /* BrowserImportMappingTests.swift */,
@@ -10544,6 +10550,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					3865A0023865A0023865A002 /* GlobalSearchCoordinator.swift in Sources */,
 				3865A0073865A0073865A007 /* GlobalSearchDocuments.swift in Sources */,
 					8561A0058561A0058561A005 /* GlobalSearchKeyEvent+QueryEditing.swift in Sources */,
+				3865A0133865A0133865A013 /* GlobalSearchPaletteModel.swift in Sources */,
 					3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */,
 				CC2639000000000000000001 /* GotoSplitCycleUITestSupport.swift in Sources */,
 					5B11E5A100000000000000B1 /* GPUSpinner.swift in Sources */,
@@ -12284,6 +12291,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				A10190000000000000000001 /* GhosttyTitleUpdateIngressTests.swift in Sources */,
 				8561A0018561A0018561A001 /* GlobalSearchInputOwnershipTests.swift in Sources */,
+				3865A0113865A0113865A011 /* GlobalSearchPaletteModelTests.swift in Sources */,
 				D5AAB5856FF095F610EB565A /* GlobalSearchShortcutBehaviorTests.swift in Sources */,
 				8561A0068561A0068561A006 /* GlobalSearchShortcutPersistencePolicyTests.swift in Sources */,
 				8561A0028561A0028561A002 /* GlobalSearchShortcutPriorityTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1392,6 +1392,9 @@
 		8561A0028561A0028561A002 /* GlobalSearchShortcutPriorityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0028561B0028561B002 /* GlobalSearchShortcutPriorityTests.swift */; };
 		8561A0048561A0048561A004 /* GlobalSearchShortcutSettingsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0048561B0048561B004 /* GlobalSearchShortcutSettingsModelTests.swift */; };
 		3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */; };
+		3865A0123865A0123865A012 /* GlobalSearchTerminalDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0123865B0123865B012 /* GlobalSearchTerminalDocumentTests.swift */; };
+		3865A0153865A0153865A015 /* GlobalSearchTerminalText.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0153865B0153865B015 /* GlobalSearchTerminalText.swift */; };
+		3865A0143865A0143865A014 /* GlobalSearchTerminalTextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3865B0143865B0143865B014 /* GlobalSearchTerminalTextTests.swift */; };
 		8561A0038561A0038561A003 /* GlobalSearchVisiblePopoverShortcutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8561B0038561B0038561B003 /* GlobalSearchVisiblePopoverShortcutTests.swift */; };
 		CC000000A1B2C3D4E5F60718 /* GotoSplitCycleUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC000001A1B2C3D4E5F60718 /* GotoSplitCycleUITests.swift */; };
 		CC2639000000000000000001 /* GotoSplitCycleUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC2639000000000000000002 /* GotoSplitCycleUITestSupport.swift */; };
@@ -4428,6 +4431,9 @@
 		8561B0028561B0028561B002 /* GlobalSearchShortcutPriorityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutPriorityTests.swift; sourceTree = "<group>"; };
 		8561B0048561B0048561B004 /* GlobalSearchShortcutSettingsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutSettingsModelTests.swift; sourceTree = "<group>"; };
 		3865B0053865B0053865B005 /* GlobalSearchShortcutSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchShortcutSettingsTests.swift; sourceTree = "<group>"; };
+		3865B0123865B0123865B012 /* GlobalSearchTerminalDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchTerminalDocumentTests.swift; sourceTree = "<group>"; };
+		3865B0153865B0153865B015 /* GlobalSearchTerminalText.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Search/GlobalSearchTerminalText.swift; sourceTree = "<group>"; };
+		3865B0143865B0143865B014 /* GlobalSearchTerminalTextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchTerminalTextTests.swift; sourceTree = "<group>"; };
 		8561B0038561B0038561B003 /* GlobalSearchVisiblePopoverShortcutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlobalSearchVisiblePopoverShortcutTests.swift; sourceTree = "<group>"; };
 		CC000001A1B2C3D4E5F60718 /* GotoSplitCycleUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GotoSplitCycleUITests.swift; sourceTree = "<group>"; };
 		CC2639000000000000000002 /* GotoSplitCycleUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/UITests/GotoSplitCycleUITestSupport.swift; sourceTree = "<group>"; };
@@ -7705,6 +7711,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				3865B0073865B0073865B007 /* GlobalSearchDocuments.swift */,
 				3865B0083865B0083865B008 /* GlobalSearchPanelCaptureManager.swift */,
 				3865B0023865B0023865B002 /* GlobalSearchCoordinator.swift */,
+				3865B0153865B0153865B015 /* GlobalSearchTerminalText.swift */,
 				3865B0133865B0133865B013 /* GlobalSearchPaletteModel.swift */,
 				8561B0058561B0058561B005 /* GlobalSearchKeyEvent+QueryEditing.swift */,
 				3865B0033865B0033865B003 /* MenubarSearchPopover.swift */,
@@ -8624,6 +8631,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				F54100A1A1B2C3D4E5F60718 /* RestorableAgentSessionStalePIDTests.swift */,
 				F5300001A1B2C3D4E5F60718 /* RovoDevSessionIndexTests.swift */,
 				3865B0043865B0043865B004 /* SearchIndexTests.swift */,
+				3865B0143865B0143865B014 /* GlobalSearchTerminalTextTests.swift */,
+				3865B0123865B0123865B012 /* GlobalSearchTerminalDocumentTests.swift */,
 				3865B0113865B0113865B011 /* GlobalSearchPaletteModelTests.swift */,
 				F5300003A1B2C3D4E5F60718 /* RovoDevTranscriptPreviewTests.swift */,
 				F5310001A1B2C3D4E5F60718 /* RovoDevHookConfigTests.swift */,
@@ -10552,6 +10561,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					8561A0058561A0058561A005 /* GlobalSearchKeyEvent+QueryEditing.swift in Sources */,
 				3865A0133865A0133865A013 /* GlobalSearchPaletteModel.swift in Sources */,
 					3865A0083865A0083865A008 /* GlobalSearchPanelCaptureManager.swift in Sources */,
+				3865A0153865A0153865A015 /* GlobalSearchTerminalText.swift in Sources */,
 				CC2639000000000000000001 /* GotoSplitCycleUITestSupport.swift in Sources */,
 					5B11E5A100000000000000B1 /* GPUSpinner.swift in Sources */,
 					A6AC72010000000000000001 /* GPUSpinnerNSView.swift in Sources */,
@@ -12297,6 +12307,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8561A0028561A0028561A002 /* GlobalSearchShortcutPriorityTests.swift in Sources */,
 				8561A0048561A0048561A004 /* GlobalSearchShortcutSettingsModelTests.swift in Sources */,
 				3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */,
+				3865A0123865A0123865A012 /* GlobalSearchTerminalDocumentTests.swift in Sources */,
+				3865A0143865A0143865A014 /* GlobalSearchTerminalTextTests.swift in Sources */,
 				8561A0038561A0038561A003 /* GlobalSearchVisiblePopoverShortcutTests.swift in Sources */,
 					937700020000000000000001 /* GrokVaultAgentPersistenceTests.swift in Sources */,
 				9520A0019520A0019520A001 /* HermesFirstClassSupportTests.swift in Sources */,

--- a/cmuxTests/GlobalSearchPaletteModelTests.swift
+++ b/cmuxTests/GlobalSearchPaletteModelTests.swift
@@ -1,0 +1,175 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+private final class PaletteClientRecorder {
+    var refreshCount = 0
+    var searchQueries: [String] = []
+    var searchResults: [SearchIndexHit] = []
+    var browseResults: [SearchIndexHit] = []
+    var activated: [(hit: SearchIndexHit, query: String)] = []
+    var dismissCount = 0
+    var paletteVisible = true
+
+    func makeClient() -> GlobalSearchPaletteModel.Client {
+        GlobalSearchPaletteModel.Client(
+            refreshLiveIndex: { self.refreshCount += 1 },
+            search: { query in
+                self.searchQueries.append(query)
+                return self.searchResults
+            },
+            browseOpenPanels: { _ in self.browseResults },
+            activate: { hit, query in self.activated.append((hit, query)) },
+            dismissPalette: { self.dismissCount += 1 },
+            isPaletteVisible: { self.paletteVisible }
+        )
+    }
+}
+
+private func makeHit(id: String = "hit-1", title: String = "Panel") -> SearchIndexHit {
+    SearchIndexHit(
+        id: id,
+        windowID: UUID(),
+        workspaceID: UUID(),
+        panelID: UUID(),
+        kind: .title,
+        title: title,
+        location: "Window > Workspace",
+        anchor: "panel",
+        snippet: title,
+        rank: 0,
+        timestamp: .now
+    )
+}
+
+private func makeKeyEvent(
+    keyCode: UInt16,
+    characters: String? = nil,
+    modifierFlags: NSEvent.ModifierFlags = []
+) -> GlobalSearchKeyEvent {
+    let event = NSEvent.keyEvent(
+        with: .keyDown,
+        location: .zero,
+        modifierFlags: modifierFlags,
+        timestamp: 0,
+        windowNumber: 0,
+        context: nil,
+        characters: characters ?? "",
+        charactersIgnoringModifiers: characters ?? "",
+        isARepeat: false,
+        keyCode: keyCode
+    )!
+    return GlobalSearchKeyEvent(event)
+}
+
+@MainActor
+@Suite(.serialized) struct GlobalSearchPaletteModelTests {
+    @Test func prepareForOpenRefreshesLiveIndexOnEveryOpen() async throws {
+        let recorder = PaletteClientRecorder()
+        let model = GlobalSearchPaletteModel(client: recorder.makeClient())
+
+        model.prepareForOpen()
+        model.prepareForOpen()
+        // The refresh task is scheduled on the main actor; let it run.
+        try await Task.sleep(for: .milliseconds(50))
+
+        #expect(recorder.refreshCount == 2)
+        #expect(model.openGeneration == 2)
+    }
+
+    @Test func prepareForOpenResetsStaleQueryAndSelection() {
+        let recorder = PaletteClientRecorder()
+        recorder.browseResults = [makeHit()]
+        let model = GlobalSearchPaletteModel(client: recorder.makeClient())
+        model.query = "stale query"
+        model.selectedIndex = 3
+
+        model.prepareForOpen()
+
+        #expect(model.query.isEmpty)
+        #expect(model.selectedIndex == 0)
+        #expect(model.results.count == 1)
+    }
+
+    @Test func queryChangeRunsDebouncedSearch() async throws {
+        let recorder = PaletteClientRecorder()
+        recorder.searchResults = [makeHit(id: "match")]
+        let model = GlobalSearchPaletteModel(
+            client: recorder.makeClient(),
+            searchDebounceDelay: .milliseconds(1)
+        )
+
+        model.queryDidChange("needle")
+        try await Task.sleep(for: .milliseconds(80))
+
+        #expect(recorder.searchQueries == ["needle"])
+        #expect(model.results.map(\.id) == ["match"])
+        #expect(!model.isSearching)
+    }
+
+    @Test func returnKeyActivatesSelectedResult() async throws {
+        let recorder = PaletteClientRecorder()
+        recorder.searchResults = [makeHit(id: "first"), makeHit(id: "second")]
+        let model = GlobalSearchPaletteModel(
+            client: recorder.makeClient(),
+            searchDebounceDelay: .milliseconds(1)
+        )
+        model.queryDidChange("needle")
+        try await Task.sleep(for: .milliseconds(80))
+
+        model.selectedIndex = 1
+        let consumed = model.handleKeyEvent(makeKeyEvent(keyCode: 36))
+
+        #expect(consumed)
+        #expect(recorder.activated.map(\.hit.id) == ["second"])
+        #expect(recorder.activated.map(\.query) == ["needle"])
+    }
+
+    @Test func escapeDismissesPalette() {
+        let recorder = PaletteClientRecorder()
+        let model = GlobalSearchPaletteModel(client: recorder.makeClient())
+
+        let consumed = model.handleKeyEvent(makeKeyEvent(keyCode: 53))
+
+        #expect(consumed)
+        #expect(recorder.dismissCount == 1)
+    }
+
+    @Test func arrowKeysClampSelectionToResults() {
+        let recorder = PaletteClientRecorder()
+        recorder.browseResults = [makeHit(id: "a"), makeHit(id: "b")]
+        let model = GlobalSearchPaletteModel(client: recorder.makeClient())
+        model.prepareForOpen()
+
+        #expect(model.handleKeyEvent(makeKeyEvent(keyCode: 126)))
+        #expect(model.selectedIndex == 0)
+        #expect(model.handleKeyEvent(makeKeyEvent(keyCode: 125)))
+        #expect(model.handleKeyEvent(makeKeyEvent(keyCode: 125)))
+        #expect(model.selectedIndex == 1)
+    }
+
+    @Test func keyEventsIgnoredWhilePaletteHidden() {
+        let recorder = PaletteClientRecorder()
+        recorder.paletteVisible = false
+        let model = GlobalSearchPaletteModel(client: recorder.makeClient())
+
+        #expect(!model.handleKeyEvent(makeKeyEvent(keyCode: 36)))
+        #expect(recorder.activated.isEmpty)
+    }
+
+    @Test func openResultOutOfBoundsDoesNothing() {
+        let recorder = PaletteClientRecorder()
+        let model = GlobalSearchPaletteModel(client: recorder.makeClient())
+
+        model.openResult(at: 5)
+
+        #expect(recorder.activated.isEmpty)
+    }
+}

--- a/cmuxTests/GlobalSearchTerminalDocumentTests.swift
+++ b/cmuxTests/GlobalSearchTerminalDocumentTests.swift
@@ -1,0 +1,92 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+private final class StubTerminalContextPanel: Panel {
+    let id = UUID()
+    let stableSurfaceIdentity = PanelStableSurfaceIdentity()
+    var panelType: PanelType { .terminal }
+    var displayTitle: String { "Stub Terminal" }
+
+    func close() {}
+    func focus() {}
+    func unfocus() {}
+    func triggerFlash(reason: WorkspaceAttentionFlashReason) {}
+}
+
+@MainActor
+private func makeContext(
+    panelID: UUID = UUID(),
+    panelTitle: String = "agent — zsh"
+) -> GlobalSearchPanelContext {
+    GlobalSearchPanelContext(
+        windowID: UUID(),
+        windowTitle: "Window",
+        workspaceID: UUID(),
+        workspaceTitle: "Workspace",
+        panelID: panelID,
+        panelTitle: panelTitle,
+        panel: StubTerminalContextPanel()
+    )
+}
+
+@MainActor
+@Suite struct GlobalSearchTerminalDocumentTests {
+    @Test func buildsDocumentWithStableIDAndTerminalKind() throws {
+        let panelID = UUID()
+        let context = makeContext(panelID: panelID)
+
+        let document = GlobalSearchDocuments.terminalDocument(for: context, text: "error: connection refused")
+
+        let unwrapped = try #require(document)
+        #expect(unwrapped.id == SearchIndexDocument.panelStableID(panelID: panelID, kind: .terminal))
+        #expect(unwrapped.kind == .terminal)
+        #expect(unwrapped.panelID == panelID)
+        #expect(unwrapped.title == "agent — zsh")
+        #expect(unwrapped.text == "error: connection refused")
+        #expect(unwrapped.location == context.location)
+    }
+
+    @Test func rebuildingForTheSamePanelKeepsTheDocumentID() {
+        let panelID = UUID()
+        let first = GlobalSearchDocuments.terminalDocument(
+            for: makeContext(panelID: panelID),
+            text: "first capture"
+        )
+        let second = GlobalSearchDocuments.terminalDocument(
+            for: makeContext(panelID: panelID),
+            text: "second capture with more output"
+        )
+
+        #expect(first?.id == second?.id)
+    }
+
+    @Test func whitespaceOnlyScrollbackProducesNoDocument() {
+        let document = GlobalSearchDocuments.terminalDocument(for: makeContext(), text: " \n\t\n ")
+
+        #expect(document == nil)
+    }
+
+    @Test func oversizedScrollbackIsCappedToIndexingLimit() {
+        let oversized = String(repeating: "x", count: GlobalSearchIndexingLimits.maxIndexedTextCharacters + 500)
+
+        let document = GlobalSearchDocuments.terminalDocument(for: makeContext(), text: oversized)
+
+        #expect(document?.text.count == GlobalSearchIndexingLimits.maxIndexedTextCharacters)
+    }
+
+    @Test func browseHitLabelsTerminalPanelsWithTerminalKind() {
+        let context = makeContext()
+
+        let hit = GlobalSearchDocuments.browseHit(for: context)
+
+        #expect(hit.kind == .terminal)
+    }
+}

--- a/cmuxTests/GlobalSearchTerminalTextTests.swift
+++ b/cmuxTests/GlobalSearchTerminalTextTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct GlobalSearchTerminalTextTests {
+    @Test func plainTextPassesThroughUnchanged() {
+        let text = "npm ERR! module not found\nnpm ERR! see log\n"
+
+        #expect(GlobalSearchTerminalText.strippedVT(text) == text)
+    }
+
+    @Test func stripsSGRColorSequences() {
+        let styled = "\u{1B}[31merror\u{1B}[0m: connection refused"
+
+        #expect(GlobalSearchTerminalText.strippedVT(styled) == "error: connection refused")
+    }
+
+    @Test func stripsCursorAndEraseSequences() {
+        let redrawn = "\u{1B}[2J\u{1B}[H\u{1B}[1;32mready\u{1B}[K"
+
+        #expect(GlobalSearchTerminalText.strippedVT(redrawn) == "ready")
+    }
+
+    @Test func stripsHyperlinkOSCTerminatedByBell() {
+        let linked = "see \u{1B}]8;;https://example.test\u{07}the docs\u{1B}]8;;\u{07} now"
+
+        #expect(GlobalSearchTerminalText.strippedVT(linked) == "see the docs now")
+    }
+
+    @Test func stripsOSCTerminatedByStringTerminator() {
+        let titled = "\u{1B}]0;agent — zsh\u{1B}\\prompt$ ls"
+
+        #expect(GlobalSearchTerminalText.strippedVT(titled) == "prompt$ ls")
+    }
+
+    @Test func stripsTwoByteEscapes() {
+        let charset = "\u{1B}(Bplain\u{1B}=text"
+
+        #expect(GlobalSearchTerminalText.strippedVT(charset) == "plaintext")
+    }
+
+    @Test func keepsNewlinesAndTabsButDropsOtherControls() {
+        let mixed = "col1\tcol2\nrow\u{07}end\u{00}"
+
+        #expect(GlobalSearchTerminalText.strippedVT(mixed) == "col1\tcol2\nrowend")
+    }
+
+    @Test func truncatedSequenceAtEndDoesNotLeakEscapeBytes() {
+        let truncated = "tail of output\u{1B}[38;5;"
+
+        let stripped = GlobalSearchTerminalText.strippedVT(truncated)
+
+        #expect(stripped == "tail of output")
+        #expect(!stripped.contains("\u{1B}"))
+    }
+
+    @Test func fingerprintIsStableAcrossCallsAndSensitiveToContent() {
+        let text = "deploy 31771540184 succeeded"
+
+        #expect(GlobalSearchTerminalText.fingerprint(text) == GlobalSearchTerminalText.fingerprint(text))
+        #expect(GlobalSearchTerminalText.fingerprint(text) != GlobalSearchTerminalText.fingerprint(text + " "))
+    }
+
+    @Test func fingerprintOfEmptyTextIsTheOffsetBasis() {
+        #expect(GlobalSearchTerminalText.fingerprint("") == 0xcbf2_9ce4_8422_2325)
+    }
+}

--- a/cmuxTests/SearchIndexTests.swift
+++ b/cmuxTests/SearchIndexTests.swift
@@ -224,6 +224,56 @@ final class SearchIndexTests: XCTestCase {
         )
     }
 
+    func testSearchFindsTerminalScrollbackAndClosePurgesItWithTheTitleDocument() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }
+
+        let index = try SearchIndex(databaseURL: fixture.databaseURL)
+        let windowID = UUID()
+        let workspaceID = UUID()
+        let panelID = UUID()
+
+        try await index.upsert(
+            SearchIndexDocument(
+                id: SearchIndexDocument.panelStableID(panelID: panelID, kind: .title),
+                windowID: windowID,
+                workspaceID: workspaceID,
+                panelID: panelID,
+                kind: .title,
+                title: "agent — zsh",
+                location: "Window > Workspace",
+                anchor: "title",
+                text: "agent — zsh"
+            )
+        )
+        try await index.upsert(
+            SearchIndexDocument(
+                id: SearchIndexDocument.panelStableID(panelID: panelID, kind: .terminal),
+                windowID: windowID,
+                workspaceID: workspaceID,
+                panelID: panelID,
+                kind: .terminal,
+                title: "agent — zsh",
+                location: "Window > Workspace",
+                anchor: "terminal",
+                text: "npm ERR! elderberry module not found"
+            )
+        )
+
+        let hits = try await index.search("elderberry", limit: 10)
+        XCTAssertEqual(hits.map(\.kind), [.terminal])
+        XCTAssertEqual(hits.first?.panelID, panelID)
+
+        // Closing the panel purges every document it owns, scrollback included,
+        // so a stale hit can no longer route to a surface that is gone.
+        try await index.deletePanel(panelID)
+
+        let scrollbackHitsAfterClose = try await index.search("elderberry", limit: 10)
+        XCTAssertEqual(scrollbackHitsAfterClose, [])
+        let titleHitsAfterClose = try await index.search("zsh", limit: 10)
+        XCTAssertEqual(titleHitsAfterClose, [])
+    }
+
     func testDeletePanelRemovesIndexedDocuments() async throws {
         let fixture = try makeFixture()
         defer { try? FileManager.default.removeItem(at: fixture.directoryURL) }


### PR DESCRIPTION
Global search reached browser and markdown panel contents but saw terminals by title only, so "which pane printed that error" had no answer while the pane was still open — the one place people look when running many agents. Refs #1786.

## What

- **`.terminal` document kind**, captured during the palette's live re-index through `boundedScreenTailVT`. Ghostty applies the row and byte bounds before anything crosses the FFI and performs the read on the teardown coordinator, so the 50 MB default scrollback (`GhosttyConfig.scrollbackLimit`) never lands on the main actor. Reading through `readTerminalTextRawSnapshot` instead would have copied the whole history there and tailed it afterwards — the stall #5757 fixed for `surface.read_text`. Bounded at 4000 rows (what session snapshots already persist), 1.5 MB of VT, and the existing 400k character cap.
- **The tail arrives as VT**, so it is sanitized before indexing — escape sequences would otherwise inflate documents, tokenize into junk, and appear inside result snippets. The sanitizer is a pure function with its own tests.
- **Unchanged scrollback is skipped** by fingerprint, so reopening the palette over idle terminals writes nothing.
- **Enter on a terminal hit** focuses the pane and opens the surface find bar on the needle through `startOrFocusTerminalSearch`, the same entry point Cmd+F uses; Ghostty searches screen and history on its own thread and scrolls to the match.
- **`TerminalPanel.close()` now purges its documents.** Terminals were the one panel type that never called `purgePanel`, so their rows survived until relaunch — harmless while it was only a title, a stale hit routing to a dead surface once it is scrollback.

## Why the popover refactor comes first

The capture hangs off `refreshLiveIndex()`, which was only reachable through SwiftUI `onAppear`. The hosting controller is built once in `init` and survives every close, so that fires around the first open only — panels opened later never got indexed. The same retained view explains the other two defects in #7445: the stale query and the missing key monitor (hence Return not activating the selected result).

So the first two commits extract the palette state into `GlobalSearchPaletteModel` and move the per-open lifecycle to `show()` / `popoverDidClose()`, which run on every open. That fixes #7445 points 2-3 as a side effect and makes the palette testable without driving a popover.

## Scope

Deliberately out: chunking and per-kind bm25 weights (a long terminal document ranks below short title documents), background indexing on terminal output, and jumping to the specific match rather than the first hit for the needle. Index freshness is the moment the palette opens.

## Verification

Local, on this machine:

- `xcodebuild -scheme cmux-unit -configuration Debug -destination 'platform=macOS' build-for-testing` — green (it caught a missing `import CmuxTerminal` that `swiftc -parse` does not)
- `xcodebuild test-without-building` over `GlobalSearchPaletteModelTests`, `GlobalSearchTerminalTextTests`, `GlobalSearchTerminalDocumentTests`, `SearchIndexTests` — 23 tests, green. The sanitizer tests earned their keep: they caught `ESC ( B` losing its designator.
- `./scripts/check-pbxproj.sh`, `./scripts/lint-pbxproj-test-wiring.sh`, `python3 -m json.tool Resources/Localizable.xcstrings` — green

CI does not run on fork PRs (`action_required`), so the runtime pass — open the palette, search for something an agent printed, press Return — is on a maintainer.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11665"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790945404&installation_model_id=21920&pr_number=11665&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11665&signature=6547d766e65c3f90b2157a1616d13464d9870233ea8d0c6ae08f9673020be5be"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Global search now indexes live terminal scrollback, so you can find which open pane printed an error instead of matching terminals by title only. Refs #1786.

- Adds a `.terminal` document kind captured on palette open via `boundedScreenTailVT`, bounded at 4000 rows and 1.5 MB so the 50 MB default scrollback never lands on the main actor.
- Strips VT escape sequences before indexing so they don't inflate documents, tokenize into junk, or appear in snippets.
- Skips unchanged scrollback by fingerprint, so reopening the palette over idle terminals writes nothing.
- Enter on a terminal hit focuses the pane and opens the surface find bar on the needle, the same entry point Cmd+F uses.
- `TerminalPanel.close()` now purges its documents; previously terminal rows survived until relaunch.

**Refactor**
- Extracts palette state into `GlobalSearchPaletteModel` and moves the per-open lifecycle from SwiftUI `onAppear` to `show()` / `popoverDidClose()`.
- The hosting controller is retained across closes, so `onAppear` only fired on first open — later panels were never indexed; the stale query and missing key monitor defects (#7445) are fixed as a side effect.

<sup>Written for commit 9283696f097b9560b5c8709175dae1255eb606a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11665?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Global Search now includes terminal panel scrollback and titles.
  - Search results identify terminal matches and open the relevant panel’s inline search.
  - Terminal content is cleaned for more relevant, bounded search results.
  - Search palette interactions now support reliable refreshing, keyboard navigation, selection, and activation.
  - Added English and Japanese labels for terminal search results.

- **Bug Fixes**
  - Closing a terminal panel now removes its content from Global Search.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->