### PR TITLE
cmux-tui: cache projection rows by explicit revisions

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7160,7 +7160,8 @@ pub struct App {
     pub(crate) tabs_footer_scroll: usize,
     projection_rails: HashMap<String, ProjectionRailState>,
     projection_rows_cache: ProjectionRowsCache,
-    agent_generation: u64,
+    agent_generations: HashMap<WorkspaceId, u64>,
+    agent_unscoped_generation: u64,
     sidebar_generation: u64,
     pub(crate) machine_rail_follow_selection: bool,
     pub(crate) workspace_rail_follow_selection: bool,
@@ -9431,7 +9432,8 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         tabs_footer_scroll: 0,
         projection_rails: HashMap::new(),
         projection_rows_cache: ProjectionRowsCache::default(),
-        agent_generation: 0,
+        agent_generations: HashMap::new(),
+        agent_unscoped_generation: 0,
         sidebar_generation: 0,
         machine_rail_follow_selection: true,
         workspace_rail_follow_selection: true,
@@ -10202,10 +10204,30 @@ impl App {
             .unwrap_or(empty_collapsed);
         let rail_generation =
             self.projection_rails.get(&spec.id).map_or(0, |state| state.rows_generation);
+        let agent_revision = if spec.includes(SidebarResourceKind::Agents) {
+            let generation = if spec.includes(SidebarResourceKind::Workspaces) {
+                self.tree
+                    .workspaces()
+                    .iter()
+                    .map(|workspace| {
+                        self.agent_generations.get(&workspace.id).copied().unwrap_or(0)
+                    })
+                    .fold(0_u64, u64::wrapping_add)
+            } else {
+                self.tree
+                    .workspaces()
+                    .get(self.sidebar_workspace_selection)
+                    .and_then(|workspace| self.agent_generations.get(&workspace.id).copied())
+                    .unwrap_or(0)
+            };
+            Some(generation.wrapping_add(self.agent_unscoped_generation))
+        } else {
+            None
+        };
         let revision = ProjectionRevision {
             tree_workspace: self.tree.workspace_revision,
             tree_pane: self.tree.pane_revision,
-            agents: spec.includes(SidebarResourceKind::Agents).then_some(self.agent_generation),
+            agents: agent_revision,
             selected_workspace: (!spec.includes(SidebarResourceKind::Workspaces))
                 .then_some(self.sidebar_workspace_selection)
                 .unwrap_or(0),
@@ -10338,8 +10360,18 @@ impl App {
         state.rows_generation = state.rows_generation.saturating_add(1);
     }
 
-    fn bump_agent_generation(&mut self) {
-        self.agent_generation = self.agent_generation.saturating_add(1);
+    fn bump_agent_generation(&mut self, surface: SurfaceId) {
+        let workspace = self
+            .tab_locations
+            .get(&surface)
+            .and_then(|[workspace, ..]| self.tree.workspaces().get(*workspace))
+            .map(|workspace| workspace.id);
+        if let Some(workspace) = workspace {
+            let generation = self.agent_generations.entry(workspace).or_default();
+            *generation = generation.saturating_add(1);
+        } else {
+            self.agent_unscoped_generation = self.agent_unscoped_generation.saturating_add(1);
+        }
     }
 
     fn invoke_sidebar_action(
@@ -15547,8 +15579,8 @@ impl App {
                 self.session.refresh_clients_background();
                 Ok(RenderAction::Draw)
             }
-            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
-                self.bump_agent_generation();
+            AppEvent::Mux(MuxEvent::AgentChanged { surface, .. }) => {
+                self.bump_agent_generation(surface);
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(_) => Ok(RenderAction::Draw),
@@ -46246,7 +46278,8 @@ mod tests {
             tabs_footer_scroll: 0,
             projection_rails: HashMap::new(),
             projection_rows_cache: ProjectionRowsCache::default(),
-            agent_generation: 0,
+            agent_generations: HashMap::new(),
+            agent_unscoped_generation: 0,
             sidebar_generation: 0,
             machine_rail_follow_selection: true,
             workspace_rail_follow_selection: true,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -86,7 +86,8 @@ use crate::session::{
 };
 use crate::sidebar_files::{FileBrowser, FileCommand, file_url, shell_single_quote};
 use crate::sidebar_projection::{
-    ProjectionBranch, ProjectionRailState, ProjectionRow, ProjectionTarget,
+    ProjectionBranch, ProjectionRailState, ProjectionRevision, ProjectionRow, ProjectionRowsCache,
+    ProjectionTarget,
 };
 use crate::ui::graphics::{
     GraphicPlacement, GraphicSourceRect, kitty_graphic_image, kitty_graphic_placement,
@@ -7158,6 +7159,9 @@ pub struct App {
     pub(crate) tabs_rail_scroll: usize,
     pub(crate) tabs_footer_scroll: usize,
     projection_rails: HashMap<String, ProjectionRailState>,
+    projection_rows_cache: ProjectionRowsCache,
+    agent_generation: u64,
+    sidebar_generation: u64,
     pub(crate) machine_rail_follow_selection: bool,
     pub(crate) workspace_rail_follow_selection: bool,
     pub(crate) tabs_rail_follow_selection: bool,
@@ -9426,6 +9430,9 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         tabs_rail_scroll: 0,
         tabs_footer_scroll: 0,
         projection_rails: HashMap::new(),
+        projection_rows_cache: ProjectionRowsCache::default(),
+        agent_generation: 0,
+        sidebar_generation: 0,
         machine_rail_follow_selection: true,
         workspace_rail_follow_selection: true,
         tabs_rail_follow_selection: true,
@@ -10183,32 +10190,39 @@ impl App {
         self.focus == FocusTarget::ProjectionRail(index)
     }
 
-    pub(crate) fn projection_rows(&self, index: usize) -> Vec<ProjectionRow> {
-        let Some(spec) = self.config.sidebar.views.get(index) else { return Vec::new() };
+    pub(crate) fn projection_rows(&mut self, index: usize) -> Vec<ProjectionRow> {
+        let Some(spec) = self.config.sidebar.views.get(index).cloned() else {
+            return Vec::new();
+        };
         let empty_collapsed = HashSet::new();
         let collapsed = self
             .projection_rails
             .get(&spec.id)
-            .map(|state| &state.collapsed)
-            .unwrap_or(&empty_collapsed);
-        let agents = if spec.includes(SidebarResourceKind::Agents) {
-            // Finished reports are historical records, not active agents.
-            // Otherwise detached "surface..." rows remain forever after exit.
-            self.session
-                .agents()
-                .into_iter()
-                .filter(|agent| !matches!(agent.state.as_str(), "done" | "unknown"))
-                .collect::<Vec<_>>()
-        } else {
-            Vec::new()
+            .map(|state| state.collapsed.clone())
+            .unwrap_or(empty_collapsed);
+        let revision = ProjectionRevision {
+            tree_workspace: self.tree.workspace_revision,
+            tree_pane: self.tree.pane_revision,
+            agents: self.agent_generation,
+            sidebar: self.sidebar_generation,
         };
-        crate::sidebar_projection::rows(
-            spec,
-            &self.tree,
-            &agents,
-            self.sidebar_workspace_selection,
-            collapsed,
-        )
+        let tree = &self.tree;
+        let session = &self.session;
+        let selected_workspace = self.sidebar_workspace_selection;
+        self.projection_rows_cache.get_or_build(&spec.id, revision, || {
+            let agents = if spec.includes(SidebarResourceKind::Agents) {
+                // Finished reports are historical records, not active agents.
+                // Otherwise detached "surface..." rows remain forever after exit.
+                session
+                    .agents()
+                    .into_iter()
+                    .filter(|agent| !matches!(agent.state.as_str(), "done" | "unknown"))
+                    .collect::<Vec<_>>()
+            } else {
+                Vec::new()
+            };
+            crate::sidebar_projection::rows(&spec, tree, &agents, selected_workspace, &collapsed)
+        })
     }
 
     pub(crate) fn sidebar_action_rows(&self, index: usize) -> Vec<SidebarActionRow> {
@@ -10309,6 +10323,14 @@ impl App {
         self.projection_rails.entry(id).or_default()
     }
 
+    fn bump_sidebar_generation(&mut self) {
+        self.sidebar_generation = self.sidebar_generation.saturating_add(1);
+    }
+
+    fn bump_agent_generation(&mut self) {
+        self.agent_generation = self.agent_generation.saturating_add(1);
+    }
+
     fn invoke_sidebar_action(
         &mut self,
         target: SidebarActionTarget,
@@ -10384,12 +10406,16 @@ impl App {
     }
 
     fn follow_sidebar_workspace(&mut self, index: usize) {
+        let changed = self.sidebar_workspace_selection != index;
         if self.sidebar_workspace_selection != index {
             self.tabs_rail_selection = 0;
             self.tabs_rail_scroll = 0;
         }
         self.sidebar_workspace_selection = index;
         self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
+        if changed {
+            self.bump_sidebar_generation();
+        }
     }
 
     fn activate_workspace(&mut self, index: usize) {
@@ -10398,10 +10424,12 @@ impl App {
         }
         self.follow_sidebar_workspace(index);
         self.tree.active_workspace = index;
+        self.bump_sidebar_generation();
         self.select_workspace_for_client(Some(index), None);
     }
 
     fn activate_projection_target(&mut self, target: ProjectionTarget) -> anyhow::Result<()> {
+        self.bump_sidebar_generation();
         match target {
             ProjectionTarget::Workspace { index, .. } => {
                 self.activate_workspace(index);
@@ -11841,6 +11869,7 @@ impl App {
             self.browser_input.forget_surface(surface);
         }
         self.tree = tree;
+        self.bump_sidebar_generation();
         self.tab_locations.clear();
         self.rebuild_tab_locations();
         self.render_states.clear();
@@ -13159,6 +13188,7 @@ impl App {
         self.viewport_states.retain(|screen, _| live_screens.contains(screen));
         self.pane_focus_history.sync_membership(&tree);
         self.tree = tree;
+        self.bump_sidebar_generation();
         self.sidebar_workspace_selection = selected_workspace
             .and_then(|selected| {
                 self.tree.workspaces().iter().position(|workspace| workspace.id == selected)
@@ -14090,6 +14120,8 @@ impl App {
         let valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
         self.projection_rails.retain(|id, _| valid_view_ids.contains(id));
+        self.projection_rows_cache.retain_view_ids(&valid_view_ids);
+        self.bump_sidebar_generation();
         self.projection_sidebar_width_overrides.retain(|id, _| valid_view_ids.contains(id));
         if let Some(id) = focused_projection_id {
             if let Some((index, view)) =
@@ -15479,6 +15511,10 @@ impl App {
                 | MuxEvent::ClientListInvalidated,
             ) => {
                 self.session.refresh_clients_background();
+                Ok(RenderAction::Draw)
+            }
+            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
+                self.bump_agent_generation();
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(_) => Ok(RenderAction::Draw),
@@ -18596,7 +18632,9 @@ impl App {
                 && let Some(branch) = selected.as_ref().and_then(|row| row.branch)
                 && selected.as_ref().is_some_and(|row| row.expanded)
             {
-                self.projection_rail_state_mut(view_index).collapsed.insert(branch);
+                if self.projection_rail_state_mut(view_index).collapsed.insert(branch) {
+                    self.bump_sidebar_generation();
+                }
             } else {
                 self.focus_adjacent_rail(RailKind::Projection(view_index), -1);
             }
@@ -18607,7 +18645,9 @@ impl App {
                 && let Some(branch) = selected.as_ref().and_then(|row| row.branch)
                 && selected.as_ref().is_some_and(|row| !row.expanded)
             {
-                self.projection_rail_state_mut(view_index).collapsed.remove(&branch);
+                if self.projection_rail_state_mut(view_index).collapsed.remove(&branch) {
+                    self.bump_sidebar_generation();
+                }
             } else if !self.focus_adjacent_rail(RailKind::Projection(view_index), 1) {
                 self.focus = FocusTarget::Pane;
             }
@@ -18625,6 +18665,7 @@ impl App {
                 state.selected_action = Some(next.saturating_sub(rows.len()));
             }
             state.follow_selection = true;
+            self.bump_sidebar_generation();
             return Ok(RenderAction::Draw);
         }
         if matches!(key.code, KeyCode::Char(' '))
@@ -18634,6 +18675,7 @@ impl App {
             if !state.collapsed.remove(&branch) {
                 state.collapsed.insert(branch);
             }
+            self.bump_sidebar_generation();
             return Ok(RenderAction::Draw);
         }
         if key.code == KeyCode::Enter {
@@ -22467,12 +22509,14 @@ impl App {
                     if !state.collapsed.remove(&branch) {
                         state.collapsed.insert(branch);
                     }
+                    self.bump_sidebar_generation();
                 }
                 Hit::ProjectionRow { view, row, target } => {
                     let state = self.projection_rail_state_mut(view);
                     state.selected = row;
                     state.selected_action = None;
                     state.follow_selection = true;
+                    self.bump_sidebar_generation();
                     self.activate_projection_target(target)?;
                     self.focus = FocusTarget::Pane;
                 }
@@ -23611,12 +23655,18 @@ impl App {
             .entry(self.config.sidebar.active_profile.clone())
             .or_default();
         if visible {
-            hidden.remove(&view_id);
+            let changed = hidden.remove(&view_id);
             self.sidebar_visible = true;
+            if changed {
+                self.bump_sidebar_generation();
+            }
         } else {
-            hidden.insert(view_id);
+            let changed = hidden.insert(view_id);
             if hides_focused {
                 self.focus = FocusTarget::Pane;
+            }
+            if changed {
+                self.bump_sidebar_generation();
             }
         }
     }
@@ -23640,6 +23690,7 @@ impl App {
             })
             .collect();
         self.sidebar_visible = true;
+        self.bump_sidebar_generation();
         if let Some(focused_view) = focused_view {
             let hidden = self
                 .hidden_sidebar_views
@@ -45758,6 +45809,9 @@ mod tests {
             tabs_rail_scroll: 0,
             tabs_footer_scroll: 0,
             projection_rails: HashMap::new(),
+            projection_rows_cache: ProjectionRowsCache::default(),
+            agent_generation: 0,
+            sidebar_generation: 0,
             machine_rail_follow_selection: true,
             workspace_rail_follow_selection: true,
             tabs_rail_follow_selection: true,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -23654,20 +23654,16 @@ impl App {
             .hidden_sidebar_views
             .entry(self.config.sidebar.active_profile.clone())
             .or_default();
+        let changed = if visible { hidden.remove(&view_id) } else { hidden.insert(view_id) };
         if visible {
-            let changed = hidden.remove(&view_id);
             self.sidebar_visible = true;
-            if changed {
-                self.bump_sidebar_generation();
-            }
         } else {
-            let changed = hidden.insert(view_id);
             if hides_focused {
                 self.focus = FocusTarget::Pane;
             }
-            if changed {
-                self.bump_sidebar_generation();
-            }
+        }
+        if changed {
+            self.bump_sidebar_generation();
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10407,12 +10407,12 @@ impl App {
         if !self.prepare_pty_input_before_mutation() {
             return Ok(());
         }
-        let previous_surface = self.tree.active_surface();
+        let previous_focus = self.active_focus_state();
         if !self.tree.select_surface(target.surface) {
             return Ok(());
         }
         self.follow_sidebar_workspace(target.workspace);
-        if previous_surface != Some(target.surface) {
+        if previous_focus != self.active_focus_state() {
             self.bump_sidebar_generation();
         }
         self.pane_focus_history.record(target.pane);
@@ -13052,7 +13052,7 @@ impl App {
         else {
             return;
         };
-        let changed = self.tree.active_surface() != Some(surface);
+        let previous_focus = self.active_focus_state();
         self.tree.active_workspace = workspace_index;
         if !self.tree.set_active_screen(workspace_index, screen_index)
             || !self.tree.set_active_pane(workspace_index, screen_index, pane_id)
@@ -13060,7 +13060,7 @@ impl App {
         {
             return;
         }
-        if changed {
+        if previous_focus != self.active_focus_state() {
             self.bump_sidebar_generation();
         }
         self.pane_focus_history.record(pane_id);
@@ -16746,6 +16746,17 @@ impl App {
 
     fn active_surface(&self) -> Option<SurfaceId> {
         self.tree.active_surface()
+    }
+
+    fn active_focus_state(&self) -> Option<(usize, usize, PaneId, Option<usize>)> {
+        let workspace_index = self.tree.active_workspace;
+        let workspace = self.tree.active_workspace()?;
+        let screen_index = workspace.active_screen;
+        let screen = workspace.screens.get(screen_index)?;
+        let pane_id = screen.active_pane;
+        let pane = screen.panes.iter().find(|pane| pane.id == pane_id)?;
+        let active_tab = pane.tabs.get(pane.active_tab).map(|_| pane.active_tab);
+        Some((workspace_index, screen_index, pane_id, active_tab))
     }
 
     /// Adopt this client's own remembered focus from the mux (or the
@@ -43900,7 +43911,7 @@ mod tests {
         let workspace_before = app.projection_rows_cache.revision_for("workspace-view").unwrap();
         let agent_before = app.projection_rows_cache.revision_for("agent-view").unwrap();
 
-        app.bump_agent_generation();
+        app.bump_agent_generation(surface.id);
         app.projection_rows(0);
         app.projection_rows(1);
         let workspace_after = app.projection_rows_cache.revision_for("workspace-view").unwrap();
@@ -43959,6 +43970,37 @@ mod tests {
         assert_eq!(second_before, second_after);
 
         mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_scope_agent_revision_to_selected_workspace() {
+        let (mux, first_surface) = test_mux("projection-agent-owner-scope-test", None);
+        let second_surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "agent-view".into(),
+            levels: vec![SidebarResourceKind::Agents],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.sidebar_workspace_selection = 0;
+        app.projection_rows(0);
+        let before = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        app.bump_agent_generation(second_surface.id);
+        app.projection_rows(0);
+        let after = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        assert_eq!(before, after);
+
+        mux.close_surface(first_surface.id).unwrap();
+        mux.close_surface(second_surface.id).unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44000,14 +44000,14 @@ mod tests {
         app.replace_tree(app.session.tree());
         app.projection_rows(0);
         app.projection_rows(1);
-        let workspace_before = app.projection_rows_cache.revision_for("workspace-view").unwrap();
-        let agent_before = app.projection_rows_cache.revision_for("agent-view").unwrap();
+        let workspace_before = app.projection_rows_cache.revision_for(0).unwrap();
+        let agent_before = app.projection_rows_cache.revision_for(1).unwrap();
 
         app.bump_agent_generation(surface.id);
         app.projection_rows(0);
         app.projection_rows(1);
-        let workspace_after = app.projection_rows_cache.revision_for("workspace-view").unwrap();
-        let agent_after = app.projection_rows_cache.revision_for("agent-view").unwrap();
+        let workspace_after = app.projection_rows_cache.revision_for(0).unwrap();
+        let agent_after = app.projection_rows_cache.revision_for(1).unwrap();
 
         assert_eq!(workspace_before, workspace_after);
         assert_ne!(agent_before, agent_after);
@@ -44044,8 +44044,8 @@ mod tests {
         app.replace_tree(app.session.tree());
         app.projection_rows(0);
         app.projection_rows(1);
-        let first_before = app.projection_rows_cache.revision_for("first-view").unwrap();
-        let second_before = app.projection_rows_cache.revision_for("second-view").unwrap();
+        let first_before = app.projection_rows_cache.revision_for(0).unwrap();
+        let second_before = app.projection_rows_cache.revision_for(1).unwrap();
         let workspace_id = app.tree.workspaces().first().unwrap().id;
 
         app.projection_rail_state_mut(0)
@@ -44054,8 +44054,8 @@ mod tests {
         app.bump_projection_rows_generation(0);
         app.projection_rows(0);
         app.projection_rows(1);
-        let first_after = app.projection_rows_cache.revision_for("first-view").unwrap();
-        let second_after = app.projection_rows_cache.revision_for("second-view").unwrap();
+        let first_after = app.projection_rows_cache.revision_for(0).unwrap();
+        let second_after = app.projection_rows_cache.revision_for(1).unwrap();
 
         assert_ne!(first_before.rail, first_after.rail);
         assert_eq!(first_before.sidebar, first_after.sidebar);
@@ -44083,11 +44083,11 @@ mod tests {
         app.replace_tree(app.session.tree());
         app.sidebar_workspace_selection = 0;
         app.projection_rows(0);
-        let before = app.projection_rows_cache.revision_for("agent-view").unwrap();
+        let before = app.projection_rows_cache.revision_for(0).unwrap();
 
         app.bump_agent_generation(second_surface.id);
         app.projection_rows(0);
-        let after = app.projection_rows_cache.revision_for("agent-view").unwrap();
+        let after = app.projection_rows_cache.revision_for(0).unwrap();
 
         assert_eq!(before, after);
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43812,6 +43812,56 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_refresh_when_focus_changes_without_active_surface() {
+        let mux =
+            Mux::new("projection-focus-without-surface-refresh-test", SurfaceOptions::default());
+        let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let first_pane = mux.with_state(|state| state.pane_of(surface.id).unwrap());
+        mux.split(first_pane, SplitDir::Right, Some((40, 24))).unwrap();
+        let second_pane = Session::Local(mux.clone()).tree().active_screen().unwrap().active_pane;
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == second_pane
+                )
+        }));
+
+        for workspace in app.tree.workspaces_mut() {
+            for screen in &mut workspace.screens {
+                for pane in &mut screen.panes {
+                    pane.tabs.clear();
+                }
+            }
+        }
+        app.activate_projection_target(crate::sidebar_projection::ProjectionTarget::Pane {
+            workspace: 0,
+            screen: 0,
+            pane: first_pane,
+        })
+        .unwrap();
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == first_pane
+                )
+        }));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn projection_rows_scope_agent_revision_to_agent_views() {
         let (mux, surface) = test_mux("projection-agent-revision-scope-test", None);
         mux.report_agent(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14120,7 +14120,7 @@ impl App {
         let valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
         self.projection_rails.retain(|id, _| valid_view_ids.contains(id));
-        self.projection_rows_cache.retain_view_ids(&valid_view_ids);
+        self.projection_rows_cache.invalidate();
         self.bump_sidebar_generation();
         self.projection_sidebar_width_overrides.retain(|id, _| valid_view_ids.contains(id));
         if let Some(id) = focused_projection_id {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16737,6 +16737,7 @@ impl App {
         self.tree.set_active_tab(workspace_index, screen_index, pane_id, tab_index);
         self.sidebar_workspace_selection =
             workspace_index.min(self.tree.workspaces().len().saturating_sub(1));
+        self.bump_sidebar_generation();
         self.pane_focus_history.record(pane_id);
         self.reported_focus = Some(crate::session::ClientFocus { pane: pane_id, tab: tab_index });
     }
@@ -18223,6 +18224,7 @@ impl App {
                     }
                     self.sidebar_workspace_selection = index;
                     self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
+                    self.bump_sidebar_generation();
                 }
             }
             WorkspaceRailTarget::Recoverable(id) => {
@@ -20609,6 +20611,7 @@ impl App {
                     self.sidebar_workspace_selection = self.tree.active_workspace;
                     self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
                     self.workspace_rail_follow_selection = true;
+                    self.bump_sidebar_generation();
                 } else if !self.sync_sidebar_files_to_focus(true) {
                     self.sidebar_files.refresh();
                 }
@@ -20638,6 +20641,7 @@ impl App {
                 self.sidebar_workspace_selection = self.tree.active_workspace;
                 self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
                 self.workspace_rail_follow_selection = true;
+                self.bump_sidebar_generation();
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13080,6 +13080,7 @@ impl App {
             .get(workspace_index)
             .and_then(|workspace| workspace.screens.get(screen_index))
             .and_then(|screen| screen.panes.get(pane_index))
+            .filter(|pane| pane.tabs.get(tab_index).is_some())
             .map(|pane| pane.id)
         else {
             return;
@@ -13254,6 +13255,9 @@ impl App {
         self.viewport_states.retain(|screen, _| live_screens.contains(screen));
         self.pane_focus_history.sync_membership(&tree);
         self.tree = tree;
+        let live_workspace_ids =
+            self.tree.workspaces().iter().map(|workspace| workspace.id).collect();
+        self.agent_generations.retain(|workspace_id, _| live_workspace_ids.contains(workspace_id));
         self.bump_sidebar_generation();
         self.sidebar_workspace_selection = selected_workspace
             .and_then(|selected| {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24813,6 +24813,7 @@ mod tests {
         swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
         workspace_creation_selection,
     };
+    use crate::sidebar_projection::ProjectionRowsCache;
     use cmux_tui_core::{FrontendFocusTarget, FrontendJournalEvent};
     use crossbeam_channel::Receiver;
     use serde_json::Value;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10396,10 +10396,14 @@ impl App {
         if !self.prepare_pty_input_before_mutation() {
             return Ok(());
         }
+        let previous_surface = self.tree.active_surface();
         if !self.tree.select_surface(target.surface) {
             return Ok(());
         }
         self.follow_sidebar_workspace(target.workspace);
+        if previous_surface != Some(target.surface) {
+            self.bump_sidebar_generation();
+        }
         self.pane_focus_history.record(target.pane);
         self.claim_active_terminal_geometry(true);
         Ok(())
@@ -10422,14 +10426,16 @@ impl App {
         if index >= self.tree.workspaces().len() || !self.prepare_pty_input_before_mutation() {
             return;
         }
+        let changed = self.tree.active_workspace != index;
         self.follow_sidebar_workspace(index);
         self.tree.active_workspace = index;
-        self.bump_sidebar_generation();
+        if changed {
+            self.bump_sidebar_generation();
+        }
         self.select_workspace_for_client(Some(index), None);
     }
 
     fn activate_projection_target(&mut self, target: ProjectionTarget) -> anyhow::Result<()> {
-        self.bump_sidebar_generation();
         match target {
             ProjectionTarget::Workspace { index, .. } => {
                 self.activate_workspace(index);
@@ -10438,10 +10444,23 @@ impl App {
                 if !self.prepare_pty_input_before_mutation() {
                     return Ok(());
                 }
+                let previous = (
+                    self.tree.active_workspace,
+                    self.tree.active_workspace().map(|workspace| workspace.active_screen),
+                    self.tree.active_screen().map(|screen| screen.active_pane),
+                );
                 self.follow_sidebar_workspace(workspace);
                 self.tree.active_workspace = workspace;
                 self.tree.set_active_screen(workspace, screen);
                 self.tree.set_active_pane(workspace, screen, pane);
+                let current = (
+                    self.tree.active_workspace,
+                    self.tree.active_workspace().map(|workspace| workspace.active_screen),
+                    self.tree.active_screen().map(|screen| screen.active_pane),
+                );
+                if previous != current {
+                    self.bump_sidebar_generation();
+                }
                 self.pane_focus_history.record(pane);
                 self.claim_active_terminal_geometry(true);
             }
@@ -13022,12 +13041,16 @@ impl App {
         else {
             return;
         };
+        let changed = self.tree.active_surface() != Some(surface);
         self.tree.active_workspace = workspace_index;
         if !self.tree.set_active_screen(workspace_index, screen_index)
             || !self.tree.set_active_pane(workspace_index, screen_index, pane_id)
             || !self.tree.set_active_tab(workspace_index, screen_index, pane_id, tab_index)
         {
             return;
+        }
+        if changed {
+            self.bump_sidebar_generation();
         }
         self.pane_focus_history.record(pane_id);
         self.claim_active_terminal_geometry(true);
@@ -22005,9 +22028,16 @@ impl App {
             let workspace_index = self.tree.active_workspace;
             let screen_index =
                 self.tree.active_workspace().map(|workspace| workspace.active_screen);
+            let changed = self
+                .tree
+                .active_screen()
+                .is_some_and(|screen| screen.active_pane != pane);
             let focused = screen_index
                 .is_some_and(|screen| self.tree.set_active_pane(workspace_index, screen, pane));
             if focused {
+                if changed {
+                    self.bump_sidebar_generation();
+                }
                 self.pane_focus_history.record(pane);
                 self.claim_active_terminal_geometry(true);
             }
@@ -22021,6 +22051,7 @@ impl App {
         delta: Option<isize>,
     ) {
         let pane = pane.or_else(|| self.active_pane());
+<<<<<<< HEAD
         if let Some(pane_id) = pane {
             let target = self.tree.pane(pane_id).and_then(|pane| {
                 if pane.tabs.is_empty() {
@@ -22034,7 +22065,11 @@ impl App {
                 })
             });
             if let Some(target) = target {
+                let changed = self.tree.pane(pane_id).is_some_and(|pane| pane.active_tab != target);
                 self.tree.set_pane_active_tab(pane_id, target);
+                if changed {
+                    self.bump_sidebar_generation();
+                }
             }
         }
         self.claim_active_terminal_geometry(true);
@@ -22055,7 +22090,14 @@ impl App {
         });
         if let Some(target) = target {
             let workspace_index = self.tree.active_workspace;
+            let changed = self
+                .tree
+                .active_workspace()
+                .is_some_and(|workspace| workspace.active_screen != target);
             selected = self.tree.set_active_screen(workspace_index, target);
+            if changed {
+                self.bump_sidebar_generation();
+            }
         }
         if selected && let Some(active) = self.active_pane() {
             self.pane_focus_history.record(active);
@@ -22067,14 +22109,23 @@ impl App {
         let mut selected = false;
         if !self.tree.workspaces().is_empty() {
             if let Some(index) = index.filter(|index| *index < self.tree.workspaces().len()) {
+                let changed = self.tree.active_workspace != index;
                 self.tree.active_workspace = index;
                 selected = true;
+                if changed {
+                    self.bump_sidebar_generation();
+                }
             } else if let Some(delta) = delta {
+                let previous = self.tree.active_workspace;
                 self.tree.active_workspace = ((self.tree.active_workspace as isize + delta)
                     .rem_euclid(self.tree.workspaces().len() as isize))
                     as usize;
                 selected = true;
+                if self.tree.active_workspace != previous {
+                    self.bump_sidebar_generation();
+                }
             }
+        }
         }
         if selected && let Some(active) = self.active_pane() {
             self.pane_focus_history.record(active);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10200,11 +10200,17 @@ impl App {
             .get(&spec.id)
             .map(|state| state.collapsed.clone())
             .unwrap_or(empty_collapsed);
+        let rail_generation =
+            self.projection_rails.get(&spec.id).map_or(0, |state| state.rows_generation);
         let revision = ProjectionRevision {
             tree_workspace: self.tree.workspace_revision,
             tree_pane: self.tree.pane_revision,
-            agents: self.agent_generation,
+            agents: spec.includes(SidebarResourceKind::Agents).then_some(self.agent_generation),
+            selected_workspace: (!spec.includes(SidebarResourceKind::Workspaces))
+                .then_some(self.sidebar_workspace_selection)
+                .unwrap_or(0),
             sidebar: self.sidebar_generation,
+            rail: rail_generation,
         };
         let tree = &self.tree;
         let session = &self.session;
@@ -10325,6 +10331,11 @@ impl App {
 
     fn bump_sidebar_generation(&mut self) {
         self.sidebar_generation = self.sidebar_generation.saturating_add(1);
+    }
+
+    fn bump_projection_rows_generation(&mut self, index: usize) {
+        let state = self.projection_rail_state_mut(index);
+        state.rows_generation = state.rows_generation.saturating_add(1);
     }
 
     fn bump_agent_generation(&mut self) {
@@ -18658,7 +18669,7 @@ impl App {
                 && selected.as_ref().is_some_and(|row| row.expanded)
             {
                 if self.projection_rail_state_mut(view_index).collapsed.insert(branch) {
-                    self.bump_sidebar_generation();
+                    self.bump_projection_rows_generation(view_index);
                 }
             } else {
                 self.focus_adjacent_rail(RailKind::Projection(view_index), -1);
@@ -18671,7 +18682,7 @@ impl App {
                 && selected.as_ref().is_some_and(|row| !row.expanded)
             {
                 if self.projection_rail_state_mut(view_index).collapsed.remove(&branch) {
-                    self.bump_sidebar_generation();
+                    self.bump_projection_rows_generation(view_index);
                 }
             } else if !self.focus_adjacent_rail(RailKind::Projection(view_index), 1) {
                 self.focus = FocusTarget::Pane;
@@ -18700,7 +18711,7 @@ impl App {
             if !state.collapsed.remove(&branch) {
                 state.collapsed.insert(branch);
             }
-            self.bump_sidebar_generation();
+            self.bump_projection_rows_generation(view_index);
             return Ok(RenderAction::Draw);
         }
         if key.code == KeyCode::Enter {
@@ -22028,10 +22039,8 @@ impl App {
             let workspace_index = self.tree.active_workspace;
             let screen_index =
                 self.tree.active_workspace().map(|workspace| workspace.active_screen);
-            let changed = self
-                .tree
-                .active_screen()
-                .is_some_and(|screen| screen.active_pane != pane);
+            let changed =
+                self.tree.active_screen().is_some_and(|screen| screen.active_pane != pane);
             let focused = screen_index
                 .is_some_and(|screen| self.tree.set_active_pane(workspace_index, screen, pane));
             if focused {
@@ -22051,7 +22060,6 @@ impl App {
         delta: Option<isize>,
     ) {
         let pane = pane.or_else(|| self.active_pane());
-<<<<<<< HEAD
         if let Some(pane_id) = pane {
             let target = self.tree.pane(pane_id).and_then(|pane| {
                 if pane.tabs.is_empty() {
@@ -22125,7 +22133,6 @@ impl App {
                     self.bump_sidebar_generation();
                 }
             }
-        }
         }
         if selected && let Some(active) = self.active_pane() {
             self.pane_focus_history.record(active);
@@ -22564,7 +22571,7 @@ impl App {
                     if !state.collapsed.remove(&branch) {
                         state.collapsed.insert(branch);
                     }
-                    self.bump_sidebar_generation();
+                    self.bump_projection_rows_generation(view);
                 }
                 Hit::ProjectionRow { view, row, target } => {
                     let state = self.projection_rail_state_mut(view);
@@ -43897,7 +43904,8 @@ mod tests {
         let first_after = app.projection_rows_cache.revision_for("first-view").unwrap();
         let second_after = app.projection_rows_cache.revision_for("second-view").unwrap();
 
-        assert_ne!(first_before, first_after);
+        assert_ne!(first_before.rail, first_after.rail);
+        assert_eq!(first_before.sidebar, first_after.sidebar);
         assert_eq!(second_before, second_after);
 
         mux.close_surface(surface.id).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13255,8 +13255,12 @@ impl App {
         self.viewport_states.retain(|screen, _| live_screens.contains(screen));
         self.pane_focus_history.sync_membership(&tree);
         self.tree = tree;
-        let live_workspace_ids =
-            self.tree.workspaces().iter().map(|workspace| workspace.id).collect();
+        let live_workspace_ids = self
+            .tree
+            .workspaces()
+            .iter()
+            .map(|workspace| workspace.id)
+            .collect::<HashSet<WorkspaceId>>();
         self.agent_generations.retain(|workspace_id, _| live_workspace_ids.contains(workspace_id));
         self.bump_sidebar_generation();
         self.sidebar_workspace_selection = selected_workspace

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43905,6 +43905,45 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_refresh_after_client_focus_partial_failure() {
+        let mux =
+            Mux::new("projection-client-focus-partial-failure-test", SurfaceOptions::default());
+        let first = mux.new_workspace(Some("Alpha".into()), Some((80, 24))).unwrap();
+        let second = mux.new_workspace(Some("Beta".into()), Some((80, 24))).unwrap();
+        let mut app =
+            projection_test_app(Session::Local(mux.clone()), vec![SidebarResourceKind::Workspaces]);
+        app.tree.active_workspace = 0;
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
+                )
+        }));
+
+        // Simulate a stale completion. The workspace index is still valid, but
+        // the tab index no longer exists when the client focus is applied.
+        app.tab_locations.insert(second.id, [1, 0, 0, usize::MAX]);
+        app.select_created_surface(second.id);
+
+        // A failed focus request must not leave a partial workspace mutation
+        // behind, or the cached active row can become stale.
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
+                )
+        }));
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
     fn projection_rows_scope_agent_revision_to_agent_views() {
         let (mux, surface) = test_mux("projection-agent-revision-scope-test", None);
         mux.report_agent(
@@ -44030,6 +44069,31 @@ mod tests {
         let after = app.projection_rows_cache.revision_for("agent-view").unwrap();
 
         assert_eq!(before, after);
+
+        mux.close_surface(first_surface.id).unwrap();
+        mux.close_surface(second_surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_agent_generations_prune_removed_workspaces() {
+        let (mux, first_surface) = test_mux("projection-agent-generation-prune-test", None);
+        let second_surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.replace_tree(app.session.tree());
+        let first_workspace = app.tree.workspaces()[0].id;
+        let second_workspace = app.tree.workspaces()[1].id;
+
+        app.bump_agent_generation(first_surface.id);
+        app.bump_agent_generation(second_surface.id);
+        assert_eq!(app.agent_generations.len(), 2);
+
+        let mut replacement = app.tree.clone();
+        replacement.workspaces_mut().remove(0);
+        replacement.active_workspace = 0;
+        app.replace_tree(replacement);
+
+        assert!(!app.agent_generations.contains_key(&first_workspace));
+        assert!(app.agent_generations.contains_key(&second_workspace));
 
         mux.close_surface(first_surface.id).unwrap();
         mux.close_surface(second_surface.id).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10192,9 +10192,9 @@ impl App {
         self.focus == FocusTarget::ProjectionRail(index)
     }
 
-    pub(crate) fn projection_rows(&mut self, index: usize) -> Vec<ProjectionRow> {
+    pub(crate) fn projection_rows(&mut self, index: usize) -> Arc<[ProjectionRow]> {
         let Some(spec) = self.config.sidebar.views.get(index).cloned() else {
-            return Vec::new();
+            return Arc::from([]);
         };
         let empty_collapsed = HashSet::new();
         let collapsed = self

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43805,6 +43805,105 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_scope_agent_revision_to_agent_views() {
+        let (mux, surface) = test_mux("projection-agent-revision-scope-test", None);
+        mux.report_agent(
+            surface.id,
+            AgentState::Working,
+            AgentSource::Hook,
+            Some("agent-session".into()),
+        )
+        .unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![
+            SidebarViewSpec {
+                id: "workspace-view".into(),
+                levels: vec![SidebarResourceKind::Workspaces],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+            SidebarViewSpec {
+                id: "agent-view".into(),
+                levels: vec![SidebarResourceKind::Agents],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+        ];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let workspace_before = app.projection_rows_cache.revision_for("workspace-view").unwrap();
+        let agent_before = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        app.bump_agent_generation();
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let workspace_after = app.projection_rows_cache.revision_for("workspace-view").unwrap();
+        let agent_after = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        assert_eq!(workspace_before, workspace_after);
+        assert_ne!(agent_before, agent_after);
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_scope_collapse_revision_to_its_rail() {
+        let (mux, surface) = test_mux("projection-sidebar-revision-scope-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![
+            SidebarViewSpec {
+                id: "first-view".into(),
+                levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+            SidebarViewSpec {
+                id: "second-view".into(),
+                levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+        ];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let first_before = app.projection_rows_cache.revision_for("first-view").unwrap();
+        let second_before = app.projection_rows_cache.revision_for("second-view").unwrap();
+        let workspace_id = app.tree.workspaces.first().unwrap().id;
+
+        app.projection_rail_state_mut(0)
+            .collapsed
+            .insert(crate::sidebar_projection::ProjectionBranch::Workspace(workspace_id));
+        app.bump_projection_rows_generation(0);
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let first_after = app.projection_rows_cache.revision_for("first-view").unwrap();
+        let second_after = app.projection_rows_cache.revision_for("second-view").unwrap();
+
+        assert_ne!(first_before, first_after);
+        assert_eq!(second_before, second_after);
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn projection_stale_action_selection_does_not_retarget_resource_row() {
         let (mux, surface) = test_mux("projection-stale-action-selection-test", None);
         mux.report_agent(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10237,7 +10237,7 @@ impl App {
         let tree = &self.tree;
         let session = &self.session;
         let selected_workspace = self.sidebar_workspace_selection;
-        self.projection_rows_cache.get_or_build(&spec.id, revision, || {
+        self.projection_rows_cache.get_or_build(index, &spec.id, revision, || {
             let agents = if spec.includes(SidebarResourceKind::Agents) {
                 // Finished reports are historical records, not active agents.
                 // Otherwise detached "surface..." rows remain forever after exit.

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -28120,6 +28120,19 @@ mod tests {
     }
 
     #[test]
+    fn selection_for_click_propagates_missing_terminal_range() {
+        let (app, mux, surface, _) =
+            selection_fixture("selection-for-click-missing-range-test", b"alpha");
+
+        assert!(
+            app.selection_for_click(surface.id, (10, 0), SelectionMode::Word).is_none(),
+            "a semantic click without a terminal range must return no selection"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_single_cell_press_does_not_store_a_zero_length_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("single-cell-press-selection-state-test", b"alpha beta");
@@ -43842,7 +43855,7 @@ mod tests {
 
         let first_screen_pane = app
             .tree
-            .workspaces
+            .workspaces()
             .first()
             .and_then(|workspace| workspace.screens.first())
             .map(|screen| screen.active_pane)
@@ -44033,7 +44046,7 @@ mod tests {
         app.projection_rows(1);
         let first_before = app.projection_rows_cache.revision_for("first-view").unwrap();
         let second_before = app.projection_rows_cache.revision_for("second-view").unwrap();
-        let workspace_id = app.tree.workspaces.first().unwrap().id;
+        let workspace_id = app.tree.workspaces().first().unwrap().id;
 
         app.projection_rail_state_mut(0)
             .collapsed

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43568,6 +43568,191 @@ mod tests {
         mux.close_surface(surface.id).unwrap();
     }
 
+    fn projection_test_app(session: Session, levels: Vec<SidebarResourceKind>) -> App {
+        let mut app = test_app(session);
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "projection-active-refresh".into(),
+            levels,
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_workspace_after_client_selection() {
+        let mux = Mux::new("projection-active-workspace-refresh-test", SurfaceOptions::default());
+        let first = mux.new_workspace(Some("Alpha".into()), Some((80, 24))).unwrap();
+        let second = mux.new_workspace(Some("Beta".into()), Some((80, 24))).unwrap();
+        let mut app =
+            projection_test_app(Session::Local(mux.clone()), vec![SidebarResourceKind::Workspaces]);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 1, .. }
+                )
+        }));
+
+        app.select_workspace_for_client(Some(0), None);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
+                )
+        }));
+
+        for surface in [first, second] {
+            mux.close_surface(surface.id).unwrap();
+        }
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_pane_after_client_focus() {
+        let mux = Mux::new("projection-active-pane-refresh-test", SurfaceOptions::default());
+        let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let first_pane = mux.with_state(|state| state.pane_of(surface.id).unwrap());
+        mux.split(first_pane, SplitDir::Right, Some((40, 24))).unwrap();
+        let second_pane = Session::Local(mux.clone()).tree().active_screen().unwrap().active_pane;
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == second_pane
+                )
+        }));
+
+        app.focus_pane_after_input(first_pane);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == first_pane
+                )
+        }));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_tab_after_client_selection() {
+        let mux = Mux::new("projection-active-tab-refresh-test", SurfaceOptions::default());
+        let first = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        let second = mux.new_tab(Some(pane), None, Some((80, 24))).unwrap();
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![
+                SidebarResourceKind::Workspaces,
+                SidebarResourceKind::Panes,
+                SidebarResourceKind::Tabs,
+            ],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Tabs
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                        if surface == second.id
+                )
+        }));
+
+        app.select_tab_for_client(Some(pane), Some(0), None);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Tabs
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                        if surface == first.id
+                )
+        }));
+
+        app.select_created_surface(second.id);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Tabs
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                        if surface == second.id
+                )
+        }));
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_screen_after_client_selection() {
+        let mux = Mux::new("projection-active-screen-refresh-test", SurfaceOptions::default());
+        let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let workspace = Session::Local(mux.clone()).tree().active_workspace().unwrap().id;
+        mux.new_screen(Some(workspace), Some((80, 24))).unwrap();
+        let second_screen_pane =
+            Session::Local(mux.clone()).tree().active_screen().unwrap().active_pane;
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == second_screen_pane
+                )
+        }));
+
+        let first_screen_pane = app
+            .tree
+            .workspaces
+            .first()
+            .and_then(|workspace| workspace.screens.first())
+            .map(|screen| screen.active_pane)
+            .unwrap();
+        app.select_screen_for_client(Some(0), None);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == first_screen_pane
+                )
+        }));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
     #[test]
     fn projection_stale_action_selection_does_not_retarget_resource_row() {
         let (mux, surface) = test_mux("projection-stale-action-selection-test", None);

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -94,6 +94,10 @@ pub(crate) struct ProjectionRowsCache {
 }
 
 impl ProjectionRowsCache {
+    pub(crate) fn invalidate(&mut self) {
+        self.entries.clear();
+    }
+
     pub(crate) fn get_or_build(
         &mut self,
         view_id: &str,
@@ -109,10 +113,6 @@ impl ProjectionRowsCache {
         self.entries
             .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
         rows
-    }
-
-    pub(crate) fn retain_view_ids(&mut self, view_ids: &HashSet<String>) {
-        self.entries.retain(|view_id, _| view_ids.contains(view_id));
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -72,6 +72,50 @@ impl Default for ProjectionRailState {
     }
 }
 
+/// Revisions that determine whether a projection row list is still valid.
+/// Tree and agent revisions come from the session snapshots, while the
+/// sidebar revision covers presentation state such as selection and collapse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProjectionRevision {
+    pub tree_workspace: u64,
+    pub tree_pane: Option<u64>,
+    pub agents: u64,
+    pub sidebar: u64,
+}
+
+struct CachedProjectionRows {
+    revision: ProjectionRevision,
+    rows: Vec<ProjectionRow>,
+}
+
+#[derive(Default)]
+pub(crate) struct ProjectionRowsCache {
+    entries: HashMap<String, CachedProjectionRows>,
+}
+
+impl ProjectionRowsCache {
+    pub(crate) fn get_or_build(
+        &mut self,
+        view_id: &str,
+        revision: ProjectionRevision,
+        build: impl FnOnce() -> Vec<ProjectionRow>,
+    ) -> Vec<ProjectionRow> {
+        if let Some(cached) = self.entries.get(view_id)
+            && cached.revision == revision
+        {
+            return cached.rows.clone();
+        }
+        let rows = build();
+        self.entries
+            .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
+        rows
+    }
+
+    pub(crate) fn retain_view_ids(&mut self, view_ids: &HashSet<String>) {
+        self.entries.retain(|view_id, _| view_ids.contains(view_id));
+    }
+}
+
 #[derive(Clone, Copy)]
 struct ProjectionContext {
     workspace: usize,

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -430,4 +430,38 @@ mod tests {
         let rows = rows(&spec(vec![SidebarResourceKind::Agents]), &tree(), &[], 0, &HashSet::new());
         assert!(rows.is_empty());
     }
+
+    #[test]
+    fn projection_cache_reuses_rows_until_revision_changes() {
+        let tree = tree();
+        let view = spec(vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Tabs]);
+        let collapsed = HashSet::new();
+        let revision = ProjectionRevision {
+            tree_workspace: tree.workspace_revision,
+            tree_pane: tree.pane_revision,
+            agents: 3,
+            sidebar: 7,
+        };
+        let mut cache = ProjectionRowsCache::default();
+        let mut builds = 0;
+        let first = cache.get_or_build("tabs", revision, || {
+            builds += 1;
+            rows(&view, &tree, &[], 0, &collapsed)
+        });
+        let second = cache.get_or_build("tabs", revision, || {
+            builds += 1;
+            rows(&view, &tree, &[], 0, &collapsed)
+        });
+
+        assert_eq!(first, second);
+        assert_eq!(builds, 1);
+
+        let changed = ProjectionRevision { sidebar: 8, ..revision };
+        let third = cache.get_or_build("tabs", changed, || {
+            builds += 1;
+            rows(&view, &tree, &[], 0, &collapsed)
+        });
+        assert_eq!(third, first);
+        assert_eq!(builds, 2);
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -1,6 +1,7 @@
 //! Pure projection of mux resources into configurable native sidebar trees.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use cmux_tui_core::{PaneId, SurfaceId, WorkspaceId};
 
@@ -94,7 +95,7 @@ pub(crate) struct ProjectionRevision {
 
 struct CachedProjectionRows {
     revision: ProjectionRevision,
-    rows: Vec<ProjectionRow>,
+    rows: Arc<[ProjectionRow]>,
 }
 
 #[derive(Default)]
@@ -112,15 +113,17 @@ impl ProjectionRowsCache {
         view_id: &str,
         revision: ProjectionRevision,
         build: impl FnOnce() -> Vec<ProjectionRow>,
-    ) -> Vec<ProjectionRow> {
+    ) -> Arc<[ProjectionRow]> {
         if let Some(cached) = self.entries.get(view_id)
             && cached.revision == revision
         {
-            return cached.rows.clone();
+            return Arc::clone(&cached.rows);
         }
-        let rows = build();
-        self.entries
-            .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
+        let rows: Arc<[ProjectionRow]> = build().into();
+        self.entries.insert(
+            view_id.to_string(),
+            CachedProjectionRows { revision, rows: Arc::clone(&rows) },
+        );
         rows
     }
 

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -338,6 +338,7 @@ fn append_level(
 mod tests {
     use super::*;
     use cmux_tui_core::{Node, SurfaceKind};
+    use std::sync::Arc;
 
     use crate::session::tree::{PaneView, ScreenView, TabView, WorkspaceView};
 
@@ -514,6 +515,7 @@ mod tests {
         });
 
         assert_eq!(first, second);
+        assert!(Arc::ptr_eq(&first, &second), "cache hits must share owned rows");
         assert_eq!(builds, 1);
 
         let changed = ProjectionRevision { sidebar: 8, ..revision };

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -57,6 +57,8 @@ pub(crate) struct ProjectionRailState {
     pub footer_scroll: usize,
     pub follow_selection: bool,
     pub collapsed: HashSet<ProjectionBranch>,
+    /// Revision for row-affecting presentation state in this rail.
+    pub rows_generation: u64,
 }
 
 impl Default for ProjectionRailState {
@@ -68,6 +70,7 @@ impl Default for ProjectionRailState {
             footer_scroll: 0,
             follow_selection: true,
             collapsed: HashSet::new(),
+            rows_generation: 0,
         }
     }
 }
@@ -79,8 +82,14 @@ impl Default for ProjectionRailState {
 pub(crate) struct ProjectionRevision {
     pub tree_workspace: u64,
     pub tree_pane: Option<u64>,
-    pub agents: u64,
+    /// Agent changes affect only views that include the Agents resource.
+    pub agents: Option<u64>,
+    /// Workspace selection affects flat views that need a workspace context.
+    pub selected_workspace: usize,
+    /// Selection and focus changes that affect every projection view.
     pub sidebar: u64,
+    /// Collapse changes are scoped to the projection rail being rendered.
+    pub rail: u64,
 }
 
 struct CachedProjectionRows {
@@ -488,8 +497,10 @@ mod tests {
         let revision = ProjectionRevision {
             tree_workspace: tree.workspace_revision,
             tree_pane: tree.pane_revision,
-            agents: 3,
+            agents: Some(3),
+            selected_workspace: 0,
             sidebar: 7,
+            rail: 0,
         };
         let mut cache = ProjectionRowsCache::default();
         let mut builds = 0;

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -508,11 +508,11 @@ mod tests {
         };
         let mut cache = ProjectionRowsCache::default();
         let mut builds = 0;
-        let first = cache.get_or_build("tabs", revision, || {
+        let first = cache.get_or_build(0, "tabs", revision, || {
             builds += 1;
             rows(&view, &tree, &[], 0, &collapsed)
         });
-        let second = cache.get_or_build("tabs", revision, || {
+        let second = cache.get_or_build(0, "tabs", revision, || {
             builds += 1;
             rows(&view, &tree, &[], 0, &collapsed)
         });
@@ -522,11 +522,18 @@ mod tests {
         assert_eq!(builds, 1);
 
         let changed = ProjectionRevision { sidebar: 8, ..revision };
-        let third = cache.get_or_build("tabs", changed, || {
+        let third = cache.get_or_build(0, "tabs", changed, || {
             builds += 1;
             rows(&view, &tree, &[], 0, &collapsed)
         });
         assert_eq!(third, first);
         assert_eq!(builds, 2);
+
+        let duplicate_id = cache.get_or_build(1, "tabs", revision, || {
+            builds += 1;
+            rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &[], 0, &collapsed)
+        });
+        assert!(duplicate_id.is_empty(), "distinct view indexes must not reuse rows by duplicate id");
+        assert_eq!(builds, 3);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -114,6 +114,11 @@ impl ProjectionRowsCache {
             .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
         rows
     }
+
+    #[cfg(test)]
+    pub(crate) fn revision_for(&self, view_id: &str) -> Option<ProjectionRevision> {
+        self.entries.get(view_id).map(|entry| entry.revision)
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -100,7 +100,7 @@ struct CachedProjectionRows {
 
 #[derive(Default)]
 pub(crate) struct ProjectionRowsCache {
-    entries: HashMap<String, CachedProjectionRows>,
+    entries: HashMap<(usize, String), CachedProjectionRows>,
 }
 
 impl ProjectionRowsCache {
@@ -110,26 +110,28 @@ impl ProjectionRowsCache {
 
     pub(crate) fn get_or_build(
         &mut self,
+        view_index: usize,
         view_id: &str,
         revision: ProjectionRevision,
         build: impl FnOnce() -> Vec<ProjectionRow>,
     ) -> Arc<[ProjectionRow]> {
-        if let Some(cached) = self.entries.get(view_id)
+        let key = (view_index, view_id.to_string());
+        if let Some(cached) = self.entries.get(&key)
             && cached.revision == revision
         {
             return Arc::clone(&cached.rows);
         }
         let rows: Arc<[ProjectionRow]> = build().into();
-        self.entries.insert(
-            view_id.to_string(),
-            CachedProjectionRows { revision, rows: Arc::clone(&rows) },
-        );
+        self.entries.insert(key, CachedProjectionRows { revision, rows: Arc::clone(&rows) });
         rows
     }
 
     #[cfg(test)]
-    pub(crate) fn revision_for(&self, view_id: &str) -> Option<ProjectionRevision> {
-        self.entries.get(view_id).map(|entry| entry.revision)
+    pub(crate) fn revision_for(&self, view_index: usize) -> Option<ProjectionRevision> {
+        self.entries
+            .iter()
+            .find(|((index, _), _)| *index == view_index)
+            .map(|(_, entry)| entry.revision)
     }
 }
 
@@ -533,7 +535,10 @@ mod tests {
             builds += 1;
             rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &[], 0, &collapsed)
         });
-        assert!(duplicate_id.is_empty(), "distinct view indexes must not reuse rows by duplicate id");
+        assert!(
+            duplicate_id.is_empty(),
+            "distinct view indexes must not reuse rows by duplicate id"
+        );
         assert_eq!(builds, 3);
     }
 }


### PR DESCRIPTION
Cache configurable sidebar projection rows by tree, agent, and sidebar revisions. This preserves row order and selected targets while avoiding repeated O(tree) projections in one frame.

Ratatui remains immediate-mode: the UI redraws each frame, while stable projection data is reused until an explicit revision changes.

Focused behavior test: projection_cache_reuses_rows_until_revision_changes.

Ratatui guidance: https://ratatui.rs/concepts/rendering/under-the-hood/ and https://docs.rs/ratatui/latest/ratatui/widgets/

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11690"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950523&installation_model_id=21920&pr_number=11690&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11690&signature=f3d2f57a4652b76cb52b7ca74095f381bf033a87f0d712b4c0a2779acfc90aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sidebar projection rows were rebuilt on every redraw; they now reuse shared cached rows until their explicit revisions change, reducing repeated O(tree) work while preserving row order, active rows, and selected targets.

- Revisions cover tree state, workspace-scoped agent updates for agent views, sidebar selection and focus, and per-rail collapse state.
- Cache entries are isolated by view index and ID, so views with duplicate IDs cannot share rows.
- Focus, selection, visibility, profile, config, and tree lifecycle changes invalidate stale rows; collapse changes affect only the changed rail.
- Tests cover shared-row reuse, scoped invalidation, lifecycle cleanup, agent filtering, duplicate view IDs, and active-row refresh.

<sup>Written for commit e0b0b19cc418f835ace9a820d9345200d3ea1c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11690?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved sidebar projection responsiveness by reusing cached rows when relevant workspace, pane, agent, rail, or sidebar state is unchanged.
  * Reduced unnecessary recalculation while keeping sidebar content current across navigation, focus, selection, visibility, expansion, workspace, pane, tab, screen, and agent changes.

* **Bug Fixes**
  * Completed and unknown agents are no longer shown in projected sidebar rows.
  * Sidebar projections now refresh automatically when relevant navigation or state changes occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->