### PR TITLE
perf(cmux-tui): cache key dispatch lookups

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -8703,6 +8703,39 @@ mod tests {
     }
 
     #[test]
+    fn key_dispatch_refreshes_after_rebinding_and_keeps_modeless_fallback() {
+        let mut keys = Keys::default();
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            Some(Action::NewPaneRight)
+        );
+        assert_eq!(
+            keys.modeless_action_for(&KeyEvent::new(KeyCode::Char('t'), KeyModifiers::ALT)),
+            Some(Action::NewTab)
+        );
+
+        keys.apply(&HashMap::from([
+            ("new-tab".to_string(), Value::String("g".to_string())),
+            ("new-pane-right".to_string(), Value::String("alt+h".to_string())),
+        ]));
+
+        // Rebinding steals the ordinary chord while preserving modeless
+        // fallback lookup for the newly configured Alt chord.
+        assert_eq!(
+            keys.action_for(&KeyEvent::new(KeyCode::Char('g'), KeyModifiers::NONE)),
+            Some(Action::NewTab)
+        );
+        assert_eq!(
+            keys.modeless_action_for(&KeyEvent::new(KeyCode::Char('h'), KeyModifiers::ALT)),
+            Some(Action::NewPaneRight)
+        );
+        assert_eq!(
+            keys.modeless_action_for(&KeyEvent::new(KeyCode::Char('t'), KeyModifiers::ALT)),
+            None
+        );
+    }
+
+    #[test]
     fn shifted_character_chords_match_enhanced_base_key_events() {
         let shifted_letter = parse_chord("super+shift+d").unwrap();
         assert!(shifted_letter.matches(&KeyEvent::new(

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -2565,7 +2565,7 @@ impl Action {
 }
 
 /// A key chord: code plus required modifiers.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub struct Chord {
     pub code: KeyCode,
     pub mods: KeyModifiers,
@@ -2593,17 +2593,20 @@ fn normalize_chord(code: KeyCode, mut mods: KeyModifiers) -> (KeyCode, KeyModifi
     }
 }
 
+fn canonical_chord(chord: Chord) -> Chord {
+    const TRACKED: KeyModifiers = KeyModifiers::CONTROL
+        .union(KeyModifiers::ALT)
+        .union(KeyModifiers::SHIFT)
+        .union(KeyModifiers::SUPER)
+        .union(KeyModifiers::HYPER)
+        .union(KeyModifiers::META);
+    let (code, mods) = normalize_chord(chord.code, chord.mods);
+    Chord { code, mods: mods & TRACKED }
+}
+
 impl Chord {
     pub fn matches(&self, key: &KeyEvent) -> bool {
-        const TRACKED: KeyModifiers = KeyModifiers::CONTROL
-            .union(KeyModifiers::ALT)
-            .union(KeyModifiers::SHIFT)
-            .union(KeyModifiers::SUPER)
-            .union(KeyModifiers::HYPER)
-            .union(KeyModifiers::META);
-        let (configured_code, configured_mods) = normalize_chord(self.code, self.mods);
-        let (event_code, event_mods) = normalize_chord(key.code, key.modifiers);
-        configured_code == event_code && configured_mods & TRACKED == event_mods & TRACKED
+        canonical_chord(*self) == canonical_chord(Chord { code: key.code, mods: key.modifiers })
     }
 
     /// Human-readable form used beside context-menu actions. Keep this
@@ -2656,6 +2659,8 @@ pub struct Keys {
     /// macOS Option mode instead of guessing from each event.
     pub macos_option_as_alt: bool,
     bindings: Vec<(Chord, Action)>,
+    action_by_chord: HashMap<Chord, Action>,
+    modeless_action_by_chord: HashMap<Chord, Action>,
     pub(crate) provider_menu_overridden: bool,
 }
 
@@ -2665,7 +2670,7 @@ impl Default for Keys {
         let alt = |code, action| (Chord { code, mods: KeyModifiers::ALT }, action);
         let command = |code, action| (Chord { code, mods: KeyModifiers::SUPER }, action);
         let prefix = Chord { code: KeyCode::Char('b'), mods: KeyModifiers::CONTROL };
-        Keys {
+        let mut keys = Keys {
             prefix,
             macos_option_as_alt: true,
             bindings: vec![
@@ -2744,12 +2749,30 @@ impl Default for Keys {
                 bind(KeyCode::Char('?'), Action::ShowShortcuts),
                 bind(KeyCode::Char('d'), Action::Detach),
             ],
+            action_by_chord: HashMap::new(),
+            modeless_action_by_chord: HashMap::new(),
             provider_menu_overridden: false,
-        }
+        };
+        keys.rebuild_dispatch_maps();
+        keys
     }
 }
 
 impl Keys {
+    fn rebuild_dispatch_maps(&mut self) {
+        self.action_by_chord.clear();
+        self.modeless_action_by_chord.clear();
+        for &(chord, action) in &self.bindings {
+            let canonical = canonical_chord(chord);
+            // Keep the first binding in canonical order. Config mutation
+            // resolves intentional collisions before this cache is built.
+            self.action_by_chord.entry(canonical).or_insert(action);
+            if self.is_modeless_binding(&chord, action) {
+                self.modeless_action_by_chord.entry(canonical).or_insert(action);
+            }
+        }
+    }
+
     fn is_modeless_binding(&self, chord: &Chord, action: Action) -> bool {
         if action == Action::SendPrefix && *chord == self.prefix {
             return false;
@@ -2769,17 +2792,18 @@ impl Keys {
 
     /// The action bound to a key event (after the prefix).
     pub fn action_for(&self, key: &KeyEvent) -> Option<Action> {
-        self.bindings.iter().find(|(chord, _)| chord.matches(key)).map(|(_, a)| *a)
+        self.action_by_chord
+            .get(&canonical_chord(Chord { code: key.code, mods: key.modifiers }))
+            .copied()
     }
 
     /// The modeless action bound to a key event. Alt- and Super-modified
     /// chords are modeless, as are Control-modified clear-history chords;
     /// other chords remain prefix-only.
     pub fn modeless_action_for(&self, key: &KeyEvent) -> Option<Action> {
-        self.bindings
-            .iter()
-            .find(|(chord, action)| self.is_modeless_binding(chord, *action) && chord.matches(key))
-            .map(|(_, a)| *a)
+        self.modeless_action_by_chord
+            .get(&canonical_chord(Chord { code: key.code, mods: key.modifiers }))
+            .copied()
     }
 
     /// The first configured shortcut for an action, including the prefix
@@ -2956,6 +2980,7 @@ impl Keys {
         }
         let prefix = self.prefix;
         self.bindings.retain(|(chord, action)| *action == Action::SendPrefix || *chord != prefix);
+        self.rebuild_dispatch_maps();
     }
 
     #[cfg(test)]
@@ -3921,6 +3946,7 @@ fn bind_user_command_chords(
             }
         }
     }
+    keys.rebuild_dispatch_maps();
 }
 
 fn normalize_ssh_machine_port(id: &str, port: Option<u16>) -> Option<u16> {


### PR DESCRIPTION
### Summary
- add behavior coverage for key dispatch refresh and modeless fallback
- cache canonical action and modeless bindings on config changes
- preserve first-binding precedence with HashMap entry insertion

### Verification
- rustfmt --check --edition 2024 cmux-tui/crates/cmux-tui/src/config.rs
- git diff --check
- Cargo tests not run per task instructions

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11687"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790949650&installation_model_id=21920&pr_number=11687&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11687&signature=c3147513d8747103ec60c22970b4b271b7ee6a9a99840a86d70a27d908dbca58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches key dispatch lookups in the `cmux-tui` TUI so key events no longer scan all bindings on every press. Previously every key event iterated the full bindings list; now dispatch uses pre-built maps rebuilt on config changes, preserving first-binding precedence. Adds tests covering dispatch refresh and modeless fallback.

<sup>Written for commit f1e2d3ff2d1ed0925893b5c14874d5c528b6af66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11687?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

