### PR TITLE
fix(cmux-tui): measure Unicode text by grapheme and cell width

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/cli/wire.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/wire.rs
@@ -827,6 +827,15 @@ mod tests {
     }
 
     #[test]
+    fn human_tables_pad_wide_cells_by_terminal_width() {
+        let output = human_text(&json!([
+            {"name":"界","value":"a"},
+            {"name":"x","value":"界"}
+        ]));
+        assert_eq!(output, "NAME  VALUE\n界    a\nx     界\n");
+    }
+
+    #[test]
     fn human_single_array_wrappers_use_the_same_table() {
         let output = human_text(&json!({
             "workspaces": [

--- a/cmux-tui/crates/cmux-tui/src/cli/wire.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/wire.rs
@@ -10,6 +10,7 @@ use cmux_tui_core::resource::{
     StreamEndReason, StreamItemEnvelope,
 };
 use serde_json::{Value, json};
+use unicode_width::UnicodeWidthStr;
 
 use super::command::{RequestPlan, WireOperation, random_prefixed};
 use super::{GlobalArgs, OutputMode, UsageError};
@@ -591,10 +592,10 @@ fn append_human(value: &Value, output: &mut String) {
             }
             let mut rows = Vec::new();
             flatten_human_object(None, object, &mut rows);
-            let width = rows.iter().map(|(key, _)| key.chars().count()).max().unwrap_or(0);
+            let width = rows.iter().map(|(key, _)| key.width()).max().unwrap_or(0);
             for (key, value) in rows {
                 output.push_str(&key);
-                output.push_str(&" ".repeat(width.saturating_sub(key.chars().count())));
+                output.push_str(&" ".repeat(width.saturating_sub(key.width())));
                 output.push_str("  ");
                 output.push_str(&value);
                 output.push('\n');
@@ -636,10 +637,10 @@ fn append_record_table(values: &[Value], output: &mut String) {
         .enumerate()
         .map(|(index, column)| {
             rows.iter()
-                .map(|row| row[index].chars().count())
+                .map(|row| row[index].width())
                 .max()
                 .unwrap_or(0)
-                .max(human_header(column).chars().count())
+                .max(human_header(column).width())
         })
         .collect::<Vec<_>>();
 
@@ -660,7 +661,7 @@ fn append_table_row(cells: &[String], widths: &[usize], output: &mut String) {
         }
         output.push_str(cell);
         if index + 1 != cells.len() {
-            output.push_str(&" ".repeat(widths[index].saturating_sub(cell.chars().count())));
+            output.push_str(&" ".repeat(widths[index].saturating_sub(cell.width())));
         }
     }
     output.push('\n');

--- a/cmux-tui/crates/cmux-tui/src/cli/wire.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/wire.rs
@@ -9,8 +9,8 @@ use cmux_tui_core::resource::{
     EnvelopeType, MAX_MESSAGE_BYTES, OperationClass, PROTOCOL, ResponseEnvelope, StreamEndEnvelope,
     StreamEndReason, StreamItemEnvelope,
 };
+use ratatui::buffer::CellWidth;
 use serde_json::{Value, json};
-use unicode_width::UnicodeWidthStr;
 
 use super::command::{RequestPlan, WireOperation, random_prefixed};
 use super::{GlobalArgs, OutputMode, UsageError};
@@ -592,10 +592,11 @@ fn append_human(value: &Value, output: &mut String) {
             }
             let mut rows = Vec::new();
             flatten_human_object(None, object, &mut rows);
-            let width = rows.iter().map(|(key, _)| key.width()).max().unwrap_or(0);
+            let width =
+                rows.iter().map(|(key, _)| usize::from(key.cell_width())).max().unwrap_or(0);
             for (key, value) in rows {
                 output.push_str(&key);
-                output.push_str(&" ".repeat(width.saturating_sub(key.width())));
+                output.push_str(&" ".repeat(width.saturating_sub(usize::from(key.cell_width()))));
                 output.push_str("  ");
                 output.push_str(&value);
                 output.push('\n');
@@ -637,10 +638,10 @@ fn append_record_table(values: &[Value], output: &mut String) {
         .enumerate()
         .map(|(index, column)| {
             rows.iter()
-                .map(|row| row[index].width())
+                .map(|row| usize::from(row[index].cell_width()))
                 .max()
                 .unwrap_or(0)
-                .max(human_header(column).width())
+                .max(usize::from(human_header(column).cell_width()))
         })
         .collect::<Vec<_>>();
 
@@ -661,7 +662,9 @@ fn append_table_row(cells: &[String], widths: &[usize], output: &mut String) {
         }
         output.push_str(cell);
         if index + 1 != cells.len() {
-            output.push_str(&" ".repeat(widths[index].saturating_sub(cell.width())));
+            output.push_str(
+                &" ".repeat(widths[index].saturating_sub(usize::from(cell.cell_width()))),
+            );
         }
     }
     output.push('\n');

--- a/cmux-tui/crates/cmux-tui/src/cli/wire.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/wire.rs
@@ -837,6 +837,16 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn human_tables_pad_halfwidth_dakuten_by_terminal_width() {
+        let output = human_text(&json!([
+            {"name":"ｶﾞ","value":"a"},
+            {"name":"x","value":"ｶﾞ"}
+        ]));
+        assert_eq!(output, "NAME  VALUE\nｶﾞ    a\nx     ｶﾞ\n");
+    }
+
+    #[test]
     fn human_single_array_wrappers_use_the_same_table() {
         let output = human_text(&json!({
             "workspaces": [

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3206,8 +3206,8 @@ fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<Status
             (Some(text), None) => {
                 // Bound per-draw expansion work on the render path.
                 let mut bounded = String::new();
-                let mut width = 0;
-                let mut scalar_count = 0;
+                let mut width: usize = 0;
+                let mut scalar_count: usize = 0;
                 for grapheme in text.graphemes(true) {
                     let grapheme_width = usize::from(grapheme.cell_width());
                     let grapheme_scalars = grapheme.chars().count();

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -152,6 +152,7 @@ use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 use wait_timeout::ChildExt;
 
@@ -3166,7 +3167,7 @@ impl StatusBarOptions {
 /// The maximum number of configured segments per status bar side.
 pub const MAX_STATUS_SEGMENTS: usize = 8;
 
-/// The maximum length of one literal status segment, in characters.
+/// The maximum width of one literal status segment, in terminal cells.
 pub const MAX_STATUS_SEGMENT_TEXT: usize = 256;
 
 /// One status bar segment: literal text with `{variable}` interpolation, or
@@ -3204,7 +3205,22 @@ fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<Status
             }
             (Some(text), None) => {
                 // Bound per-draw expansion work on the render path.
-                StatusSegmentContent::Text(text.chars().take(MAX_STATUS_SEGMENT_TEXT).collect())
+                let mut bounded = String::new();
+                let mut width = 0;
+                let mut scalar_count = 0;
+                for grapheme in text.graphemes(true) {
+                    let grapheme_width = grapheme.width();
+                    let grapheme_scalars = grapheme.chars().count();
+                    if width.saturating_add(grapheme_width) > MAX_STATUS_SEGMENT_TEXT
+                        || scalar_count.saturating_add(grapheme_scalars) > MAX_STATUS_SEGMENT_TEXT
+                    {
+                        break;
+                    }
+                    bounded.push_str(grapheme);
+                    width += grapheme_width;
+                    scalar_count += grapheme_scalars;
+                }
+                StatusSegmentContent::Text(bounded)
             }
             (None, Some(run)) => {
                 if run.first().is_none_or(|program| program.is_empty()) {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -149,11 +149,11 @@ use cmux_tui_core::{DEFAULT_SCROLLBACK_LIMIT_BYTES, SurfaceOptions};
 
 const MAX_SCROLLBACK_LIMIT_BYTES: usize = 1_000_000_000;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratatui::buffer::CellWidth;
 use ratatui::style::Color;
 use serde::{Deserialize, Deserializer};
 use serde_json::{Value, json};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
 use wait_timeout::ChildExt;
 
 use crate::localization::catalog;
@@ -3209,7 +3209,7 @@ fn resolve_status_segments(raw: Vec<RawStatusSegment>, side: &str) -> Vec<Status
                 let mut width = 0;
                 let mut scalar_count = 0;
                 for grapheme in text.graphemes(true) {
-                    let grapheme_width = grapheme.width();
+                    let grapheme_width = usize::from(grapheme.cell_width());
                     let grapheme_scalars = grapheme.chars().count();
                     if width.saturating_add(grapheme_width) > MAX_STATUS_SEGMENT_TEXT
                         || scalar_count.saturating_add(grapheme_scalars) > MAX_STATUS_SEGMENT_TEXT
@@ -3422,7 +3422,7 @@ pub fn load() -> Config {
     if let Some(glyph) = raw.sidebar.rail_glyph {
         if glyph.eq_ignore_ascii_case("none") {
             config.sidebar.rail_glyph = String::new();
-        } else if glyph.chars().count() == 1 && glyph.width() == 1 {
+        } else if glyph.chars().count() == 1 && glyph.cell_width() == 1 {
             // The renderer reserves exactly one cell for the glyph.
             config.sidebar.rail_glyph = glyph;
         } else {
@@ -5884,8 +5884,8 @@ fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColo
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ratatui::buffer::CellWidth;
     use std::cell::{Cell, RefCell};
-    use unicode_width::UnicodeWidthStr;
 
     #[test]
     fn config_diagnostics_do_not_echo_parser_details() {
@@ -9122,7 +9122,7 @@ mod tests {
         let StatusSegmentContent::Text(text) = &resolved[0].content else {
             panic!("literal status text did not resolve as text");
         };
-        assert_eq!(text.width(), MAX_STATUS_SEGMENT_TEXT);
+        assert_eq!(usize::from(text.cell_width()), MAX_STATUS_SEGMENT_TEXT);
         assert_eq!(text, &"界".repeat(MAX_STATUS_SEGMENT_TEXT / 2));
     }
 

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -5869,6 +5869,7 @@ fn overlay_ghostty_defaults(defaults: &mut DefaultColors, overrides: DefaultColo
 mod tests {
     use super::*;
     use std::cell::{Cell, RefCell};
+    use unicode_width::UnicodeWidthStr;
 
     #[test]
     fn config_diagnostics_do_not_echo_parser_details() {
@@ -9095,6 +9096,18 @@ mod tests {
             })
             .collect();
         assert_eq!(resolve_status_segments(overflow, "left").len(), MAX_STATUS_SEGMENTS);
+    }
+
+    #[test]
+    fn status_text_cap_uses_terminal_cells_without_splitting_graphemes() {
+        let text = format!("{}e\u{301}abc", "界".repeat(130));
+        let raw = vec![RawStatusSegment { text: Some(text), ..RawStatusSegment::default() }];
+        let resolved = resolve_status_segments(raw, "left");
+        let StatusSegmentContent::Text(text) = &resolved[0].content else {
+            panic!("literal status text did not resolve as text");
+        };
+        assert_eq!(text.width(), MAX_STATUS_SEGMENT_TEXT);
+        assert_eq!(text, &"界".repeat(MAX_STATUS_SEGMENT_TEXT / 2));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -9127,6 +9127,20 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn status_text_cap_uses_terminal_cells_for_halfwidth_dakuten() {
+        let raw = vec![RawStatusSegment {
+            text: Some("界ﾞ".repeat(100)),
+            ..RawStatusSegment::default()
+        }];
+        let resolved = resolve_status_segments(raw, "left");
+        let StatusSegmentContent::Text(text) = &resolved[0].content else {
+            panic!("literal status text did not resolve as text");
+        };
+        assert_eq!(text, &"界ﾞ".repeat(85));
+    }
+
+    #[test]
     fn chip_styles_and_separators_parse() {
         let raw: RawConfig = serde_json::from_value(json!({
             "tabs": {"style": "pill"},

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -3422,7 +3422,10 @@ pub fn load() -> Config {
     if let Some(glyph) = raw.sidebar.rail_glyph {
         if glyph.eq_ignore_ascii_case("none") {
             config.sidebar.rail_glyph = String::new();
-        } else if glyph.chars().count() == 1 && glyph.cell_width() == 1 {
+        } else if glyph.chars().count() == 1
+            && glyph.chars().all(|character| !character.is_control())
+            && glyph.cell_width() == 1
+        {
             // The renderer reserves exactly one cell for the glyph.
             config.sidebar.rail_glyph = glyph;
         } else {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -9211,6 +9211,25 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn rail_glyph_accepts_standalone_halfwidth_sound_marks() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_cmux_tui_config = std::env::var_os("CMUX_TUI_CONFIG");
+        let dir = TestDirectory::new("rail-glyph-halfwidth-sound-marks");
+        let path = dir.path.join("cmux-tui.json");
+        for glyph in ["\u{ff9e}", "\u{ff9f}"] {
+            std::fs::write(&path, format!(r#"{{"sidebar":{{"rail_glyph":"{glyph}"}}}}"#)).unwrap();
+            // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+            unsafe { std::env::set_var("CMUX_TUI_CONFIG", &path) };
+
+            let config = load();
+
+            assert_eq!(config.sidebar.rail_glyph, glyph);
+        }
+        restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
+    }
+
+    #[test]
     fn plus_buttons_parse_labels_actions_and_menus() {
         let raw: RawConfig = serde_json::from_value(json!({
             "tabs": {"plus": {

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -9223,10 +9223,19 @@ mod tests {
             unsafe { std::env::set_var("CMUX_TUI_CONFIG", &path) };
 
             let config = load();
+            restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config.clone());
 
             assert_eq!(config.sidebar.rail_glyph, glyph);
         }
+
+        std::fs::write(&path, r#"{"sidebar":{"rail_glyph":"\n"}}"#).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("CMUX_TUI_CONFIG", &path) };
+
+        let config = load();
         restore_env_var("CMUX_TUI_CONFIG", old_cmux_tui_config);
+
+        assert_eq!(config.sidebar.rail_glyph, Config::default().sidebar.rail_glyph);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -766,7 +766,7 @@ pub(crate) fn middle_truncate(input: &str, max_width: usize) -> String {
     let back_width = keep_width / 2;
     let graphemes = input.graphemes(true).collect::<Vec<_>>();
     let mut front = String::new();
-    let mut width = 0;
+    let mut width: usize = 0;
     for grapheme in graphemes.iter().copied() {
         let grapheme_width = usize::from(grapheme.cell_width());
         if width.saturating_add(grapheme_width) > front_width {

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -752,11 +752,11 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
 }
 
 pub(crate) fn middle_truncate(input: &str, max_width: usize) -> String {
-    if usize::from(input.cell_width()) <= max_width {
-        return input.to_string();
-    }
     if max_width == 0 {
         return String::new();
+    }
+    if usize::from(input.cell_width()) <= max_width {
+        return input.to_string();
     }
     if max_width <= 3 {
         return ".".repeat(max_width);

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -786,6 +786,12 @@ mod tests {
     }
 
     #[test]
+    fn middle_truncation_respects_graphemes_and_terminal_cells() {
+        assert_eq!(middle_truncate("界界界界", 7), "界...界");
+        assert_eq!(middle_truncate("e\u{301}clair", 5), "e\u{301}...r");
+    }
+
+    #[test]
     fn truncation_uses_terminal_cell_width_and_preserves_graphemes() {
         assert_eq!(truncate("復元失敗", 5), "復元…");
         assert_eq!(truncate("e\u{301}clair", 2), "e\u{301}…");

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -746,23 +746,45 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
     out
 }
 
-pub(crate) fn middle_truncate(input: &str, max_chars: usize) -> String {
-    let chars = input.chars().collect::<Vec<_>>();
-    if chars.len() <= max_chars {
+pub(crate) fn middle_truncate(input: &str, max_width: usize) -> String {
+    if input.width() <= max_width {
         return input.to_string();
     }
-    if max_chars == 0 {
+    if max_width == 0 {
         return String::new();
     }
-    if max_chars <= 3 {
-        return ".".repeat(max_chars);
+    if max_width <= 3 {
+        return ".".repeat(max_width);
     }
-    let keep = max_chars - 3;
-    let front = keep.div_ceil(2);
-    let back = keep / 2;
-    let mut output = chars[..front].iter().collect::<String>();
+    let keep_width = max_width - 3;
+    let front_width = keep_width.div_ceil(2);
+    let back_width = keep_width / 2;
+    let graphemes = input.graphemes(true).collect::<Vec<_>>();
+    let mut front = String::new();
+    let mut width = 0;
+    for grapheme in graphemes.iter().copied() {
+        let grapheme_width = grapheme.width();
+        if width.saturating_add(grapheme_width) > front_width {
+            break;
+        }
+        front.push_str(grapheme);
+        width += grapheme_width;
+    }
+    let mut back = Vec::new();
+    width = 0;
+    for grapheme in graphemes.iter().rev().copied() {
+        let grapheme_width = grapheme.width();
+        if width.saturating_add(grapheme_width) > back_width {
+            break;
+        }
+        back.push(grapheme);
+        width += grapheme_width;
+    }
+    let mut output = front;
     output.push_str("...");
-    output.extend(&chars[chars.len() - back..]);
+    for grapheme in back.iter().rev() {
+        output.push_str(grapheme);
+    }
     output
 }
 

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -814,6 +814,13 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn truncation_uses_terminal_cell_width_for_halfwidth_dakuten() {
+        assert_eq!(middle_truncate("界ﾞ界ﾞ", 5), "...");
+        assert_eq!(truncate("界ﾞ界ﾞ", 5), "界ﾞ…");
+    }
+
+    #[test]
     fn truncation_uses_terminal_cell_width_and_preserves_graphemes() {
         assert_eq!(truncate("復元失敗", 5), "復元…");
         assert_eq!(truncate("e\u{301}clair", 2), "e\u{301}…");

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -813,6 +813,11 @@ mod tests {
     }
 
     #[test]
+    fn middle_truncation_zero_width_input_respects_zero_budget() {
+        assert_eq!(middle_truncate("\u{200b}", 0), "");
+    }
+
+    #[test]
     fn middle_truncation_respects_graphemes_and_terminal_cells() {
         assert_eq!(middle_truncate("界界界界", 7), "界...界");
         assert_eq!(middle_truncate("e\u{301}clair", 5), "e\u{301}...r");

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -16,11 +16,10 @@ pub(crate) mod terminal_grid;
 
 use cmux_tui_core::Rect;
 use ratatui::Frame;
-use ratatui::buffer::Buffer;
+use ratatui::buffer::{Buffer, CellWidth};
 use ratatui::layout::{Position, Rect as RatatuiRect};
 use ratatui::style::{Color, Modifier, Style};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, Hit, RailKind};
 use crate::config::Action;
@@ -84,13 +83,13 @@ pub(crate) fn copy_buffer_row_cropped(
         .width
         .min(source_right.saturating_sub(source_left))
         .min(target_right.saturating_sub(target_rect.x));
-    let partial_left =
-        source_left > source.area.x && source[(source_left - 1, source_y)].symbol().width() > 1;
+    let partial_left = source_left > source.area.x
+        && source[(source_left - 1, source_y)].symbol().cell_width() > 1;
     for dx in 0..width {
         let source_cell = &source[(source_left + dx, source_y)];
         let target_cell = &mut target[(target_rect.x + dx, target_rect.y)];
         *target_cell = source_cell.clone();
-        let symbol_width = source_cell.symbol().width() as u16;
+        let symbol_width = source_cell.symbol().cell_width();
         if (dx == 0 && partial_left) || symbol_width > width.saturating_sub(dx) {
             target_cell.set_symbol(" ");
         }
@@ -226,12 +225,18 @@ fn draw_machine_transition(app: &mut App, frame: &mut Frame) -> bool {
         }
     }
     let center_y = area.y.saturating_add(area.height / 2);
-    let title_width = name.width().min(area.width as usize);
-    let title_x = area.x.saturating_add(area.width.saturating_sub(title_width as u16) / 2);
-    buffer.set_stringn(title_x, center_y.saturating_sub(1), &name, title_width, title_style);
-    let status_width = status.width().min(area.width as usize);
-    let status_x = area.x.saturating_add(area.width.saturating_sub(status_width as u16) / 2);
-    buffer.set_stringn(status_x, center_y, status, status_width, style);
+    let title_width = name.cell_width().min(area.width);
+    let title_x = area.x.saturating_add(area.width.saturating_sub(title_width) / 2);
+    buffer.set_stringn(
+        title_x,
+        center_y.saturating_sub(1),
+        &name,
+        title_width as usize,
+        title_style,
+    );
+    let status_width = status.cell_width().min(area.width);
+    let status_x = area.x.saturating_add(area.width.saturating_sub(status_width) / 2);
+    buffer.set_stringn(status_x, center_y, status, status_width as usize, style);
     true
 }
 
@@ -278,7 +283,7 @@ fn draw_surface_status(app: &mut App, frame: &mut Frame) {
         return;
     }
     let copy_label = status_copy_label();
-    let copy_width = copy_label.width().min(area.width as usize) as u16;
+    let copy_width = copy_label.cell_width().min(area.width);
     let show_copy = area.width > copy_width.saturating_add(2);
     let message_width = if show_copy {
         area.width.saturating_sub(copy_width.saturating_add(1))
@@ -286,7 +291,7 @@ fn draw_surface_status(app: &mut App, frame: &mut Frame) {
         area.width
     };
     let text = status_display_text(message, message_width as usize);
-    let text_width = text.width() as u16;
+    let text_width = text.cell_width();
     let style = Style::default().fg(Color::Red).add_modifier(Modifier::BOLD);
     draw_interactive_status_message(
         app,
@@ -405,7 +410,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     let mut hits = Vec::new();
     let put = |frame: &mut Frame, x: &mut u16, text: &str, style: Style| -> (u16, u16) {
         let start = *x;
-        let width = text.width().min(area.width.saturating_sub(*x) as usize) as u16;
+        let width = text.cell_width().min(area.width.saturating_sub(*x));
         if width > 0 {
             frame.buffer_mut().set_stringn(*x, status_y, text, width as usize, style);
             *x += width;
@@ -484,7 +489,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
     // over the pane border above this row.
     let available_label_width = area.width.saturating_sub(x) as usize;
     let copy_label = status_copy_label();
-    let copy_width = copy_label.width();
+    let copy_width = usize::from(copy_label.cell_width());
     let show_copy =
         app.status_message.is_some() && available_label_width > copy_width.saturating_add(3);
     let status_text = app.status_message.as_deref().map(|message| {
@@ -510,7 +515,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
                     String::new()
                 }
             });
-    let label_w = label.width().min(area.width as usize) as u16;
+    let label_w = label.cell_width().min(area.width);
     // Right-aligned custom segments sit left of the label; draw them and
     // shrink the viewport track accordingly.
     let mut right_x = area.width.saturating_sub(label_w);
@@ -522,7 +527,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
         if segment.text.is_empty() {
             continue;
         }
-        let width = (segment.text.width() as u16).min(right_x.saturating_sub(x));
+        let width = segment.text.cell_width().min(right_x.saturating_sub(x));
         if width == 0 {
             break;
         }
@@ -535,7 +540,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
             segment_style(segment),
         );
         if let Some(separator) = right_separator {
-            let separator_width = (separator.width() as u16).min(right_x.saturating_sub(x));
+            let separator_width = separator.cell_width().min(right_x.saturating_sub(x));
             if separator_width == 0 {
                 break;
             }
@@ -593,7 +598,7 @@ fn draw_status_bar(app: &mut App, frame: &mut Frame) {
             },
         );
         if let Some(status_text) = status_text {
-            let status_width = status_text.width() as u16;
+            let status_width = status_text.cell_width();
             draw_interactive_status_message(
                 app,
                 frame,
@@ -644,7 +649,7 @@ fn draw_prefix_help_bar(app: &App, frame: &mut Frame, bar_x: u16, y: u16) {
         .display_label()
         .map(|label| format!(" {label} "))
         .unwrap_or_default();
-    let prefix_width = prefix.width() as u16;
+    let prefix_width = prefix.cell_width();
     if prefix_width > 0 && x.saturating_add(prefix_width) <= area.width {
         frame.buffer_mut().set_stringn(x, y, &prefix, prefix_width as usize, keycap);
         x += prefix_width;
@@ -680,8 +685,8 @@ fn draw_prefix_help_bar(app: &App, frame: &mut Frame, bar_x: u16, y: u16) {
         let Some(key) = app.config.keys.prefixed_key_label(action) else { continue };
         let key = format!(" {key} ");
         let label = format!(" {} ", catalog().action_label(action));
-        let key_width = key.width() as u16;
-        let label_width = label.width() as u16;
+        let key_width = key.cell_width();
+        let label_width = label.cell_width();
         if x.saturating_add(key_width).saturating_add(label_width) > area.width {
             break;
         }
@@ -712,7 +717,7 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
     let byte_truncated = prefix_end < s.len();
     let bounded_prefix = &s[..prefix_end];
 
-    if !byte_truncated && bounded_prefix.width() <= max {
+    if !byte_truncated && usize::from(bounded_prefix.cell_width()) <= max {
         return bounded_prefix.to_string();
     }
 
@@ -733,7 +738,7 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
         complete_prefix.len().min(content_byte_budget).saturating_add('…'.len_utf8()),
     );
     for grapheme in complete_prefix.graphemes(true) {
-        let grapheme_width = grapheme.width();
+        let grapheme_width = usize::from(grapheme.cell_width());
         if width.saturating_add(grapheme_width) > content_width
             || out.len().saturating_add(grapheme.len()) > content_byte_budget
         {
@@ -747,7 +752,7 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
 }
 
 pub(crate) fn middle_truncate(input: &str, max_width: usize) -> String {
-    if input.width() <= max_width {
+    if usize::from(input.cell_width()) <= max_width {
         return input.to_string();
     }
     if max_width == 0 {
@@ -763,7 +768,7 @@ pub(crate) fn middle_truncate(input: &str, max_width: usize) -> String {
     let mut front = String::new();
     let mut width = 0;
     for grapheme in graphemes.iter().copied() {
-        let grapheme_width = grapheme.width();
+        let grapheme_width = usize::from(grapheme.cell_width());
         if width.saturating_add(grapheme_width) > front_width {
             break;
         }
@@ -773,7 +778,7 @@ pub(crate) fn middle_truncate(input: &str, max_width: usize) -> String {
     let mut back = Vec::new();
     width = 0;
     for grapheme in graphemes.iter().rev().copied() {
-        let grapheme_width = grapheme.width();
+        let grapheme_width = usize::from(grapheme.cell_width());
         if width.saturating_add(grapheme_width) > back_width {
             break;
         }

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -702,8 +702,9 @@ fn label_width(label: &str) -> u16 {
 #[cfg(test)]
 mod tests {
     use cmux_tui_core::Rect;
+    use unicode_width::UnicodeWidthStr;
 
-    use super::toast_rect_for_label;
+    use super::{label_width, toast_rect_for_label, wrapped_message_lines};
     use crate::localization::catalog_for_locale;
 
     #[test]
@@ -718,5 +719,13 @@ mod tests {
             toast_rect_for_label(Rect { x: 10, y: 2, width: 10, height: 5 }, " 界 "),
             Some(Rect { x: 16, y: 5, width: 3, height: 1 })
         );
+    }
+
+    #[test]
+    fn overlay_labels_and_wrapping_use_terminal_cell_width() {
+        assert_eq!(label_width(" 界 "), 4);
+        let lines = wrapped_message_lines("界界界", 4, 2);
+        assert_eq!(lines, vec!["界界", "界"]);
+        assert!(lines.iter().all(|line| line.width() <= 4));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -741,4 +741,18 @@ mod tests {
         assert_eq!(lines, vec!["界界", "界"]);
         assert!(lines.iter().all(|line| line.width() <= 4));
     }
+
+    #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn wrapping_trims_whitespace_graphemes_without_orphaning_marks() {
+        let lines = wrapped_message_lines("a \u{301}b", 2, 2);
+        assert_eq!(lines, vec!["a", "b"]);
+    }
+
+    #[test]
+    #[allow(clippy::unicode_not_nfc)]
+    fn wrapping_uses_terminal_cell_width_for_halfwidth_dakuten() {
+        let lines = wrapped_message_lines("界ﾞ界ﾞ", 5, 2);
+        assert_eq!(lines, vec!["界ﾞ", "界ﾞ"]);
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -710,7 +710,7 @@ fn label_width(label: &str) -> u16 {
 }
 
 fn grapheme_prefix_end(input: &str, max_width: usize) -> usize {
-    let mut width = 0;
+    let mut width: usize = 0;
     let mut end = 0;
     for (index, grapheme) in input.grapheme_indices(true) {
         let grapheme_width = usize::from(grapheme.cell_width());

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -5,11 +5,10 @@
 
 use cmux_tui_core::Rect;
 use ratatui::Frame;
-use ratatui::buffer::Buffer;
+use ratatui::buffer::{Buffer, CellWidth};
 use ratatui::layout::Position;
 use ratatui::style::{Modifier, Style};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, ContextMenu, MenuItem};
 use crate::localization::catalog;
@@ -345,17 +344,23 @@ fn wrapped_message_lines(message: &str, width: usize, limit: usize) -> Vec<Strin
             break;
         }
         let split = if end < remaining.len() {
-            remaining[..end].rfind(char::is_whitespace).filter(|index| *index > 0).unwrap_or(end)
+            remaining[..end]
+                .grapheme_indices(true)
+                .rev()
+                .find(|(_, grapheme)| grapheme_is_whitespace(grapheme))
+                .map(|(index, _)| index)
+                .filter(|index| *index > 0)
+                .unwrap_or(end)
         } else {
             end
         };
-        lines.push(remaining[..split].trim().to_string());
-        remaining = remaining[split..].trim_start();
+        lines.push(trim_grapheme_whitespace(&remaining[..split]).to_string());
+        remaining = trim_grapheme_whitespace_start(&remaining[split..]);
     }
     if !remaining.is_empty()
         && let Some(last) = lines.last_mut()
     {
-        while format!("{last}…").width() > width && !last.is_empty() {
+        while usize::from(format!("{last}…").cell_width()) > width && !last.is_empty() {
             let end = last.grapheme_indices(true).next_back().map_or(0, |(index, _)| index);
             last.truncate(end);
         }
@@ -423,7 +428,7 @@ pub fn draw_menu(app: &mut App, frame: &mut Frame) {
             let title_x = x + 2;
             let title_w = width.saturating_sub(4) as usize;
             let prefix = format!(" {} · ", search.label);
-            let prefix_w = prefix.width().min(title_w);
+            let prefix_w = usize::from(prefix.cell_width()).min(title_w);
             let search_style = base.add_modifier(Modifier::BOLD);
             buf.set_stringn(title_x, y, &prefix, title_w, search_style);
             let value_x = title_x + prefix_w as u16;
@@ -440,7 +445,7 @@ pub fn draw_menu(app: &mut App, frame: &mut Frame) {
             } else if value_w > 0 {
                 let (shown, _) = search.input.visible_text_and_cursor(value_w.saturating_sub(1));
                 buf.set_stringn(value_x, y, &shown, value_w, search_style);
-                let cursor_x = value_x + shown.width().min(value_w.saturating_sub(1)) as u16;
+                let cursor_x = value_x + shown.cell_width().min(value_w.saturating_sub(1) as u16);
                 buf.set_stringn(cursor_x, y, "▏", 1, search_style);
             }
         }
@@ -471,7 +476,7 @@ pub fn draw_menu(app: &mut App, frame: &mut Frame) {
                     set_cell(buf, inner_x + dx, row_y, " ", style);
                 }
                 let shortcut_width =
-                    item.shortcut().map(|shortcut| shortcut.width() as u16 + 2).unwrap_or(0);
+                    item.shortcut().map(|shortcut| shortcut.cell_width() + 2).unwrap_or(0);
                 let arrow_width = matches!(item, MenuItem::Submenu { .. }) as u16 * 2;
                 buf.set_stringn(
                     inner_x + pad + 1,
@@ -482,7 +487,7 @@ pub fn draw_menu(app: &mut App, frame: &mut Frame) {
                 );
                 if let Some(shortcut) = item.shortcut() {
                     let shortcut_width =
-                        (shortcut.width() as u16).min(row_content_w.saturating_sub(pad * 2));
+                        shortcut.cell_width().min(row_content_w.saturating_sub(pad * 2));
                     if shortcut_width > 0 {
                         let shortcut_x = x + level
                             .rect
@@ -532,11 +537,17 @@ pub fn draw_shortcut_help(app: &mut App, frame: &mut Frame) {
         .rows
         .iter()
         .map(|(action, shortcuts)| {
-            app.action_display_label(*action).width() + shortcuts.width() + 9
+            usize::from(app.action_display_label(*action).cell_width())
+                + usize::from(shortcuts.cell_width())
+                + 9
         })
         .max()
         .unwrap_or(44)
-        .max(catalog.shortcuts.title.width() + close_text.width() + 8);
+        .max(
+            usize::from(catalog.shortcuts.title.cell_width())
+                + usize::from(close_text.cell_width())
+                + 8,
+        );
     let width = (desired_width as u16).min(76).min(screen.width.saturating_sub(2)).max(24);
     let height = (total_rows as u16 + 4).min(screen.height.saturating_sub(2)).max(7);
     let x = (screen.width - width) / 2;
@@ -551,7 +562,7 @@ pub fn draw_shortcut_help(app: &mut App, frame: &mut Frame) {
     let Some(help) = app.shortcut_help.as_mut() else { return };
     help.rect = rect;
     help.visible_rows = visible_rows;
-    let close_width = close_text.width().min(width.saturating_sub(4) as usize) as u16;
+    let close_width = close_text.cell_width().min(width.saturating_sub(4));
     help.close_button = Rect {
         x: x + width.saturating_sub(close_width + 3),
         y: y + 1,
@@ -605,7 +616,7 @@ pub fn draw_shortcut_help(app: &mut App, frame: &mut Frame) {
         let row_y = y + 2 + line as u16;
         let label = app.action_display_label(*action);
         let shortcuts = format!(" {shortcuts} ");
-        let shortcut_width = (shortcuts.width() as u16).min(inner_width / 2);
+        let shortcut_width = shortcuts.cell_width().min(inner_width / 2);
         let shortcut_x = x + width.saturating_sub(shortcut_width + 2);
         let shortcut_x = if scrollbar_track.height > 0 {
             shortcut_x.min(scrollbar_track.x.saturating_sub(shortcut_width + 1))
@@ -695,14 +706,14 @@ fn draw_border(buf: &mut Buffer, rect: Rect, style: Style) {
 }
 
 fn label_width(label: &str) -> u16 {
-    label.width().min(u16::MAX as usize) as u16
+    label.cell_width()
 }
 
 fn grapheme_prefix_end(input: &str, max_width: usize) -> usize {
     let mut width = 0;
     let mut end = 0;
     for (index, grapheme) in input.grapheme_indices(true) {
-        let grapheme_width = grapheme.width();
+        let grapheme_width = usize::from(grapheme.cell_width());
         if width.saturating_add(grapheme_width) > max_width {
             break;
         }
@@ -712,10 +723,35 @@ fn grapheme_prefix_end(input: &str, max_width: usize) -> usize {
     end
 }
 
+fn grapheme_is_whitespace(grapheme: &str) -> bool {
+    grapheme.chars().next().is_some_and(char::is_whitespace)
+}
+
+fn trim_grapheme_whitespace_start(input: &str) -> &str {
+    let start = input
+        .grapheme_indices(true)
+        .find(|(_, grapheme)| !grapheme_is_whitespace(grapheme))
+        .map_or(input.len(), |(index, _)| index);
+    &input[start..]
+}
+
+fn trim_grapheme_whitespace_end(input: &str) -> &str {
+    let end = input
+        .grapheme_indices(true)
+        .rev()
+        .find(|(_, grapheme)| !grapheme_is_whitespace(grapheme))
+        .map_or(0, |(index, grapheme)| index + grapheme.len());
+    &input[..end]
+}
+
+fn trim_grapheme_whitespace(input: &str) -> &str {
+    trim_grapheme_whitespace_end(trim_grapheme_whitespace_start(input))
+}
+
 #[cfg(test)]
 mod tests {
     use cmux_tui_core::Rect;
-    use unicode_width::UnicodeWidthStr;
+    use ratatui::buffer::CellWidth;
 
     use super::{label_width, toast_rect_for_label, wrapped_message_lines};
     use crate::localization::catalog_for_locale;
@@ -739,7 +775,7 @@ mod tests {
         assert_eq!(label_width(" 界 "), 4);
         let lines = wrapped_message_lines("界界界", 4, 2);
         assert_eq!(lines, vec!["界界", "界"]);
-        assert!(lines.iter().all(|line| line.width() <= 4));
+        assert!(lines.iter().all(|line| line.cell_width() <= 4));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -8,6 +8,7 @@ use ratatui::Frame;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Position;
 use ratatui::style::{Modifier, Style};
+use unicode_segmentation::UnicodeSegmentation;
 use unicode_width::UnicodeWidthStr;
 
 use crate::app::{App, ContextMenu, MenuItem};
@@ -339,10 +340,7 @@ fn wrapped_message_lines(message: &str, width: usize, limit: usize) -> Vec<Strin
     let mut lines = Vec::new();
     let mut remaining = sanitized.as_str();
     while !remaining.is_empty() && lines.len() < limit {
-        let mut end = remaining.len();
-        while end > 0 && remaining[..end].width() > width {
-            end = remaining[..end].char_indices().next_back().map_or(0, |(index, _)| index);
-        }
+        let end = grapheme_prefix_end(remaining, width);
         if end == 0 {
             break;
         }
@@ -358,7 +356,8 @@ fn wrapped_message_lines(message: &str, width: usize, limit: usize) -> Vec<Strin
         && let Some(last) = lines.last_mut()
     {
         while format!("{last}…").width() > width && !last.is_empty() {
-            last.pop();
+            let end = last.grapheme_indices(true).next_back().map_or(0, |(index, _)| index);
+            last.truncate(end);
         }
         last.push('…');
     }
@@ -696,7 +695,21 @@ fn draw_border(buf: &mut Buffer, rect: Rect, style: Style) {
 }
 
 fn label_width(label: &str) -> u16 {
-    label.chars().count() as u16
+    label.width().min(u16::MAX as usize) as u16
+}
+
+fn grapheme_prefix_end(input: &str, max_width: usize) -> usize {
+    let mut width = 0;
+    let mut end = 0;
+    for (index, grapheme) in input.grapheme_indices(true) {
+        let grapheme_width = grapheme.width();
+        if width.saturating_add(grapheme_width) > max_width {
+            break;
+        }
+        width += grapheme_width;
+        end = index + grapheme.len();
+    }
+    end
 }
 
 #[cfg(test)]
@@ -717,7 +730,7 @@ mod tests {
     fn toast_occlusion_uses_the_rendered_character_clamp() {
         assert_eq!(
             toast_rect_for_label(Rect { x: 10, y: 2, width: 10, height: 5 }, " 界 "),
-            Some(Rect { x: 16, y: 5, width: 3, height: 1 })
+            Some(Rect { x: 15, y: 5, width: 4, height: 1 })
         );
     }
 


### PR DESCRIPTION
Summary:
- middle truncation keeps extended graphemes intact and fits terminal-cell budgets
- overlay labels and wrapped messages use cell widths without splitting graphemes
- human CLI tables pad by display width, and literal status text caps at 256 cells

Regression coverage is the first commit; the implementation is the second commit.

Docs used:
- https://docs.rs/unicode-segmentation/latest/unicode_segmentation/trait.UnicodeSegmentation.html
- https://docs.rs/unicode-width/latest/unicode_width/trait.UnicodeWidthStr.html

Checks: rustfmt --edition 2024 --check; git diff --check. Cargo/Rust tests were not run locally per cmux-tui Testbox policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11686"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790949600&installation_model_id=21920&pr_number=11686&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11686&signature=1b409f954b967a1a978f967b9cd9e5b81fb55ba1e6c234e0e395571c78f21692"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Unicode text handling in `cmux-tui` so wide characters and combining graphemes are measured by terminal cell width instead of character count. This fixes truncation, wrapping, padding, and layout for CJK and accented text, and tightens rail glyph validation to accept standalone halfwidth sound marks while rejecting control characters.

- Middle truncation keeps graphemes intact, fits terminal-cell budgets, and honors a zero-width budget.
- Overlay labels and wrapped messages use cell widths and trim whitespace at grapheme boundaries without orphaning combining marks.
- Literal status bar text caps at 256 terminal cells instead of 256 characters.
- Human CLI tables pad columns by display width.

<sup>Written for commit ddd082edd2b10d59f56376fbe60093eb0676876e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal text alignment across tables, status bars, overlays, and truncated content.
  * Preserved wide characters and combining marks during wrapping, truncation, and layout calculations.
  * Fixed display sizing and spacing for multilingual text, including halfwidth dakuten sequences.
  * Prevented visual glitches caused by splitting combined characters or grapheme clusters.
  * Improved status-bar and sidebar rendering when labels contain wide or combining characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->