### PR TITLE
Restore the caret next to the titlebar plus button

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -256076,6 +256076,244 @@
         }
       }
     },
+    "titlebar.newWorkspace.menu.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "قائمة مساحة العمل الجديدة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meni novog radnog prostora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu for nyt arbejdsområde"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menü „Neuer Arbeitsbereich“"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Workspace Menu"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menú de nuevo espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu Nouvel espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu Nuova area di lavoro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ワークスペースメニュー"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 작업 공간 메뉴"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Meny for nytt arbeidsområde"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu nowej przestrzeni roboczej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Menu de Nova Área de Trabalho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Меню нового рабочего пространства"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "เมนูเวิร์กสเปซใหม่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni Çalışma Alanı Menüsü"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Меню нової робочої області"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建工作区菜单"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增工作區選單"
+          }
+        }
+      }
+    },
+    "titlebar.newWorkspace.menu.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "خيارات مساحة العمل الجديدة"
+          }
+        },
+        "bs": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcije novog radnog prostora"
+          }
+        },
+        "da": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Indstillinger for nyt arbejdsområde"
+          }
+        },
+        "de": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Optionen für neuen Arbeitsbereich"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New workspace options"
+          }
+        },
+        "es": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opciones de nuevo espacio de trabajo"
+          }
+        },
+        "fr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Options du nouvel espace de travail"
+          }
+        },
+        "it": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opzioni nuova area di lavoro"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ワークスペースのオプション"
+          }
+        },
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 작업 공간 옵션"
+          }
+        },
+        "nb": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Alternativer for nytt arbeidsområde"
+          }
+        },
+        "pl": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opcje nowej przestrzeni roboczej"
+          }
+        },
+        "pt-BR": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Opções de nova área de trabalho"
+          }
+        },
+        "ru": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Параметры нового рабочего пространства"
+          }
+        },
+        "th": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ตัวเลือกเวิร์กสเปซใหม่"
+          }
+        },
+        "tr": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Yeni çalışma alanı seçenekleri"
+          }
+        },
+        "uk": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Параметри нової робочої області"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新建工作区选项"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新增工作區選項"
+          }
+        }
+      }
+    },
     "titlebar.newWorkspace.tooltip": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate+NewWorkspaceContextMenu.swift
+++ b/Sources/AppDelegate+NewWorkspaceContextMenu.swift
@@ -41,9 +41,12 @@ extension AppDelegate {
         return true
     }
 
+    /// Pops the menu below `anchorView`, or at `location` (in `anchorView`
+    /// coordinates) when the caller only knows where the click landed.
     @discardableResult
     func showNewWorkspaceContextMenu(
         anchorView: NSView,
+        at location: NSPoint? = nil,
         debugSource: String = "titlebar.newWorkspace.contextMenu"
     ) -> Bool {
         let context = contextForMainWindow(anchorView.window)
@@ -62,7 +65,7 @@ extension AppDelegate {
 
         menu.popUp(
             positioning: nil,
-            at: NSPoint(x: 0, y: anchorView.bounds.maxY + 2),
+            at: location ?? NSPoint(x: 0, y: anchorView.bounds.maxY + 2),
             in: anchorView
         )
         return true

--- a/Sources/Update/MinimalModeSidebarControls.swift
+++ b/Sources/Update/MinimalModeSidebarControls.swift
@@ -45,7 +45,10 @@ enum TitlebarControlsHitRegions {
         let sidebarX = startX
         let notificationsX = sidebarX + config.buttonSize + config.spacing
         let newTabX = notificationsX + config.buttonSize + config.spacing
-        let focusBackX = newTabX + config.buttonSize + config.spacing
+        let newTabWidth = TitlebarNewWorkspaceSplitButtonMetrics.primaryWidth(config: config)
+        let newWorkspaceMenuX = newTabX + newTabWidth
+        let newWorkspaceMenuWidth = TitlebarNewWorkspaceSplitButtonMetrics.dropdownWidth(config: config)
+        let focusBackX = newWorkspaceMenuX + newWorkspaceMenuWidth + config.spacing
         let focusForwardX = focusBackX + config.buttonSize + config.spacing
 
         let minX: CGFloat = switch slot {
@@ -55,12 +58,21 @@ enum TitlebarControlsHitRegions {
             notificationsX
         case .newTab:
             newTabX
+        case .newWorkspaceMenu:
+            newWorkspaceMenuX
         case .focusHistoryBack:
             focusBackX
         case .focusHistoryForward:
             focusForwardX
         }
-        let width: CGFloat = config.buttonSize
+        let width: CGFloat = switch slot {
+        case .newTab:
+            newTabWidth
+        case .newWorkspaceMenu:
+            newWorkspaceMenuWidth
+        case .toggleSidebar, .showNotifications, .focusHistoryBack, .focusHistoryForward:
+            config.buttonSize
+        }
         return minX...(minX + width)
     }
 
@@ -218,6 +230,12 @@ final class MinimalModeSidebarControlActionView: NSView {
             CmuxExtensionSidebarSelection.showMenu(anchorView: self, event: event)
         case .newTab:
             _ = AppDelegate.shared?.showNewWorkspaceContextMenu(anchorView: self, event: event)
+        case .newWorkspaceMenu:
+            _ = AppDelegate.shared?.showNewWorkspaceContextMenu(
+                anchorView: self,
+                event: event,
+                debugSource: "titlebar.minimalSidebar.newWorkspaceMenu.rightClick"
+            )
         case .focusHistoryBack:
             _ = AppDelegate.shared?.showFocusHistoryContextMenu(anchorView: self, event: event, direction: .back)
         case .focusHistoryForward:

--- a/Sources/Update/TitlebarNewWorkspaceSplitButton.swift
+++ b/Sources/Update/TitlebarNewWorkspaceSplitButton.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+import AppKit
+import CmuxSettings
+
+/// Geometry shared by the visible split button and the hidden minimal-mode
+/// click lanes (`TitlebarControlsHitRegions`), so both stay in lockstep.
+enum TitlebarNewWorkspaceSplitButtonMetrics {
+    static func primaryWidth(config: TitlebarControlsStyleConfig) -> CGFloat { max(config.iconSize + 4, config.buttonSize - 3) }
+
+    static func dropdownWidth(config: TitlebarControlsStyleConfig) -> CGFloat { max(14, floor(config.buttonSize * 0.70)) }
+
+    static func dropdownIconSize(config: TitlebarControlsStyleConfig) -> CGFloat { max(6, config.iconSize - 6) }
+
+    static func totalWidth(config: TitlebarControlsStyleConfig) -> CGFloat { primaryWidth(config: config) + dropdownWidth(config: config) }
+}
+
+/// The titlebar "+" control: a primary segment that creates a workspace and a
+/// caret segment that opens the New Workspace menu (the same menu right-click
+/// shows on either segment).
+struct TitlebarNewWorkspaceSplitButton: View {
+    let config: TitlebarControlsStyleConfig
+    let foregroundColor: Color
+    let onNewTab: () -> Void
+    @State private var menuAnchorView: NSView?
+    @State private var hoveredSegment: TitlebarNewWorkspaceSplitButtonSegment?
+
+    private var dropdownWidth: CGFloat {
+        TitlebarNewWorkspaceSplitButtonMetrics.dropdownWidth(config: config)
+    }
+
+    private var primaryWidth: CGFloat {
+        TitlebarNewWorkspaceSplitButtonMetrics.primaryWidth(config: config)
+    }
+
+    private var isHovering: Bool { hoveredSegment != nil }
+
+    private var foregroundOpacity: Double {
+        titlebarControlForegroundOpacity(isHovering: isHovering, isPressed: false, isEnabled: true)
+    }
+
+    private var borderOpacity: Double {
+        titlebarControlBorderOpacity(config: config, isHovering: isHovering, isPressed: false, isEnabled: true)
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            Button(action: onNewTab) {
+                CmuxSystemSymbolImage(systemName: "plus", pointSize: config.iconSize, weight: .medium)
+                    .frame(width: primaryWidth, height: config.buttonSize)
+            }
+            .buttonStyle(.plain)
+            .frame(width: primaryWidth, height: config.buttonSize)
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .ignore)
+            .accessibilityIdentifier("titlebarControl.newTab")
+            .accessibilityLabel(String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace"))
+            .overlay {
+                TitlebarSplitButtonRightClickView { anchorView, event in
+                    _ = AppDelegate.shared?.showNewWorkspaceContextMenu(anchorView: anchorView, event: event)
+                }
+            }
+            .background(foregroundColor.opacity(segmentBackgroundOpacity(for: .newTab)))
+            .onHover { hovering in
+                updateHoveredSegment(.newTab, hovering: hovering)
+            }
+            .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newWorkspace.tooltip", defaultValue: "New workspace")))
+
+            Button(
+                action: {
+                    guard let menuAnchorView else { return }
+                    _ = AppDelegate.shared?.showNewWorkspaceContextMenu(
+                        anchorView: menuAnchorView,
+                        debugSource: "titlebar.newWorkspace.menu"
+                    )
+                }
+            ) {
+                ZStack {
+                    Rectangle()
+                        .fill(Color.clear)
+                    CmuxSystemSymbolImage(
+                        systemName: "chevron.down",
+                        pointSize: TitlebarNewWorkspaceSplitButtonMetrics.dropdownIconSize(config: config),
+                        weight: .bold
+                    )
+                }
+                .frame(width: dropdownWidth, height: config.buttonSize)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .frame(width: dropdownWidth, height: config.buttonSize)
+            .contentShape(Rectangle())
+            .accessibilityElement(children: .ignore)
+            .accessibilityIdentifier("titlebarControl.newWorkspaceMenu")
+            .accessibilityLabel(String(localized: "titlebar.newWorkspace.menu.accessibilityLabel", defaultValue: "New Workspace Menu"))
+            .background(TitlebarControlAnchorView { menuAnchorView = $0 })
+            .overlay {
+                TitlebarSplitButtonRightClickView { anchorView, event in
+                    _ = AppDelegate.shared?.showNewWorkspaceContextMenu(
+                        anchorView: anchorView,
+                        event: event,
+                        debugSource: "titlebar.newWorkspace.menu.rightClick"
+                    )
+                }
+            }
+            .background(foregroundColor.opacity(segmentBackgroundOpacity(for: .menu)))
+            .onHover { hovering in
+                updateHoveredSegment(.menu, hovering: hovering)
+            }
+            .safeHelp(String(localized: "titlebar.newWorkspace.menu.tooltip", defaultValue: "New workspace options"))
+        }
+        .foregroundStyle(foregroundColor.opacity(foregroundOpacity))
+        .frame(width: primaryWidth + dropdownWidth, height: config.buttonSize)
+        .background {
+            if config.buttonBackground && !isHovering {
+                RoundedRectangle(cornerRadius: config.buttonCornerRadius, style: .continuous)
+                    .fill(Color(nsColor: .controlBackgroundColor).opacity(0.45))
+            }
+        }
+        .clipShape(RoundedRectangle(cornerRadius: config.buttonCornerRadius, style: .continuous))
+        .overlay {
+            if borderOpacity > 0 {
+                RoundedRectangle(cornerRadius: config.buttonCornerRadius, style: .continuous)
+                    .stroke(foregroundColor.opacity(borderOpacity), lineWidth: 0.5)
+            }
+        }
+        .contentShape(Rectangle())
+        .animation(.easeInOut(duration: 0.12), value: hoveredSegment)
+        .background(TitlebarChromeGeometryReporter(keyPrefix: "titlebarControl_newTabSplit"))
+        .titlebarInteractiveControl()
+    }
+
+    private func segmentBackgroundOpacity(for segment: TitlebarNewWorkspaceSplitButtonSegment) -> Double {
+        if hoveredSegment == segment {
+            return titlebarControlActiveHoverBackgroundOpacity(
+                isHovering: isHovering,
+                isPressed: false,
+                isEnabled: true
+            )
+        }
+        return titlebarControlPassiveHoverBackgroundOpacity(
+            isHovering: isHovering,
+            isPressed: false,
+            isEnabled: true
+        )
+    }
+
+    private func updateHoveredSegment(
+        _ segment: TitlebarNewWorkspaceSplitButtonSegment,
+        hovering: Bool
+    ) {
+        guard titlebarControlsShouldTrackButtonHover(config: config) else { return }
+        if hovering {
+            hoveredSegment = segment
+        } else if hoveredSegment == segment {
+            hoveredSegment = nil
+        }
+    }
+}
+
+private enum TitlebarNewWorkspaceSplitButtonSegment: Equatable {
+    case newTab
+    case menu
+}
+
+private struct TitlebarSplitButtonRightClickView: NSViewRepresentable {
+    let onRightMouseDown: (NSView, NSEvent) -> Void
+
+    func makeNSView(context: Context) -> TitlebarSplitButtonRightClickNSView {
+        let view = TitlebarSplitButtonRightClickNSView()
+        view.onRightMouseDown = onRightMouseDown
+        return view
+    }
+
+    func updateNSView(_ nsView: TitlebarSplitButtonRightClickNSView, context: Context) {
+        nsView.onRightMouseDown = onRightMouseDown
+    }
+}
+
+private final class TitlebarSplitButtonRightClickNSView: NSView {
+    var onRightMouseDown: ((NSView, NSEvent) -> Void)?
+
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard bounds.contains(point),
+              NSApp.currentEvent?.type == .rightMouseDown else {
+            return nil
+        }
+        return self
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        onRightMouseDown?(self, event)
+    }
+}

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1174,24 +1174,16 @@ struct TitlebarControlsView: View {
             .background(NotificationsAnchorView { viewModel.notificationsAnchorView = $0 })
             .safeHelp(KeyboardShortcutSettings.Action.showNotifications.tooltip(String(localized: "titlebar.notifications.tooltip", defaultValue: "Show notifications")))
 
-            TitlebarControlButton(
+            TitlebarNewWorkspaceSplitButton(
                 config: config,
                 foregroundColor: foregroundColor,
-                accessibilityIdentifier: "titlebarControl.newTab",
-                accessibilityLabel: String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace"),
-                action: {
+                onNewTab: {
                     #if DEBUG
                     cmuxDebugLog("titlebar.newTab")
                     #endif
                     onNewTab()
-                },
-                rightClickAction: { anchorView, event in
-                    _ = AppDelegate.shared?.showNewWorkspaceContextMenu(anchorView: anchorView, event: event)
                 }
-            ) {
-                iconLabel(systemName: "plus", config: config, iconGeometryKeyPrefix: "titlebarControl_newTabIcon")
-            }
-            .safeHelp(KeyboardShortcutSettings.Action.newTab.tooltip(String(localized: "titlebar.newWorkspace.tooltip", defaultValue: "New workspace")))
+            )
 
             TitlebarControlButton(
                 config: config,
@@ -1597,6 +1589,11 @@ struct HiddenTitlebarSidebarControlsView: View {
                     onToggleNotifications(anchorView)
                 case .newTab:
                     onNewTab()
+                case .newWorkspaceMenu:
+                    _ = AppDelegate.shared?.showNewWorkspaceContextMenu(
+                        anchorView: anchorView,
+                        debugSource: "titlebar.minimalSidebar.newWorkspaceMenu"
+                    )
                 case .focusHistoryBack:
                     let availability = focusHistoryNavigationAvailability(
                         preferredWindow: hostWindowForFocusHistoryNavigation
@@ -2745,6 +2742,9 @@ final class UpdateTitlebarAccessoryController {
 
     private func prewarmTitlebarSymbols() {
         let iconSizes = TitlebarControlsStyle.allCases.map { $0.config.iconSize }
+        let dropdownSizes = TitlebarControlsStyle.allCases.map {
+            TitlebarNewWorkspaceSplitButtonMetrics.dropdownIconSize(config: $0.config)
+        }
         RenderableSystemSymbol.prewarmAppKitImages(
             systemNames: ["bell", "arrow.left", "arrow.right"],
             pointSizes: iconSizes,
@@ -2754,6 +2754,11 @@ final class UpdateTitlebarAccessoryController {
             systemNames: ["plus"],
             pointSizes: iconSizes,
             weight: .medium
+        )
+        RenderableSystemSymbol.prewarmAppKitImages(
+            systemNames: ["chevron.down"],
+            pointSizes: dropdownSizes,
+            weight: .bold
         )
         RenderableSystemSymbol.prewarmAppKitImages(
             systemNames: ["arrow.down.to.line"],

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -354,6 +354,21 @@ final class WindowDecorationsController {
                     tabManager: context.tabManager,
                     debugSource: "titlebar.minimalSidebarControl"
                 )
+            case .newWorkspaceMenu:
+                if let anchorView {
+                    _ = appDelegate.showNewWorkspaceContextMenu(
+                        anchorView: anchorView,
+                        debugSource: "titlebar.minimalSidebarControl.newWorkspaceMenu"
+                    )
+                } else if let contentView = window.contentView {
+                    // Window-monitor path: no control view exists yet, so drop
+                    // the menu where the click landed.
+                    _ = appDelegate.showNewWorkspaceContextMenu(
+                        anchorView: contentView,
+                        at: contentView.convert(locationInWindow, from: nil),
+                        debugSource: "titlebar.minimalSidebarControl.newWorkspaceMenu"
+                    )
+                }
             case .focusHistoryBack:
                 guard context.tabManager.canNavigateBack else { return }
                 context.tabManager.navigateBack()

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -813,6 +813,7 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
     case toggleSidebar
     case showNotifications
     case newTab
+    case newWorkspaceMenu
     case focusHistoryBack
     case focusHistoryForward
 
@@ -824,6 +825,8 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
             return "titlebarControl.showNotifications"
         case .newTab:
             return "titlebarControl.newTab"
+        case .newWorkspaceMenu:
+            return "titlebarControl.newWorkspaceMenu"
         case .focusHistoryBack:
             return "titlebarControl.focusHistoryBack"
         case .focusHistoryForward:
@@ -839,6 +842,8 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
             return String(localized: "titlebar.notifications.accessibilityLabel", defaultValue: "Notifications")
         case .newTab:
             return String(localized: "titlebar.newWorkspace.accessibilityLabel", defaultValue: "New Workspace")
+        case .newWorkspaceMenu:
+            return String(localized: "titlebar.newWorkspace.menu.accessibilityLabel", defaultValue: "New Workspace Menu")
         case .focusHistoryBack:
             return String(localized: "menu.history.focusBack", defaultValue: "Focus Back")
         case .focusHistoryForward:
@@ -854,6 +859,8 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
             return "showNotifications"
         case .newTab:
             return "newTab"
+        case .newWorkspaceMenu:
+            return "newWorkspaceMenu"
         case .focusHistoryBack:
             return "focusHistoryBack"
         case .focusHistoryForward:
@@ -863,7 +870,7 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
 
     var acceptsContextMenu: Bool {
         switch self {
-        case .toggleSidebar, .newTab, .focusHistoryBack, .focusHistoryForward:
+        case .toggleSidebar, .newTab, .newWorkspaceMenu, .focusHistoryBack, .focusHistoryForward:
             return true
         case .showNotifications:
             return false

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2780,6 +2780,7 @@
 		F50030020000000000000001 /* TitlebarInteractiveControlModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50030020000000000000002 /* TitlebarInteractiveControlModifier.swift */; };
 		F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F50030040000000000000002 /* TitlebarInteractiveControlTests.swift */; };
 		C4160A070000000000000001 /* TitlebarLayoutDebugWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A070000000000000002 /* TitlebarLayoutDebugWindow.swift */; };
+		C10D00110000000000000011 /* TitlebarNewWorkspaceSplitButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D00120000000000000012 /* TitlebarNewWorkspaceSplitButton.swift */; };
 		A10507000000000000000001 /* TitleUpdateAmplificationRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10507000000000000000002 /* TitleUpdateAmplificationRegressionTests.swift */; };
 		9009A0029009A0029009A001 /* TmuxCompatLaunchContextError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9009A0029009A0029009A002 /* TmuxCompatLaunchContextError.swift */; };
 		E30760030000000000000002 /* TmuxOverlayExperimentSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30760030000000000000001 /* TmuxOverlayExperimentSettings.swift */; };
@@ -5798,6 +5799,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		F50030020000000000000002 /* TitlebarInteractiveControlModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlebarInteractiveControlModifier.swift; sourceTree = "<group>"; };
 		F50030040000000000000002 /* TitlebarInteractiveControlTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlebarInteractiveControlTests.swift; sourceTree = "<group>"; };
 		C4160A070000000000000002 /* TitlebarLayoutDebugWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitlebarLayoutDebugWindow.swift; sourceTree = "<group>"; };
+		C10D00120000000000000012 /* TitlebarNewWorkspaceSplitButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Update/TitlebarNewWorkspaceSplitButton.swift; sourceTree = "<group>"; };
 		A10507000000000000000002 /* TitleUpdateAmplificationRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TitleUpdateAmplificationRegressionTests.swift; sourceTree = "<group>"; };
 		9009A0029009A0029009A002 /* TmuxCompatLaunchContextError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxCompatLaunchContextError.swift; sourceTree = "<group>"; };
 		E30760030000000000000001 /* TmuxOverlayExperimentSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TmuxOverlayExperimentSettings.swift; sourceTree = "<group>"; };
@@ -7996,6 +7998,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5001218 /* UpdateTitlebarAccessory.swift */,
 				C4160A060000000000000002 /* TitlebarChromeGeometryReporting.swift */,
 				C0DE3150A00000000000002 /* MinimalModeSidebarControls.swift */,
+				C10D00120000000000000012 /* TitlebarNewWorkspaceSplitButton.swift */,
 				A5001219 /* WindowToolbarController.swift */,
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
@@ -11528,6 +11531,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 					C4160A060000000000000001 /* TitlebarChromeGeometryReporting.swift in Sources */,
 					F50030020000000000000001 /* TitlebarInteractiveControlModifier.swift in Sources */,
 				C4160A070000000000000001 /* TitlebarLayoutDebugWindow.swift in Sources */,
+				C10D00110000000000000011 /* TitlebarNewWorkspaceSplitButton.swift in Sources */,
 				E30760030000000000000002 /* TmuxOverlayExperimentSettings.swift in Sources */,
 				E30760040000000000000002 /* TmuxOverlayExperimentTarget.swift in Sources */,
 				B35751000000000000000002 /* TmuxResumeParser.swift in Sources */,

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -559,10 +559,19 @@ struct TitlebarControlsHoverPolicyTests {
             let ranges = TitlebarControlsHitRegions.buttonXRanges(config: config)
 
             checkEqual(ranges.count, MinimalModeSidebarControlActionSlot.allCases.count)
-            for range in ranges {
+            for (index, range) in ranges.enumerated() {
+                let slot = MinimalModeSidebarControlActionSlot(rawValue: index)
+                let expectedWidth: CGFloat = switch slot {
+                case .some(.newTab):
+                    TitlebarNewWorkspaceSplitButtonMetrics.primaryWidth(config: config)
+                case .some(.newWorkspaceMenu):
+                    TitlebarNewWorkspaceSplitButtonMetrics.dropdownWidth(config: config)
+                case .some(.toggleSidebar), .some(.showNotifications), .some(.focusHistoryBack), .some(.focusHistoryForward), nil:
+                    config.buttonSize
+                }
                 checkEqual(
                     range.upperBound - range.lowerBound,
-                    config.buttonSize,
+                    expectedWidth,
                     accuracy: 0.001,
                     "Expected titlebar hit lane width to match its visible control for style \(style)"
                 )

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -886,11 +886,37 @@ final class WindowDragHandleHitTests: XCTestCase {
                 "titlebarControl.toggleSidebar",
                 "titlebarControl.showNotifications",
                 "titlebarControl.newTab",
+                "titlebarControl.newWorkspaceMenu",
                 "titlebarControl.focusHistoryBack",
                 "titlebarControl.focusHistoryForward",
             ],
             "The hidden minimal-mode click lanes must match the visible titlebar control order."
         )
+        let menuLane = ranges[MinimalModeSidebarControlActionSlot.newWorkspaceMenu.rawValue]
+        let newTabLane = ranges[MinimalModeSidebarControlActionSlot.newTab.rawValue]
+        XCTAssertEqual(
+            menuLane.lowerBound,
+            newTabLane.upperBound,
+            accuracy: 0.001,
+            "The caret lane must butt against the plus lane: the split button has no gap between its segments."
+        )
+        XCTAssertEqual(
+            menuLane.upperBound - menuLane.lowerBound,
+            TitlebarNewWorkspaceSplitButtonMetrics.dropdownWidth(config: config),
+            accuracy: 0.001,
+            "The hidden New Workspace menu lane should match the visible split-button caret width."
+        )
+        XCTAssertLessThan(
+            TitlebarNewWorkspaceSplitButtonMetrics.dropdownIconSize(config: config),
+            config.iconSize - 2,
+            "The caret glyph should stay visibly smaller than the primary titlebar icons."
+        )
+        for x in [menuLane.lowerBound + 1, (menuLane.lowerBound + menuLane.upperBound) / 2, menuLane.upperBound - 1] {
+            XCTAssertTrue(
+                TitlebarControlsHitRegions.pointFallsInButtonColumn(NSPoint(x: x, y: 14), config: config),
+                "The whole caret lane should receive left clicks."
+            )
+        }
         XCTAssertEqual(
             ranges[0].lowerBound,
             TitlebarControlsLayoutMetrics.hintLeadingPadding + config.groupPadding.leading,


### PR DESCRIPTION
https://github.com/manaflow-ai/cmux/pull/11626 folded the New Workspace split button into a plain plus button, so the menu was reachable only by right-click. This brings the caret back.

`TitlebarNewWorkspaceSplitButton` replaces the plain button: the plus segment creates a workspace, the caret segment opens the same New Workspace menu that right-click shows on either segment. The minimal-mode hidden click lanes get a matching `.newWorkspaceMenu` slot so the hit geometry matches the visible control, and `chevron.down` is prewarmed with the other titlebar symbols. The removed Cloud VM menu section and the split-button debug window stay gone.

First commit adds the lane/width tests (red), second commit restores the control (green).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the caret next to the titlebar plus button so the New Workspace menu is reachable by click again, not just right-click.

**Bug Fixes**
- The plus segment creates a workspace; the caret segment opens the same New Workspace menu that right-click shows.
- The hidden minimal-mode click lanes get a matching `.newWorkspaceMenu` slot so hit geometry matches the visible control.
- The minimal-mode window-monitor path opens the menu below the control, or at the click point when no control exists.
- `chevron.down` is prewarmed with the other titlebar symbols.
- The removed Cloud VM menu section and the split-button debug window stay gone.

<sup>Written for commit 026ac2c3e60840c3f02c2eeab01a536e793473a0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11680?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

