### PR TITLE
perf(cmux-tui): index TreeView surface locations

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13150,8 +13150,8 @@ impl App {
         }
 
         let shifted_tabs = {
-            let pane =
-                &mut self.tree.workspaces[workspace_index].screens[screen_index].panes[pane_index];
+            let pane = &mut self.tree.workspaces_mut()[workspace_index].screens[screen_index].panes
+                [pane_index];
             pane.tabs.remove(tab_index);
             adjust_active_tab_after_removal(pane, tab_index);
             pane.tabs
@@ -13175,7 +13175,7 @@ impl App {
     /// This path is defensive only. Normal surface exits use the indexed path
     /// above and touch one pane instead of scanning the entire topology.
     fn remove_surface_from_cached_tree_scan_and_rebuild_locations(&mut self, surface: SurfaceId) {
-        for workspace in &mut self.tree.workspaces {
+        for workspace in self.tree.workspaces_mut() {
             for screen in &mut workspace.screens {
                 for pane in &mut screen.panes {
                     let Some(index) = pane.tabs.iter().position(|tab| tab.surface == surface)

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13128,6 +13128,7 @@ impl App {
     /// topology refresh arrives. The backend projection still owns parent
     /// pane, screen, and workspace collapse.
     fn remove_surface_from_cached_tree(&mut self, surface: SurfaceId) {
+        self.tree.invalidate_location_index();
         let Some([workspace_index, screen_index, pane_index, tab_index]) =
             self.tab_locations.get(&surface).copied()
         else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -39805,6 +39805,7 @@ mod tests {
                     }],
                 }],
             }],
+            ..TreeView::default()
         }
     }
 
@@ -45489,6 +45490,7 @@ mod tests {
                     }],
                 }],
             }],
+            ..TreeView::default()
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2532,7 +2532,7 @@ impl OrderedSession {
             return;
         }
         self.retired_surfaces.lock().unwrap().retain(|surface| {
-            tree.workspaces
+            tree.workspaces()
                 .iter()
                 .flat_map(|workspace| workspace.screens.iter())
                 .flat_map(|screen| screen.panes.iter())
@@ -6851,7 +6851,7 @@ impl PaneFocusHistory {
 
     fn reconcile_membership(&mut self, tree: &TreeView) {
         let live = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -6860,7 +6860,7 @@ impl PaneFocusHistory {
         self.recency.retain(|pane, _| live.contains(pane));
         self.baseline.retain(|pane, _| live.contains(pane));
         for pane in tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -7219,7 +7219,7 @@ fn client_focus_identity() -> Option<String> {
 
 fn preserve_client_view(previous: &TreeView, next: &mut TreeView) {
     let workspace_indices = next
-        .workspaces
+        .workspaces()
         .iter()
         .enumerate()
         .map(|(index, workspace)| (workspace.id, index))
@@ -7230,12 +7230,12 @@ fn preserve_client_view(previous: &TreeView, next: &mut TreeView) {
         next.active_workspace = index;
     }
 
-    for previous_workspace in &previous.workspaces {
+    for previous_workspace in previous.workspaces() {
         let Some(next_workspace_index) = workspace_indices.get(&previous_workspace.id).copied()
         else {
             continue;
         };
-        let next_workspace = &mut next.workspaces[next_workspace_index];
+        let next_workspace = &mut next.workspaces_mut()[next_workspace_index];
         let screen_indices = next_workspace
             .screens
             .iter()
@@ -10178,8 +10178,8 @@ impl App {
             return Vec::new();
         }
         let workspace_index =
-            self.sidebar_workspace_selection.min(self.tree.workspaces.len().saturating_sub(1));
-        let Some(workspace) = self.tree.workspaces.get(workspace_index) else {
+            self.sidebar_workspace_selection.min(self.tree.workspaces().len().saturating_sub(1));
+        let Some(workspace) = self.tree.workspaces().get(workspace_index) else {
             return Vec::new();
         };
         workspace
@@ -10244,7 +10244,7 @@ impl App {
     }
 
     fn activate_workspace(&mut self, index: usize) {
-        if index >= self.tree.workspaces.len() || !self.prepare_pty_input_before_mutation() {
+        if index >= self.tree.workspaces().len() || !self.prepare_pty_input_before_mutation() {
             return;
         }
         self.follow_sidebar_workspace(index);
@@ -10263,7 +10263,7 @@ impl App {
                 }
                 self.follow_sidebar_workspace(workspace);
                 self.tree.active_workspace = workspace;
-                if let Some(workspace_view) = self.tree.workspaces.get_mut(workspace) {
+                if let Some(workspace_view) = self.tree.workspaces_mut().get_mut(workspace) {
                     workspace_view.active_screen = screen;
                     if let Some(screen_view) = workspace_view.screens.get_mut(screen) {
                         screen_view.active_pane = pane;
@@ -11257,7 +11257,7 @@ impl App {
         };
         let Some(workspace_id) = self
             .tree
-            .workspaces
+            .workspaces()
             .iter()
             .find(|workspace| workspace.key == workspace_key)
             .map(|workspace| workspace.id)
@@ -11726,7 +11726,7 @@ impl App {
         self.sidebar_files =
             FileBrowser::new(std::env::current_dir().unwrap_or_else(|_| PathBuf::from(".")));
         self.sidebar_workspace_selection =
-            self.tree.active_workspace.min(self.tree.workspaces.len().saturating_sub(1));
+            self.tree.active_workspace.min(self.tree.workspaces().len().saturating_sub(1));
         self.sidebar_recoverable_workspace_selection = 0;
         self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
         self.tabs_rail_selection = 0;
@@ -12756,7 +12756,7 @@ impl App {
                     .get(&surface)
                     .and_then(|[workspace, screen, pane, _]| {
                         self.tree
-                            .workspaces
+                            .workspaces()
                             .get(*workspace)
                             .and_then(|workspace| workspace.screens.get(*screen))
                             .and_then(|screen| screen.panes.get(*pane))
@@ -12838,7 +12838,7 @@ impl App {
             return;
         };
         self.tree.active_workspace = workspace_index;
-        let Some(workspace) = self.tree.workspaces.get_mut(workspace_index) else { return };
+        let Some(workspace) = self.tree.workspaces_mut().get_mut(workspace_index) else { return };
         workspace.active_screen = screen_index;
         let Some(screen) = workspace.screens.get_mut(screen_index) else { return };
         let Some(pane_id) = screen.panes.get(pane_index).map(|pane| pane.id) else { return };
@@ -12942,7 +12942,7 @@ impl App {
             };
             let Some(tab) = self
                 .tree
-                .workspaces
+                .workspaces_mut()
                 .get_mut(workspace)
                 .and_then(|workspace| workspace.screens.get_mut(screen))
                 .and_then(|screen| screen.panes.get_mut(pane))
@@ -12962,7 +12962,7 @@ impl App {
         let previous_active = self.active_pane();
         let selected_workspace = self
             .tree
-            .workspaces
+            .workspaces()
             .get(self.sidebar_workspace_selection)
             .map(|workspace| workspace.id);
         preserve_client_view(&self.tree, &mut tree);
@@ -12981,7 +12981,7 @@ impl App {
             self.quit = true;
         }
         let live_browsers = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -12991,7 +12991,7 @@ impl App {
             .collect::<HashSet<_>>();
         let removed_browsers = self
             .tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -13004,7 +13004,7 @@ impl App {
             self.browser_input.forget_surface(surface);
         }
         let live_screens = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .map(|screen| screen.id)
@@ -13014,10 +13014,10 @@ impl App {
         self.tree = tree;
         self.sidebar_workspace_selection = selected_workspace
             .and_then(|selected| {
-                self.tree.workspaces.iter().position(|workspace| workspace.id == selected)
+                self.tree.workspaces().iter().position(|workspace| workspace.id == selected)
             })
             .unwrap_or_else(|| {
-                self.sidebar_workspace_selection.min(self.tree.workspaces.len().saturating_sub(1))
+                self.sidebar_workspace_selection.min(self.tree.workspaces().len().saturating_sub(1))
             });
         if self.active_pane() != previous_active
             && let Some(active) = self.active_pane()
@@ -13038,7 +13038,7 @@ impl App {
             self.pane_focus_history.sync_membership(&tree);
         }
         let live_surfaces = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -13110,7 +13110,7 @@ impl App {
 
     fn rebuild_tab_locations(&mut self) {
         self.tab_locations.clear();
-        for (workspace_index, workspace) in self.tree.workspaces.iter().enumerate() {
+        for (workspace_index, workspace) in self.tree.workspaces().iter().enumerate() {
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
                 for (pane_index, pane) in screen.panes.iter().enumerate() {
                     for (tab_index, tab) in pane.tabs.iter().enumerate() {
@@ -13138,7 +13138,7 @@ impl App {
 
         let location_is_current = self
             .tree
-            .workspaces
+            .workspaces()
             .get(workspace_index)
             .and_then(|workspace| workspace.screens.get(screen_index))
             .and_then(|screen| screen.panes.get(pane_index))
@@ -14376,8 +14376,9 @@ impl App {
         self.replace_tree(self.session.tree());
         self.claim_active_terminal_geometry(false);
         if self.surface_only.is_none() {
-            self.sidebar_workspace_selection =
-                self.sidebar_workspace_selection.min(self.tree.workspaces.len().saturating_sub(1));
+            self.sidebar_workspace_selection = self
+                .sidebar_workspace_selection
+                .min(self.tree.workspaces().len().saturating_sub(1));
             self.sync_sidebar_files_to_focus(false);
         }
         self.pane_areas.clear();
@@ -15083,7 +15084,7 @@ impl App {
                 }
                 match result {
                     Ok(tree) => {
-                        let empty = tree.workspaces.is_empty();
+                        let empty = tree.workspaces().is_empty();
                         self.replace_authoritative_tree(tree, destination_generation);
                         self.session.refresh_clients_background();
                         if empty {
@@ -16512,7 +16513,7 @@ impl App {
     fn pane_for_surface(&self, surface: SurfaceId) -> Option<PaneId> {
         let [workspace, screen, pane, _] = self.tab_locations.get(&surface).copied()?;
         self.tree
-            .workspaces
+            .workspaces()
             .get(workspace)?
             .screens
             .get(screen)?
@@ -16533,7 +16534,7 @@ impl App {
         let Some(client_id) = self.client_focus_id.clone() else { return };
         let Some(focus) = self.session.client_focus(&client_id) else { return };
         let mut location = None;
-        for (workspace_index, workspace) in self.tree.workspaces.iter().enumerate() {
+        for (workspace_index, workspace) in self.tree.workspaces().iter().enumerate() {
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
                 if let Some(pane) = screen.panes.iter().find(|pane| pane.id == focus.pane) {
                     let tab = focus.tab.min(pane.tabs.len().saturating_sub(1));
@@ -16543,7 +16544,7 @@ impl App {
         }
         let Some((workspace_index, screen_index, pane_id, tab_index)) = location else { return };
         self.tree.active_workspace = workspace_index;
-        if let Some(workspace) = self.tree.workspaces.get_mut(workspace_index) {
+        if let Some(workspace) = self.tree.workspaces_mut().get_mut(workspace_index) {
             workspace.active_screen = screen_index;
             if let Some(screen) = workspace.screens.get_mut(screen_index) {
                 screen.active_pane = pane_id;
@@ -16553,7 +16554,7 @@ impl App {
             }
         }
         self.sidebar_workspace_selection =
-            workspace_index.min(self.tree.workspaces.len().saturating_sub(1));
+            workspace_index.min(self.tree.workspaces().len().saturating_sub(1));
         self.pane_focus_history.record(pane_id);
         self.reported_focus = Some(crate::session::ClientFocus { pane: pane_id, tab: tab_index });
     }
@@ -17803,7 +17804,7 @@ impl App {
     ) -> Option<ManagedWorkspaceDescriptor> {
         let workspace_key = self
             .tree
-            .workspaces
+            .workspaces()
             .iter()
             .find(|workspace| workspace.id == workspace_id)?
             .key
@@ -17946,7 +17947,7 @@ impl App {
     fn workspace_rail_targets(&self) -> Vec<WorkspaceRailTarget> {
         let mut targets = self
             .tree
-            .workspaces
+            .workspaces()
             .iter()
             .map(|workspace| WorkspaceRailTarget::Workspace(workspace.id))
             .collect::<Vec<_>>();
@@ -17969,7 +17970,7 @@ impl App {
         match self.workspace_rail_selection {
             WorkspaceRailSelection::Workspace => self
                 .tree
-                .workspaces
+                .workspaces()
                 .get(self.sidebar_workspace_selection)
                 .map(|workspace| WorkspaceRailTarget::Workspace(workspace.id)),
             WorkspaceRailSelection::Recoverable => self
@@ -17989,7 +17990,7 @@ impl App {
         match target {
             WorkspaceRailTarget::Workspace(id) => {
                 if let Some(index) =
-                    self.tree.workspaces.iter().position(|workspace| workspace.id == id)
+                    self.tree.workspaces().iter().position(|workspace| workspace.id == id)
                 {
                     if self.sidebar_workspace_selection != index {
                         self.tabs_rail_selection = 0;
@@ -18846,8 +18847,11 @@ impl App {
                 } else if key.code == KeyCode::Enter {
                     match targets.get(current).cloned() {
                         Some(WorkspaceRailTarget::Workspace(id)) => {
-                            if let Some(index) =
-                                self.tree.workspaces.iter().position(|workspace| workspace.id == id)
+                            if let Some(index) = self
+                                .tree
+                                .workspaces()
+                                .iter()
+                                .position(|workspace| workspace.id == id)
                             {
                                 self.select_workspace_for_client(Some(index), None);
                                 self.focus = FocusTarget::Pane;
@@ -19773,7 +19777,7 @@ impl App {
     fn open_rename_surface_prompt(&mut self, surface: SurfaceId) {
         let Some(buffer) = self
             .tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -19802,7 +19806,7 @@ impl App {
     fn open_rename_workspace_prompt_for(&mut self, workspace_id: WorkspaceId) {
         let Some(buffer) = self
             .tree
-            .workspaces
+            .workspaces()
             .iter()
             .find(|ws| ws.id == workspace_id)
             .map(|workspace| workspace.name.clone())
@@ -20109,8 +20113,12 @@ impl App {
                 ));
             }
             MenuAction::CopyWorkspaceId(id) => {
-                if let Some(short_id) =
-                    self.tree.workspaces.iter().find(|ws| ws.id == id).map(|ws| ws.short_id.clone())
+                if let Some(short_id) = self
+                    .tree
+                    .workspaces()
+                    .iter()
+                    .find(|ws| ws.id == id)
+                    .map(|ws| ws.short_id.clone())
                 {
                     self.copy_short_id(short_id);
                 }
@@ -20118,7 +20126,7 @@ impl App {
             MenuAction::RenameScreen(id) => {
                 let buffer = self
                     .tree
-                    .workspaces
+                    .workspaces()
                     .iter()
                     .flat_map(|ws| ws.screens.iter())
                     .find(|s| s.id == id)
@@ -20743,7 +20751,7 @@ impl App {
         {
             return None;
         }
-        let len = self.tree.workspaces.len();
+        let len = self.tree.workspaces().len();
         for index in 0..len {
             let start = area.y + 2 + index as u16 * 3;
             if y < start {
@@ -20758,7 +20766,7 @@ impl App {
 
     fn tab_location(&self, surface: SurfaceId) -> Option<(PaneId, usize)> {
         self.tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|ws| ws.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -21819,13 +21827,13 @@ impl App {
 
     fn select_workspace_for_client(&mut self, index: Option<usize>, delta: Option<isize>) {
         let mut selected = false;
-        if !self.tree.workspaces.is_empty() {
-            if let Some(index) = index.filter(|index| *index < self.tree.workspaces.len()) {
+        if !self.tree.workspaces().is_empty() {
+            if let Some(index) = index.filter(|index| *index < self.tree.workspaces().len()) {
                 self.tree.active_workspace = index;
                 selected = true;
             } else if let Some(delta) = delta {
                 self.tree.active_workspace = ((self.tree.active_workspace as isize + delta)
-                    .rem_euclid(self.tree.workspaces.len() as isize))
+                    .rem_euclid(self.tree.workspaces().len() as isize))
                     as usize;
                 selected = true;
             }
@@ -24011,7 +24019,7 @@ impl App {
             .get(&surface)
             .and_then(|[workspace, screen, pane, tab]| {
                 self.tree
-                    .workspaces
+                    .workspaces()
                     .get(*workspace)
                     .and_then(|workspace| workspace.screens.get(*screen))
                     .and_then(|screen| screen.panes.get(*pane))
@@ -24023,7 +24031,7 @@ impl App {
 
     fn browser_source(&self, surface: SurfaceId) -> Option<BrowserSource> {
         self.tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|ws| ws.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -25627,9 +25635,9 @@ mod tests {
         app.activate_menu(MenuAction::ShowShortcuts).unwrap();
         assert!(app.shortcut_help.is_some());
 
-        let mut inactive_workspace = app.tree.workspaces[0].clone();
+        let mut inactive_workspace = app.tree.workspaces_mut()[0].clone();
         inactive_workspace.id = 14;
-        app.tree.workspaces.push(inactive_workspace);
+        app.tree.workspaces_mut().push(inactive_workspace);
         app.hits.clear();
         app.hits.push((
             Rect { x: 2, y: 6, width: 10, height: 1 },
@@ -25647,7 +25655,7 @@ mod tests {
 
         let mut inactive_screen = app.tree.active_screen().unwrap().clone();
         inactive_screen.id = 13;
-        app.tree.workspaces[0].screens.push(inactive_screen);
+        app.tree.workspaces_mut()[0].screens.push(inactive_screen);
         app.hits.clear();
         app.hits.push((
             Rect { x: 30, y: 30, width: 10, height: 1 },
@@ -25666,7 +25674,7 @@ mod tests {
         let mut inactive_pane = app.tree.active_screen().unwrap().panes[0].clone();
         inactive_pane.id = 12;
         inactive_pane.tabs[0].surface = 51;
-        app.tree.workspaces[0].screens[0].panes.push(inactive_pane);
+        app.tree.workspaces_mut()[0].screens[0].panes.push(inactive_pane);
         app.pane_areas.push(PaneArea {
             pane: 12,
             surface: 51,
@@ -26368,7 +26376,7 @@ mod tests {
             }
         }
         let tree = app.session.tree();
-        assert_eq!(tree.workspaces[0].screens[0].panes.len(), 1);
+        assert_eq!(tree.workspaces()[0].screens[0].panes.len(), 1);
         assert_eq!(tree.active_surface(), Some(original.id));
         mux.close_surface(original.id).unwrap();
     }
@@ -27208,7 +27216,7 @@ mod tests {
     fn pane_focus_history_overlays_authoritative_recency() {
         let mut history = PaneFocusHistory::default();
         let mut tree = notify_tree(1, false);
-        tree.workspaces[0].screens[0].panes[0].focused_at = 8;
+        tree.workspaces_mut()[0].screens[0].panes[0].focused_at = 8;
         history.reconcile_membership(&tree);
 
         assert_eq!(history.recency(2), (false, 8));
@@ -27233,11 +27241,11 @@ mod tests {
     fn pane_focus_history_freezes_remote_baseline_until_membership_changes() {
         let mut history = PaneFocusHistory::default();
         let mut initial = notify_tree(1, false);
-        initial.workspaces[0].screens[0].panes[0].focused_at = 8;
+        initial.workspaces_mut()[0].screens[0].panes[0].focused_at = 8;
         history.reconcile_membership(&initial);
 
         let mut peer_refresh = initial.clone();
-        peer_refresh.workspaces[0].screens[0].panes[0].focused_at = 99;
+        peer_refresh.workspaces_mut()[0].screens[0].panes[0].focused_at = 99;
         history.sync_membership(&peer_refresh);
 
         assert_eq!(history.recency(2), (false, 8));
@@ -27250,7 +27258,7 @@ mod tests {
         history.reconcile_membership(&notify_tree(1, false));
 
         let mut replacement = notify_tree(2, false);
-        let screen = &mut replacement.workspaces[0].screens[0];
+        let screen = &mut replacement.workspaces_mut()[0].screens[0];
         screen.active_pane = 99;
         screen.layout = Node::Leaf(99);
         screen.panes[0].id = 99;
@@ -28931,7 +28939,7 @@ mod tests {
         app.select_workspace_for_client(Some(1), None);
         // The report records the session's last focus for later attaches and
         // leaves the live shared focus alone, so attached clients stay put.
-        let second_pane = app.tree.workspaces[1].screens[0].active_pane;
+        let second_pane = app.tree.workspaces()[1].screens[0].active_pane;
         assert_eq!(mux.with_state(|state| state.active_workspace), 0);
         assert_eq!(mux.session_focus(), Some((second_pane, Some(0))));
 
@@ -34678,7 +34686,7 @@ mod tests {
         let mux = Mux::new("cached-surface-exit-index-test", SurfaceOptions::default());
         let mut app = test_app(Session::Local(mux));
         let mut tree = notify_tree(41, false);
-        let pane = &mut tree.workspaces[0].screens[0].panes[0];
+        let pane = &mut tree.workspaces_mut()[0].screens[0].panes[0];
         let mut second = pane.tabs[0].clone();
         second.surface = 41;
         let mut third = pane.tabs[0].clone();
@@ -34692,7 +34700,7 @@ mod tests {
 
         app.remove_surface_from_cached_tree(40);
 
-        let pane = &app.tree.workspaces[0].screens[0].panes[0];
+        let pane = &app.tree.workspaces()[0].screens[0].panes[0];
         assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![41, 43]);
         assert_eq!(pane.active_tab, 0);
         assert!(!app.tab_locations.contains_key(&40));
@@ -34708,7 +34716,7 @@ mod tests {
         let mux = Mux::new("stale-surface-exit-index-test", SurfaceOptions::default());
         let mut app = test_app(Session::Local(mux));
         let mut tree = notify_tree(41, false);
-        let pane = &mut tree.workspaces[0].screens[0].panes[0];
+        let pane = &mut tree.workspaces_mut()[0].screens[0].panes[0];
         let mut second = pane.tabs[0].clone();
         second.surface = 41;
         let mut third = pane.tabs[0].clone();
@@ -34723,7 +34731,7 @@ mod tests {
         app.tab_locations.insert(40, [0, 0, 0, 1]);
         app.remove_surface_from_cached_tree(40);
 
-        let pane = &app.tree.workspaces[0].screens[0].panes[0];
+        let pane = &app.tree.workspaces()[0].screens[0].panes[0];
         assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![41, 43]);
         assert_eq!(pane.active_tab, 1);
         assert_eq!(app.tab_locations.get(&41), Some(&[0, 0, 0, 0]));
@@ -34733,7 +34741,7 @@ mod tests {
         // The fallback must repair the index so the next exit uses the
         // indexed path instead of scanning the whole tree again.
         app.remove_surface_from_cached_tree(41);
-        let pane = &app.tree.workspaces[0].screens[0].panes[0];
+        let pane = &app.tree.workspaces()[0].screens[0].panes[0];
         assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![43]);
         assert_eq!(app.tab_locations.get(&43), Some(&[0, 0, 0, 0]));
         assert!(!app.tab_locations.contains_key(&41));
@@ -36113,7 +36121,7 @@ mod tests {
             refresh_sequence: 1,
         }))
         .unwrap();
-        assert_eq!(app.tree.workspaces[0].screens[0].panes[0].tabs[0].surface, 22);
+        assert_eq!(app.tree.workspaces()[0].screens[0].panes[0].tabs[0].surface, 22);
         assert_eq!(app.pointer_route_phase, PointerRoutePhase::DrawPending);
         assert_eq!(app.deferred_input.len(), 1);
 
@@ -36132,7 +36140,7 @@ mod tests {
             result: Ok(older),
         })
         .unwrap();
-        assert_eq!(app.tree.workspaces[0].screens[0].panes[0].tabs[0].surface, 22);
+        assert_eq!(app.tree.workspaces()[0].screens[0].panes[0].tabs[0].surface, 22);
     }
 
     #[test]
@@ -36415,7 +36423,7 @@ mod tests {
             RenderAction::Draw
         );
         assert!(!app.tab_locations.contains_key(&surface));
-        assert!(app.tree.workspaces[0].screens[0].panes[0].tabs.is_empty());
+        assert!(app.tree.workspaces()[0].screens[0].panes[0].tabs.is_empty());
         assert!(!app.rendered_terminal_sizes.contains_key(&surface));
         assert!(!app.rendered_terminal_bounds.contains_key(&surface));
 
@@ -41110,7 +41118,7 @@ mod tests {
         );
 
         app.machine_ui.as_mut().unwrap().request = None;
-        app.tree.workspaces[0].key = "local-workspace".into();
+        app.tree.workspaces_mut()[0].key = "local-workspace".into();
         app.open_rename_workspace_prompt_for(4);
         assert!(app.prompt.is_none());
         assert!(app.status_message.is_some());
@@ -41534,7 +41542,7 @@ mod tests {
         app.replace_tree(app.session.tree());
         app.apply_machine_ui_update(provider_machine_ui_with_lifecycle());
         let stale_key = "00000000-0000-4000-8000-000000000099";
-        app.tree.workspaces[0].key = stale_key.into();
+        app.tree.workspaces_mut()[0].key = stale_key.into();
 
         app.apply_managed_workspace_session_mutation(ManagedWorkspaceSessionMutation::Rename {
             workspace_key: stale_key.into(),
@@ -41549,7 +41557,7 @@ mod tests {
             app.status_message.as_deref(),
             Some(localization::catalog().session.operation_failed)
         );
-        assert!(app.tree.workspaces.iter().any(|workspace| workspace.id == placement.workspace));
+        assert!(app.tree.workspaces().iter().any(|workspace| workspace.id == placement.workspace));
     }
 
     #[test]
@@ -42128,7 +42136,7 @@ mod tests {
             Some(&unavailable),
         )
         .unwrap();
-        assert!(Session::Local(mux.clone()).tree().workspaces.is_empty());
+        assert!(Session::Local(mux.clone()).tree().workspaces().is_empty());
 
         let mut app = test_app(Session::Local(mux));
         app.sidebar_view = SidebarView::Workspaces;
@@ -42338,7 +42346,7 @@ mod tests {
             Some(&ui),
         )
         .unwrap();
-        assert!(Session::Local(mux).tree().workspaces.is_empty());
+        assert!(Session::Local(mux).tree().workspaces().is_empty());
     }
 
     #[test]
@@ -42353,7 +42361,7 @@ mod tests {
 
         app.run_action(Action::NewScreen).unwrap();
 
-        assert!(Session::Local(mux).tree().workspaces.is_empty());
+        assert!(Session::Local(mux).tree().workspaces().is_empty());
         assert_eq!(
             app.status_message.as_deref(),
             Some(localization::catalog().sidebar.no_active_session)
@@ -42373,7 +42381,7 @@ mod tests {
             Some(MachineRequest::CreateManagedIsolatedWorkspace(MachineKey(41)))
         ));
         assert!(!app.quit);
-        assert!(Session::Local(mux).tree().workspaces.is_empty());
+        assert!(Session::Local(mux).tree().workspaces().is_empty());
     }
 
     #[test]
@@ -43250,7 +43258,7 @@ mod tests {
 
         let tree = app.session.tree();
         let renamed = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -43299,7 +43307,7 @@ mod tests {
 
         let tree = app.session.tree();
         let renamed = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -43608,7 +43616,7 @@ mod tests {
         app.replace_tree(app.session.tree());
         app.sidebar_workspace_selection = 1;
         app.workspace_rail_scroll = 3;
-        let selected_workspace = app.tree.workspaces[1].id;
+        let selected_workspace = app.tree.workspaces()[1].id;
         let mut initial = MachineUiState::new(MachineSnapshot {
             machines: vec![descriptor(1), descriptor(2), descriptor(3)],
             active: Some(MachineKey(1)),
@@ -43625,7 +43633,7 @@ mod tests {
         });
         app.apply_machine_ui_update(update);
         let mut reordered = app.tree.clone();
-        reordered.workspaces.swap(0, 1);
+        reordered.workspaces_mut().swap(0, 1);
         app.replace_tree(reordered);
 
         assert_eq!(
@@ -43633,7 +43641,7 @@ mod tests {
             Some(crate::machine::MachineRailTarget::Machine(MachineKey(2)))
         );
         assert_eq!(app.machine_rail_scroll, 6);
-        assert_eq!(app.tree.workspaces[app.sidebar_workspace_selection].id, selected_workspace);
+        assert_eq!(app.tree.workspaces()[app.sidebar_workspace_selection].id, selected_workspace);
         assert_eq!(app.workspace_rail_scroll, 3);
     }
 
@@ -44635,7 +44643,7 @@ mod tests {
         mux.new_workspace(None, None).unwrap();
         let (mut app, events) = test_app_with_events(Session::Local(mux));
         app.replace_tree(app.session.tree());
-        let original_workspace_count = app.tree.workspaces.len();
+        let original_workspace_count = app.tree.workspaces().len();
         let original_surface = app.tree.active_surface();
         app.machine_ui = Some(provider_machine_ui());
         app.sidebar_width_override = Some(25);
@@ -44651,7 +44659,7 @@ mod tests {
         settle_machine_action(&mut app, &events);
 
         assert_eq!(app.session_generation, 1);
-        assert_eq!(app.tree.workspaces.len(), original_workspace_count);
+        assert_eq!(app.tree.workspaces().len(), original_workspace_count);
         assert_eq!(app.tree.active_surface(), original_surface);
         assert_eq!(app.sidebar_width_override, Some(25));
         assert_eq!(app.machine_sidebar_width_override, Some(17));
@@ -44669,7 +44677,7 @@ mod tests {
         mux.new_workspace(None, None).unwrap();
         let (mut app, events) = test_app_with_events(Session::Local(mux));
         app.replace_tree(app.session.tree());
-        let original_workspace_count = app.tree.workspaces.len();
+        let original_workspace_count = app.tree.workspaces().len();
         let original_surface = app.tree.active_surface();
         app.machine_ui = Some(provider_machine_ui());
         let (controller, _) = fake_controller(FakeMachineAction::Fail("candidate refused"));
@@ -44680,7 +44688,7 @@ mod tests {
 
         assert_eq!(app.session_generation, 1);
         assert_eq!(app.session_label, "test");
-        assert_eq!(app.tree.workspaces.len(), original_workspace_count);
+        assert_eq!(app.tree.workspaces().len(), original_workspace_count);
         assert_eq!(app.tree.active_surface(), original_surface);
         let expected =
             format!("{}: candidate refused", localization::catalog().sidebar.machine_action_failed);
@@ -45504,17 +45512,17 @@ mod tests {
     #[test]
     fn remote_tree_refresh_preserves_this_clients_tab() {
         let mut previous = notify_tree(11, false);
-        let pane = &mut previous.workspaces[0].screens[0].panes[0];
+        let pane = &mut previous.workspaces_mut()[0].screens[0].panes[0];
         let mut second = pane.tabs[0].clone();
         second.surface = 12;
         pane.tabs.push(second);
         pane.active_tab = 0;
 
         let mut other_client_selection = previous.clone();
-        other_client_selection.workspaces[0].screens[0].panes[0].active_tab = 1;
+        other_client_selection.workspaces_mut()[0].screens[0].panes[0].active_tab = 1;
         preserve_client_view(&previous, &mut other_client_selection);
         assert_eq!(
-            other_client_selection.workspaces[0].screens[0].panes[0].active_surface(),
+            other_client_selection.workspaces()[0].screens[0].panes[0].active_surface(),
             Some(11)
         );
     }
@@ -45523,7 +45531,7 @@ mod tests {
     fn remote_tree_refresh_scales_to_one_thousand_workspaces() {
         let mut previous = TreeView::default();
         for index in 0..1_000_u64 {
-            let mut workspace = notify_tree(40_000 + index * 2, false).workspaces.remove(0);
+            let mut workspace = notify_tree(40_000 + index * 2, false).workspaces_mut().remove(0);
             workspace.id = 10_000 + index;
             workspace.key = format!("workspace-{index}");
             let screen = &mut workspace.screens[0];
@@ -45536,13 +45544,13 @@ mod tests {
             second.surface += 1;
             pane.tabs.push(second);
             pane.active_tab = (index % 2) as usize;
-            previous.workspaces.push(workspace);
+            previous.workspaces_mut().push(workspace);
         }
         previous.active_workspace = 999;
 
         let expected_active_workspace = previous.active_workspace().unwrap().id;
         let expected_surfaces = previous
-            .workspaces
+            .workspaces()
             .iter()
             .map(|workspace| {
                 let pane = &workspace.screens[0].panes[0];
@@ -45550,16 +45558,16 @@ mod tests {
             })
             .collect::<HashMap<_, _>>();
         let mut refreshed = previous.clone();
-        refreshed.workspaces.reverse();
+        refreshed.workspaces_mut().reverse();
         refreshed.active_workspace = 0;
-        for workspace in &mut refreshed.workspaces {
+        for workspace in refreshed.workspaces_mut() {
             workspace.screens[0].panes[0].active_tab ^= 1;
         }
 
         preserve_client_view(&previous, &mut refreshed);
 
         assert_eq!(refreshed.active_workspace().unwrap().id, expected_active_workspace);
-        for workspace in &refreshed.workspaces {
+        for workspace in &refreshed.workspaces() {
             let pane = &workspace.screens[0].panes[0];
             assert_eq!(pane.active_surface(), expected_surfaces.get(&workspace.id).copied());
         }
@@ -45581,7 +45589,7 @@ mod tests {
     #[test]
     fn remote_tree_refresh_keeps_restored_zoom_and_focus_aligned() {
         let mut previous = notify_tree(11, false);
-        let screen = &mut previous.workspaces[0].screens[0];
+        let screen = &mut previous.workspaces_mut()[0].screens[0];
         let mut second = screen.panes[0].clone();
         second.id = 5;
         second.tabs[0].surface = 12;
@@ -45596,13 +45604,13 @@ mod tests {
         screen.active_pane = 5;
 
         let mut restored = previous.clone();
-        let restored_screen = &mut restored.workspaces[0].screens[0];
+        let restored_screen = &mut restored.workspaces_mut()[0].screens[0];
         restored_screen.zoomed_pane = Some(2);
         restored_screen.active_pane = 2;
 
         preserve_client_view(&previous, &mut restored);
 
-        let restored_screen = &restored.workspaces[0].screens[0];
+        let restored_screen = &restored.workspaces()[0].screens[0];
         assert_eq!(restored_screen.zoomed_pane, Some(2));
         assert_eq!(restored_screen.active_pane, 2);
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -28541,6 +28541,7 @@ mod tests {
             workspace_revision: 1,
             pane_revision: Some(1),
             active_workspace: 0,
+            ..TreeView::default()
         };
 
         app.reclip_viewport_panes();
@@ -28743,6 +28744,7 @@ mod tests {
             workspace_revision: 1,
             pane_revision: Some(1),
             active_workspace: 0,
+            ..TreeView::default()
         };
         let started_at = Instant::now();
         let mut motion = ViewportMotion::new(started_at);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -34687,6 +34687,7 @@ mod tests {
         pane.tabs.push(third);
         pane.active_tab = 1;
         app.replace_tree(tree);
+        assert_eq!(app.tree.surface(40).map(|tab| tab.surface), Some(40));
 
         app.remove_surface_from_cached_tree(40);
 
@@ -34696,6 +34697,9 @@ mod tests {
         assert!(!app.tab_locations.contains_key(&40));
         assert_eq!(app.tab_locations.get(&41), Some(&[0, 0, 0, 0]));
         assert_eq!(app.tab_locations.get(&43), Some(&[0, 0, 0, 1]));
+        assert!(app.tree.surface(40).is_none());
+        assert_eq!(app.tree.surface(41).map(|tab| tab.surface), Some(41));
+        assert_eq!(app.tree.surface(43).map(|tab| tab.surface), Some(43));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -28537,8 +28537,8 @@ mod tests {
         app.content_area = Rect { x: 0, y: 0, width: 80, height: 24 };
         app.viewport_layout = layout;
         app.viewport_virtual_width = pane_count * 80;
-        app.tree = TreeView {
-            workspaces: vec![WorkspaceView {
+        app.tree = TreeView::from_parts(
+            vec![WorkspaceView {
                 id: 3,
                 resource_id: None,
                 key: "workspace".to_string(),
@@ -28547,11 +28547,10 @@ mod tests {
                 screens: vec![screen],
                 active_screen: 0,
             }],
-            workspace_revision: 1,
-            pane_revision: Some(1),
-            active_workspace: 0,
-            ..TreeView::default()
-        };
+            1,
+            Some(1),
+            0,
+        );
 
         app.reclip_viewport_panes();
         app.viewport_offset = (pane_count - 1) * 80;
@@ -28684,8 +28683,8 @@ mod tests {
             (2, VirtualRect { x: 80, y: 0, width: 53, height: 24 }),
         ];
         app.viewport_virtual_width = 133;
-        app.tree = TreeView {
-            workspaces: vec![WorkspaceView {
+        app.tree = TreeView::from_parts(
+            vec![WorkspaceView {
                 id: 3,
                 resource_id: None,
                 key: "workspace".to_string(),
@@ -28750,11 +28749,10 @@ mod tests {
                 }],
                 active_screen: 0,
             }],
-            workspace_revision: 1,
-            pane_revision: Some(1),
-            active_workspace: 0,
-            ..TreeView::default()
-        };
+            1,
+            Some(1),
+            0,
+        );
         let started_at = Instant::now();
         let mut motion = ViewportMotion::new(started_at);
         motion.retarget(53, true, started_at);
@@ -39788,11 +39786,8 @@ mod tests {
         if active_surface != created_surface {
             tabs.push(tab(active_surface));
         }
-        TreeView {
-            workspace_revision: 0,
-            pane_revision: Some(1),
-            active_workspace: 0,
-            workspaces: vec![WorkspaceView {
+        TreeView::from_parts(
+            vec![WorkspaceView {
                 id: 4,
                 resource_id: None,
                 key: "00000000-0000-4000-8000-000000000004".to_string(),
@@ -39820,8 +39815,10 @@ mod tests {
                     }],
                 }],
             }],
-            ..TreeView::default()
-        }
+            0,
+            Some(1),
+            0,
+        )
     }
 
     #[test]
@@ -45459,11 +45456,8 @@ mod tests {
     }
 
     fn notify_tree(surface: u64, unread: bool) -> TreeView {
-        TreeView {
-            workspace_revision: 0,
-            pane_revision: Some(1),
-            active_workspace: 0,
-            workspaces: vec![WorkspaceView {
+        TreeView::from_parts(
+            vec![WorkspaceView {
                 id: 4,
                 resource_id: None,
                 key: "00000000-0000-4000-8000-000000000004".to_string(),
@@ -45505,8 +45499,10 @@ mod tests {
                     }],
                 }],
             }],
-            ..TreeView::default()
-        }
+            0,
+            Some(1),
+            0,
+        )
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -34283,6 +34283,9 @@ mod tests {
         assert!(std::ptr::eq(index_before, index_after));
         assert_eq!(app.tree.pane(2).unwrap().tabs[0].title, "live-title");
 
+        assert!(app.mux_titles.push(41, "live-title".to_string()));
+        assert_eq!(app.handle(AppEvent::MuxTitlesReady).unwrap(), RenderAction::None);
+
         app.replace_tree(notify_tree(41, false));
         assert_eq!(app.tree.pane(2).unwrap().tabs[0].title, "live-title");
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -12940,18 +12940,11 @@ impl App {
             else {
                 continue;
             };
-            let Some(tab) = self
+            if self
                 .tree
-                .workspaces_mut()
-                .get_mut(workspace)
-                .and_then(|workspace| workspace.screens.get_mut(screen))
-                .and_then(|screen| screen.panes.get_mut(pane))
-                .and_then(|pane| pane.tabs.get_mut(tab))
-            else {
-                continue;
-            };
-            if tab.title.as_str() != title.as_ref() {
-                tab.title = title.to_string();
+                .update_surface_title_at(surface, [workspace, screen, pane, tab], title.to_string())
+                .is_some_and(|changed| changed)
+            {
                 changed = true;
             }
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7230,64 +7230,105 @@ fn preserve_client_view(previous: &TreeView, next: &mut TreeView) {
         next.active_workspace = index;
     }
 
+    let mut screen_updates = Vec::new();
+    let mut pane_updates = Vec::new();
+    let mut tab_updates = Vec::new();
     for previous_workspace in previous.workspaces() {
         let Some(next_workspace_index) = workspace_indices.get(&previous_workspace.id).copied()
         else {
             continue;
         };
-        let next_workspace = &mut next.workspaces_mut()[next_workspace_index];
-        let screen_indices = next_workspace
-            .screens
-            .iter()
-            .enumerate()
-            .map(|(index, screen)| (screen.id, index))
-            .collect::<HashMap<_, _>>();
+        let Some(screen_indices) = next.workspaces().get(next_workspace_index).map(|workspace| {
+            workspace
+                .screens
+                .iter()
+                .enumerate()
+                .map(|(index, screen)| (screen.id, index))
+                .collect::<HashMap<_, _>>()
+        }) else {
+            continue;
+        };
         if let Some(active) =
             previous_workspace.screens.get(previous_workspace.active_screen).map(|screen| screen.id)
             && let Some(index) = screen_indices.get(&active).copied()
         {
-            next_workspace.active_screen = index;
+            screen_updates.push((next_workspace_index, index));
         }
 
         for previous_screen in &previous_workspace.screens {
             let Some(next_screen_index) = screen_indices.get(&previous_screen.id).copied() else {
                 continue;
             };
-            let next_screen = &mut next_workspace.screens[next_screen_index];
-            let pane_indices = next_screen
-                .panes
-                .iter()
-                .enumerate()
-                .map(|(index, pane)| (pane.id, index))
-                .collect::<HashMap<_, _>>();
+            let Some((zoomed_pane, pane_indices)) = next
+                .workspaces()
+                .get(next_workspace_index)
+                .and_then(|workspace| workspace.screens.get(next_screen_index))
+                .map(|screen| {
+                    (
+                        screen.zoomed_pane,
+                        screen
+                            .panes
+                            .iter()
+                            .enumerate()
+                            .map(|(index, pane)| (pane.id, index))
+                            .collect::<HashMap<_, _>>(),
+                    )
+                })
+            else {
+                continue;
+            };
             if let Some(zoomed_pane) =
-                next_screen.zoomed_pane.filter(|zoomed| pane_indices.contains_key(zoomed))
+                zoomed_pane.filter(|zoomed| pane_indices.contains_key(zoomed))
             {
-                next_screen.active_pane = zoomed_pane;
-            } else if next_screen.zoomed_pane.is_none()
+                pane_updates.push((next_workspace_index, next_screen_index, zoomed_pane));
+            } else if zoomed_pane.is_none()
                 && pane_indices.contains_key(&previous_screen.active_pane)
             {
-                next_screen.active_pane = previous_screen.active_pane;
+                pane_updates.push((
+                    next_workspace_index,
+                    next_screen_index,
+                    previous_screen.active_pane,
+                ));
             }
 
             for previous_pane in &previous_screen.panes {
                 let Some(next_pane_index) = pane_indices.get(&previous_pane.id).copied() else {
                     continue;
                 };
-                let next_pane = &mut next_screen.panes[next_pane_index];
-                let tab_indices = next_pane
-                    .tabs
-                    .iter()
-                    .enumerate()
-                    .map(|(index, tab)| (tab.surface, index))
-                    .collect::<HashMap<_, _>>();
+                let Some((pane_id, tab_indices)) = next
+                    .workspaces()
+                    .get(next_workspace_index)
+                    .and_then(|workspace| workspace.screens.get(next_screen_index))
+                    .and_then(|screen| screen.panes.get(next_pane_index))
+                    .map(|pane| {
+                        (
+                            pane.id,
+                            pane.tabs
+                                .iter()
+                                .enumerate()
+                                .map(|(index, tab)| (tab.surface, index))
+                                .collect::<HashMap<_, _>>(),
+                        )
+                    })
+                else {
+                    continue;
+                };
                 if let Some(active) = previous_pane.active_surface()
                     && let Some(index) = tab_indices.get(&active).copied()
                 {
-                    next_pane.active_tab = index;
+                    tab_updates.push((next_workspace_index, next_screen_index, pane_id, index));
                 }
             }
         }
+    }
+    for (workspace_index, screen_index) in screen_updates {
+        next.set_active_screen(workspace_index, screen_index);
+    }
+    for (workspace_index, screen_index, pane_id) in pane_updates {
+        next.set_active_pane(workspace_index, screen_index, pane_id);
+    }
+    for (workspace_index, screen_index, pane_id, tab_index) in tab_updates {
+        next.set_active_tab(workspace_index, screen_index, pane_id, tab_index);
     }
 }
 
@@ -10263,12 +10304,8 @@ impl App {
                 }
                 self.follow_sidebar_workspace(workspace);
                 self.tree.active_workspace = workspace;
-                if let Some(workspace_view) = self.tree.workspaces_mut().get_mut(workspace) {
-                    workspace_view.active_screen = screen;
-                    if let Some(screen_view) = workspace_view.screens.get_mut(screen) {
-                        screen_view.active_pane = pane;
-                    }
-                }
+                self.tree.set_active_screen(workspace, screen);
+                self.tree.set_active_pane(workspace, screen, pane);
                 self.pane_focus_history.record(pane);
                 self.claim_active_terminal_geometry(true);
             }
@@ -12837,14 +12874,22 @@ impl App {
         else {
             return;
         };
+        let Some(pane_id) = self
+            .tree
+            .workspaces()
+            .get(workspace_index)
+            .and_then(|workspace| workspace.screens.get(screen_index))
+            .and_then(|screen| screen.panes.get(pane_index))
+            .map(|pane| pane.id)
+        else {
+            return;
+        };
         self.tree.active_workspace = workspace_index;
-        let Some(workspace) = self.tree.workspaces_mut().get_mut(workspace_index) else { return };
-        workspace.active_screen = screen_index;
-        let Some(screen) = workspace.screens.get_mut(screen_index) else { return };
-        let Some(pane_id) = screen.panes.get(pane_index).map(|pane| pane.id) else { return };
-        screen.active_pane = pane_id;
-        if let Some(pane) = screen.panes.get_mut(pane_index) {
-            pane.active_tab = tab_index;
+        if !self.tree.set_active_screen(workspace_index, screen_index)
+            || !self.tree.set_active_pane(workspace_index, screen_index, pane_id)
+            || !self.tree.set_active_tab(workspace_index, screen_index, pane_id, tab_index)
+        {
+            return;
         }
         self.pane_focus_history.record(pane_id);
         self.claim_active_terminal_geometry(true);
@@ -12942,7 +12987,7 @@ impl App {
             };
             if self
                 .tree
-                .update_surface_title_at(surface, [workspace, screen, pane, tab], title.to_string())
+                .update_surface_title_at(surface, [workspace, screen, pane, tab], title.as_ref())
                 .is_some_and(|changed| changed)
             {
                 changed = true;
@@ -16537,15 +16582,9 @@ impl App {
         }
         let Some((workspace_index, screen_index, pane_id, tab_index)) = location else { return };
         self.tree.active_workspace = workspace_index;
-        if let Some(workspace) = self.tree.workspaces_mut().get_mut(workspace_index) {
-            workspace.active_screen = screen_index;
-            if let Some(screen) = workspace.screens.get_mut(screen_index) {
-                screen.active_pane = pane_id;
-                if let Some(pane) = screen.panes.iter_mut().find(|pane| pane.id == pane_id) {
-                    pane.active_tab = tab_index;
-                }
-            }
-        }
+        self.tree.set_active_screen(workspace_index, screen_index);
+        self.tree.set_active_pane(workspace_index, screen_index, pane_id);
+        self.tree.set_active_tab(workspace_index, screen_index, pane_id, tab_index);
         self.sidebar_workspace_selection =
             workspace_index.min(self.tree.workspaces().len().saturating_sub(1));
         self.pane_focus_history.record(pane_id);
@@ -21760,14 +21799,11 @@ impl App {
 
     fn focus_pane_after_input(&mut self, pane: PaneId) {
         if self.prepare_pty_input_before_mutation() {
-            let focused = if let Some(screen) = self.tree.active_workspace_mut_screen()
-                && screen.panes.iter().any(|candidate| candidate.id == pane)
-            {
-                screen.active_pane = pane;
-                true
-            } else {
-                false
-            };
+            let workspace_index = self.tree.active_workspace;
+            let screen_index =
+                self.tree.active_workspace().map(|workspace| workspace.active_screen);
+            let focused = screen_index
+                .is_some_and(|screen| self.tree.set_active_pane(workspace_index, screen, pane));
             if focused {
                 self.pane_focus_history.record(pane);
                 self.claim_active_terminal_geometry(true);
@@ -21782,16 +21818,20 @@ impl App {
         delta: Option<isize>,
     ) {
         let pane = pane.or_else(|| self.active_pane());
-        if let Some(pane_id) = pane
-            && let Some(pane) = self.tree.pane_mut(pane_id)
-            && !pane.tabs.is_empty()
-        {
-            if let Some(index) = index.filter(|index| *index < pane.tabs.len()) {
-                pane.active_tab = index;
-            } else if let Some(delta) = delta {
-                pane.active_tab = ((pane.active_tab as isize + delta)
-                    .rem_euclid(pane.tabs.len() as isize))
-                    as usize;
+        if let Some(pane_id) = pane {
+            let target = self.tree.pane(pane_id).and_then(|pane| {
+                if pane.tabs.is_empty() {
+                    return None;
+                }
+                index.filter(|index| *index < pane.tabs.len()).or_else(|| {
+                    delta.map(|delta| {
+                        ((pane.active_tab as isize + delta).rem_euclid(pane.tabs.len() as isize))
+                            as usize
+                    })
+                })
+            });
+            if let Some(target) = target {
+                self.tree.set_pane_active_tab(pane_id, target);
             }
         }
         self.claim_active_terminal_geometry(true);
@@ -21799,18 +21839,20 @@ impl App {
 
     fn select_screen_for_client(&mut self, index: Option<usize>, delta: Option<isize>) {
         let mut selected = false;
-        if let Some(workspace) = self.tree.active_workspace_mut()
-            && !workspace.screens.is_empty()
-        {
-            if let Some(index) = index.filter(|index| *index < workspace.screens.len()) {
-                workspace.active_screen = index;
-                selected = true;
-            } else if let Some(delta) = delta {
-                workspace.active_screen = ((workspace.active_screen as isize + delta)
-                    .rem_euclid(workspace.screens.len() as isize))
-                    as usize;
-                selected = true;
+        let target = self.tree.active_workspace().and_then(|workspace| {
+            if workspace.screens.is_empty() {
+                return None;
             }
+            index.filter(|index| *index < workspace.screens.len()).or_else(|| {
+                delta.map(|delta| {
+                    ((workspace.active_screen as isize + delta)
+                        .rem_euclid(workspace.screens.len() as isize)) as usize
+                })
+            })
+        });
+        if let Some(target) = target {
+            let workspace_index = self.tree.active_workspace;
+            selected = self.tree.set_active_screen(workspace_index, target);
         }
         if selected && let Some(active) = self.active_pane() {
             self.pane_focus_history.record(active);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -34282,8 +34282,12 @@ mod tests {
         let mut app = test_app(Session::Local(mux));
 
         app.replace_tree(notify_tree(41, false));
+        assert!(app.tree.pane(2).is_some());
+        let index_before = app.tree.location_index.get().unwrap() as *const _;
         assert!(app.mux_titles.push(41, "live-title".to_string()));
         app.handle(AppEvent::MuxTitlesReady).unwrap();
+        let index_after = app.tree.location_index.get().unwrap() as *const _;
+        assert!(std::ptr::eq(index_before, index_after));
         assert_eq!(app.tree.pane(2).unwrap().tabs[0].title, "live-title");
 
         app.replace_tree(notify_tree(41, false));

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -45563,7 +45563,7 @@ mod tests {
         preserve_client_view(&previous, &mut refreshed);
 
         assert_eq!(refreshed.active_workspace().unwrap().id, expected_active_workspace);
-        for workspace in &refreshed.workspaces() {
+        for workspace in refreshed.workspaces() {
             let pane = &workspace.screens[0].panes[0];
             assert_eq!(pane.active_surface(), expected_surfaces.get(&workspace.id).copied());
         }

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -359,10 +359,10 @@ fn bootstrap_mutation_id() -> anyhow::Result<String> {
 }
 
 fn initial_bootstrap(tree: &TreeView) -> InitialBootstrap {
-    if tree.workspaces.is_empty() {
+    if tree.workspaces().is_empty() {
         return InitialBootstrap::FirstWorkspace;
     }
-    if tree.workspaces.iter().all(|workspace| workspace.screens.is_empty()) {
+    if tree.workspaces().iter().all(|workspace| workspace.screens.is_empty()) {
         return InitialBootstrap::ShellInActiveWorkspace;
     }
     InitialBootstrap::LayoutIntact
@@ -715,9 +715,9 @@ impl Session {
                     }
                     InitialBootstrap::ShellInActiveWorkspace => {
                         let workspace = tree
-                            .workspaces
+                            .workspaces()
                             .get(tree.active_workspace)
-                            .or_else(|| tree.workspaces.first())
+                            .or_else(|| tree.workspaces().first())
                             .expect("bare-session bootstrap requires at least one workspace")
                             .id;
                         mux.create_terminal_in_workspace(workspace, None, None, None, size)?;
@@ -732,7 +732,7 @@ impl Session {
                     InitialBootstrap::FirstWorkspace => {
                         remote.request(with_size(json!({"cmd": "new-workspace"}), size))?;
                         anyhow::ensure!(
-                            !remote.refresh_tree()?.workspaces.is_empty(),
+                            !remote.refresh_tree()?.workspaces().is_empty(),
                             "remote session did not expose the workspace it created"
                         );
                     }
@@ -798,7 +798,7 @@ impl Session {
                         let refreshed = remote.refresh_tree()?;
                         if let Some(create_result) = create_result {
                             let bootstrapped = refreshed
-                                .workspaces
+                                .workspaces()
                                 .iter()
                                 .any(|workspace| !workspace.screens.is_empty());
                             if !bootstrapped {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -319,7 +319,7 @@ struct AgentUpdate {
 impl RemoteTreeCache {
     fn replace(&mut self, view: TreeView, refresh_generation: u64) {
         self.surface_tabs.clear();
-        for (workspace_index, workspace) in view.workspaces.iter().enumerate() {
+        for (workspace_index, workspace) in view.workspaces().iter().enumerate() {
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
                 for (pane_index, pane) in screen.panes.iter().enumerate() {
                     for (tab_index, tab) in pane.tabs.iter().enumerate() {
@@ -364,7 +364,7 @@ impl RemoteTreeCache {
         };
         let Some(tab) = self
             .view
-            .workspaces
+            .workspaces_mut()
             .get_mut(workspace)
             .and_then(|workspace| workspace.screens.get_mut(screen))
             .and_then(|screen| screen.panes.get_mut(pane))
@@ -3500,7 +3500,7 @@ impl RemoteSession {
         );
         drop(capabilities);
         let raw_surface_ids = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -3515,7 +3515,7 @@ impl RemoteSession {
         let mut tree = tree;
         tree.retain_not_retired(&retired_surface_ids);
         let live_surface_ids = tree
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -3742,7 +3742,7 @@ fn dump_mirror(surface: &RemoteSurface) -> String {
 }
 
 fn browser_sources_from_tree(tree: &TreeView) -> HashMap<SurfaceId, BrowserSource> {
-    tree.workspaces
+    tree.workspaces()
         .iter()
         .flat_map(|ws| ws.screens.iter())
         .flat_map(|screen| screen.panes.iter())
@@ -3752,7 +3752,7 @@ fn browser_sources_from_tree(tree: &TreeView) -> HashMap<SurfaceId, BrowserSourc
 }
 
 fn browser_source_from_tree(tree: &TreeView, id: SurfaceId) -> Option<BrowserSource> {
-    tree.workspaces
+    tree.workspaces()
         .iter()
         .flat_map(|ws| ws.screens.iter())
         .flat_map(|screen| screen.panes.iter())
@@ -6154,7 +6154,7 @@ mod tests {
         session.ensure_initial(Some((80, 24))).unwrap();
 
         assert!(
-            session.tree().workspaces.iter().all(|workspace| workspace.screens.is_empty()),
+            session.tree().workspaces().iter().all(|workspace| workspace.screens.is_empty()),
             "an unguarded create must never run"
         );
     }
@@ -7918,8 +7918,8 @@ mod tests {
         );
 
         assert!(cache.update_title(4, "server title".to_string()));
-        assert_eq!(cache.view.workspaces[0].screens[0].panes[0].tabs[0].title, "server title");
-        assert_eq!(cache.view.workspaces[1].screens[0].panes[0].tabs[0].title, "other title");
+        assert_eq!(cache.view.workspaces()[0].screens[0].panes[0].tabs[0].title, "server title");
+        assert_eq!(cache.view.workspaces()[1].screens[0].panes[0].tabs[0].title, "other title");
         assert!(!cache.update_title(99, "missing".to_string()));
     }
 
@@ -7947,7 +7947,7 @@ mod tests {
         assert!(cache.update_title(4, "event title".to_string()));
         cache.replace(tree("stale snapshot"), refresh_generation);
 
-        assert_eq!(cache.view.workspaces[0].screens[0].panes[0].tabs[0].title, "event title");
+        assert_eq!(cache.view.workspaces()[0].screens[0].panes[0].tabs[0].title, "event title");
     }
 
     #[test]
@@ -7974,7 +7974,7 @@ mod tests {
         let refresh_generation = cache.title_generation();
         cache.replace(tree("fresh snapshot"), refresh_generation);
 
-        assert_eq!(cache.view.workspaces[0].screens[0].panes[0].tabs[0].title, "fresh snapshot");
+        assert_eq!(cache.view.workspaces()[0].screens[0].panes[0].tabs[0].title, "fresh snapshot");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -358,25 +358,10 @@ impl RemoteTreeCache {
     }
 
     fn update_view_title(&mut self, surface_id: SurfaceId, title: String) -> bool {
-        let Some([workspace, screen, pane, tab]) = self.surface_tabs.get(&surface_id).copied()
-        else {
-            return false;
-        };
-        let Some(tab) = self
-            .view
-            .workspaces_mut()
-            .get_mut(workspace)
-            .and_then(|workspace| workspace.screens.get_mut(screen))
-            .and_then(|screen| screen.panes.get_mut(pane))
-            .and_then(|pane| pane.tabs.get_mut(tab))
-        else {
-            return false;
-        };
-        if tab.surface != surface_id {
+        if !self.surface_tabs.contains_key(&surface_id) {
             return false;
         }
-        tab.title = title;
-        true
+        self.view.update_surface_title(surface_id, title)
     }
 
     fn title_generation(&self) -> u64 {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -358,10 +358,10 @@ impl RemoteTreeCache {
     }
 
     fn update_view_title(&mut self, surface_id: SurfaceId, title: String) -> bool {
-        if !self.surface_tabs.contains_key(&surface_id) {
+        let Some(location) = self.surface_tabs.get(&surface_id).copied() else {
             return false;
-        }
-        self.view.update_surface_title(surface_id, title)
+        };
+        self.view.update_surface_title_at(surface_id, location, title)
     }
 
     fn title_generation(&self) -> u64 {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7902,7 +7902,9 @@ mod tests {
             0,
         );
 
+        assert!(cache.view.location_index.get().is_none());
         assert!(cache.update_title(4, "server title".to_string()));
+        assert!(cache.view.location_index.get().is_none());
         assert_eq!(cache.view.workspaces()[0].screens[0].panes[0].tabs[0].title, "server title");
         assert_eq!(cache.view.workspaces()[1].screens[0].panes[0].tabs[0].title, "other title");
         assert!(!cache.update_title(99, "missing".to_string()));

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -361,7 +361,7 @@ impl RemoteTreeCache {
         let Some(location) = self.surface_tabs.get(&surface_id).copied() else {
             return false;
         };
-        self.view.update_surface_title_at(surface_id, location, title).is_some()
+        self.view.update_surface_title_at(surface_id, location, &title).is_some()
     }
 
     fn title_generation(&self) -> u64 {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -361,7 +361,7 @@ impl RemoteTreeCache {
         let Some(location) = self.surface_tabs.get(&surface_id).copied() else {
             return false;
         };
-        self.view.update_surface_title_at(surface_id, location, title)
+        self.view.update_surface_title_at(surface_id, location, title).is_some()
     }
 
     fn title_generation(&self) -> u64 {

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1065,38 +1065,53 @@ mod tests {
 
     #[test]
     fn indexed_lookup_fails_closed_after_direct_public_topology_mutation() {
-        let mut tree = parse_tree(&json!({
-            "workspaces": [{
-                "id": 1,
-                "active": true,
-                "screens": [{
-                    "id": 2,
+        let tree = || {
+            parse_tree(&json!({
+                "workspaces": [{
+                    "id": 1,
                     "active": true,
-                    "active_pane": 3,
-                    "layout": {"type": "leaf", "pane": 3},
-                    "panes": [{
-                        "id": 3,
-                        "active_tab": 0,
-                        "tabs": [
-                            {"surface": 7, "title": "first"},
-                            {"surface": 8, "title": "retained"}
-                        ]
+                    "screens": [{
+                        "id": 2,
+                        "active": true,
+                        "active_pane": 3,
+                        "layout": {"type": "leaf", "pane": 3},
+                        "panes": [{
+                            "id": 3,
+                            "active_tab": 0,
+                            "tabs": [
+                                {"surface": 7, "title": "first"},
+                                {"surface": 8, "title": "retained"}
+                            ]
+                        }]
                     }]
                 }]
-            }]
-        }));
+            }))
+        };
 
-        assert_eq!(tree.pane(3).map(|pane| pane.tabs[0].surface), Some(7));
-        let duplicate_pane = tree.workspaces[0].screens[0].panes[0].clone();
-        tree.workspaces[0].screens[0].panes.push(duplicate_pane);
-        assert!(tree.pane(3).is_none());
+        let mut appended = tree();
+        assert!(appended.surface(7).is_some());
+        let tab = appended.workspaces[0].screens[0].panes[0].tabs[0].clone();
+        appended.workspaces[0].screens[0].panes[0].tabs.push(tab);
+        assert!(appended.surface(7).is_some());
 
-        assert_eq!(tree.surface(8).map(|tab| tab.title.as_str()), Some("retained"));
-        let duplicate = tree.workspaces[0].screens[0].panes[0].tabs[1].clone();
-        tree.workspaces[0].screens[0].panes[0].tabs.insert(0, duplicate);
+        let mut inserted = tree();
+        assert!(inserted.surface(8).is_some());
+        let tab = inserted.workspaces[0].screens[0].panes[0].tabs[0].clone();
+        inserted.workspaces[0].screens[0].panes[0].tabs.insert(0, tab);
+        assert!(inserted.surface(8).is_none());
+        assert!(!inserted.select_surface(8));
 
-        assert!(tree.surface(8).is_none());
-        assert!(!tree.select_surface(8));
+        let mut removed = tree();
+        assert!(removed.surface(8).is_some());
+        removed.workspaces[0].screens[0].panes[0].tabs.remove(0);
+        assert!(removed.surface(8).is_none());
+        assert!(!removed.select_surface(8));
+
+        let mut replaced = tree();
+        assert!(replaced.surface(8).is_some());
+        replaced.workspaces[0].screens[0].panes[0].tabs[0].surface = 8;
+        assert!(replaced.surface(8).is_none());
+        assert!(!replaced.select_surface(8));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -28,8 +28,8 @@ pub struct TreeView {
 
 #[derive(Clone, Default)]
 pub(crate) struct TreeLocationIndex {
-    panes: HashMap<PaneId, (usize, usize, usize)>,
-    surfaces: HashMap<SurfaceId, (usize, usize, usize, usize)>,
+    panes: HashMap<PaneId, (usize, usize, usize, usize, usize, usize)>,
+    surfaces: HashMap<SurfaceId, (usize, usize, usize, usize, usize, usize, usize, usize)>,
 }
 
 impl TreeLocationIndex {
@@ -42,6 +42,9 @@ impl TreeLocationIndex {
                         workspace_index,
                         screen_index,
                         pane_index,
+                        tree.workspaces.len(),
+                        workspace.screens.len(),
+                        screen.panes.len(),
                     ));
                     for (tab_index, tab) in pane.tabs.iter().enumerate() {
                         // The previous scans selected the first duplicate in tree order.
@@ -50,6 +53,10 @@ impl TreeLocationIndex {
                             screen_index,
                             pane_index,
                             tab_index,
+                            tree.workspaces.len(),
+                            workspace.screens.len(),
+                            screen.panes.len(),
+                            pane.tabs.len(),
                         ));
                     }
                 }
@@ -213,8 +220,7 @@ impl TreeView {
     }
 
     pub fn pane(&self, id: PaneId) -> Option<&PaneView> {
-        let (workspace_index, screen_index, pane_index) =
-            self.location_index().panes.get(&id).copied()?;
+        let (workspace_index, screen_index, pane_index) = self.pane_location(id)?;
         self.workspaces
             .get(workspace_index)?
             .screens
@@ -234,8 +240,7 @@ impl TreeView {
     }
 
     pub fn surface(&self, id: SurfaceId) -> Option<&TabView> {
-        let (workspace_index, screen_index, pane_index, tab_index) =
-            self.location_index().surfaces.get(&id).copied()?;
+        let (workspace_index, screen_index, pane_index, tab_index) = self.surface_location(id)?;
         self.workspaces
             .get(workspace_index)?
             .screens
@@ -263,8 +268,9 @@ impl TreeView {
     /// Single-surface clients reapply this to every remote tree snapshot so
     /// unrelated focus changes cannot move them to another terminal.
     pub fn select_surface(&mut self, id: SurfaceId) -> bool {
-        let location = self.location_index().surfaces.get(&id).copied();
-        let Some((workspace_index, screen_index, pane_index, tab_index)) = location else {
+        let Some((workspace_index, screen_index, pane_index, tab_index)) =
+            self.surface_location(id)
+        else {
             return false;
         };
         self.active_workspace = workspace_index;
@@ -288,6 +294,59 @@ impl TreeView {
 
     fn location_index(&self) -> &TreeLocationIndex {
         self.location_index.get_or_init(|| TreeLocationIndex::build(self))
+    }
+
+    fn pane_location(&self, id: PaneId) -> Option<(usize, usize, usize)> {
+        let &(workspace_index, screen_index, pane_index, workspace_count, screen_count, pane_count) =
+            self.location_index().panes.get(&id)?;
+        if self.workspaces.len() != workspace_count {
+            return None;
+        }
+        let workspace = self.workspaces.get(workspace_index)?;
+        if workspace.screens.len() != screen_count {
+            return None;
+        }
+        let screen = workspace.screens.get(screen_index)?;
+        if screen.panes.len() != pane_count {
+            return None;
+        }
+        screen
+            .panes
+            .get(pane_index)
+            .filter(|pane| pane.id == id)
+            .map(|_| (workspace_index, screen_index, pane_index))
+    }
+
+    fn surface_location(&self, id: SurfaceId) -> Option<(usize, usize, usize, usize)> {
+        let &(
+            workspace_index,
+            screen_index,
+            pane_index,
+            tab_index,
+            workspace_count,
+            screen_count,
+            pane_count,
+            tab_count,
+        ) = self.location_index().surfaces.get(&id)?;
+        if self.workspaces.len() != workspace_count {
+            return None;
+        }
+        let workspace = self.workspaces.get(workspace_index)?;
+        if workspace.screens.len() != screen_count {
+            return None;
+        }
+        let screen = workspace.screens.get(screen_index)?;
+        if screen.panes.len() != pane_count {
+            return None;
+        }
+        let pane = screen.panes.get(pane_index)?;
+        if pane.tabs.len() != tab_count {
+            return None;
+        }
+        pane.tabs
+            .get(tab_index)
+            .filter(|tab| tab.surface == id)
+            .map(|_| (workspace_index, screen_index, pane_index, tab_index))
     }
 
     pub(crate) fn invalidate_location_index(&mut self) {
@@ -1021,6 +1080,11 @@ mod tests {
                 }]
             }]
         }));
+
+        assert_eq!(tree.pane(3).map(|pane| pane.tabs[0].surface), Some(7));
+        let duplicate_pane = tree.workspaces[0].screens[0].panes[0].clone();
+        tree.workspaces[0].screens[0].panes.push(duplicate_pane);
+        assert!(tree.pane(3).is_none());
 
         assert_eq!(tree.surface(8).map(|tab| tab.title.as_str()), Some("retained"));
         let duplicate = tree.workspaces[0].screens[0].panes[0].tabs[1].clone();

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1000,6 +1000,37 @@ mod tests {
     }
 
     #[test]
+    fn indexed_lookup_fails_closed_after_direct_public_topology_mutation() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [{
+                    "id": 2,
+                    "active": true,
+                    "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "active_tab": 0,
+                        "tabs": [
+                            {"surface": 7, "title": "first"},
+                            {"surface": 8, "title": "retained"}
+                        ]
+                    }]
+                }]
+            }]
+        }));
+
+        assert_eq!(tree.surface(8).map(|tab| tab.title.as_str()), Some("retained"));
+        let duplicate = tree.workspaces[0].screens[0].panes[0].tabs[1].clone();
+        tree.workspaces[0].screens[0].panes[0].tabs.insert(0, duplicate);
+
+        assert!(tree.surface(8).is_none());
+        assert!(!tree.select_surface(8));
+    }
+
+    #[test]
     fn terminal_resolution_ignores_internal_ids_and_browser_tabs() {
         let tree = parse_tree(&json!({
             "workspaces": [{

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -290,7 +290,7 @@ impl TreeView {
         self.location_index.get_or_init(|| TreeLocationIndex::build(self))
     }
 
-    fn invalidate_location_index(&mut self) {
+    pub(crate) fn invalidate_location_index(&mut self) {
         self.location_index = OnceLock::new();
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -913,6 +913,44 @@ mod tests {
     }
 
     #[test]
+    fn surface_and_pane_lookup_keep_first_match_after_tree_mutation() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [{
+                    "id": 2,
+                    "active": true,
+                    "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "active_tab": 0,
+                        "tabs": [{"surface": 7, "title": "first"}]
+                    }]
+                }]
+            }, {
+                "id": 4,
+                "screens": [{
+                    "id": 5,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "tabs": [{"surface": 7, "title": "duplicate"}]
+                    }]
+                }]
+            }]
+        }));
+
+        assert_eq!(tree.surface(7).map(|tab| tab.title.as_str()), Some("first"));
+        assert_eq!(tree.pane(3).map(|pane| pane.tabs[0].title.as_str()), Some("first"));
+
+        tree.retain_not_retired(&HashSet::from([7]));
+        assert!(tree.surface(7).is_none());
+        assert!(tree.pane(3).is_some());
+    }
+
+    #[test]
     fn terminal_resolution_ignores_internal_ids_and_browser_tabs() {
         let tree = parse_tree(&json!({
             "workspaces": [{

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -2,6 +2,7 @@
 //! plus the JSON parser for the remote `list-workspaces` shape.
 
 use std::collections::{BTreeMap, HashMap, HashSet};
+use std::sync::OnceLock;
 
 use cmux_tui_core::resource::{
     BrowserPublicId, ContentPublicId, PanePublicId, ScreenPublicId, TabPublicId, TerminalPublicId,
@@ -21,6 +22,41 @@ pub struct TreeView {
     pub workspace_revision: u64,
     pub pane_revision: Option<u64>,
     pub active_workspace: usize,
+    #[doc(hidden)]
+    pub(crate) location_index: OnceLock<TreeLocationIndex>,
+}
+
+#[derive(Clone, Default)]
+pub(crate) struct TreeLocationIndex {
+    panes: HashMap<PaneId, (usize, usize, usize)>,
+    surfaces: HashMap<SurfaceId, (usize, usize, usize, usize)>,
+}
+
+impl TreeLocationIndex {
+    fn build(tree: &TreeView) -> Self {
+        let mut index = Self::default();
+        for (workspace_index, workspace) in tree.workspaces.iter().enumerate() {
+            for (screen_index, screen) in workspace.screens.iter().enumerate() {
+                for (pane_index, pane) in screen.panes.iter().enumerate() {
+                    index.panes.entry(pane.id).or_insert((
+                        workspace_index,
+                        screen_index,
+                        pane_index,
+                    ));
+                    for (tab_index, tab) in pane.tabs.iter().enumerate() {
+                        // The previous scans selected the first duplicate in tree order.
+                        index.surfaces.entry(tab.surface).or_insert((
+                            workspace_index,
+                            screen_index,
+                            pane_index,
+                            tab_index,
+                        ));
+                    }
+                }
+            }
+        }
+        index
+    }
 }
 
 #[derive(Clone)]
@@ -91,6 +127,7 @@ impl TreeView {
     /// with explicit detach/retire evidence. The local surface mirror is a
     /// lazy cache and can be empty during startup or reconnect.
     pub fn retain_not_retired(&mut self, retired: &HashSet<SurfaceId>) {
+        self.invalidate_location_index();
         for workspace in &mut self.workspaces {
             for screen in &mut workspace.screens {
                 for pane in &mut screen.panes {
@@ -160,10 +197,12 @@ impl TreeView {
     }
 
     pub fn active_workspace_mut(&mut self) -> Option<&mut WorkspaceView> {
+        self.invalidate_location_index();
         self.workspaces.get_mut(self.active_workspace)
     }
 
     pub fn active_workspace_mut_screen(&mut self) -> Option<&mut ScreenView> {
+        self.invalidate_location_index();
         let workspace = self.workspaces.get_mut(self.active_workspace)?;
         workspace.screens.get_mut(workspace.active_screen)
     }
@@ -174,14 +213,19 @@ impl TreeView {
     }
 
     pub fn pane(&self, id: PaneId) -> Option<&PaneView> {
+        let (workspace_index, screen_index, pane_index) =
+            self.location_index().panes.get(&id).copied()?;
         self.workspaces
-            .iter()
-            .flat_map(|ws| ws.screens.iter())
-            .flat_map(|screen| screen.panes.iter())
-            .find(|p| p.id == id)
+            .get(workspace_index)?
+            .screens
+            .get(screen_index)?
+            .panes
+            .get(pane_index)
+            .filter(|pane| pane.id == id)
     }
 
     pub fn pane_mut(&mut self, id: PaneId) -> Option<&mut PaneView> {
+        self.invalidate_location_index();
         self.workspaces
             .iter_mut()
             .flat_map(|workspace| workspace.screens.iter_mut())
@@ -190,12 +234,17 @@ impl TreeView {
     }
 
     pub fn surface(&self, id: SurfaceId) -> Option<&TabView> {
+        let (workspace_index, screen_index, pane_index, tab_index) =
+            self.location_index().surfaces.get(&id).copied()?;
         self.workspaces
-            .iter()
-            .flat_map(|workspace| workspace.screens.iter())
-            .flat_map(|screen| screen.panes.iter())
-            .flat_map(|pane| pane.tabs.iter())
-            .find(|tab| tab.surface == id)
+            .get(workspace_index)?
+            .screens
+            .get(screen_index)?
+            .panes
+            .get(pane_index)?
+            .tabs
+            .get(tab_index)
+            .filter(|tab| tab.surface == id)
     }
 
     /// Resolve the stable public terminal identity to the current internal
@@ -214,17 +263,7 @@ impl TreeView {
     /// Single-surface clients reapply this to every remote tree snapshot so
     /// unrelated focus changes cannot move them to another terminal.
     pub fn select_surface(&mut self, id: SurfaceId) -> bool {
-        let location =
-            self.workspaces.iter().enumerate().find_map(|(workspace_index, workspace)| {
-                workspace.screens.iter().enumerate().find_map(|(screen_index, screen)| {
-                    screen.panes.iter().enumerate().find_map(|(pane_index, pane)| {
-                        pane.tabs
-                            .iter()
-                            .position(|tab| tab.surface == id)
-                            .map(|tab_index| (workspace_index, screen_index, pane_index, tab_index))
-                    })
-                })
-            });
+        let location = self.location_index().surfaces.get(&id).copied();
         let Some((workspace_index, screen_index, pane_index, tab_index)) = location else {
             return false;
         };
@@ -244,14 +283,15 @@ impl TreeView {
     }
 
     pub fn surface_kind(&self, id: SurfaceId) -> SurfaceKind {
-        self.workspaces
-            .iter()
-            .flat_map(|ws| ws.screens.iter())
-            .flat_map(|screen| screen.panes.iter())
-            .flat_map(|pane| pane.tabs.iter())
-            .find(|tab| tab.surface == id)
-            .map(|tab| tab.kind)
-            .unwrap_or(SurfaceKind::Pty)
+        self.surface(id).map(|tab| tab.kind).unwrap_or(SurfaceKind::Pty)
+    }
+
+    fn location_index(&self) -> &TreeLocationIndex {
+        self.location_index.get_or_init(|| TreeLocationIndex::build(self))
+    }
+
+    fn invalidate_location_index(&mut self) {
+        self.location_index = OnceLock::new();
     }
 }
 
@@ -926,7 +966,10 @@ mod tests {
                     "panes": [{
                         "id": 3,
                         "active_tab": 0,
-                        "tabs": [{"surface": 7, "title": "first"}]
+                        "tabs": [
+                            {"surface": 7, "title": "first"},
+                            {"surface": 8, "title": "retained"}
+                        ]
                     }]
                 }]
             }, {
@@ -944,9 +987,14 @@ mod tests {
 
         assert_eq!(tree.surface(7).map(|tab| tab.title.as_str()), Some("first"));
         assert_eq!(tree.pane(3).map(|pane| pane.tabs[0].title.as_str()), Some("first"));
+        tree.active_workspace = 1;
+        assert!(tree.select_surface(7));
+        assert_eq!(tree.active_workspace, 0);
+        assert_eq!(tree.active_surface(), Some(7));
 
         tree.retain_not_retired(&HashSet::from([7]));
         assert!(tree.surface(7).is_none());
+        assert_eq!(tree.surface(8).map(|tab| tab.title.as_str()), Some("retained"));
         assert!(tree.pane(3).is_some());
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 
 #[derive(Clone, Default)]
 pub struct TreeView {
-    pub(crate) workspaces: Vec<WorkspaceView>,
+    workspaces: Vec<WorkspaceView>,
     #[allow(dead_code)]
     pub workspace_revision: u64,
     pub pane_revision: Option<u64>,
@@ -349,9 +349,16 @@ impl TreeView {
         self.location_index.get_or_init(|| TreeLocationIndex::build(self))
     }
 
+    /// Mutably access the workspace topology and invalidate cached locations.
+    /// Callers must use this guard before changing workspaces, screens, panes,
+    /// or tabs so indexed lookups rebuild against the new topology.
     pub(crate) fn workspaces_mut(&mut self) -> &mut Vec<WorkspaceView> {
         self.invalidate_location_index();
         &mut self.workspaces
+    }
+
+    pub(crate) fn workspaces(&self) -> &[WorkspaceView] {
+        &self.workspaces
     }
 
     fn pane_location(&self, id: PaneId) -> Option<(usize, usize, usize)> {
@@ -1132,7 +1139,7 @@ mod tests {
     }
 
     #[test]
-    fn indexed_lookup_fails_closed_after_direct_public_topology_mutation() {
+    fn indexed_lookup_fails_closed_after_internal_topology_mutation() {
         let tree = || {
             parse_tree(&json!({
                 "workspaces": [{
@@ -1180,6 +1187,39 @@ mod tests {
         replaced.workspaces[0].screens[0].panes[0].tabs[0].surface = 8;
         assert!(replaced.surface(8).is_none());
         assert!(!replaced.select_surface(8));
+    }
+
+    #[test]
+    fn topology_mutation_guard_invalidates_index_before_nested_mutation() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [{
+                    "id": 2,
+                    "active": true,
+                    "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "active_tab": 0,
+                        "tabs": [
+                            {"surface": 7, "title": "first"},
+                            {"surface": 8, "title": "retained"}
+                        ]
+                    }]
+                }]
+            }]
+        }));
+
+        assert_eq!(tree.surface(8).map(|tab| tab.title.as_str()), Some("retained"));
+        let mut inserted = tree.workspaces_mut()[0].screens[0].panes[0].tabs[0].clone();
+        inserted.title = "inserted".to_string();
+        tree.workspaces_mut()[0].screens[0].panes[0].tabs.insert(0, inserted);
+
+        assert_eq!(tree.surface(8).map(|tab| tab.title.as_str()), Some("retained"));
+        assert_eq!(tree.surface(7).map(|tab| tab.title.as_str()), Some("inserted"));
+        assert!(tree.select_surface(8));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -409,6 +409,7 @@ pub fn tree_from_state_with_notifications(
         workspace_revision: state.workspace_revision,
         pane_revision: Some(state.pane_revision),
         active_workspace: state.active_workspace,
+        location_index: OnceLock::new(),
         workspaces: state
             .workspaces
             .iter()

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -28,8 +28,35 @@ pub struct TreeView {
 
 #[derive(Clone, Default)]
 pub(crate) struct TreeLocationIndex {
-    panes: HashMap<PaneId, (usize, usize, usize, usize, usize, usize)>,
-    surfaces: HashMap<SurfaceId, (usize, usize, usize, usize, usize, usize, usize, usize)>,
+    panes: HashMap<PaneId, PaneLocation>,
+    surfaces: HashMap<SurfaceId, SurfaceLocation>,
+}
+
+#[derive(Clone, Copy)]
+struct PaneLocation {
+    workspace_index: usize,
+    screen_index: usize,
+    pane_index: usize,
+    workspace_id: WorkspaceId,
+    previous_workspace: Option<WorkspaceId>,
+    screen_id: ScreenId,
+    previous_screen: Option<ScreenId>,
+    previous_pane: Option<PaneId>,
+}
+
+#[derive(Clone, Copy)]
+struct SurfaceLocation {
+    workspace_index: usize,
+    screen_index: usize,
+    pane_index: usize,
+    tab_index: usize,
+    workspace_id: WorkspaceId,
+    previous_workspace: Option<WorkspaceId>,
+    screen_id: ScreenId,
+    previous_screen: Option<ScreenId>,
+    pane_id: PaneId,
+    previous_pane: Option<PaneId>,
+    previous_tab: Option<SurfaceId>,
 }
 
 impl TreeLocationIndex {
@@ -38,26 +65,52 @@ impl TreeLocationIndex {
         for (workspace_index, workspace) in tree.workspaces.iter().enumerate() {
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
                 for (pane_index, pane) in screen.panes.iter().enumerate() {
-                    index.panes.entry(pane.id).or_insert((
+                    index.panes.entry(pane.id).or_insert(PaneLocation {
                         workspace_index,
                         screen_index,
                         pane_index,
-                        tree.workspaces.len(),
-                        workspace.screens.len(),
-                        screen.panes.len(),
-                    ));
+                        workspace_id: workspace.id,
+                        previous_workspace: workspace_index
+                            .checked_sub(1)
+                            .and_then(|index| tree.workspaces.get(index))
+                            .map(|workspace| workspace.id),
+                        screen_id: screen.id,
+                        previous_screen: screen_index
+                            .checked_sub(1)
+                            .and_then(|index| workspace.screens.get(index))
+                            .map(|screen| screen.id),
+                        previous_pane: pane_index
+                            .checked_sub(1)
+                            .and_then(|index| screen.panes.get(index))
+                            .map(|pane| pane.id),
+                    });
                     for (tab_index, tab) in pane.tabs.iter().enumerate() {
                         // The previous scans selected the first duplicate in tree order.
-                        index.surfaces.entry(tab.surface).or_insert((
+                        index.surfaces.entry(tab.surface).or_insert(SurfaceLocation {
                             workspace_index,
                             screen_index,
                             pane_index,
                             tab_index,
-                            tree.workspaces.len(),
-                            workspace.screens.len(),
-                            screen.panes.len(),
-                            pane.tabs.len(),
-                        ));
+                            workspace_id: workspace.id,
+                            previous_workspace: workspace_index
+                                .checked_sub(1)
+                                .and_then(|index| tree.workspaces.get(index))
+                                .map(|workspace| workspace.id),
+                            screen_id: screen.id,
+                            previous_screen: screen_index
+                                .checked_sub(1)
+                                .and_then(|index| workspace.screens.get(index))
+                                .map(|screen| screen.id),
+                            pane_id: pane.id,
+                            previous_pane: pane_index
+                                .checked_sub(1)
+                                .and_then(|index| screen.panes.get(index))
+                                .map(|pane| pane.id),
+                            previous_tab: tab_index
+                                .checked_sub(1)
+                                .and_then(|index| pane.tabs.get(index))
+                                .map(|tab| tab.surface),
+                        });
                     }
                 }
             }
@@ -302,56 +355,71 @@ impl TreeView {
     }
 
     fn pane_location(&self, id: PaneId) -> Option<(usize, usize, usize)> {
-        let &(workspace_index, screen_index, pane_index, workspace_count, screen_count, pane_count) =
-            self.location_index().panes.get(&id)?;
-        if self.workspaces.len() != workspace_count {
-            return None;
-        }
+        let location = self.location_index().panes.get(&id)?;
+        let workspace_index = location.workspace_index;
+        let screen_index = location.screen_index;
+        let pane_index = location.pane_index;
         let workspace = self.workspaces.get(workspace_index)?;
-        if workspace.screens.len() != screen_count {
+        if workspace.id != location.workspace_id
+            || (workspace_index > 0
+                && self.workspaces.get(workspace_index - 1).map(|workspace| workspace.id)
+                    != location.previous_workspace)
+        {
             return None;
         }
         let screen = workspace.screens.get(screen_index)?;
-        if screen.panes.len() != pane_count {
+        if screen.id != location.screen_id
+            || (screen_index > 0
+                && workspace.screens.get(screen_index - 1).map(|screen| screen.id)
+                    != location.previous_screen)
+        {
             return None;
         }
-        screen
-            .panes
-            .get(pane_index)
-            .filter(|pane| pane.id == id)
-            .map(|_| (workspace_index, screen_index, pane_index))
+        screen.panes.get(pane_index).filter(|pane| pane.id == id)?;
+        if pane_index > 0
+            && screen.panes.get(pane_index - 1).map(|pane| pane.id) != location.previous_pane
+        {
+            return None;
+        }
+        Some((workspace_index, screen_index, pane_index))
     }
 
     fn surface_location(&self, id: SurfaceId) -> Option<(usize, usize, usize, usize)> {
-        let &(
-            workspace_index,
-            screen_index,
-            pane_index,
-            tab_index,
-            workspace_count,
-            screen_count,
-            pane_count,
-            tab_count,
-        ) = self.location_index().surfaces.get(&id)?;
-        if self.workspaces.len() != workspace_count {
-            return None;
-        }
+        let location = self.location_index().surfaces.get(&id)?;
+        let workspace_index = location.workspace_index;
+        let screen_index = location.screen_index;
+        let pane_index = location.pane_index;
+        let tab_index = location.tab_index;
         let workspace = self.workspaces.get(workspace_index)?;
-        if workspace.screens.len() != screen_count {
+        if workspace.id != location.workspace_id
+            || (workspace_index > 0
+                && self.workspaces.get(workspace_index - 1).map(|workspace| workspace.id)
+                    != location.previous_workspace)
+        {
             return None;
         }
         let screen = workspace.screens.get(screen_index)?;
-        if screen.panes.len() != pane_count {
+        if screen.id != location.screen_id
+            || (screen_index > 0
+                && workspace.screens.get(screen_index - 1).map(|screen| screen.id)
+                    != location.previous_screen)
+        {
             return None;
         }
         let pane = screen.panes.get(pane_index)?;
-        if pane.tabs.len() != tab_count {
+        if pane.id != location.pane_id
+            || (pane_index > 0
+                && screen.panes.get(pane_index - 1).map(|pane| pane.id) != location.previous_pane)
+        {
             return None;
         }
-        pane.tabs
-            .get(tab_index)
-            .filter(|tab| tab.surface == id)
-            .map(|_| (workspace_index, screen_index, pane_index, tab_index))
+        pane.tabs.get(tab_index).filter(|tab| tab.surface == id)?;
+        if tab_index > 0
+            && pane.tabs.get(tab_index - 1).map(|tab| tab.surface) != location.previous_tab
+        {
+            return None;
+        }
+        Some((workspace_index, screen_index, pane_index, tab_index))
     }
 
     pub(crate) fn invalidate_location_index(&mut self) {

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -17,7 +17,7 @@ use serde_json::Value;
 
 #[derive(Clone, Default)]
 pub struct TreeView {
-    pub workspaces: Vec<WorkspaceView>,
+    pub(crate) workspaces: Vec<WorkspaceView>,
     #[allow(dead_code)]
     pub workspace_revision: u64,
     pub pane_revision: Option<u64>,
@@ -294,6 +294,11 @@ impl TreeView {
 
     fn location_index(&self) -> &TreeLocationIndex {
         self.location_index.get_or_init(|| TreeLocationIndex::build(self))
+    }
+
+    pub(crate) fn workspaces_mut(&mut self) -> &mut Vec<WorkspaceView> {
+        self.invalidate_location_index();
+        &mut self.workspaces
     }
 
     fn pane_location(&self, id: PaneId) -> Option<(usize, usize, usize)> {

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -183,6 +183,21 @@ pub struct TabNotificationView {
 }
 
 impl TreeView {
+    pub(crate) fn from_parts(
+        workspaces: Vec<WorkspaceView>,
+        workspace_revision: u64,
+        pane_revision: Option<u64>,
+        active_workspace: usize,
+    ) -> Self {
+        Self {
+            workspaces,
+            workspace_revision,
+            pane_revision,
+            active_workspace,
+            location_index: OnceLock::new(),
+        }
+    }
+
     /// Retain the server's authoritative tab topology, removing only tabs
     /// with explicit detach/retire evidence. The local surface mirror is a
     /// lazy cache and can be empty during startup or reconnect.

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -331,6 +331,7 @@ impl TreeView {
             [workspace_index, screen_index, pane_index, tab_index],
             title,
         )
+        .is_some()
     }
 
     pub(crate) fn update_surface_title_at(
@@ -338,7 +339,7 @@ impl TreeView {
         id: SurfaceId,
         [workspace_index, screen_index, pane_index, tab_index]: [usize; 4],
         title: String,
-    ) -> bool {
+    ) -> Option<bool> {
         let Some(tab) = self
             .workspaces
             .get_mut(workspace_index)
@@ -346,13 +347,14 @@ impl TreeView {
             .and_then(|screen| screen.panes.get_mut(pane_index))
             .and_then(|pane| pane.tabs.get_mut(tab_index))
         else {
-            return false;
+            return None;
         };
         if tab.surface != id {
-            return false;
+            return None;
         }
+        let changed = tab.title != title;
         tab.title = title;
-        true
+        Some(changed)
     }
 
     /// Resolve the stable public terminal identity to the current internal

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1303,6 +1303,36 @@ mod tests {
     }
 
     #[test]
+    fn focus_updates_reuse_the_existing_location_index() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [{
+                    "id": 2,
+                    "active": true,
+                    "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "active_tab": 0,
+                        "tabs": [{"surface": 7, "title": "first"}]
+                    }]
+                }]
+            }]
+        }));
+
+        let index_before = tree.location_index() as *const TreeLocationIndex;
+        assert!(tree.set_active_screen(0, 0));
+        assert!(tree.set_active_pane(0, 0, 3));
+        assert!(tree.set_active_tab(0, 0, 3, 0));
+        let index_after = tree.location_index() as *const TreeLocationIndex;
+
+        assert!(std::ptr::eq(index_before, index_after));
+        assert_eq!(tree.active_surface(), Some(7));
+    }
+
+    #[test]
     fn terminal_resolution_ignores_internal_ids_and_browser_tabs() {
         let tree = parse_tree(&json!({
             "workspaces": [{

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -271,6 +271,84 @@ impl TreeView {
         self.workspaces.get(self.active_workspace)
     }
 
+    /// Update focus state without invalidating topology locations.
+    pub(crate) fn set_active_screen(
+        &mut self,
+        workspace_index: usize,
+        screen_index: usize,
+    ) -> bool {
+        let Some(workspace) = self.workspaces.get_mut(workspace_index) else { return false };
+        if screen_index >= workspace.screens.len() {
+            return false;
+        }
+        workspace.active_screen = screen_index;
+        true
+    }
+
+    /// Update focus state without invalidating topology locations.
+    pub(crate) fn set_active_pane(
+        &mut self,
+        workspace_index: usize,
+        screen_index: usize,
+        pane_id: PaneId,
+    ) -> bool {
+        let Some(screen) = self
+            .workspaces
+            .get_mut(workspace_index)
+            .and_then(|workspace| workspace.screens.get_mut(screen_index))
+        else {
+            return false;
+        };
+        if !screen.panes.iter().any(|pane| pane.id == pane_id) {
+            return false;
+        }
+        screen.active_pane = pane_id;
+        true
+    }
+
+    /// Update focus state without invalidating topology locations.
+    pub(crate) fn set_active_tab(
+        &mut self,
+        workspace_index: usize,
+        screen_index: usize,
+        pane_id: PaneId,
+        tab_index: usize,
+    ) -> bool {
+        let Some(pane) = self
+            .workspaces
+            .get_mut(workspace_index)
+            .and_then(|workspace| workspace.screens.get_mut(screen_index))
+            .and_then(|screen| screen.panes.iter_mut().find(|pane| pane.id == pane_id))
+        else {
+            return false;
+        };
+        if tab_index >= pane.tabs.len() {
+            return false;
+        }
+        pane.active_tab = tab_index;
+        true
+    }
+
+    /// Update focus state without invalidating topology locations.
+    pub(crate) fn set_pane_active_tab(&mut self, pane_id: PaneId, tab_index: usize) -> bool {
+        let Some((workspace_index, screen_index, pane_index)) = self.pane_location(pane_id) else {
+            return false;
+        };
+        let Some(pane) = self
+            .workspaces
+            .get_mut(workspace_index)
+            .and_then(|workspace| workspace.screens.get_mut(screen_index))
+            .and_then(|screen| screen.panes.get_mut(pane_index))
+        else {
+            return false;
+        };
+        if pane.id != pane_id || tab_index >= pane.tabs.len() {
+            return false;
+        }
+        pane.active_tab = tab_index;
+        true
+    }
+
     pub fn active_workspace_mut(&mut self) -> Option<&mut WorkspaceView> {
         self.invalidate_location_index();
         self.workspaces.get_mut(self.active_workspace)
@@ -320,7 +398,7 @@ impl TreeView {
             .filter(|tab| tab.surface == id)
     }
 
-    pub(crate) fn update_surface_title(&mut self, id: SurfaceId, title: String) -> bool {
+    pub(crate) fn update_surface_title(&mut self, id: SurfaceId, title: &str) -> bool {
         let (workspace_index, screen_index, pane_index, tab_index) = match self.surface_location(id)
         {
             Some(location) => location,
@@ -338,7 +416,7 @@ impl TreeView {
         &mut self,
         id: SurfaceId,
         [workspace_index, screen_index, pane_index, tab_index]: [usize; 4],
-        title: String,
+        title: &str,
     ) -> Option<bool> {
         let Some(tab) = self
             .workspaces
@@ -353,7 +431,9 @@ impl TreeView {
             return None;
         }
         let changed = tab.title != title;
-        tab.title = title;
+        if changed {
+            tab.title = title.to_owned();
+        }
         Some(changed)
     }
 
@@ -1295,7 +1375,7 @@ mod tests {
         }));
 
         let index_before = tree.location_index() as *const TreeLocationIndex;
-        assert!(tree.update_surface_title(7, "renamed".to_string()));
+        assert!(tree.update_surface_title(7, "renamed"));
         let index_after = tree.location_index() as *const TreeLocationIndex;
 
         assert!(std::ptr::eq(index_before, index_after));
@@ -1326,6 +1406,7 @@ mod tests {
         assert!(tree.set_active_screen(0, 0));
         assert!(tree.set_active_pane(0, 0, 3));
         assert!(tree.set_active_tab(0, 0, 3, 0));
+        assert!(tree.set_pane_active_tab(3, 0));
         let index_after = tree.location_index() as *const TreeLocationIndex;
 
         assert!(std::ptr::eq(index_before, index_after));

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1238,6 +1238,34 @@ mod tests {
     }
 
     #[test]
+    fn title_updates_reuse_the_existing_location_index() {
+        let mut tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [{
+                    "id": 2,
+                    "active": true,
+                    "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{
+                        "id": 3,
+                        "active_tab": 0,
+                        "tabs": [{"surface": 7, "title": "first"}]
+                    }]
+                }]
+            }]
+        }));
+
+        let index_before = tree.location_index();
+        assert!(tree.update_surface_title(7, "renamed".to_string()));
+        let index_after = tree.location_index();
+
+        assert!(std::ptr::eq(index_before, index_after));
+        assert_eq!(tree.surface(7).map(|tab| tab.title.as_str()), Some("renamed"));
+    }
+
+    #[test]
     fn terminal_resolution_ignores_internal_ids_and_browser_tabs() {
         let tree = parse_tree(&json!({
             "workspaces": [{

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -320,6 +320,28 @@ impl TreeView {
             .filter(|tab| tab.surface == id)
     }
 
+    pub(crate) fn update_surface_title(&mut self, id: SurfaceId, title: String) -> bool {
+        let (workspace_index, screen_index, pane_index, tab_index) = match self.surface_location(id)
+        {
+            Some(location) => location,
+            None => return false,
+        };
+        let Some(tab) = self
+            .workspaces
+            .get_mut(workspace_index)
+            .and_then(|workspace| workspace.screens.get_mut(screen_index))
+            .and_then(|screen| screen.panes.get_mut(pane_index))
+            .and_then(|pane| pane.tabs.get_mut(tab_index))
+        else {
+            return false;
+        };
+        if tab.surface != id {
+            return false;
+        }
+        tab.title = title;
+        true
+    }
+
     /// Resolve the stable public terminal identity to the current internal
     /// surface slot used by the renderer and filtered event subscription.
     pub fn resolve_terminal(&self, terminal_id: &TerminalPublicId) -> Option<SurfaceId> {
@@ -1257,9 +1279,9 @@ mod tests {
             }]
         }));
 
-        let index_before = tree.location_index();
+        let index_before = tree.location_index() as *const TreeLocationIndex;
         assert!(tree.update_surface_title(7, "renamed".to_string()));
-        let index_after = tree.location_index();
+        let index_after = tree.location_index() as *const TreeLocationIndex;
 
         assert!(std::ptr::eq(index_before, index_after));
         assert_eq!(tree.surface(7).map(|tab| tab.title.as_str()), Some("renamed"));

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -326,6 +326,19 @@ impl TreeView {
             Some(location) => location,
             None => return false,
         };
+        self.update_surface_title_at(
+            id,
+            [workspace_index, screen_index, pane_index, tab_index],
+            title,
+        )
+    }
+
+    pub(crate) fn update_surface_title_at(
+        &mut self,
+        id: SurfaceId,
+        [workspace_index, screen_index, pane_index, tab_index]: [usize; 4],
+        title: String,
+    ) -> bool {
         let Some(tab) = self
             .workspaces
             .get_mut(workspace_index)

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -89,7 +89,7 @@ pub(crate) fn rows(
     // Workspace rows are the common projection and can reach roughly 1000
     // entries. Reserve that baseline up front so a render does not repeatedly
     // grow and copy the backing buffer while appending the tree.
-    let mut rows = Vec::with_capacity(tree.workspaces.len());
+    let mut rows = Vec::with_capacity(tree.workspaces().len());
     let agents_by_surface: HashMap<SurfaceId, &AgentInfo> =
         agents.iter().map(|agent| (agent.surface, agent)).collect();
     append_level(
@@ -99,7 +99,7 @@ pub(crate) fn rows(
         None,
         tree,
         &agents_by_surface,
-        selected_workspace.min(tree.workspaces.len().saturating_sub(1)),
+        selected_workspace.min(tree.workspaces().len().saturating_sub(1)),
         collapsed,
     );
     rows
@@ -121,7 +121,7 @@ fn append_level(
     match resource {
         SidebarResourceKind::Machines => {}
         SidebarResourceKind::Workspaces => {
-            for (workspace_index, workspace) in tree.workspaces.iter().enumerate() {
+            for (workspace_index, workspace) in tree.workspaces().iter().enumerate() {
                 let branch = has_children.then_some(ProjectionBranch::Workspace(workspace.id));
                 let expanded = branch.is_none_or(|branch| !collapsed.contains(&branch));
                 output.push(ProjectionRow {
@@ -158,7 +158,7 @@ fn append_level(
         }
         SidebarResourceKind::Panes => {
             let workspace_index = context.map_or(selected_workspace, |context| context.workspace);
-            let Some(workspace) = tree.workspaces.get(workspace_index) else { return };
+            let Some(workspace) = tree.workspaces().get(workspace_index) else { return };
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
                 for pane in &screen.panes {
                     if context.is_some_and(|context| {
@@ -211,7 +211,7 @@ fn append_level(
         SidebarResourceKind::Tabs | SidebarResourceKind::Agents => {
             let agent_only = resource == SidebarResourceKind::Agents;
             let workspace_index = context.map_or(selected_workspace, |context| context.workspace);
-            let Some(workspace) = tree.workspaces.get(workspace_index) else { return };
+            let Some(workspace) = tree.workspaces().get(workspace_index) else { return };
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
                 if context.is_some_and(|context| {
                     context.screen.is_some_and(|candidate| candidate != screen_index)

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -284,8 +284,8 @@ mod tests {
     use crate::session::tree::{PaneView, ScreenView, TabView, WorkspaceView};
 
     fn tree() -> TreeView {
-        TreeView {
-            workspaces: vec![WorkspaceView {
+        TreeView::from_parts(
+            vec![WorkspaceView {
                 id: 1,
                 resource_id: None,
                 key: "workspace-1".into(),
@@ -313,11 +313,10 @@ mod tests {
                 }],
                 active_screen: 0,
             }],
-            workspace_revision: 1,
-            pane_revision: Some(1),
-            active_workspace: 0,
-            ..TreeView::default()
-        }
+            1,
+            Some(1),
+            0,
+        )
     }
 
     fn tab(surface: SurfaceId, title: &str) -> TabView {

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -316,6 +316,7 @@ mod tests {
             workspace_revision: 1,
             pane_revision: Some(1),
             active_workspace: 0,
+            ..TreeView::default()
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/ui/omnibar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/omnibar.rs
@@ -138,7 +138,7 @@ fn draw_idle(
     let suffix = " ⏸ chrome tab hidden";
     let tree_stalled = app
         .tree
-        .workspaces
+        .workspaces()
         .iter()
         .flat_map(|ws| ws.screens.iter())
         .flat_map(|screen| screen.panes.iter())

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -498,11 +498,11 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
         .as_ref()
         .map(|ui| ui.recoverable_workspaces().into_iter().cloned().collect::<Vec<_>>())
         .unwrap_or_default();
-    let body_rows = (app.tree.workspaces.len() + recoverable.len()) * metrics.stride;
+    let body_rows = (app.tree.workspaces().len() + recoverable.len()) * metrics.stride;
     let selected_body = (app.workspace_sidebar_focused() && app.workspace_rail_follow_selection)
         .then(|| match app.workspace_rail_selection {
             WorkspaceRailSelection::Workspace
-                if app.sidebar_workspace_selection < app.tree.workspaces.len() =>
+                if app.sidebar_workspace_selection < app.tree.workspaces().len() =>
             {
                 Some(rail::RowSpan::new(
                     app.sidebar_workspace_selection * metrics.stride,
@@ -513,7 +513,7 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
                 if app.sidebar_recoverable_workspace_selection < recoverable.len() =>
             {
                 Some(rail::RowSpan::new(
-                    (app.tree.workspaces.len() + app.sidebar_recoverable_workspace_selection)
+                    (app.tree.workspaces().len() + app.sidebar_recoverable_workspace_selection)
                         * metrics.stride,
                     metrics.height,
                 ))
@@ -562,7 +562,7 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
             },
         ));
     }
-    for (i, ws) in app.tree.workspaces.iter().enumerate() {
+    for (i, ws) in app.tree.workspaces().iter().enumerate() {
         let span = rail::RowSpan::new(i * metrics.stride, metrics.height);
         let Some(y) = viewport.body_y(span) else { continue };
         let active = i == app.tree.active_workspace;
@@ -602,7 +602,7 @@ fn draw_workspaces(app: &mut App, frame: &mut Frame) {
     }
 
     for (index, workspace) in recoverable.iter().enumerate() {
-        let row = app.tree.workspaces.len() + index;
+        let row = app.tree.workspaces().len() + index;
         let span = rail::RowSpan::new(row * metrics.stride, metrics.height);
         let Some(y) = viewport.body_y(span) else { continue };
         let selected = app.workspace_sidebar_focused()
@@ -852,7 +852,7 @@ fn unread_summary(app: &App) -> Option<(usize, Color)> {
     let mut highest = None;
     for notification in app
         .tree
-        .workspaces
+        .workspaces()
         .iter()
         .flat_map(|workspace| workspace.screens.iter())
         .flat_map(|screen| screen.panes.iter())


### PR DESCRIPTION
Adds a lazy TreeView location index for pane and surface lookup and selection. HashMap entry insertion keeps first-match behavior for duplicate IDs. Topology mutators invalidate the cache, and clones retain the snapshot index.

Regression coverage verifies duplicate lookup order and cache invalidation after retirement.

Hosted verification: https://github.com/manaflow-ai/cmux/actions/runs/33640014062 (MSRV check failed with exit 101; logs unavailable because GitHub API rate limit was exhausted). Local checks: rustfmt --check and git diff --check.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11689"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950415&installation_model_id=21920&pr_number=11689&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11689&signature=c5f904af6da6a70a1651402608be9cf8b1d28a9dfb542cbaab4b6e526ad32451"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up `cmux-tui` `TreeView` pane, surface, and selection lookups with a lazy location index while preserving first-match behavior for duplicate IDs. Topology changes invalidate or reject stale entries, and cached title and focus updates reuse the index without rebuilding it.

- Tree topology mutations must go through `workspaces_mut()`; constructors and clones initialize or preserve the cached index.
- Cached surface removal safely falls back when its stored location is stale.
- Regression tests cover duplicate ordering, stale ancestors, direct mutations, cache invalidation, and title/focus updates.

<sup>Written for commit c43d539415e5e012fa341c7ae1b19ffd34a7f653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when locating and selecting tabs and surfaces after workspace layout changes.
  * Kept workspace and surface tracking accurate when panes or tabs are inserted, removed, replaced, or reordered.
  * Prevented stale location data from affecting navigation and tab lookups.
  * Improved surface title synchronization after workspace changes.
  * Improved sidebar, omnibar, and remote-session handling of workspace and surface information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->