### PR TITLE
fix(cmux-tui): consolidate selection and grapheme handling

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -2449,6 +2449,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                #[cfg(test)]
                 kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
@@ -2934,6 +2935,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                #[cfg(test)]
                 kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
@@ -3978,6 +3980,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                #[cfg(test)]
                 kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
@@ -4464,7 +4467,7 @@ impl Surface {
         };
         #[cfg(not(unix))]
         let next = requested;
-        let graphics_changed = {
+        let generation = {
             let mut term = pty.term.lock().unwrap();
             let mut limits = pty.kitty_graphics_limits.lock().unwrap();
             if *limits == next {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1218,6 +1218,9 @@ type PtyGeometryTestHook = Arc<dyn Fn(PtyGeometryTestStep) + Send + Sync>;
 #[cfg(test)]
 type DeferredCellPixelAckTestHook = Arc<dyn Fn() + Send + Sync>;
 
+#[cfg(test)]
+type KittyLimitsTestHook = Arc<dyn Fn() + Send + Sync>;
+
 pub struct PtySurface {
     pub(crate) meta: SurfaceMeta,
     terminal: Arc<PtyTerminalRuntime>,
@@ -1445,6 +1448,8 @@ pub struct PtyTerminalRuntime {
     geometry_test_hook: Mutex<Option<PtyGeometryTestHook>>,
     #[cfg(test)]
     deferred_cell_pixel_ack_test_hook: Mutex<Option<DeferredCellPixelAckTestHook>>,
+    #[cfg(test)]
+    kitty_limits_test_hook: Mutex<Option<KittyLimitsTestHook>>,
     #[cfg(test)]
     test_master_control: Option<Arc<TestMasterPtyControl>>,
     #[cfg(test)]
@@ -2388,6 +2393,8 @@ impl Surface {
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        #[cfg(test)]
+        let kitty_limits_test_hook = Mutex::new(None);
         let surface = Arc::new(Surface::Pty(PtySurface {
             meta: SurfaceMeta {
                 id,
@@ -2442,6 +2449,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
                 #[cfg(test)]
@@ -2870,6 +2878,8 @@ impl Surface {
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        #[cfg(test)]
+        let kitty_limits_test_hook = Mutex::new(None);
         let surface = Arc::new(Surface::Pty(PtySurface {
             meta: SurfaceMeta {
                 id,
@@ -2924,6 +2934,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
                 #[cfg(test)]
@@ -3908,6 +3919,8 @@ impl Surface {
         let (frame_requests, frame_rx) = sync_channel(1);
         #[cfg(test)]
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        #[cfg(test)]
+        let kitty_limits_test_hook = Mutex::new(None);
         let command = opts
             .command
             .clone()
@@ -3965,6 +3978,7 @@ impl Surface {
                 geometry_test_hook: Mutex::new(None),
                 #[cfg(test)]
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 #[cfg(test)]
                 test_master_control: None,
                 #[cfg(test)]
@@ -4137,6 +4151,7 @@ impl Surface {
         let (frame_requests, _frame_rx) = sync_channel(1);
         let test_master_control = Arc::new(TestMasterPtyControl::default());
         let frame_producer_before_upgrade = Arc::new(Mutex::new(None));
+        let kitty_limits_test_hook = Mutex::new(None);
 
         let surface = Arc::new(Surface::Pty(PtySurface {
             meta: SurfaceMeta {
@@ -4192,6 +4207,7 @@ impl Surface {
                 kitty_graphics_limits: Box::new(Mutex::new(initial_kitty_limits)),
                 geometry_test_hook: Mutex::new(None),
                 deferred_cell_pixel_ack_test_hook: Mutex::new(None),
+                kitty_limits_test_hook,
                 test_master_control: Some(test_master_control),
                 vt_replay_builds: AtomicUsize::new(0),
                 mux,
@@ -4453,6 +4469,8 @@ impl Surface {
         if !graphics_changed {
             return Ok(());
         }
+        #[cfg(test)]
+        pty.run_kitty_limits_test_hook();
         let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
         pty.request_frame(generation);
         Ok(())
@@ -6315,6 +6333,14 @@ impl PtySurface {
         let hook = self.geometry_test_hook.lock().unwrap().clone();
         if let Some(hook) = hook {
             hook(step);
+        }
+    }
+
+    #[cfg(test)]
+    fn run_kitty_limits_test_hook(&self) {
+        let hook = self.kitty_limits_test_hook.lock().unwrap().clone();
+        if let Some(hook) = hook {
+            hook();
         }
     }
 
@@ -8414,6 +8440,35 @@ mod tests {
                 Ok(AttachFrame::Resized { .. } | AttachFrame::ResizedWithColors { .. })
             ),
             "a byte-stream mirror was left on the pre-eviction Kitty scene"
+        );
+    }
+
+    #[test]
+    fn kitty_limit_generation_stays_paired_with_terminal_mutation() {
+        let mux = Mux::new_for_test("kitty-limit-generation", SurfaceOptions::default());
+        let surface = Surface::spawn_for_test(
+            1,
+            SurfaceOptions::default(),
+            Arc::downgrade(&mux),
+        )
+        .unwrap();
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+        let weak_surface = Arc::downgrade(&surface);
+        surface.as_pty().unwrap().kitty_limits_test_hook.lock().unwrap().replace(Arc::new(
+            move || {
+                let probe = weak_surface
+                    .upgrade()
+                    .and_then(|surface| surface.try_pointer_snapshot());
+                probe_tx.send(probe).unwrap();
+            },
+        ));
+
+        surface.set_kitty_graphics_limits(0, 0, 0, 0).unwrap();
+
+        assert_eq!(
+            probe_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            Some(PointerSnapshotProbe::Contended),
+            "terminal mutation and its render generation must share the terminal lock"
         );
     }
 

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4464,14 +4464,14 @@ impl Surface {
                 render.latest = None;
                 render.initial_graphics = None;
             }
+            if !graphics_changed {
+                return Ok(());
+            }
             let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
             #[cfg(test)]
             pty.run_kitty_limits_test_hook();
-            (graphics_changed, generation)
+            generation
         };
-        if !graphics_changed {
-            return Ok(());
-        }
         pty.request_frame(generation);
         Ok(())
     }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8482,6 +8482,36 @@ mod tests {
     }
 
     #[test]
+    fn terminal_generation_snapshot_stays_paired_with_terminal_lock() {
+        let mux = Mux::new_for_test("terminal-generation-snapshot", SurfaceOptions::default());
+        let surface =
+            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
+        let (probe_tx, probe_rx) = std::sync::mpsc::channel();
+        let callback_surface = surface.clone();
+
+        let captured_generation = surface
+            .with_terminal_and_generation(|_terminal, generation| {
+                probe_tx.send(callback_surface.try_pointer_snapshot()).unwrap();
+                generation
+            })
+            .expect("test fixture surface must be a PTY");
+
+        assert_eq!(
+            probe_rx.recv_timeout(Duration::from_secs(1)).unwrap(),
+            Some(PointerSnapshotProbe::Contended),
+            "terminal generation callbacks must hold the terminal lock"
+        );
+        let observed_generation = match surface.try_pointer_snapshot() {
+            Some(PointerSnapshotProbe::Ready(snapshot)) => snapshot.content_generation,
+            other => panic!("expected a stable post-callback snapshot, got {other:?}"),
+        };
+        assert_eq!(
+            captured_generation, observed_generation,
+            "the generation callback must match the locked terminal snapshot"
+        );
+    }
+
+    #[test]
     fn geometry_updates_skip_vt_replay_without_byte_attach_subscribers() {
         let mux = Mux::new_for_test("resize-without-byte-attach", SurfaceOptions::default());
         let surface =

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8446,19 +8446,14 @@ mod tests {
     #[test]
     fn kitty_limit_generation_stays_paired_with_terminal_mutation() {
         let mux = Mux::new_for_test("kitty-limit-generation", SurfaceOptions::default());
-        let surface = Surface::spawn_for_test(
-            1,
-            SurfaceOptions::default(),
-            Arc::downgrade(&mux),
-        )
-        .unwrap();
+        let surface =
+            Surface::spawn_for_test(1, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
         let (probe_tx, probe_rx) = std::sync::mpsc::channel();
         let weak_surface = Arc::downgrade(&surface);
         surface.as_pty().unwrap().kitty_limits_test_hook.lock().unwrap().replace(Arc::new(
             move || {
-                let probe = weak_surface
-                    .upgrade()
-                    .and_then(|surface| surface.try_pointer_snapshot());
+                let probe =
+                    weak_surface.upgrade().and_then(|surface| surface.try_pointer_snapshot());
                 probe_tx.send(probe).unwrap();
             },
         ));

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4393,6 +4393,21 @@ impl Surface {
         Some(result)
     }
 
+    /// Run `f` with exclusive access to the terminal and its content generation.
+    /// The generation is captured while the terminal lock is held, so the
+    /// callback cannot pair a semantic result with a different terminal state.
+    pub fn with_terminal_and_generation<R>(
+        &self,
+        f: impl FnOnce(&mut Terminal, u64) -> R,
+    ) -> Option<R> {
+        let pty = self.as_pty()?;
+        let mut term = pty.term.lock().unwrap();
+        let generation = pty.render_generation.load(Ordering::Acquire);
+        let result = f(&mut term, generation);
+        pty.mouse_encoders.lock().unwrap().sync_from_terminal(&term);
+        Some(result)
+    }
+
     fn configure_terminal_kitty_graphics_limits(
         terminal: &mut Terminal,
         limits: KittyGraphicsLimits,

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4464,14 +4464,14 @@ impl Surface {
                 render.latest = None;
                 render.initial_graphics = None;
             }
-            graphics_changed
+            let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
+            #[cfg(test)]
+            pty.run_kitty_limits_test_hook();
+            (graphics_changed, generation)
         };
         if !graphics_changed {
             return Ok(());
         }
-        #[cfg(test)]
-        pty.run_kitty_limits_test_hook();
-        let generation = pty.render_generation.fetch_add(1, Ordering::AcqRel) + 1;
         pty.request_frame(generation);
         Ok(())
     }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8465,6 +8465,20 @@ mod tests {
             Some(PointerSnapshotProbe::Contended),
             "terminal mutation and its render generation must share the terminal lock"
         );
+
+        let changed_generation = match surface.try_pointer_snapshot() {
+            Some(PointerSnapshotProbe::Ready(snapshot)) => snapshot.content_generation,
+            other => panic!("expected a stable post-mutation snapshot, got {other:?}"),
+        };
+        surface.set_kitty_graphics_limits(0, 0, 0, 0).unwrap();
+        let no_op_generation = match surface.try_pointer_snapshot() {
+            Some(PointerSnapshotProbe::Ready(snapshot)) => snapshot.content_generation,
+            other => panic!("expected a stable no-op snapshot, got {other:?}"),
+        };
+        assert_eq!(
+            no_op_generation, changed_generation,
+            "unchanged Kitty limits must not invalidate terminal content"
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5375,11 +5375,20 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
-    semantic_range: Option<SelectionRange>,
+    semantic_range: Option<GenerationTaggedSelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
     /// press.
     repeatable: bool,
+}
+
+/// A semantic range is valid only for the terminal content generation that
+/// produced it. Screen coordinates can move when output, reflow, or scrollback
+/// changes the terminal, so never union a range from an older generation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct GenerationTaggedSelectionRange {
+    content_generation: u64,
+    range: SelectionRange,
 }
 
 /// The most recent semantic drag result. Pointer reports often repeat the
@@ -17236,7 +17245,9 @@ impl App {
                 self.selection_click_sequence
                     .as_ref()
                     .and_then(|sequence| sequence.semantic_range)
+                    .filter(|initial| content_generation == Some(initial.content_generation))
                     .map(|initial| {
+                        let initial = initial.range;
                         let start = if (initial.start.row, initial.start.column)
                             <= (range.start.row, range.start.column)
                         {
@@ -22507,6 +22518,9 @@ impl App {
                         modifiers,
                         now,
                     );
+                    let content_generation = (mode != SelectionMode::Cell)
+                        .then(|| self.terminal_content_generation(area.surface))
+                        .flatten();
                     if mode == SelectionMode::Cell && modifiers == KeyModifiers::NONE {
                         // Ghostty's cell behavior returns no range on press.
                         // Keep only the tracked anchor until a drag moves it.
@@ -22519,16 +22533,22 @@ impl App {
                             if let Some(sequence) = self.selection_click_sequence.as_mut()
                                 && mode != SelectionMode::Cell
                             {
-                                sequence.semantic_range = Some(SelectionRange {
-                                    start: SelectionPoint {
-                                        column: selection.range().0.0,
-                                        row: selection.range().0.1 as u32,
-                                    },
-                                    end: SelectionPoint {
-                                        column: selection.range().1.0,
-                                        row: selection.range().1.1 as u32,
-                                    },
-                                });
+                                if let Some(content_generation) = content_generation {
+                                    sequence.semantic_range =
+                                        Some(GenerationTaggedSelectionRange {
+                                            content_generation,
+                                            range: SelectionRange {
+                                                start: SelectionPoint {
+                                                    column: selection.range().0.0,
+                                                    row: selection.range().0.1 as u32,
+                                                },
+                                                end: SelectionPoint {
+                                                    column: selection.range().1.0,
+                                                    row: selection.range().1.1 as u32,
+                                                },
+                                            },
+                                        });
+                                }
                             }
                             self.replace_selection(Some(selection));
                         } else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27585,6 +27585,59 @@ mod tests {
     }
 
     #[test]
+    fn shift_double_click_selects_a_complete_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-double-click-word-selection-test", b"alpha beta gamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (4, 0))),
+            "Shift double click must select the complete word when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn shift_triple_click_selects_a_complete_line() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-triple-click-line-selection-test", b"alpha beta\ngamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        for _ in 0..3 {
+            app.handle_mouse(click).unwrap();
+            app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+                .unwrap();
+        }
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (10, 0))),
+            "Shift triple click must select the complete line when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_single_cell_press_does_not_store_a_zero_length_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("single-cell-press-selection-state-test", b"alpha beta");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -22919,6 +22919,7 @@ impl App {
             // The selected endpoints are screen coordinates. If terminal
             // content changed while the button was held, copying them could
             // return unrelated text from the new generation.
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return Ok(RenderAction::Draw);
         }
@@ -22950,6 +22951,7 @@ impl App {
         if let Some(expected) = expected_content_generation
             && self.terminal_content_generation(sel.surface) != Some(expected)
         {
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return;
         }
@@ -22962,6 +22964,7 @@ impl App {
         if let Some(expected) = expected_content_generation
             && self.terminal_content_generation(sel.surface) != Some(expected)
         {
+            self.reset_selection_click_sequence();
             self.replace_selection(None);
             return;
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17251,10 +17251,7 @@ impl App {
                         } else {
                             range.end
                         };
-                        SelectionRange {
-                            start,
-                            end,
-                        }
+                        SelectionRange { start, end }
                     })
                     .unwrap_or(range)
             } else {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5375,6 +5375,10 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
+    /// Generation of the semantic selection currently installed on `App`.
+    /// `None` means the range cannot be safely copied because no stable
+    /// terminal snapshot was available.
+    semantic_content_generation: Option<u64>,
     semantic_range: Option<GenerationTaggedSelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
@@ -16951,6 +16955,8 @@ impl App {
             && sequence.surface == surface
         {
             sequence.mode = SelectionMode::Cell;
+            sequence.semantic_content_generation = None;
+            sequence.semantic_range = None;
         }
     }
 
@@ -17105,6 +17111,7 @@ impl App {
             anchor: cell,
             dragged: false,
             tracked_anchor,
+            semantic_content_generation: None,
             semantic_range: None,
             repeatable: true,
         });
@@ -17152,7 +17159,20 @@ impl App {
             && sequence.surface == surface
         {
             sequence.mode = mode;
+            sequence.semantic_content_generation = None;
         }
+    }
+
+    fn current_semantic_selection_generation(&self, surface: SurfaceId) -> Option<u64> {
+        let Some(sequence) =
+            self.selection_click_sequence.as_ref().filter(|sequence| sequence.surface == surface)
+        else {
+            return None;
+        };
+        let Some(expected) = sequence.semantic_content_generation else {
+            return None;
+        };
+        (self.terminal_content_generation(surface) == Some(expected)).then_some(expected)
     }
 
     fn update_semantic_selection(
@@ -17280,6 +17300,19 @@ impl App {
             });
         } else {
             self.semantic_selection_cache = None;
+        }
+        if let Some(sequence) =
+            self.selection_click_sequence.as_mut().filter(|sequence| sequence.surface == surface)
+        {
+            if let (Some(content_generation), Some(range)) = (content_generation, range) {
+                sequence.semantic_content_generation = Some(content_generation);
+                if mode == SelectionMode::Word {
+                    sequence.semantic_range =
+                        Some(GenerationTaggedSelectionRange { content_generation, range });
+                }
+            } else {
+                sequence.semantic_content_generation = None;
+            }
         }
         match range {
             Some(range) => self.replace_selection(Some(Self::selection_from_range(surface, range))),
@@ -22548,6 +22581,10 @@ impl App {
                                                 },
                                             },
                                         });
+                                    sequence.semantic_content_generation = Some(content_generation);
+                                } else {
+                                    sequence.semantic_content_generation = None;
+                                    sequence.semantic_range = None;
                                 }
                             }
                             self.replace_selection(Some(selection));
@@ -22862,6 +22899,13 @@ impl App {
         let semantic_select = was_select
             && self.selection_mode_surface.is_some()
             && self.selection_mode != SelectionMode::Cell;
+        let semantic_content_generation = if semantic_select {
+            self.selection_mode_surface
+                .and_then(|surface| self.current_semantic_selection_generation(surface))
+        } else {
+            None
+        };
+        let stale_semantic_selection = semantic_select && semantic_content_generation.is_none();
         let selection_dragged = was_select
             && self.selection_click_sequence.as_ref().is_some_and(|sequence| sequence.dragged);
         let was_drag = self.drag.is_some();
@@ -22870,6 +22914,13 @@ impl App {
             // Keep the sequence through the gesture so word and line drags use
             // their semantic mode, then make the next press a plain click.
             self.reset_selection_click_sequence();
+        }
+        if stale_semantic_selection {
+            // The selected endpoints are screen coordinates. If terminal
+            // content changed while the button was held, copying them could
+            // return unrelated text from the new generation.
+            self.replace_selection(None);
+            return Ok(RenderAction::Draw);
         }
         if !was_select {
             return Ok(if was_drag { RenderAction::Draw } else { RenderAction::None });
@@ -22882,7 +22933,7 @@ impl App {
         }
         match self.selection {
             Some(sel) if sel.anchor != sel.head || semantic_select => {
-                self.copy_selection(sel);
+                self.copy_selection(sel, semantic_content_generation);
                 Ok(RenderAction::Draw)
             }
             _ => {
@@ -22895,13 +22946,25 @@ impl App {
 
     /// Copy the selected text to the host clipboard via OSC 52 (the host
     /// terminal owns the clipboard; this works over SSH too).
-    fn copy_selection(&mut self, sel: Selection) {
+    fn copy_selection(&mut self, sel: Selection, expected_content_generation: Option<u64>) {
+        if let Some(expected) = expected_content_generation
+            && self.terminal_content_generation(sel.surface) != Some(expected)
+        {
+            self.replace_selection(None);
+            return;
+        }
         let Some(surface) = self.session.surface(sel.surface) else { return };
         let (start, end) = sel.range();
         let Some(text) = surface.with_terminal(|t| t.selection_text_absolute(start, end)).flatten()
         else {
             return;
         };
+        if let Some(expected) = expected_content_generation
+            && self.terminal_content_generation(sel.surface) != Some(expected)
+        {
+            self.replace_selection(None);
+            return;
+        }
         if text.is_empty() {
             return;
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -21064,17 +21064,14 @@ impl App {
                     terminal_admission,
                 )
             }
-            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
-                // Scrolling is a distinct gesture and ends click-repeat state.
-                self.reset_selection_click_sequence();
-                self.handle_horizontal_scroll_with_admission(
+            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => self
+                .handle_horizontal_scroll_with_admission(
                     mouse.column,
                     mouse.row,
                     matches!(mouse.kind, MouseEventKind::ScrollRight),
                     mouse.modifiers,
                     terminal_admission,
-                )
-            }
+                ),
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17207,8 +17207,8 @@ impl App {
             self.semantic_selection_cache = None;
             return;
         };
-        let content_generation = self.terminal_content_generation(surface);
-        if let Some(generation) = content_generation
+        let cache_generation = self.terminal_content_generation(surface);
+        if let Some(generation) = cache_generation
             && let Some(cache) = self.semantic_selection_cache
             && cache.surface == surface
             && cache.mode == mode
@@ -17223,46 +17223,49 @@ impl App {
             }
             return;
         }
-        let range = handle
-            .with_terminal(|terminal| match mode {
-                SelectionMode::Word => {
-                    // Ghostty's nearest-word lookup is directional. Keep both
-                    // queries paired so reverse drags through whitespace or
-                    // punctuation preserve the outer bounds.
-                    let first = terminal
-                        .select_word_between_screen(anchor_point, current_point)
-                        .ok()
-                        .flatten()?;
-                    let second = terminal
-                        .select_word_between_screen(current_point, anchor_point)
-                        .ok()
-                        .flatten()?;
-                    let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
-                    Some(if current_before_anchor {
-                        SelectionRange { start: second.start, end: first.end }
-                    } else {
-                        SelectionRange { start: first.start, end: second.end }
-                    })
-                }
-                SelectionMode::Line => {
-                    let select_line =
-                        |point| {
+        let (range, content_generation) = handle
+            .with_terminal_and_generation(|terminal, generation| {
+                let range = match mode {
+                    SelectionMode::Word => {
+                        // Ghostty's nearest-word lookup is directional. Keep both
+                        // queries paired so reverse drags through whitespace or
+                        // punctuation preserve the outer bounds.
+                        let first = terminal
+                            .select_word_between_screen(anchor_point, current_point)
+                            .ok()
+                            .flatten()?;
+                        let second = terminal
+                            .select_word_between_screen(current_point, anchor_point)
+                            .ok()
+                            .flatten()?;
+                        let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
+                        Some(if current_before_anchor {
+                            SelectionRange { start: second.start, end: first.end }
+                        } else {
+                            SelectionRange { start: first.start, end: second.end }
+                        })
+                    }
+                    SelectionMode::Line => {
+                        let select_line = |point| {
                             terminal.select_line_screen(point).ok().flatten().or_else(|| {
                                 terminal.select_line_screen_untrimmed(point).ok().flatten()
                             })
                         };
-                    let first = select_line(anchor_point)?;
-                    let second = select_line(current_point)?;
-                    let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
-                    Some(if current_before_anchor {
-                        SelectionRange { start: second.start, end: first.end }
-                    } else {
-                        SelectionRange { start: first.start, end: second.end }
-                    })
-                }
-                SelectionMode::Cell => None,
+                        let first = select_line(anchor_point)?;
+                        let second = select_line(current_point)?;
+                        let current_before_anchor = (current.1, current.0) < (anchor.1, anchor.0);
+                        Some(if current_before_anchor {
+                            SelectionRange { start: second.start, end: first.end }
+                        } else {
+                            SelectionRange { start: first.start, end: second.end }
+                        })
+                    }
+                    SelectionMode::Cell => None,
+                };
+                Some((range, generation))
             })
-            .flatten();
+            .flatten()
+            .map_or((None, None), |(range, generation)| (range.flatten(), Some(generation)));
         let range = range.map(|range| {
             if mode == SelectionMode::Word {
                 self.selection_click_sequence

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -22854,6 +22854,12 @@ impl App {
         if !was_select {
             return Ok(if was_drag { RenderAction::Draw } else { RenderAction::None });
         }
+        if !semantic_select && !selection_dragged {
+            // A click without motion is not a selection. Clear the provisional
+            // cell anchor created on press, including any prior selection.
+            self.replace_selection(None);
+            return Ok(RenderAction::Draw);
+        }
         match self.selection {
             Some(sel) if sel.anchor != sel.head || semantic_select => {
                 self.copy_selection(sel);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27925,6 +27925,37 @@ mod tests {
     }
 
     #[test]
+    fn cell_drag_selects_both_halves_of_a_wide_glyph() {
+        let drag_selection = |name: &str, start: u16, end: u16| {
+            let (mut app, mux, surface, content) =
+                selection_fixture(name, "foo 界 bar".as_bytes());
+            let press = MouseEvent {
+                kind: MouseEventKind::Down(MouseButton::Left),
+                column: content.x + start,
+                row: content.y,
+                modifiers: KeyModifiers::NONE,
+            };
+            app.handle_mouse(press).unwrap();
+            app.handle_mouse(MouseEvent {
+                kind: MouseEventKind::Drag(MouseButton::Left),
+                column: content.x + end,
+                row: content.y,
+                modifiers: KeyModifiers::NONE,
+            })
+            .unwrap();
+
+            let selection = app.selection.expect("cell drag must create a selection");
+            assert!(selection.contains_viewport(4, 0, 0));
+            assert!(selection.contains_viewport(5, 0, 0));
+            mux.close_surface(surface.id).unwrap();
+            selection.range()
+        };
+
+        assert_eq!(drag_selection("wide-cell-tail-to-narrow-test", 5, 7), ((4, 0), (7, 0)));
+        assert_eq!(drag_selection("wide-cell-lead-to-tail-test", 4, 5), ((4, 0), (5, 0)));
+    }
+
+    #[test]
     fn a_single_cell_press_does_not_store_a_zero_length_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("single-cell-press-selection-state-test", b"alpha beta");
@@ -27944,59 +27975,6 @@ mod tests {
 
         app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
             .unwrap();
-        mux.close_surface(surface.id).unwrap();
-    }
-
-    #[test]
-    fn shift_double_click_selects_a_complete_word() {
-        let (mut app, mux, surface, content) =
-            selection_fixture("shift-double-click-word-selection-test", b"alpha beta gamma");
-
-        let click = MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Left),
-            column: content.x + 1,
-            row: content.y,
-            modifiers: KeyModifiers::SHIFT,
-        };
-        app.handle_mouse(click).unwrap();
-        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
-            .unwrap();
-        app.handle_mouse(click).unwrap();
-        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
-            .unwrap();
-
-        assert_eq!(
-            app.selection.map(|selection| selection.range()),
-            Some(((0, 0), (4, 0))),
-            "Shift double click must select the complete word when bypassing PTY mouse reporting"
-        );
-
-        mux.close_surface(surface.id).unwrap();
-    }
-
-    #[test]
-    fn shift_triple_click_selects_a_complete_line() {
-        let (mut app, mux, surface, content) =
-            selection_fixture("shift-triple-click-line-selection-test", b"alpha beta\ngamma");
-
-        let click = MouseEvent {
-            kind: MouseEventKind::Down(MouseButton::Left),
-            column: content.x + 1,
-            row: content.y,
-            modifiers: KeyModifiers::SHIFT,
-        };
-        for _ in 0..3 {
-            app.handle_mouse(click).unwrap();
-            app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
-                .unwrap();
-        }
-
-        assert_eq!(
-            app.selection.map(|selection| selection.range()),
-            Some(((0, 0), (10, 0))),
-            "Shift triple click must select the complete line when bypassing PTY mouse reporting"
-        );
-
         mux.close_surface(surface.id).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -28225,6 +28225,45 @@ mod tests {
     }
 
     #[test]
+    fn double_click_drag_back_shrinks_to_the_press_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-word-drag-back-test", b"alpha beta gamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 7,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 15,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 7,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((6, 0), (10, 0))),
+            "dragging back must shrink to the word selected at the press"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_anchors_at_second_press() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-second-press-anchor-test", b"a b c");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -20974,17 +20974,14 @@ impl App {
                     terminal_admission,
                 )
             }
-            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
-                // Scrolling is a distinct gesture and ends click-repeat state.
-                self.reset_selection_click_sequence();
-                self.handle_horizontal_scroll_with_admission(
+            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => self
+                .handle_horizontal_scroll_with_admission(
                     mouse.column,
                     mouse.row,
                     matches!(mouse.kind, MouseEventKind::ScrollRight),
                     mouse.modifiers,
                     terminal_admission,
-                )
-            }
+                ),
         }
     }
 
@@ -23973,6 +23970,10 @@ impl App {
         modifiers: KeyModifiers,
         terminal_admission: Option<TerminalPointerAdmission>,
     ) -> anyhow::Result<RenderAction> {
+        // Scrolling is a distinct gesture and ends click-repeat state. Keep
+        // this reset in the handler so direct callers cannot preserve a stale
+        // repeat sequence.
+        self.reset_selection_click_sequence();
         if self.menu.is_some() || self.prompt.is_some() {
             return Ok(RenderAction::None);
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27942,8 +27942,7 @@ mod tests {
     #[test]
     fn cell_drag_selects_both_halves_of_a_wide_glyph() {
         let drag_selection = |name: &str, start: u16, end: u16| {
-            let (mut app, mux, surface, content) =
-                selection_fixture(name, "foo 界 bar".as_bytes());
+            let (mut app, mux, surface, content) = selection_fixture(name, "foo 界 bar".as_bytes());
             let press = MouseEvent {
                 kind: MouseEventKind::Down(MouseButton::Left),
                 column: content.x + start,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27942,6 +27942,44 @@ mod tests {
         );
         app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
             .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn failed_semantic_repeat_resets_the_click_sequence() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("failed-semantic-repeat-reset-test", b"alpha\n");
+        let first_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(first_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..first_click })
+            .unwrap();
+
+        let blank_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            row: content.y + 1,
+            ..first_click
+        };
+        app.handle_mouse(blank_click).unwrap();
+        assert_eq!(app.selection_mode, SelectionMode::Word);
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..blank_click })
+            .unwrap();
+        assert!(app.selection.is_none(), "an unsupported semantic cell must not retain selection");
+
+        app.handle_mouse(blank_click).unwrap();
+        assert_eq!(
+            app.selection_mode,
+            SelectionMode::Cell,
+            "a failed semantic repeat must reset the next click to cell mode"
+        );
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..blank_click })
+            .unwrap();
+
         mux.close_surface(surface.id).unwrap();
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27859,6 +27859,30 @@ mod tests {
     }
 
     #[test]
+    fn plain_click_clears_an_existing_selection() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("plain-click-clears-selection-test", b"alpha beta gamma");
+        app.replace_selection(Some(Selection {
+            surface: surface.id,
+            anchor: (0, 0),
+            head: (4, 0),
+        }));
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert!(app.selection.is_none(), "a plain click must clear an existing selection");
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_selects_a_complete_whitespace_run() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-whitespace-selection-test", b"alpha   beta");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -21009,14 +21009,17 @@ impl App {
                     terminal_admission,
                 )
             }
-            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => self
-                .handle_horizontal_scroll_with_admission(
+            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
+                // Scrolling is a distinct gesture and ends click-repeat state.
+                self.reset_selection_click_sequence();
+                self.handle_horizontal_scroll_with_admission(
                     mouse.column,
                     mouse.row,
                     matches!(mouse.kind, MouseEventKind::ScrollRight),
                     mouse.modifiers,
                     terminal_admission,
-                ),
+                )
+            }
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16985,24 +16985,27 @@ impl App {
         surface: SurfaceId,
         cell: (u16, u64),
         mode: SelectionMode,
-    ) -> Option<Selection> {
+    ) -> Option<(Selection, Option<u64>)> {
         if mode == SelectionMode::Cell {
-            return Some(Selection { surface, anchor: cell, head: cell });
+            return Some((Selection { surface, anchor: cell, head: cell }, None));
         }
         let point = Self::selection_point(cell)?;
         let handle = self.session.surface(surface)?;
-        let range = handle
-            .with_terminal(|terminal| match mode {
-                SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
-                SelectionMode::Line => terminal
-                    .select_line_screen(point)
-                    .ok()
-                    .flatten()
-                    .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
-                SelectionMode::Cell => None,
-            })
-            .flatten()?;
-        Some(Self::selection_from_range(surface, range))
+        let (range, content_generation) =
+            handle.with_terminal_and_generation(|terminal, generation| {
+                let range = match mode {
+                    SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
+                    SelectionMode::Line => terminal
+                        .select_line_screen(point)
+                        .ok()
+                        .flatten()
+                        .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
+                    SelectionMode::Cell => None,
+                };
+                (range, generation)
+            })?;
+        let range = range?;
+        Some((Self::selection_from_range(surface, range), Some(content_generation)))
     }
 
     fn terminal_active_screen(&self, surface: SurfaceId) -> Option<Screen> {
@@ -17307,8 +17310,12 @@ impl App {
             if let (Some(content_generation), Some(range)) = (content_generation, range) {
                 sequence.semantic_content_generation = Some(content_generation);
                 if mode == SelectionMode::Word {
-                    sequence.semantic_range =
-                        Some(GenerationTaggedSelectionRange { content_generation, range });
+                    let anchor_generation =
+                        sequence.semantic_range.map(|anchor| anchor.content_generation);
+                    if anchor_generation != Some(content_generation) {
+                        sequence.semantic_range =
+                            Some(GenerationTaggedSelectionRange { content_generation, range });
+                    }
                 }
             } else {
                 sequence.semantic_content_generation = None;
@@ -22551,9 +22558,6 @@ impl App {
                         modifiers,
                         now,
                     );
-                    let content_generation = (mode != SelectionMode::Cell)
-                        .then(|| self.terminal_content_generation(area.surface))
-                        .flatten();
                     if mode == SelectionMode::Cell && modifiers == KeyModifiers::NONE {
                         // Ghostty's cell behavior returns no range on press.
                         // Keep only the tracked anchor until a drag moves it.
@@ -22561,7 +22565,8 @@ impl App {
                     } else {
                         self.selection_mode = mode;
                         self.selection_mode_surface = Some(area.surface);
-                        if let Some(selection) = self.selection_for_click(area.surface, cell, mode)
+                        if let Some((selection, content_generation)) =
+                            self.selection_for_click(area.surface, cell, mode)
                         {
                             if let Some(sequence) = self.selection_click_sequence.as_mut()
                                 && mode != SelectionMode::Cell

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27984,6 +27984,30 @@ mod tests {
     }
 
     #[test]
+    fn forwarded_pty_click_resets_host_repeat_sequence() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("forwarded-pty-click-repeat-reset-test", b"alpha beta");
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        assert!(app.selection_click_sequence.is_some());
+
+        surface.with_terminal(|terminal| terminal.vt_write(b"\x1b[?1002h\x1b[?1006h"));
+        app.handle_mouse(click).unwrap();
+        assert!(app.selection_click_sequence.is_none());
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn plain_click_clears_an_existing_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("plain-click-clears-selection-test", b"alpha beta gamma");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16972,6 +16972,18 @@ impl App {
         Some(SelectionPoint { column: cell.0, row: u32::try_from(cell.1).ok()? })
     }
 
+    fn canonical_selection_cell(&self, surface: SurfaceId, cell: (u16, u64)) -> (u16, u64) {
+        let Some(point) = Self::selection_point(cell) else { return cell };
+        self.session
+            .surface(surface)
+            .and_then(|handle| {
+                handle.with_terminal(|terminal| terminal.normalize_selection_point_screen(point))
+            })
+            .flatten()
+            .map(|point| (point.column, u64::from(point.row)))
+            .unwrap_or(cell)
+    }
+
     fn selection_from_range(surface: SurfaceId, range: SelectionRange) -> Selection {
         Selection {
             surface,
@@ -22554,7 +22566,10 @@ impl App {
                     let offset = self.surface_scroll_offset(area.surface);
                     let source_x = area.content_source_x();
                     let col = source_x.saturating_add(x - content.x);
-                    let cell = (col, offset + (y - content.y) as u64);
+                    let cell = self.canonical_selection_cell(
+                        area.surface,
+                        (col, offset + (y - content.y) as u64),
+                    );
                     let mode = self.begin_selection_click(
                         area.surface,
                         cell,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17281,7 +17281,7 @@ impl App {
                 Some((range, generation))
             })
             .flatten()
-            .map_or((None, None), |(range, generation)| (range.flatten(), Some(generation)));
+            .map_or((None, None), |(range, generation)| (range, Some(generation)));
         let range = range.map(|range| {
             if mode == SelectionMode::Word {
                 self.selection_click_sequence

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27825,6 +27825,90 @@ mod tests {
     }
 
     #[test]
+    fn shift_double_click_selects_a_complete_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-double-click-word-selection-test", b"alpha beta gamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (4, 0))),
+            "Shift double click must select the complete word when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn shift_triple_click_selects_a_complete_line() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-triple-click-line-selection-test", b"alpha beta\ngamma");
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        for _ in 0..3 {
+            app.handle_mouse(click).unwrap();
+            app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+                .unwrap();
+        }
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (10, 0))),
+            "Shift triple click must select the complete line when bypassing PTY mouse reporting"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn changing_shift_modifier_prevents_a_repeat_selection() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("shift-repeat-modifier-mismatch-test", b"alpha beta gamma");
+
+        let shift_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::SHIFT,
+        };
+        app.handle_mouse(shift_click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Up(MouseButton::Left),
+            ..shift_click
+        })
+        .unwrap();
+        let plain_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            modifiers: KeyModifiers::NONE,
+            ..shift_click
+        };
+        app.handle_mouse(plain_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..plain_click })
+            .unwrap();
+
+        assert!(app.selection.is_none(), "a modifier change must reset the click sequence");
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_failed_word_lookup_downgrades_to_a_cell_gesture() {
         let (mut app, mux, surface, content) =
             selection_fixture("failed-word-lookup-selection-state-test", b"alpha");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -15776,6 +15776,7 @@ impl App {
                     mouse,
                     input_sequence,
                     terminal_pointer_admission,
+                    Instant::now(),
                 )?;
                 Ok(if dismissed { action.merge(RenderAction::Draw) } else { action })
             }
@@ -17010,12 +17011,14 @@ impl App {
         modifiers: KeyModifiers,
         now: Instant,
     ) -> bool {
+        let host_selection_modifier =
+            |modifiers| modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT;
         if !previous.repeatable
             || screen.is_none()
             || previous.surface != surface
             || previous.screen != screen
-            || previous.modifiers != KeyModifiers::NONE
-            || modifiers != KeyModifiers::NONE
+            || previous.modifiers != modifiers
+            || !host_selection_modifier(modifiers)
         {
             return false;
         }
@@ -17035,9 +17038,9 @@ impl App {
         cell: (u16, u64),
         position: (u16, u16),
         modifiers: KeyModifiers,
+        now: Instant,
     ) -> SelectionMode {
         self.semantic_selection_cache = None;
-        let now = Instant::now();
         let previous = self.selection_click_sequence.take();
         let screen = self.terminal_active_screen(surface);
         let repeated = previous.as_ref().is_some_and(|previous| {
@@ -17186,6 +17189,9 @@ impl App {
         let range = handle
             .with_terminal(|terminal| match mode {
                 SelectionMode::Word => {
+                    // Ghostty's nearest-word lookup is directional. Keep both
+                    // queries paired so reverse drags through whitespace or
+                    // punctuation preserve the outer bounds.
                     let first = terminal
                         .select_word_between_screen(anchor_point, current_point)
                         .ok()
@@ -20771,7 +20777,12 @@ impl App {
 
     #[cfg(test)]
     fn handle_mouse(&mut self, mouse: MouseEvent) -> anyhow::Result<RenderAction> {
-        self.handle_mouse_with_sequence(mouse, None, None)
+        self.handle_mouse_with_sequence(mouse, None, None, Instant::now())
+    }
+
+    #[cfg(test)]
+    fn handle_mouse_at(&mut self, mouse: MouseEvent, now: Instant) -> anyhow::Result<RenderAction> {
+        self.handle_mouse_with_sequence(mouse, None, None, now)
     }
 
     fn handle_mouse_with_sequence(
@@ -20779,6 +20790,7 @@ impl App {
         mouse: MouseEvent,
         replay_sequence: Option<u64>,
         terminal_admission: Option<TerminalPointerAdmission>,
+        now: Instant,
     ) -> anyhow::Result<RenderAction> {
         // A live physical sample supersedes retained motion. Replayed input
         // only supersedes motion that was retained earlier in the same
@@ -20839,6 +20851,7 @@ impl App {
                 mouse.row,
                 mouse.modifiers,
                 terminal_admission,
+                now,
             ),
             MouseEventKind::Drag(MouseButton::Left) => {
                 if self.forward_pty_mouse_drag(
@@ -20961,14 +20974,17 @@ impl App {
                     terminal_admission,
                 )
             }
-            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => self
-                .handle_horizontal_scroll_with_admission(
+            MouseEventKind::ScrollLeft | MouseEventKind::ScrollRight => {
+                // Scrolling is a distinct gesture and ends click-repeat state.
+                self.reset_selection_click_sequence();
+                self.handle_horizontal_scroll_with_admission(
                     mouse.column,
                     mouse.row,
                     matches!(mouse.kind, MouseEventKind::ScrollRight),
                     mouse.modifiers,
                     terminal_admission,
-                ),
+                )
+            }
         }
     }
 
@@ -22094,7 +22110,7 @@ impl App {
         y: u16,
         modifiers: KeyModifiers,
     ) -> anyhow::Result<RenderAction> {
-        self.handle_left_down_with_admission(x, y, modifiers, None)
+        self.handle_left_down_with_admission(x, y, modifiers, None, Instant::now())
     }
 
     fn handle_left_down_with_admission(
@@ -22103,15 +22119,16 @@ impl App {
         y: u16,
         modifiers: KeyModifiers,
         terminal_admission: Option<TerminalPointerAdmission>,
+        now: Instant,
     ) -> anyhow::Result<RenderAction> {
         self.replace_selection(None);
         self.status_selection = None;
         self.finish_active_drag();
 
         // A repeat is valid only for presses that land directly in a PTY
-        // content cell. Any chrome, overlay, browser, or modified click ends
-        // the pending terminal click sequence.
-        let repeat_target = modifiers == KeyModifiers::NONE
+        // content cell. Shift is the host-selection override when an inner
+        // PTY application owns mouse input, so preserve it for repeats.
+        let repeat_target = (modifiers == KeyModifiers::NONE || modifiers == KeyModifiers::SHIFT)
             && self.hit_at(x, y).is_none()
             && self.pane_area_at(x, y).is_some_and(|area| {
                 self.surface_kind(area.surface) == Some(SurfaceKind::Pty)
@@ -22431,6 +22448,7 @@ impl App {
                     terminal_admission,
                 ) != PtyMousePressResult::NotOwned
                 {
+                    self.reset_selection_click_sequence();
                     return Ok(RenderAction::Draw);
                 } else {
                     if self.active_pane() != Some(area.pane) {
@@ -22455,6 +22473,7 @@ impl App {
                         cell,
                         (x.saturating_sub(content.x), y.saturating_sub(content.y)),
                         modifiers,
+                        now,
                     );
                     if mode == SelectionMode::Cell && modifiers == KeyModifiers::NONE {
                         // Ghostty's cell behavior returns no range on press.
@@ -23954,7 +23973,6 @@ impl App {
         modifiers: KeyModifiers,
         terminal_admission: Option<TerminalPointerAdmission>,
     ) -> anyhow::Result<RenderAction> {
-        self.reset_selection_click_sequence();
         if self.menu.is_some() || self.prompt.is_some() {
             return Ok(RenderAction::None);
         }
@@ -27595,12 +27613,19 @@ mod tests {
             row: content.y,
             modifiers: KeyModifiers::SHIFT,
         };
-        app.handle_mouse(click).unwrap();
-        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
-            .unwrap();
-        app.handle_mouse(click).unwrap();
-        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
-            .unwrap();
+        let now = Instant::now();
+        app.handle_mouse_at(click, now).unwrap();
+        app.handle_mouse_at(
+            MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click },
+            now,
+        )
+        .unwrap();
+        app.handle_mouse_at(click, now).unwrap();
+        app.handle_mouse_at(
+            MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click },
+            now,
+        )
+        .unwrap();
 
         assert_eq!(
             app.selection.map(|selection| selection.range()),
@@ -27622,10 +27647,14 @@ mod tests {
             row: content.y,
             modifiers: KeyModifiers::SHIFT,
         };
+        let now = Instant::now();
         for _ in 0..3 {
-            app.handle_mouse(click).unwrap();
-            app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
-                .unwrap();
+            app.handle_mouse_at(click, now).unwrap();
+            app.handle_mouse_at(
+                MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click },
+                now,
+            )
+            .unwrap();
         }
 
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16991,8 +16991,8 @@ impl App {
         }
         let point = Self::selection_point(cell)?;
         let handle = self.session.surface(surface)?;
-        let (range, content_generation) =
-            handle.with_terminal_and_generation(|terminal, generation| {
+        let (range, content_generation) = handle
+            .with_terminal_and_generation(|terminal, generation| {
                 let point = terminal.normalize_selection_point_screen(point)?;
                 let range = match mode {
                     SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
@@ -17003,8 +17003,9 @@ impl App {
                         .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
                     SelectionMode::Cell => None,
                 };
-                (range, generation)
-            })?;
+                Some((range, generation))
+            })
+            .flatten()?;
         let range = range?;
         Some((Self::selection_from_range(surface, range), Some(content_generation)))
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27837,6 +27837,36 @@ mod tests {
     }
 
     #[test]
+    fn whitespace_double_click_drag_preserves_whitespace_anchor() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-whitespace-drag-selection-test", b"alpha   beta");
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 6,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 9,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((5, 0), (11, 0))),
+            "dragging from whitespace must retain its initial whitespace range"
+        );
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_extends_selection_by_complete_words() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-word-drag-selection-test", b"alpha beta gamma");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27603,6 +27603,85 @@ mod tests {
     }
 
     #[test]
+    fn horizontal_scroll_resets_selection_click_repeat() {
+        let (mut app, mux, surface, content) = selection_fixture(
+            "horizontal-scroll-resets-selection-click-repeat-test",
+            b"alpha beta gamma",
+        );
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        assert!(app.selection_click_sequence.is_some());
+
+        app.content_area = content;
+        app.viewport_virtual_width = u64::from(content.width) * 2;
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::ScrollRight,
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+        assert!(app.selection_click_sequence.is_none());
+        assert!(app.viewport_states[&app.active_screen_id().unwrap()].target > 0.0);
+
+        app.handle_mouse(click).unwrap();
+        assert_eq!(app.selection_mode, SelectionMode::Cell);
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn pty_owned_click_resets_selection_click_repeat() {
+        let (mut app, mux, surface, content) = selection_fixture(
+            "pty-owned-click-resets-selection-click-repeat-test",
+            b"alpha beta gamma",
+        );
+
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        assert!(app.selection_click_sequence.is_some());
+
+        surface.with_terminal(|terminal| terminal.vt_write(b"\x1b[?1002h\x1b[?1006h"));
+        app.encode_buf.clear();
+        app.handle_mouse(click).unwrap();
+        assert!(app.selection_click_sequence.is_none());
+        assert!(matches!(app.drag, Some(Drag::PtyMouse { button: MouseButton::Left, .. })));
+        assert_eq!(app.encode_buf, b"\x1b[<0;2;1M");
+
+        // Let the stored PTY release reservation finish before turning mouse
+        // tracking off, matching the normal terminal ownership transition.
+        surface.with_terminal(|terminal| terminal.vt_write(b"\x1b[?1002l\x1b[?1006l"));
+        app.encode_buf.clear();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        assert!(app.drag.is_none());
+
+        app.handle_mouse(click).unwrap();
+        assert_eq!(app.selection_mode, SelectionMode::Cell);
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn shift_double_click_selects_a_complete_word() {
         let (mut app, mux, surface, content) =
             selection_fixture("shift-double-click-word-selection-test", b"alpha beta gamma");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17226,6 +17226,22 @@ impl App {
                 SelectionMode::Cell => None,
             })
             .flatten();
+        let range = range.map(|range| {
+            if mode == SelectionMode::Word {
+                self.selection
+                    .filter(|selection| selection.surface == surface)
+                    .map(|selection| {
+                        let initial = selection.range();
+                        SelectionRange {
+                            start: initial.0.min(range.start),
+                            end: initial.1.max(range.end),
+                        }
+                    })
+                    .unwrap_or(range)
+            } else {
+                range
+            }
+        });
         if let Some(generation) = content_generation {
             self.semantic_selection_cache = Some(SemanticSelectionCache {
                 surface,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5375,6 +5375,7 @@ struct SelectionClickSequence {
     anchor: (u16, u64),
     dragged: bool,
     tracked_anchor: Option<TrackedScreenPoint>,
+    semantic_range: Option<SelectionRange>,
     /// A failed semantic press keeps `tracked_anchor` alive for a same-press
     /// cell drag, but it must not keep the repeat count alive for the next
     /// press.
@@ -17092,6 +17093,7 @@ impl App {
             anchor: cell,
             dragged: false,
             tracked_anchor,
+            semantic_range: None,
             repeatable: true,
         });
         mode
@@ -17228,13 +17230,27 @@ impl App {
             .flatten();
         let range = range.map(|range| {
             if mode == SelectionMode::Word {
-                self.selection
-                    .filter(|selection| selection.surface == surface)
-                    .map(|selection| {
-                        let initial = selection.range();
+                self.selection_click_sequence
+                    .as_ref()
+                    .and_then(|sequence| sequence.semantic_range)
+                    .map(|initial| {
+                        let start = if (initial.start.row, initial.start.column)
+                            <= (range.start.row, range.start.column)
+                        {
+                            initial.start
+                        } else {
+                            range.start
+                        };
+                        let end = if (initial.end.row, initial.end.column)
+                            >= (range.end.row, range.end.column)
+                        {
+                            initial.end
+                        } else {
+                            range.end
+                        };
                         SelectionRange {
-                            start: initial.0.min(range.start),
-                            end: initial.1.max(range.end),
+                            start,
+                            end,
                         }
                     })
                     .unwrap_or(range)
@@ -22497,6 +22513,20 @@ impl App {
                         self.selection_mode_surface = Some(area.surface);
                         if let Some(selection) = self.selection_for_click(area.surface, cell, mode)
                         {
+                            if let Some(sequence) = self.selection_click_sequence.as_mut()
+                                && mode != SelectionMode::Cell
+                            {
+                                sequence.semantic_range = Some(SelectionRange {
+                                    start: SelectionPoint {
+                                        column: selection.range().0.0,
+                                        row: selection.range().0.1 as u32,
+                                    },
+                                    end: SelectionPoint {
+                                        column: selection.range().1.0,
+                                        row: selection.range().1.1 as u32,
+                                    },
+                                });
+                            }
                             self.replace_selection(Some(selection));
                         } else {
                             // A semantic lookup can legitimately return no

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27891,6 +27891,34 @@ mod tests {
             Some(((0, 0), (10, 0))),
             "Shift triple click must select the complete line when bypassing PTY mouse reporting"
         );
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn double_clicking_the_trailing_cell_of_a_wide_word_selects_the_word() {
+        let (mut app, mux, surface, content) =
+            selection_fixture("double-click-wide-word-selection-test", "foo 界 bar".as_bytes());
+
+        // The CJK character occupies columns 4 and 5. A click on the trailing
+        // cell must behave like a click on the grapheme's leading cell.
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 5,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((4, 0), (4, 0))),
+            "double-clicking a wide grapheme's trailing cell must select its word"
+        );
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17047,6 +17047,9 @@ impl App {
         let repeated = previous.as_ref().is_some_and(|previous| {
             Self::selection_repeat_allowed(previous, surface, screen, position, modifiers, now)
         });
+        if !repeated {
+            self.replace_selection(None);
+        }
         let (mut count, mut tracked_anchor) = if repeated {
             let previous = previous.expect("repeated selection click has prior state");
             (previous.count.saturating_add(1).min(3), previous.tracked_anchor)
@@ -27947,6 +27950,17 @@ mod tests {
             Some(((6, 0), (15, 0))),
             "double-click drag must start at the selected word and end at the whole target word"
         );
+
+        let plain_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 2,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(plain_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..plain_click })
+            .unwrap();
+        assert!(app.selection.is_none(), "a plain click after a selection drag must clear it");
 
         mux.close_surface(surface.id).unwrap();
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16993,6 +16993,7 @@ impl App {
         let handle = self.session.surface(surface)?;
         let (range, content_generation) =
             handle.with_terminal_and_generation(|terminal, generation| {
+                let point = terminal.normalize_selection_point_screen(point)?;
                 let range = match mode {
                     SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
                     SelectionMode::Line => terminal
@@ -17225,6 +17226,8 @@ impl App {
         }
         let (range, content_generation) = handle
             .with_terminal_and_generation(|terminal, generation| {
+                let anchor_point = terminal.normalize_selection_point_screen(anchor_point)?;
+                let current_point = terminal.normalize_selection_point_screen(current_point)?;
                 let range = match mode {
                     SelectionMode::Word => {
                         // Ghostty's nearest-word lookup is directional. Keep both

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -28303,6 +28303,45 @@ mod tests {
     }
 
     #[test]
+    fn double_click_drag_to_a_wide_word_trailing_cell_selects_the_word() {
+        let (mut app, mux, surface, content) = selection_fixture(
+            "double-click-wide-word-drag-selection-test",
+            "alpha 界 omega".as_bytes(),
+        );
+
+        let first_click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 1,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(first_click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..first_click })
+            .unwrap();
+        app.handle_mouse(first_click).unwrap();
+
+        // The wide character starts at column 6 and occupies trailing spacer
+        // column 7. Dragging to that cell must use the grapheme lead.
+        let trailing = MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 7,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(trailing).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..trailing })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 0), (6, 0))),
+            "double-click drag to a wide grapheme's trailing cell must select its word"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn double_click_drag_anchors_at_second_press() {
         let (mut app, mux, surface, content) =
             selection_fixture("double-click-second-press-anchor-test", b"a b c");

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27889,11 +27889,8 @@ mod tests {
             modifiers: KeyModifiers::SHIFT,
         };
         app.handle_mouse(shift_click).unwrap();
-        app.handle_mouse(MouseEvent {
-            kind: MouseEventKind::Up(MouseButton::Left),
-            ..shift_click
-        })
-        .unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..shift_click })
+            .unwrap();
         let plain_click = MouseEvent {
             kind: MouseEventKind::Down(MouseButton::Left),
             modifiers: KeyModifiers::NONE,

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -2251,6 +2251,23 @@ impl SurfaceHandle {
         }
     }
 
+    pub fn with_terminal_and_generation<R>(
+        &self,
+        f: impl FnOnce(&mut Terminal, u64) -> R,
+    ) -> Option<R> {
+        match self {
+            SurfaceHandle::Local(surface, _) => surface.with_terminal_and_generation(f),
+            SurfaceHandle::Remote(surface, _) if surface.kind == SurfaceKind::Pty => {
+                let mut terminal = surface.term.lock().unwrap();
+                let generation = surface.content_generation.load(Ordering::Acquire);
+                let result = f(&mut terminal, generation);
+                surface.sync_mouse_encoders(&terminal);
+                Some(result)
+            }
+            SurfaceHandle::Remote(_, _) | SurfaceHandle::RemoteBrowserUnsupported => None,
+        }
+    }
+
     pub fn encode_mouse(
         &self,
         input: MouseInput,

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -442,7 +442,7 @@ fn renderable_cell_text(text: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ghostty_vt::{Callbacks, CursorInfo, CursorShape, RenderState, Terminal};
+    use ghostty_vt::{Callbacks, CursorShape, RenderState, Terminal};
     use ratatui::Terminal as RatatuiTerminal;
     use ratatui::backend::TestBackend;
 

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use cmux_tui_core::{Rect, SurfaceRenderFrame};
-use ghostty_vt::{Cell as VtCell, CellWidth, ColorSpec, Rgb};
+use ghostty_vt::{Cell as VtCell, CellWidth, ColorSpec, CursorInfo, Rgb};
 use ratatui::Frame;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect as RatatuiRect;
@@ -127,15 +127,45 @@ fn draw_render_frame_with_catalog(
         );
     }
 
-    render
-        .frame
-        .cursor
-        .filter(|cursor| {
-            cursor.x >= source_x
-                && usize::from(cursor.x - source_x) < live_cols
-                && (cursor.y as usize) < live_rows
-        })
-        .map(|cursor| (rect.x + cursor.x - source_x, rect.y + cursor.y))
+    render.frame.cursor.and_then(|cursor| {
+        cropped_cursor_position(
+            cursor,
+            render.frame.styled_rows(),
+            source_x,
+            live_cols,
+            live_rows,
+        )
+        .map(|(x, y)| (rect.x + x, rect.y + y))
+    })
+}
+
+/// Return a cursor position that is drawable in a horizontally cropped frame.
+/// Ghostty can report a cursor on a wide grapheme's trailing spacer. That
+/// spacer is not an independent drawable cell, so place the cursor on the
+/// grapheme lead before applying crop bounds.
+fn cropped_cursor_position(
+    cursor: CursorInfo,
+    rows: &[Vec<VtCell>],
+    source_x: u16,
+    live_cols: usize,
+    live_rows: usize,
+) -> Option<(u16, u16)> {
+    let mut x = cursor.x;
+    if x > 0
+        && rows
+            .get(cursor.y as usize)
+            .and_then(|row| row.get(x as usize))
+            .is_some_and(|cell| cell.width == CellWidth::SpacerTail)
+        && rows
+            .get(cursor.y as usize)
+            .and_then(|row| row.get((x - 1) as usize))
+            .is_some_and(|cell| cell.width == CellWidth::Wide)
+    {
+        x -= 1;
+    }
+
+    (x >= source_x && usize::from(x - source_x) < live_cols && (cursor.y as usize) < live_rows)
+        .then_some((x - source_x, cursor.y))
 }
 
 fn partial_wide_cell(

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -412,7 +412,7 @@ fn renderable_cell_text(text: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ghostty_vt::{Callbacks, RenderState, Terminal};
+    use ghostty_vt::{Callbacks, CursorInfo, CursorShape, RenderState, Terminal};
     use ratatui::Terminal as RatatuiTerminal;
     use ratatui::backend::TestBackend;
 
@@ -545,6 +545,68 @@ mod tests {
 
         let clipped_tail = draw_crop(2);
         assert_eq!(row_text(clipped_tail.backend().buffer(), 0, 0, 2), " b");
+    }
+
+    #[test]
+    fn cropped_grid_places_a_wide_cell_cursor_on_the_lead_cell() {
+        let mut terminal = Terminal::new(6, 1, 0, Callbacks::default()).unwrap();
+        terminal.vt_write("a界bc".as_bytes());
+        let mut state = RenderState::new().unwrap();
+        state.update(&mut terminal).unwrap();
+        let mut render = SurfaceRenderFrame {
+            frame: state.build_frame().unwrap(),
+            content_generation: 1,
+            scrollback_rows: 0,
+            history_epoch: terminal.history_epoch(),
+            pointer_semantics: terminal.pointer_semantic_snapshot(),
+            palette_colors: std::array::from_fn(|idx| state.palette_color(idx as u8)),
+            palette_overridden: std::array::from_fn(|idx| state.palette_overridden(idx as u8)),
+        };
+        // A terminal cursor may be reported on the trailing spacer of a wide
+        // grapheme. The renderer must use the lead column for its placement.
+        render.frame.cursor = Some(CursorInfo {
+            x: 2,
+            y: 0,
+            shape: CursorShape::Block,
+            blinking: false,
+        });
+
+        let mut output = RatatuiTerminal::new(TestBackend::new(3, 1)).unwrap();
+        let mut cursor = None;
+        output
+            .draw(|frame| {
+                cursor = draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 3, height: 1 }, source_x: 1 },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    |_, _| false,
+                );
+            })
+            .unwrap();
+
+        assert_eq!(cursor, Some((0, 0)));
+
+        // Cropping from the spacer itself must not leave a cursor on a blank
+        // partial-glyph cell.
+        let mut output = RatatuiTerminal::new(TestBackend::new(2, 1)).unwrap();
+        let mut cursor = None;
+        output
+            .draw(|frame| {
+                cursor = draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 2, height: 1 }, source_x: 2 },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    |_, _| false,
+                );
+            })
+            .unwrap();
+        assert_eq!(cursor, None);
     }
 
     fn row_text(buffer: &Buffer, y: u16, x: u16, width: u16) -> String {

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -634,6 +634,28 @@ mod tests {
                     crate::localization::catalog_for_locale("en_US.UTF-8"),
                     |_, _| false,
                 );
+        })
+            .unwrap();
+        assert_eq!(cursor, None);
+
+        // A lead at the right crop edge is also blanked because its spacer
+        // falls outside the live width, so it must not receive a cursor.
+        let mut output = RatatuiTerminal::new(TestBackend::new(1, 1)).unwrap();
+        let mut cursor = None;
+        output
+            .draw(|frame| {
+                cursor = draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 1, height: 1 },
+                        source_x: 1,
+                    },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    |_, _| false,
+                );
             })
             .unwrap();
         assert_eq!(cursor, None);

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -151,21 +151,30 @@ fn cropped_cursor_position(
     live_rows: usize,
 ) -> Option<(u16, u16)> {
     let mut x = cursor.x;
+    let row = rows.get(cursor.y as usize)?;
     if x > 0
-        && rows
-            .get(cursor.y as usize)
-            .and_then(|row| row.get(x as usize))
-            .is_some_and(|cell| cell.width == CellWidth::SpacerTail)
-        && rows
-            .get(cursor.y as usize)
-            .and_then(|row| row.get((x - 1) as usize))
-            .is_some_and(|cell| cell.width == CellWidth::Wide)
+        && row.get(x as usize).is_some_and(|cell| cell.width == CellWidth::SpacerTail)
+        && row.get((x - 1) as usize).is_some_and(|cell| cell.width == CellWidth::Wide)
     {
         x -= 1;
     }
 
-    (x >= source_x && usize::from(x - source_x) < live_cols && (cursor.y as usize) < live_rows)
-        .then_some((x - source_x, cursor.y))
+    if x < source_x || usize::from(x - source_x) >= live_cols || (cursor.y as usize) >= live_rows {
+        return None;
+    }
+
+    // A wide lead is drawable only when its trailing spacer is also inside
+    // the crop. This matches partial_wide_cell, which blanks split pairs.
+    if row.get(x as usize).is_some_and(|cell| cell.width == CellWidth::Wide)
+        && (usize::from(x - source_x).saturating_add(1) >= live_cols
+            || !row
+                .get(x.saturating_add(1) as usize)
+                .is_some_and(|cell| cell.width == CellWidth::SpacerTail))
+    {
+        return None;
+    }
+
+    Some((x - source_x, cursor.y))
 }
 
 fn partial_wide_cell(

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -128,14 +128,8 @@ fn draw_render_frame_with_catalog(
     }
 
     render.frame.cursor.and_then(|cursor| {
-        cropped_cursor_position(
-            cursor,
-            render.frame.styled_rows(),
-            source_x,
-            live_cols,
-            live_rows,
-        )
-        .map(|(x, y)| (rect.x + x, rect.y + y))
+        cropped_cursor_position(cursor, render.frame.styled_rows(), source_x, live_cols, live_rows)
+            .map(|(x, y)| (rect.x + x, rect.y + y))
     })
 }
 
@@ -603,12 +597,8 @@ mod tests {
         };
         // A terminal cursor may be reported on the trailing spacer of a wide
         // grapheme. The renderer must use the lead column for its placement.
-        render.frame.cursor = Some(CursorInfo {
-            x: 2,
-            y: 0,
-            shape: CursorShape::Block,
-            blinking: false,
-        });
+        render.frame.cursor =
+            Some(CursorInfo { x: 2, y: 0, shape: CursorShape::Block, blinking: false });
 
         let mut output = RatatuiTerminal::new(TestBackend::new(3, 1)).unwrap();
         let mut cursor = None;
@@ -616,7 +606,10 @@ mod tests {
             .draw(|frame| {
                 cursor = draw_render_frame_with_catalog(
                     frame,
-                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 3, height: 1 }, source_x: 1 },
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 3, height: 1 },
+                        source_x: 1,
+                    },
                     &render,
                     &Theme::default(),
                     &ChromeTheme::dark(),
@@ -636,14 +629,17 @@ mod tests {
             .draw(|frame| {
                 cursor = draw_render_frame_with_catalog(
                     frame,
-                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 2, height: 1 }, source_x: 2 },
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 2, height: 1 },
+                        source_x: 2,
+                    },
                     &render,
                     &Theme::default(),
                     &ChromeTheme::dark(),
                     crate::localization::catalog_for_locale("en_US.UTF-8"),
                     |_, _| false,
                 );
-        })
+            })
             .unwrap();
         assert_eq!(cursor, None);
 

--- a/cmux-tui/crates/ghostty-vt/src/render.rs
+++ b/cmux-tui/crates/ghostty-vt/src/render.rs
@@ -742,7 +742,7 @@ fn raw_cell_bg_spec(raw: sys::GhosttyCell) -> Option<ColorSpec> {
     }
 }
 
-fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
+pub(crate) fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
     let mut wide = sys::GHOSTTY_CELL_WIDE_NARROW;
     let result = unsafe {
         sys::ghostty_cell_get(raw, sys::GHOSTTY_CELL_DATA_WIDE, &mut wide as *mut _ as *mut c_void)

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -3012,7 +3012,10 @@ impl Terminal {
     /// Move a screen selection point from a wide grapheme's trailing spacer
     /// cell to its leading cell. Mouse reports identify grid cells, so a
     /// click on either half of a wide character must address the same text.
-    pub fn normalize_selection_point_screen(&self, point: SelectionPoint) -> Option<SelectionPoint> {
+    pub fn normalize_selection_point_screen(
+        &self,
+        point: SelectionPoint,
+    ) -> Option<SelectionPoint> {
         let width = self.cell_width_screen(point)?;
         if width != CellWidth::SpacerTail || point.column == 0 {
             return Some(point);
@@ -3022,11 +3025,8 @@ impl Terminal {
     }
 
     fn cell_width_screen(&self, point: SelectionPoint) -> Option<CellWidth> {
-        let grid_ref = self.grid_ref(
-            sys::GHOSTTY_POINT_TAG_SCREEN,
-            point.column,
-            u64::from(point.row),
-        )?;
+        let grid_ref =
+            self.grid_ref(sys::GHOSTTY_POINT_TAG_SCREEN, point.column, u64::from(point.row))?;
         let mut raw = sys::GhosttyCell::default();
         check(unsafe { sys::ghostty_grid_ref_cell(&grid_ref, &mut raw) }).ok()?;
         Some(crate::render::cell_width(raw))

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -3009,6 +3009,29 @@ impl Terminal {
         self.selection_range(&selection).map(Some)
     }
 
+    /// Move a screen selection point from a wide grapheme's trailing spacer
+    /// cell to its leading cell. Mouse reports identify grid cells, so a
+    /// click on either half of a wide character must address the same text.
+    pub fn normalize_selection_point_screen(&self, point: SelectionPoint) -> Option<SelectionPoint> {
+        let width = self.cell_width_screen(point)?;
+        if width != CellWidth::SpacerTail || point.column == 0 {
+            return Some(point);
+        }
+        let leading = SelectionPoint { column: point.column - 1, ..point };
+        (self.cell_width_screen(leading) == Some(CellWidth::Wide)).then_some(leading)
+    }
+
+    fn cell_width_screen(&self, point: SelectionPoint) -> Option<CellWidth> {
+        let grid_ref = self.grid_ref(
+            sys::GHOSTTY_POINT_TAG_SCREEN,
+            point.column,
+            u64::from(point.row),
+        )?;
+        let mut raw = sys::GhosttyCell::default();
+        check(unsafe { sys::ghostty_grid_ref_cell(&grid_ref, &mut raw) }).ok()?;
+        Some(crate::render::cell_width(raw))
+    }
+
     /// Select the nearest word between two absolute screen coordinates.
     /// This is useful while dragging because it skips whitespace and other
     /// empty cells without inventing boundaries in the UI layer.


### PR DESCRIPTION
Consolidates the selection fixes from #11445, #11511, and #11525 on current main.

What changed:
- Preserve host click repeats for plain and Shift clicks, and clear repeats for PTY-owned clicks.
- Keep semantic anchors and content-generation pairing valid across drag, release, and Kitty limit updates.
- Normalize wide-grapheme points before semantic selection and cover trailing-cell word selection.
- Keep the click-repeat reset in `handle_horizontal_scroll_with_admission`, so direct handler callers cannot retain stale state. The outer dispatch does not duplicate this reset.

Overlap disposition:
- #11445 reset behavior and regression tests are retained.
- #11511 semantic-generation changes are retained; its duplicate Shift-repeat and scroll-dispatch changes are folded into the #11445 path.
- #11525 wide-grapheme normalization and generation pairing are retained on top.

Checks: `git diff --check` passed. No local Cargo/Rust tests were run per task constraints.

This PR is a replacement consolidation and should not be merged automatically with #11445, #11511, or #11525.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952243&installation_model_id=21920&pr_number=11693&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11693&signature=866689861af7c75a1337fb8712ef5c3d80633644757d7f9c194e26f883bc645b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Consolidates terminal selection and wide-grapheme fixes so repeated host clicks select the intended word or line without retaining stale ranges.

**Bug Fixes**
- Click repeats now survive plain clicks and Shift-clicks, including pointer movement between presses; clicks forwarded to the PTY and scrolling reset them, while plain clicks clear existing selections.
- Semantic ranges are paired with terminal content generations and rejected after stale or failed lookups, including before copying; failed semantic repeats reset the next click to cell mode.
- Whitespace anchors and reverse semantic drags retain their expected bounds.
- Wide-grapheme clicks and drag endpoints use the leading cell, and cropped wide-grapheme cursors are hidden.
- Unchanged Kitty graphics limits no longer advance the render generation; test hooks remain test-only.
- Regression tests cover repeat resets, Shift selection, stale content, whitespace anchors, wide graphemes, and cursor cropping.

<sup>Written for commit 7cc1a7480f6f320be4bd49b588619d5dd3059cdc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11693?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented text from being copied when terminal content changes during selection.
  * Improved word and line selection with Shift-click.
  * Fixed selection behavior for wide characters, including clicks on trailing cells.
  * Corrected cursor placement for wide characters in horizontally cropped terminal views.
  * Cleared stale selections after terminal updates, scrolling, or PTY-owned click resets.
  * Plain clicks without dragging now clear existing selections.
  * Improved repeated selection handling when terminal content changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->