### PR TITLE
web: verify Stack access tokens locally on the iroh broker routes

### DIFF
--- a/web/app/lib/stack.ts
+++ b/web/app/lib/stack.ts
@@ -1,5 +1,6 @@
 import { StackServerApp } from "@stackframe/stack";
 import { env } from "../env";
+import { stackApiBaseURL } from "../../services/auth/stackApiBaseURL";
 import { cloudDb } from "../../db/client";
 import { withFreshAccountMetadataUser } from "../../services/account/metadataMutation";
 import { canonicalizeEmailForMatching } from "../../services/billing/emailMatching";
@@ -160,29 +161,7 @@ async function updateStackUserViaApi(
     throw new Error("Stack Auth is not configured");
   }
 
-  const configuredBaseURL =
-    process.env.STACK_API_BASE_URL?.trim() ||
-    process.env.NEXT_PUBLIC_SERVER_STACK_API_URL?.trim() ||
-    process.env.NEXT_PUBLIC_STACK_API_URL?.trim() ||
-    process.env.STACK_API_URL?.trim() ||
-    "https://api.stack-auth.com";
-  let parsedBaseURL: URL;
-  try {
-    parsedBaseURL = new URL(configuredBaseURL);
-  } catch {
-    throw new Error("Stack Auth API URL is invalid");
-  }
-  if (
-    parsedBaseURL.protocol !== "https:" ||
-    !parsedBaseURL.hostname ||
-    parsedBaseURL.username ||
-    parsedBaseURL.password ||
-    parsedBaseURL.search ||
-    parsedBaseURL.hash
-  ) {
-    throw new Error("Stack Auth API URL must use HTTPS");
-  }
-  const normalizedBaseURL = parsedBaseURL.toString().replace(/\/+$/u, "");
+  const normalizedBaseURL = stackApiBaseURL();
   const baseURL = /\/api\/v1$/u.test(normalizedBaseURL)
     ? normalizedBaseURL
     : `${normalizedBaseURL}/api/v1`;

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "web",
@@ -33,6 +34,7 @@
         "effect": "^3.21.2",
         "freestyle": "0.2.9",
         "fzstd": "^0.1.1",
+        "jose": "^6.2.3",
         "next": "16.3.4",
         "next-intl": "^4.11.2",
         "next-themes": "^0.4.6",

--- a/web/package.json
+++ b/web/package.json
@@ -71,6 +71,7 @@
     "effect": "^3.21.2",
     "freestyle": "0.2.9",
     "fzstd": "^0.1.1",
+    "jose": "^6.2.3",
     "next": "16.3.4",
     "next-intl": "^4.11.2",
     "next-themes": "^0.4.6",

--- a/web/services/auth/stackAccessToken.ts
+++ b/web/services/auth/stackAccessToken.ts
@@ -1,0 +1,171 @@
+import {
+  createRemoteJWKSet,
+  errors as joseErrors,
+  jwtVerify,
+  type JWTPayload,
+  type JWTVerifyGetKey,
+} from "jose";
+
+import { env } from "../../app/env";
+import { stackApiBaseURL } from "./stackApiBaseURL";
+
+/**
+ * Identity proven by a Stack Auth access token whose signature we checked
+ * ourselves against Stack's published keys. No Stack API call is involved.
+ */
+export type StackAccessTokenIdentity = {
+  readonly userId: string;
+  readonly projectId: string;
+  readonly refreshTokenId: string | null;
+  readonly isAnonymous: boolean;
+  readonly expiresAt: Date;
+};
+
+export type StackAccessTokenVerifier = {
+  readonly projectId: string;
+  /** Stack API origin, e.g. https://api.stack-auth.com, no trailing slash. */
+  readonly apiBaseURL: string;
+  /** Test seam: replaces the remote JWKS resolver. */
+  readonly getKey?: JWTVerifyGetKey;
+  /** Test seam: replaces the wall clock used for exp/iat checks. */
+  readonly now?: () => Date;
+};
+
+// Stack signs access tokens with ES256 and rotates the signing key under a
+// new `kid`. Anything else (HS256, none, RS*) is rejected before key lookup.
+const STACK_ACCESS_TOKEN_ALGORITHMS = ["ES256"];
+// Vercel functions and Stack's signers both keep good time; one minute covers
+// the observed skew without accepting meaningfully expired tokens.
+const CLOCK_TOLERANCE_SECONDS = 60;
+// Per-instance JWKS cache. Keys rotate rarely; an unknown `kid` triggers one
+// refresh, and the cooldown stops a flood of forged tokens from turning into a
+// flood of JWKS fetches from every instance.
+const JWKS_CACHE_MAX_AGE_MS = 10 * 60 * 1_000;
+const JWKS_REFRESH_COOLDOWN_MS = 30 * 1_000;
+const JWKS_FETCH_TIMEOUT_MS = 3_000;
+const KEY_SET_FAILURE_LOG_INTERVAL_MS = 60 * 1_000;
+
+/**
+ * Verifier configuration from the environment, or null when Stack is not
+ * configured. Lives here (not in app/lib/stack) so tests that mock the Stack
+ * SDK module keep working and so the JWKS origin follows the SDK's API origin.
+ */
+export function stackAccessTokenVerifierFromEnv(): StackAccessTokenVerifier | null {
+  const projectId = env.NEXT_PUBLIC_STACK_PROJECT_ID;
+  if (!projectId) return null;
+  let apiBaseURL: string;
+  try {
+    apiBaseURL = stackApiBaseURL().replace(/\/api\/v1$/u, "");
+  } catch {
+    return null;
+  }
+  return { projectId, apiBaseURL };
+}
+
+export function stackIssuer(apiBaseURL: string, projectId: string): string {
+  return `${apiBaseURL.replace(/\/+$/u, "")}/api/v1/projects/${projectId}`;
+}
+
+export function stackJwksURL(apiBaseURL: string, projectId: string): URL {
+  return new URL(`${stackIssuer(apiBaseURL, projectId)}/.well-known/jwks.json`);
+}
+
+const remoteKeySets = new Map<string, JWTVerifyGetKey>();
+
+function remoteKeySet(url: URL): JWTVerifyGetKey {
+  const cached = remoteKeySets.get(url.href);
+  if (cached) return cached;
+  const created = createRemoteJWKSet(url, {
+    cacheMaxAge: JWKS_CACHE_MAX_AGE_MS,
+    cooldownDuration: JWKS_REFRESH_COOLDOWN_MS,
+    timeoutDuration: JWKS_FETCH_TIMEOUT_MS,
+  });
+  remoteKeySets.set(url.href, created);
+  return created;
+}
+
+/** Test hook: drop cached remote key sets. */
+export function clearStackAccessTokenKeySetsForTests(): void {
+  remoteKeySets.clear();
+}
+
+let lastKeySetFailureLogAt = 0;
+
+/**
+ * Verify a Stack access token locally.
+ *
+ * Returns the identity when the token is a well-formed ES256 JWT, signed by a
+ * key in Stack's JWKS for this project, issued by this project, addressed to
+ * this project, and not expired. Returns null for every other outcome,
+ * including JWKS fetch failures, so the caller falls back to Stack's API and
+ * behavior degrades to today's path instead of failing closed on our side.
+ *
+ * Revocation is not visible here: a session revoked at Stack keeps a valid
+ * signature until `exp`. Stack access tokens live one hour.
+ */
+export async function verifyStackAccessTokenLocally(
+  accessToken: string,
+  verifier: StackAccessTokenVerifier,
+): Promise<StackAccessTokenIdentity | null> {
+  if (!looksLikeCompactJws(accessToken)) return null;
+  const getKey = verifier.getKey
+    ?? remoteKeySet(stackJwksURL(verifier.apiBaseURL, verifier.projectId));
+  let payload: JWTPayload;
+  try {
+    ({ payload } = await jwtVerify(accessToken, getKey, {
+      algorithms: STACK_ACCESS_TOKEN_ALGORITHMS,
+      issuer: stackIssuer(verifier.apiBaseURL, verifier.projectId),
+      audience: verifier.projectId,
+      clockTolerance: CLOCK_TOLERANCE_SECONDS,
+      ...(verifier.now ? { currentDate: verifier.now() } : {}),
+    }));
+  } catch (error) {
+    if (!isTokenRejection(error)) logKeySetFailure(error);
+    return null;
+  }
+  if (typeof payload.sub !== "string" || payload.sub.length === 0) return null;
+  if (
+    payload.project_id !== undefined
+    && payload.project_id !== verifier.projectId
+  ) {
+    return null;
+  }
+  if (typeof payload.exp !== "number") return null;
+  return {
+    userId: payload.sub,
+    projectId: verifier.projectId,
+    refreshTokenId: typeof payload.refresh_token_id === "string"
+      ? payload.refresh_token_id
+      : null,
+    isAnonymous: payload.is_anonymous === true,
+    expiresAt: new Date(payload.exp * 1_000),
+  };
+}
+
+function looksLikeCompactJws(value: string): boolean {
+  if (value.length < 20 || value.length > 8_192) return false;
+  const parts = value.split(".");
+  return parts.length === 3 && parts.every((part) => part.length > 0);
+}
+
+/** A rejection of this token, as opposed to a failure to obtain Stack's keys. */
+function isTokenRejection(error: unknown): boolean {
+  return error instanceof joseErrors.JWTExpired
+    || error instanceof joseErrors.JWTClaimValidationFailed
+    || error instanceof joseErrors.JWTInvalid
+    || error instanceof joseErrors.JWSInvalid
+    || error instanceof joseErrors.JWSSignatureVerificationFailed
+    || error instanceof joseErrors.JOSEAlgNotAllowed
+    || error instanceof joseErrors.JOSENotSupported
+    || error instanceof joseErrors.JWKSNoMatchingKey
+    || error instanceof joseErrors.JWKSMultipleMatchingKeys;
+}
+
+function logKeySetFailure(error: unknown): void {
+  const now = Date.now();
+  if (now - lastKeySetFailureLogAt < KEY_SET_FAILURE_LOG_INTERVAL_MS) return;
+  lastKeySetFailureLogAt = now;
+  console.warn("stack access token key set unavailable; falling back to Stack API", {
+    reason: error instanceof Error ? error.name : "unknown",
+  });
+}

--- a/web/services/auth/stackApiBaseURL.ts
+++ b/web/services/auth/stackApiBaseURL.ts
@@ -1,0 +1,31 @@
+/**
+ * Stack API origin with no trailing slash, e.g. `https://api.stack-auth.com`.
+ * Same precedence the Stack SDK uses; HTTPS only. Shared by the server-key
+ * PATCH helper and by local access-token verification (JWKS URL), so a
+ * self-hosted Stack origin drives both.
+ */
+export function stackApiBaseURL(): string {
+  const configuredBaseURL =
+    process.env.STACK_API_BASE_URL?.trim() ||
+    process.env.NEXT_PUBLIC_SERVER_STACK_API_URL?.trim() ||
+    process.env.NEXT_PUBLIC_STACK_API_URL?.trim() ||
+    process.env.STACK_API_URL?.trim() ||
+    "https://api.stack-auth.com";
+  let parsedBaseURL: URL;
+  try {
+    parsedBaseURL = new URL(configuredBaseURL);
+  } catch {
+    throw new Error("Stack Auth API URL is invalid");
+  }
+  if (
+    parsedBaseURL.protocol !== "https:" ||
+    !parsedBaseURL.hostname ||
+    parsedBaseURL.username ||
+    parsedBaseURL.password ||
+    parsedBaseURL.search ||
+    parsedBaseURL.hash
+  ) {
+    throw new Error("Stack Auth API URL must use HTTPS");
+  }
+  return parsedBaseURL.toString().replace(/\/+$/u, "");
+}

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -30,7 +30,7 @@ export type IrohRouteOperation =
 type RouteDependencies = {
   readonly verify?: (
     request: Request,
-    options: { readonly allowCookie: false },
+    options: { readonly allowCookie: false; readonly requireStackSession: boolean },
   ) => Promise<{ readonly id: string } | null>;
   readonly broker?: IrohTrustBrokerShape;
   readonly runtime?: Layer.Layer<IrohTrustBroker, never, never>;
@@ -49,11 +49,16 @@ export async function handleIrohRoute(
   dependencies: RouteDependencies = {},
 ): Promise<Response> {
   // Identity only: the broker needs the user id, and local token verification
-  // keeps this ~100 req/s route off Stack's per-request API budget.
+  // keeps the ~100 req/s registration traffic off Stack's per-request API
+  // budget. Pair grants, revocation, and relay tokens are rare and sensitive,
+  // so they still ask Stack and refuse a revoked session immediately.
   const verify = dependencies.verify ?? verifyRequestIdentity;
   let user: { readonly id: string } | null;
   try {
-    user = await verify(request, { allowCookie: false });
+    user = await verify(request, {
+      allowCookie: false,
+      requireStackSession: requiresStackSession(operation),
+    });
   } catch (error) {
     // A Stack Auth throttle or outage is not the caller's fault. Answering 401
     // told every host that its credentials were rejected, and the irx host
@@ -205,6 +210,20 @@ export function buildConnectivityInvalidationRequest(
     body: JSON.stringify({ revision }),
   });
 }
+export function requiresStackSession(operation: IrohRouteOperation): boolean {
+  switch (operation) {
+    case "challenge":
+    case "register":
+    case "discover":
+    case "endpoint_attestation":
+      return false;
+    case "revoke":
+    case "pair_grant":
+    case "relay_token":
+      return true;
+  }
+}
+
 function invoke(
   broker: IrohTrustBrokerShape,
   operation: IrohRouteOperation,

--- a/web/services/iroh/routeHandler.ts
+++ b/web/services/iroh/routeHandler.ts
@@ -3,7 +3,7 @@ import * as Effect from "effect/Effect";
 import type * as Layer from "effect/Layer";
 import { after } from "next/server";
 import { env } from "../../app/env";
-import { unauthorized, verifyRequest, type AuthedUser } from "../vms/auth";
+import { unauthorized, verifyRequestIdentity } from "../vms/auth";
 import { authProviderErrorResponse } from "../vms/authErrors";
 import { enforceBrowserMutationProtection, jsonResponse } from "../vms/routeHelpers";
 import { irohExpectedError } from "./errors";
@@ -28,7 +28,10 @@ export type IrohRouteOperation =
   | "relay_token";
 
 type RouteDependencies = {
-  readonly verify?: typeof verifyRequest;
+  readonly verify?: (
+    request: Request,
+    options: { readonly allowCookie: false },
+  ) => Promise<{ readonly id: string } | null>;
   readonly broker?: IrohTrustBrokerShape;
   readonly runtime?: Layer.Layer<IrohTrustBroker, never, never>;
   readonly publishConnectivityInvalidation?: (
@@ -45,8 +48,10 @@ export async function handleIrohRoute(
   operation: IrohRouteOperation,
   dependencies: RouteDependencies = {},
 ): Promise<Response> {
-  const verify = dependencies.verify ?? verifyRequest;
-  let user: AuthedUser | null;
+  // Identity only: the broker needs the user id, and local token verification
+  // keeps this ~100 req/s route off Stack's per-request API budget.
+  const verify = dependencies.verify ?? verifyRequestIdentity;
+  let user: { readonly id: string } | null;
   try {
     user = await verify(request, { allowCookie: false });
   } catch (error) {

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -571,6 +571,11 @@ export type VerifiedIdentity = {
 
 type VerifyIdentityOptions = {
   readonly allowCookie?: boolean;
+  /**
+   * Skip the local token check and ask Stack, so a revoked session is refused
+   * immediately. Use for sensitive, low-volume operations.
+   */
+  readonly requireStackSession?: boolean;
   /** Test seam for the local token verifier. */
   readonly verifyAccessToken?: (
     accessToken: string,
@@ -595,7 +600,7 @@ export async function verifyRequestIdentity(
 ): Promise<VerifiedIdentity | null> {
   if (!isStackConfigured()) return null;
   const tokens = parseNativeStackTokens(request);
-  if (tokens) {
+  if (tokens && !options.requireStackSession) {
     const verifier = options.verifyAccessToken
       ? null
       : stackAccessTokenVerifierFromEnv();

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -2,6 +2,11 @@ import { createHash } from "node:crypto";
 import { eq } from "drizzle-orm";
 import type { Team } from "@stackframe/stack";
 import { getStackServerApp, isStackConfigured } from "../../app/lib/stack";
+import {
+  stackAccessTokenVerifierFromEnv,
+  verifyStackAccessTokenLocally,
+  type StackAccessTokenIdentity,
+} from "../auth/stackAccessToken";
 import { hasAuthRateLimitSignal } from "./authErrors";
 import { cloudDb } from "../../db/client";
 import { accountDeletionTombstones } from "../../db/schema";
@@ -556,6 +561,53 @@ export async function verifyRequest(
     return await authedUserFromStackUser(user, options);
   }
   return null;
+}
+
+export type VerifiedIdentity = {
+  readonly id: string;
+  /** How the identity was established; surfaced for logs and tests. */
+  readonly source: "access_token" | "stack";
+};
+
+type VerifyIdentityOptions = {
+  readonly allowCookie?: boolean;
+  /** Test seam for the local token verifier. */
+  readonly verifyAccessToken?: (
+    accessToken: string,
+  ) => Promise<StackAccessTokenIdentity | null>;
+};
+
+/**
+ * Establish only WHO the caller is, for routes that need the user id and
+ * nothing else (the iroh trust broker). A native bearer token is verified
+ * locally against Stack's published signing keys, so the ~100 req/s of device
+ * registration traffic no longer costs one Stack `users/me` call each. Any
+ * token the local check cannot accept (expired, unknown key, malformed, keys
+ * unavailable) falls back to `verifyRequest`, which asks Stack and refreshes.
+ *
+ * Trade-off, stated: a session revoked at Stack stays accepted here until its
+ * access token expires. Stack access tokens live one hour. Routes that gate
+ * money or account mutation must keep using `verifyRequest`.
+ */
+export async function verifyRequestIdentity(
+  request: Request,
+  options: VerifyIdentityOptions = {},
+): Promise<VerifiedIdentity | null> {
+  if (!isStackConfigured()) return null;
+  const tokens = parseNativeStackTokens(request);
+  if (tokens) {
+    const verifier = options.verifyAccessToken
+      ? null
+      : stackAccessTokenVerifierFromEnv();
+    const local = options.verifyAccessToken
+      ? await options.verifyAccessToken(tokens.accessToken)
+      : verifier
+        ? await verifyStackAccessTokenLocally(tokens.accessToken, verifier)
+        : null;
+    if (local) return { id: local.userId, source: "access_token" };
+  }
+  const user = await verifyRequest(request, { allowCookie: options.allowCookie });
+  return user ? { id: user.id, source: "stack" } : null;
 }
 
 async function authedUserFromStackUser(

--- a/web/tests/iroh-route-handler.test.ts
+++ b/web/tests/iroh-route-handler.test.ts
@@ -4,6 +4,8 @@ import { IrohDatabaseError, IrohQuotaExceededError } from "../services/iroh/erro
 import {
   buildConnectivityInvalidationRequest,
   handleIrohRoute,
+  requiresStackSession,
+  type IrohRouteOperation,
 } from "../services/iroh/routeHandler";
 import type { IrohTrustBrokerShape } from "../services/iroh/trustBroker";
 import type { AuthedUser } from "../services/vms/auth";
@@ -191,6 +193,32 @@ describe("Iroh route boundary", () => {
     });
     expect(response.status).toBe(401);
     expect(called).toBe(false);
+  });
+
+  test("only high-volume operations use the local token fast path", async () => {
+    const seen: Array<[IrohRouteOperation, boolean]> = [];
+    for (const operation of [
+      "challenge", "register", "discover", "endpoint_attestation",
+      "revoke", "pair_grant", "relay_token",
+    ] as const) {
+      await handleIrohRoute(authedPost("/api/devices/iroh/x", {}), operation, {
+        verify: async (_request, options) => {
+          seen.push([operation, options.requireStackSession]);
+          return null;
+        },
+        broker: broker(),
+      });
+    }
+    expect(seen).toEqual([
+      ["challenge", false],
+      ["register", false],
+      ["discover", false],
+      ["endpoint_attestation", false],
+      ["revoke", true],
+      ["pair_grant", true],
+      ["relay_token", true],
+    ]);
+    expect(requiresStackSession("pair_grant")).toBe(true);
   });
 
   test("maps a Stack Auth throttle to 429 with Retry-After instead of 401", async () => {

--- a/web/tests/stack-access-token.test.ts
+++ b/web/tests/stack-access-token.test.ts
@@ -1,0 +1,148 @@
+import { beforeAll, describe, expect, test } from "bun:test";
+import {
+  SignJWT,
+  createLocalJWKSet,
+  exportJWK,
+  generateKeyPair,
+  type JWK,
+  type JWTVerifyGetKey,
+  type KeyObject,
+} from "jose";
+
+import {
+  stackIssuer,
+  stackJwksURL,
+  verifyStackAccessTokenLocally,
+} from "../services/auth/stackAccessToken";
+
+const PROJECT = "454ecd03-1db2-4050-845e-4ce5b0cd9895";
+const OTHER_PROJECT = "9790718f-0000-4000-8000-000000000000";
+const API = "https://api.stack-auth.com";
+const NOW = new Date("2026-09-02T12:00:00Z");
+
+let signingKey: KeyObject | CryptoKey;
+let otherKey: KeyObject | CryptoKey;
+let getKey: JWTVerifyGetKey;
+
+beforeAll(async () => {
+  const pair = await generateKeyPair("ES256");
+  const other = await generateKeyPair("ES256");
+  signingKey = pair.privateKey;
+  otherKey = other.privateKey;
+  const jwk: JWK = { ...(await exportJWK(pair.publicKey)), kid: "k1", alg: "ES256", use: "sig" };
+  getKey = createLocalJWKSet({ keys: [jwk] });
+});
+
+function claims(overrides: Record<string, unknown> = {}) {
+  return {
+    sub: "user-1",
+    project_id: PROJECT,
+    refresh_token_id: "rt-1",
+    role: "authenticated",
+    is_anonymous: false,
+    ...overrides,
+  };
+}
+
+async function sign(
+  payload: Record<string, unknown>,
+  options: {
+    key?: KeyObject | CryptoKey;
+    kid?: string;
+    alg?: string;
+    issuer?: string | null;
+    audience?: string | null;
+    expiresAt?: Date;
+  } = {},
+): Promise<string> {
+  const jwt = new SignJWT(payload)
+    .setProtectedHeader({ alg: options.alg ?? "ES256", kid: options.kid ?? "k1" })
+    .setIssuedAt(Math.floor(NOW.getTime() / 1_000))
+    .setExpirationTime(Math.floor((options.expiresAt ?? new Date(NOW.getTime() + 3_600_000)).getTime() / 1_000));
+  if (options.issuer !== null) jwt.setIssuer(options.issuer ?? stackIssuer(API, PROJECT));
+  if (options.audience !== null) jwt.setAudience(options.audience ?? PROJECT);
+  return jwt.sign(options.key ?? signingKey);
+}
+
+const verifier = () => ({ projectId: PROJECT, apiBaseURL: API, getKey, now: () => NOW });
+
+describe("Stack access token local verification", () => {
+  test("derives the issuer and JWKS URL from the Stack API origin", () => {
+    expect(stackIssuer(`${API}/`, PROJECT)).toBe(`${API}/api/v1/projects/${PROJECT}`);
+    expect(stackJwksURL(API, PROJECT).href).toBe(
+      `${API}/api/v1/projects/${PROJECT}/.well-known/jwks.json`,
+    );
+  });
+
+  test("accepts a token signed by a published key for this project", async () => {
+    const identity = await verifyStackAccessTokenLocally(await sign(claims()), verifier());
+    expect(identity).toEqual({
+      userId: "user-1",
+      projectId: PROJECT,
+      refreshTokenId: "rt-1",
+      isAnonymous: false,
+      expiresAt: new Date(NOW.getTime() + 3_600_000),
+    });
+  });
+
+  test("rejects an expired token beyond the clock tolerance", async () => {
+    const token = await sign(claims(), { expiresAt: new Date(NOW.getTime() - 120_000) });
+    expect(await verifyStackAccessTokenLocally(token, verifier())).toBeNull();
+  });
+
+  test("accepts a token that expired within the clock tolerance", async () => {
+    const token = await sign(claims(), { expiresAt: new Date(NOW.getTime() - 30_000) });
+    expect(await verifyStackAccessTokenLocally(token, verifier())).not.toBeNull();
+  });
+
+  test("rejects a token for another project (audience, issuer, or claim)", async () => {
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims(), { audience: OTHER_PROJECT }), verifier(),
+    )).toBeNull();
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims(), { issuer: stackIssuer(API, OTHER_PROJECT) }), verifier(),
+    )).toBeNull();
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims({ project_id: OTHER_PROJECT })), verifier(),
+    )).toBeNull();
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims(), { issuer: null }), verifier(),
+    )).toBeNull();
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims(), { audience: null }), verifier(),
+    )).toBeNull();
+  });
+
+  test("rejects a signature from a key Stack did not publish", async () => {
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims(), { key: otherKey }), verifier(),
+    )).toBeNull();
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims(), { key: otherKey, kid: "unknown" }), verifier(),
+    )).toBeNull();
+  });
+
+  test("rejects unsigned or non-ES256 tokens and garbage", async () => {
+    const [header, payload] = (await sign(claims())).split(".");
+    const noneHeader = Buffer.from(JSON.stringify({ alg: "none" })).toString("base64url");
+    expect(await verifyStackAccessTokenLocally(`${noneHeader}.${payload}.`, verifier())).toBeNull();
+    expect(await verifyStackAccessTokenLocally(`${header}.${payload}.AAAA`, verifier())).toBeNull();
+    expect(await verifyStackAccessTokenLocally("not-a-jwt", verifier())).toBeNull();
+    expect(await verifyStackAccessTokenLocally("", verifier())).toBeNull();
+  });
+
+  test("rejects a token without a subject", async () => {
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims({ sub: undefined })), verifier(),
+    )).toBeNull();
+  });
+
+  test("treats a key-set failure as not verified so the caller can fall back", async () => {
+    const failingGetKey: JWTVerifyGetKey = async () => {
+      throw new TypeError("fetch failed");
+    };
+    expect(await verifyStackAccessTokenLocally(
+      await sign(claims()), { ...verifier(), getKey: failingGetKey },
+    )).toBeNull();
+  });
+});

--- a/web/tests/vm-auth-identity.test.ts
+++ b/web/tests/vm-auth-identity.test.ts
@@ -5,10 +5,6 @@ const getUser = mock(async (): Promise<unknown> => null);
 mock.module("../app/lib/stack", () => ({
   getStackServerApp: () => ({ getUser }),
   isStackConfigured: () => true,
-  stackAccessTokenVerifierConfig: () => ({
-    projectId: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
-    apiBaseURL: "https://api.stack-auth.com",
-  }),
   stackServerApp: { getUser },
 }));
 

--- a/web/tests/vm-auth-identity.test.ts
+++ b/web/tests/vm-auth-identity.test.ts
@@ -101,6 +101,16 @@ describe("verifyRequestIdentity", () => {
     expect(identity?.source).toBe("access_token");
   });
 
+  test("requireStackSession skips the local check and asks Stack", async () => {
+    const identity = await verifyRequestIdentity(nativeRequest("good-token"), {
+      allowCookie: false,
+      requireStackSession: true,
+      verifyAccessToken: localIdentity,
+    });
+    expect(identity).toEqual({ id: "stack-user-1", source: "stack" });
+    expect(getUser).toHaveBeenCalledTimes(1);
+  });
+
   test("without native credentials and with cookies disallowed there is no identity", async () => {
     const identity = await verifyRequestIdentity(
       new Request("https://cmux.test/api/devices/iroh/register", {

--- a/web/tests/vm-auth-identity.test.ts
+++ b/web/tests/vm-auth-identity.test.ts
@@ -1,0 +1,119 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+const getUser = mock(async (): Promise<unknown> => null);
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+  stackAccessTokenVerifierConfig: () => ({
+    projectId: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+    apiBaseURL: "https://api.stack-auth.com",
+  }),
+  stackServerApp: { getUser },
+}));
+
+const {
+  verifyRequestIdentity,
+  clearNativeAuthCacheForTests,
+  clearStackThrottleCircuitForTests,
+} = await import("../services/vms/auth");
+
+const fakeStackUser = {
+  id: "stack-user-1",
+  displayName: "Test User",
+  primaryEmail: "test@example.com",
+  selectedTeam: null,
+  clientReadOnlyMetadata: {},
+  listTeams: async () => [],
+};
+
+function nativeRequest(access: string, refresh = "refresh-1"): Request {
+  return new Request("https://cmux.test/api/devices/iroh/register", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${access}`,
+      "x-stack-refresh-token": refresh,
+    },
+  });
+}
+
+const localIdentity = async (token: string) => token === "good-token"
+  ? {
+    userId: "jwt-user-1",
+    projectId: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+    refreshTokenId: "rt-1",
+    isAnonymous: false,
+    expiresAt: new Date(Date.now() + 60_000),
+  }
+  : null;
+
+// bun's MockFunction typing in this tree lacks mockImplementation; the
+// devices-route test uses the same cast.
+function stackThrottles(): void {
+  (getUser as unknown as {
+    mockImplementation(implementation: () => Promise<never>): void;
+  }).mockImplementation(async () => {
+    throw new AggregateError([new Error("Rate limited, no retry-after header received")]);
+  });
+}
+
+beforeEach(() => {
+  clearNativeAuthCacheForTests();
+  clearStackThrottleCircuitForTests();
+  getUser.mockClear();
+  getUser.mockResolvedValue(fakeStackUser);
+});
+
+describe("verifyRequestIdentity", () => {
+  test("a locally verified access token never calls Stack", async () => {
+    const identity = await verifyRequestIdentity(nativeRequest("good-token"), {
+      allowCookie: false,
+      verifyAccessToken: localIdentity,
+    });
+    expect(identity).toEqual({ id: "jwt-user-1", source: "access_token" });
+    expect(getUser).toHaveBeenCalledTimes(0);
+  });
+
+  test("a token the local check cannot accept falls back to Stack", async () => {
+    const identity = await verifyRequestIdentity(nativeRequest("stale-token"), {
+      allowCookie: false,
+      verifyAccessToken: localIdentity,
+    });
+    expect(identity).toEqual({ id: "stack-user-1", source: "stack" });
+    expect(getUser).toHaveBeenCalledTimes(1);
+  });
+
+  test("a Stack failure on the fallback propagates so routes can map it", async () => {
+    stackThrottles();
+    await expect(verifyRequestIdentity(nativeRequest("stale-token"), {
+      allowCookie: false,
+      verifyAccessToken: localIdentity,
+    })).rejects.toThrow(/rate limited/i);
+  });
+
+  test("a locally verified token bypasses an open Stack throttle circuit", async () => {
+    stackThrottles();
+    await expect(verifyRequestIdentity(nativeRequest("stale-token"), {
+      allowCookie: false,
+      verifyAccessToken: localIdentity,
+    })).rejects.toThrow(/rate limited/i);
+
+    const identity = await verifyRequestIdentity(nativeRequest("good-token"), {
+      allowCookie: false,
+      verifyAccessToken: localIdentity,
+    });
+    expect(identity?.source).toBe("access_token");
+  });
+
+  test("without native credentials and with cookies disallowed there is no identity", async () => {
+    const identity = await verifyRequestIdentity(
+      new Request("https://cmux.test/api/devices/iroh/register", {
+        method: "POST",
+        headers: { cookie: "stack-session=abc" },
+      }),
+      { allowCookie: false, verifyAccessToken: localIdentity },
+    );
+    expect(identity).toBeNull();
+    expect(getUser).toHaveBeenCalledTimes(0);
+  });
+});


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11633. The iroh trust-broker routes carry roughly 100 to 140 requests per second from stable Macs, and every request verified the caller with a Stack `users/me` call. That kept Stack's project-wide rate limit exhausted and made every Stack-backed route (checkout, sign-in, devices, relay) fail at random. The circuit breaker in 11633 limits the damage; this removes the dependency.

The broker only needs the user id. The bearer token is an ES256 JWT that Stack signs with per-project keys published at `/api/v1/projects/<id>/.well-known/jwks.json`. The server now verifies it locally.

- `services/auth/stackAccessToken.ts`: `jose.jwtVerify` against Stack's remote JWKS. ES256 only; issuer, audience, and `project_id` pinned to our project; 60 s clock tolerance. Per-instance key cache (10 min max age, 30 s refresh cooldown on unknown `kid`, 3 s fetch timeout) so a cold Vercel instance pays one small fetch and a flood of forged tokens cannot turn into a flood of JWKS fetches. Every rejection and every key-set failure returns null.
- `verifyRequestIdentity` in `services/vms/auth.ts`: local verification first; anything not accepted falls back to the existing Stack path, which refreshes tokens and is gated by the throttle circuit. Cookie routes are untouched.
- `handleIrohRoute` uses `verifyRequestIdentity`. Devices, relay, VM, billing, and account routes keep the full Stack verification because they need teams and billing plan.
- `stackApiBaseURL` moved to `services/auth/stackApiBaseURL.ts` and is shared with the existing server-key PATCH helper, so a self-hosted Stack origin drives the JWKS URL too. No new exports on `app/lib/stack`, which 24 test files mock.

Verified against Stack itself, not only unit tests: a real access token from the dev project verifies with the real JWKS; a tampered signature and a wrong project return null. Warm verification takes well under a millisecond.

Trade-off, stated: a session revoked at Stack stays accepted on the iroh routes until its access token expires. Stack access tokens live one hour (`exp - iat = 3600` on a real token). Before this PR the same lag was 5 minutes via the native auth cache TTL. Pairing still requires pair grants, and registration mutations still pass the account-deletion tombstone check in the repository.

Commit 1 adds the tests (verifier: valid, expired, tolerance, wrong audience/issuer/project, foreign key, unknown kid, alg none, garbage, no subject, key-set failure; identity path: no Stack call for a valid token, fallback, throttle propagation, circuit bypass, cookie-only). Commit 2 adds the implementation. `bun run typecheck` and eslint are clean for the changed files; suites `stack-access-token`, `vm-auth-identity`, `iroh-route-handler`, `vm-auth-cache`, `devices-route`, `relay-token-route`, `vm-route-auth` pass.

Rollout check after deploy: Stack SDK "Rate limited" lines in `vercel logs` should fall to near zero and the iroh 429 share in Axiom should collapse while 201s stay flat.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790948817&installation_model_id=21920&pr_number=11682&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11682&signature=e947d452e545fdbab1ceea9b65ea47e439f56523664473af65332c9c28354c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Verifies Stack access tokens locally on iroh broker routes so the ~100 req/s no longer hits Stack's `users/me` API, which was exhausting the project-wide rate limit and causing random failures on Stack-backed routes.

- Adds `jose.jwtVerify` against Stack's per-project JWKS with ES256, pinned issuer/audience/project, 60s clock tolerance, and a per-instance key cache.
- `verifyRequestIdentity` falls back to the existing Stack API path (which refreshes tokens and is gated by the throttle circuit) when local verification can't accept a token.
- `handleIrohRoute` now uses `verifyRequestIdentity`; the high-volume operations (`challenge`, `register`, `discover`, `endpoint_attestation`) take the local fast path, while `revoke`, `pair_grant`, and `relay_token` still require a live Stack session check.
- `stackApiBaseURL` is shared so a self-hosted Stack origin drives the JWKS URL too.
- Trade-off: a session revoked at Stack stays accepted on the high-volume iroh routes until its access token expires (1 hour) instead of the previous 5-minute cache TTL.

<sup>Written for commit 7e90598c868cad123a551b82a281ee01a659524c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11682?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

