### PR TITLE
cmux-tui: join host input reader during shutdown

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1240,7 +1240,13 @@ impl HostInputProducer {
         // This is only a wake hint. Keep it nonblocking so shutdown can join
         // the reader even when the app event channel is full.
         match self.events.try_send(AppEvent::HostInputReady) {
-            Ok(()) | Err(TrySendError::Full(AppEvent::HostInputReady)) => true,
+            Ok(()) => true,
+            Err(TrySendError::Full(AppEvent::HostInputReady)) => {
+                // A full channel already has queued work. The event loop
+                // drains retained host input before each wait and after every
+                // queued event, so this wake hint is redundant.
+                true
+            }
             Err(TrySendError::Disconnected(AppEvent::HostInputReady)) => {
                 self.ingress.close();
                 false

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1170,7 +1170,11 @@ impl HostInputShutdown {
         // crossterm wrapper caps every poll at CROSSTERM_POLL_INTERVAL and
         // only calls read after poll reports a ready event, so joining here
         // cannot wait on an idle terminal read.
-        if let Some(reader) = self.reader.lock().unwrap().take()
+        let reader = {
+            let mut slot = self.reader.lock().unwrap();
+            slot.take()
+        };
+        if let Some(reader) = reader
             && reader.thread().id() != std::thread::current().id()
         {
             let _ = reader.join();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1201,6 +1201,8 @@ impl HostInputProducer {
         if !wake {
             return true;
         }
+        // This is only a wake hint. Keep it nonblocking so shutdown can join
+        // the reader even when the app event channel is full.
         match self.events.try_send(AppEvent::HostInputReady) {
             Ok(()) | Err(TrySendError::Full(AppEvent::HostInputReady)) => true,
             Err(TrySendError::Disconnected(AppEvent::HostInputReady)) => {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1120,12 +1120,15 @@ impl HostInputIngress {
 
 struct HostInputRuntime {
     ingress: Arc<HostInputIngress>,
-    reader: Arc<Mutex<Option<JoinHandle<()>>>>,
+    reader: Arc<HostInputReaderControl>,
 }
 
 impl HostInputRuntime {
     fn new() -> Self {
-        Self { ingress: Arc::new(HostInputIngress::default()), reader: Arc::new(Mutex::new(None)) }
+        Self {
+            ingress: Arc::new(HostInputIngress::default()),
+            reader: Arc::new(HostInputReaderControl::default()),
+        }
     }
 
     fn producer(&self, events: SyncSender<AppEvent>) -> HostInputProducer {
@@ -1137,9 +1140,11 @@ impl HostInputRuntime {
     }
 
     fn attach_reader(&self, reader: JoinHandle<()>) {
-        let mut slot = self.reader.lock().unwrap();
-        assert!(slot.is_none(), "host input reader can only be attached once");
-        *slot = Some(reader);
+        let mut state = self.reader.state.lock().unwrap();
+        assert!(!state.shutting_down, "host input reader cannot attach during shutdown");
+        assert!(state.reader.is_none(), "host input reader can only be attached once");
+        state.reader_thread = Some(reader.thread().id());
+        state.reader = Some(reader);
     }
 
     fn shutdown_control(&self) -> HostInputShutdown {
@@ -1160,7 +1165,7 @@ impl Drop for HostInputRuntime {
 #[derive(Clone)]
 struct HostInputShutdown {
     ingress: Arc<HostInputIngress>,
-    reader: Arc<Mutex<Option<JoinHandle<()>>>>,
+    reader: Arc<HostInputReaderControl>,
 }
 
 impl HostInputShutdown {
@@ -1170,16 +1175,47 @@ impl HostInputShutdown {
         // crossterm wrapper caps every poll at CROSSTERM_POLL_INTERVAL and
         // only calls read after poll reports a ready event, so joining here
         // cannot wait on an idle terminal read.
+        let current_thread = std::thread::current().id();
         let reader = {
-            let mut slot = self.reader.lock().unwrap();
-            slot.take()
+            let mut state = self.reader.state.lock().unwrap();
+            if state.complete {
+                return;
+            }
+            if state.shutting_down {
+                if state.reader_thread == Some(current_thread) {
+                    return;
+                }
+                while !state.complete {
+                    state = self.reader.complete.wait(state).unwrap();
+                }
+                return;
+            }
+            state.shutting_down = true;
+            state.reader.take()
         };
         if let Some(reader) = reader
-            && reader.thread().id() != std::thread::current().id()
+            && reader.thread().id() != current_thread
         {
             let _ = reader.join();
         }
+        let mut state = self.reader.state.lock().unwrap();
+        state.complete = true;
+        self.reader.complete.notify_all();
     }
+}
+
+#[derive(Default)]
+struct HostInputReaderControl {
+    state: Mutex<HostInputReaderState>,
+    complete: Condvar,
+}
+
+#[derive(Default)]
+struct HostInputReaderState {
+    reader: Option<JoinHandle<()>>,
+    reader_thread: Option<std::thread::ThreadId>,
+    shutting_down: bool,
+    complete: bool,
 }
 
 struct HostInputProducer {
@@ -24972,6 +25008,48 @@ mod tests {
             "runtime shutdown must join the input reader before returning"
         );
         drop(events_rx);
+    }
+
+    #[test]
+    fn host_input_runtime_shutdown_serializes_concurrent_callers() {
+        let mut runtime = HostInputRuntime::new();
+        let ingress = runtime.ingress.clone();
+        let (closed_tx, closed_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let reader = std::thread::spawn(move || {
+            while !ingress.is_closed() {
+                std::thread::yield_now();
+            }
+            closed_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        runtime.attach_reader(reader);
+
+        let shutdown = runtime.shutdown_control();
+        let first_shutdown = shutdown.clone();
+        let (first_done_tx, first_done_rx) = std::sync::mpsc::sync_channel(1);
+        let first = std::thread::spawn(move || {
+            first_shutdown.shutdown();
+            first_done_tx.send(()).unwrap();
+        });
+        closed_rx.recv().unwrap();
+
+        let second_shutdown = shutdown.clone();
+        let (second_done_tx, second_done_rx) = std::sync::mpsc::sync_channel(1);
+        let second = std::thread::spawn(move || {
+            second_shutdown.shutdown();
+            second_done_tx.send(()).unwrap();
+        });
+        assert!(
+            second_done_rx.try_recv().is_err(),
+            "concurrent shutdown must wait for the reader join"
+        );
+
+        release_tx.send(()).unwrap();
+        first.join().unwrap();
+        second.join().unwrap();
+        assert!(first_done_rx.try_recv().is_ok());
+        assert!(second_done_rx.try_recv().is_ok());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24888,6 +24888,27 @@ mod tests {
     }
 
     #[test]
+    fn host_input_runtime_shutdown_joins_reader_before_returning() {
+        let mut runtime = HostInputRuntime::new();
+        let ingress = runtime.ingress.clone();
+        let (finished_tx, finished_rx) = std::sync::mpsc::sync_channel(1);
+        let reader = std::thread::spawn(move || {
+            while !ingress.is_closed() {
+                std::thread::yield_now();
+            }
+            finished_tx.send(()).unwrap();
+        });
+
+        runtime.attach_reader(reader);
+        runtime.shutdown();
+
+        assert!(
+            finished_rx.try_recv().is_ok(),
+            "runtime shutdown must join the input reader before returning"
+        );
+    }
+
+    #[test]
     fn host_input_ingress_keeps_latest_adjacent_resize() {
         let ingress = HostInputIngress::default();
         ingress.send(Event::Resize(80, 24)).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1166,9 +1166,12 @@ struct HostInputShutdown {
 impl HostInputShutdown {
     fn shutdown(&self) {
         self.ingress.close();
+        // The reader checks the closed ingress before each read. The
+        // crossterm wrapper caps every poll at CROSSTERM_POLL_INTERVAL and
+        // only calls read after poll reports a ready event, so joining here
+        // cannot wait on an idle terminal read.
         if let Some(reader) = self.reader.lock().unwrap().take()
             && reader.thread().id() != std::thread::current().id()
-            && reader.is_finished()
         {
             let _ = reader.join();
         }
@@ -24954,8 +24957,8 @@ mod tests {
         runtime.shutdown();
 
         assert!(
-            finished_rx.recv_timeout(Duration::from_secs(1)).is_ok(),
-            "runtime shutdown must cancel the input reader"
+            finished_rx.try_recv().is_ok(),
+            "runtime shutdown must join the input reader before returning"
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24993,7 +24993,7 @@ mod tests {
     fn host_input_runtime_shutdown_joins_reader_before_returning() {
         let mut runtime = HostInputRuntime::new();
         let ingress = runtime.ingress.clone();
-        let (events_tx, events_rx) = std::sync::mpsc::sync_channel(1);
+        let (events_tx, events_rx) = crossbeam_channel::bounded(1);
         events_tx.send(AppEvent::HostInputReady).unwrap();
         let input = runtime.producer(events_tx);
         let (finished_tx, finished_rx) = std::sync::mpsc::sync_channel(1);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24949,8 +24949,13 @@ mod tests {
     fn host_input_runtime_shutdown_joins_reader_before_returning() {
         let mut runtime = HostInputRuntime::new();
         let ingress = runtime.ingress.clone();
+        let (events_tx, events_rx) = std::sync::mpsc::sync_channel(1);
+        events_tx.send(AppEvent::HostInputReady).unwrap();
+        let input = runtime.producer(events_tx);
         let (finished_tx, finished_rx) = std::sync::mpsc::sync_channel(1);
         let reader = std::thread::spawn(move || {
+            let key = Event::Key(KeyEvent::new(KeyCode::Char('x'), KeyModifiers::NONE));
+            assert!(input.send(key));
             while !ingress.is_closed() {
                 std::thread::yield_now();
             }
@@ -24964,6 +24969,7 @@ mod tests {
             finished_rx.try_recv().is_ok(),
             "runtime shutdown must join the input reader before returning"
         );
+        drop(events_rx);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1166,7 +1166,10 @@ struct HostInputShutdown {
 impl HostInputShutdown {
     fn shutdown(&self) {
         self.ingress.close();
-        if let Some(reader) = self.reader.lock().unwrap().take() {
+        if let Some(reader) = self.reader.lock().unwrap().take()
+            && reader.thread().id() != std::thread::current().id()
+            && reader.is_finished()
+        {
             let _ = reader.join();
         }
     }
@@ -24951,8 +24954,8 @@ mod tests {
         runtime.shutdown();
 
         assert!(
-            finished_rx.try_recv().is_ok(),
-            "runtime shutdown must join the input reader before returning"
+            finished_rx.recv_timeout(Duration::from_secs(1)).is_ok(),
+            "runtime shutdown must cancel the input reader"
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1120,11 +1120,12 @@ impl HostInputIngress {
 
 struct HostInputRuntime {
     ingress: Arc<HostInputIngress>,
+    reader: Arc<Mutex<Option<JoinHandle<()>>>>,
 }
 
 impl HostInputRuntime {
     fn new() -> Self {
-        Self { ingress: Arc::new(HostInputIngress::default()) }
+        Self { ingress: Arc::new(HostInputIngress::default()), reader: Arc::new(Mutex::new(None)) }
     }
 
     fn producer(&self, events: SyncSender<AppEvent>) -> HostInputProducer {
@@ -1134,11 +1135,40 @@ impl HostInputRuntime {
     fn pop_if(&self, accept: impl FnOnce(&HostInputMessage) -> bool) -> Option<HostInputMessage> {
         self.ingress.pop_if(accept)
     }
+
+    fn attach_reader(&self, reader: JoinHandle<()>) {
+        let mut slot = self.reader.lock().unwrap();
+        assert!(slot.is_none(), "host input reader can only be attached once");
+        *slot = Some(reader);
+    }
+
+    fn shutdown_control(&self) -> HostInputShutdown {
+        HostInputShutdown { ingress: self.ingress.clone(), reader: self.reader.clone() }
+    }
+
+    fn shutdown(&self) {
+        self.shutdown_control().shutdown();
+    }
 }
 
 impl Drop for HostInputRuntime {
     fn drop(&mut self) {
+        self.shutdown();
+    }
+}
+
+#[derive(Clone)]
+struct HostInputShutdown {
+    ingress: Arc<HostInputIngress>,
+    reader: Arc<Mutex<Option<JoinHandle<()>>>>,
+}
+
+impl HostInputShutdown {
+    fn shutdown(&self) {
         self.ingress.close();
+        if let Some(reader) = self.reader.lock().unwrap().take() {
+            let _ = reader.join();
+        }
     }
 }
 
@@ -9104,6 +9134,7 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
     // would corrupt the raw-mode screen, so route fd 2 into the client log.
     crate::client_log::redirect_stderr_into_log();
     let mut terminal_restore = TerminalRestoreGuard::new(stdout_lock.clone());
+    terminal_restore.set_host_input_shutdown(host_input.shutdown_control());
     if let Err(e) = (|| -> anyhow::Result<()> {
         let _guard = stdout_lock.lock();
         stdout_lock.recover_stream_locked()?;
@@ -9144,7 +9175,7 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
     // startup terminal probes so their replies cannot be consumed as key
     // input. Backpressure here must never block mutation completions.
     let input = host_input.producer(tx.clone());
-    if let Err(error) = std::thread::Builder::new().name("input".into()).spawn(move || {
+    let input_reader = match std::thread::Builder::new().name("input".into()).spawn(move || {
         for event in crate::ui::graphics::finish_startup_input(pending_input) {
             if !input.send(event) {
                 return;
@@ -9174,8 +9205,10 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
             }
         }
     }) {
-        return Err(terminal_restore.restore_after_error(error.into()));
-    }
+        Ok(reader) => reader,
+        Err(error) => return Err(terminal_restore.restore_after_error(error.into())),
+    };
+    host_input.attach_reader(input_reader);
 
     let graphics_writer = if graphics_supported {
         let graphics_ready = tx.clone();
@@ -9197,8 +9230,10 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
     let default_hook = std::panic::take_hook();
     let restore_lock = stdout_lock.clone();
     let panic_keyboard_protocol = terminal_restore.host_keyboard_protocol().clone();
+    let panic_host_input_shutdown = host_input.shutdown_control();
     let panic_graphics_shutdown = graphics_shutdown;
     std::panic::set_hook(Box::new(move |info| {
+        panic_host_input_shutdown.shutdown();
         if let Some(graphics_shutdown) = &panic_graphics_shutdown {
             graphics_shutdown.cancel_for_panic_hook();
         }
@@ -9481,6 +9516,7 @@ fn report_after_unwind<T>(
 struct TerminalRestoreGuard {
     stdout_lock: Arc<StdoutLock>,
     host_keyboard_protocol: HostKeyboardProtocolOwnership,
+    host_input_shutdown: Option<HostInputShutdown>,
     graphics_shutdown: Option<GraphicsWriterShutdown>,
     armed: bool,
 }
@@ -9490,6 +9526,7 @@ impl TerminalRestoreGuard {
         Self {
             stdout_lock,
             host_keyboard_protocol: HostKeyboardProtocolOwnership::default(),
+            host_input_shutdown: None,
             graphics_shutdown: None,
             armed: true,
         }
@@ -9507,11 +9544,18 @@ impl TerminalRestoreGuard {
         self.graphics_shutdown = graphics_shutdown;
     }
 
+    fn set_host_input_shutdown(&mut self, host_input_shutdown: HostInputShutdown) {
+        self.host_input_shutdown = Some(host_input_shutdown);
+    }
+
     fn restore(&mut self) -> anyhow::Result<()> {
         if !self.armed {
             return Ok(());
         }
         self.armed = false;
+        if let Some(host_input_shutdown) = &self.host_input_shutdown {
+            host_input_shutdown.shutdown();
+        }
         if let Some(graphics_shutdown) = &self.graphics_shutdown {
             graphics_shutdown.cancel_and_wait();
         }
@@ -9543,6 +9587,9 @@ impl Drop for TerminalRestoreGuard {
     fn drop(&mut self) {
         if self.armed {
             self.armed = false;
+            if let Some(host_input_shutdown) = &self.host_input_shutdown {
+                host_input_shutdown.shutdown();
+            }
             if let Some(graphics_shutdown) = &self.graphics_shutdown {
                 graphics_shutdown.cancel_and_wait();
             }
@@ -10732,6 +10779,7 @@ impl App {
     }
 
     fn shutdown_runtime_components(&mut self) {
+        self.host_input.shutdown();
         self.shutdown_background_workers();
         self.cancel_pointer_interaction();
         self.session.begin_shutdown();


### PR DESCRIPTION
Fixes the host input reader lifecycle in run_with_machine_updates_inner.

The input thread handle is now owned by HostInputRuntime. Shutdown closes the bounded ingress, wakes blocked producers, and joins the reader before terminal restoration, including startup-error and panic cleanup paths.

Regression coverage is split across two commits: the first adds the reader-shutdown behavior test, and the second implements the lifecycle fix.

Validation: rustfmt and git diff checks passed locally. Hosted focused cmux-tui verification was dispatched for host_input_runtime_shutdown_joins_reader_before_returning.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11673"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790946722&installation_model_id=21920&pr_number=11673&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11673&signature=2035544d99aeee63eeb64887587ee80d74879569d961c97fa485353a0d3e5849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`cmux-tui` previously closed the host input ingress without waiting for its reader; it now joins the reader before terminal restoration and shutdown completes. This prevents lingering input during normal exits, cancellation, startup failures, and panic cleanup.

- Serializes concurrent shutdown callers, avoids self-joins, and releases the control lock while waiting.
- Bounds cleanup by checking the closed ingress before reads and capping crossterm polls.
- Keeps wake hints nonblocking when the event channel is full and adds regression coverage for reader joins and concurrent shutdown.

<sup>Written for commit cf53b9632e951ced2d12f923b140a578e9293364. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved application shutdown handling for host input.
  - Input processing now stops cleanly when the application exits, restores the terminal, or encounters a panic.
  - Prevented lingering input activity after shutdown, reducing the risk of terminal state issues.
  - Improved handling of simultaneous shutdown events for more consistent cleanup and responsiveness.
  - Ensured input wake notifications remain responsive even when the application is busy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->