### PR TITLE
Fix tab scroll range fitting complexity

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -196,6 +196,35 @@ fn clip_tab_bar_rect(logical: Rect, bar: Rect, source_x: u16) -> Option<Rect> {
     })
 }
 
+fn tab_scroll_for_active(
+    widths: &[u16],
+    active_tab: usize,
+    requested_scroll: usize,
+    inner_width: u16,
+    plus_width: u16,
+    arrow_width: u16,
+) -> usize {
+    let max_scroll = widths.len().saturating_sub(1);
+    let mut scroll = requested_scroll.min(max_scroll);
+    if widths.is_empty() || scroll >= active_tab {
+        return scroll;
+    }
+
+    let mut range_width: u64 =
+        widths[scroll..=active_tab].iter().map(|width| u64::from(*width)).sum();
+    while scroll < active_tab {
+        let left_arrow = if scroll > 0 { arrow_width } else { 0 };
+        let available = inner_width
+            .saturating_sub(left_arrow.saturating_add(plus_width).saturating_add(arrow_width));
+        if range_width <= u64::from(available) {
+            break;
+        }
+        range_width -= u64::from(widths[scroll]);
+        scroll += 1;
+    }
+    scroll
+}
+
 fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool) {
     let Some(bar) = area.bar else { return };
     let Some(screen_view) = app.tree.active_screen() else { return };
@@ -322,23 +351,15 @@ fn draw_tab_bar(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
     let plus_w: u16 = (plus_label.width() as u16).max(1);
     let arrow_w: u16 = 1;
 
-    // Clamp the requested scroll, then bump it until the active tab fits.
-    let max_scroll = tabs.len().saturating_sub(1);
-    let mut scroll = app.tab_scroll.get(&pane_id).copied().unwrap_or(0).min(max_scroll);
-    let fits = |scroll: usize| {
-        let left_arrow = if scroll > 0 { arrow_w } else { 0 };
-        let mut budget = inner_w.saturating_sub(left_arrow + plus_w + arrow_w);
-        for w in &widths[scroll..=active_tab.max(scroll)] {
-            if *w > budget {
-                return false;
-            }
-            budget -= *w;
-        }
-        true
-    };
-    while scroll < active_tab && !fits(scroll) {
-        scroll += 1;
-    }
+    // Advance the requested scroll in one pass until the active range fits.
+    let scroll = tab_scroll_for_active(
+        &widths,
+        active_tab,
+        app.tab_scroll.get(&pane_id).copied().unwrap_or(0),
+        inner_w,
+        plus_w,
+        arrow_w,
+    );
     app.tab_scroll.insert(pane_id, scroll);
 
     let mut hits = Vec::new();

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -695,7 +695,7 @@ fn push_resize_hits(app: &mut App, area: &PaneArea) {
 
 #[cfg(test)]
 mod tests {
-    use super::{client_border_labels, clip_tab_bar_rect};
+    use super::{client_border_labels, clip_tab_bar_rect, tab_scroll_for_active};
     use crate::session::{ClientInfo, ClientSizeInfo};
     use cmux_tui_core::Rect;
 
@@ -704,6 +704,22 @@ mod tests {
         let bar = Rect { x: 0, y: 0, width: 8, height: 1 };
         let logical = Rect { x: 1, y: 0, width: 3, height: 1 };
         assert_eq!(clip_tab_bar_rect(logical, bar, 10), None);
+    }
+
+    #[test]
+    fn tab_scroll_preserves_requested_offset_when_active_range_fits() {
+        assert_eq!(tab_scroll_for_active(&[4, 5, 6, 7], 2, 1, 15, 1, 1), 1);
+    }
+
+    #[test]
+    fn tab_scroll_advances_to_the_first_offset_that_fits_active_tab() {
+        assert_eq!(tab_scroll_for_active(&[4, 5, 6, 7], 3, 0, 16, 1, 1), 2);
+    }
+
+    #[test]
+    fn tab_scroll_handles_a_large_tab_set_without_changing_selection_semantics() {
+        let widths = vec![3; 100_000];
+        assert_eq!(tab_scroll_for_active(&widths, 99_999, 0, 12, 1, 1), 99_997);
     }
 
     fn client(id: u64, surface: u64, size: Option<(u16, u16)>) -> ClientInfo {


### PR DESCRIPTION
## Summary
- add behavior coverage for preserving offsets and fitting active tabs at scale
- replace repeated range scans with one-pass accumulated width subtraction

The renderer keeps Ratatui's standard model: compute bounded Rects and write widgets into the frame buffer. See https://docs.rs/ratatui/latest/ratatui/struct.Frame.html and https://docs.rs/ratatui/latest/ratatui/layout/struct.Rect.html.

## Verification
- rustfmt
- git diff --check
- focused cmux-tui hosted workflow: https://github.com/manaflow-ai/cmux/actions/runs/33639066113

Two commits are intentional: the first adds the failing behavior tests, the second adds the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11684"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790949542&installation_model_id=21920&pr_number=11684&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11684&signature=2afcd7c7f4014fd01dd9eb3b402477fa346a1f85a4de792fd98fd86e6c3f93c7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes tab scroll range fitting so large tab sets no longer cause quadratic work. Replaces repeated range scans with a one-pass accumulated width subtraction and adds tests for preserving requested offsets and fitting active tabs at scale.

<sup>Written for commit e40f6cad33cbc9ceafab64b9a9517b48750a1d0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11684?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

