### PR TITLE
Check manifest size problems without the arrayContaining shim

### DIFF
--- a/web/tests/vm-image-sizes.test.ts
+++ b/web/tests/vm-image-sizes.test.ts
@@ -139,10 +139,12 @@ describe("imageManifestProblems with sizes", () => {
       ],
     };
     const problems = imageManifestProblems(bad);
-    expect(problems).toEqual(expect.arrayContaining([
-      expect.stringContaining("freestyle/base: defaults mix sized and size-less entries"),
-      expect.stringContaining("freestyle/base/lg: 2 entries flagged defaultForKind"),
-      expect.stringContaining("d: size huge is not on the ladder"),
-    ]));
+    for (const expected of [
+      "freestyle/base: defaults mix sized and size-less entries",
+      "freestyle/base/lg: 2 entries flagged defaultForKind",
+      "d: size huge is not on the ladder",
+    ]) {
+      expect(problems.some((problem) => problem.includes(expected))).toBe(true);
+    }
   });
 });


### PR DESCRIPTION
web-typecheck fails on main at e341deb259 (https://github.com/manaflow-ai/cmux/actions/runs/33637390962): https://github.com/manaflow-ai/cmux/pull/11664 added tests/vm-image-sizes.test.ts using expect.arrayContaining and expect.stringContaining, which the bun:test type shim (tests/bun-test.d.ts) does not declare. Check each expected problem directly, the same fix https://github.com/manaflow-ai/cmux/pull/11648 applied to vm-image-manifest.test.ts. Both files typecheck and pass locally.

https://claude.ai/code/session_01H5V288HnYi8R7ciVie6Exq

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11681"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948751&installation_model_id=21920&pr_number=11681&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11681&signature=b2e3ea05313856847fae72a1159facccf33ee5c60a4f385565669e4f990282c5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `web-typecheck` by replacing `expect.arrayContaining`/`expect.stringContaining` in `web/tests/vm-image-sizes.test.ts` with direct checks, since the `bun:test` type shim doesn't declare those matchers.

<sup>Written for commit c36dd26094a2c65ab6905808042b2b98440865e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

