### PR TITLE
cli: cmux coderouter status|machines|claude, local edge verification tooling

### DIFF
--- a/CLI/CMUXCLI+Coderouter.swift
+++ b/CLI/CMUXCLI+Coderouter.swift
@@ -1,0 +1,431 @@
+import Darwin
+import Foundation
+
+// `cmux coderouter <status|machines|claude>`: the team-level settings of the
+// cmux coderouter model plane that Cloud machines route their agents through.
+// The CLI is presentation only; each verb maps to one `coderouter.*` socket
+// method handled by the app's `CoderouterClient`, which holds the Stack
+// session. Every other `cmux coderouter ...` verb, and all of `cmux cr ...`,
+// is exec'd into the installed CodeRouter CLI before any socket is opened.
+extension CMUXCLI {
+    static let coderouterUsage = """
+        Usage: cmux coderouter <status|machines|claude> [options]
+
+        Team settings for the cmux coderouter model plane that Cloud machines
+        route codex, claude, pi, and opencode through. Any other verb, and every
+        `cmux cr ...`, runs the installed CodeRouter CLI unchanged.
+
+          cmux coderouter status [--team <id>] [--json]
+              Sign-in state, selected team, and the team's Claude upstream.
+
+          cmux coderouter machines [--team <id>] [--json]
+              30-day coderouter usage per Cloud machine (tokens, API-equivalent USD).
+
+          cmux coderouter claude show [--team <id>] [--json]
+              The upstream Cloud machines send `claude` traffic to: kind, masked
+              identifier, region, last update. Secrets are never printed.
+
+          cmux coderouter claude set oauth-token [--stdin] [--team <id>] [--json]
+              Use a Claude Code OAuth token (sk-ant-oat01-...). Run
+              `claude setup-token` first, then paste the token at the hidden
+              prompt, or provide it in CLAUDE_CODE_OAUTH_TOKEN, or pipe it in
+              with --stdin. Never pass a token as an argument.
+
+          cmux coderouter claude set api-key [--stdin] [--team <id>] [--json]
+              Use an Anthropic API key (sk-ant-...) from ANTHROPIC_API_KEY,
+              --stdin, or a hidden prompt.
+
+          cmux coderouter claude set bedrock [--region <r>] [--model <claude-id>=<bedrock-id>]... [--team <id>] [--json]
+              Use Amazon Bedrock with AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY,
+              and optional AWS_SESSION_TOKEN from your shell environment.
+              --region defaults to AWS_REGION or AWS_DEFAULT_REGION.
+
+          cmux coderouter claude clear [--team <id>] [--json]
+              Remove the team's Claude upstream. Cloud machines lose `claude`
+              until a new one is set.
+
+        A team has exactly one Claude upstream; setting one replaces the previous.
+        Requires `cmux auth login` and a team where you can manage coderouter.
+
+        Examples:
+          claude setup-token
+          cmux coderouter claude set oauth-token
+          cmux coderouter claude show
+          cmux coderouter machines --json
+        """
+
+    /// The first-argument verbs cmux owns under `cmux coderouter`. Everything
+    /// else keeps the pre-existing passthrough into the installed CodeRouter CLI,
+    /// so `cmux coderouter accounts`, `cmux coderouter login`, and a bare
+    /// `cmux coderouter` behave exactly as before.
+    static let cmuxOwnedCoderouterVerbs: Set<String> = ["status", "machines", "claude", "help", "--help", "-h"]
+
+    static func isCmuxOwnedCoderouterInvocation(_ args: [String]) -> Bool {
+        guard let first = args.first?.lowercased() else { return false }
+        return cmuxOwnedCoderouterVerbs.contains(first)
+    }
+
+    func runCoderouterCommand(commandArgs: [String], client: SocketClient, jsonOutput: Bool) throws {
+        let sub = commandArgs.first?.lowercased() ?? "help"
+        let rest = Array(commandArgs.dropFirst())
+
+        switch sub {
+        case "help", "--help", "-h":
+            print(Self.coderouterUsage)
+
+        case "status":
+            let (teamOpt, remaining) = parseOption(rest, name: "--team")
+            try rejectUnexpectedCoderouterArguments(remaining, command: "coderouter status")
+            let auth = try client.sendV2(method: "auth.status")
+            let signedIn = (auth["signed_in"] as? Bool) ?? false
+            var upstreamResponse: [String: Any]? = nil
+            var upstreamError: String? = nil
+            if signedIn {
+                do {
+                    upstreamResponse = try client.sendV2(method: "coderouter.claude_upstream.get", params: teamParams(teamOpt))
+                } catch let error as CLIError {
+                    upstreamError = error.message
+                }
+            }
+            if jsonOutput {
+                var payload: [String: Any] = ["signed_in": signedIn]
+                if let user = auth["user"] { payload["user"] = user }
+                if let team = auth["selected_team_id"] { payload["selected_team_id"] = team }
+                if let upstreamResponse {
+                    payload["team_id"] = upstreamResponse["teamId"] ?? NSNull()
+                    payload["claude_upstream"] = upstreamResponse["upstream"] ?? NSNull()
+                }
+                if let upstreamError { payload["claude_upstream_error"] = upstreamError }
+                print(jsonString(payload))
+                return
+            }
+            guard signedIn else {
+                print("Not signed in. Run `cmux auth login`, then retry.")
+                return
+            }
+            let user = auth["user"] as? [String: Any]
+            let email = (user?["email"] as? String).map(Self.sanitizeForTerminal) ?? "unknown account"
+            print("Signed in as \(email)")
+            let teamID = (upstreamResponse?["teamId"] as? String) ?? (auth["selected_team_id"] as? String)
+            if let teamID, !teamID.isEmpty {
+                print("Team: \(Self.sanitizeForTerminal(teamID))")
+            }
+            if let upstreamError {
+                print("Claude upstream: unavailable (\(upstreamError))")
+            } else if let upstreamResponse {
+                printClaudeUpstream(upstreamResponse["upstream"] as? [String: Any])
+            }
+
+        case "machines", "machine":
+            let (teamOpt, remaining) = parseOption(rest, name: "--team")
+            try rejectUnexpectedCoderouterArguments(remaining, command: "coderouter machines")
+            let response = try client.sendV2(method: "coderouter.machines", params: teamParams(teamOpt))
+            if jsonOutput {
+                print(jsonString(response))
+                return
+            }
+            printMachineUsage(response)
+
+        case "claude":
+            try runCoderouterClaudeCommand(commandArgs: rest, client: client, jsonOutput: jsonOutput)
+
+        default:
+            throw CLIError(message: """
+                Unknown coderouter subcommand: \(sub)
+
+                \(Self.coderouterUsage)
+                """)
+        }
+    }
+
+    private func runCoderouterClaudeCommand(commandArgs: [String], client: SocketClient, jsonOutput: Bool) throws {
+        let sub = commandArgs.first?.lowercased() ?? "show"
+        let rest = Array(commandArgs.dropFirst())
+
+        switch sub {
+        case "help", "--help", "-h":
+            print(Self.coderouterUsage)
+
+        case "show", "get", "status":
+            let (teamOpt, remaining) = parseOption(rest, name: "--team")
+            try rejectUnexpectedCoderouterArguments(remaining, command: "coderouter claude show")
+            let response = try client.sendV2(method: "coderouter.claude_upstream.get", params: teamParams(teamOpt))
+            if jsonOutput {
+                print(jsonString(response))
+                return
+            }
+            printClaudeUpstream(response["upstream"] as? [String: Any])
+
+        case "set":
+            try runCoderouterClaudeSet(commandArgs: rest, client: client, jsonOutput: jsonOutput)
+
+        case "clear", "remove", "rm", "delete", "unset":
+            let (teamOpt, remaining) = parseOption(rest, name: "--team")
+            try rejectUnexpectedCoderouterArguments(remaining, command: "coderouter claude clear")
+            let response = try client.sendV2(method: "coderouter.claude_upstream.clear", params: teamParams(teamOpt))
+            if jsonOutput {
+                print(jsonString(response))
+                return
+            }
+            if (response["removed"] as? Bool) == true {
+                print("OK Claude upstream removed. Cloud machines have no `claude` route until a new one is set.")
+            } else {
+                print("No Claude upstream was set.")
+            }
+
+        default:
+            throw CLIError(message: """
+                Unknown coderouter claude subcommand: \(sub)
+
+                \(Self.coderouterUsage)
+                """)
+        }
+    }
+
+    private func runCoderouterClaudeSet(commandArgs: [String], client: SocketClient, jsonOutput: Bool) throws {
+        guard let kindArg = commandArgs.first, !Self.isCoderouterFlagToken(kindArg) else {
+            throw CLIError(message: """
+                coderouter claude set requires a credential kind: oauth-token, api-key, or bedrock.
+
+                \(Self.coderouterUsage)
+                """)
+        }
+        let rest = Array(commandArgs.dropFirst())
+        let (teamOpt, rem0) = parseOption(rest, name: "--team")
+        var params: [String: Any] = teamParams(teamOpt)
+
+        switch kindArg.lowercased() {
+        case "oauth-token", "oauth", "claude-code":
+            let forceStdin = rem0.contains("--stdin")
+            try rejectUnexpectedCoderouterArguments(rem0.filter { $0 != "--stdin" }, command: "coderouter claude set oauth-token")
+            let token = try readCoderouterSecret(
+                label: "Claude Code OAuth token",
+                envVar: "CLAUDE_CODE_OAUTH_TOKEN",
+                forceStdin: forceStdin,
+                hint: "Run `claude setup-token` to mint one."
+            )
+            guard token.hasPrefix("sk-ant-oat01-") else {
+                throw CLIError(message: "That is not a Claude Code OAuth token (expected sk-ant-oat01-...). For an Anthropic API key use `cmux coderouter claude set api-key`.")
+            }
+            params["kind"] = "anthropic_oauth"
+            params["token"] = token
+
+        case "api-key", "apikey", "anthropic-key":
+            let forceStdin = rem0.contains("--stdin")
+            try rejectUnexpectedCoderouterArguments(rem0.filter { $0 != "--stdin" }, command: "coderouter claude set api-key")
+            let apiKey = try readCoderouterSecret(
+                label: "Anthropic API key",
+                envVar: "ANTHROPIC_API_KEY",
+                forceStdin: forceStdin,
+                hint: "Create one in the Anthropic console."
+            )
+            guard apiKey.hasPrefix("sk-ant-"), !apiKey.hasPrefix("sk-ant-oat") else {
+                throw CLIError(message: "That is not an Anthropic API key (expected sk-ant-...). For a Claude Code OAuth token use `cmux coderouter claude set oauth-token`.")
+            }
+            params["kind"] = "anthropic_api_key"
+            params["apiKey"] = apiKey
+
+        case "bedrock":
+            let (regionOpt, rem1) = parseOption(rem0, name: "--region")
+            var modelIDs: [String: String] = [:]
+            var remaining = rem1
+            while let index = remaining.firstIndex(of: "--model") {
+                guard index + 1 < remaining.count else {
+                    throw CLIError(message: "coderouter claude set bedrock: --model requires <claude-model-id>=<bedrock-model-id>.")
+                }
+                let pair = remaining[index + 1]
+                guard let equals = pair.firstIndex(of: "="), equals > pair.startIndex, pair.index(after: equals) < pair.endIndex else {
+                    throw CLIError(message: "coderouter claude set bedrock: --model expects <claude-model-id>=<bedrock-model-id>, got '\(Self.sanitizeForTerminal(pair))'.")
+                }
+                modelIDs[String(pair[..<equals])] = String(pair[pair.index(after: equals)...])
+                remaining.removeSubrange(index...(index + 1))
+            }
+            try rejectUnexpectedCoderouterArguments(remaining, command: "coderouter claude set bedrock")
+            let env = ProcessInfo.processInfo.environment
+            let region = Self.nonEmpty(regionOpt) ?? Self.nonEmpty(env["AWS_REGION"]) ?? Self.nonEmpty(env["AWS_DEFAULT_REGION"])
+            guard let region else {
+                throw CLIError(message: "coderouter claude set bedrock requires --region <r> or AWS_REGION / AWS_DEFAULT_REGION.")
+            }
+            guard let accessKeyID = Self.nonEmpty(env["AWS_ACCESS_KEY_ID"]),
+                  let secretAccessKey = Self.nonEmpty(env["AWS_SECRET_ACCESS_KEY"]) else {
+                throw CLIError(message: "coderouter claude set bedrock reads AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY from your shell environment; export both, then retry.")
+            }
+            params["kind"] = "bedrock"
+            params["region"] = region
+            params["accessKeyId"] = accessKeyID
+            params["secretAccessKey"] = secretAccessKey
+            if let sessionToken = Self.nonEmpty(env["AWS_SESSION_TOKEN"]) {
+                params["sessionToken"] = sessionToken
+            }
+            if !modelIDs.isEmpty {
+                params["modelIds"] = modelIDs
+            }
+
+        default:
+            throw CLIError(message: "coderouter claude set: unsupported credential kind '\(Self.sanitizeForTerminal(kindArg))'. Use oauth-token, api-key, or bedrock.")
+        }
+
+        let response = try client.sendV2(method: "coderouter.claude_upstream.set", params: params)
+        if jsonOutput {
+            print(jsonString(response))
+            return
+        }
+        let upstream = response["upstream"] as? [String: Any]
+        let kind = (upstream?["kind"] as? String).map(Self.sanitizeForTerminal) ?? (params["kind"] as? String) ?? "?"
+        let identifier = (upstream?["identifier"] as? String).map(Self.sanitizeForTerminal) ?? ""
+        let replaced = (response["created"] as? Bool) == false
+        print("OK Claude upstream \(replaced ? "replaced" : "set"): \(kind)\(identifier.isEmpty ? "" : " \(identifier)")")
+        if let teamID = (response["teamId"] as? String).map(Self.sanitizeForTerminal), !teamID.isEmpty {
+            print("  team: \(teamID)")
+        }
+        if let region = (upstream?["region"] as? String).map(Self.sanitizeForTerminal), !region.isEmpty {
+            print("  region: \(region)")
+        }
+        print("Cloud machines route `claude` through this upstream now.")
+    }
+
+    /// Secret intake order: `--stdin` (or a non-TTY stdin) reads one line from
+    /// stdin; otherwise the named environment variable; otherwise a hidden
+    /// terminal prompt. Argv is deliberately not an option: it leaks into shell
+    /// history and process listings.
+    private func readCoderouterSecret(label: String, envVar: String, forceStdin: Bool, hint: String) throws -> String {
+        let stdinIsTerminal = isatty(STDIN_FILENO) == 1
+        if forceStdin || !stdinIsTerminal {
+            if !forceStdin, let fromEnv = Self.nonEmpty(ProcessInfo.processInfo.environment[envVar]) {
+                return fromEnv
+            }
+            let data = FileHandle.standardInput.readDataToEndOfFile()
+            let text = String(decoding: data, as: UTF8.self)
+            guard let line = text.split(whereSeparator: \.isNewline).map({ $0.trimmingCharacters(in: .whitespaces) }).first(where: { !$0.isEmpty }) else {
+                throw CLIError(message: "No \(label) on stdin. \(hint)")
+            }
+            return line
+        }
+        if let fromEnv = Self.nonEmpty(ProcessInfo.processInfo.environment[envVar]) {
+            return fromEnv
+        }
+        return try readHiddenTerminalLine(prompt: "\(label) (input hidden; \(hint.lowercased().hasSuffix(".") ? String(hint.dropLast()) : hint)): ")
+    }
+
+    private func readHiddenTerminalLine(prompt: String) throws -> String {
+        FileHandle.standardError.write(Data(prompt.utf8))
+        var original = termios()
+        let hasTerminal = tcgetattr(STDIN_FILENO, &original) == 0
+        if hasTerminal {
+            var hidden = original
+            hidden.c_lflag &= ~tcflag_t(ECHO)
+            _ = tcsetattr(STDIN_FILENO, TCSAFLUSH, &hidden)
+        }
+        defer {
+            if hasTerminal {
+                _ = tcsetattr(STDIN_FILENO, TCSANOW, &original)
+            }
+            FileHandle.standardError.write(Data("\n".utf8))
+        }
+        guard let line = readLine(strippingNewline: true) else {
+            throw CLIError(message: "No input received.")
+        }
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw CLIError(message: "No input received.")
+        }
+        return trimmed
+    }
+
+    private func printClaudeUpstream(_ upstream: [String: Any]?) {
+        guard let upstream else {
+            print("Claude upstream: none. Cloud machines cannot run `claude` until one is set:")
+            print("  claude setup-token && cmux coderouter claude set oauth-token")
+            return
+        }
+        let kind = Self.sanitizeForTerminal((upstream["kind"] as? String) ?? "?")
+        let identifier = (upstream["identifier"] as? String).map(Self.sanitizeForTerminal) ?? ""
+        print("Claude upstream: \(kind)\(identifier.isEmpty ? "" : " \(identifier)")")
+        if let region = (upstream["region"] as? String).map(Self.sanitizeForTerminal), !region.isEmpty {
+            print("  region: \(region)")
+        }
+        if let modelIDs = upstream["modelIds"] as? [String: Any], !modelIDs.isEmpty {
+            for key in modelIDs.keys.sorted() {
+                let value = (modelIDs[key] as? String).map(Self.sanitizeForTerminal) ?? "?"
+                print("  model: \(Self.sanitizeForTerminal(key)) -> \(value)")
+            }
+        }
+        if let updatedAt = (upstream["updatedAt"] as? String).map(Self.sanitizeForTerminal), !updatedAt.isEmpty {
+            print("  updated: \(updatedAt)")
+        }
+    }
+
+    private func printMachineUsage(_ response: [String: Any]) {
+        let kind = (response["kind"] as? String) ?? "unavailable"
+        guard kind == "ready" else {
+            print("Machine usage is unavailable right now (the coderouter usage ledger did not answer). Retry in a moment.")
+            return
+        }
+        let machines = (response["machines"] as? [[String: Any]]) ?? []
+        let periodDays = (response["periodDays"] as? Int) ?? 30
+        guard !machines.isEmpty else {
+            print("No coderouter usage from Cloud machines in the last \(periodDays) days.")
+            return
+        }
+        var totalUSD = 0.0
+        var totalTokens = 0
+        for machine in machines {
+            let vmID = Self.sanitizeForTerminal((machine["vmId"] as? String) ?? "?")
+            let name = (machine["displayName"] as? String).map(Self.sanitizeForTerminal) ?? ""
+            let totals = (machine["totals"] as? [String: Any]) ?? [:]
+            let tokens = Self.intValue(totals["totalTokens"]) ?? 0
+            let usd = Self.doubleValue(totals["apiEquivalentUsd"]) ?? 0
+            totalTokens += tokens
+            totalUSD += usd
+            let nameText = name.isEmpty ? "" : "  \(name)"
+            print("\(vmID)\(nameText)  tokens=\(tokens)  \(Self.formatUSD(usd))")
+        }
+        print("Total (\(periodDays)d): \(machines.count) machine\(machines.count == 1 ? "" : "s"), tokens=\(totalTokens), \(Self.formatUSD(totalUSD)) API-equivalent")
+    }
+
+    private func teamParams(_ teamOpt: String?) -> [String: Any] {
+        var params: [String: Any] = [:]
+        if let teamOpt = Self.nonEmpty(teamOpt) {
+            params["teamId"] = teamOpt
+        }
+        return params
+    }
+
+    private func rejectUnexpectedCoderouterArguments(_ args: [String], command: String) throws {
+        if let unknown = args.first(where: Self.isCoderouterFlagToken) {
+            throw CLIError(message: "\(command): unknown flag '\(Self.sanitizeForTerminal(unknown))'.\n\n\(Self.coderouterUsage)")
+        }
+        if let extra = args.first {
+            throw CLIError(message: "\(command): unexpected argument '\(Self.sanitizeForTerminal(extra))'.")
+        }
+    }
+
+    private static func isCoderouterFlagToken(_ value: String) -> Bool {
+        value.hasPrefix("-") && value != "-"
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else {
+            return nil
+        }
+        return trimmed
+    }
+
+    private static func intValue(_ raw: Any?) -> Int? {
+        if let value = raw as? Int { return value }
+        if let value = raw as? Double { return Int(value) }
+        if let value = raw as? NSNumber { return value.intValue }
+        return nil
+    }
+
+    private static func doubleValue(_ raw: Any?) -> Double? {
+        if let value = raw as? Double { return value }
+        if let value = raw as? Int { return Double(value) }
+        if let value = raw as? NSNumber { return value.doubleValue }
+        return nil
+    }
+
+    private static func formatUSD(_ value: Double) -> String {
+        String(format: "$%.2f", value)
+    }
+}

--- a/CLI/CMUXCLI+CommandSuggestions.swift
+++ b/CLI/CMUXCLI+CommandSuggestions.swift
@@ -78,6 +78,8 @@ extension CMUXCLI {
         "close-window",
         "close-workspace",
         "cloud",
+        "coderouter",
+        "cr",
         "codex",
         "codex-hook",
         "codex-teams",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4922,6 +4922,21 @@ struct CMUXCLI {
         return explicitValue == defaultValue ? catalogValue : explicitValue
     }
 
+    private func localizedCoderouterCommands() -> String {
+        let defaultValue = "coderouter <status|machines|claude> [--team <id>] [--json]    (team model-plane settings; other verbs pass through)"
+        let bundle = CLIExecutableLocator.enclosingAppBundle() ?? .main
+        let catalogValue = String(
+            localized: "cli.coderouter.commands",
+            defaultValue: "coderouter <status|machines|claude> [--team <id>] [--json]    (team model-plane settings; other verbs pass through)",
+            bundle: bundle
+        )
+        let explicitValue = CMUXDiffViewerLocalization.string(
+            "cli.coderouter.commands",
+            defaultValue: defaultValue
+        )
+        return explicitValue == defaultValue ? catalogValue : explicitValue
+    }
+
     private func localizedCoderouterNotFound() -> String {
         let defaultValue = "Required CLI not found. Install the command and retry."
         let bundle = CLIExecutableLocator.enclosingAppBundle() ?? .main
@@ -5082,7 +5097,11 @@ struct CMUXCLI {
             let status = try CodexTeamsAppServerSupervisor(arguments: rawCommandArgs).run()
             exit(status)
         }
-        if command == "coderouter" || command == "cr" {
+        // `cmux cr ...` is always the installed CodeRouter CLI. `cmux coderouter`
+        // keeps that passthrough except for the verbs cmux owns (`status`,
+        // `machines`, `claude`, help), which manage the team's model plane
+        // through the app socket (CMUXCLI+Coderouter.swift).
+        if command == "cr" || (command == "coderouter" && !Self.isCmuxOwnedCoderouterInvocation(rawCommandArgs)) {
             try runCoderouterAlias(commandArgs: rawCommandArgs)
             return
         }
@@ -6538,6 +6557,9 @@ struct CMUXCLI {
 
         case "ai-accounts":
             try runAIAccountsCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
+
+        case "coderouter":
+            try runCoderouterCommand(commandArgs: commandArgs, client: client, jsonOutput: jsonOutput)
 
         case "mobile":
             let sub = commandArgs.first?.lowercased()
@@ -18457,6 +18479,8 @@ struct CMUXCLI {
             return Self.commentsUsage
         case "ai-accounts":
             return Self.aiAccountsUsage
+        case "coderouter":
+            return Self.coderouterUsage
         case "ping":
             return """
             Usage: cmux ping
@@ -41008,6 +41032,7 @@ export default CMUXSessionRestore;
           auth <status|login|logout>
           login | logout                                      (aliases for auth login/logout)
           \(localizedCoderouterAliases())
+          \(localizedCoderouterCommands())
           vm <base|new|ls|tree|status|stats|rename|snapshot|fork|restore|rm|run|route|agent|exec|push|pull|wait|shell|tui|desktop|open|ports|tools|handoff|promote-template|ssh> [args...]    (alias: cloud)
           remotes <list|add|remove> [--route <host:port>] [--tag <tag>] [--json]    (alias: remote)
           ai-accounts <list|upload|remove> [--team <id>] [--json]

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Wire/ControlCommandExecutionPolicy.swift
@@ -16,12 +16,13 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
     /// from the main thread.
     case socketWorker(mainThreadCallable: Bool)
 
-    /// Classifies a method: every `vm.`-, `remotes.`-, and
-    /// `aiAccounts.`-prefixed method and the fixed socket-worker set run on the
+    /// Classifies a method: every `vm.`-, `remotes.`-, `aiAccounts.`-, and
+    /// `coderouter.`-prefixed method and the fixed socket-worker set run on the
     /// worker; everything else runs on the main actor.
     ///
-    /// `remotes.*` (the `cmux remotes` device-registry verbs) and
-    /// `aiAccounts.*` (the team's subrouter AI-account verbs) make blocking,
+    /// `remotes.*` (the `cmux remotes` device-registry verbs), `aiAccounts.*`
+    /// (the team's subrouter AI-account verbs), and `coderouter.*` (the team's
+    /// coderouter Claude upstream and per-machine usage) make blocking,
     /// authenticated web API calls just like `vm.*`, so they must stay off the
     /// main actor; prefix matches keep each verb family in lockstep without
     /// listing each method.
@@ -38,7 +39,7 @@ public enum ControlCommandExecutionPolicy: Sendable, Equatable {
         }
 #endif
         if method.hasPrefix("vm.") || method.hasPrefix("remotes.") || method.hasPrefix("aiAccounts.")
-            || Self.socketWorkerMethods.contains(method) {
+            || method.hasPrefix("coderouter.") || Self.socketWorkerMethods.contains(method) {
             self = .socketWorker(
                 mainThreadCallable: Self.mainThreadCallableSocketWorkerMethods.contains(method)
             )

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandExecutionPolicyTests.swift
@@ -26,6 +26,16 @@ struct ControlCommandExecutionPolicyTests {
         #expect(ControlCommandExecutionPolicy(forMethod: "aiAccounts.remove") == .socketWorker(mainThreadCallable: false))
     }
 
+    @Test func coderouterPrefixedMethodsRunOnTheSocketWorker() {
+        // `cmux coderouter` verbs (team Claude upstream, per-machine usage) make
+        // blocking authenticated web API calls like `aiAccounts.*`; off the
+        // worker the dispatcher answers method_not_found.
+        #expect(ControlCommandExecutionPolicy(forMethod: "coderouter.claude_upstream.get") == .socketWorker(mainThreadCallable: false))
+        #expect(ControlCommandExecutionPolicy(forMethod: "coderouter.claude_upstream.set") == .socketWorker(mainThreadCallable: false))
+        #expect(ControlCommandExecutionPolicy(forMethod: "coderouter.claude_upstream.clear") == .socketWorker(mainThreadCallable: false))
+        #expect(ControlCommandExecutionPolicy(forMethod: "coderouter.machines") == .socketWorker(mainThreadCallable: false))
+    }
+
     @Test func fixedWorkerSetRunsOnTheSocketWorker() {
         for method in [
             "system.ping", "system.capabilities", "auth.status", "auth.sign_in_url",

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -36703,6 +36703,31 @@
         }
       }
     },
+    "cli.coderouter.commands": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (إعدادات مستوى النماذج للفريق؛ تُمرَّر الأوامر الأخرى كما هي)" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (postavke modelne ravni tima; ostale komande se prosljeđuju)" } },
+        "da": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (teamets modelplan-indstillinger; andre kommandoer sendes videre)" } },
+        "de": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (Team-Einstellungen der Modellebene; andere Befehle werden durchgereicht)" } },
+        "en": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (team model-plane settings; other verbs pass through)" } },
+        "es": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (ajustes del plano de modelos del equipo; los demás verbos se pasan sin cambios)" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (réglages du plan de modèles de l'équipe ; les autres verbes sont transmis tels quels)" } },
+        "it": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (impostazioni del piano modelli del team; gli altri comandi passano inalterati)" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (チームのモデルプレーン設定。その他のサブコマンドはそのまま渡されます)" } },
+        "km": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (ការកំណត់ model plane របស់ក្រុម; ពាក្យបញ្ជាផ្សេងទៀតត្រូវបានបញ្ជូនបន្ត)" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (팀 모델 플레인 설정; 다른 하위 명령은 그대로 전달됩니다)" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (teamets modellplan-innstillinger; andre kommandoer sendes videre)" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (ustawienia płaszczyzny modeli zespołu; pozostałe polecenia są przekazywane dalej)" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (configurações do plano de modelos da equipe; outros verbos são repassados)" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (настройки модельного плана команды; остальные команды передаются как есть)" } },
+        "th": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (การตั้งค่า model plane ของทีม; คำสั่งอื่นส่งผ่านตามเดิม)" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (ekibin model düzlemi ayarları; diğer komutlar olduğu gibi iletilir)" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (налаштування модельного плану команди; інші команди передаються без змін)" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (团队模型平面设置；其他子命令原样透传)" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "coderouter <status|machines|claude> [--team <id>] [--json]    (團隊模型平面設定；其他子命令原樣透傳)" } }
+      }
+    },
     "cli.coderouter.error.launchFailed": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2425,6 +2425,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         VMClient.bootstrap(auth: auth.coordinator)
         RemotesClient.bootstrap(auth: auth.coordinator)
         AIAccountsClient.bootstrap(auth: auth.coordinator)
+        CoderouterClient.bootstrap(auth: auth.coordinator)
         MachineUsageClient.bootstrap(auth: auth.coordinator)
         PhonePushClient.shared.configure(auth: auth.coordinator)
         MobileHostService.shared.configure(auth: auth.coordinator)

--- a/Sources/Cloud/CoderouterClient.swift
+++ b/Sources/Cloud/CoderouterClient.swift
@@ -1,0 +1,230 @@
+import CmuxAuthRuntime
+import CmuxControlSocket
+import Foundation
+
+enum CoderouterClientError: Error, CustomStringConvertible {
+    case notSignedIn
+    case sessionRefreshFailed
+    case httpStatus(Int, String)
+    case malformedResponse(String)
+    case backendUnreachable(url: String, detail: String)
+
+    var description: String {
+        switch self {
+        case .notSignedIn:
+            return "Not signed in. Run `cmux auth login`, then retry."
+        case .sessionRefreshFailed:
+            return "Signed in, but cmux could not refresh your session (network or server issue). Retry in a moment."
+        case let .httpStatus(status, body):
+            return CoderouterClient.formatHTTPError(status: status, body: body)
+        case let .malformedResponse(message):
+            return "The coderouter service returned an unexpected response: \(message)"
+        case let .backendUnreachable(url, detail):
+            return "Could not reach the cmux backend at \(url): \(detail)"
+        }
+    }
+}
+
+/// The credential shapes `PUT /api/coderouter/claude-upstream` accepts. The
+/// team's Claude leg uses exactly one of these; setting a new one replaces the
+/// previous upstream. Secrets travel from the CLI process over the local
+/// socket into this actor and out to the cmux backend; they are never logged,
+/// echoed, or persisted on the Mac.
+enum ClaudeUpstreamInput: Sendable {
+    case anthropicAPIKey(String)
+    case anthropicOAuth(token: String)
+    case bedrock(region: String, accessKeyID: String, secretAccessKey: String, sessionToken: String?, modelIDs: [String: String])
+
+    var kind: String {
+        switch self {
+        case .anthropicAPIKey: return "anthropic_api_key"
+        case .anthropicOAuth: return "anthropic_oauth"
+        case .bedrock: return "bedrock"
+        }
+    }
+
+    var jsonBody: [String: Any] {
+        switch self {
+        case let .anthropicAPIKey(apiKey):
+            return ["kind": kind, "apiKey": apiKey]
+        case let .anthropicOAuth(token):
+            return ["kind": kind, "token": token]
+        case let .bedrock(region, accessKeyID, secretAccessKey, sessionToken, modelIDs):
+            var body: [String: Any] = [
+                "kind": kind,
+                "region": region,
+                "accessKeyId": accessKeyID,
+                "secretAccessKey": secretAccessKey,
+            ]
+            if let sessionToken, !sessionToken.isEmpty {
+                body["sessionToken"] = sessionToken
+            }
+            if !modelIDs.isEmpty {
+                body["modelIds"] = modelIDs
+            }
+            return body
+        }
+    }
+}
+
+/// Team-level coderouter settings the app manages for the CLI (`cmux
+/// coderouter ...`): the Claude upstream credential and per-machine usage.
+/// Same origin, session auth, and team header as `AIAccountsClient`; the
+/// backend authorizes `manage` for writes and `use-or-manage` for reads.
+actor CoderouterClient {
+    @MainActor private(set) static var shared: CoderouterClient!
+
+    @MainActor
+    static func bootstrap(auth: AuthCoordinator, session: URLSession = .shared) {
+        shared = CoderouterClient(session: session, auth: auth)
+    }
+
+    private let session: URLSession
+    private let auth: AuthCoordinator
+
+    init(session: URLSession = .shared, auth: AuthCoordinator) {
+        self.session = session
+        self.auth = auth
+    }
+
+    /// `{ teamId, upstream: { kind, identifier, region, modelIds, updatedAt } | null }`.
+    /// `identifier` is already masked by the server; no secret is returned.
+    func claudeUpstream(teamID: String?) async throws -> JSONValue {
+        let (data, http) = try await request("GET", path: "/api/coderouter/claude-upstream", teamID: teamID)
+        try ensureOK(http, data: data)
+        return try bridgedJSONObject(data)
+    }
+
+    /// Replaces the team's Claude upstream. Returns the same shape as
+    /// `claudeUpstream` plus `created: true` when no upstream existed before.
+    func setClaudeUpstream(_ input: ClaudeUpstreamInput, teamID: String?) async throws -> JSONValue {
+        let (data, http) = try await request(
+            "PUT",
+            path: "/api/coderouter/claude-upstream",
+            jsonBody: input.jsonBody,
+            teamID: teamID
+        )
+        try ensureOK(http, data: data)
+        var object = try decodeJSONObject(data)
+        object["created"] = http.statusCode == 201
+        guard let value = JSONValue(foundationObject: object) else {
+            throw CoderouterClientError.malformedResponse("response is not valid JSON")
+        }
+        return value
+    }
+
+    /// Removes the team's Claude upstream. A 404 (nothing configured) is
+    /// reported as `removed: false` instead of an error so `clear` is idempotent.
+    func clearClaudeUpstream(teamID: String?) async throws -> JSONValue {
+        let (data, http) = try await request("DELETE", path: "/api/coderouter/claude-upstream", teamID: teamID)
+        if http.statusCode == 404 {
+            return .object(["removed": .bool(false)])
+        }
+        try ensureOK(http, data: data)
+        return try bridgedJSONObject(data)
+    }
+
+    private func bridgedJSONObject(_ data: Data) throws -> JSONValue {
+        let object = try decodeJSONObject(data)
+        guard let value = JSONValue(foundationObject: object) else {
+            throw CoderouterClientError.malformedResponse("response is not valid JSON")
+        }
+        return value
+    }
+
+    private func request(
+        _ method: String,
+        path: String,
+        jsonBody: [String: Any]? = nil,
+        teamID explicitTeamID: String?
+    ) async throws -> (Data, HTTPURLResponse) {
+        let tokens: (accessToken: String, refreshToken: String)
+        do {
+            tokens = try await auth.currentTokens()
+        } catch AuthError.networkError {
+            throw CoderouterClientError.sessionRefreshFailed
+        } catch {
+            throw CoderouterClientError.notSignedIn
+        }
+        let resolvedTeamID = await auth.resolvedTeamID
+
+        guard var comps = URLComponents(url: AuthEnvironment.vmAPIBaseURL, resolvingAgainstBaseURL: false) else {
+            throw CoderouterClientError.malformedResponse("the cmux backend URL is misconfigured")
+        }
+        comps.path = (comps.path.hasSuffix("/") ? String(comps.path.dropLast()) : comps.path) + path
+        guard let url = comps.url else {
+            throw CoderouterClientError.malformedResponse("could not build the request URL")
+        }
+
+        var req = URLRequest(url: url)
+        req.httpMethod = method
+        req.timeoutInterval = 15
+        req.setValue("Bearer \(tokens.accessToken)", forHTTPHeaderField: "Authorization")
+        req.setValue(tokens.refreshToken, forHTTPHeaderField: "X-Stack-Refresh-Token")
+        let teamID = explicitTeamID?.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let teamID = teamID?.isEmpty == false ? teamID : resolvedTeamID, !teamID.isEmpty {
+            req.setValue(teamID, forHTTPHeaderField: "X-Cmux-Team-Id")
+        }
+        if let jsonBody {
+            req.setValue("application/json", forHTTPHeaderField: "content-type")
+            req.httpBody = try JSONSerialization.data(withJSONObject: jsonBody, options: [])
+        }
+
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await session.data(for: req)
+        } catch let error as URLError {
+            switch error.code {
+            case .cannotConnectToHost, .cannotFindHost, .timedOut, .networkConnectionLost, .notConnectedToInternet:
+                let base = "\(AuthEnvironment.vmAPIBaseURL.scheme ?? "http")://\(AuthEnvironment.vmAPIBaseURL.host ?? "?"):\(AuthEnvironment.vmAPIBaseURL.port ?? -1)"
+                throw CoderouterClientError.backendUnreachable(url: base, detail: error.localizedDescription)
+            default:
+                throw error
+            }
+        }
+        guard let http = response as? HTTPURLResponse else {
+            throw CoderouterClientError.malformedResponse("non-HTTP response")
+        }
+        return (data, http)
+    }
+
+    private func ensureOK(_ http: HTTPURLResponse, data: Data) throws {
+        guard (200...299).contains(http.statusCode) else {
+            let body = String(data: data, encoding: .utf8) ?? ""
+            throw CoderouterClientError.httpStatus(http.statusCode, body)
+        }
+    }
+
+    private func decodeJSONObject(_ data: Data) throws -> [String: Any] {
+        let parsed = try JSONSerialization.jsonObject(with: data, options: [])
+        guard let obj = parsed as? [String: Any] else {
+            throw CoderouterClientError.malformedResponse("expected a JSON object")
+        }
+        return obj
+    }
+
+    static func formatHTTPError(status: Int, body: String) -> String {
+        if status == 401 {
+            return "Not signed in or session expired. Run `cmux auth login`, then retry."
+        }
+        if status == 403 {
+            return "This account cannot manage the team's coderouter settings."
+        }
+        let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        var serverError: String?
+        if let data = trimmed.data(using: .utf8),
+           let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
+            let code = object["error"] as? String
+            let message = object["message"] as? String
+            serverError = [code, message].compactMap { $0 }.joined(separator: ": ")
+        }
+        if let serverError = serverError.map(AIAccountsClient.redactSecrets), !serverError.isEmpty {
+            if status == 400 {
+                return "coderouter rejected the credential (HTTP 400): \(serverError). Check the token shape and retry."
+            }
+            return "coderouter request failed (HTTP \(status)): \(serverError)"
+        }
+        return "coderouter request failed (HTTP \(status))."
+    }
+}

--- a/Sources/Cloud/CoderouterSocketCommands.swift
+++ b/Sources/Cloud/CoderouterSocketCommands.swift
@@ -1,0 +1,172 @@
+import Foundation
+
+// `coderouter.*` socket methods behind `cmux coderouter <status|machines|claude>`.
+// The CLI is presentation only; the app owns the Stack session and the team
+// selection, so the credential a user pastes travels CLI -> local socket ->
+// this handler -> cmux backend and nowhere else. Every other `cmux coderouter`
+// or `cmux cr` invocation is exec'd into the installed CodeRouter CLI before
+// the socket is opened (see `runCoderouterAlias`).
+extension TerminalController {
+    nonisolated func socketWorkerCoderouterResponse(
+        method: String,
+        id: Any?,
+        params: [String: Any]
+    ) -> String {
+        let teamID = Self.coderouterString(params["teamId"]) ?? Self.coderouterString(params["team_id"])
+        switch method {
+        case "coderouter.claude_upstream.get":
+            return coderouterCall(id: id) {
+                let result = try await CoderouterClient.shared.claudeUpstream(teamID: teamID)
+                return (result.foundationObject as? [String: Any]) ?? [:]
+            }
+        case "coderouter.claude_upstream.set":
+            let input: ClaudeUpstreamInput
+            switch Self.claudeUpstreamInput(from: params) {
+            case .success(let parsed):
+                input = parsed
+            case .failure(let message):
+                return v2Error(id: id, code: "invalid_params", message: message)
+            }
+            return coderouterCall(id: id) {
+                let result = try await CoderouterClient.shared.setClaudeUpstream(input, teamID: teamID)
+                return (result.foundationObject as? [String: Any]) ?? [:]
+            }
+        case "coderouter.claude_upstream.clear":
+            return coderouterCall(id: id) {
+                let result = try await CoderouterClient.shared.clearClaudeUpstream(teamID: teamID)
+                return (result.foundationObject as? [String: Any]) ?? [:]
+            }
+        case "coderouter.machines":
+            return coderouterCall(id: id) {
+                guard let client = await MachineUsageClient.shared else {
+                    throw CoderouterClientError.malformedResponse("machine usage is not available yet; retry in a moment")
+                }
+                let usage = try await client.teamUsage(teamID: teamID)
+                return Self.machineUsagePayload(usage)
+            }
+        default:
+            return v2Error(id: id, code: "method_not_found", message: "Unknown method")
+        }
+    }
+
+    private enum ClaudeUpstreamParse {
+        case success(ClaudeUpstreamInput)
+        case failure(String)
+    }
+
+    /// Socket params -> credential input. Shape checks here are the cheap
+    /// client-side ones (which fields a kind needs); the backend validates the
+    /// token grammar and is the authority.
+    private nonisolated static func claudeUpstreamInput(from params: [String: Any]) -> ClaudeUpstreamParse {
+        guard let kind = coderouterString(params["kind"])?.lowercased(), !kind.isEmpty else {
+            return .failure("coderouter.claude_upstream.set requires `kind`: anthropic_api_key, anthropic_oauth, or bedrock.")
+        }
+        switch kind {
+        case "anthropic_api_key":
+            guard let apiKey = socketWorkerSecret(params["apiKey"]) else {
+                return .failure("anthropic_api_key requires `apiKey`.")
+            }
+            return .success(.anthropicAPIKey(apiKey))
+        case "anthropic_oauth":
+            guard let token = socketWorkerSecret(params["token"]) else {
+                return .failure("anthropic_oauth requires `token` (from `claude setup-token`).")
+            }
+            return .success(.anthropicOAuth(token: token))
+        case "bedrock":
+            guard let region = socketWorkerSecret(params["region"]) else {
+                return .failure("bedrock requires `region`.")
+            }
+            guard let accessKeyID = socketWorkerSecret(params["accessKeyId"]) else {
+                return .failure("bedrock requires `accessKeyId`.")
+            }
+            guard let secretAccessKey = socketWorkerSecret(params["secretAccessKey"]) else {
+                return .failure("bedrock requires `secretAccessKey`.")
+            }
+            let sessionToken = socketWorkerSecret(params["sessionToken"])
+            var modelIDs: [String: String] = [:]
+            if let raw = params["modelIds"] {
+                guard let object = raw as? [String: Any] else {
+                    return .failure("bedrock `modelIds` must be an object of claude model id -> Bedrock model id.")
+                }
+                for (key, value) in object {
+                    guard let mapped = value as? String, !mapped.isEmpty else {
+                        return .failure("bedrock `modelIds[\(key)]` must be a non-empty string.")
+                    }
+                    modelIDs[key] = mapped
+                }
+            }
+            return .success(.bedrock(
+                region: region,
+                accessKeyID: accessKeyID,
+                secretAccessKey: secretAccessKey,
+                sessionToken: sessionToken,
+                modelIDs: modelIDs
+            ))
+        default:
+            return .failure("Unknown Claude upstream kind '\(kind)'. Use anthropic_api_key, anthropic_oauth, or bedrock.")
+        }
+    }
+
+    /// Socket params arrive as untyped JSON; only string values are accepted
+    /// (numbers or objects in a credential field are a caller bug, not data).
+    private nonisolated static func coderouterString(_ value: Any?) -> String? {
+        guard let string = value as? String else { return nil }
+        let trimmed = string.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private nonisolated static func socketWorkerSecret(_ value: Any?) -> String? {
+        coderouterString(value)
+    }
+
+    /// Mirrors the `GET /api/coderouter/vm-usage/team` JSON so `--json` output
+    /// matches the web contract (`vmId`, `providerVmId`, `displayName`, `totals`).
+    private nonisolated static func machineUsagePayload(_ usage: TeamMachineUsage) -> [String: Any] {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        func totals(_ value: MachineUsageTotals) -> [String: Any] {
+            [
+                "inputTokens": value.inputTokens,
+                "cachedInputTokens": value.cachedInputTokens,
+                "outputTokens": value.outputTokens,
+                "totalTokens": value.totalTokens,
+                "apiEquivalentUsd": value.apiEquivalentUsd,
+            ]
+        }
+        return [
+            "teamId": usage.teamID,
+            "periodDays": usage.periodDays,
+            "kind": usage.kind.rawValue,
+            "asOf": usage.asOf.map(formatter.string(from:)) as Any? ?? NSNull(),
+            "machines": usage.machines.map { machine -> [String: Any] in
+                [
+                    "vmId": machine.vmID,
+                    "providerVmId": machine.providerVmID as Any? ?? NSNull(),
+                    "displayName": machine.displayName as Any? ?? NSNull(),
+                    "totals": totals(machine.totals),
+                ]
+            },
+        ]
+    }
+
+    /// `v2VmCall` with the coderouter client's sign-in failures surfaced as the
+    /// stable `auth_required` code the CLI already understands for `vm`.
+    private nonisolated func coderouterCall(
+        id: Any?,
+        _ work: @escaping () async throws -> [String: Any]
+    ) -> String {
+        v2VmCall(id: id, timeoutSeconds: 60) {
+            do {
+                return try await work()
+            } catch CoderouterClientError.notSignedIn {
+                throw VMClientError.notSignedIn
+            } catch CoderouterClientError.sessionRefreshFailed {
+                throw VMClientError.sessionRefreshFailed
+            } catch MachineUsageClientError.notSignedIn {
+                throw VMClientError.notSignedIn
+            } catch MachineUsageClientError.sessionRefreshFailed {
+                throw VMClientError.sessionRefreshFailed
+            }
+        }
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -1713,6 +1713,8 @@ class TerminalController {
             return socketWorkerRemotesResponse(method: method, id: request.id, params: request.params)
         case let method where method.hasPrefix("aiAccounts."):
             return socketWorkerAIAccountsResponse(method: method, id: request.id, params: request.params)
+        case let method where method.hasPrefix("coderouter."):
+            return socketWorkerCoderouterResponse(method: method, id: request.id, params: request.params)
         default:
 #if !DEBUG
             // debug.sidebar.simulate_drag stays policy-listed in Release but
@@ -2906,6 +2908,10 @@ class TerminalController {
             "aiAccounts.list",
             "aiAccounts.upload",
             "aiAccounts.remove",
+            "coderouter.claude_upstream.get",
+            "coderouter.claude_upstream.set",
+            "coderouter.claude_upstream.clear",
+            "coderouter.machines",
             "window.list",
             "window.current",
             "window.focus",

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */; };
 		805500000000000000000001 /* CLIBrowserEvalOutputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 805500000000000000000002 /* CLIBrowserEvalOutputTests.swift */; };
 		CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */; };
+		C0DE60C0000000000000A032 /* CLICoderouterCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE60C0000000000000A031 /* CLICoderouterCommandTests.swift */; };
 		C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */; };
 		C0D3F1F10000000000000103 /* CLICodexHookTimeoutRegressionTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F10000000000000104 /* CLICodexHookTimeoutRegressionTestSupport.swift */; };
 		918100000000000000000002 /* CLICodexResumeNotificationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 918100000000000000000001 /* CLICodexResumeNotificationTests.swift */; };
@@ -722,6 +723,7 @@
 		79390007AA11BB22CC33DD07 /* CMUXCLI+ClaudeHookDeliveryTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79390008AA11BB22CC33DD08 /* CMUXCLI+ClaudeHookDeliveryTarget.swift */; };
 		C72280000000000000000002 /* CMUXCLI+ClaudeHookWorkspaceRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C72280000000000000000001 /* CMUXCLI+ClaudeHookWorkspaceRouting.swift */; };
 		2DA8D48D99FB520EB179B015 /* CMUXCLI+ClaudePushNotificationHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CF59318F1D5B2195AC77C28 /* CMUXCLI+ClaudePushNotificationHook.swift */; };
+		C0DE60C0000000000000A022 /* CMUXCLI+Coderouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE60C0000000000000A021 /* CMUXCLI+Coderouter.swift */; };
 		C0D3F1F00000000000000101 /* CMUXCLI+CodexFireAndForgetHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F00000000000000102 /* CMUXCLI+CodexFireAndForgetHooks.swift */; };
 		D96290030000000000000001 /* CMUXCLI+CodexResumeBindingVerification.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96290040000000000000001 /* CMUXCLI+CodexResumeBindingVerification.swift */; };
 		B90000D2A1B2C3D4E5F60719 /* CMUXCLI+CommandSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B90000D1A1B2C3D4E5F60719 /* CMUXCLI+CommandSuggestions.swift */; };
@@ -977,6 +979,8 @@
 		E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A3000000000000000102 /* CmuxWorkspaces */; };
 		C0A1E5CE01C0A1E5CE01A001 /* CoalesceLatestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1E5CE01C0A1E5CE01A002 /* CoalesceLatestPublisher.swift */; };
 		AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BEE8C1CB174E3AB4F89EDE /* CoalesceLatestPublisherDemandTests.swift */; };
+		C0DE60C0000000000000A002 /* CoderouterClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE60C0000000000000A001 /* CoderouterClient.swift */; };
+		C0DE60C0000000000000A012 /* CoderouterSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE60C0000000000000A011 /* CoderouterSocketCommands.swift */; };
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
@@ -3697,6 +3701,7 @@
 		A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAuthAliasTests.swift; sourceTree = "<group>"; };
 		805500000000000000000002 /* CLIBrowserEvalOutputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIBrowserEvalOutputTests.swift; sourceTree = "<group>"; };
 		CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICallerWorkspaceDefaultTests.swift; sourceTree = "<group>"; };
+		C0DE60C0000000000000A031 /* CLICoderouterCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICoderouterCommandTests.swift; sourceTree = "<group>"; };
 		C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTests.swift; sourceTree = "<group>"; };
 		C0D3F1F10000000000000104 /* CLICodexHookTimeoutRegressionTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTestSupport.swift; sourceTree = "<group>"; };
 		918100000000000000000001 /* CLICodexResumeNotificationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexResumeNotificationTests.swift; sourceTree = "<group>"; };
@@ -3840,6 +3845,7 @@
 		79390008AA11BB22CC33DD08 /* CMUXCLI+ClaudeHookDeliveryTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+ClaudeHookDeliveryTarget.swift"; sourceTree = "<group>"; };
 		C72280000000000000000001 /* CMUXCLI+ClaudeHookWorkspaceRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+ClaudeHookWorkspaceRouting.swift"; sourceTree = "<group>"; };
 		4CF59318F1D5B2195AC77C28 /* CMUXCLI+ClaudePushNotificationHook.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+ClaudePushNotificationHook.swift"; sourceTree = "<group>"; };
+		C0DE60C0000000000000A021 /* CMUXCLI+Coderouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+Coderouter.swift"; sourceTree = "<group>"; };
 		C0D3F1F00000000000000102 /* CMUXCLI+CodexFireAndForgetHooks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+CodexFireAndForgetHooks.swift"; sourceTree = "<group>"; };
 		D96290040000000000000001 /* CMUXCLI+CodexResumeBindingVerification.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+CodexResumeBindingVerification.swift"; sourceTree = "<group>"; };
 		B90000D1A1B2C3D4E5F60719 /* CMUXCLI+CommandSuggestions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+CommandSuggestions.swift"; sourceTree = "<group>"; };
@@ -4032,6 +4038,8 @@
 		A6AC72080000000000000002 /* CMUXWorkspaceLoadingCLIRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXWorkspaceLoadingCLIRegressionTests.swift; sourceTree = "<group>"; };
 		C0A1E5CE01C0A1E5CE01A002 /* CoalesceLatestPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoalesceLatestPublisher.swift; sourceTree = "<group>"; };
 		43BEE8C1CB174E3AB4F89EDE /* CoalesceLatestPublisherDemandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoalesceLatestPublisherDemandTests.swift; sourceTree = "<group>"; };
+		C0DE60C0000000000000A001 /* CoderouterClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoderouterClient.swift; sourceTree = "<group>"; };
+		C0DE60C0000000000000A011 /* CoderouterSocketCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoderouterSocketCommands.swift; sourceTree = "<group>"; };
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
@@ -6524,6 +6532,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */,
 				9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */,
 				REE0CA0000000000000000E1 /* AIAccountsClient.swift */,
+				C0DE60C0000000000000A011 /* CoderouterSocketCommands.swift */,
+				C0DE60C0000000000000A001 /* CoderouterClient.swift */,
 				REE0CA0000000000000000F1 /* AIAccountCredentialSources.swift */,
 				REE0CA0000000000000000A1 /* RemotesClient.swift */,
 				C1A070000000000000000017 /* RemotesClientError.swift */,
@@ -8390,6 +8400,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				805500000000000000000003 /* BrowserValueTextFormatter.swift */,
 				B9000001A1B2C3D4E5F60719 /* cmux.swift */,
 				REE0CA0000000000000000C1 /* CMUXCLI+Remotes.swift */,
+				C0DE60C0000000000000A021 /* CMUXCLI+Coderouter.swift */,
 				1E4DB33FA55F1B13C60EFFC8 /* SSHPTYAttachReconnectInputFilter.swift */,
 				E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */,
 				E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */,
@@ -9225,6 +9236,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5D4120AA1B2C3D4E5F60718 /* CLIRovoDevHookPersistenceTests.swift */,
 				A5D4120CA1B2C3D4E5F60718 /* CLILegacyHookAliasTests.swift */,
 				A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */,
+				C0DE60C0000000000000A031 /* CLICoderouterCommandTests.swift */,
 				A5D4120EA1B2C3D4E5F60F02 /* CLIVMTransferTests.swift */,
 				C0DE35530000000000000102 /* BundledCLILinkageTests.swift */,
 				C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */,
@@ -10315,6 +10327,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C51A73000000000000000013 /* CmuxWorkerEntrypoint.swift in Sources */,
 				E30750000000000000000004 /* CmuxWorkspaceDefinition.swift in Sources */,
 				C0A1E5CE01C0A1E5CE01A001 /* CoalesceLatestPublisher.swift in Sources */,
+				C0DE60C0000000000000A002 /* CoderouterClient.swift in Sources */,
+				C0DE60C0000000000000A012 /* CoderouterSocketCommands.swift in Sources */,
 				A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */,
 				A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */,
 					C8711C000000000000000002 /* CodexRolloutIdentity.swift in Sources */,
@@ -11828,6 +11842,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				79390007AA11BB22CC33DD07 /* CMUXCLI+ClaudeHookDeliveryTarget.swift in Sources */,
 				C72280000000000000000002 /* CMUXCLI+ClaudeHookWorkspaceRouting.swift in Sources */,
 				2DA8D48D99FB520EB179B015 /* CMUXCLI+ClaudePushNotificationHook.swift in Sources */,
+					C0DE60C0000000000000A022 /* CMUXCLI+Coderouter.swift in Sources */,
 				C0D3F1F00000000000000101 /* CMUXCLI+CodexFireAndForgetHooks.swift in Sources */,
 				D96290030000000000000001 /* CMUXCLI+CodexResumeBindingVerification.swift in Sources */,
 				B90000D2A1B2C3D4E5F60719 /* CMUXCLI+CommandSuggestions.swift in Sources */,
@@ -12162,6 +12177,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */,
 					805500000000000000000001 /* CLIBrowserEvalOutputTests.swift in Sources */,
 					CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */,
+				C0DE60C0000000000000A032 /* CLICoderouterCommandTests.swift in Sources */,
 				C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */,
 				C0D3F1F10000000000000103 /* CLICodexHookTimeoutRegressionTestSupport.swift in Sources */,
 				918100000000000000000002 /* CLICodexResumeNotificationTests.swift in Sources */,

--- a/cmuxTests/CLICoderouterCommandTests.swift
+++ b/cmuxTests/CLICoderouterCommandTests.swift
@@ -1,0 +1,337 @@
+import XCTest
+import Darwin
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+// `cmux coderouter <status|machines|claude>` drives the app's `coderouter.*`
+// socket methods; every other `cmux coderouter` verb still execs the installed
+// CodeRouter CLI. These run the bundled CLI against a mock socket server and
+// assert the wire method, the params, and the printed result.
+extension CLINotifyProcessIntegrationRegressionTests {
+    private static let sampleOAuthToken = "sk-ant-oat01-abcdefghijklmnopqrstuvwxyz0123456789ABCDEFGHIJ"
+
+    private static func upstreamPayload(kind: String, identifier: String, created: Bool? = nil) -> [String: Any] {
+        var payload: [String: Any] = [
+            "teamId": "team_local",
+            "upstream": [
+                "kind": kind,
+                "identifier": identifier,
+                "region": NSNull(),
+                "modelIds": [String: Any](),
+                "updatedAt": "2026-09-02T10:00:00.000Z",
+            ] as [String: Any],
+        ]
+        if let created { payload["created"] = created }
+        return payload
+    }
+
+    private func runCoderouterCLI(
+        _ arguments: [String],
+        socketName: String,
+        standardInput: String? = nil,
+        extraEnvironment: [String: String] = [:],
+        waitForSocket: Bool = true,
+        handler: @escaping (String, [String: Any]) -> String?
+    ) throws -> (result: ProcessRunResult, state: MockSocketServerState) {
+        let cliPath = try bundledCLIPath()
+        let socketPath = makeSocketPath(socketName)
+        let listenerFD = try bindUnixSocket(at: socketPath)
+        let state = MockSocketServerState()
+
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return self.malformedRequestResponse(raw: line)
+            }
+            let params = (payload["params"] as? [String: Any]) ?? [:]
+            if let result = handler(method, params) {
+                return result.replacingOccurrences(of: "__ID__", with: id)
+            }
+            return self.v2Response(
+                id: id,
+                ok: false,
+                error: ["code": "unexpected", "message": "Unexpected method \(method)"]
+            )
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment.removeValue(forKey: "CLAUDE_CODE_OAUTH_TOKEN")
+        environment.removeValue(forKey: "ANTHROPIC_API_KEY")
+        for (key, value) in extraEnvironment {
+            environment[key] = value
+        }
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: arguments,
+            environment: environment,
+            standardInput: standardInput,
+            timeout: 5
+        )
+        if waitForSocket {
+            wait(for: [serverHandled], timeout: 5)
+        }
+        return (result, state)
+    }
+
+    /// The mock responds with `__ID__` so the handler closure does not need the
+    /// request id; `runCoderouterCLI` substitutes it.
+    private func okResponse(_ result: [String: Any]) -> String {
+        v2Response(id: "__ID__", ok: true, result: result)
+    }
+
+    func testCoderouterClaudeShowPrintsMaskedUpstream() throws {
+        let (result, state) = try runCoderouterCLI(
+            ["coderouter", "claude", "show"],
+            socketName: "coderouter-show"
+        ) { method, _ in
+            guard method == "coderouter.claude_upstream.get" else { return nil }
+            return self.okResponse(Self.upstreamPayload(kind: "anthropic_oauth", identifier: "sk-ant-oat01-...HIJ"))
+        }
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(
+            result.stdout,
+            "Claude upstream: anthropic_oauth sk-ant-oat01-...HIJ\n  updated: 2026-09-02T10:00:00.000Z\n"
+        )
+        XCTAssertTrue(
+            state.commands.contains { $0.contains(#""method":"coderouter.claude_upstream.get""#) },
+            "Expected claude show to call coderouter.claude_upstream.get, saw \(state.commands)"
+        )
+    }
+
+    func testCoderouterClaudeShowWithoutUpstreamExplainsSetup() throws {
+        let (result, _) = try runCoderouterCLI(
+            ["coderouter", "claude", "show"],
+            socketName: "coderouter-show-none"
+        ) { method, _ in
+            guard method == "coderouter.claude_upstream.get" else { return nil }
+            return self.okResponse(["teamId": "team_local", "upstream": NSNull()])
+        }
+
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertTrue(result.stdout.hasPrefix("Claude upstream: none."), result.stdout)
+        XCTAssertTrue(result.stdout.contains("cmux coderouter claude set oauth-token"), result.stdout)
+    }
+
+    func testCoderouterClaudeSetOAuthTokenReadsStdinAndNeverEchoesIt() throws {
+        nonisolated(unsafe) var receivedParams: [String: Any] = [:]
+        let (result, state) = try runCoderouterCLI(
+            ["coderouter", "claude", "set", "oauth-token", "--stdin", "--team", "team_explicit"],
+            socketName: "coderouter-set-oauth",
+            standardInput: "\(Self.sampleOAuthToken)\n"
+        ) { method, params in
+            guard method == "coderouter.claude_upstream.set" else { return nil }
+            receivedParams = params
+            return self.okResponse(Self.upstreamPayload(kind: "anthropic_oauth", identifier: "sk-ant-oat01-...HIJ", created: true))
+        }
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(receivedParams["kind"] as? String, "anthropic_oauth")
+        XCTAssertEqual(receivedParams["token"] as? String, Self.sampleOAuthToken)
+        XCTAssertEqual(receivedParams["teamId"] as? String, "team_explicit")
+        XCTAssertEqual(
+            result.stdout,
+            "OK Claude upstream set: anthropic_oauth sk-ant-oat01-...HIJ\n  team: team_local\nCloud machines route `claude` through this upstream now.\n"
+        )
+        XCTAssertFalse(result.stdout.contains(Self.sampleOAuthToken), "the secret must never be printed")
+        XCTAssertFalse(result.stderr.contains(Self.sampleOAuthToken), "the secret must never be printed")
+        XCTAssertEqual(state.commands.filter { $0.contains(#""method":"coderouter.claude_upstream.set""#) }.count, 1)
+    }
+
+    func testCoderouterClaudeSetOAuthTokenReadsEnvironmentVariable() throws {
+        nonisolated(unsafe) var receivedToken: String?
+        let (result, _) = try runCoderouterCLI(
+            ["coderouter", "claude", "set", "oauth-token", "--json"],
+            socketName: "coderouter-set-oauth-env",
+            extraEnvironment: ["CLAUDE_CODE_OAUTH_TOKEN": Self.sampleOAuthToken]
+        ) { method, params in
+            guard method == "coderouter.claude_upstream.set" else { return nil }
+            receivedToken = params["token"] as? String
+            return self.okResponse(Self.upstreamPayload(kind: "anthropic_oauth", identifier: "sk-ant-oat01-...HIJ", created: false))
+        }
+
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(receivedToken, Self.sampleOAuthToken)
+        let printed = try XCTUnwrap(jsonObject(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)))
+        XCTAssertEqual(printed["created"] as? Bool, false)
+        XCTAssertEqual((printed["upstream"] as? [String: Any])?["kind"] as? String, "anthropic_oauth")
+    }
+
+    func testCoderouterClaudeSetOAuthTokenRejectsAPIKeyShapeBeforeTheSocket() throws {
+        let (result, state) = try runCoderouterCLI(
+            ["coderouter", "claude", "set", "oauth-token"],
+            socketName: "coderouter-set-oauth-bad",
+            extraEnvironment: ["CLAUDE_CODE_OAUTH_TOKEN": "sk-ant-api03-not-an-oauth-token-0123456789"],
+            waitForSocket: false
+        ) { _, _ in nil }
+
+        XCTAssertNotEqual(result.status, 0)
+        XCTAssertTrue(result.stderr.contains("not a Claude Code OAuth token"), result.stderr)
+        XCTAssertFalse(
+            state.commands.contains { $0.contains("coderouter.claude_upstream.set") },
+            "a malformed token must not be sent to the app: \(state.commands)"
+        )
+    }
+
+    func testCoderouterClaudeSetAPIKeyReadsEnvironment() throws {
+        nonisolated(unsafe) var receivedParams: [String: Any] = [:]
+        let apiKey = "sk-ant-api03-0123456789abcdefghijklmnopqrstuvwxyz"
+        let (result, _) = try runCoderouterCLI(
+            ["coderouter", "claude", "set", "api-key"],
+            socketName: "coderouter-set-api-key",
+            extraEnvironment: ["ANTHROPIC_API_KEY": apiKey]
+        ) { method, params in
+            guard method == "coderouter.claude_upstream.set" else { return nil }
+            receivedParams = params
+            return self.okResponse(Self.upstreamPayload(kind: "anthropic_api_key", identifier: "sk-ant-...wxyz", created: true))
+        }
+
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(receivedParams["kind"] as? String, "anthropic_api_key")
+        XCTAssertEqual(receivedParams["apiKey"] as? String, apiKey)
+        XCTAssertTrue(result.stdout.hasPrefix("OK Claude upstream set: anthropic_api_key sk-ant-...wxyz\n"), result.stdout)
+    }
+
+    func testCoderouterClaudeSetBedrockReadsAWSEnvironmentAndModelMap() throws {
+        nonisolated(unsafe) var receivedParams: [String: Any] = [:]
+        let (result, _) = try runCoderouterCLI(
+            [
+                "coderouter", "claude", "set", "bedrock",
+                "--region", "us-west-2",
+                "--model", "claude-sonnet-4-5=us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+            ],
+            socketName: "coderouter-set-bedrock",
+            extraEnvironment: [
+                "AWS_ACCESS_KEY_ID": "TESTKEYIDNOTREAL0001",
+                "AWS_SECRET_ACCESS_KEY": "0123456789abcdefghijklmnopqrstuvwxyzABCD",
+                "AWS_SESSION_TOKEN": "session-token-value",
+            ]
+        ) { method, params in
+            guard method == "coderouter.claude_upstream.set" else { return nil }
+            receivedParams = params
+            var payload = Self.upstreamPayload(kind: "bedrock", identifier: "TEST...0001", created: true)
+            var upstream = payload["upstream"] as? [String: Any]
+            upstream?["region"] = "us-west-2"
+            payload["upstream"] = upstream
+            return self.okResponse(payload)
+        }
+
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(receivedParams["kind"] as? String, "bedrock")
+        XCTAssertEqual(receivedParams["region"] as? String, "us-west-2")
+        XCTAssertEqual(receivedParams["accessKeyId"] as? String, "TESTKEYIDNOTREAL0001")
+        XCTAssertEqual(receivedParams["secretAccessKey"] as? String, "0123456789abcdefghijklmnopqrstuvwxyzABCD")
+        XCTAssertEqual(receivedParams["sessionToken"] as? String, "session-token-value")
+        XCTAssertEqual(
+            (receivedParams["modelIds"] as? [String: String])?["claude-sonnet-4-5"],
+            "us.anthropic.claude-sonnet-4-5-20250929-v1:0"
+        )
+        XCTAssertTrue(result.stdout.contains("  region: us-west-2\n"), result.stdout)
+    }
+
+    func testCoderouterClaudeClearIsIdempotent() throws {
+        let (result, state) = try runCoderouterCLI(
+            ["coderouter", "claude", "clear"],
+            socketName: "coderouter-clear"
+        ) { method, _ in
+            guard method == "coderouter.claude_upstream.clear" else { return nil }
+            return self.okResponse(["removed": false])
+        }
+
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(result.stdout, "No Claude upstream was set.\n")
+        XCTAssertTrue(state.commands.contains { $0.contains(#""method":"coderouter.claude_upstream.clear""#) })
+    }
+
+    func testCoderouterMachinesPrintsPerMachineSpend() throws {
+        let (result, _) = try runCoderouterCLI(
+            ["coderouter", "machines"],
+            socketName: "coderouter-machines"
+        ) { method, _ in
+            guard method == "coderouter.machines" else { return nil }
+            return self.okResponse([
+                "teamId": "team_local",
+                "periodDays": 30,
+                "kind": "ready",
+                "asOf": "2026-09-02T10:00:00.000Z",
+                "machines": [
+                    [
+                        "vmId": "vm_a",
+                        "providerVmId": "fs-1",
+                        "displayName": "builder",
+                        "totals": ["inputTokens": 1000, "cachedInputTokens": 0, "outputTokens": 234, "totalTokens": 1234, "apiEquivalentUsd": 0.5],
+                    ] as [String: Any],
+                ],
+            ])
+        }
+
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(
+            result.stdout,
+            "vm_a  builder  tokens=1234  $0.50\nTotal (30d): 1 machine, tokens=1234, $0.50 API-equivalent\n"
+        )
+    }
+
+    func testCoderouterStatusCombinesAuthAndUpstream() throws {
+        let (result, state) = try runCoderouterCLI(
+            ["coderouter", "status"],
+            socketName: "coderouter-status"
+        ) { method, _ in
+            switch method {
+            case "auth.status":
+                return self.okResponse([
+                    "signed_in": true,
+                    "user": ["email": "dev@example.com"],
+                    "selected_team_id": "team_local",
+                ])
+            case "coderouter.claude_upstream.get":
+                return self.okResponse(Self.upstreamPayload(kind: "anthropic_api_key", identifier: "sk-ant-...wxyz"))
+            default:
+                return nil
+            }
+        }
+
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertEqual(
+            result.stdout,
+            "Signed in as dev@example.com\nTeam: team_local\nClaude upstream: anthropic_api_key sk-ant-...wxyz\n  updated: 2026-09-02T10:00:00.000Z\n"
+        )
+        XCTAssertTrue(state.commands.contains { $0.contains(#""method":"auth.status""#) })
+    }
+
+    func testCoderouterUnknownVerbStillPassesThroughToTheInstalledCLI() throws {
+        // With an empty PATH the passthrough cannot find `coderouter`/`cr`; the
+        // point is that the socket is never consulted for a non-cmux verb.
+        let emptyPath = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-empty-path-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: emptyPath, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: emptyPath) }
+
+        let (result, state) = try runCoderouterCLI(
+            ["coderouter", "accounts"],
+            socketName: "coderouter-passthrough",
+            extraEnvironment: ["PATH": emptyPath.path],
+            waitForSocket: false
+        ) { _, _ in nil }
+
+        XCTAssertEqual(result.status, 127, result.stderr)
+        XCTAssertTrue(state.commands.isEmpty, "passthrough verbs must not touch the cmux socket: \(state.commands)")
+    }
+}

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -85,6 +85,7 @@ Environment:
 | `events` | Stream reconnectable cmux events as newline-delimited JSON. |
 | `sessions [list]` | List saved agent session records without requiring a running cmux socket. Filters: `--agent <name>`, `--session <id>`, `--workspace <id>`, `--surface <id>`, `--cwd <text>`. Overrides: `--state-dir <path>`, `--codex-home <path>`. Text output defaults to 100 results; `--limit <n>` takes a positive integer and `--all` removes the limit. Supports `--json`. |
 | `auth` | Manage auth status, login, and logout through the app. |
+| `coderouter`, `cr` | `cmux coderouter <status|machines|claude>` manages the team's coderouter model plane through the app (sign-in state, per-machine usage, the Claude upstream credential). Every other `cmux coderouter ...` verb and all of `cmux cr ...` exec the installed CodeRouter CLI (`coderouter` or `cr` on PATH) unchanged, exit 127 when it is missing. |
 | `vm`, `cloud` | Manage cloud VMs. `cloud` is an alias for `vm`. |
 | `remotes`, `remote` | Manage remote Macs in the team device registry so they appear in the iOS app's device list. `remote` is an alias for `remotes`. |
 | `rpc` | Call a raw v2 socket method with optional JSON params. |
@@ -327,6 +328,20 @@ Remotes subcommands:
 | `remotes list`, `remotes ls` | List the team's registered remotes (name, deviceId, routes, tag, last seen). Supports `--json`. |
 | `remotes add <name>` | Register or update a remote with one or more `--route <host:port>`. Supports `--tag` and `--json`. Idempotent on `<name>` (re-adding updates routes). The host must be a Tailscale address the phone can authenticate to (CGNAT `100.64.x.x`-`100.127.x.x` or `*.ts.net`); loopback, plain LAN IPs, and bare hostnames are rejected. |
 | `remotes remove <name-or-deviceId>` | Remove a remote you registered. Aliases `rm`, `delete`. Supports `--json`. |
+
+CodeRouter subcommands (cmux-owned; anything else passes through to the installed CodeRouter CLI):
+
+| Command | Contract |
+| --- | --- |
+| `coderouter status` | Sign-in state (`auth.status`), selected team, and the team's Claude upstream (kind, masked identifier, region, last update). Supports `--team <id>` and `--json`. |
+| `coderouter machines` | 30-day coderouter usage per Cloud machine from `GET /api/coderouter/vm-usage/team`: vmId, display name, total tokens, API-equivalent USD, plus a total line. Alias `machine`. Supports `--team <id>` and `--json` (raw team-usage payload). |
+| `coderouter claude show` | The team's Claude upstream, or setup instructions when none is set. Aliases `get`, `status`. Supports `--team <id>` and `--json`. |
+| `coderouter claude set oauth-token` | Set a Claude Code OAuth token (`sk-ant-oat01-...`, from `claude setup-token`) as the team's Claude upstream. The token is read from `CLAUDE_CODE_OAUTH_TOKEN`, from stdin with `--stdin` or a non-TTY stdin, or from a hidden terminal prompt; never from argv. A non-`sk-ant-oat01-` value is rejected before the socket is used. Replaces any previous upstream. Prints the masked identifier only. Supports `--team <id>` and `--json`. |
+| `coderouter claude set api-key` | Same intake (`ANTHROPIC_API_KEY`, `--stdin`, hidden prompt) for an Anthropic API key (`sk-ant-...`, not `sk-ant-oat`). |
+| `coderouter claude set bedrock` | Amazon Bedrock upstream from `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`; `--region <r>` (default `AWS_REGION` / `AWS_DEFAULT_REGION`); repeatable `--model <claude-id>=<bedrock-id>`. |
+| `coderouter claude clear` | Remove the team's Claude upstream. Idempotent (`No Claude upstream was set.` when nothing was configured). Aliases `remove`, `rm`, `delete`, `unset`. Supports `--team <id>` and `--json`. |
+
+Socket methods: `coderouter.claude_upstream.get|set|clear`, `coderouter.machines`. Sign-in failures surface as the `auth_required` code, like `vm`.
 
 Theme subcommands:
 
@@ -661,6 +676,7 @@ the expected text without connecting to a cmux socket.
 - `cmux cloud --help` -> `Usage: cmux cloud <base|new|ls|tree|status|stats|rename|snapshot|fork|restore|rm|run|route|agent|prompt|exec|push|pull|wait|shell|tui|desktop|open|ports|tools|handoff|promote-template|attach|ssh|ssh-info> [args...]`
 - `cmux remotes --help` -> `Usage: cmux remotes <list|add|remove> [options]`
 - `cmux remote --help` -> `Usage: cmux remotes <list|add|remove> [options]`
+- `cmux coderouter --help` -> `Usage: cmux coderouter <status|machines|claude> [options]`
 - `cmux rpc --help` -> `Usage: cmux rpc <method> [json-params]`
 - `cmux comments --help` -> `Usage: cmux comments <subcommand> [options]`
 - `cmux help --help` -> `Usage: cmux help`

--- a/docs/coderouter-operations.md
+++ b/docs/coderouter-operations.md
@@ -182,3 +182,51 @@ Hexclave Analytics remains the authorization system around this data, but is
 not the metrics store today: its hosted custom-event ingestion currently
 accepts only `$page-view` and `$click`. Reconsider it when Hexclave exposes a
 server-authenticated, team-scoped custom-event ingestion API.
+
+## Team Claude upstream from the CLI
+
+Cloud machines send `claude` traffic to `https://coderouter.dev/v1/messages`, and coderouter
+forwards it to exactly one per-team upstream (`coderouter_claude_upstreams`). The cmux CLI
+manages it through the app's session, so no credential is typed into a browser or argv:
+
+```bash
+claude setup-token                              # mints a long-lived sk-ant-oat01-... token
+cmux coderouter claude set oauth-token          # hidden prompt; or CLAUDE_CODE_OAUTH_TOKEN / --stdin
+cmux coderouter claude show                     # kind + masked identifier, never the secret
+cmux coderouter machines                        # 30-day spend per Cloud machine
+cmux coderouter claude clear
+```
+
+`set api-key` takes `ANTHROPIC_API_KEY`; `set bedrock` takes `AWS_ACCESS_KEY_ID`,
+`AWS_SECRET_ACCESS_KEY`, optional `AWS_SESSION_TOKEN`, `--region`, and `--model
+<claude-id>=<bedrock-id>`. The CLI is presentation only: it calls
+`coderouter.claude_upstream.{get,set,clear}` and `coderouter.machines` on the app socket,
+and `Sources/Cloud/CoderouterClient.swift` performs the `GET/PUT/DELETE
+/api/coderouter/claude-upstream` request with the Stack session and team header. Other
+`cmux coderouter` verbs, and all of `cmux cr`, still exec the installed CodeRouter CLI.
+
+## Verifying the edge model plane locally
+
+`web/scripts/coderouter/local-edge.mjs` stands in for the Freestyle TLS egress edge: a
+private CA, TLS termination on `127.0.0.1:8443`, the two edge headers overwritten on every
+request (the real edge does the same), and re-origination to any coderouter origin. Real
+agent CLIs then run with placeholder keys exactly as a Cloud machine does, against a local
+`bun dev` with a scratch Postgres and the `coderouter_dev` ClickHouse database:
+
+```bash
+# origin: cd web && bun dev on <port> with a local DB (docs/cloud-vm-local-dev.md)
+node scripts/coderouter/local-edge.mjs --origin http://127.0.0.1:<port> \
+  --route-token <crt_ bound to a cloud_vms.id> --vm-id <cloud_vms.id>
+eval "$(...)"                                   # the exports it prints: CA bundle + base URLs
+curl -sS "$CMUX_CODEROUTER_URL/api/coderouter/vm-usage/self" -H "authorization: Bearer $OPENAI_API_KEY"
+codex exec 'Reply with exactly pong.'           # rustls trusts SSL_CERT_FILE
+claude -p 'Reply with exactly pong.'            # Node trusts NODE_EXTRA_CA_CERTS
+```
+
+What to check: `--no-inject` (or a raw request with the placeholder) returns 401, a token
+bound to another `cloud_vms.id` returns 403 `vm_mismatch`, a forged `x-cmux-vm-id` from the
+client is overwritten and logged by the edge, `usage_events` rows in ClickHouse carry the
+`vm_id`, `agent`, `upstream_kind`, and cost, and `vm-usage/self` reflects them. For the real
+edge against local code, expose the dev server through a quick tunnel, set
+`CMUX_CODEROUTER_EDGE_ORIGIN` to it, and run `scripts/cloud-vm/smoke-vm-api.mjs --create
+--paid --edge-check`, which creates a Freestyle VM whose inline rule points at the tunnel.

--- a/web/scripts/cloud-vm/smoke-vm-api.mjs
+++ b/web/scripts/cloud-vm/smoke-vm-api.mjs
@@ -32,13 +32,22 @@ const edgeCheck = rest.includes("--edge-check");
 // PUT /api/coderouter/claude-upstream, then one `claude -p` turn runs in the
 // guest through the edge. Proves routing, upstream rewrite, and the usage row.
 const claudeCheck = rest.includes("--claude-check");
+// Either an Anthropic API key (CMUX_SMOKE_CLAUDE_API_KEY) or a full
+// PUT /api/coderouter/claude-upstream body (CMUX_SMOKE_CLAUDE_UPSTREAM_JSON,
+// e.g. a bedrock upstream) becomes the smoke team's Claude upstream.
 const claudeUpstreamApiKey = process.env.CMUX_SMOKE_CLAUDE_API_KEY?.trim() ?? "";
+const claudeUpstreamJson = process.env.CMUX_SMOKE_CLAUDE_UPSTREAM_JSON?.trim() ?? "";
+const claudeUpstreamBody = claudeUpstreamJson
+  ? claudeUpstreamJson
+  : claudeUpstreamApiKey
+    ? JSON.stringify({ kind: "anthropic_api_key", apiKey: claudeUpstreamApiKey })
+    : "";
 if (claudeCheck && !edgeCheck) {
   console.error("--claude-check requires --edge-check");
   process.exit(2);
 }
-if (claudeCheck && !claudeUpstreamApiKey) {
-  console.error("--claude-check requires CMUX_SMOKE_CLAUDE_API_KEY in the environment");
+if (claudeCheck && !claudeUpstreamBody) {
+  console.error("--claude-check requires CMUX_SMOKE_CLAUDE_API_KEY or CMUX_SMOKE_CLAUDE_UPSTREAM_JSON in the environment");
   process.exit(2);
 }
 const provider = optionValue(rest, "--provider") ?? "freestyle";
@@ -184,7 +193,7 @@ try {
     const upstream = await fetchWithTimeout(`${targetUrl}/api/coderouter/claude-upstream`, {
       method: "PUT",
       headers: { ...authHeaders, "content-type": "application/json" },
-      body: JSON.stringify({ kind: "anthropic_api_key", apiKey: claudeUpstreamApiKey }),
+      body: claudeUpstreamBody,
     });
     const upstreamText = await upstream.text();
     if (upstream.status !== 200 && upstream.status !== 201) {

--- a/web/scripts/cloud-vm/smoke-vm-api.mjs
+++ b/web/scripts/cloud-vm/smoke-vm-api.mjs
@@ -13,7 +13,7 @@ import {
   requireEnvKeys,
 } from "./projects.mjs";
 
-const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider freestyle|default] [--image <manifest image id or version>] [--url https://preview.example] [--vercel-curl] [--skip-attach] [--paid] [--edge-check]";
+const usage = "Usage: smoke-vm-api.mjs [web-dir] <staging|production> [--create] [--provider freestyle|default] [--image <manifest image id or version>] [--url https://preview.example] [--vercel-curl] [--skip-attach] [--paid] [--edge-check] [--claude-check]";
 const args = process.argv.slice(2);
 const { webDir, target, project, rest } = parseWebDirAndTarget(args, usage);
 const shouldCreate = rest.includes("--create");
@@ -27,6 +27,20 @@ const paid = rest.includes("--paid");
 // no route token on disk, the injected token reaches coderouter, and one
 // codex turn completes through the edge.
 const edgeCheck = rest.includes("--edge-check");
+// --claude-check extends --edge-check to the Claude leg: the smoke team gets an
+// Anthropic API key upstream (CMUX_SMOKE_CLAUDE_API_KEY, never logged) through
+// PUT /api/coderouter/claude-upstream, then one `claude -p` turn runs in the
+// guest through the edge. Proves routing, upstream rewrite, and the usage row.
+const claudeCheck = rest.includes("--claude-check");
+const claudeUpstreamApiKey = process.env.CMUX_SMOKE_CLAUDE_API_KEY?.trim() ?? "";
+if (claudeCheck && !edgeCheck) {
+  console.error("--claude-check requires --edge-check");
+  process.exit(2);
+}
+if (claudeCheck && !claudeUpstreamApiKey) {
+  console.error("--claude-check requires CMUX_SMOKE_CLAUDE_API_KEY in the environment");
+  process.exit(2);
+}
 const provider = optionValue(rest, "--provider") ?? "freestyle";
 const image = optionValue(rest, "--image");
 const targetUrl = optionValue(rest, "--url") ?? project.url;
@@ -166,6 +180,20 @@ try {
     beforeCount: Array.isArray(authedJson.vms) ? authedJson.vms.length : null,
   };
 
+  if (claudeCheck) {
+    const upstream = await fetchWithTimeout(`${targetUrl}/api/coderouter/claude-upstream`, {
+      method: "PUT",
+      headers: { ...authHeaders, "content-type": "application/json" },
+      body: JSON.stringify({ kind: "anthropic_api_key", apiKey: claudeUpstreamApiKey }),
+    });
+    const upstreamText = await upstream.text();
+    if (upstream.status !== 200 && upstream.status !== 201) {
+      throw new Error(`PUT /api/coderouter/claude-upstream expected 200/201, got ${upstream.status}: ${upstreamText}`);
+    }
+    const parsedUpstream = JSON.parse(upstreamText);
+    result.claudeUpstream = parsedUpstream.upstream?.identifier ?? null;
+  }
+
   if (shouldCreate) {
     const createStartedAt = performance.now();
     const create = await fetchWithTimeout(`${targetUrl}/api/vm`, {
@@ -272,11 +300,28 @@ try {
         codexOutcome,
         codexTail: codexOut.slice(-400),
       };
+      if (claudeCheck) {
+        // Claude Code trusts the edge CA through NODE_EXTRA_CA_CERTS exported by
+        // agent-config.sh and authenticates with the placeholder x-api-key; the
+        // edge-injected route token selects the team's upstream.
+        const claude = await exec(
+          `${guestEnv} cd /root && claude -p 'Reply with exactly the single word pong and nothing else.' --model claude-haiku-4-5-20251001 2>&1 | tail -20`,
+          240_000,
+        );
+        const claudeOut = `${claude.stdout ?? ""}${claude.stderr ?? ""}`;
+        const claudePong = claudeOut.split("\n").some((line) => line.trim().toLowerCase().replace(/[.!]$/, "") === "pong");
+        edge.claudeExit = claude.exitCode;
+        edge.claudeOutcome = claudePong ? "answered" : /claude_upstream_not_configured|no upstream/i.test(claudeOut) ? "no_upstream" : "failed";
+        edge.claudeTail = claudeOut.slice(-400);
+        const selfUsage = await exec(`${guestEnv} curl -sS --max-time 20 -H "authorization: Bearer $OPENAI_API_KEY" "$CMUX_CODEROUTER_URL/api/coderouter/vm-usage/self"`);
+        edge.selfUsage = (selfUsage.stdout ?? "").trim().slice(0, 600);
+      }
       const problems = [];
       if (!steered) problems.push(`guest /etc/hosts is not steered to the edge for ${host || "the coderouter origin"}`);
       if (tokenOnDisk) problems.push(`route token found in guest files: ${tokenOnDisk}`);
       if (modelsStatus !== "200") problems.push(`GET /api/coderouter/vm-usage/self from the guest returned ${modelsStatus || "nothing"}`);
       if (codexOutcome === "failed") problems.push(`codex turn through the edge did not answer: ${edge.codexTail}`);
+      if (claudeCheck && edge.claudeOutcome !== "answered") problems.push(`claude turn through the edge did not answer: ${edge.claudeTail}`);
       if (problems.length > 0) throw new Error(`edge check failed: ${problems.join("; ")}`);
     }
 

--- a/web/scripts/coderouter/local-edge.mjs
+++ b/web/scripts/coderouter/local-edge.mjs
@@ -49,6 +49,11 @@ const routeToken = option("--route-token", process.env.CMUX_LOCAL_EDGE_ROUTE_TOK
 const vmId = option("--vm-id", process.env.CMUX_LOCAL_EDGE_VM_ID ?? "");
 const port = Number(option("--port", "8443"));
 const stateDir = option("--state-dir", path.join(tmpdir(), "cmux-local-edge"));
+// --dump-dir writes each /v1 request and response body (bodies only, never the
+// injected headers) so a client's exact wire shape can be compared against the
+// origin's answer when a leg fails.
+const dumpDir = option("--dump-dir", "");
+if (dumpDir) mkdirSync(dumpDir, { recursive: true, mode: 0o700 });
 const extraOriginHeaders = Object.fromEntries(
   options("--origin-header").map((pair) => {
     const eq = pair.indexOf("=");
@@ -112,6 +117,10 @@ const server = https.createServer({ key: readFileSync(leafKey), cert: readFileSy
   Object.assign(headers, extraOriginHeaders);
   delete headers.connection;
 
+  const dumpBase = dumpDir && req.url.startsWith("/v1/") ? path.join(dumpDir, `${String(id).padStart(4, "0")}-${req.method}-${req.url.replace(/[^a-z0-9]+/gi, "_").slice(0, 40)}`) : "";
+  const reqChunks = [];
+  const resChunks = [];
+  if (dumpBase) req.on("data", (chunk) => reqChunks.push(chunk));
   const upstream = originAgent.request(
     {
       protocol: origin.protocol,
@@ -125,8 +134,17 @@ const server = https.createServer({ key: readFileSync(leafKey), cert: readFileSy
       const responseHeaders = { ...upstreamRes.headers };
       delete responseHeaders.connection;
       res.writeHead(upstreamRes.statusCode ?? 502, responseHeaders);
+      if (dumpBase) upstreamRes.on("data", (chunk) => resChunks.push(chunk));
       upstreamRes.pipe(res);
       upstreamRes.on("end", () => {
+        if (dumpBase) {
+          const requestHeaders = { ...req.headers };
+          delete requestHeaders[ROUTE_TOKEN_HEADER];
+          delete requestHeaders["authorization"];
+          delete requestHeaders["x-api-key"];
+          writeFileSync(`${dumpBase}.req.json`, JSON.stringify({ headers: requestHeaders, body: Buffer.concat(reqChunks).toString("utf8") }, null, 2));
+          writeFileSync(`${dumpBase}.res.txt`, `HTTP ${upstreamRes.statusCode}\n${JSON.stringify(upstreamRes.headers)}\n\n${Buffer.concat(resChunks).toString("utf8")}`);
+        }
         const forged = forgedToken || forgedVmId ? ` forged-headers-overwritten(token=${forgedToken ? "yes" : "no"},vm=${forgedVmId ? "yes" : "no"})` : "";
         const agent = (req.headers["user-agent"] ?? "").toString().slice(0, 40);
         console.error(`[edge] #${id} ${req.method} ${req.url} -> ${upstreamRes.statusCode} ${Date.now() - startedAt}ms ua="${agent}"${forged}`);

--- a/web/scripts/coderouter/local-edge.mjs
+++ b/web/scripts/coderouter/local-edge.mjs
@@ -1,0 +1,151 @@
+#!/usr/bin/env node
+// Local stand-in for the Freestyle TLS egress edge, for verifying the coderouter
+// model plane end to end on one machine: it terminates TLS with a private CA,
+// OVERWRITES the two edge headers (`x-coderouter-route-token`, `x-cmux-vm-id`)
+// on every request like the real edge does, and re-originates to a coderouter
+// origin (a local `bun dev`, a tunnel, or a preview). Real agent CLIs (codex,
+// claude, pi, curl) then run against it with placeholder keys, exactly as a
+// Cloud machine would, and the origin's routing, VM binding, and usage ledger
+// can be checked without a VM.
+//
+//   node scripts/coderouter/local-edge.mjs --origin http://127.0.0.1:4682 \
+//     --route-token crt_... --vm-id <cloud_vms.id> [--port 8443] [--no-inject] \
+//     [--origin-header name=value] [--state-dir <dir>]
+//
+// It prints the `export` lines a client shell needs (CA bundle for Node, rustls,
+// and curl; base URLs; placeholder keys). `--no-inject` forwards without the
+// headers to prove the placeholder alone is not a credential.
+import { execFileSync } from "node:child_process";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import http from "node:http";
+import https from "node:https";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+const ROUTE_TOKEN_HEADER = "x-coderouter-route-token";
+const VM_ID_HEADER = "x-cmux-vm-id";
+const PLACEHOLDER = "cmux-vm-edge-placeholder";
+
+const args = process.argv.slice(2);
+function option(name, fallback) {
+  const index = args.indexOf(name);
+  if (index === -1) return fallback;
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) throw new Error(`${name} needs a value`);
+  return value;
+}
+function options(name) {
+  const values = [];
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === name && args[i + 1] !== undefined) values.push(args[i + 1]);
+  }
+  return values;
+}
+
+const originText = option("--origin", "http://127.0.0.1:3777");
+const origin = new URL(originText);
+const inject = !args.includes("--no-inject");
+const routeToken = option("--route-token", process.env.CMUX_LOCAL_EDGE_ROUTE_TOKEN ?? "");
+const vmId = option("--vm-id", process.env.CMUX_LOCAL_EDGE_VM_ID ?? "");
+const port = Number(option("--port", "8443"));
+const stateDir = option("--state-dir", path.join(tmpdir(), "cmux-local-edge"));
+const extraOriginHeaders = Object.fromEntries(
+  options("--origin-header").map((pair) => {
+    const eq = pair.indexOf("=");
+    if (eq <= 0) throw new Error(`--origin-header expects name=value, got ${pair}`);
+    return [pair.slice(0, eq).toLowerCase(), pair.slice(eq + 1)];
+  }),
+);
+if (inject && (!routeToken || !vmId)) {
+  console.error("--route-token and --vm-id are required unless --no-inject is set");
+  process.exit(2);
+}
+if (inject && !/^crt_[A-Za-z0-9._-]+$/.test(routeToken)) {
+  console.error("--route-token must be a crt_ route token");
+  process.exit(2);
+}
+
+// One private CA and one leaf for 127.0.0.1 / localhost, reused across runs so
+// clients can keep a CA bundle path. openssl is present on macOS and the devbox.
+mkdirSync(stateDir, { recursive: true, mode: 0o700 });
+const caKey = path.join(stateDir, "ca.key");
+const caCert = path.join(stateDir, "ca.crt");
+const leafKey = path.join(stateDir, "edge.key");
+const leafCert = path.join(stateDir, "edge.crt");
+if (!existsSync(caCert) || !existsSync(leafCert)) {
+  const openssl = (...a) => execFileSync("openssl", a, { stdio: ["ignore", "ignore", "inherit"] });
+  openssl("req", "-x509", "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:prime256v1", "-nodes",
+    "-keyout", caKey, "-out", caCert, "-days", "3650", "-subj", "/CN=cmux local edge CA",
+    "-addext", "basicConstraints=critical,CA:TRUE", "-addext", "keyUsage=critical,keyCertSign,cRLSign");
+  const csr = path.join(stateDir, "edge.csr");
+  const ext = path.join(stateDir, "edge.ext");
+  writeFileSync(ext, [
+    "basicConstraints=CA:FALSE",
+    "keyUsage=digitalSignature,keyEncipherment",
+    "extendedKeyUsage=serverAuth",
+    "subjectAltName=DNS:localhost,IP:127.0.0.1,IP:::1",
+  ].join("\n") + "\n");
+  openssl("req", "-newkey", "ec", "-pkeyopt", "ec_paramgen_curve:prime256v1", "-nodes",
+    "-keyout", leafKey, "-out", csr, "-subj", "/CN=cmux local edge");
+  openssl("x509", "-req", "-in", csr, "-CA", caCert, "-CAkey", caKey, "-CAcreateserial",
+    "-out", leafCert, "-days", "825", "-extfile", ext);
+}
+
+const originAgent = origin.protocol === "https:" ? https : http;
+let requestCounter = 0;
+
+const server = https.createServer({ key: readFileSync(leafKey), cert: readFileSync(leafCert) }, (req, res) => {
+  const id = (requestCounter += 1);
+  const startedAt = Date.now();
+  const headers = { ...req.headers };
+  // The guest never legitimately sends these; a value here is a forgery attempt
+  // that the real edge replaces. Record it, then overwrite (or strip).
+  const forgedToken = headers[ROUTE_TOKEN_HEADER];
+  const forgedVmId = headers[VM_ID_HEADER];
+  delete headers[ROUTE_TOKEN_HEADER];
+  delete headers[VM_ID_HEADER];
+  if (inject) {
+    headers[ROUTE_TOKEN_HEADER] = routeToken;
+    headers[VM_ID_HEADER] = vmId;
+  }
+  headers.host = origin.host;
+  Object.assign(headers, extraOriginHeaders);
+  delete headers.connection;
+
+  const upstream = originAgent.request(
+    {
+      protocol: origin.protocol,
+      hostname: origin.hostname,
+      port: origin.port || (origin.protocol === "https:" ? 443 : 80),
+      method: req.method,
+      path: req.url,
+      headers,
+    },
+    (upstreamRes) => {
+      const responseHeaders = { ...upstreamRes.headers };
+      delete responseHeaders.connection;
+      res.writeHead(upstreamRes.statusCode ?? 502, responseHeaders);
+      upstreamRes.pipe(res);
+      upstreamRes.on("end", () => {
+        const forged = forgedToken || forgedVmId ? ` forged-headers-overwritten(token=${forgedToken ? "yes" : "no"},vm=${forgedVmId ? "yes" : "no"})` : "";
+        const agent = (req.headers["user-agent"] ?? "").toString().slice(0, 40);
+        console.error(`[edge] #${id} ${req.method} ${req.url} -> ${upstreamRes.statusCode} ${Date.now() - startedAt}ms ua="${agent}"${forged}`);
+      });
+    },
+  );
+  upstream.on("error", (error) => {
+    console.error(`[edge] #${id} ${req.method} ${req.url} -> origin error ${error.message}`);
+    if (!res.headersSent) res.writeHead(502, { "content-type": "application/json" });
+    res.end(JSON.stringify({ error: "local_edge_origin_unreachable", message: error.message }));
+  });
+  req.pipe(upstream);
+});
+
+server.listen(port, "127.0.0.1", () => {
+  const base = `https://127.0.0.1:${port}`;
+  console.error(`[edge] listening on ${base} -> ${origin.origin} (${inject ? `injecting ${VM_ID_HEADER}=${vmId}` : "NOT injecting"})`);
+  console.log(`export SSL_CERT_FILE=${caCert} NODE_EXTRA_CA_CERTS=${caCert} CURL_CA_BUNDLE=${caCert}`);
+  console.log(`export OPENAI_BASE_URL=${base}/v1 OPENAI_API_KEY=${PLACEHOLDER}`);
+  console.log(`export ANTHROPIC_BASE_URL=${base} ANTHROPIC_API_KEY=${PLACEHOLDER}`);
+  console.log(`export CMUX_CODEROUTER_URL=${base}${vmId ? ` CMUX_VM_ID=${vmId}` : ""}`);
+});


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/11622 (base branch `feat-freestyle-coderouter-edge`). Merge that first.

## `cmux coderouter` gains cmux-owned verbs

`cmux coderouter` and `cmux cr` were pure passthroughs to the installed CodeRouter CLI. `cmux cr` stays that way, and so does every `cmux coderouter` verb except the ones cmux now owns:

```
cmux coderouter status [--team <id>] [--json]        sign-in, team, Claude upstream
cmux coderouter machines [--team <id>] [--json]      30-day coderouter spend per Cloud machine
cmux coderouter claude show
cmux coderouter claude set oauth-token [--stdin]     sk-ant-oat01-... from `claude setup-token`
cmux coderouter claude set api-key [--stdin]         sk-ant-... (ANTHROPIC_API_KEY)
cmux coderouter claude set bedrock [--region r] [--model <claude-id>=<bedrock-id>]...
cmux coderouter claude clear
```

Secrets come from `CLAUDE_CODE_OAUTH_TOKEN` / `ANTHROPIC_API_KEY` / `AWS_*`, from stdin (`--stdin` or a pipe), or from a hidden terminal prompt; never from argv. A non-`sk-ant-oat01-` value is rejected before the socket is touched. The CLI is presentation only: `coderouter.claude_upstream.{get,set,clear}` and `coderouter.machines` run on the socket worker (`ControlCommandExecutionPolicy` prefix, regression test), and `Sources/Cloud/CoderouterClient.swift` performs `GET/PUT/DELETE /api/coderouter/claude-upstream` with the app's Stack session and team header. `coderouter.machines` reuses `MachineUsageClient`. Help line localized in all 20 catalog languages (`cli.coderouter.commands`); usage text follows the plain-string convention of `ai-accounts`. Docs: `docs/cli-contract.md`, `docs/coderouter-operations.md`.

Tests: `cmuxTests/CLICoderouterCommandTests.swift` (bundled CLI against a mock socket: wire methods, params, printed output, secret never echoed, malformed token stops before the socket, passthrough verbs never open the socket) and `ControlCommandExecutionPolicyTests`.

## Local verification tooling for the edge model plane

`web/scripts/coderouter/local-edge.mjs` stands in for the Freestyle TLS egress edge on one Mac: private CA, TLS termination, the two edge headers overwritten on every request (as the real edge does), re-origination to any coderouter origin, optional `--dump-dir` for /v1 bodies. `smoke-vm-api.mjs --edge-check --claude-check` adds a Claude Code turn in the guest with `CMUX_SMOKE_CLAUDE_API_KEY` or `CMUX_SMOKE_CLAUDE_UPSTREAM_JSON` as the team upstream.

Verified against a local `bun dev` + scratch Postgres + `coderouter_dev` ClickHouse:
- edge emulator: placeholder alone 401; injected bound token 200; forged `x-cmux-vm-id`/token overwritten; token bound to VM A with header B or no header rejected (`vm_mismatch`); `/v1/models`, `/v1/messages` (stream and non-stream), `/v1/messages/count_tokens` through a Bedrock upstream; `usage_events` rows carry `vm_id`, `agent`, `upstream_kind`, cost; `/vm-usage/team` shows the machine.
- real edge: a Freestyle VM created through a quick tunnel to the local server; hosts steered, no token on disk, bound probe 200, codex reached the origin, and Claude Code 2.1.252 answered through Bedrock once https://github.com/manaflow-ai/cmux/commit/0dc0a8b651b (on the base PR) dropped `context_management`, which Bedrock rejects.
- tagged build `crcli`: every verb above driven through the debug socket against the local server.

Not exercised live: an `anthropic_oauth` upstream (no `sk-ant-oat01` token on this Mac). That is the dogfood step.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11691"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790950672&installation_model_id=21920&pr_number=11691&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11691&signature=f620fd88443663ed07557648a43a9ffe9b88e3667e8603cb912d6a652ac51b31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`cmux coderouter` now owns `status`, `machines`, and `claude` for team-level CodeRouter settings, while `cmux cr` and all other `cmux coderouter` verbs still pass through unchanged. It also adds local edge emulation and a Claude smoke-check path for end-to-end model-plane verification without a real VM.

**New Features**

- `status` shows sign-in, team, and Claude upstream state; `machines` shows 30-day spend per Cloud machine.
- `claude set` supports OAuth tokens, API keys, and Bedrock settings, with `show` and `clear` for lifecycle management.
- Credentials come from environment variables, stdin, or a hidden prompt, and malformed OAuth tokens fail before any socket request.
- The app performs authenticated upstream and usage requests on the socket worker, with localized help, documentation, and regression coverage.
- `local-edge.mjs` emulates the Freestyle TLS edge, overwrites routing headers, re-originates requests, and can dump `/v1` bodies.
- `--claude-check` accepts `CMUX_SMOKE_CLAUDE_API_KEY` or `CMUX_SMOKE_CLAUDE_UPSTREAM_JSON` for Claude coverage in the VM smoke test.

<sup>Written for commit e2b4e77b95e1c17af6709b9838d287cef60f2172. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11691?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

