### PR TITLE
Vpc dogfood fixes

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/CmuxInternalHostnames.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/CmuxInternalHostnames.swift
@@ -4,10 +4,12 @@ import Foundation
 /// address, and the `/etc/hosts` management that makes the name resolve.
 ///
 /// The name only works from a Mac whose WireGuard tunnel is up (the address
-/// it resolves to is unroutable otherwise), so this is deliberately a courtesy
-/// convenience layered on the private IP, never a substitute for it: every
-/// caller that offers a `.internal` link falls back to the bare address when
-/// the entry cannot be written or has not been synced yet.
+/// it resolves to is unroutable otherwise) AND whose `/etc/hosts` has been
+/// synced (`cmux vpn hosts`), so nothing in the app builds a clickable link
+/// out of it — `directPortURL` uses the raw address instead, unconditionally.
+/// The `.internal` name is a manual-use convenience (typed into a terminal,
+/// an SSH config) that this module still builds and publishes to
+/// `/etc/hosts`; it is just never the thing a click depends on.
 ///
 /// Shared between the app (which builds the link a person clicks) and the CLI
 /// (`cmux vpn hosts`, which owns writing `/etc/hosts`) so the slug algorithm
@@ -63,6 +65,19 @@ public enum CmuxInternalHostnames {
 
     private static func slugOrRaw(_ raw: String) -> String {
         slug(raw) ?? raw
+    }
+
+    /// The URL a click on a machine's port row actually navigates to: straight
+    /// to its private-network address, over the WireGuard tunnel — never
+    /// through a provider port-forwarding proxy, which Freestyle's public
+    /// platform does not offer for arbitrary ports. Deliberately the raw
+    /// address, not the `.internal` name `cmux vpn hosts` publishes: that name
+    /// only resolves once `/etc/hosts` has been synced, and a link that only
+    /// sometimes works is worse than one that always does. An IPv6 literal is
+    /// bracketed the way every URL scheme requires.
+    public static func directPortURL(privateAddress: String, port: Int) -> String {
+        let bracketed = privateAddress.contains(":") ? "[\(privateAddress)]" : privateAddress
+        return "http://\(bracketed):\(port)"
     }
 
     /// Render entries as the managed block's body (no markers): one `ip host`

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxInternalHostnamesTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/CmuxInternalHostnamesTests.swift
@@ -81,4 +81,20 @@ struct CmuxInternalHostnamesTests {
         let current = "127.0.0.1 localhost\n"
         #expect(CmuxInternalHostnames.mergedHostsFile(current: current, body: "") == current)
     }
+
+    @Test("A port link is always the raw private address, never the .internal name")
+    func directPortURLUsesTheRawAddress() {
+        // Deliberately not the `.internal` name: it only resolves once
+        // `cmux vpn hosts` has synced `/etc/hosts`, and a link that only
+        // sometimes works is worse than one that always does.
+        #expect(CmuxInternalHostnames.directPortURL(privateAddress: "10.0.0.2", port: 8000) == "http://10.0.0.2:8000")
+    }
+
+    @Test("Brackets an IPv6 address the way every URL scheme requires")
+    func directPortURLBracketsIPv6() {
+        #expect(
+            CmuxInternalHostnames.directPortURL(privateAddress: "fd60:1e5e:6720::3", port: 22)
+                == "http://[fd60:1e5e:6720::3]:22"
+        )
+    }
 }

--- a/Sources/Cloud/CloudMachineLinkManager.swift
+++ b/Sources/Cloud/CloudMachineLinkManager.swift
@@ -38,6 +38,22 @@ actor CloudMachineLinkManager {
     /// A failed link is not retried for this long, so a polling sidebar does not hammer
     /// a machine whose route is broken.
     private let retryBackoff: TimeInterval = 15
+    /// How long a link may take to report its socket when this Mac is already
+    /// enrolled: the daemon accepts the session immediately, so anything slower
+    /// than this is a broken route rather than a slow one.
+    private let connectTimeout: Duration = .seconds(60)
+    /// The budget for a *first* link to a machine, which must also cover
+    /// enrollment. Enrollment cannot be done up front — the control plane can
+    /// only approve an invitation the client has already claimed (it looks for
+    /// it in `remote enroll pending`), so claiming and approving necessarily
+    /// race inside this one window. Each approval poll is a control-plane round
+    /// trip that shells into the machine twice (`enroll pending`, then
+    /// `enroll approve`), and on a machine that just booted those execs are
+    /// slow enough to blow a 60s budget: enrollment completed, but only after
+    /// the link had been timed out and its client killed, so every freshly
+    /// created machine hung at "connecting" for a minute and then needed a
+    /// manual retry that succeeded instantly.
+    private let enrollingConnectTimeout: Duration = .seconds(240)
     /// This Mac's resolved Ghostty default colors ("#rrggbb"), pushed to each machine as
     /// its cmux-tui session defaults (`set-default-colors`) so remote panes render with
     /// the local theme. Injected so tests need no Ghostty runtime.
@@ -99,7 +115,13 @@ actor CloudMachineLinkManager {
             }
             defer { approval?.cancel() }
             do {
-                return try await link.connect(route: endpoint.route, session: endpoint.session, invitationURI: endpoint.invitation?.uri)
+                return try await link.connect(
+                    route: endpoint.route,
+                    session: endpoint.session,
+                    invitationURI: endpoint.invitation?.uri,
+                    // Enrollment rides this same window (see enrollingConnectTimeout).
+                    timeout: endpoint.invitation == nil ? connectTimeout : enrollingConnectTimeout
+                )
             } catch {
                 await link.disconnect()
                 throw error
@@ -231,12 +253,18 @@ actor CloudMachineLinkManager {
     /// for the signed-in user, so approving the claim encodes "already authenticated".
     private func approveEnrollment(machineID: String, invitationID: String, client: VMClient) async {
         let deadline = Date().addingTimeInterval(5 * 60)
+        // The client claims its invitation as soon as it is spawned, so the
+        // first approval attempt is worth making almost immediately; a full
+        // poll interval spent asleep here is dead time inside the connect
+        // budget. Later attempts back off to the steady interval.
+        var delay: Duration = .milliseconds(250)
         while Date() < deadline, !Task.isCancelled {
             do {
-                try await Task.sleep(for: .seconds(2))
+                try await Task.sleep(for: delay)
             } catch {
                 return
             }
+            delay = .seconds(2)
             let approval: VMCmuxRemoteApproval
             do {
                 approval = try await client.approveCmuxRemoteEnrollment(id: machineID, invitationId: invitationID)

--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -45,13 +45,13 @@ final class CloudTreeNode: NSObject {
         case browser(CloudTreeBrowserRow)
         /// "Ports" group under a cloud machine.
         case portsGroup(machine: SurfaceMachineID)
-        /// The resource plus the URL a person would paste to reach it —
-        /// `http://<machine-name>.internal:<port>` when the machine has a
-        /// private address (resolved by the app's own DNS override, so the
-        /// name only works from a Mac with the tunnel active), else
-        /// `http://<private-ip>:<port>`, else nil when the machine has no
-        /// private address to build one from (public-only machines, or one
-        /// this Mac hasn't attached to yet).
+        /// The resource plus the URL a click actually opens —
+        /// `http://<private-ip>:<port>`, reachable over the WireGuard tunnel —
+        /// or nil when the machine has no private address yet (public-only
+        /// machines, or one this Mac hasn't attached to yet). Deliberately the
+        /// raw address, never the `.internal` name: that name only resolves
+        /// once `cmux vpn hosts` has synced `/etc/hosts`, so a link built from
+        /// it would work only sometimes.
         case port(SurfaceResource, url: String?)
         /// A single explanatory line (asleep, connecting, link error, empty).
         case placeholder(machine: SurfaceMachineID, CloudTreePlaceholder)
@@ -505,12 +505,8 @@ enum CloudTreeNodeBuilder {
         guard let port, let address = info?.privateAddress else { return nil }
         // Cloud machines only: the local Mac has no private-network address to
         // begin with, so it never reaches here with one.
-        if case .cloud(let id) = machine {
-            let hostname = CmuxInternalHostnames.hostname(id: id, label: info?.name)
-            return "http://\(hostname):\(port)"
-        }
-        let bracketed = address.contains(":") ? "[\(address)]" : address
-        return "http://\(bracketed):\(port)"
+        guard machine.isLocal == false else { return nil }
+        return CmuxInternalHostnames.directPortURL(privateAddress: address, port: port)
     }
 
     private static func cloudChildren(machine: SurfaceMachineID, info: SurfaceMachineInfo?, snapshot: SurfaceCatalogSnapshot) -> [CloudTreeNode] {

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -321,8 +321,11 @@ struct CloudTreeLeafRow<Accessories: View>: View {
     }
 
     private var titleColor: AnyShapeStyle {
-        if titleIsLink { return AnyShapeStyle(Color.accentColor) }
-        return titleDimmed ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary)
+        // Underlined-but-primary, not accent-tinted: a port link sits among
+        // plain-text rows in the same tree, and the accent color read as an
+        // unrelated highlight rather than "this text is a link" the way the
+        // underline alone already says.
+        titleDimmed ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary)
     }
 
     private func detailText(_ text: String) -> some View {

--- a/Sources/Cloud/CloudTuiCommandLine.swift
+++ b/Sources/Cloud/CloudTuiCommandLine.swift
@@ -128,9 +128,23 @@ struct CloudTuiCommandLine: Sendable {
     }
 
     /// The compatibility tree used to translate a public `term_…` id to the
-    /// numeric surface id required by `attach-surface` byte streams.
+    /// numeric surface id required by `attach-surface` byte streams. Each tab
+    /// in it carries `terminal_resource_id` (the public id the app holds) next
+    /// to `surface`, which is the join the resolver needs.
+    ///
+    /// This rides the raw command bridge rather than a top-level
+    /// `list-workspaces` subcommand: the resource CLI reads that leading word
+    /// as a resource scope and rejects it with `unknown resource scope
+    /// "list-workspaces"`, so the tree was unreachable from the CLI even though
+    /// the daemon still serves the command over the wire.
     static func legacyListWorkspacesArguments(socketPath: String) -> [String] {
-        ["--socket", socketPath, "--json", "list-workspaces"]
+        // A fixed literal, so this cannot fail to encode and the request stays
+        // byte-stable across runs.
+        [
+            "--socket", socketPath,
+            "--json", "raw", "command",
+            "--request-json", #"{"id":1,"cmd":"list-workspaces"}"#,
+        ]
     }
 
     /// Resolves a stable terminal resource ID to the current generation's

--- a/Sources/Cloud/NewMachineSheet.swift
+++ b/Sources/Cloud/NewMachineSheet.swift
@@ -74,28 +74,6 @@ struct NewMachineSheet: View {
                         .fixedSize(horizontal: false, vertical: true)
                 }
             }
-            if model.supportsSize {
-                GridRow {
-                    label(String(localized: "machines.new.size.label", defaultValue: "Size"))
-                    VStack(alignment: .leading, spacing: 4) {
-                        Picker("", selection: $model.memoryMb) {
-                            ForEach(model.memoryOptions, id: \.self) { mb in
-                                Text(NewMachineModel.memoryLabel(mb: mb)).tag(mb)
-                            }
-                        }
-                        .pickerStyle(.menu)
-                        .labelsHidden()
-                        .frame(maxWidth: 140, alignment: .leading)
-                        .accessibilityIdentifier("NewMachineSheet.size")
-                        Text(String(
-                            localized: "machines.new.size.summary",
-                            defaultValue: "Memory. CPU scales with it."
-                        ))
-                        .cmuxFont(size: 11)
-                        .foregroundStyle(.secondary)
-                    }
-                }
-            }
             if let image = model.selectedImage {
                 GridRow {
                     label(String(localized: "machines.new.image.label", defaultValue: "Image"))

--- a/Sources/Surfaces/CmuxTuiSnapshotParser.swift
+++ b/Sources/Surfaces/CmuxTuiSnapshotParser.swift
@@ -384,8 +384,13 @@ struct CmuxTuiSnapshotParser: Sendable {
         return pool.filter { !($0.kind == .display && pointed.contains($0.id)) } + parsed
     }
 
-    /// A forwarded port, shown as a browser resource.
-    static func portBrowser(machine: SurfaceMachineID, port: Int) -> SurfaceResource {
+    /// A forwarded port, shown as a browser resource. `directURL`, when
+    /// given, is where opening it actually navigates — the machine's private
+    /// address over the WireGuard tunnel, never a provider port-forwarding
+    /// proxy (Freestyle's public platform has none for arbitrary ports). nil
+    /// only for a machine with no private-network address yet, which falls
+    /// back to the legacy provider-minted-endpoint path.
+    static func portBrowser(machine: SurfaceMachineID, port: Int, directURL: String? = nil) -> SurfaceResource {
         SurfaceResource(
             id: SurfaceResourceID(machine: machine, kind: .browser, key: "port:\(port)"),
             title: ":\(port)",
@@ -394,7 +399,7 @@ struct CmuxTuiSnapshotParser: Sendable {
             agent: nil,
             remoteWorkspace: nil,
             port: port,
-            url: nil
+            url: directURL
         )
     }
 

--- a/Sources/Surfaces/CmuxTuiSurfaceProvider+ManualMirror.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProvider+ManualMirror.swift
@@ -399,7 +399,21 @@ extension CmuxTuiSurfaceProvider {
         return results
     }
 
-    nonisolated private static func isExplicitUnsupportedResolverError(_ error: Error) -> Bool {
+    /// Whether the daemon's answer means "this resolver cannot serve me",
+    /// which sends the caller to the compatibility tree instead of failing
+    /// closed.
+    ///
+    /// Two answers qualify. `operation.unsupported` is a daemon that predates
+    /// the resolver. `invalid_terminal_id` is an id-space mismatch:
+    /// `resolve-terminal` takes a *terminal host* id (UUIDv4 hex, per
+    /// spec/sdk-schema.json), while everything the app holds is a public
+    /// `term_…` resource id whose hex is not a UUIDv4 and which no command maps
+    /// to a host id. So the modern resolver can never answer for the ids this
+    /// app has, and treating that as a hard failure made every cloud terminal
+    /// fail with "cmux-tui did not report the new terminal". The compatibility
+    /// tree does carry the mapping (`terminal_resource_id` beside `surface`),
+    /// so the fallback is the path that actually resolves.
+    nonisolated static func isExplicitUnsupportedResolverError(_ error: Error) -> Bool {
         guard case let CloudMachineLink.LinkError.exited(_, output) = error else { return false }
         let lines = output.split(whereSeparator: \.isNewline)
         for line in lines {
@@ -408,6 +422,11 @@ extension CmuxTuiSurfaceProvider {
             else { continue }
             if object["code"] as? String == "operation.unsupported"
                 || object["error_code"] as? String == "operation.unsupported" {
+                return true
+            }
+            let detailError = (object["details"] as? [String: Any])?["error"] as? String
+            if object["message"] as? String == "invalid_terminal_id"
+                || detailError == "invalid_terminal_id" {
                 return true
             }
         }

--- a/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
+++ b/Sources/Surfaces/CmuxTuiSurfaceProviders.swift
@@ -1,3 +1,4 @@
+import CmuxFoundation
 import Foundation
 
 /// Owns one ``CmuxTuiSurfaceProvider`` per cloud machine and keeps the catalog's machine
@@ -304,8 +305,10 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             where reconnectableSessionIDs.contains(ObjectIdentifier(session)) {
                 session.reconnect(socketPath: connected.socketPath)
             }
+            let privateAddress = summary.preferredPrivateAddress
             for port in await ports(client: client, force: force) {
-                resources.append(CmuxTuiSnapshotParser.portBrowser(machine: machine, port: port))
+                let directURL = privateAddress.map { CmuxInternalHostnames.directPortURL(privateAddress: $0, port: port) }
+                resources.append(CmuxTuiSnapshotParser.portBrowser(machine: machine, port: port, directURL: directURL))
             }
         } catch {
             let status = await links.status(machineID: machineID)
@@ -452,7 +455,20 @@ final class CmuxTuiSurfaceProvider: SurfaceProvider {
             guard let port = resource.port ?? (desktop ? CmuxTuiSnapshotParser.desktopPort : nil) else {
                 throw SurfaceCatalogError.unsupported("browser \(resource.id) has no port")
             }
-            if let url = endpointURL(port: port, desktop: desktop) {
+            // A forwarded-port row (`portBrowser`, id key "port:<n>") already
+            // carries the URL to open — its own private address over the
+            // WireGuard tunnel — and must navigate there directly, never
+            // through the endpoint()/openPort proxy below: Freestyle's public
+            // platform has no port-forwarding proxy for arbitrary ports, so
+            // that call fails outright for exactly the machines this exists
+            // for. A regular daemon browser's `url` is a different thing (the
+            // remote tab's own address, not a locally-openable link) and must
+            // still go through the proxy/CDP path, so this only ever fires
+            // for the id shape `portBrowser` mints.
+            if !desktop, resource.id.key.hasPrefix("port:"),
+               let directURLString = resource.url, let directURL = URL(string: directURLString) {
+                created = try SurfacePaneFactory.makeBrowserPane(url: directURL, at: destination, focus: focus)
+            } else if let url = endpointURL(port: port, desktop: desktop) {
                 created = try SurfacePaneFactory.makeBrowserPane(url: url, at: destination, focus: focus)
             } else {
                 // Optimistic: the pane exists before its endpoint does. Minting the preview

--- a/cmuxTests/CloudManualMirrorTransportTests.swift
+++ b/cmuxTests/CloudManualMirrorTransportTests.swift
@@ -274,6 +274,60 @@ struct CloudManualMirrorTransportTests {
         )
     }
 
+    /// The compatibility tree is only reachable over the raw command bridge.
+    /// Sent as a leading `list-workspaces` word, the resource CLI reads it as a
+    /// resource scope and answers `unknown resource scope "list-workspaces"`,
+    /// which left the tree — and so every cloud terminal's surface — unresolvable.
+    @Test
+    func legacyWorkspaceTreeIsRequestedOverTheRawCommandBridge() throws {
+        let arguments = CloudTuiCommandLine.legacyListWorkspacesArguments(socketPath: "/tmp/cmux.sock")
+        #expect(arguments.prefix(5).elementsEqual(["--socket", "/tmp/cmux.sock", "--json", "raw", "command"]))
+        let requestIndex = try #require(arguments.firstIndex(of: "--request-json")) + 1
+        let request = try #require(
+            JSONSerialization.jsonObject(with: Data(arguments[requestIndex].utf8)) as? [String: Any]
+        )
+        #expect(request["cmd"] as? String == "list-workspaces")
+        // The bare subcommand spelling is what the CLI rejects.
+        #expect(!arguments.contains { $0 == "list-workspaces" })
+    }
+
+    /// `resolve-terminal` takes a terminal *host* id (UUIDv4 hex); the app only
+    /// ever holds a public `term_…` resource id, whose hex is not a UUIDv4 and
+    /// which no command maps to a host id. The daemon answers
+    /// `invalid_terminal_id`, and treating that as a hard failure made every
+    /// cloud terminal fail with "cmux-tui did not report the new terminal"
+    /// instead of falling back to the tree that can resolve it.
+    @Test
+    func idSpaceRejectionFallsBackToTheCompatibilityTree() {
+        let daemonAnswer = """
+        {"code":"raw.command_failed","details":{"error":"invalid_terminal_id","id":1,"ok":false},        "message":"invalid_terminal_id","retryable":false}
+        """
+        #expect(
+            CmuxTuiSurfaceProvider.isExplicitUnsupportedResolverError(
+                CloudMachineLink.LinkError.exited(status: 1, output: daemonAnswer)
+            )
+        )
+        // A daemon predating the resolver keeps its own fallback signal.
+        #expect(
+            CmuxTuiSurfaceProvider.isExplicitUnsupportedResolverError(
+                CloudMachineLink.LinkError.exited(
+                    status: 1,
+                    output: #"{"code":"operation.unsupported"}"#
+                )
+            )
+        )
+        // An unrelated failure must still fail closed rather than silently
+        // resolving a terminal against a stale tree.
+        #expect(
+            !CmuxTuiSurfaceProvider.isExplicitUnsupportedResolverError(
+                CloudMachineLink.LinkError.exited(
+                    status: 1,
+                    output: #"{"code":"internal","message":"boom"}"#
+                )
+            )
+        )
+    }
+
     @Test
     func legacyTreeResolverRejectsNonIntegralSurfaceValuesAndScansManyIDsOnce() throws {
         let tree: [String: Any] = [

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -196,19 +196,30 @@ type FreestyleNetworkAddress = {
  * Private wins unconditionally, and deliberately never falls back: a machine on
  * a VPC has no public inbound rule, so a public route for it would not be a
  * degraded path but a guaranteed timeout with a misleading address in the
- * error. IPv6 is preferred within the network only because the daemon binds
- * `[::]` — the IPv4 address is the honest second choice on a network whose v6
- * allocation was declined, not a fallback for an unreachable v6.
+ * error.
+ *
+ * Within the network, IPv4 is preferred, because only the v4 path is reliable
+ * over the WireGuard tunnel. The tunnel routes the VPC's v4 prefix as a subnet,
+ * so it reaches any member the moment that member exists; its v6 path does not
+ * pick up members created after the tunnel came up. A VM created into an
+ * established tunnel therefore answers on its private v4 and blackholes on its
+ * private v6 from the same Mac, while both work VM-to-VM inside the VPC. With
+ * v6 first, every freshly created machine spent the full 60s connect timeout
+ * and surfaced as "Command timed out"; only machines predating the tunnel
+ * connected. Preferring v4 also matches the app's own `preferredPrivateAddress`
+ * (v4 then v6), so the address a person copies from the sidebar is the address
+ * the daemon is dialed on. The public fallback below stays v6 — Freestyle
+ * allocates no public v4 at all.
  */
 export function freestyleCmuxRemoteRoute(addresses: FreestyleRouteAddresses, vmId: string): string {
   const networks = addresses.vpcs ?? addresses.networks ?? [];
   for (const network of networks) {
-    const ipv6 = network.ipv6?.trim();
-    if (ipv6) return `ws://[${ipv6}]:${CMUX_TUI_PORT}/v1/link`;
-  }
-  for (const network of networks) {
     const ipv4 = network.ipv4?.trim();
     if (ipv4) return `ws://${ipv4}:${CMUX_TUI_PORT}/v1/link`;
+  }
+  for (const network of networks) {
+    const ipv6 = network.ipv6?.trim();
+    if (ipv6) return `ws://[${ipv6}]:${CMUX_TUI_PORT}/v1/link`;
   }
   if (networks.length > 0) {
     throw new ProviderError(

--- a/web/tests/vm-freestyle-provider.test.ts
+++ b/web/tests/vm-freestyle-provider.test.ts
@@ -87,8 +87,12 @@ describe("Freestyle platform contract", () => {
   });
 
   test("cmux-remote route prefers the private VPC address and never falls back from it", () => {
-    // On a VPC: the private IPv6 wins even when a public address exists,
-    // because a VPC machine has no public inbound rule.
+    // On a VPC: the private address wins even when a public address exists,
+    // because a VPC machine has no public inbound rule. v4 is preferred within
+    // the network — the tunnel routes the VPC's v4 prefix as a subnet and so
+    // reaches new members immediately, while its v6 path does not pick up VMs
+    // created after the tunnel came up, stalling their connect for the full
+    // timeout.
     expect(
       freestyleCmuxRemoteRoute(
         {
@@ -97,14 +101,14 @@ describe("Freestyle platform contract", () => {
         },
         VM_ID,
       ),
-    ).toBe("ws://[fd7a:115c:a1e0::a]:1337/v1/link");
-    // v4-only membership is the honest second choice, not a public fallback.
+    ).toBe("ws://10.40.0.10:1337/v1/link");
+    // v6-only membership is the honest second choice, not a public fallback.
     expect(
       freestyleCmuxRemoteRoute(
-        { publicIpv6: "2602:f75c:0:1::2a", vpcs: [{ ipv4: "10.40.0.10", ipv6: null }] },
+        { publicIpv6: "2602:f75c:0:1::2a", vpcs: [{ ipv4: null, ipv6: "fd7a:115c:a1e0::a" }] },
         VM_ID,
       ),
-    ).toBe("ws://10.40.0.10:1337/v1/link");
+    ).toBe("ws://[fd7a:115c:a1e0::a]:1337/v1/link");
     // A membership with no address is unreachable and must say so, not
     // silently dial a public address the firewall will drop.
     expect(() =>


### PR DESCRIPTION
## Summary

- What changed?
- Why?

## Testing

- How did you test this change?
- What did you verify manually?

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11674"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790946748&installation_model_id=21920&pr_number=11674&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11674&signature=cb3fba900b5695ff42aafbbecb45c6adf2470535658d06b19004dab4d4fdd2a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes several VPC dogfooding issues: cloud terminal surfaces now resolve correctly, VPC machines connect over IPv4, and first-time links allow time for enrollment.

**Bug Fixes**
- Cloud terminal resolution now requests the workspace tree over the raw command bridge and treats `invalid_terminal_id` as a fallback trigger.
- VPC route prefers IPv4 over IPv6 because the tunnel routes the v4 prefix as a subnet and reaches new machines immediately.
- First-link timeout is extended to 240s to cover enrollment; the first approval poll happens immediately instead of after a full interval.
- Port links now use the machine's private IP directly (with IPv6 bracketed) instead of the `.internal` hostname.

<sup>Written for commit 95a2dfb59ac15dda4847b1217688cc39ba50af63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Port links now open directly through the machine’s private address, including IPv6 support.
  - Freestyle connections prefer private IPv4 routes for improved tunnel reliability.

- **Bug Fixes**
  - Cloud machine enrollment now allows more time for approval and responds faster initially.
  - Improved compatibility with legacy workspace and terminal-resource connections.
  - Port links avoid unreliable proxy routing where applicable.
  - Linked titles now use standard text color while remaining underlined.

- **UI Changes**
  - Removed the memory-size selector from the New Machine sheet.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->