### PR TITLE
Optimize remote attach progress lookups

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1944,7 +1944,7 @@ impl RemoteSession {
         let session = Arc::new(RemoteSession {
             interactive_writer,
             disconnect_state: Mutex::new(DisconnectState::default()),
-            pending: Mutex::new(HashMap::new()),
+            pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
             attach_progress: AtomicU64::new(0),
             shutdown: AtomicBool::new(false),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6527,6 +6527,40 @@ mod tests {
         assert_eq!(deadline.next_wait(started + maximum, 3, 3), None);
     }
 
+    #[test]
+    fn attach_progress_reverse_index_tracks_only_live_matching_requests() {
+        let mut pending = PendingRemoteRequests::default();
+        let unrelated_progress = Arc::new(AtomicU64::new(0));
+        for id in 0..1_000 {
+            pending.insert(
+                id,
+                PendingRemoteRequest {
+                    response: channel().0,
+                    progress: unrelated_progress.clone(),
+                    attach_surface: Some(8),
+                },
+            );
+        }
+        let matching_progress = Arc::new(AtomicU64::new(0));
+        pending.insert(
+            1_000,
+            PendingRemoteRequest {
+                response: channel().0,
+                progress: matching_progress.clone(),
+                attach_surface: Some(7),
+            },
+        );
+
+        assert!(pending.progress_for_attach_surface(7));
+        assert_eq!(matching_progress.load(Ordering::Acquire), 1);
+        assert_eq!(unrelated_progress.load(Ordering::Acquire), 0);
+
+        let removed = pending.remove(1_000).expect("matching request is pending");
+        drop(removed);
+        assert!(!pending.progress_for_attach_surface(7));
+        assert_eq!(matching_progress.load(Ordering::Acquire), 1);
+    }
+
     #[cfg(unix)]
     #[test]
     fn queued_attach_preserves_two_request_wire_order() {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1071,12 +1071,16 @@ impl PendingRemoteRequests {
         self.requests.insert(id, request);
     }
 
-    fn remove(&mut self, id: u64) -> Option<PendingRemoteRequest> {
-        let request = self.requests.remove(&id)?;
+    fn get(&self, id: &u64) -> Option<&PendingRemoteRequest> {
+        self.requests.get(id)
+    }
+
+    fn remove(&mut self, id: &u64) -> Option<PendingRemoteRequest> {
+        let request = self.requests.remove(id)?;
         if let Some(surface) = request.attach_surface {
             let mut remove_surface = false;
             if let Some(ids) = self.attach_surface_requests.get_mut(&surface) {
-                ids.remove(&id);
+                ids.remove(id);
                 remove_surface = ids.is_empty();
             }
             if remove_surface {
@@ -6611,7 +6615,7 @@ mod tests {
         assert_eq!(matching_progress.load(Ordering::Acquire), 1);
         assert_eq!(unrelated_progress.load(Ordering::Acquire), 0);
 
-        let removed = pending.remove(1_000).expect("matching request is pending");
+        let removed = pending.remove(&1_000).expect("matching request is pending");
         drop(removed);
         assert!(!pending.progress_for_attach_surface(7));
         assert_eq!(matching_progress.load(Ordering::Acquire), 1);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3911,7 +3911,7 @@ fn test_session_with_writer(
     Arc::new(RemoteSession {
         interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
         disconnect_state: Mutex::new(DisconnectState::default()),
-        pending: Mutex::new(HashMap::new()),
+        pending: Mutex::new(PendingRemoteRequests::default()),
         next_id: AtomicU64::new(1),
         attach_progress: AtomicU64::new(0),
         shutdown: AtomicBool::new(false),
@@ -5153,7 +5153,7 @@ mod tests {
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
             disconnect_state: Mutex::new(DisconnectState::default()),
-            pending: Mutex::new(HashMap::new()),
+            pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
             attach_progress: AtomicU64::new(0),
             shutdown: AtomicBool::new(false),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1057,6 +1057,69 @@ struct PendingRemoteRequest {
     attach_surface: Option<SurfaceId>,
 }
 
+#[derive(Default)]
+struct PendingRemoteRequests {
+    requests: HashMap<u64, PendingRemoteRequest>,
+    attach_surface_requests: HashMap<SurfaceId, HashSet<u64>>,
+}
+
+impl PendingRemoteRequests {
+    fn insert(&mut self, id: u64, request: PendingRemoteRequest) {
+        if let Some(surface) = request.attach_surface {
+            self.attach_surface_requests.entry(surface).or_default().insert(id);
+        }
+        self.requests.insert(id, request);
+    }
+
+    fn remove(&mut self, id: u64) -> Option<PendingRemoteRequest> {
+        let request = self.requests.remove(&id)?;
+        if let Some(surface) = request.attach_surface {
+            let mut remove_surface = false;
+            if let Some(ids) = self.attach_surface_requests.get_mut(&surface) {
+                ids.remove(&id);
+                remove_surface = ids.is_empty();
+            }
+            if remove_surface {
+                self.attach_surface_requests.remove(&surface);
+            }
+        }
+        Some(request)
+    }
+
+    fn progress_for_attach_surface(&self, surface: SurfaceId) -> bool {
+        let Some(ids) = self.attach_surface_requests.get(&surface) else { return false };
+        let mut progressed = false;
+        for id in ids {
+            if let Some(request) = self.requests.get(id) {
+                request.progress.fetch_add(1, Ordering::Release);
+                progressed = true;
+            }
+        }
+        progressed
+    }
+
+    fn is_empty(&self) -> bool {
+        self.requests.is_empty()
+    }
+
+    fn len(&self) -> usize {
+        self.requests.len()
+    }
+
+    fn values(&self) -> impl Iterator<Item = &PendingRemoteRequest> {
+        self.requests.values()
+    }
+}
+
+impl IntoIterator for PendingRemoteRequests {
+    type Item = (u64, PendingRemoteRequest);
+    type IntoIter = std::collections::hash_map::IntoIter<u64, PendingRemoteRequest>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.requests.into_iter()
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum RemoteProgressTarget {
     Request(u64),
@@ -1519,7 +1582,7 @@ pub struct RemoteSession {
     /// reader failure so closing our own transport does not report a fake
     /// remote diagnostic.
     disconnect_state: Mutex<DisconnectState>,
-    pending: Mutex<HashMap<u64, PendingRemoteRequest>>,
+    pending: Mutex<PendingRemoteRequests>,
     next_id: AtomicU64,
     attach_progress: AtomicU64,
     shutdown: AtomicBool,
@@ -2120,14 +2183,7 @@ impl RemoteSession {
                 }
             }
             RemoteProgressTarget::AttachSurface(surface) => {
-                let mut progressed = false;
-                for request in
-                    pending.values().filter(|request| request.attach_surface == Some(surface))
-                {
-                    request.progress.fetch_add(1, Ordering::Release);
-                    progressed = true;
-                }
-                progressed
+                pending.progress_for_attach_surface(surface)
             }
         };
         drop(pending);


### PR DESCRIPTION
## Summary
- index pending attach requests by surface
- update the index on request insert, removal, and shutdown
- cover live-request filtering with a focused stress test

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/session/remote.rs`
- `git diff --check`
- Hosted cmux-tui verification to follow

No local Rust or Cargo tests were run per repository policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790949544&installation_model_id=21920&pr_number=11685&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11685&signature=d232f671a2213a71722ef610df8f8d11a2b49e20a469555901a4dff84a616979"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Indexes pending remote attach requests by attach surface, so progress updates no longer scan every pending request. The new wrapper preserves request lookup behavior and keeps its reverse index synchronized during insertion, removal, and shutdown.

- Adds coverage confirming unrelated surfaces and removed requests do not receive progress updates.

<sup>Written for commit b7e18bdd17e1d496fc167235bffc7d977d9a5b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote session progress tracking so updates apply only to active pending requests.
  * Prevented stale or completed requests from receiving progress updates, keeping status information accurate during remote operations.
  * Improved progress consistency when multiple requests are associated with the same attached surface.
  * Enhanced handling of concurrent remote operations to reduce inconsistent progress reporting.

* **Tests**
  * Added coverage verifying progress tracking across attached surfaces and pending requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->