### PR TITLE
cloud: fix typecheck in the devbox size scripts

### DIFF
--- a/web/scripts/derive-devbox-sizes.ts
+++ b/web/scripts/derive-devbox-sizes.ts
@@ -22,7 +22,7 @@
  * the master already has that shape, so it is recorded without a second
  * snapshot.
  */
-import { Freestyle } from "freestyle";
+import { Freestyle, type FirewallSpec } from "freestyle";
 import { writeFileSync } from "node:fs";
 import {
   VM_IMAGE_SIZE_NAMES,
@@ -55,7 +55,7 @@ for (const name of requested) {
 const sizes = requested as VmImageSizeName[];
 const replaceSlug = hasFlag("--replace-slug");
 
-const FIREWALL = { rules: [{ action: "allow" as const, source: {}, destination: { public: true } }] };
+const FIREWALL: FirewallSpec = { rules: [{ action: "allow", source: {}, destination: { public: true } }] };
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
 type Exec = { exec: (options: { command: string; timeoutMs?: number; linuxUser?: string }) => Promise<{ stdout?: string | null; stderr?: string | null; statusCode?: number | null }> };

--- a/web/scripts/devbox-image-common.ts
+++ b/web/scripts/devbox-image-common.ts
@@ -362,7 +362,7 @@ export function promoteImageManifestEntry(
       }
     }
   }
-  const promotedSizes = new Set(variants.map((variant) => variant.size?.name ?? ""));
+  const promotedSizes = new Set<string>(variants.map((variant) => variant.size?.name ?? ""));
   const demoted = manifest.images.map((candidate) => {
     if (candidate.provider !== entry.provider) return candidate;
     const next: DevboxManifestEntry = { ...candidate };


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11664: `tsc --noEmit` failed on the new size scripts. `FirewallSpec` needs the literal `destination.public: true`, and the promoted-size set is keyed by the string `sizeKey` returns.

https://claude.ai/code/session_017SYRh8isujtDXJPoCg2GU5

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a typecheck failure in the devbox size scripts that followed the size promotion work.

- Annotates the firewall constant with the `FirewallSpec` type so `destination.public: true` is typed correctly.
- Keys the promoted-size set as `Set<string>` to match the string returned by `sizeKey`.

<sup>Written for commit fcd5a01d38c2280c25da942331f8b63f8950b52c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

