### PR TITLE
fix(cmux-tui): retain agent updates across topology races

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -385,16 +385,17 @@ impl RemoteTreeCache {
 
     fn replace_agents(&mut self, agents: Vec<AgentInfo>, refresh_generation: u64) {
         self.agents = agents;
-        let snapshot_surfaces =
-            self.agents.iter().map(|agent| agent.surface).collect::<HashSet<_>>();
         let updates = std::mem::take(&mut self.agent_updates);
         for (surface, update) in updates {
             if self.surface_tabs.contains_key(&surface) {
                 // A pending update may have been observed during an earlier
-                // refresh whose topology omitted this surface. Once the
-                // surface is visible again, prefer that event even when the
-                // current refresh started after it.
-                if update.generation > refresh_generation || !snapshot_surfaces.contains(&surface) {
+                // refresh whose topology omitted this surface. Reapply it
+                // only when it is newer than the current snapshot boundary.
+                // An equal-or-older update was already included in the
+                // boundary and must not resurrect an agent omitted by the
+                // authoritative roster response when a stale topology
+                // briefly shows the surface again.
+                if update.generation > refresh_generation {
                     self.replace_agent(update.agent);
                 }
             } else if update.generation > refresh_generation {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7709,6 +7709,48 @@ mod tests {
     }
 
     #[test]
+    fn agent_refresh_does_not_resurrect_after_confirmed_omission() {
+        let tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "screens": [{
+                    "id": 2,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "tabs": [{"surface": 4, "title": "agent terminal"}],
+                    }],
+                }],
+            }],
+        }));
+        let mut cache = RemoteTreeCache::default();
+        cache.replace(tree.clone(), 0);
+
+        // The event races the first refresh and is retained while the
+        // topology omits the surface.
+        let refresh_generation = cache.agent_generation();
+        cache.update_agent(AgentInfo {
+            surface: 4,
+            state: "working".into(),
+            source: "hook".into(),
+            session: Some("review".into()),
+            agent: None,
+            updated_at_ms: 41,
+        });
+        cache.replace(TreeView::default(), cache.title_generation());
+        cache.replace_agents(Vec::new(), refresh_generation);
+
+        // A later refresh confirms the agent is absent. A stale topology may
+        // briefly show the surface again, but the old event must not return.
+        let confirmed_generation = cache.agent_generation();
+        cache.replace(tree, cache.title_generation());
+        cache.replace_agents(Vec::new(), confirmed_generation);
+
+        assert!(cache.agents.is_empty());
+        assert!(cache.agent_updates.is_empty());
+    }
+
+    #[test]
     fn agent_refresh_retains_updates_when_topology_temporarily_omits_surface() {
         let tree = parse_tree(&json!({
             "workspaces": [{

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7698,6 +7698,46 @@ mod tests {
     }
 
     #[test]
+    fn agent_refresh_retains_updates_when_topology_temporarily_omits_surface() {
+        let tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "screens": [{
+                    "id": 2,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "tabs": [{"surface": 4, "title": "agent terminal"}],
+                    }],
+                }],
+            }],
+        }));
+        let mut cache = RemoteTreeCache::default();
+        cache.replace(tree.clone(), 0);
+        let refresh_generation = cache.agent_generation();
+        let update = AgentInfo {
+            surface: 4,
+            state: "working".into(),
+            source: "hook".into(),
+            session: Some("review".into()),
+            updated_at_ms: 41,
+        };
+        cache.update_agent(update.clone());
+
+        // The tree response can lag the event stream and omit a live surface.
+        cache.replace(TreeView::default(), cache.title_generation());
+        cache.replace_agents(Vec::new(), refresh_generation);
+
+        assert_eq!(cache.agent_updates.get(&4).map(|pending| &pending.agent), Some(&update));
+
+        // A later topology response makes the pending event visible again.
+        cache.replace(tree, cache.title_generation());
+        cache.replace_agents(Vec::new(), refresh_generation);
+
+        assert_eq!(cache.agents, vec![update]);
+    }
+
+    #[test]
     fn browser_state_without_frame_keeps_cached_frame() {
         let surface = RemoteSurface {
             id: 1,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -385,12 +385,23 @@ impl RemoteTreeCache {
 
     fn replace_agents(&mut self, agents: Vec<AgentInfo>, refresh_generation: u64) {
         self.agents = agents;
+        let snapshot_surfaces =
+            self.agents.iter().map(|agent| agent.surface).collect::<HashSet<_>>();
         let updates = std::mem::take(&mut self.agent_updates);
-        for update in updates.into_values() {
-            if update.generation > refresh_generation
-                && self.surface_tabs.contains_key(&update.agent.surface)
-            {
-                self.replace_agent(update.agent);
+        for (surface, update) in updates {
+            if self.surface_tabs.contains_key(&surface) {
+                // A pending update may have been observed during an earlier
+                // refresh whose topology omitted this surface. Once the
+                // surface is visible again, prefer that event even when the
+                // current refresh started after it.
+                if update.generation > refresh_generation || !snapshot_surfaces.contains(&surface) {
+                    self.replace_agent(update.agent);
+                }
+            } else if update.generation > refresh_generation {
+                // The topology response can lag the event stream. Keep a
+                // newer event until a later topology confirms the surface is
+                // gone instead of dropping it at this refresh boundary.
+                self.agent_updates.insert(surface, update);
             }
         }
     }


### PR DESCRIPTION
Summary:
- retain agent events that arrive during a refresh when the topology snapshot temporarily omits the surface
- reapply a retained event when the surface returns, while allowing a later missing topology to confirm removal

Regression coverage is the first commit; the fix is the second commit.

Checks: rustfmt --edition 2024 --check; git diff --check. Cargo/Rust tests were not run locally per cmux-tui Testbox policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11672"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790946577&installation_model_id=21920&pr_number=11672&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11672&signature=373446bb17e43883f2b67a20d2a314fad241d804cf8778160b00f168b9666df2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in the cmux-tui remote tree cache where agent updates arriving during a refresh could be lost if the topology snapshot temporarily omitted the surface.

**Bug Fixes**
- Retains agent events that arrive during a refresh when the topology omits the surface, and reapplies them once the surface returns.
- Prevents an older event from resurrecting an agent when a stale topology briefly shows the surface after a later refresh confirmed the removal.

<sup>Written for commit 2ebb5a5227557659e30b42865c9263be93662c70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11672?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

