### PR TITLE
fix(tui): join local PTY reaper during teardown

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1407,6 +1407,10 @@ pub struct PtyTerminalRuntime {
     /// journal barrier.
     reader_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
     reader_completion: Arc<ReaderCompletion>,
+    /// Owned child-reaper join fence. Shutdown uses the same bounded deadline
+    /// as the reader so the child wait cannot outlive terminal teardown.
+    reaper_thread: Mutex<Option<std::thread::JoinHandle<()>>>,
+    reaper_completion: Arc<ReaderCompletion>,
     term: Mutex<Box<Terminal>>,
     stream_progress: Box<TerminalStreamProgress>,
     mouse_encoders: Mutex<Box<MouseEncoders>>,
@@ -2411,6 +2415,8 @@ impl Surface {
                 journal_capture_active: AtomicBool::new(false),
                 reader_thread: Mutex::new(None),
                 reader_completion: Arc::new(ReaderCompletion::default()),
+                reaper_thread: Mutex::new(None),
+                reaper_completion: Arc::new(ReaderCompletion::default()),
                 term: Mutex::new(Box::new(term)),
                 stream_progress: Box::new(TerminalStreamProgress::default()),
                 mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
@@ -2618,9 +2624,6 @@ impl Surface {
             }
         });
         if let Err(error) = reaper {
-            // The failed spawn drops the closure and its child guard, which
-            // kills and waits for the child. Close the ConPTY master before
-            // returning so reader and frame threads can release the surface.
             close_local_terminal_master_after_exit(&surface);
             return Err(error.into());
         }
@@ -2890,6 +2893,8 @@ impl Surface {
                 journal_capture_active: AtomicBool::new(false),
                 reader_thread: Mutex::new(None),
                 reader_completion: Arc::new(ReaderCompletion::default()),
+                reaper_thread: Mutex::new(None),
+                reaper_completion: Arc::new(ReaderCompletion::default()),
                 term: Mutex::new(Box::new(term)),
                 stream_progress: Box::new(TerminalStreamProgress::default()),
                 mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
@@ -3933,6 +3938,8 @@ impl Surface {
                 journal_capture_active: AtomicBool::new(false),
                 reader_thread: Mutex::new(None),
                 reader_completion: Arc::new(ReaderCompletion::default()),
+                reaper_thread: Mutex::new(None),
+                reaper_completion: Arc::new(ReaderCompletion::default()),
                 term: Mutex::new(Box::new(term)),
                 stream_progress: Box::new(TerminalStreamProgress::default()),
                 mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
@@ -4158,6 +4165,8 @@ impl Surface {
                 journal_capture_active: AtomicBool::new(false),
                 reader_thread: Mutex::new(None),
                 reader_completion: Arc::new(ReaderCompletion::default()),
+                reaper_thread: Mutex::new(None),
+                reaper_completion: Arc::new(ReaderCompletion::default()),
                 term: Mutex::new(Box::new(term)),
                 stream_progress: Box::new(TerminalStreamProgress::default()),
                 mouse_encoders: Mutex::new(Box::new(mouse_encoders)),
@@ -4269,6 +4278,20 @@ impl Surface {
         });
         let previous = pty.reader_thread.lock().unwrap().replace(reader);
         assert!(previous.is_none(), "test PTY already owns a reader thread");
+    }
+
+    #[cfg(test)]
+    pub(crate) fn install_terminal_reaper_for_test(&self, reaper: std::thread::JoinHandle<()>) {
+        let pty = self.as_pty().expect("test reaper requires a PTY surface");
+        pty.reaper_completion.reset();
+        let completion = pty.reaper_completion.clone();
+        let reaper = std::thread::spawn(move || {
+            let result = reaper.join();
+            completion.complete();
+            result.expect("installed test terminal reaper panicked");
+        });
+        let previous = pty.reaper_thread.lock().unwrap().replace(reaper);
+        assert!(previous.is_none(), "test PTY already owns a reaper thread");
     }
 
     #[cfg(test)]
@@ -6938,9 +6961,58 @@ fn set_terminal_scroll_offset(term: &mut Terminal, target: u64) -> bool {
 #[cfg(test)]
 mod tests {
     use base64::Engine as _;
+    use std::sync::mpsc::sync_channel;
 
     use super::*;
     use crate::MuxEvent;
+
+    #[test]
+    fn finish_terminal_reader_joins_owned_reaper_before_deadline() {
+        let mux = Mux::new_for_test("reaper-join", SurfaceOptions::default());
+        let surface = Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux))
+            .expect("test PTY should spawn");
+        let (started_tx, started_rx) = sync_channel(0);
+        let reaper = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+        });
+        surface.install_terminal_reaper_for_test(reaper);
+        started_rx.recv().unwrap();
+
+        let pty = surface.as_pty().unwrap();
+        surface.finish_terminal_reader(Instant::now() + Duration::from_secs(1));
+
+        assert!(
+            pty.reaper_thread.lock().unwrap().is_none(),
+            "terminal teardown must consume the child-reaper join handle"
+        );
+    }
+
+    #[test]
+    fn finish_terminal_reader_retains_reaper_after_deadline() {
+        let mux = Mux::new_for_test("reaper-timeout", SurfaceOptions::default());
+        let surface = Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux))
+            .expect("test PTY should spawn");
+        let (started_tx, started_rx) = sync_channel(0);
+        let (release_tx, release_rx) = sync_channel(0);
+        let reaper = std::thread::spawn(move || {
+            started_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        surface.install_terminal_reaper_for_test(reaper);
+        started_rx.recv().unwrap();
+
+        let pty = surface.as_pty().unwrap();
+        surface.finish_terminal_reader(Instant::now());
+        assert!(
+            pty.reaper_thread.lock().unwrap().is_some(),
+            "a live child-reaper handle must remain owned after timeout"
+        );
+
+        release_tx.send(()).unwrap();
+        assert!(pty.reaper_completion.wait_until(Instant::now() + Duration::from_secs(1)));
+        surface.finish_terminal_reader(Instant::now() + Duration::from_secs(1));
+        assert!(pty.reaper_thread.lock().unwrap().is_none());
+    }
 
     #[test]
     fn pty_child_startup_guard_kills_and_waits_on_drop() {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4321,6 +4321,28 @@ impl Surface {
     }
 
     #[cfg(test)]
+    pub(crate) fn install_terminal_reaper_that_finishes_for_test(
+        self: &Arc<Self>,
+        started: std::sync::mpsc::SyncSender<()>,
+        proceed: std::sync::mpsc::Receiver<()>,
+    ) -> Arc<ReaderCompletion> {
+        let pty = self.as_pty().expect("test reaper requires a PTY surface");
+        pty.reaper_completion.reset();
+        let completion = pty.reaper_completion.clone();
+        let reaper_completion = completion.clone();
+        let surface = self.clone();
+        let reaper = std::thread::spawn(move || {
+            started.send(()).unwrap();
+            proceed.recv().unwrap();
+            reaper_completion.complete();
+            surface.finish_terminal_reader(Instant::now() + Duration::from_secs(1));
+        });
+        let previous = pty.reaper_thread.lock().unwrap().replace(reaper);
+        assert!(previous.is_none(), "test PTY already owns a reaper thread");
+        completion
+    }
+
+    #[cfg(test)]
     pub(crate) fn wait_for_terminal_reader_for_test(&self, deadline: Instant) -> bool {
         self.as_pty().is_some_and(|pty| pty.reader_completion.wait_until(deadline))
     }
@@ -7036,6 +7058,24 @@ mod tests {
 
         release_tx.send(()).unwrap();
         assert!(pty.reaper_completion.wait_until(Instant::now() + Duration::from_secs(1)));
+        surface.finish_terminal_reader(Instant::now() + Duration::from_secs(1));
+        assert!(pty.reaper_thread.lock().unwrap().is_none());
+    }
+
+    #[test]
+    fn finish_terminal_reader_does_not_self_join_reaper() {
+        let mux = Mux::new_for_test("reaper-self-join", SurfaceOptions::default());
+        let surface = Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux))
+            .expect("test PTY should spawn");
+        let (started_tx, started_rx) = sync_channel(0);
+        let (proceed_tx, proceed_rx) = sync_channel(0);
+        let completion =
+            surface.install_terminal_reaper_that_finishes_for_test(started_tx, proceed_rx);
+        started_rx.recv().unwrap();
+        proceed_tx.send(()).unwrap();
+
+        assert!(completion.wait_until(Instant::now() + Duration::from_secs(1)));
+        let pty = surface.as_pty().unwrap();
         surface.finish_terminal_reader(Instant::now() + Duration::from_secs(1));
         assert!(pty.reaper_thread.lock().unwrap().is_none());
     }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4255,7 +4255,10 @@ impl Surface {
         let pty = self.as_pty()?;
         let reaper = pty.reaper_thread.lock().unwrap().take();
         if let Some(reaper) = reaper {
-            if pty.reaper_completion.wait_until(deadline) {
+            if reaper.thread().id() == std::thread::current().id() {
+                *pty.reaper_thread.lock().unwrap() = Some(reaper);
+                eprintln!("cmux-tui: child reaper skipped self-join during shutdown");
+            } else if pty.reaper_completion.wait_until(deadline) {
                 if reaper.join().is_err() {
                     eprintln!("cmux-tui: child reaper thread panicked during shutdown");
                 }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1291,7 +1291,6 @@ struct ReaderCompletion {
 }
 
 impl ReaderCompletion {
-    #[cfg(test)]
     fn reset(&self) {
         *self.finished.lock().unwrap() = false;
     }
@@ -2614,18 +2613,20 @@ impl Surface {
         // so final output is visible before the mux observes completion.
         let reaper_completion =
             surface.as_pty().expect("local PTY surface owns its reaper").reaper_completion.clone();
-        let surface_ref = Arc::downgrade(&surface);
+        reaper_completion.reset();
+        // Keep the surface alive with the join handle until the child wait
+        // completes. This prevents a deadline timeout from detaching a live
+        // reaper when teardown drops the last external surface reference.
+        let reaper_surface = surface.clone();
         let reaper_thread =
             match std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn(move || {
                 let _reaper_completion = ReaderCompletionGuard(reaper_completion);
                 let exit = child.wait_for_exit();
-                if let Some(surface) = surface_ref.upgrade() {
-                    if let Some(pty) = surface.as_pty() {
-                        *pty.exit.lock().unwrap() = Some(exit);
-                    }
-                    close_local_terminal_master_after_exit(&surface);
-                    publish_local_exit_if_ready(&surface);
+                if let Some(pty) = reaper_surface.as_pty() {
+                    *pty.exit.lock().unwrap() = Some(exit);
                 }
+                close_local_terminal_master_after_exit(&reaper_surface);
+                publish_local_exit_if_ready(&reaper_surface);
             }) {
                 Ok(reaper_thread) => reaper_thread,
                 Err(error) => {
@@ -7035,6 +7036,36 @@ mod tests {
 
         release_tx.send(()).unwrap();
         assert!(pty.reaper_completion.wait_until(Instant::now() + Duration::from_secs(1)));
+        surface.finish_terminal_reader(Instant::now() + Duration::from_secs(1));
+        assert!(pty.reaper_thread.lock().unwrap().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn local_surface_reaper_timeout_retains_production_handle() {
+        let mux = Mux::new_for_test("production-reaper-timeout", SurfaceOptions::default());
+        let surface = Surface::spawn(
+            2,
+            SurfaceOptions {
+                command: Some(vec!["/bin/sh".into(), "-c".into(), "read _".into()]),
+                ..SurfaceOptions::default()
+            },
+            Arc::downgrade(&mux),
+        )
+        .expect("local PTY should spawn");
+        let pty = surface.as_pty().expect("spawned surface should be a PTY");
+
+        surface.finish_terminal_reader(Instant::now());
+        assert!(
+            pty.reaper_thread.lock().unwrap().is_some(),
+            "a live production child-reaper handle must remain owned after timeout"
+        );
+
+        surface.kill();
+        assert!(
+            pty.reaper_completion.wait_until(Instant::now() + Duration::from_secs(1)),
+            "killing the local PTY must release the production reaper"
+        );
         surface.finish_terminal_reader(Instant::now() + Duration::from_secs(1));
         assert!(pty.reaper_thread.lock().unwrap().is_none());
     }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2612,21 +2612,33 @@ impl Surface {
 
         // Child reaper: retain the native status and rendezvous with PTY EOF
         // so final output is visible before the mux observes completion.
-        let reaper = std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn({
-            let surface = surface.clone();
-            move || {
+        let reaper_completion =
+            surface.as_pty().expect("local PTY surface owns its reaper").reaper_completion.clone();
+        let surface_ref = Arc::downgrade(&surface);
+        let reaper_thread =
+            match std::thread::Builder::new().name(format!("surface-{id}-wait")).spawn(move || {
+                let _reaper_completion = ReaderCompletionGuard(reaper_completion);
                 let exit = child.wait_for_exit();
-                if let Some(pty) = surface.as_pty() {
-                    *pty.exit.lock().unwrap() = Some(exit);
+                if let Some(surface) = surface_ref.upgrade() {
+                    if let Some(pty) = surface.as_pty() {
+                        *pty.exit.lock().unwrap() = Some(exit);
+                    }
+                    close_local_terminal_master_after_exit(&surface);
+                    publish_local_exit_if_ready(&surface);
                 }
-                close_local_terminal_master_after_exit(&surface);
-                publish_local_exit_if_ready(&surface);
-            }
-        });
-        if let Err(error) = reaper {
-            close_local_terminal_master_after_exit(&surface);
-            return Err(error.into());
-        }
+            }) {
+                Ok(reaper_thread) => reaper_thread,
+                Err(error) => {
+                    close_local_terminal_master_after_exit(&surface);
+                    return Err(error.into());
+                }
+            };
+        *surface
+            .as_pty()
+            .expect("local PTY surface owns its reaper")
+            .reaper_thread
+            .lock()
+            .unwrap() = Some(reaper_thread);
 
         Ok(surface)
     }
@@ -4240,6 +4252,19 @@ impl Surface {
 
     pub(crate) fn finish_terminal_reader(&self, deadline: Instant) -> Option<TerminalJournalGap> {
         let pty = self.as_pty()?;
+        let reaper = pty.reaper_thread.lock().unwrap().take();
+        if let Some(reaper) = reaper {
+            if pty.reaper_completion.wait_until(deadline) {
+                if reaper.join().is_err() {
+                    eprintln!("cmux-tui: child reaper thread panicked during shutdown");
+                }
+            } else {
+                *pty.reaper_thread.lock().unwrap() = Some(reaper);
+                eprintln!(
+                    "cmux-tui: child reaper did not stop before the shared shutdown deadline"
+                );
+            }
+        }
         if let Some(reader) = pty.reader_thread.lock().unwrap().take() {
             if pty.reader_completion.wait_until(deadline) {
                 if reader.join().is_err() {


### PR DESCRIPTION
Summary
- retain the successful local PTY child reaper JoinHandle in the surface runtime
- join the reaper and reader against one absolute shutdown deadline
- add a lifecycle test proving teardown consumes the owned reaper handle

The startup-failure cleanup in #11414 and terminal-host guard work in #11425 are separate.

Validation
- rustfmt --edition 2024
- git diff --check
- Rust tests deferred to hosted verification per cmux-tui instructions.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Local PTY teardown previously left the child reaper unmanaged; it now owns and joins the reaper alongside the reader against one absolute shutdown deadline. If the reaper misses that deadline, shutdown remains bounded while its handle stays owned for later cleanup.

- Resets the reaper completion fence before each spawn so stale completions cannot skip a join.
- Skips self-joins and logs reaper timeout or panic outcomes.
- Adds unit and production PTY coverage for successful joins, timeout retention, and self-join teardown.

<sup>Written for commit 4019f02ff158775f064ba93f009fd5b6a9ee22de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal shutdown reliability by tracking and joining background terminal processes within the shutdown deadline.
  * Prevented shutdown from waiting indefinitely when a background process does not complete, while retaining it for continued cleanup.
  * Ensured failed terminal startup cleans up associated resources and avoids shutdown deadlocks, including self-join scenarios.
  * Added coverage for normal completion, timeout handling, startup failures, and production shutdown behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->