### PR TITLE
Notif redesign scrollspy

### DIFF
--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsScrollSpy.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsScrollSpy.swift
@@ -9,10 +9,13 @@ enum SettingsScrollSpy {
     /// reported relative to it.
     static let coordinateSpace = "settingsDetailScroll"
 
-    /// A section becomes "current" once its top scrolls to within this many
-    /// points of the viewport top. Sits below the detail's top padding so the
-    /// first section is selected at rest.
-    static let activationLine: CGFloat = 96
+    /// A section becomes "current" once its top scrolls up to within this many
+    /// points of the viewport top — i.e. when its header essentially reaches the
+    /// top edge. Aligned with the detail's 20pt top padding so the section
+    /// sitting at the top is the highlighted one, and the first section is
+    /// selected at rest. Keep this small: larger values switch the highlight
+    /// while the next section's header is still well below the top (too early).
+    static let activationLine: CGFloat = 20
 
     /// Picks the active section from the reported top offsets.
     ///

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsScrollSpy.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsScrollSpy.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// Scroll-spy plumbing for the settings detail pane: each section reports its
+/// top offset within the detail `ScrollView`, and the sidebar highlight follows
+/// whichever section currently sits at the top of the viewport. This is the
+/// reverse of the existing click→scroll flow (which stays as-is).
+enum SettingsScrollSpy {
+    /// Named coordinate space of the detail `ScrollView`; section offsets are
+    /// reported relative to it.
+    static let coordinateSpace = "settingsDetailScroll"
+
+    /// A section becomes "current" once its top scrolls to within this many
+    /// points of the viewport top. Sits below the detail's top padding so the
+    /// first section is selected at rest.
+    static let activationLine: CGFloat = 96
+
+    /// Picks the active section from the reported top offsets.
+    ///
+    /// Offsets are each section top's `minY` in the scroll coordinate space:
+    /// ~0 when a section is pinned to the top, negative once scrolled above it.
+    /// The active section is the one whose top is nearest the activation line
+    /// from above (i.e. already scrolled past it). When nothing has reached the
+    /// line yet (viewport sitting above the first section), the topmost section
+    /// wins so the first row stays selected at rest.
+    static func activeSection(
+        offsets: [SettingsSectionID: CGFloat],
+        activationLine: CGFloat = SettingsScrollSpy.activationLine
+    ) -> SettingsSectionID? {
+        guard !offsets.isEmpty else { return nil }
+        let reached = offsets.filter { $0.value <= activationLine }
+        if let best = reached.max(by: { $0.value < $1.value }) {
+            return best.key
+        }
+        return offsets.min(by: { $0.value < $1.value })?.key
+    }
+}
+
+/// Collects each section's top offset (keyed by section) up the view tree.
+struct SettingsSectionOffsetKey: PreferenceKey {
+    static var defaultValue: [SettingsSectionID: CGFloat] { [:] }
+    static func reduce(
+        value: inout [SettingsSectionID: CGFloat],
+        nextValue: () -> [SettingsSectionID: CGFloat]
+    ) {
+        value.merge(nextValue()) { _, new in new }
+    }
+}
+
+extension View {
+    /// Tags a settings section with its scroll anchor id (matching
+    /// `SettingsWindowRoot.anchorID(for:)`) and reports its top offset in the
+    /// detail scroll's coordinate space so scroll-spy can track it. Replaces the
+    /// bare `.id(anchorID(for:))` the sections used before.
+    func settingsSectionAnchor(_ section: SettingsSectionID) -> some View {
+        background(
+            GeometryReader { proxy in
+                Color.clear.preference(
+                    key: SettingsSectionOffsetKey.self,
+                    value: [section: proxy.frame(in: .named(SettingsScrollSpy.coordinateSpace)).minY]
+                )
+            }
+        )
+        .id("section:\(section.rawValue)")
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -65,6 +65,12 @@ public struct SettingsWindowRoot: View {
     // seeds the row's `TimelineView` fade. Read by every
     // `SettingsCardRow` through `\.settingsSearchHighlightState`.
     @State private var searchHighlight = SettingsSearchHighlightState(anchorID: nil, token: 0, startedAt: nil)
+    // Scroll-spy suppression window. A sidebar click drives an animated
+    // programmatic scroll; while that animation runs, scroll-spy must not
+    // override the clicked selection with intermediate sections it passes over.
+    // `applyScrollNavigation` arms this; `handleScrollSpy` ignores updates until
+    // it elapses.
+    @State private var programmaticScrollUntil: Date = .distantPast
 
     private var defaultsStore: UserDefaultsSettingsStore { runtime.userDefaultsStore }
     private var jsonStore: JSONConfigStore { runtime.jsonStore }
@@ -346,6 +352,12 @@ public struct SettingsWindowRoot: View {
                     .padding(.bottom, 20)
                 }
                 .toggleStyle(.switch)
+                // Scroll-spy: sections report their top offset in this space and
+                // the sidebar highlight follows the section at the top.
+                .coordinateSpace(name: SettingsScrollSpy.coordinateSpace)
+                .onPreferenceChange(SettingsSectionOffsetKey.self) { offsets in
+                    handleScrollSpy(offsets)
+                }
                 .onAppear {
                     // Legacy SettingsView.onAppear scrolls to the restored
                     // section so reopening the Settings window lands on
@@ -394,6 +406,9 @@ public struct SettingsWindowRoot: View {
         let anchorID = (notification.userInfo?["anchor"] as? String) ?? self.anchorID(for: target)
         let shouldHighlight = (notification.userInfo?["highlight"] as? Bool) ?? false
         let sectionID = self.anchorID(for: target)
+        // Suppress scroll-spy for the duration of the programmatic scroll so it
+        // doesn't fight the animation or land on a section passed en route.
+        programmaticScrollUntil = Date().addingTimeInterval(0.45)
         settingsNavigationGeneration += 1
         let navigationGeneration = settingsNavigationGeneration
         // Arm (or clear) the highlight before the scroll so the pulse is
@@ -429,6 +444,30 @@ public struct SettingsWindowRoot: View {
         }
     }
 
+    /// Scroll-spy entry point: given the sections' reported top offsets, moves
+    /// the sidebar highlight to the section at the top of the viewport.
+    ///
+    /// Disabled while searching (the sidebar is a filtered result list, not a
+    /// continuous section map) and while a click-driven programmatic scroll is
+    /// still animating (so a click's target isn't overridden mid-scroll).
+    private func handleScrollSpy(_ offsets: [SettingsSectionID: CGFloat]) {
+        guard !isSearching else { return }
+        guard Date() >= programmaticScrollUntil else { return }
+        guard let active = SettingsScrollSpy.activeSection(offsets: offsets) else { return }
+        highlightSectionFromScroll(active)
+    }
+
+    /// Updates the sidebar highlight and section pane to `section` *directly*,
+    /// bypassing `selectSidebarEntry`/the navigation post — otherwise scroll-spy
+    /// would trigger a scroll and fight the user. Guarded so it only writes on a
+    /// real change, which also throttles the `@AppStorage` (UserDefaults) writes
+    /// to once per section boundary crossing.
+    private func highlightSectionFromScroll(_ section: SettingsSectionID) {
+        let entryID = sectionEntryID(for: section)
+        if selectedSidebarEntryID != entryID { selectedSidebarEntryID = entryID }
+        if selectedSectionRaw != section.rawValue { selectedSectionRaw = section.rawValue }
+    }
+
     @ViewBuilder
     private var sectionStack: some View {
         // Order matches the legacy in-app SettingsView scroll order:
@@ -440,14 +479,14 @@ public struct SettingsWindowRoot: View {
             catalog: catalog,
             accountFlow: accountFlow
         )
-        .id(anchorID(for: .account))
+        .settingsSectionAnchor(.account)
 
         AppSection(
             defaultsStore: defaultsStore,
             catalog: catalog,
             hostActions: hostActions
         )
-        .id(anchorID(for: .app))
+        .settingsSectionAnchor(.app)
 
         TerminalSection(
             defaultsStore: defaultsStore,
@@ -455,25 +494,25 @@ public struct SettingsWindowRoot: View {
             catalog: catalog,
             hostActions: hostActions
         )
-        .id(anchorID(for: .terminal))
+        .settingsSectionAnchor(.terminal)
 
         TextBoxSection(defaultsStore: defaultsStore, catalog: catalog)
-            .id(anchorID(for: .textBox))
+            .settingsSectionAnchor(.textBox)
 
         SleepyModeSection(hostActions: hostActions, store: hostActions.sleepyModeStore())
-            .id(anchorID(for: .sleepyMode))
+            .settingsSectionAnchor(.sleepyMode)
 
         MobileSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)
-            .id(anchorID(for: .mobile))
+            .settingsSectionAnchor(.mobile)
 
         CloudMachinesSection(hostActions: hostActions)
-            .id(anchorID(for: .cloudMachines))
+            .settingsSectionAnchor(.cloudMachines)
 
         IrohNetworkingSection(hostActions: hostActions)
-            .id(anchorID(for: .networking))
+            .settingsSectionAnchor(.networking)
 
         SidebarSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)
-            .id(anchorID(for: .sidebarAppearance))
+            .settingsSectionAnchor(.sidebarAppearance)
 
         CustomSidebarsSection(
             defaultsStore: defaultsStore,
@@ -481,10 +520,10 @@ public struct SettingsWindowRoot: View {
             catalog: catalog,
             errorLog: runtime.errorLog
         )
-        .id(anchorID(for: .customSidebars))
+        .settingsSectionAnchor(.customSidebars)
 
         BetaFeaturesSection(defaultsStore: defaultsStore, catalog: catalog)
-            .id(anchorID(for: .betaFeatures))
+            .settingsSectionAnchor(.betaFeatures)
         AutomationSection(
             defaultsStore: defaultsStore,
             jsonStore: jsonStore,
@@ -493,7 +532,7 @@ public struct SettingsWindowRoot: View {
             errorLog: runtime.errorLog,
             hostActions: hostActions
         )
-        .id(anchorID(for: .automation))
+        .settingsSectionAnchor(.automation)
 
         ComputerUseSection(
             jsonStore: jsonStore,
@@ -501,7 +540,7 @@ public struct SettingsWindowRoot: View {
             errorLog: runtime.errorLog,
             hostActions: hostActions
         )
-        .id(anchorID(for: .computerUse))
+        .settingsSectionAnchor(.computerUse)
 
         BrowserSection(
             defaultsStore: defaultsStore,
@@ -509,7 +548,7 @@ public struct SettingsWindowRoot: View {
             hostActions: hostActions,
             importAnchorID: anchorID(for: .browserImport)
         )
-        .id(anchorID(for: .browser))
+        .settingsSectionAnchor(.browser)
 
         GlobalHotkeySection(
             defaultsStore: defaultsStore,
@@ -517,7 +556,7 @@ public struct SettingsWindowRoot: View {
             catalog: catalog, errorLog: runtime.errorLog,
             hostActions: hostActions
         )
-        .id(anchorID(for: .globalHotkey))
+        .settingsSectionAnchor(.globalHotkey)
 
         KeyboardShortcutsSection(
             jsonStore: jsonStore, userDefaultsStore: defaultsStore,
@@ -525,7 +564,7 @@ public struct SettingsWindowRoot: View {
             errorLog: runtime.errorLog,
             hostActions: hostActions
         )
-        .id(anchorID(for: .keyboardShortcuts))
+        .settingsSectionAnchor(.keyboardShortcuts)
 
         WorkspaceColorsSection(
             defaultsStore: defaultsStore,
@@ -533,10 +572,10 @@ public struct SettingsWindowRoot: View {
             catalog: catalog,
             errorLog: runtime.errorLog
         )
-        .id(anchorID(for: .workspaceColors))
+        .settingsSectionAnchor(.workspaceColors)
 
         SettingsJSONSection(jsonStore: jsonStore, hostActions: hostActions)
-            .id(anchorID(for: .settingsJSON))
+            .settingsSectionAnchor(.settingsJSON)
 
         ResetSection(
             defaultsStore: defaultsStore,
@@ -544,7 +583,7 @@ public struct SettingsWindowRoot: View {
             catalog: catalog,
             hostActions: hostActions
         )
-        .id(anchorID(for: .reset))
+        .settingsSectionAnchor(.reset)
     }
 
     private func anchorID(for section: SettingsSectionID) -> String {

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsScrollSpyTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsScrollSpyTests.swift
@@ -1,0 +1,33 @@
+import Testing
+import Foundation
+import CoreGraphics
+
+@testable import CmuxSettingsUI
+
+@Suite struct SettingsScrollSpyTests {
+    // Offsets are each section top's minY in the scroll space: ~0 at the top,
+    // negative once scrolled above the viewport top.
+
+    @Test func picksTopmostSectionWhenNothingHasReachedTheLine() {
+        // Viewport sitting above the first section: every top is below the line.
+        let offsets: [SettingsSectionID: CGFloat] = [.account: 120, .app: 500, .terminal: 900]
+        #expect(SettingsScrollSpy.activeSection(offsets: offsets, activationLine: 96) == .account)
+    }
+
+    @Test func picksSectionNearestLineFromAbove() {
+        // account scrolled just above the line, app just under it.
+        let offsets: [SettingsSectionID: CGFloat] = [.account: -50, .app: 40, .terminal: 600]
+        #expect(SettingsScrollSpy.activeSection(offsets: offsets, activationLine: 96) == .app)
+    }
+
+    @Test func picksLastSectionScrolledPast() {
+        let offsets: [SettingsSectionID: CGFloat] = [
+            .account: -300, .app: -120, .terminal: -10, .textBox: 400,
+        ]
+        #expect(SettingsScrollSpy.activeSection(offsets: offsets, activationLine: 96) == .terminal)
+    }
+
+    @Test func emptyOffsetsReturnNil() {
+        #expect(SettingsScrollSpy.activeSection(offsets: [:], activationLine: 96) == nil)
+    }
+}

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -147668,6 +147668,363 @@
         }
       }
     },
+    "notifications.group.today": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "اليوم"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Danas"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I dag"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Heute"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Today"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoy"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Aujourd’hui"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Oggi"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今日"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오늘"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I dag"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dzisiaj"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hoje"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сегодня"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "วันนี้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Bugün"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Сьогодні"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今天"
+          }
+        }
+      }
+    },
+    "notifications.group.yesterday": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "أمس"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Jučer"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I går"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Gestern"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yesterday"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ayer"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hier"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ieri"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昨日"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "어제"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "I går"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wczoraj"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ontem"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Вчера"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เมื่อวาน"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dün"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Учора"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昨天"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "昨天"
+          }
+        }
+      }
+    },
+    "notifications.group.earlier": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "سابقًا"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ranije"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tidligere"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Früher"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Earlier"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anteriores"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Plus tôt"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Precedenti"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "それ以前"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이전"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tidligere"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Wcześniej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Anteriores"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Ранее"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ก่อนหน้านี้"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Daha önce"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Раніше"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更早"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "更早"
+          }
+        }
+      }
+    },
     "notifications.title": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/App/MenuBarExtraController.swift
+++ b/Sources/App/MenuBarExtraController.swift
@@ -251,26 +251,48 @@ final class MenuBarExtraController: NSObject, NSMenuDelegate {
         let insertionIndex = menu.index(of: showNotificationsItem)
         guard insertionIndex >= 0 else { return }
 
-        for (offset, notification) in recentNotifications.enumerated() {
-            let tabTitle = AppDelegate.shared?.tabTitle(for: notification.tabId)
-            let item = makeNotificationItem(notification: notification, tabTitle: tabTitle)
-            menu.insertItem(item, at: insertionIndex + offset)
-            notificationItems.append(item)
+        // Group into Today / Yesterday / Earlier, inserting a section header
+        // before each group so the menu-bar list reads the same as the popover
+        // and in-app page. Headers are tracked in `notificationItems` so they
+        // are cleared and rebuilt together with the cards.
+        var offset = 0
+        for group in NotificationPresentation.grouped(recentNotifications) {
+            let header = makeSectionHeaderItem(title: group.title)
+            menu.insertItem(header, at: insertionIndex + offset)
+            notificationItems.append(header)
+            offset += 1
+            for notification in group.notifications {
+                let tabTitle = AppDelegate.shared?.tabTitle(for: notification.tabId)
+                let item = makeNotificationItem(notification: notification, tabTitle: tabTitle)
+                menu.insertItem(item, at: insertionIndex + offset)
+                notificationItems.append(item)
+                offset += 1
+            }
         }
     }
 
-    private func makeNotificationItem(notification: TerminalNotification, tabTitle: String?) -> NSMenuItem {
-        let item = NSMenuItem(title: "", action: #selector(openNotificationItemAction(_:)), keyEquivalent: "")
-        item.target = self
-        item.attributedTitle = MenuBarNotificationLineFormatter.attributedTitle(notification: notification, tabTitle: tabTitle)
-        item.toolTip = MenuBarNotificationLineFormatter.tooltip(notification: notification, tabTitle: tabTitle)
-        item.representedObject = NotificationMenuItemPayload(notification: notification)
+    private func makeSectionHeaderItem(title: String) -> NSMenuItem {
+        if #available(macOS 14.0, *) {
+            return NSMenuItem.sectionHeader(title: title)
+        }
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.isEnabled = false
         return item
     }
 
-    @objc private func openNotificationItemAction(_ sender: NSMenuItem) {
-        guard let payload = sender.representedObject as? NotificationMenuItemPayload else { return }
-        onOpenNotification(payload.notification)
+    private func makeNotificationItem(notification: TerminalNotification, tabTitle: String?) -> NSMenuItem {
+        // Use a custom view so the notification can carry its own tinted "card"
+        // background — a native menu item can only style its text. The view
+        // owns the click (a custom item view doesn't route through the item's
+        // target/action), so it fires `onOpenNotification` on mouseDown.
+        let item = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+        let onOpen = onOpenNotification
+        item.view = NotificationMenuItemView(notification: notification, tabTitle: tabTitle) {
+            onOpen(notification)
+        }
+        item.toolTip = MenuBarNotificationLineFormatter.tooltip(notification: notification, tabTitle: tabTitle)
+        item.representedObject = NotificationMenuItemPayload(notification: notification)
+        return item
     }
 
     @discardableResult
@@ -784,5 +806,249 @@ enum MenuBarIconRenderer {
             height: rect.height
         )
         (text as NSString).draw(in: textRect, withAttributes: attrs)
+    }
+}
+
+/// A premium-looking custom view for a notification row inside the menu-bar
+/// dropdown. A native `NSMenuItem` can only style its text, so it can't carry
+/// its own background; giving the item a custom `view` lets us draw a subtle
+/// tinted "card" behind each notification, an icon chip, and a relative
+/// timestamp so notifications stand out from the plain command items around
+/// them. Modeled on `MouseDownMenuItemView`: full-width so the highlight spans
+/// the menu, hover tracking, and `mouseDown` cancels menu tracking then fires
+/// the open action (a custom item view does not route through the item's
+/// target/action automatically).
+@MainActor
+final class NotificationMenuItemView: NSView {
+    private static let defaultWidth: CGFloat = 320
+    private static let cardInsetH: CGFloat = 6
+    private static let cardInsetV: CGFloat = 2
+    private static let cardCornerRadius: CGFloat = 8
+    private static let contentPadH: CGFloat = 10
+    private static let contentPadV: CGFloat = 8
+    private static let chipSize: CGFloat = 26
+    private static let chipCornerRadius: CGFloat = 6
+    private static let chipToTextSpacing: CGFloat = 10
+
+    private let notification: TerminalNotification
+    private let action: () -> Void
+
+    private let chipContainer = NSView()
+    private let chipImageView = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let timeLabel = NSTextField(labelWithString: "")
+    private let bodyLabel = NSTextField(labelWithString: "")
+    private let workspaceLabel = NSTextField(labelWithString: "")
+    private let unreadDot = NSView()
+
+    private var trackingArea: NSTrackingArea?
+    private var isHighlighted = false {
+        didSet {
+            guard oldValue != isHighlighted else { return }
+            needsDisplay = true
+            applyColors()
+        }
+    }
+
+    init(notification: TerminalNotification, tabTitle: String?, action: @escaping () -> Void) {
+        self.notification = notification
+        self.action = action
+        super.init(frame: NSRect(x: 0, y: 0, width: Self.defaultWidth, height: 44))
+        // Let the highlight/card span the full menu width like a native item.
+        autoresizingMask = [.width]
+        wantsLayer = true
+
+        let baseSize = GlobalFontMagnification.menuFont(ofSize: NSFont.systemFontSize).pointSize
+
+        chipContainer.wantsLayer = true
+        chipContainer.layer?.cornerRadius = Self.chipCornerRadius
+        chipContainer.translatesAutoresizingMaskIntoConstraints = false
+        chipImageView.translatesAutoresizingMaskIntoConstraints = false
+        chipImageView.imageScaling = .scaleProportionallyUpOrDown
+        let symbolConfig = NSImage.SymbolConfiguration(pointSize: baseSize - 1, weight: .semibold)
+        chipImageView.image = NSImage(
+            systemSymbolName: NotificationPresentation.symbolName(for: notification),
+            accessibilityDescription: nil
+        )?.withSymbolConfiguration(symbolConfig)
+        chipContainer.addSubview(chipImageView)
+
+        configureLabel(titleLabel, font: .systemFont(ofSize: baseSize, weight: .semibold), maxLines: 1)
+        configureLabel(timeLabel, font: .systemFont(ofSize: baseSize - 2), maxLines: 1)
+        configureLabel(bodyLabel, font: .systemFont(ofSize: baseSize - 1), maxLines: 2)
+        configureLabel(workspaceLabel, font: .systemFont(ofSize: baseSize - 2), maxLines: 1)
+
+        titleLabel.stringValue = notification.title
+        timeLabel.stringValue = NotificationPresentation.relativeTimeString(for: notification.createdAt)
+        let detail = notification.body.isEmpty ? notification.subtitle : notification.body
+        bodyLabel.stringValue = detail
+        bodyLabel.isHidden = detail.isEmpty
+        workspaceLabel.stringValue = tabTitle ?? ""
+        workspaceLabel.isHidden = (tabTitle ?? "").isEmpty
+
+        // Title takes remaining width and truncates; time hugs the trailing edge.
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        timeLabel.setContentHuggingPriority(.required, for: .horizontal)
+        timeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        unreadDot.wantsLayer = true
+        unreadDot.layer?.cornerRadius = 3.5
+        unreadDot.translatesAutoresizingMaskIntoConstraints = false
+        unreadDot.isHidden = notification.isRead
+
+        let titleRow = NSStackView(views: [titleLabel, unreadDot, timeLabel])
+        titleRow.orientation = .horizontal
+        titleRow.alignment = .centerY
+        titleRow.spacing = 6
+        titleRow.distribution = .fill
+        titleRow.setHuggingPriority(.defaultLow, for: .horizontal)
+
+        let textColumn = NSStackView(views: [titleRow, bodyLabel, workspaceLabel])
+        textColumn.orientation = .vertical
+        textColumn.alignment = .leading
+        textColumn.spacing = 2
+        textColumn.translatesAutoresizingMaskIntoConstraints = false
+        titleRow.translatesAutoresizingMaskIntoConstraints = false
+
+        addSubview(chipContainer)
+        addSubview(textColumn)
+
+        let leading = Self.cardInsetH + Self.contentPadH
+        let trailing = Self.cardInsetH + Self.contentPadH + 2
+        let top = Self.cardInsetV + Self.contentPadV
+        NSLayoutConstraint.activate([
+            chipContainer.leadingAnchor.constraint(equalTo: leadingAnchor, constant: leading),
+            chipContainer.topAnchor.constraint(equalTo: topAnchor, constant: top),
+            chipContainer.widthAnchor.constraint(equalToConstant: Self.chipSize),
+            chipContainer.heightAnchor.constraint(equalToConstant: Self.chipSize),
+            chipImageView.centerXAnchor.constraint(equalTo: chipContainer.centerXAnchor),
+            chipImageView.centerYAnchor.constraint(equalTo: chipContainer.centerYAnchor),
+
+            unreadDot.widthAnchor.constraint(equalToConstant: 7),
+            unreadDot.heightAnchor.constraint(equalToConstant: 7),
+
+            textColumn.leadingAnchor.constraint(equalTo: chipContainer.trailingAnchor, constant: Self.chipToTextSpacing),
+            textColumn.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -trailing),
+            textColumn.topAnchor.constraint(equalTo: topAnchor, constant: top),
+            // A vertical NSStackView with .leading alignment does not stretch its
+            // rows to the column width, so pin each row's width to the column.
+            // This right-aligns the time in the title row and gives the body a
+            // definite width to wrap within.
+            titleRow.widthAnchor.constraint(equalTo: textColumn.widthAnchor),
+            bodyLabel.widthAnchor.constraint(equalTo: textColumn.widthAnchor),
+            workspaceLabel.widthAnchor.constraint(equalTo: textColumn.widthAnchor),
+            // The view's bottom is the lower of the chip and the text column,
+            // plus the bottom inset — so short (title-only) and tall (title +
+            // 2-line body + workspace) notifications both size correctly.
+            bottomAnchor.constraint(greaterThanOrEqualTo: textColumn.bottomAnchor, constant: top),
+            bottomAnchor.constraint(greaterThanOrEqualTo: chipContainer.bottomAnchor, constant: top),
+        ])
+
+        setAccessibilityElement(true)
+        setAccessibilityRole(.menuItem)
+        let axParts = [notification.title, detail, tabTitle ?? ""].filter { !$0.isEmpty }
+        setAccessibilityLabel(axParts.joined(separator: ", "))
+
+        applyColors()
+
+        // Resolve the content height once so the menu allocates the right row
+        // height. Width is fixed to the default here; the menu sizes to its
+        // widest item, so this card (usually the widest) defines that width and
+        // the measured height holds. A wider menu only reduces body wrapping.
+        layoutSubtreeIfNeeded()
+        frame = NSRect(x: 0, y: 0, width: Self.defaultWidth, height: fittingSize.height)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    private func configureLabel(_ label: NSTextField, font: NSFont, maxLines: Int) {
+        label.font = font
+        label.maximumNumberOfLines = maxLines
+        label.lineBreakMode = maxLines == 1 ? .byTruncatingTail : .byWordWrapping
+        if maxLines > 1 {
+            label.cell?.truncatesLastVisibleLine = true
+        }
+        label.translatesAutoresizingMaskIntoConstraints = false
+    }
+
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let area = NSTrackingArea(
+            rect: bounds,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        trackingArea = area
+        addTrackingArea(area)
+    }
+
+    override func mouseEntered(with event: NSEvent) { isHighlighted = true }
+    override func mouseExited(with event: NSEvent) { isHighlighted = false }
+
+    override func mouseDown(with event: NSEvent) {
+        isHighlighted = true
+        enclosingMenuItem?.menu?.cancelTrackingWithoutAnimation()
+        action()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyColors()
+        needsDisplay = true
+    }
+
+    private var isDark: Bool {
+        effectiveAppearance.bestMatch(from: [.darkAqua, .aqua]) == .darkAqua
+    }
+
+    private var cardFill: NSColor {
+        if notification.isRead {
+            return (isDark ? NSColor.white : NSColor.black).withAlphaComponent(isDark ? 0.06 : 0.045)
+        }
+        return NSColor.controlAccentColor.withAlphaComponent(isDark ? 0.22 : 0.12)
+    }
+
+    private func applyColors() {
+        let selectedText = NSColor.selectedMenuItemTextColor
+        if isHighlighted {
+            titleLabel.textColor = selectedText
+            timeLabel.textColor = selectedText.withAlphaComponent(0.85)
+            bodyLabel.textColor = selectedText.withAlphaComponent(0.9)
+            workspaceLabel.textColor = selectedText.withAlphaComponent(0.75)
+            chipContainer.layer?.backgroundColor = NSColor.white.withAlphaComponent(0.25).cgColor
+            chipImageView.contentTintColor = .white
+            unreadDot.layer?.backgroundColor = NSColor.white.cgColor
+        } else {
+            titleLabel.textColor = .labelColor
+            timeLabel.textColor = .tertiaryLabelColor
+            bodyLabel.textColor = .secondaryLabelColor
+            workspaceLabel.textColor = .tertiaryLabelColor
+            let chipFill: NSColor = notification.isRead
+                ? (isDark ? NSColor.white : NSColor.black).withAlphaComponent(0.10)
+                : NSColor.controlAccentColor.withAlphaComponent(isDark ? 0.35 : 0.18)
+            chipContainer.layer?.backgroundColor = chipFill.cgColor
+            chipImageView.contentTintColor = notification.isRead ? .secondaryLabelColor : .controlAccentColor
+            unreadDot.layer?.backgroundColor = NSColor.controlAccentColor.cgColor
+        }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        let cardRect = bounds.insetBy(dx: Self.cardInsetH, dy: Self.cardInsetV)
+        let path = NSBezierPath(
+            roundedRect: cardRect,
+            xRadius: Self.cardCornerRadius,
+            yRadius: Self.cardCornerRadius
+        )
+        (isHighlighted ? NSColor.selectedContentBackgroundColor : cardFill).setFill()
+        path.fill()
     }
 }

--- a/Sources/NotificationsPage.swift
+++ b/Sources/NotificationsPage.swift
@@ -52,31 +52,38 @@ struct NotificationsPage: View {
         // O(rows + tabs) rather than O(rows × tabs), which matters when many
         // notifications accumulate (issue #5794).
         let tabTitles = AppDelegate.shared?.tabTitlesByTabId() ?? [:]
+        // Group into Today / Yesterday / Earlier sections, preserving order.
+        let groups = NotificationPresentation.grouped(notificationStore.notifications)
         return ScrollView {
-            LazyVStack(spacing: 8) {
-                ForEach(notificationStore.notifications) { notification in
-                    NotificationRow(
-                        notification: notification,
-                        tabTitle: tabTitle(for: notification.tabId, in: tabTitles),
-                        isFocused: focusedNotificationId == notification.id,
-                        onOpen: {
-                            // SwiftUI action closures aren't guaranteed to be main-actor
-                            // isolated; hop to the main actor for window focus + tab selection.
-                            Task { @MainActor in
-                                _ = AppDelegate.shared?.openTerminalNotification(notification)
-                            }
-                        },
-                        onClear: {
-                            notificationStore.remove(id: notification.id)
-                        },
-                        focusedNotificationId: $focusedNotificationId
-                    )
-                    // Each NotificationRow renders heavily-modified nested stacks.
-                    // Equatable + .equatable() lets a NotificationStore publish that
-                    // touches one notification skip body re-evaluation for the other
-                    // rows, instead of re-laying out the whole LazyVStack on every
-                    // publish (issue #5794, same class as #2586 / #5752).
-                    .equatable()
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(groups) { group in
+                    NotificationGroupHeader(title: group.title, count: group.notifications.count)
+                        .padding(.top, 2)
+                        .padding(.horizontal, 4)
+                    ForEach(group.notifications) { notification in
+                        NotificationRow(
+                            notification: notification,
+                            tabTitle: tabTitle(for: notification.tabId, in: tabTitles),
+                            isFocused: focusedNotificationId == notification.id,
+                            onOpen: {
+                                // SwiftUI action closures aren't guaranteed to be main-actor
+                                // isolated; hop to the main actor for window focus + tab selection.
+                                Task { @MainActor in
+                                    _ = AppDelegate.shared?.openTerminalNotification(notification)
+                                }
+                            },
+                            onClear: {
+                                notificationStore.remove(id: notification.id)
+                            },
+                            focusedNotificationId: $focusedNotificationId
+                        )
+                        // Each NotificationRow renders heavily-modified nested stacks.
+                        // Equatable + .equatable() lets a NotificationStore publish that
+                        // touches one notification skip body re-evaluation for the other
+                        // rows, instead of re-laying out the whole LazyVStack on every
+                        // publish (issue #5794, same class as #2586 / #5752).
+                        .equatable()
+                    }
                 }
             }
             .padding(16)
@@ -320,22 +327,25 @@ struct NotificationRow: View, Equatable {
         HStack(alignment: .top, spacing: 12) {
             Button(action: onOpen) {
                 HStack(alignment: .top, spacing: 12) {
-                    Circle()
-                        .fill(notification.isRead ? Color.clear : cmuxAccentColor())
-                        .frame(width: 8, height: 8)
-                        .overlay(
-                            Circle()
-                                .stroke(cmuxAccentColor().opacity(notification.isRead ? 0.2 : 1), lineWidth: 1)
-                        )
-                        .padding(.top, 6)
+                    NotificationIconChip(
+                        symbolName: NotificationPresentation.symbolName(for: notification),
+                        isUnread: !notification.isRead,
+                        size: 30
+                    )
 
                     VStack(alignment: .leading, spacing: 6) {
-                        HStack {
+                        HStack(spacing: 6) {
                             Text(notification.title)
                                 .cmuxFont(.headline)
                                 .foregroundColor(.primary)
-                            Spacer()
-                            Text(notification.createdAt.formatted(date: .omitted, time: .shortened))
+                            Spacer(minLength: 6)
+                            if !notification.isRead {
+                                Circle()
+                                    .fill(cmuxAccentColor())
+                                    .frame(width: 7, height: 7)
+                                    .accessibilityHidden(true)
+                            }
+                            Text(NotificationPresentation.relativeTimeString(for: notification.createdAt))
                                 .cmuxFont(.caption)
                                 .foregroundColor(.secondary)
                         }
@@ -378,8 +388,23 @@ struct NotificationRow: View, Equatable {
         }
         .padding(12)
         .background(
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(Color(nsColor: .controlBackgroundColor))
+                // Unread cards get an accent wash so they stand out from read
+                // history at a glance.
+                if !notification.isRead {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(cmuxAccentColor().opacity(0.10))
+                }
+            }
+        )
+        .overlay(
             RoundedRectangle(cornerRadius: 10)
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .strokeBorder(
+                    notification.isRead ? Color.clear : cmuxAccentColor().opacity(0.35),
+                    lineWidth: 1
+                )
         )
     }
 }

--- a/Sources/TerminalNotification.swift
+++ b/Sources/TerminalNotification.swift
@@ -80,3 +80,104 @@ struct TerminalNotification: Identifiable, Hashable, Sendable {
         return retargetsToLiveSurfaceOwner || tabId == targetTabId
     }
 }
+
+/// Shared presentation helpers for notifications, used by every notification
+/// surface (menu-bar dropdown, titlebar popover, in-app page) so the icon and
+/// timestamp treatment stay identical across them (cmux shared-behavior policy).
+/// Pure and Foundation-only so it is unit-testable without a UI or a live clock.
+enum NotificationPresentation {
+    /// SF Symbol name for a notification's leading icon chip. Reply-capable
+    /// notifications read as a reply glyph; everything else uses the bell.
+    static func symbolName(for notification: TerminalNotification) -> String {
+        switch notification.replyShape {
+        case .text:
+            return "arrowshape.turn.up.left.fill"
+        case .none:
+            return "bell.fill"
+        }
+    }
+
+    /// Time bucket a notification belongs to when the list is grouped by
+    /// recency. Cases are ordered newest-first for display.
+    enum TimeBucket: Int, CaseIterable, Sendable {
+        case today
+        case yesterday
+        case earlier
+
+        /// Localized section-header title.
+        var title: String {
+            switch self {
+            case .today:
+                return String(localized: "notifications.group.today", defaultValue: "Today")
+            case .yesterday:
+                return String(localized: "notifications.group.yesterday", defaultValue: "Yesterday")
+            case .earlier:
+                return String(localized: "notifications.group.earlier", defaultValue: "Earlier")
+            }
+        }
+    }
+
+    /// A run of notifications sharing one time bucket, for grouped rendering.
+    struct Group: Identifiable, Sendable {
+        let bucket: TimeBucket
+        let notifications: [TerminalNotification]
+        var id: Int { bucket.rawValue }
+        var title: String { bucket.title }
+    }
+
+    /// Short, localized relative timestamp (e.g. "now", "2 min. ago",
+    /// "yesterday"). More scannable than an absolute clock time; the absolute
+    /// time stays available in each surface's tooltip.
+    ///
+    /// `dateTimeStyle = .named` returns a localized "now" for near-zero
+    /// differences, so no custom string is needed. The date is clamped to
+    /// `now` first so minor clock skew (a notification stamped a beat in the
+    /// future) reads as "now" rather than "in 3 seconds".
+    static func relativeTimeString(for date: Date, relativeTo now: Date = Date()) -> String {
+        let clamped = min(date, now)
+        // RelativeDateTimeFormatter is a non-Sendable class; build a fresh one
+        // per call rather than sharing mutable global state across actors.
+        // Call sites are infrequent (menu rebuild, popover open), so the cost
+        // is immaterial.
+        let formatter = RelativeDateTimeFormatter()
+        formatter.unitsStyle = .abbreviated
+        formatter.dateTimeStyle = .named
+        return formatter.localizedString(for: clamped, relativeTo: now)
+    }
+
+    /// The recency bucket for a single notification, computed relative to the
+    /// supplied `now` (injectable so it is testable without the live clock).
+    static func timeBucket(
+        for date: Date,
+        now: Date,
+        calendar: Calendar
+    ) -> TimeBucket {
+        let startOfToday = calendar.startOfDay(for: now)
+        // Any time today — or a slightly-future timestamp from clock skew —
+        // counts as "today".
+        if date >= startOfToday { return .today }
+        guard let startOfYesterday = calendar.date(byAdding: .day, value: -1, to: startOfToday) else {
+            return .earlier
+        }
+        return date >= startOfYesterday ? .yesterday : .earlier
+    }
+
+    /// Groups notifications into ordered `Today / Yesterday / Earlier` sections,
+    /// preserving the input order (newest-first) within each section and
+    /// omitting empty sections.
+    static func grouped(
+        _ notifications: [TerminalNotification],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [Group] {
+        var byBucket: [TimeBucket: [TerminalNotification]] = [:]
+        for notification in notifications {
+            let bucket = timeBucket(for: notification.createdAt, now: now, calendar: calendar)
+            byBucket[bucket, default: []].append(notification)
+        }
+        return TimeBucket.allCases.compactMap { bucket in
+            guard let items = byBucket[bucket], !items.isEmpty else { return nil }
+            return Group(bucket: bucket, notifications: items)
+        }
+    }
+}

--- a/Sources/Update/NotificationPopoverRow.swift
+++ b/Sources/Update/NotificationPopoverRow.swift
@@ -22,15 +22,16 @@ struct NotificationPopoverRow: View, Equatable {
         // primary-action Button, not nested in its label. Nested SwiftUI buttons don't
         // produce reliable independent hit targets on macOS — clicks on a nested button
         // can be consumed by the outer button's tap area.
-        ZStack(alignment: .trailing) {
+        ZStack(alignment: .topTrailing) {
             // Primary row action wrapped as a Button so the row participates in the
             // key-view loop: keyboard users can tab to a row and activate it with
-            // space/return. Visual styling is owned by rowContent; the button background
-            // lets the NSTrackingArea-driven hover tint shine through.
+            // space/return. Visual styling is owned by rowContent; the rounded card
+            // background carries the unread tint and the NSTrackingArea-driven hover tint.
             Button(action: onOpen) {
                 rowContent
                     .background(
-                        Color.primary.opacity(isHovering ? 0.11 : 0)
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .fill(rowBackgroundColor)
                     )
             }
             .buttonStyle(.plain)
@@ -51,6 +52,7 @@ struct NotificationPopoverRow: View, Equatable {
             }
 
             clearButton
+                .padding(.top, 8)
                 .padding(.trailing, 10)
                 .opacity(isHovering ? 1 : 0)
                 .allowsHitTesting(isHovering)
@@ -60,6 +62,9 @@ struct NotificationPopoverRow: View, Equatable {
                 // invisible button.
                 .accessibilityHidden(!isHovering)
         }
+        // Inset each row so the rounded card reads as a distinct cell with gutters.
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
         .frame(maxWidth: .infinity, alignment: .leading)
         // Hover detection runs through an AppKit NSTrackingArea (HoverTrackingRepresentable)
         // because SwiftUI's `.onHover` / `.onContinuousHover` arbitrate with the row's
@@ -90,39 +95,56 @@ struct NotificationPopoverRow: View, Equatable {
             }
     }
 
+    private var hasWorkspaceTitle: Bool {
+        guard let workspaceTitle else { return false }
+        return !workspaceTitle.isEmpty
+    }
+
+    // Unread rows get an accent tint; read rows a very subtle neutral card.
+    // Hovering deepens either so the whole card reads as the hover target.
+    private var rowBackgroundColor: Color {
+        if notification.isRead {
+            return Color.primary.opacity(isHovering ? 0.09 : 0.035)
+        }
+        return cmuxAccentColor().opacity(isHovering ? 0.17 : 0.10)
+    }
+
     private var rowContent: some View {
-        HStack(spacing: 0) {
-            Rectangle()
-                .fill(notification.isRead ? Color.clear : cmuxAccentColor())
-                .frame(width: 2.5)
-                .padding(.vertical, 6)
+        HStack(alignment: .top, spacing: 10) {
+            NotificationIconChip(
+                symbolName: NotificationPresentation.symbolName(for: notification),
+                isUnread: !notification.isRead
+            )
 
             VStack(alignment: .leading, spacing: 2) {
                 HStack(alignment: .firstTextBaseline, spacing: 6) {
-                    if let workspaceTitle, !workspaceTitle.isEmpty {
-                        Text(workspaceTitle)
-                            .cmuxFont(size: 12.5, weight: .semibold)
-                            .foregroundColor(.primary)
-                            .lineLimit(1)
-                            .layoutPriority(1)
-                            .accessibilityIdentifier(
-                                "NotificationPopoverRow.\(notification.id.uuidString).workspaceTitle"
-                            )
-                    } else {
-                        Text(notification.title)
-                            .cmuxFont(size: 12.5, weight: .semibold)
-                            .foregroundColor(.primary)
-                            .lineLimit(1)
+                    Text(hasWorkspaceTitle ? (workspaceTitle ?? "") : notification.title)
+                        .cmuxFont(size: 12.5, weight: .semibold)
+                        .foregroundColor(.primary)
+                        .lineLimit(1)
+                        .layoutPriority(1)
+                        .accessibilityIdentifier(
+                            hasWorkspaceTitle
+                                ? "NotificationPopoverRow.\(notification.id.uuidString).workspaceTitle"
+                                : "NotificationPopoverRow.\(notification.id.uuidString).title"
+                        )
+                    Spacer(minLength: 6)
+                    if !notification.isRead {
+                        Circle()
+                            .fill(cmuxAccentColor())
+                            .frame(width: 6, height: 6)
+                            .accessibilityHidden(true)
                     }
-                    Spacer(minLength: 0)
-                    Text(notification.createdAt.formatted(date: .omitted, time: .shortened))
+                    Text(NotificationPresentation.relativeTimeString(for: notification.createdAt))
                         .cmuxFont(size: 10.5)
                         .foregroundColor(.secondary)
-                        .padding(.trailing, 34)
                         .layoutPriority(2)
+                        // Reserve room for the hover-only clear button so the time
+                        // doesn't slide under it.
+                        .padding(.trailing, isHovering ? 22 : 0)
                 }
 
-                if let workspaceTitle, !workspaceTitle.isEmpty {
+                if hasWorkspaceTitle {
                     Text(notification.title)
                         .cmuxFont(size: 10.5, weight: .medium)
                         .foregroundColor(.secondary)
@@ -137,13 +159,12 @@ struct NotificationPopoverRow: View, Equatable {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            .padding(.leading, 10)
-            .padding(.vertical, 8)
 
             Spacer(minLength: 0)
         }
-        .frame(minHeight: Self.rowHeight)
-        .padding(.leading, 4)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .frame(minHeight: Self.rowHeight, alignment: .top)
     }
 
     private var clearButton: some View {
@@ -157,5 +178,49 @@ struct NotificationPopoverRow: View, Equatable {
             .frame(width: 20, height: 20)
         }
         .buttonStyle(.plain)
+    }
+}
+
+/// Leading icon chip shared across the notification surfaces (titlebar popover,
+/// in-app page). A rounded tinted square holding an SF Symbol derived from the
+/// notification; accent-tinted when unread, neutral when read. Mirrors the
+/// menu-bar dropdown's chip so all surfaces read as one design.
+struct NotificationIconChip: View {
+    let symbolName: String
+    let isUnread: Bool
+    var size: CGFloat = 26
+
+    var body: some View {
+        RoundedRectangle(cornerRadius: 6, style: .continuous)
+            .fill(isUnread ? cmuxAccentColor().opacity(0.18) : Color.primary.opacity(0.08))
+            .frame(width: size, height: size)
+            .overlay(
+                CmuxSystemSymbolImage(systemName: symbolName, pointSize: size * 0.46, weight: .semibold)
+                    .foregroundColor(isUnread ? cmuxAccentColor() : .secondary)
+            )
+            .accessibilityHidden(true)
+    }
+}
+
+/// Small uppercase section header with a count pill, shown above each
+/// `Today / Yesterday / Earlier` group of notifications.
+struct NotificationGroupHeader: View {
+    let title: String
+    let count: Int
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Text(title.localizedUppercase)
+                .cmuxFont(size: 10.5, weight: .semibold)
+                .foregroundColor(.secondary)
+            Text("\(count)")
+                .cmuxFont(size: 10, weight: .semibold)
+                .foregroundColor(.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(Capsule().fill(Color.primary.opacity(0.08)))
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
     }
 }

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -2552,50 +2552,54 @@ private struct NotificationsPopoverView: View {
             // the list boundary, which is the same anti-pattern CLAUDE.md flags for the
             // sidebar/sessions panel (https://github.com/manaflow-ai/cmux/issues/2586).
             let snapshot = notificationStore.notifications
-            let lastIndex = snapshot.count - 1
+            // Group into Today / Yesterday / Earlier sections from the value
+            // snapshot (not by reading the store below the list boundary, #2586).
+            let groups = NotificationPresentation.grouped(snapshot)
             // One tabId -> title index per render, not an O(tabs) scan per row (#5794).
             let titleSnapshot = loadedWorkspaceTitles ?? currentWorkspaceTitles()
             ScrollView {
-                LazyVStack(spacing: 0) {
-                    ForEach(Array(snapshot.enumerated()), id: \.element.id) { index, notification in
-                        NotificationPopoverRow(
-                            notification: notification,
-                            workspaceTitle: titleSnapshot[notification.tabId],
-                            onOpen: { open(notification) },
-                            onClear: {
-                                withAnimation(.easeOut(duration: 0.18)) {
-                                    notificationStore.remove(id: notification.id)
-                                }
-                            },
-                            onToggleRead: {
-                                if notification.isRead {
-                                    notificationStore.markUnread(id: notification.id)
-                                } else {
-                                    notificationStore.markRead(id: notification.id)
-                                    // A user-initiated "Mark as Read" on a pane-scoped
-                                    // notification should also clear the pane's focused-read
-                                    // indicator so the pane badge disappears. For
-                                    // workspace-level notifications (surfaceId == nil), do not
-                                    // call clearFocusedReadIndicator — it treats nil as
-                                    // "clear any pane indicator on this tab" and would wipe
-                                    // an unrelated pane badge.
-                                    if let surfaceId = notification.surfaceId {
-                                        notificationStore.clearFocusedReadIndicator(
-                                            forTabId: notification.tabId,
-                                            surfaceId: surfaceId
-                                        )
+                LazyVStack(alignment: .leading, spacing: 2) {
+                    ForEach(groups) { group in
+                        NotificationGroupHeader(title: group.title, count: group.notifications.count)
+                            .padding(.horizontal, 18)
+                            .padding(.top, 10)
+                            .padding(.bottom, 1)
+                        ForEach(group.notifications) { notification in
+                            NotificationPopoverRow(
+                                notification: notification,
+                                workspaceTitle: titleSnapshot[notification.tabId],
+                                onOpen: { open(notification) },
+                                onClear: {
+                                    withAnimation(.easeOut(duration: 0.18)) {
+                                        notificationStore.remove(id: notification.id)
+                                    }
+                                },
+                                onToggleRead: {
+                                    if notification.isRead {
+                                        notificationStore.markUnread(id: notification.id)
+                                    } else {
+                                        notificationStore.markRead(id: notification.id)
+                                        // A user-initiated "Mark as Read" on a pane-scoped
+                                        // notification should also clear the pane's focused-read
+                                        // indicator so the pane badge disappears. For
+                                        // workspace-level notifications (surfaceId == nil), do not
+                                        // call clearFocusedReadIndicator — it treats nil as
+                                        // "clear any pane indicator on this tab" and would wipe
+                                        // an unrelated pane badge.
+                                        if let surfaceId = notification.surfaceId {
+                                            notificationStore.clearFocusedReadIndicator(
+                                                forTabId: notification.tabId,
+                                                surfaceId: surfaceId
+                                            )
+                                        }
                                     }
                                 }
-                            }
-                        )
-                        .equatable()  // snapshot-boundary: skip unchanged rows (#5794)
-                        if index < lastIndex {
-                            Divider()
-                                .opacity(0.4)
-                                .padding(.leading, 18)
+                            )
+                            .equatable()  // snapshot-boundary: skip unchanged rows (#5794)
                         }
                     }
                 }
+                .padding(.bottom, 6)
             }
         }
     }

--- a/cmuxTests/NotificationAndMenuBarTests.swift
+++ b/cmuxTests/NotificationAndMenuBarTests.swift
@@ -6,6 +6,7 @@ import WebKit
 import ObjectiveC.runtime
 import Bonsplit
 import CmuxSettings
+import CmuxNotifications
 import UserNotifications
 
 #if canImport(cmux_DEV)
@@ -2091,6 +2092,150 @@ final class MenuBarNotificationLineFormatterTests: XCTestCase {
         )
 
         XCTAssertFalse(title.hasSuffix("…"))
+    }
+}
+
+final class NotificationPresentationTests: XCTestCase {
+    private func makeNotification(
+        replyShape: TerminalNotificationReplyShape = .none,
+        createdAt: Date = Date(timeIntervalSince1970: 0)
+    ) -> TerminalNotification {
+        TerminalNotification(
+            id: UUID(),
+            tabId: UUID(),
+            surfaceId: nil,
+            title: "Title",
+            subtitle: "",
+            body: "Body",
+            createdAt: createdAt,
+            isRead: false,
+            replyShape: replyShape
+        )
+    }
+
+    func testSymbolNameUsesReplyGlyphForTextReply() {
+        XCTAssertEqual(
+            NotificationPresentation.symbolName(for: makeNotification(replyShape: .text)),
+            "arrowshape.turn.up.left.fill"
+        )
+    }
+
+    func testSymbolNameUsesBellForNonReply() {
+        XCTAssertEqual(
+            NotificationPresentation.symbolName(for: makeNotification(replyShape: .none)),
+            "bell.fill"
+        )
+    }
+
+    func testRelativeTimeStringClampsFutureSkewToNow() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let nowResult = NotificationPresentation.relativeTimeString(for: now, relativeTo: now)
+        XCTAssertFalse(nowResult.isEmpty)
+        // Minor future clock skew must not read as "in N seconds"; clamping
+        // makes it produce the same string as an exactly-now notification.
+        XCTAssertEqual(
+            NotificationPresentation.relativeTimeString(for: now.addingTimeInterval(5), relativeTo: now),
+            nowResult
+        )
+    }
+
+    func testRelativeTimeStringReportsElapsedForOlderNotifications() {
+        let now = Date(timeIntervalSince1970: 10_000)
+        let nowResult = NotificationPresentation.relativeTimeString(for: now, relativeTo: now)
+        let anHourAgo = now.addingTimeInterval(-3600)
+        let result = NotificationPresentation.relativeTimeString(for: anHourAgo, relativeTo: now)
+        XCTAssertFalse(result.isEmpty)
+        XCTAssertNotEqual(result, nowResult)
+    }
+}
+
+
+final class NotificationGroupingTests: XCTestCase {
+    private var calendar: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        return c
+    }
+
+    private func fixedNow(_ cal: Calendar) -> Date {
+        cal.date(from: DateComponents(year: 2026, month: 3, day: 15, hour: 12))!
+    }
+
+    private func makeNotification(createdAt: Date, id: UUID = UUID()) -> TerminalNotification {
+        TerminalNotification(
+            id: id,
+            tabId: UUID(),
+            surfaceId: nil,
+            title: "t",
+            subtitle: "",
+            body: "b",
+            createdAt: createdAt,
+            isRead: false
+        )
+    }
+
+    func testGroupsOrderedTodayYesterdayEarlier() {
+        let cal = calendar
+        let now = fixedNow(cal)
+        let groups = NotificationPresentation.grouped(
+            [
+                makeNotification(createdAt: now.addingTimeInterval(-3600)),      // today
+                makeNotification(createdAt: now.addingTimeInterval(-26 * 3600)), // yesterday
+                makeNotification(createdAt: now.addingTimeInterval(-72 * 3600)), // earlier
+            ],
+            now: now,
+            calendar: cal
+        )
+        XCTAssertEqual(groups.map(\.bucket), [.today, .yesterday, .earlier])
+        XCTAssertEqual(groups.map { $0.notifications.count }, [1, 1, 1])
+    }
+
+    func testEmptyBucketsAreOmitted() {
+        let cal = calendar
+        let now = fixedNow(cal)
+        let groups = NotificationPresentation.grouped(
+            [
+                makeNotification(createdAt: now.addingTimeInterval(-60)),
+                makeNotification(createdAt: now.addingTimeInterval(-120)),
+            ],
+            now: now,
+            calendar: cal
+        )
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups.first?.bucket, .today)
+        XCTAssertEqual(groups.first?.notifications.count, 2)
+    }
+
+    func testMidnightBoundarySplitsTodayAndYesterday() {
+        let cal = calendar
+        let now = fixedNow(cal)
+        let startOfToday = cal.startOfDay(for: now)
+        XCTAssertEqual(
+            NotificationPresentation.timeBucket(for: startOfToday, now: now, calendar: cal),
+            .today
+        )
+        XCTAssertEqual(
+            NotificationPresentation.timeBucket(for: startOfToday.addingTimeInterval(-1), now: now, calendar: cal),
+            .yesterday
+        )
+    }
+
+    func testOrderPreservedWithinBucket() {
+        let cal = calendar
+        let now = fixedNow(cal)
+        let first = makeNotification(createdAt: now.addingTimeInterval(-60))
+        let second = makeNotification(createdAt: now.addingTimeInterval(-120))
+        let groups = NotificationPresentation.grouped([first, second], now: now, calendar: cal)
+        XCTAssertEqual(groups.first?.notifications.map(\.id), [first.id, second.id])
+    }
+
+    func testFutureSkewCountsAsToday() {
+        let cal = calendar
+        let now = fixedNow(cal)
+        XCTAssertEqual(
+            NotificationPresentation.timeBucket(for: now.addingTimeInterval(30), now: now, calendar: cal),
+            .today
+        )
     }
 }
 

--- a/docs/superpowers/specs/2026-09-02-notifications-redesign-and-settings-scrollspy-design.md
+++ b/docs/superpowers/specs/2026-09-02-notifications-redesign-and-settings-scrollspy-design.md
@@ -1,0 +1,201 @@
+# Notifications redesign + Settings scroll-spy — Design
+
+Date: 2026-09-02
+Branch / build tag: `notif-redesign-scrollspy`
+
+## Goal
+
+Two independent UI improvements requested from screenshots:
+
+1. **Notifications** — make the notifications in the app's menus look modern, immediately
+   recognizable, and organized. Applies to **all three** notification surfaces so they stay
+   consistent.
+2. **Settings scroll-spy** — as the user scrolls the Preferences detail pane, the left
+   sidebar highlight should follow the section currently in view (currently only the
+   reverse — click sidebar → scroll — exists).
+
+Verification is a tagged Debug build the user dogfoods. No second-model review unless the
+user opts in.
+
+---
+
+## Part A — Notifications redesign
+
+### A.0 Decisions
+
+- **Organization:** time buckets (`Today` / `Yesterday` / `Earlier`), newest-first within
+  each bucket. Unread notifications are **emphasized in place** and do **not** reorder when
+  they become read (no jumping).
+- **Unread emphasis:** soft accent-tinted row background (~7% accent), accent-colored
+  title, and a small filled accent dot next to the timestamp.
+- **Timestamps:** relative ("2m", "1h", "Yesterday"); absolute time moves to the tooltip.
+- **Leading type-icon chip:** a rounded tinted square holding an SF Symbol derived from the
+  notification's shape/action (completion → `checkmark.circle.fill`, reply-shaped → a reply
+  symbol, otherwise `bell.fill`).
+
+### A.1 Shared logic (single source of truth)
+
+The repo's shared-behavior policy requires one implementation reused across every surface,
+not three copies. New file under the shared notifications module (co-located with
+`TerminalNotification`):
+
+- `NotificationGrouping` — pure function `group(_ notifications:) -> [NotificationGroup]`
+  where `NotificationGroup { id: Bucket, title: String, notifications: [TerminalNotification] }`.
+  Buckets: `.today`, `.yesterday`, `.earlier`, computed from `createdAt` against the user's
+  calendar. Input order (newest-first) is preserved within each bucket. Pure and
+  `Calendar`-injectable so it is unit-testable without touching "now".
+- `NotificationPresentation` (or free functions):
+  - `categorySymbolName(for:) -> String` — SF Symbol for the leading chip.
+  - `relativeTimestamp(for:relativeTo:) -> String` — short relative string, localized.
+  - `absoluteTimestamp(for:) -> String` — for tooltips (existing `.formatted` shape).
+
+All three surfaces consume these helpers.
+
+### A.2 Surface 1 — Titlebar popover (`NotificationsPopoverView` + `NotificationPopoverRow`)
+
+`Sources/Update/UpdateTitlebarAccessory.swift`, `Sources/Update/NotificationPopoverRow.swift`.
+
+- `content` builds groups via `NotificationGrouping` and renders, per group, a **sticky-ish
+  group header** (uppercase secondary caption + per-group count) followed by the group's
+  rows. Keep the existing `LazyVStack` + snapshot-boundary discipline (`.equatable()`, no
+  store reads below the list boundary — issue #2586/#5794). Group headers are cheap value
+  views.
+- `NotificationPopoverRow` redesign, preserving all existing behavior (hover clear button,
+  context menu, accessibility identifiers/actions, key-view participation, `Equatable`
+  snapshot rule):
+  - Add leading **icon chip** (rounded tinted square, ~28pt) using `categorySymbolName`.
+  - Replace the 2.5pt hard accent bar with **tinted row background** for unread
+    (`cmuxAccentColor().opacity(~0.07)`) behind the existing hover tint, + a **filled accent
+    dot** beside the relative timestamp. Read rows: no tint, hollow/no dot.
+  - Title in accent color when unread, primary when read.
+  - Timestamp becomes relative; full date/time moves to `help`/tooltip.
+  - Row height may grow slightly to fit the chip; keep the fixed-min-height approach.
+- The row's `Equatable ==` already compares `notification` + `workspaceTitle`; relative
+  timestamp is derived from `notification.createdAt`, so no new stored inputs are needed.
+  (Relative strings drift over time, but the popover is short-lived; recompute on open.)
+
+### A.3 Surface 2 — In-app Notifications page (`NotificationsPage` + `NotificationRow`)
+
+`Sources/NotificationsPage.swift`.
+
+- `notificationsList` groups via `NotificationGrouping`; render group headers + rows in the
+  existing `LazyVStack` (keep `.equatable()` per-row). Preserve focus handling
+  (`focusedNotificationId`, default-action modifier) — the first focusable row stays the
+  first notification overall.
+- `NotificationRow` gets the same modern treatment as the popover row (icon chip, tinted
+  unread background on the existing rounded card, accent title, relative time, filled dot).
+  Keep the rounded `controlBackground` card; unread cards get the accent tint blended in.
+- Keep the empty / unread-indicator / clear-all / jump-to-latest states unchanged.
+
+### A.4 Surface 3 — Menu-bar dropdown (`MenuBarExtraController`)
+
+`Sources/App/MenuBarExtraController.swift`, `MenuBarNotificationLineFormatter`.
+
+- Native `NSMenu`, so no SwiftUI: apply the **same grouping** by inserting disabled
+  section-header items (`Today` / `Yesterday` / `Earlier`) between runs of notifications,
+  driven by `NotificationGrouping` over the `recentNotifications` snapshot (still capped at
+  the existing inline limit).
+- `MenuBarNotificationLineFormatter` uses `relativeTimestamp` for the attributed line's time
+  and keeps the unread bullet. Tooltip keeps the absolute time.
+- Header items are non-selectable (`isEnabled = false`), tracked alongside `notificationItems`
+  so they are removed/rebuilt together.
+
+### A.5 Localization
+
+New user-facing strings — bucket titles (`Today`, `Yesterday`, `Earlier`), relative-time
+units, any new accessibility labels — added to `Resources/Localizable.xcstrings` via
+`String(localized:)`. These surfaces are macOS-only (no web catalog). A localization audit
+is part of the handoff. Prefer the system's relative formatting
+(`RelativeDateTimeFormatter` / `Date.FormatStyle`) where it yields correctly localized
+short output; otherwise localize explicit keys.
+
+### A.6 Notifications testing
+
+- Unit tests for `NotificationGrouping`: fixed `Calendar` + fixed "now"; assert bucket
+  assignment at boundaries (just-before/after midnight, 24h+), ordering preserved, empty
+  buckets omitted.
+- Unit test for `categorySymbolName` mapping per notification shape/action.
+- Test wiring verified (`./scripts/lint-pbxproj-test-wiring.sh`) so new test files are not
+  silently skipped.
+
+---
+
+## Part B — Settings scroll-spy
+
+`Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift`.
+
+### B.1 Mechanism
+
+- Add a named coordinate space on the detail `ScrollView` (e.g. `.coordinateSpace(name: "settingsScroll")`).
+- Each rendered section already carries `.id(anchorID(for: section))`. Attach a lightweight
+  `GeometryReader`-backed `background` (or overlay) to each section that publishes its top
+  `minY` in the `settingsScroll` space through a `PreferenceKey`
+  (`SettingsSectionOffsetsKey: [SettingsSectionID: CGFloat]`, reduce = merge).
+- An `.onPreferenceChange(SettingsSectionOffsetsKey.self)` handler picks the **active
+  section**: the last section whose top offset is `<= activationLine` (a small inset below
+  the viewport top, e.g. 12pt). Update the sidebar highlight to that section.
+
+### B.2 Updating the highlight without a scroll feedback loop
+
+- The `List` selection getter reads `selectedSidebarEntryID`; its setter
+  (`sidebarSelectionBinding`) posts a navigate→scroll. Scroll-spy must **not** go through the
+  setter.
+- Add `private func highlightSectionFromScroll(_ section:)` that writes `selectedSectionRaw`
+  and `selectedSidebarEntryID = sectionEntryID(for: section)` **directly** (guarded so it
+  only writes on an actual change — this also throttles the `@AppStorage` /
+  `UserDefaults.didChangeNotification` writes to once per boundary crossing). No navigation
+  notification is posted, so no scroll is triggered; the List highlight simply follows.
+
+### B.3 Robustness
+
+- **Post-click suppression:** clicking a sidebar row animates a programmatic scroll. Record
+  `programmaticScrollUntil = Date() + ~0.4s` in `applyScrollNavigation` (and the `onAppear`
+  restore). While `Date() < programmaticScrollUntil`, `onPreferenceChange` ignores updates so
+  spy does not fight the animation or land on an intermediate section.
+- **Hysteresis:** only switch to a new section when its top crosses the activation line by a
+  small margin, avoiding flicker between two sections at the boundary.
+- **Search off:** while `isSearching` is true the sidebar is a filtered result list, not a
+  continuous section map — disable spy (return early) so it doesn't fight search selection.
+- **Deep search-hit selection:** spy sets the section header row. It does not attempt to
+  track individual setting rows.
+
+### B.4 Scroll-spy testing
+
+- Prefer a pure helper `activeSection(offsets:activationLine:current:hysteresis:) -> SettingsSectionID?`
+  extracted from the handler, unit-tested with synthetic offset dictionaries (boundary,
+  hysteresis, empty). UI-driving the real scroll in a unit test is brittle; the pure
+  selection function is the behavior worth covering.
+
+### B.5 Non-goals
+
+- No change to section content, ordering, or the click→scroll path.
+- Not adopting macOS-15-only scroll APIs (`onScrollGeometryChange`); the PreferenceKey
+  approach works across supported macOS versions (reporters may be on older macOS).
+
+---
+
+## Approaches considered (and rejected)
+
+- **Notifications organization "New group on top"** — rejected: rows visibly jump when read
+  and recency is duplicated. Time buckets with in-place emphasis is the standard, stable
+  model.
+- **Scroll-spy via AppKit `NSScrollView` contentOffset observation** — rejected: heavier,
+  more bridging code, and the pane is SwiftUI; the PreferenceKey path is sufficient.
+- **Scroll-spy via `onScrollGeometryChange`** — rejected: macOS 15+ only.
+
+## Files touched (anticipated)
+
+- `Sources/TerminalNotification.swift` area — new `NotificationGrouping` / presentation
+  helpers (new file(s) in the same module).
+- `Sources/Update/NotificationPopoverRow.swift`, `Sources/Update/UpdateTitlebarAccessory.swift`.
+- `Sources/NotificationsPage.swift`.
+- `Sources/App/MenuBarExtraController.swift` (+ `MenuBarNotificationLineFormatter`).
+- `Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift`.
+- `Resources/Localizable.xcstrings`.
+- New test files under `cmuxTests/` (+ pbxproj wiring) and/or the settings package tests.
+
+## Out of scope
+
+- Notification delivery, sound, phone-forwarding logic — untouched.
+- The three surfaces' non-list states (empty, jump-to-latest, clear-all) keep current
+  behavior; only visual row/grouping treatment changes.


### PR DESCRIPTION
## Summary

- What changed: Tuned the scroll-spy activation trigger in Settings/Preferences — the left-nav tab now only switches to a section once that section's header actually reaches the top edge, instead of switching prematurely. The activation offset moved from 96pt down to 20pt after manual feel-testing.
- Why: The old trigger switched the highlighted tab before the matching section was actually visible on screen, so the sidebar didn't track what you were looking at.

## Testing

- How did you test this change? Built and ran the debug app (`./scripts/reload.sh --tag notif-redesign-scrollspy --launch`).
- What did you verify manually? Opened Preferences and scrolled through each settings section, confirming the left-tab highlight now switches only once a section's header crosses the top edge at the tuned offset — not before.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

<img width="316" height="477" alt="Screenshot 2026-09-02 at 2 54 07 PM" src="https://github.com/user-attachments/assets/d986d56d-ae82-45d3-8c16-c478578a10a9" />
<img width="316" height="477" alt="Screenshot 2026-09-02 at 2 54 07 PM" src="https://github.com/user-attachments/assets/9803e259-3d9a-4dca-895c-1403f890bf13" />

## Review Trigger (Copy/Paste as PR comment)

​```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
​```

## Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11667"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790945717&installation_model_id=21920&pr_number=11667&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11667&signature=e0534af40452fb1f7043ebc0d080c5e919cce1dfdedd2d60bd9e6945bc3d410a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigns notifications into grouped, card-style rows across the menu-bar dropdown, titlebar popover, and in-app page, and fixes the Settings sidebar scroll-spy so the highlight only switches once a section's header reaches the top edge.

Previously the sidebar tab switched before the matching section was visible; the activation offset moved from 96pt down to 20pt.

**Bug Fixes**
- New `SettingsScrollSpy` tracks each section's top offset via a `PreferenceKey` and updates the highlight directly, bypassing the navigation scroll path to avoid a feedback loop.
- Highlight updates are suppressed during search and for 0.45s after a sidebar click so the animation isn't overridden.
- Added unit tests for `SettingsScrollSpy` covering boundary and empty-offset cases.

**New Features**
- Shared `NotificationPresentation` helpers (icon symbol, localized relative timestamp, Today/Yesterday/Earlier grouping) are reused across all three surfaces.
- Menu-bar dropdown rows now use a custom `NotificationMenuItemView` that draws a tinted rounded card with an icon chip, relative time, and unread accent.
- Titlebar popover and in-app page rows get matching icon chips, relative timestamps, and unread accent tints, grouped under time-bucket headers.
- Added unit tests for `NotificationPresentation` and `NotificationGrouping`.

<sup>Written for commit 41c0309bc1906522765e89304f544194c8208a89. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11667?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Notifications are now grouped into Today, Yesterday, and Earlier sections across the app and menu bar.
  - Notification rows now show relative times, clearer icons, unread indicators, and improved visual emphasis.
  - Settings navigation now highlights the section currently visible while scrolling.
  - Added localized headings for notification time groups.

- **Bug Fixes**
  - Improved settings navigation behavior during searches and programmatic scrolling.

- **Tests**
  - Added coverage for notification grouping, time formatting, and settings scroll tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->