### PR TITLE
Admin Pro roster: stream behind Suspense, cancel scans on unmount

### DIFF
--- a/web/app/[locale]/dashboard/admin/admin-pro-list.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-pro-list.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import { useFormatter, useTranslations } from "next-intl";
-import { useRef, useState } from "react";
+import { useCallback, useRef, useState } from "react";
+
+import { useAdminSearch } from "./admin-search-context";
 
 type GrantRecord = {
   readonly plan: string | null;
@@ -63,8 +65,6 @@ type Snapshot = {
   };
 };
 
-/** The server-rendered roster, passed from the page so nothing waits on a button. */
-export type ProListSnapshotProps = Snapshot;
 
 type ScanState = {
   readonly status: "idle" | "scanning" | "done" | "error";
@@ -84,7 +84,6 @@ type ListState =
       readonly teamGrants: readonly TeamGrant[];
       readonly userScan: ScanState;
       readonly teamScan: ScanState;
-      readonly loadedAt: string;
     };
 
 type Translate = ReturnType<typeof useTranslations<"dashboard.admin">>;
@@ -95,14 +94,10 @@ const MAX_SCAN_PAGES = 200;
 const buttonClass =
   "border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:bg-foreground hover:text-background disabled:cursor-not-allowed disabled:opacity-50 disabled:hover:bg-background disabled:hover:text-foreground";
 
-export function AdminProList({
-  initialSnapshot,
-  onPickQuery,
-}: {
-  initialSnapshot: Snapshot | null;
-  onPickQuery?: (query: string) => void;
-}) {
+export function AdminProList({ initialSnapshot }: { initialSnapshot: Snapshot | null }) {
   const t = useTranslations("dashboard.admin");
+  const search = useAdminSearch();
+  const onPickQuery = search?.pickQuery;
   const [state, setState] = useState<ListState>(() =>
     initialSnapshot
       ? loadedState(initialSnapshot)
@@ -110,28 +105,85 @@ export function AdminProList({
   );
   const runSeq = useRef(0);
   const started = useRef(false);
+  const aborter = useRef<AbortController | null>(null);
 
-  // Streams the directory scans as soon as the section is on screen. A
-  // callback ref runs once per mount without an effect; reload restarts it.
-  function startOnMount(node: HTMLElement | null) {
-    if (!node || started.current) return;
-    started.current = true;
-    if (initialSnapshot) {
-      const seq = ++runSeq.current;
-      void walk("users", seq);
-      void walk("teams", seq);
-    } else {
-      void load();
+  /** Invalidates the current run: in-flight fetches abort and loops stop at their next check. */
+  const beginRun = useCallback((): { seq: number; signal: AbortSignal } => {
+    aborter.current?.abort();
+    const controller = new AbortController();
+    aborter.current = controller;
+    return { seq: ++runSeq.current, signal: controller.signal };
+  }, []);
+
+  const walk = useCallback(async (kind: "users" | "teams", seq: number, signal: AbortSignal) => {
+    // Only the run that started this scan may update it; a reload or unmount
+    // starts a new sequence and results from the old fetches are dropped.
+    const patchScan = (scan: ScanState) => {
+      if (seq !== runSeq.current) return;
+      setState((current) => {
+        if (current.kind !== "loaded") return current;
+        return kind === "users" ? { ...current, userScan: scan } : { ...current, teamScan: scan };
+      });
+    };
+    let cursor: string | null = null;
+    let pages = 0;
+    let scanned = 0;
+    while (pages < MAX_SCAN_PAGES) {
+      if (seq !== runSeq.current) return;
+      const params = new URLSearchParams({ kind });
+      if (cursor) params.set("cursor", cursor);
+      let response: Response;
+      try {
+        response = await fetch(`/api/admin/pro-users/scan?${params}`, { headers: { accept: "application/json" }, signal });
+      } catch {
+        // An abort means this run was superseded or the section unmounted.
+        if (signal.aborted) return;
+        patchScan({ status: "error", scanned, pages, message: t("errors.network") });
+        return;
+      }
+      if (seq !== runSeq.current) return;
+      if (!response.ok) {
+        patchScan({ status: "error", scanned, pages, message: errorMessage(t, response.status) });
+        return;
+      }
+      let page: { rows: unknown[]; scanned: number; nextCursor: string | null };
+      try {
+        page = (await response.json()) as typeof page;
+      } catch {
+        patchScan({ status: "error", scanned, pages, message: t("errors.generic") });
+        return;
+      }
+      if (seq !== runSeq.current) return;
+      const nextPages = pages + 1;
+      const nextScanned = scanned + page.scanned;
+      const rows = page.rows;
+      setState((current) => {
+        if (current.kind !== "loaded") return current;
+        return kind === "users"
+          ? { ...current, userGrants: [...current.userGrants, ...(rows as UserGrant[])], userScan: { status: "scanning", scanned: nextScanned, pages: nextPages } }
+          : { ...current, teamGrants: [...current.teamGrants, ...(rows as TeamGrant[])], teamScan: { status: "scanning", scanned: nextScanned, pages: nextPages } };
+      });
+      pages = nextPages;
+      scanned = nextScanned;
+      cursor = page.nextCursor;
+      if (!cursor) break;
     }
-  }
+    patchScan({
+      status: pages >= MAX_SCAN_PAGES && cursor ? "error" : "done",
+      scanned,
+      pages,
+      message: pages >= MAX_SCAN_PAGES && cursor ? t("list.scanTruncated") : undefined,
+    });
+  }, [t]);
 
-  async function load() {
-    const seq = ++runSeq.current;
+  const load = useCallback(async () => {
+    const { seq, signal } = beginRun();
     setState({ kind: "loading" });
     let response: Response;
     try {
-      response = await fetch("/api/admin/pro-users", { headers: { accept: "application/json" } });
+      response = await fetch("/api/admin/pro-users", { headers: { accept: "application/json" }, signal });
     } catch {
+      if (signal.aborted) return;
       if (seq === runSeq.current) setState({ kind: "error", message: t("errors.network") });
       return;
     }
@@ -151,69 +203,32 @@ export function AdminProList({
     setState(loadedState(snapshot));
     // Manual grants need a directory walk; run both walks after the snapshot
     // is on screen so the Stripe list is never blocked on them.
-    void walk("users", seq);
-    void walk("teams", seq);
-  }
+    void walk("users", seq, signal);
+    void walk("teams", seq, signal);
+  }, [beginRun, t, walk]);
 
-  async function walk(kind: "users" | "teams", seq: number) {
-    let cursor: string | null = null;
-    let pages = 0;
-    let scanned = 0;
-    while (pages < MAX_SCAN_PAGES) {
-      if (seq !== runSeq.current) return;
-      const params = new URLSearchParams({ kind });
-      if (cursor) params.set("cursor", cursor);
-      let response: Response;
-      try {
-        response = await fetch(`/api/admin/pro-users/scan?${params}`, { headers: { accept: "application/json" } });
-      } catch {
-        patchScan(kind, seq, { status: "error", scanned, pages, message: t("errors.network") });
-        return;
-      }
-      if (seq !== runSeq.current) return;
-      if (!response.ok) {
-        patchScan(kind, seq, { status: "error", scanned, pages, message: errorMessage(t, response.status) });
-        return;
-      }
-      let page: { rows: unknown[]; scanned: number; nextCursor: string | null };
-      try {
-        page = (await response.json()) as typeof page;
-      } catch {
-        patchScan(kind, seq, { status: "error", scanned, pages, message: t("errors.generic") });
-        return;
-      }
-      if (seq !== runSeq.current) return;
-      const nextPages = pages + 1;
-      const nextScanned = scanned + page.scanned;
-      const rows = page.rows;
-      setState((current) => {
-        if (current.kind !== "loaded") return current;
-        return kind === "users"
-          ? { ...current, userGrants: [...current.userGrants, ...(rows as UserGrant[])], userScan: { status: "scanning", scanned: nextScanned, pages: nextPages } }
-          : { ...current, teamGrants: [...current.teamGrants, ...(rows as TeamGrant[])], teamScan: { status: "scanning", scanned: nextScanned, pages: nextPages } };
-      });
-      pages = nextPages;
-      scanned = nextScanned;
-      cursor = page.nextCursor;
-      if (!cursor) break;
+  // Streams the directory scans as soon as the section is on screen, and
+  // stops them when it leaves. The callback is stable, so React invokes it
+  // with the element on mount and null on unmount only (StrictMode replays
+  // attach, detach, attach; the detach resets `started` so the re-attach can
+  // restart the aborted run). No effect is needed.
+  const startOnMount = useCallback((node: HTMLElement | null) => {
+    if (node === null) {
+      started.current = false;
+      aborter.current?.abort();
+      runSeq.current += 1;
+      return;
     }
-    patchScan(kind, seq, {
-      status: pages >= MAX_SCAN_PAGES && cursor ? "error" : "done",
-      scanned,
-      pages,
-      message: pages >= MAX_SCAN_PAGES && cursor ? t("list.scanTruncated") : undefined,
-    });
-  }
-
-  // Only the run that started this scan may update it; a reload starts a new
-  // sequence and results from the old fetches are dropped.
-  function patchScan(kind: "users" | "teams", seq: number, scan: ScanState) {
-    if (seq !== runSeq.current) return;
-    setState((current) => {
-      if (current.kind !== "loaded") return current;
-      return kind === "users" ? { ...current, userScan: scan } : { ...current, teamScan: scan };
-    });
-  }
+    if (started.current) return;
+    started.current = true;
+    if (initialSnapshot) {
+      const { seq, signal } = beginRun();
+      void walk("users", seq, signal);
+      void walk("teams", seq, signal);
+    } else {
+      void load();
+    }
+  }, [beginRun, initialSnapshot, load, walk]);
 
   return (
     <section ref={startOnMount} className="border border-border p-3">
@@ -432,7 +447,6 @@ function loadedState(snapshot: Snapshot): Extract<ListState, { kind: "loaded" }>
     teamGrants: [],
     userScan: { status: "scanning", scanned: 0, pages: 0 },
     teamScan: { status: "scanning", scanned: 0, pages: 0 },
-    loadedAt: new Date().toISOString(),
   };
 }
 

--- a/web/app/[locale]/dashboard/admin/admin-pro-panel.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-pro-panel.tsx
@@ -5,7 +5,7 @@ import { useFormatter, useTranslations } from "next-intl";
 import { useId, useRef, useState, type ReactNode } from "react";
 
 import { Modal } from "../../components/modal";
-import { AdminProList, type ProListSnapshotProps } from "./admin-pro-list";
+import { AdminSearchContext } from "./admin-search-context";
 
 type GrantRecord = {
   readonly plan: string | null;
@@ -88,7 +88,7 @@ const primaryButtonClass =
 const dangerButtonClass =
   "border border-border bg-background px-2.5 py-1 text-xs font-medium text-foreground focus-visible:outline focus-visible:outline-1 focus-visible:outline-foreground hover:border-foreground disabled:cursor-not-allowed disabled:opacity-50";
 
-export function AdminProPanel({ initialSnapshot }: { initialSnapshot: ProListSnapshotProps | null }) {
+export function AdminProPanel({ roster }: { roster: ReactNode }) {
   const t = useTranslations("dashboard.admin");
   const inputId = useId();
   const [query, setQuery] = useState("");
@@ -383,15 +383,18 @@ export function AdminProPanel({ initialSnapshot }: { initialSnapshot: ProListSna
         </ResultSection>
       ) : null}
 
-      <AdminProList
-        initialSnapshot={initialSnapshot}
-        onPickQuery={(value) => {
-          setQuery(value);
-          setNotice(null);
-          void runSearch(value);
-          if (typeof window !== "undefined") window.scrollTo({ top: 0, behavior: "smooth" });
+      <AdminSearchContext.Provider
+        value={{
+          pickQuery: (value) => {
+            setQuery(value);
+            setNotice(null);
+            void runSearch(value);
+            if (typeof window !== "undefined") window.scrollTo({ top: 0, behavior: "smooth" });
+          },
         }}
-      />
+      >
+        {roster}
+      </AdminSearchContext.Provider>
 
       <ConfirmDialog
         t={t}

--- a/web/app/[locale]/dashboard/admin/admin-pro-panel.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-pro-panel.tsx
@@ -2,7 +2,7 @@
 
 import { Dialog } from "@base-ui-components/react/dialog";
 import { useFormatter, useTranslations } from "next-intl";
-import { useId, useRef, useState, type ReactNode } from "react";
+import { useCallback, useId, useMemo, useRef, useState, type ReactNode } from "react";
 
 import { Modal } from "../../components/modal";
 import { AdminSearchContext } from "./admin-search-context";
@@ -98,7 +98,7 @@ export function AdminProPanel({ roster }: { roster: ReactNode }) {
   const [notice, setNotice] = useState<string | null>(null);
   const requestSeq = useRef(0);
 
-  async function runSearch(value: string) {
+  const runSearch = useCallback(async (value: string) => {
     const trimmed = value.trim();
     // Every submit claims a new sequence number, including a too-short query,
     // so an older in-flight search cannot land on top of the reset state.
@@ -140,7 +140,17 @@ export function AdminProPanel({ roster }: { roster: ReactNode }) {
         pendingGrants: body.pendingGrants ?? [],
       },
     });
-  }
+  }, [t]);
+
+  // Stable context value: the roster below re-renders only when this
+  // callback changes, not on every keystroke or notice in the panel.
+  const pickQuery = useCallback((value: string) => {
+    setQuery(value);
+    setNotice(null);
+    void runSearch(value);
+    if (typeof window !== "undefined") window.scrollTo({ top: 0, behavior: "smooth" });
+  }, [runSearch]);
+  const searchContextValue = useMemo(() => ({ pickQuery }), [pickQuery]);
 
   async function confirmPending() {
     if (!pending) return;
@@ -383,16 +393,7 @@ export function AdminProPanel({ roster }: { roster: ReactNode }) {
         </ResultSection>
       ) : null}
 
-      <AdminSearchContext.Provider
-        value={{
-          pickQuery: (value) => {
-            setQuery(value);
-            setNotice(null);
-            void runSearch(value);
-            if (typeof window !== "undefined") window.scrollTo({ top: 0, behavior: "smooth" });
-          },
-        }}
-      >
+      <AdminSearchContext.Provider value={searchContextValue}>
         {roster}
       </AdminSearchContext.Provider>
 

--- a/web/app/[locale]/dashboard/admin/admin-pro-roster.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-pro-roster.tsx
@@ -1,0 +1,24 @@
+import {
+  loadProListSnapshotWithin,
+  type ProListSnapshot,
+} from "@/services/admin/proList";
+
+import { AdminProList } from "./admin-pro-list";
+
+/**
+ * Server component rendered inside a Suspense boundary: the rest of the admin
+ * page streams first, and the roster arrives when its bounded database read
+ * completes. Any failure or timeout renders the client list in its retry
+ * state instead of holding the page.
+ */
+export async function AdminProRoster() {
+  let snapshot: ProListSnapshot | null = null;
+  try {
+    snapshot = await loadProListSnapshotWithin();
+  } catch (error) {
+    console.error("admin.pro_list.initial_load_failed", {
+      failure: error instanceof Error ? error.name : "unknown",
+    });
+  }
+  return <AdminProList initialSnapshot={snapshot} />;
+}

--- a/web/app/[locale]/dashboard/admin/admin-search-context.tsx
+++ b/web/app/[locale]/dashboard/admin/admin-search-context.tsx
@@ -1,0 +1,10 @@
+"use client";
+
+import { createContext, useContext } from "react";
+
+/** Lets the server-streamed roster hand a picked row to the search panel. */
+export const AdminSearchContext = createContext<{ pickQuery: (query: string) => void } | null>(null);
+
+export function useAdminSearch(): { pickQuery: (query: string) => void } | null {
+  return useContext(AdminSearchContext);
+}

--- a/web/app/[locale]/dashboard/admin/page.tsx
+++ b/web/app/[locale]/dashboard/admin/page.tsx
@@ -1,13 +1,14 @@
 import { getTranslations } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
+import { Suspense } from "react";
 
 import { getRequestScopedStackUser, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { ADMIN_EMAIL_DOMAINS, isAdminUser } from "@/services/admin/access";
-import { loadProListSnapshot, type ProListSnapshot } from "@/services/admin/proList";
 import { withPrioritySpan } from "@/services/telemetry";
 
 import { AdminProPanel } from "./admin-pro-panel";
+import { AdminProRoster } from "./admin-pro-roster";
 
 // Admin membership is a request-fresh check on the signed-in user.
 export const instant = false;
@@ -36,22 +37,13 @@ export default async function DashboardAdminPage({
   }
 
   const t = await getTranslations({ locale, namespace: "dashboard.admin" });
-  // The Stripe-backed roster renders with the page; the client streams the
-  // directory scans on mount. A database outage leaves the roster in an
-  // error state with a retry, but never blocks the rest of the page.
-  let initialSnapshot: ProListSnapshot | null = null;
-  try {
-    initialSnapshot = await withPrioritySpan(
-      "cmux-admin-dashboard",
-      "cmux.admin.pro_list",
-      { "http.route": "/dashboard/admin", "cmux.locale": locale },
-      () => loadProListSnapshot(),
-    );
-  } catch (error) {
-    console.error("admin.pro_list.initial_load_failed", {
-      failure: error instanceof Error ? error.name : "unknown",
-    });
-  }
+  // The roster streams in behind a Suspense boundary so a slow database read
+  // never holds the search panel; the client then streams the directory scans.
+  const roster = (
+    <Suspense fallback={<RosterFallback title={t("list.title")} loading={t("list.loading")} />}>
+      <AdminProRoster />
+    </Suspense>
+  );
 
   return (
     <div className="mx-auto w-full max-w-5xl px-3 py-4">
@@ -66,7 +58,16 @@ export default async function DashboardAdminPage({
           })}
         </p>
       </div>
-      <AdminProPanel initialSnapshot={initialSnapshot} />
+      <AdminProPanel roster={roster} />
     </div>
+  );
+}
+
+function RosterFallback({ title, loading }: { title: string; loading: string }) {
+  return (
+    <section className="border border-border p-3" aria-busy="true">
+      <h2 className="text-sm font-medium">{title}</h2>
+      <p className="mt-1 text-muted">{loading}</p>
+    </section>
   );
 }

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -375,3 +375,32 @@ export async function loadProListSnapshot(
     throw error;
   }
 }
+
+export class ProListTimeoutError extends Error {
+  constructor(readonly afterMs: number) {
+    super(`Pro roster snapshot took longer than ${afterMs}ms`);
+    this.name = "ProListTimeoutError";
+  }
+}
+
+/** Default budget for the server-rendered roster before the page falls back to a retry state. */
+export const PRO_LIST_RENDER_TIMEOUT_MS = 8_000;
+
+/**
+ * Bounds how long the page render waits for the roster. A stalled database
+ * must not hold the admin page; the client shows a retry instead.
+ */
+export async function loadProListSnapshotWithin(
+  timeoutMs: number = PRO_LIST_RENDER_TIMEOUT_MS,
+  load: () => Promise<ProListSnapshot> = () => loadProListSnapshot(),
+): Promise<ProListSnapshot> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new ProListTimeoutError(timeoutMs)), timeoutMs);
+  });
+  try {
+    return await Promise.race([load(), timeout]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -480,21 +480,31 @@ export async function loadProListSnapshot(
     // Each read gets its own short transaction, so a failed optional read
     // (missing admin_plan_grants table) aborts only its own transaction and
     // the catch below still yields an empty pending list.
-    // guard() runs both before acquiring a transaction and again inside it,
-    // after SET LOCAL, so a slow acquisition cannot start a read past the
-    // deadline either.
+    // The three database reads are independent: run them concurrently, each
+    // in its own short statement-timeout transaction (a failed optional read
+    // on a missing admin_plan_grants table aborts only its own). guard()
+    // runs before acquiring each transaction and again inside it, after SET
+    // LOCAL, so a slow acquisition cannot start a read past the deadline.
     guard();
-    const subscribers = await withStatementTimeout(db, budgetFor(), async (scoped) => {
-      guard();
-      return await listStripeProSubscribers({ db: scoped });
-    });
-    guard();
-    // Query inside the timeout scope, names outside it: the transaction ends
-    // before any Stack request starts.
-    const teamRows = await withStatementTimeout(db, budgetFor(), async (scoped) => {
-      guard();
-      return await listStripeTeamSubscriptionRows({ db: scoped });
-    });
+    const [subscribers, teamRows, pendingGrants] = await Promise.all([
+      withStatementTimeout(db, budgetFor(), async (scoped) => {
+        guard();
+        return await listStripeProSubscribers({ db: scoped });
+      }),
+      withStatementTimeout(db, budgetFor(), async (scoped) => {
+        guard();
+        return await listStripeTeamSubscriptionRows({ db: scoped });
+      }),
+      withStatementTimeout(db, budgetFor(), async (scoped) => {
+        guard();
+        return await listAllPendingEmailGrants({ db: scoped });
+      }).catch((error: unknown) => {
+        if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
+        throw error;
+      }),
+    ]);
+    // Names resolve only after every transaction has ended, outside any of
+    // them, so a slow provider never holds a database connection.
     guard();
     const teamSubscriptions: CappedList<StripeTeamSubscription> = {
       truncated: teamRows.truncated,
@@ -504,14 +514,6 @@ export async function loadProListSnapshot(
         clock,
       }),
     };
-    guard();
-    const pendingGrants = await withStatementTimeout(db, budgetFor(), async (scoped) => {
-      guard();
-      return await listAllPendingEmailGrants({ db: scoped });
-    }).catch((error: unknown) => {
-      if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
-      throw error;
-    });
     return {
       subscribers: subscribers.rows,
       teamSubscriptions: teamSubscriptions.rows,

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -460,8 +460,8 @@ export async function loadProListSnapshot(
   const clock = options.clock ?? realProListClock;
   const now = () => clock.now();
   const guard = () => {
-    if (options.deadlineMs !== undefined && now() > options.deadlineMs) {
-      throw new ProListTimeoutError(Math.max(0, options.deadlineMs - now()));
+    if (options.deadlineMs !== undefined && now() >= options.deadlineMs) {
+      throw new ProListTimeoutError(0);
     }
   };
   // Each read's statement timeout is the smaller of the configured budget and

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -385,7 +385,6 @@ export async function loadProListSnapshot(
     readonly deadlineMs?: number;
   } = {},
 ): Promise<ProListSnapshot> {
-  const db = options.db ?? cloudDb();
   const guard = () => {
     if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
       throw new ProListTimeoutError(Math.max(0, options.deadlineMs - Date.now()));
@@ -401,6 +400,9 @@ export async function loadProListSnapshot(
     return configured === undefined ? remaining : Math.min(configured, remaining);
   };
   try {
+    // Client creation can fail the same way a read does (no DATABASE_URL), so
+    // it lives inside the same error boundary.
+    const db = options.db ?? cloudDb();
     // Each read gets its own short transaction, so a failed optional read
     // (missing admin_plan_grants table) aborts only its own transaction and
     // the catch below still yields an empty pending list.

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -93,6 +93,22 @@ export type ProListScanPage<Row> = {
 };
 
 type CloudDb = ReturnType<typeof cloudDb>;
+
+/** Clock and scheduler seam so timeout behavior is testable with virtual time. */
+export type ProListClock = {
+  now(): number;
+  /** Schedules `fn` after `ms`; returns a cancel function. */
+  schedule(fn: () => void, ms: number): () => void;
+};
+
+export const realProListClock: ProListClock = {
+  now: () => Date.now(),
+  schedule: (fn, ms) => {
+    const timer = setTimeout(fn, ms);
+    return () => clearTimeout(timer);
+  },
+};
+
 export type ProListDb = Pick<CloudDb, "select"> & {
   /** Present on the real client; the roster uses it to scope a statement timeout. */
   transaction?<Result>(operation: (tx: Pick<CloudDb, "select" | "execute">) => Promise<Result>): Promise<Result>;
@@ -178,23 +194,13 @@ export async function listStripeProSubscribers(
   return { rows: out, truncated };
 }
 
-/**
- * Every team with an active Stripe Team row, with its Stack display name
- * when reachable. Name lookups run a few at a time so a large roster cannot
- * open thousands of Stack requests at once.
- */
-export async function listStripeTeamSubscriptions(
-  options: {
-    readonly db?: ProListDb;
-    readonly app?: ProListStackApp;
-    readonly concurrency?: number;
-    /** No new name lookup starts once this instant (ms since epoch) has passed. */
-    readonly deadlineMs?: number;
-    readonly now?: () => number;
-  } = {},
-): Promise<CappedList<StripeTeamSubscription>> {
+export type StripeTeamSubscriptionRow = Omit<StripeTeamSubscription, "displayName">;
+
+/** The database half of the team roster: active Stripe Team rows, one per team, no Stack calls. */
+export async function listStripeTeamSubscriptionRows(
+  options: { readonly db?: ProListDb } = {},
+): Promise<CappedList<StripeTeamSubscriptionRow>> {
   const db = options.db ?? cloudDb();
-  const app = options.app ?? defaultProListStackApp();
   const fetched = await db
     .select({
       teamId: stripeSubscriptions.stackTeamId,
@@ -216,34 +222,81 @@ export async function listStripeTeamSubscriptions(
     .orderBy(desc(stripeSubscriptions.currentPeriodEnd), desc(stripeSubscriptions.updatedAt))
     .limit(PRO_LIST_MAX_ROWS + 1);
   const truncated = fetched.length > PRO_LIST_MAX_ROWS;
-  const rows = fetched.slice(0, PRO_LIST_MAX_ROWS);
   const seen = new Set<string>();
-  const unique = rows.filter((row) => {
-    if (!row.teamId || seen.has(row.teamId)) return false;
+  const rows: StripeTeamSubscriptionRow[] = [];
+  for (const row of fetched.slice(0, PRO_LIST_MAX_ROWS)) {
+    if (!row.teamId || seen.has(row.teamId)) continue;
     seen.add(row.teamId);
-    return true;
-  });
-  const now = options.now ?? Date.now;
-  const resolved = await mapWithConcurrency(
-    unique,
+    rows.push({
+      teamId: row.teamId,
+      subscriptionId: row.subscriptionId,
+      status: row.status,
+      seats: row.seats ?? null,
+      cancelAtPeriodEnd: Boolean(row.cancelAtPeriodEnd),
+      currentPeriodEnd: row.currentPeriodEnd ? row.currentPeriodEnd.toISOString() : null,
+    });
+  }
+  return { rows, truncated };
+}
+
+export type TeamNameResolveOptions = {
+  readonly app?: ProListStackApp;
+  readonly concurrency?: number;
+  /** No new name lookup starts once this instant (ms since epoch) has passed. */
+  readonly deadlineMs?: number;
+  readonly clock?: ProListClock;
+};
+
+/**
+ * The Stack half of the team roster: display names, resolved OUTSIDE any
+ * database transaction so a slow provider never holds a connection. Lookups
+ * run a few at a time, none starts after the deadline, and one that outlives
+ * the remaining budget is abandoned (its name stays null).
+ */
+export async function resolveStripeTeamNames(
+  rows: readonly StripeTeamSubscriptionRow[],
+  options: TeamNameResolveOptions = {},
+): Promise<StripeTeamSubscription[]> {
+  const app = options.app ?? defaultProListStackApp();
+  const clock = options.clock ?? realProListClock;
+  return await mapWithConcurrency(
+    rows,
     options.concurrency ?? PRO_LIST_TEAM_LOOKUP_CONCURRENCY,
     async (row): Promise<StripeTeamSubscription> => {
-      if (options.deadlineMs !== undefined && now() > options.deadlineMs) {
+      const remaining = options.deadlineMs === undefined ? undefined : options.deadlineMs - clock.now();
+      if (remaining !== undefined && remaining <= 0) {
         throw new ProListTimeoutError(0);
       }
-      const team = await app.getTeam(row.teamId!).catch(() => null);
-      return {
-        teamId: row.teamId!,
-        displayName: team?.displayName ?? null,
-        subscriptionId: row.subscriptionId,
-        status: row.status,
-        seats: row.seats ?? null,
-        cancelAtPeriodEnd: Boolean(row.cancelAtPeriodEnd),
-        currentPeriodEnd: row.currentPeriodEnd ? row.currentPeriodEnd.toISOString() : null,
-      };
+      const team = await raceWithin(app.getTeam(row.teamId).catch(() => null), remaining, clock);
+      return { ...row, displayName: team?.displayName ?? null };
     },
   );
-  return { rows: resolved, truncated };
+}
+
+/** Resolves to null when `promise` has not settled within `ms` (undefined = no limit). */
+async function raceWithin<Value>(
+  promise: Promise<Value | null>,
+  ms: number | undefined,
+  clock: ProListClock,
+): Promise<Value | null> {
+  if (ms === undefined) return await promise;
+  let cancel: (() => void) | undefined;
+  const timeout = new Promise<null>((resolve) => {
+    cancel = clock.schedule(() => resolve(null), ms);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    cancel?.();
+  }
+}
+
+/** Every team with an active Stripe Team row, with its Stack display name when reachable. */
+export async function listStripeTeamSubscriptions(
+  options: { readonly db?: ProListDb } & TeamNameResolveOptions = {},
+): Promise<CappedList<StripeTeamSubscription>> {
+  const { rows, truncated } = await listStripeTeamSubscriptionRows({ db: options.db });
+  return { rows: await resolveStripeTeamNames(rows, options), truncated };
 }
 
 /**
@@ -399,11 +452,12 @@ export async function loadProListSnapshot(
      * when the caller stops waiting: at most one in-flight statement.
      */
     readonly deadlineMs?: number;
-    /** Clock source, injectable for tests. */
-    readonly now?: () => number;
+    /** Clock and scheduler, injectable for tests. */
+    readonly clock?: ProListClock;
   } = {},
 ): Promise<ProListSnapshot> {
-  const now = options.now ?? Date.now;
+  const clock = options.clock ?? realProListClock;
+  const now = () => clock.now();
   const guard = () => {
     if (options.deadlineMs !== undefined && now() > options.deadlineMs) {
       throw new ProListTimeoutError(Math.max(0, options.deadlineMs - now()));
@@ -429,13 +483,19 @@ export async function loadProListSnapshot(
     const subscribers = await withStatementTimeout(db, budgetFor(), async (scoped) =>
       await listStripeProSubscribers({ db: scoped }));
     guard();
-    const teamSubscriptions = await withStatementTimeout(db, budgetFor(), async (scoped) =>
-      await listStripeTeamSubscriptions({
-        db: scoped,
+    // Query inside the timeout scope, names outside it: the transaction ends
+    // before any Stack request starts.
+    const teamRows = await withStatementTimeout(db, budgetFor(), async (scoped) =>
+      await listStripeTeamSubscriptionRows({ db: scoped }));
+    guard();
+    const teamSubscriptions: CappedList<StripeTeamSubscription> = {
+      truncated: teamRows.truncated,
+      rows: await resolveStripeTeamNames(teamRows.rows, {
         app: options.app,
         deadlineMs: options.deadlineMs,
-        now,
-      }));
+        clock,
+      }),
+    };
     guard();
     const pendingGrants = await withStatementTimeout(db, budgetFor(), async (scoped) =>
       await listAllPendingEmailGrants({ db: scoped }),
@@ -477,25 +537,10 @@ export const PRO_LIST_RENDER_TIMEOUT_MS = 8_000;
  * budget is applied as a statement timeout, so the reads are cancelled by
  * Postgres rather than left running after the page gave up on them.
  */
-/** Clock and scheduler seam so timeout behavior is testable with virtual time. */
-export type ProListClock = {
-  now(): number;
-  /** Schedules `fn` after `ms`; returns a cancel function. */
-  schedule(fn: () => void, ms: number): () => void;
-};
-
-export const realProListClock: ProListClock = {
-  now: () => Date.now(),
-  schedule: (fn, ms) => {
-    const timer = setTimeout(fn, ms);
-    return () => clearTimeout(timer);
-  },
-};
-
 export type ProListLoadBudget = {
   readonly statementTimeoutMs: number;
   readonly deadlineMs: number;
-  readonly now: () => number;
+  readonly clock: ProListClock;
 };
 
 export async function loadProListSnapshotWithin(
@@ -514,7 +559,7 @@ export async function loadProListSnapshotWithin(
     // it from starting any new read or name lookup and the statement timeout
     // ends the one in flight, so at most one bounded statement outlives this.
     return await Promise.race([
-      load({ statementTimeoutMs: timeoutMs, deadlineMs, now: () => clock.now() }),
+      load({ statementTimeoutMs: timeoutMs, deadlineMs, clock }),
       timeout,
     ]);
   } finally {

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -479,14 +479,21 @@ export async function loadProListSnapshot(
     // Each read gets its own short transaction, so a failed optional read
     // (missing admin_plan_grants table) aborts only its own transaction and
     // the catch below still yields an empty pending list.
+    // guard() runs both before acquiring a transaction and again inside it,
+    // after SET LOCAL, so a slow acquisition cannot start a read past the
+    // deadline either.
     guard();
-    const subscribers = await withStatementTimeout(db, budgetFor(), async (scoped) =>
-      await listStripeProSubscribers({ db: scoped }));
+    const subscribers = await withStatementTimeout(db, budgetFor(), async (scoped) => {
+      guard();
+      return await listStripeProSubscribers({ db: scoped });
+    });
     guard();
     // Query inside the timeout scope, names outside it: the transaction ends
     // before any Stack request starts.
-    const teamRows = await withStatementTimeout(db, budgetFor(), async (scoped) =>
-      await listStripeTeamSubscriptionRows({ db: scoped }));
+    const teamRows = await withStatementTimeout(db, budgetFor(), async (scoped) => {
+      guard();
+      return await listStripeTeamSubscriptionRows({ db: scoped });
+    });
     guard();
     const teamSubscriptions: CappedList<StripeTeamSubscription> = {
       truncated: teamRows.truncated,
@@ -497,9 +504,10 @@ export async function loadProListSnapshot(
       }),
     };
     guard();
-    const pendingGrants = await withStatementTimeout(db, budgetFor(), async (scoped) =>
-      await listAllPendingEmailGrants({ db: scoped }),
-    ).catch((error: unknown) => {
+    const pendingGrants = await withStatementTimeout(db, budgetFor(), async (scoped) => {
+      guard();
+      return await listAllPendingEmailGrants({ db: scoped });
+    }).catch((error: unknown) => {
       if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
       throw error;
     });

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -188,6 +188,9 @@ export async function listStripeTeamSubscriptions(
     readonly db?: ProListDb;
     readonly app?: ProListStackApp;
     readonly concurrency?: number;
+    /** No new name lookup starts once this instant (ms since epoch) has passed. */
+    readonly deadlineMs?: number;
+    readonly now?: () => number;
   } = {},
 ): Promise<CappedList<StripeTeamSubscription>> {
   const db = options.db ?? cloudDb();
@@ -220,10 +223,14 @@ export async function listStripeTeamSubscriptions(
     seen.add(row.teamId);
     return true;
   });
+  const now = options.now ?? Date.now;
   const resolved = await mapWithConcurrency(
     unique,
     options.concurrency ?? PRO_LIST_TEAM_LOOKUP_CONCURRENCY,
     async (row): Promise<StripeTeamSubscription> => {
+      if (options.deadlineMs !== undefined && now() > options.deadlineMs) {
+        throw new ProListTimeoutError(0);
+      }
       const team = await app.getTeam(row.teamId!).catch(() => null);
       return {
         teamId: row.teamId!,
@@ -239,7 +246,10 @@ export async function listStripeTeamSubscriptions(
   return { rows: resolved, truncated };
 }
 
-/** Runs `work` over `items` with at most `limit` in flight, preserving order. */
+/**
+ * Runs `work` over `items` with at most `limit` in flight, preserving order.
+ * The first rejection stops every worker from starting more items.
+ */
 export async function mapWithConcurrency<Item, Result>(
   items: readonly Item[],
   limit: number,
@@ -247,10 +257,16 @@ export async function mapWithConcurrency<Item, Result>(
 ): Promise<Result[]> {
   const results: Result[] = new Array(items.length);
   let next = 0;
+  let failed = false;
   const workers = Array.from({ length: Math.max(1, Math.min(limit, items.length)) }, async () => {
-    while (next < items.length) {
+    while (!failed && next < items.length) {
       const index = next++;
-      results[index] = await work(items[index]!);
+      try {
+        results[index] = await work(items[index]!);
+      } catch (error) {
+        failed = true;
+        throw error;
+      }
     }
   });
   await Promise.all(workers);
@@ -383,11 +399,14 @@ export async function loadProListSnapshot(
      * when the caller stops waiting: at most one in-flight statement.
      */
     readonly deadlineMs?: number;
+    /** Clock source, injectable for tests. */
+    readonly now?: () => number;
   } = {},
 ): Promise<ProListSnapshot> {
+  const now = options.now ?? Date.now;
   const guard = () => {
-    if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
-      throw new ProListTimeoutError(Math.max(0, options.deadlineMs - Date.now()));
+    if (options.deadlineMs !== undefined && now() > options.deadlineMs) {
+      throw new ProListTimeoutError(Math.max(0, options.deadlineMs - now()));
     }
   };
   // Each read's statement timeout is the smaller of the configured budget and
@@ -396,7 +415,7 @@ export async function loadProListSnapshot(
   const budgetFor = (): number | undefined => {
     const configured = options.statementTimeoutMs;
     if (options.deadlineMs === undefined) return configured;
-    const remaining = Math.max(1, options.deadlineMs - Date.now());
+    const remaining = Math.max(1, options.deadlineMs - now());
     return configured === undefined ? remaining : Math.min(configured, remaining);
   };
   try {
@@ -411,7 +430,12 @@ export async function loadProListSnapshot(
       await listStripeProSubscribers({ db: scoped }));
     guard();
     const teamSubscriptions = await withStatementTimeout(db, budgetFor(), async (scoped) =>
-      await listStripeTeamSubscriptions({ db: scoped, app: options.app }));
+      await listStripeTeamSubscriptions({
+        db: scoped,
+        app: options.app,
+        deadlineMs: options.deadlineMs,
+        now,
+      }));
     guard();
     const pendingGrants = await withStatementTimeout(db, budgetFor(), async (scoped) =>
       await listAllPendingEmailGrants({ db: scoped }),
@@ -453,22 +477,47 @@ export const PRO_LIST_RENDER_TIMEOUT_MS = 8_000;
  * budget is applied as a statement timeout, so the reads are cancelled by
  * Postgres rather than left running after the page gave up on them.
  */
+/** Clock and scheduler seam so timeout behavior is testable with virtual time. */
+export type ProListClock = {
+  now(): number;
+  /** Schedules `fn` after `ms`; returns a cancel function. */
+  schedule(fn: () => void, ms: number): () => void;
+};
+
+export const realProListClock: ProListClock = {
+  now: () => Date.now(),
+  schedule: (fn, ms) => {
+    const timer = setTimeout(fn, ms);
+    return () => clearTimeout(timer);
+  },
+};
+
+export type ProListLoadBudget = {
+  readonly statementTimeoutMs: number;
+  readonly deadlineMs: number;
+  readonly now: () => number;
+};
+
 export async function loadProListSnapshotWithin(
   timeoutMs: number = PRO_LIST_RENDER_TIMEOUT_MS,
-  load: (budget: { statementTimeoutMs: number; deadlineMs: number }) => Promise<ProListSnapshot> =
+  load: (budget: ProListLoadBudget) => Promise<ProListSnapshot> =
     (budget) => loadProListSnapshot(budget),
+  clock: ProListClock = realProListClock,
 ): Promise<ProListSnapshot> {
-  const deadlineMs = Date.now() + timeoutMs;
-  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadlineMs = clock.now() + timeoutMs;
+  let cancel: (() => void) | undefined;
   const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => reject(new ProListTimeoutError(timeoutMs)), timeoutMs);
+    cancel = clock.schedule(() => reject(new ProListTimeoutError(timeoutMs)), timeoutMs);
   });
   try {
     // When the timer wins, the load is not awaited further; the deadline stops
-    // it from starting any new read and the statement timeout ends the one in
-    // flight, so at most one bounded statement outlives this call.
-    return await Promise.race([load({ statementTimeoutMs: timeoutMs, deadlineMs }), timeout]);
+    // it from starting any new read or name lookup and the statement timeout
+    // ends the one in flight, so at most one bounded statement outlives this.
+    return await Promise.race([
+      load({ statementTimeoutMs: timeoutMs, deadlineMs, now: () => clock.now() }),
+      timeout,
+    ]);
   } finally {
-    if (timer) clearTimeout(timer);
+    cancel?.();
   }
 }

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -386,28 +386,34 @@ export async function loadProListSnapshot(
   } = {},
 ): Promise<ProListSnapshot> {
   const db = options.db ?? cloudDb();
-  const budget = options.statementTimeoutMs;
   const guard = () => {
     if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
       throw new ProListTimeoutError(Math.max(0, options.deadlineMs - Date.now()));
     }
   };
+  // Each read's statement timeout is the smaller of the configured budget and
+  // what is left of the absolute deadline, so a read started late in the
+  // budget cannot hold a connection past the point the page stopped waiting.
+  const budgetFor = (): number | undefined => {
+    const configured = options.statementTimeoutMs;
+    if (options.deadlineMs === undefined) return configured;
+    const remaining = Math.max(1, options.deadlineMs - Date.now());
+    return configured === undefined ? remaining : Math.min(configured, remaining);
+  };
   try {
     // Each read gets its own short transaction, so a failed optional read
     // (missing admin_plan_grants table) aborts only its own transaction and
     // the catch below still yields an empty pending list.
-    const subscribers = await withStatementTimeout(db, budget, async (scoped) => {
-      guard();
-      return await listStripeProSubscribers({ db: scoped });
-    });
-    const teamSubscriptions = await withStatementTimeout(db, budget, async (scoped) => {
-      guard();
-      return await listStripeTeamSubscriptions({ db: scoped, app: options.app });
-    });
-    const pendingGrants = await withStatementTimeout(db, budget, async (scoped) => {
-      guard();
-      return await listAllPendingEmailGrants({ db: scoped });
-    }).catch((error: unknown) => {
+    guard();
+    const subscribers = await withStatementTimeout(db, budgetFor(), async (scoped) =>
+      await listStripeProSubscribers({ db: scoped }));
+    guard();
+    const teamSubscriptions = await withStatementTimeout(db, budgetFor(), async (scoped) =>
+      await listStripeTeamSubscriptions({ db: scoped, app: options.app }));
+    guard();
+    const pendingGrants = await withStatementTimeout(db, budgetFor(), async (scoped) =>
+      await listAllPendingEmailGrants({ db: scoped }),
+    ).catch((error: unknown) => {
       if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
       throw error;
     });

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -375,24 +375,42 @@ export async function loadProListSnapshot(
   options: {
     readonly db?: ProListDb;
     readonly app?: ProListStackApp;
-    /** Server-side cancel budget for the reads; see withStatementTimeout. */
+    /** Server-side cancel budget per read; see withStatementTimeout. */
     readonly statementTimeoutMs?: number;
+    /**
+     * Absolute time (ms since epoch) after which no further read starts.
+     * Combined with the statement timeout this bounds the work left behind
+     * when the caller stops waiting: at most one in-flight statement.
+     */
+    readonly deadlineMs?: number;
   } = {},
 ): Promise<ProListSnapshot> {
+  const db = options.db ?? cloudDb();
+  const budget = options.statementTimeoutMs;
+  const guard = () => {
+    if (options.deadlineMs !== undefined && Date.now() > options.deadlineMs) {
+      throw new ProListTimeoutError(Math.max(0, options.deadlineMs - Date.now()));
+    }
+  };
   try {
-    const db = options.db ?? cloudDb();
-    const [subscribers, teamSubscriptions, pendingGrants] = await withStatementTimeout(
-      db,
-      options.statementTimeoutMs,
-      async (scoped) => await Promise.all([
-        listStripeProSubscribers({ db: scoped }),
-        listStripeTeamSubscriptions({ db: scoped, app: options.app }),
-        listAllPendingEmailGrants({ db: scoped }).catch((error: unknown) => {
-          if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
-          throw error;
-        }),
-      ]),
-    );
+    // Each read gets its own short transaction, so a failed optional read
+    // (missing admin_plan_grants table) aborts only its own transaction and
+    // the catch below still yields an empty pending list.
+    const subscribers = await withStatementTimeout(db, budget, async (scoped) => {
+      guard();
+      return await listStripeProSubscribers({ db: scoped });
+    });
+    const teamSubscriptions = await withStatementTimeout(db, budget, async (scoped) => {
+      guard();
+      return await listStripeTeamSubscriptions({ db: scoped, app: options.app });
+    });
+    const pendingGrants = await withStatementTimeout(db, budget, async (scoped) => {
+      guard();
+      return await listAllPendingEmailGrants({ db: scoped });
+    }).catch((error: unknown) => {
+      if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
+      throw error;
+    });
     return {
       subscribers: subscribers.rows,
       teamSubscriptions: teamSubscriptions.rows,
@@ -429,15 +447,19 @@ export const PRO_LIST_RENDER_TIMEOUT_MS = 8_000;
  */
 export async function loadProListSnapshotWithin(
   timeoutMs: number = PRO_LIST_RENDER_TIMEOUT_MS,
-  load: (statementTimeoutMs: number) => Promise<ProListSnapshot> =
-    (statementTimeoutMs) => loadProListSnapshot({ statementTimeoutMs }),
+  load: (budget: { statementTimeoutMs: number; deadlineMs: number }) => Promise<ProListSnapshot> =
+    (budget) => loadProListSnapshot(budget),
 ): Promise<ProListSnapshot> {
+  const deadlineMs = Date.now() + timeoutMs;
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new ProListTimeoutError(timeoutMs)), timeoutMs);
   });
   try {
-    return await Promise.race([load(timeoutMs), timeout]);
+    // When the timer wins, the load is not awaited further; the deadline stops
+    // it from starting any new read and the statement timeout ends the one in
+    // flight, so at most one bounded statement outlives this call.
+    return await Promise.race([load({ statementTimeoutMs: timeoutMs, deadlineMs }), timeout]);
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -250,8 +250,9 @@ export type TeamNameResolveOptions = {
 /**
  * The Stack half of the team roster: display names, resolved OUTSIDE any
  * database transaction so a slow provider never holds a connection. Lookups
- * run a few at a time, none starts after the deadline, and one that outlives
- * the remaining budget is abandoned (its name stays null).
+ * run a few at a time; none starts after the deadline and one that outlives
+ * the remaining budget is abandoned. Either way the row is kept with a null
+ * name, so a slow provider degrades the roster instead of failing it.
  */
 export async function resolveStripeTeamNames(
   rows: readonly StripeTeamSubscriptionRow[],
@@ -265,7 +266,7 @@ export async function resolveStripeTeamNames(
     async (row): Promise<StripeTeamSubscription> => {
       const remaining = options.deadlineMs === undefined ? undefined : options.deadlineMs - clock.now();
       if (remaining !== undefined && remaining <= 0) {
-        throw new ProListTimeoutError(0);
+        return { ...row, displayName: null };
       }
       const team = await raceWithin(app.getTeam(row.teamId).catch(() => null), remaining, clock);
       return { ...row, displayName: team?.displayName ?? null };

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -7,7 +7,7 @@
 //   no metadata filter, so these are found by paging through all accounts in
 //   bounded pages that the page walks one request at a time.
 
-import { and, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
+import { and, desc, eq, inArray, isNotNull, isNull, sql } from "drizzle-orm";
 
 import { cloudDb } from "../../db/client";
 import { adminPlanGrants, stripeCustomers, stripeSubscriptions } from "../../db/schema";
@@ -92,7 +92,32 @@ export type ProListScanPage<Row> = {
   readonly nextCursor: string | null;
 };
 
-export type ProListDb = Pick<ReturnType<typeof cloudDb>, "select">;
+type CloudDb = ReturnType<typeof cloudDb>;
+export type ProListDb = Pick<CloudDb, "select"> & {
+  /** Present on the real client; the roster uses it to scope a statement timeout. */
+  transaction?<Result>(operation: (tx: Pick<CloudDb, "select" | "execute">) => Promise<Result>): Promise<Result>;
+};
+
+/**
+ * Runs `work` inside a transaction with a Postgres statement timeout, so a
+ * read that outlives the caller's budget is cancelled by the server instead
+ * of lingering in the pool. Doubles without `transaction` run `work` directly.
+ */
+export async function withStatementTimeout<Result>(
+  db: ProListDb,
+  timeoutMs: number | undefined,
+  work: (db: ProListDb) => Promise<Result>,
+): Promise<Result> {
+  if (!timeoutMs || !Number.isFinite(timeoutMs) || timeoutMs <= 0 || typeof db.transaction !== "function") {
+    return await work(db);
+  }
+  const ms = Math.floor(timeoutMs);
+  return await db.transaction(async (tx) => {
+    // SET does not take bind parameters; ms is a validated integer.
+    await tx.execute(sql.raw(`set local statement_timeout = ${ms}`));
+    return await work(tx as ProListDb);
+  });
+}
 
 export type ProListStackApp = {
   getTeam(teamId: string): Promise<Pick<AdminStackTeam, "id" | "displayName"> | null>;
@@ -347,17 +372,27 @@ export class ProListDatabaseUnavailableError extends Error {
  * ProListDatabaseUnavailableError.
  */
 export async function loadProListSnapshot(
-  options: { readonly db?: ProListDb; readonly app?: ProListStackApp } = {},
+  options: {
+    readonly db?: ProListDb;
+    readonly app?: ProListStackApp;
+    /** Server-side cancel budget for the reads; see withStatementTimeout. */
+    readonly statementTimeoutMs?: number;
+  } = {},
 ): Promise<ProListSnapshot> {
   try {
-    const [subscribers, teamSubscriptions, pendingGrants] = await Promise.all([
-      listStripeProSubscribers(options),
-      listStripeTeamSubscriptions(options),
-      listAllPendingEmailGrants(options).catch((error: unknown) => {
-        if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
-        throw error;
-      }),
-    ]);
+    const db = options.db ?? cloudDb();
+    const [subscribers, teamSubscriptions, pendingGrants] = await withStatementTimeout(
+      db,
+      options.statementTimeoutMs,
+      async (scoped) => await Promise.all([
+        listStripeProSubscribers({ db: scoped }),
+        listStripeTeamSubscriptions({ db: scoped, app: options.app }),
+        listAllPendingEmailGrants({ db: scoped }).catch((error: unknown) => {
+          if (isMissingGrantsTableError(error)) return { rows: [], truncated: false };
+          throw error;
+        }),
+      ]),
+    );
     return {
       subscribers: subscribers.rows,
       teamSubscriptions: teamSubscriptions.rows,
@@ -388,18 +423,21 @@ export const PRO_LIST_RENDER_TIMEOUT_MS = 8_000;
 
 /**
  * Bounds how long the page render waits for the roster. A stalled database
- * must not hold the admin page; the client shows a retry instead.
+ * must not hold the admin page; the client shows a retry instead. The same
+ * budget is applied as a statement timeout, so the reads are cancelled by
+ * Postgres rather than left running after the page gave up on them.
  */
 export async function loadProListSnapshotWithin(
   timeoutMs: number = PRO_LIST_RENDER_TIMEOUT_MS,
-  load: () => Promise<ProListSnapshot> = () => loadProListSnapshot(),
+  load: (statementTimeoutMs: number) => Promise<ProListSnapshot> =
+    (statementTimeoutMs) => loadProListSnapshot({ statementTimeoutMs }),
 ): Promise<ProListSnapshot> {
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeout = new Promise<never>((_, reject) => {
     timer = setTimeout(() => reject(new ProListTimeoutError(timeoutMs)), timeoutMs);
   });
   try {
-    return await Promise.race([load(), timeout]);
+    return await Promise.race([load(timeoutMs), timeout]);
   } finally {
     if (timer) clearTimeout(timer);
   }

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -239,6 +239,38 @@ describe("Pro roster", () => {
     expect(committed).toBe(2);
   });
 
+  test("later reads get only the remaining deadline as their statement timeout", async () => {
+    const executed: string[] = [];
+    const base = fakeDb(new Map());
+    let now = 1_000_000;
+    const realNow = Date.now;
+    Date.now = () => now;
+    try {
+      const db: ProListDb = {
+        ...base,
+        transaction: async (operation) => {
+          const result = await operation({
+            select: base.select,
+            execute: (async (query: { queryChunks?: Array<{ value?: string[] }> }) => {
+              executed.push((query.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join("")).join(""));
+              // Each read consumes 3 seconds of an 8 second deadline.
+              now += 3000;
+            }) as never,
+          });
+          return result;
+        },
+      };
+      await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 8000 });
+      expect(executed).toEqual([
+        "set local statement_timeout = 8000",
+        "set local statement_timeout = 5000",
+        "set local statement_timeout = 2000",
+      ]);
+    } finally {
+      Date.now = realNow;
+    }
+  });
+
   test("no read starts after the deadline has passed", async () => {
     const base = fakeDb(new Map());
     await expect(

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -375,11 +375,15 @@ describe("Pro roster", () => {
     expect(selects).toBe(0);
   });
 
-  test("no read starts after the deadline has passed", async () => {
-    const base = fakeDb(new Map());
-    await expect(
-      loadProListSnapshot({ db: base, app: fakeApp({}), deadlineMs: 99, clock: { now: () => 100, schedule: () => () => undefined } }),
-    ).rejects.toBeInstanceOf(ProListTimeoutError);
+  test("no read starts at or after the deadline", async () => {
+    for (const nowValue of [99, 100]) {
+      let selects = 0;
+      const db = { select: (() => { selects += 1; throw new Error("select must not run"); }) as never } as unknown as ProListDb;
+      await expect(
+        loadProListSnapshot({ db, app: fakeApp({}), deadlineMs: 99, clock: { now: () => nowValue, schedule: () => () => undefined } }),
+      ).rejects.toBeInstanceOf(ProListTimeoutError);
+      expect(selects).toBe(0);
+    }
   });
 
   test("isValidScanCursor accepts opaque tokens and rejects junk", () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -304,11 +304,10 @@ describe("Pro roster", () => {
       listTeams: async () => Object.assign([], { nextCursor: null }) as never,
     };
     const clock: ProListClock = { now: () => now, schedule: () => () => undefined };
-    await expect(
-      listStripeTeamSubscriptions({ db: fakeDb(new Map([[stripeSubscriptions, subs]])), app, concurrency: 1, deadlineMs: 25, clock }),
-    ).rejects.toBeInstanceOf(ProListTimeoutError);
-    // Three lookups fit before the deadline (0, 10, 20); the fourth never starts.
+    const { rows } = await listStripeTeamSubscriptions({ db: fakeDb(new Map([[stripeSubscriptions, subs]])), app, concurrency: 1, deadlineMs: 25, clock });
+    // Three lookups fit before the deadline (0, 10, 20); the rest keep null names.
     expect(lookups).toBe(3);
+    expect(rows.map((row) => row.displayName)).toEqual(["t0", "t1", "t2", null, null, null]);
   });
 
   test("a hung team name lookup is abandoned at the remaining budget", async () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -13,6 +13,7 @@ import {
   PRO_LIST_MAX_ROWS,
   listStripeProSubscribers,
   listStripeTeamSubscriptions,
+  resolveStripeTeamNames,
   scanManualTeamGrants,
   scanManualUserGrants,
   type ProListDb,
@@ -282,7 +283,8 @@ describe("Pro roster", () => {
         return result;
       },
     };
-    await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 8000, now: () => now });
+    const clock: ProListClock = { now: () => now, schedule: () => () => undefined };
+    await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 8000, clock });
     expect(executed).toEqual([
       "set local statement_timeout = 8000",
       "set local statement_timeout = 5000",
@@ -301,11 +303,49 @@ describe("Pro roster", () => {
       listUsers: async () => Object.assign([], { nextCursor: null }) as never,
       listTeams: async () => Object.assign([], { nextCursor: null }) as never,
     };
+    const clock: ProListClock = { now: () => now, schedule: () => () => undefined };
     await expect(
-      listStripeTeamSubscriptions({ db: fakeDb(new Map([[stripeSubscriptions, subs]])), app, concurrency: 1, deadlineMs: 25, now: () => now }),
+      listStripeTeamSubscriptions({ db: fakeDb(new Map([[stripeSubscriptions, subs]])), app, concurrency: 1, deadlineMs: 25, clock }),
     ).rejects.toBeInstanceOf(ProListTimeoutError);
     // Three lookups fit before the deadline (0, 10, 20); the fourth never starts.
     expect(lookups).toBe(3);
+  });
+
+  test("a hung team name lookup is abandoned at the remaining budget", async () => {
+    const { clock, advance } = virtualClock(0);
+    const app: ProListStackApp = {
+      getTeam: () => new Promise(() => undefined),
+      listUsers: async () => Object.assign([], { nextCursor: null }) as never,
+      listTeams: async () => Object.assign([], { nextCursor: null }) as never,
+    };
+    const row = { teamId: "t1", subscriptionId: "sub_1", status: "active", seats: null, cancelAtPeriodEnd: false, currentPeriodEnd: null };
+    const pending = resolveStripeTeamNames([row], { app, deadlineMs: 500, clock });
+    advance(500);
+    expect(await pending).toEqual([{ ...row, displayName: null }]);
+  });
+
+  test("the team query commits before any name lookup starts", async () => {
+    const order: string[] = [];
+    const base = fakeDb(new Map([[stripeSubscriptions, [
+      { teamId: "t1", subscriptionId: "sub_1", status: "active", seats: 1, cancelAtPeriodEnd: false, currentPeriodEnd: null },
+    ]]]));
+    const db: ProListDb = {
+      ...base,
+      transaction: async (operation) => {
+        order.push("begin");
+        const result = await operation({ select: base.select, execute: (async () => undefined) as never });
+        order.push("commit");
+        return result;
+      },
+    };
+    const app: ProListStackApp = {
+      async getTeam(teamId) { order.push(`lookup ${teamId}`); return { id: teamId, displayName: "Acme" }; },
+      listUsers: async () => Object.assign([], { nextCursor: null }) as never,
+      listTeams: async () => Object.assign([], { nextCursor: null }) as never,
+    };
+    const snapshot = await loadProListSnapshot({ db, app, statementTimeoutMs: 1000 });
+    expect(snapshot.teamSubscriptions[0]?.displayName).toBe("Acme");
+    expect(order).toEqual(["begin", "commit", "begin", "commit", "lookup t1", "begin", "commit"]);
   });
 
   test("a missing database config becomes ProListDatabaseUnavailableError, a timeout stays a timeout", async () => {
@@ -314,14 +354,14 @@ describe("Pro roster", () => {
     } as unknown as ProListDb;
     await expect(loadProListSnapshot({ db: noConfig, app: fakeApp({}) })).rejects.toBeInstanceOf(ProListDatabaseUnavailableError);
     await expect(
-      loadProListSnapshot({ db: fakeDb(new Map()), app: fakeApp({}), deadlineMs: 99, now: () => 100 }),
+      loadProListSnapshot({ db: fakeDb(new Map()), app: fakeApp({}), deadlineMs: 99, clock: { now: () => 100, schedule: () => () => undefined } }),
     ).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 
   test("no read starts after the deadline has passed", async () => {
     const base = fakeDb(new Map());
     await expect(
-      loadProListSnapshot({ db: base, app: fakeApp({}), deadlineMs: 99, now: () => 100 }),
+      loadProListSnapshot({ db: base, app: fakeApp({}), deadlineMs: 99, clock: { now: () => 100, schedule: () => () => undefined } }),
     ).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -276,8 +276,8 @@ describe("Pro roster", () => {
           select: base.select,
           execute: (async (query: { queryChunks?: Array<{ value?: string[] }> }) => {
             executed.push((query.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join("")).join(""));
-            // Each read consumes 3 seconds of an 8 second deadline.
-            now += 3000;
+            // Each read consumes 2 seconds of an 8 second deadline.
+            now += 2000;
           }) as never,
         });
         return result;
@@ -287,8 +287,8 @@ describe("Pro roster", () => {
     await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 8000, clock });
     expect(executed).toEqual([
       "set local statement_timeout = 8000",
-      "set local statement_timeout = 5000",
-      "set local statement_timeout = 2000",
+      "set local statement_timeout = 6000",
+      "set local statement_timeout = 4000",
     ]);
   });
 
@@ -356,6 +356,24 @@ describe("Pro roster", () => {
     await expect(
       loadProListSnapshot({ db: fakeDb(new Map()), app: fakeApp({}), deadlineMs: 99, clock: { now: () => 100, schedule: () => () => undefined } }),
     ).rejects.toBeInstanceOf(ProListTimeoutError);
+  });
+
+  test("a transaction setup that crosses the deadline starts no read", async () => {
+    let now = 0;
+    let selects = 0;
+    const db: ProListDb = {
+      select: (() => { selects += 1; throw new Error("select must not run"); }) as never,
+      transaction: async (operation) =>
+        await operation({
+          select: (() => { selects += 1; throw new Error("select must not run"); }) as never,
+          // Acquiring the transaction and SET LOCAL together take longer than the budget.
+          execute: (async () => { now += 2000; }) as never,
+        }),
+    };
+    await expect(
+      loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 1000, deadlineMs: 1000, clock: { now: () => now, schedule: () => () => undefined } }),
+    ).rejects.toBeInstanceOf(ProListTimeoutError);
+    expect(selects).toBe(0);
   });
 
   test("no read starts after the deadline has passed", async () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -3,6 +3,8 @@ import { describe, expect, test } from "bun:test";
 import {
   isValidScanCursor,
   listAllPendingEmailGrants,
+  loadProListSnapshotWithin,
+  ProListTimeoutError,
   mapWithConcurrency,
   PRO_LIST_MAX_ROWS,
   listStripeProSubscribers,
@@ -164,6 +166,14 @@ describe("Pro roster", () => {
     expect(rows.map((row) => row.displayName)).toEqual(subs.map((sub) => `Team ${sub.teamId}`));
     expect(peak).toBeLessThanOrEqual(4);
     expect(await mapWithConcurrency([], 3, async () => 1)).toEqual([]);
+  });
+
+  test("the page-render load is bounded by a timeout", async () => {
+    const snapshot = { subscribers: [], teamSubscriptions: [], pendingGrants: [], truncated: { subscribers: false, teamSubscriptions: false, pendingGrants: false } };
+    expect(await loadProListSnapshotWithin(1000, async () => snapshot)).toBe(snapshot);
+    await expect(
+      loadProListSnapshotWithin(5, () => new Promise(() => undefined)),
+    ).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 
   test("isValidScanCursor accepts opaque tokens and rejects junk", () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -265,10 +265,10 @@ describe("Pro roster", () => {
     expect(committed).toBe(2);
   });
 
-  test("later reads get only the remaining deadline as their statement timeout", async () => {
+  test("each read's statement timeout is capped by the remaining deadline", async () => {
     const executed: string[] = [];
     const base = fakeDb(new Map());
-    let now = 1_000_000;
+    const now = 1_000_000;
     const db: ProListDb = {
       ...base,
       transaction: async (operation) => {
@@ -276,20 +276,19 @@ describe("Pro roster", () => {
           select: base.select,
           execute: (async (query: { queryChunks?: Array<{ value?: string[] }> }) => {
             executed.push((query.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join("")).join(""));
-            // Each read consumes 2 seconds of an 8 second deadline.
-            now += 2000;
           }) as never,
         });
         return result;
       },
     };
     const clock: ProListClock = { now: () => now, schedule: () => () => undefined };
+    // Reads start together, so each sees the full budget when there is time
+    // left; a read that starts with 3 seconds left gets 3 seconds.
     await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 8000, clock });
-    expect(executed).toEqual([
-      "set local statement_timeout = 8000",
-      "set local statement_timeout = 6000",
-      "set local statement_timeout = 4000",
-    ]);
+    expect(executed).toEqual(Array(3).fill("set local statement_timeout = 8000"));
+    executed.length = 0;
+    await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 3000, clock });
+    expect(executed).toEqual(Array(3).fill("set local statement_timeout = 3000"));
   });
 
   test("team name lookups stop once the deadline has passed", async () => {
@@ -344,7 +343,10 @@ describe("Pro roster", () => {
     };
     const snapshot = await loadProListSnapshot({ db, app, statementTimeoutMs: 1000 });
     expect(snapshot.teamSubscriptions[0]?.displayName).toBe("Acme");
-    expect(order).toEqual(["begin", "commit", "begin", "commit", "lookup t1", "begin", "commit"]);
+    // All three transactions have committed before the first name lookup.
+    const lookupAt = order.indexOf("lookup t1");
+    expect(order.slice(0, lookupAt).filter((step) => step === "commit")).toHaveLength(3);
+    expect(order.slice(lookupAt)).toEqual(["lookup t1"]);
   });
 
   test("a missing database config becomes ProListDatabaseUnavailableError, a timeout stays a timeout", async () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -3,8 +3,10 @@ import { describe, expect, test } from "bun:test";
 import {
   isValidScanCursor,
   listAllPendingEmailGrants,
+  loadProListSnapshot,
   loadProListSnapshotWithin,
   ProListTimeoutError,
+  withStatementTimeout,
   mapWithConcurrency,
   PRO_LIST_MAX_ROWS,
   listStripeProSubscribers,
@@ -168,12 +170,36 @@ describe("Pro roster", () => {
     expect(await mapWithConcurrency([], 3, async () => 1)).toEqual([]);
   });
 
-  test("the page-render load is bounded by a timeout", async () => {
+  test("the page-render load is bounded by a timeout and passes the same budget to the reads", async () => {
     const snapshot = { subscribers: [], teamSubscriptions: [], pendingGrants: [], truncated: { subscribers: false, teamSubscriptions: false, pendingGrants: false } };
-    expect(await loadProListSnapshotWithin(1000, async () => snapshot)).toBe(snapshot);
+    const budgets: number[] = [];
+    expect(await loadProListSnapshotWithin(1000, async (budget) => { budgets.push(budget); return snapshot; })).toBe(snapshot);
+    expect(budgets).toEqual([1000]);
     await expect(
       loadProListSnapshotWithin(5, () => new Promise(() => undefined)),
     ).rejects.toBeInstanceOf(ProListTimeoutError);
+  });
+
+  test("reads run under a scoped statement timeout when the client supports transactions", async () => {
+    const executed: string[] = [];
+    const base = fakeDb(new Map());
+    const db: ProListDb = {
+      ...base,
+      transaction: async (operation) =>
+        await operation({
+          select: base.select,
+          execute: (async (query: { queryChunks?: Array<{ value?: string[] }> }) => {
+            executed.push((query.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join("")).join(""));
+          }) as never,
+        }),
+    };
+    const snapshot = await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000 });
+    expect(executed).toEqual(["set local statement_timeout = 8000"]);
+    expect(snapshot.subscribers).toEqual([]);
+    // No transaction support, or no budget: reads run directly.
+    expect(await withStatementTimeout(base, 8000, async () => "direct")).toBe("direct");
+    expect(await withStatementTimeout(db, undefined, async () => "direct")).toBe("direct");
+    expect(executed).toHaveLength(1);
   });
 
   test("isValidScanCursor accepts opaque tokens and rejects junk", () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -173,7 +173,12 @@ describe("Pro roster", () => {
   test("the page-render load is bounded by a timeout and passes the same budget to the reads", async () => {
     const snapshot = { subscribers: [], teamSubscriptions: [], pendingGrants: [], truncated: { subscribers: false, teamSubscriptions: false, pendingGrants: false } };
     const budgets: number[] = [];
-    expect(await loadProListSnapshotWithin(1000, async (budget) => { budgets.push(budget); return snapshot; })).toBe(snapshot);
+    const before = Date.now();
+    expect(await loadProListSnapshotWithin(1000, async (budget) => {
+      budgets.push(budget.statementTimeoutMs);
+      expect(budget.deadlineMs).toBeGreaterThanOrEqual(before + 1000);
+      return snapshot;
+    })).toBe(snapshot);
     expect(budgets).toEqual([1000]);
     await expect(
       loadProListSnapshotWithin(5, () => new Promise(() => undefined)),
@@ -194,12 +199,51 @@ describe("Pro roster", () => {
         }),
     };
     const snapshot = await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000 });
-    expect(executed).toEqual(["set local statement_timeout = 8000"]);
+    // One short transaction per read, so an optional read that fails aborts only its own.
+    expect(executed).toEqual(Array(3).fill("set local statement_timeout = 8000"));
     expect(snapshot.subscribers).toEqual([]);
     // No transaction support, or no budget: reads run directly.
     expect(await withStatementTimeout(base, 8000, async () => "direct")).toBe("direct");
     expect(await withStatementTimeout(db, undefined, async () => "direct")).toBe("direct");
-    expect(executed).toHaveLength(1);
+    expect(executed).toHaveLength(3);
+  });
+
+  test("a missing grants table inside a transaction still yields an empty pending list", async () => {
+    const base = fakeDb(new Map());
+    let committed = 0;
+    const db: ProListDb = {
+      ...base,
+      transaction: async (operation) => {
+        const result = await operation({
+          select: ((...args: unknown[]) => {
+            const chain = (base.select as (...a: unknown[]) => { from: (t: unknown) => unknown })(...args);
+            return {
+              from: (table: unknown) => {
+                if (table === adminPlanGrants) {
+                  const failing = { leftJoin: () => failing, where: () => failing, orderBy: () => failing, limit: async () => { throw Object.assign(new Error("Failed query"), { cause: { code: "42P01" } }); } };
+                  return failing;
+                }
+                return chain.from(table);
+              },
+            };
+          }) as never,
+          execute: (async () => undefined) as never,
+        });
+        committed += 1;
+        return result;
+      },
+    };
+    const snapshot = await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 100 });
+    expect(snapshot.pendingGrants).toEqual([]);
+    // The two healthy reads committed; the failing one never reached commit.
+    expect(committed).toBe(2);
+  });
+
+  test("no read starts after the deadline has passed", async () => {
+    const base = fakeDb(new Map());
+    await expect(
+      loadProListSnapshot({ db: base, app: fakeApp({}), deadlineMs: Date.now() - 1 }),
+    ).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 
   test("isValidScanCursor accepts opaque tokens and rejects junk", () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -5,6 +5,7 @@ import {
   listAllPendingEmailGrants,
   loadProListSnapshot,
   loadProListSnapshotWithin,
+  ProListDatabaseUnavailableError,
   ProListTimeoutError,
   withStatementTimeout,
   mapWithConcurrency,
@@ -269,6 +270,16 @@ describe("Pro roster", () => {
     } finally {
       Date.now = realNow;
     }
+  });
+
+  test("a missing database config becomes ProListDatabaseUnavailableError, a timeout stays a timeout", async () => {
+    const noConfig = {
+      select: () => { throw new Error("DATABASE_URL is required for Cloud VM database access"); },
+    } as unknown as ProListDb;
+    await expect(loadProListSnapshot({ db: noConfig, app: fakeApp({}) })).rejects.toBeInstanceOf(ProListDatabaseUnavailableError);
+    await expect(
+      loadProListSnapshot({ db: fakeDb(new Map()), app: fakeApp({}), deadlineMs: Date.now() - 1 }),
+    ).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 
   test("no read starts after the deadline has passed", async () => {

--- a/web/tests/admin-pro-list.test.ts
+++ b/web/tests/admin-pro-list.test.ts
@@ -7,6 +7,7 @@ import {
   loadProListSnapshotWithin,
   ProListDatabaseUnavailableError,
   ProListTimeoutError,
+  type ProListClock,
   withStatementTimeout,
   mapWithConcurrency,
   PRO_LIST_MAX_ROWS,
@@ -63,6 +64,29 @@ function fakeApp(input: {
     async listTeams(options) {
       calls.push({ kind: "teams", ...options });
       return page(input.teams ?? [], options) as never;
+    },
+  };
+}
+
+/** Virtual clock: time only moves when a test advances it; timers fire on demand. */
+function virtualClock(start = 1_000_000) {
+  let now = start;
+  const timers: Array<{ at: number; fn: () => void; cancelled: boolean }> = [];
+  const clock: ProListClock = {
+    now: () => now,
+    schedule: (fn, ms) => {
+      const timer = { at: now + ms, fn, cancelled: false };
+      timers.push(timer);
+      return () => { timer.cancelled = true; };
+    },
+  };
+  return {
+    clock,
+    advance(ms: number) {
+      now += ms;
+      for (const timer of timers) {
+        if (!timer.cancelled && timer.at <= now) { timer.cancelled = true; timer.fn(); }
+      }
     },
   };
 }
@@ -173,17 +197,17 @@ describe("Pro roster", () => {
 
   test("the page-render load is bounded by a timeout and passes the same budget to the reads", async () => {
     const snapshot = { subscribers: [], teamSubscriptions: [], pendingGrants: [], truncated: { subscribers: false, teamSubscriptions: false, pendingGrants: false } };
-    const budgets: number[] = [];
-    const before = Date.now();
+    const { clock, advance } = virtualClock(50_000);
+    const budgets: Array<[number, number]> = [];
     expect(await loadProListSnapshotWithin(1000, async (budget) => {
-      budgets.push(budget.statementTimeoutMs);
-      expect(budget.deadlineMs).toBeGreaterThanOrEqual(before + 1000);
+      budgets.push([budget.statementTimeoutMs, budget.deadlineMs]);
       return snapshot;
-    })).toBe(snapshot);
-    expect(budgets).toEqual([1000]);
-    await expect(
-      loadProListSnapshotWithin(5, () => new Promise(() => undefined)),
-    ).rejects.toBeInstanceOf(ProListTimeoutError);
+    }, clock)).toBe(snapshot);
+    expect(budgets).toEqual([[1000, 51_000]]);
+    const pending = loadProListSnapshotWithin(1000, () => new Promise(() => undefined), clock);
+    advance(999);
+    advance(1);
+    await expect(pending).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 
   test("reads run under a scoped statement timeout when the client supports transactions", async () => {
@@ -244,32 +268,44 @@ describe("Pro roster", () => {
     const executed: string[] = [];
     const base = fakeDb(new Map());
     let now = 1_000_000;
-    const realNow = Date.now;
-    Date.now = () => now;
-    try {
-      const db: ProListDb = {
-        ...base,
-        transaction: async (operation) => {
-          const result = await operation({
-            select: base.select,
-            execute: (async (query: { queryChunks?: Array<{ value?: string[] }> }) => {
-              executed.push((query.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join("")).join(""));
-              // Each read consumes 3 seconds of an 8 second deadline.
-              now += 3000;
-            }) as never,
-          });
-          return result;
-        },
-      };
-      await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 8000 });
-      expect(executed).toEqual([
-        "set local statement_timeout = 8000",
-        "set local statement_timeout = 5000",
-        "set local statement_timeout = 2000",
-      ]);
-    } finally {
-      Date.now = realNow;
-    }
+    const db: ProListDb = {
+      ...base,
+      transaction: async (operation) => {
+        const result = await operation({
+          select: base.select,
+          execute: (async (query: { queryChunks?: Array<{ value?: string[] }> }) => {
+            executed.push((query.queryChunks ?? []).map((chunk) => (chunk.value ?? []).join("")).join(""));
+            // Each read consumes 3 seconds of an 8 second deadline.
+            now += 3000;
+          }) as never,
+        });
+        return result;
+      },
+    };
+    await loadProListSnapshot({ db, app: fakeApp({}), statementTimeoutMs: 8000, deadlineMs: now + 8000, now: () => now });
+    expect(executed).toEqual([
+      "set local statement_timeout = 8000",
+      "set local statement_timeout = 5000",
+      "set local statement_timeout = 2000",
+    ]);
+  });
+
+  test("team name lookups stop once the deadline has passed", async () => {
+    const subs = Array.from({ length: 6 }, (_, i) => ({
+      teamId: `t${i}`, subscriptionId: `sub_${i}`, status: "active", seats: 1, cancelAtPeriodEnd: false, currentPeriodEnd: null,
+    }));
+    let now = 0;
+    let lookups = 0;
+    const app: ProListStackApp = {
+      async getTeam(teamId) { lookups += 1; now += 10; return { id: teamId, displayName: teamId }; },
+      listUsers: async () => Object.assign([], { nextCursor: null }) as never,
+      listTeams: async () => Object.assign([], { nextCursor: null }) as never,
+    };
+    await expect(
+      listStripeTeamSubscriptions({ db: fakeDb(new Map([[stripeSubscriptions, subs]])), app, concurrency: 1, deadlineMs: 25, now: () => now }),
+    ).rejects.toBeInstanceOf(ProListTimeoutError);
+    // Three lookups fit before the deadline (0, 10, 20); the fourth never starts.
+    expect(lookups).toBe(3);
   });
 
   test("a missing database config becomes ProListDatabaseUnavailableError, a timeout stays a timeout", async () => {
@@ -278,14 +314,14 @@ describe("Pro roster", () => {
     } as unknown as ProListDb;
     await expect(loadProListSnapshot({ db: noConfig, app: fakeApp({}) })).rejects.toBeInstanceOf(ProListDatabaseUnavailableError);
     await expect(
-      loadProListSnapshot({ db: fakeDb(new Map()), app: fakeApp({}), deadlineMs: Date.now() - 1 }),
+      loadProListSnapshot({ db: fakeDb(new Map()), app: fakeApp({}), deadlineMs: 99, now: () => 100 }),
     ).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 
   test("no read starts after the deadline has passed", async () => {
     const base = fakeDb(new Map());
     await expect(
-      loadProListSnapshot({ db: base, app: fakeApp({}), deadlineMs: Date.now() - 1 }),
+      loadProListSnapshot({ db: base, app: fakeApp({}), deadlineMs: 99, now: () => 100 }),
     ).rejects.toBeInstanceOf(ProListTimeoutError);
   });
 


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11668 from the local review gate.

- The roster is an async server component inside a Suspense boundary with an eight-second budget (`loadProListSnapshotWithin`), so a slow or stalled database read never holds the admin page; the section falls back to its retry state instead.
- The client list reaches the search box through a small context, so the server-streamed roster can still fill the search on row click.
- Mount and scan handlers are stable `useCallback`s (same pattern as the vault transcript viewer), so the ref callback runs only on real mount and unmount. Unmount aborts in-flight fetches and invalidates the run, so leaving the page stops the directory walks.
- Removed the unused render timestamp that could differ between server render and hydration.

https://claude.ai/code/session_01PrCfEysHKCZFpXcqeRiPHL

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams the admin Pro roster behind Suspense with an eight-second load budget, so a slow or stalled database read no longer holds the admin page; the roster falls back to its retry state instead. Leaving the page now cancels in-flight directory scans.

- The budget is also a render deadline: the three database reads run concurrently in their own statement-timeout transactions, and no read or Stack name lookup starts once it passes; the deadline is re-checked inside each transaction after `SET LOCAL`, so a slow transaction acquisition can't start a read after it.
- Each read's statement timeout is the lesser of the budget and the time left, so the server cancels timed-out reads and a failing optional read doesn't break the others.
- The team roster query commits before any Stack display-name lookup starts; names resolve outside the transaction with a per-lookup limit equal to the remaining render budget, so a slow provider never holds a database connection. Rows at or past the deadline keep a null display name instead of rejecting the roster.
- Client creation stays inside the same error boundary, so a missing database config surfaces as the 503 unavailable error instead of a raw failure.
- The server-streamed roster fills the search box on row click through a small client context; the callback and context value are stable, so panel state changes don't re-render the roster rows.
- The page-render load uses a timeout wrapper with an injectable clock; tests cover the bounded wait and deadline behavior.
- Removed the unused render timestamp that could differ between server render and hydration.

<sup>Written for commit 25c454c6fdec0b25245f778ab65ff833528ba728. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Admin dashboards now render the main page immediately while the professional roster loads separately.
  - Added a loading state while roster data is being retrieved.
  - Selecting a roster entry populates and runs the related search.

- **Bug Fixes**
  - Roster loading is time-limited, preventing slow requests from blocking the page.
  - Improved interrupted scan and reload handling to prevent stale results.
  - Missing roster data sources are handled gracefully without blocking other results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->