### PR TITLE
fix(cmux-tui): preserve close callback on event queue overflow

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -13,7 +13,9 @@ const MAX_CONTROL_LINE_BYTES: usize = 1_048_576;
 const MAX_WRITER_QUEUE: usize = 256;
 const MAX_PENDING_REQUESTS: usize = 256;
 const MAX_EVENT_QUEUE: usize = 1_024;
-const MAX_EVENT_QUEUE_BYTES: usize = MAX_CONTROL_LINE_BYTES;
+// Keep the per-line parser cap separate from the total event budget. A short
+// burst of large events must not consume the entire queue after one frame.
+const MAX_EVENT_QUEUE_BYTES: usize = 4 * MAX_CONTROL_LINE_BYTES;
 
 pub type EventHandler = Box<dyn Fn(&Value) + Send + Sync>;
 pub type CloseHandler = Box<dyn Fn() + Send + Sync>;
@@ -46,7 +48,7 @@ mod unix {
     use super::*;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-    use std::sync::{Arc, Condvar, Mutex};
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -78,10 +80,7 @@ mod unix {
         dispatch_tx: std::sync::mpsc::SyncSender<Dispatch>,
         close_signal_tx: std::sync::mpsc::SyncSender<()>,
         queued_event_bytes: AtomicUsize,
-        pending_events: Mutex<usize>,
-        event_drain: Condvar,
         worker_done: AtomicBool,
-        worker_thread: Mutex<Option<std::thread::ThreadId>>,
     }
 
     enum Dispatch {
@@ -149,41 +148,8 @@ mod unix {
             }
         }
 
-        fn start_event(&self) -> bool {
-            let mut pending = self.pending_events.lock().expect("control event drain lock");
-            if self.closed.load(Ordering::Acquire) {
-                return false;
-            }
-            *pending += 1;
-            true
-        }
-
-        fn finish_event(&self) {
-            let mut pending = self.pending_events.lock().expect("control event drain lock");
-            *pending = pending.checked_sub(1).expect("control event pending count");
-            if *pending == 0 {
-                self.event_drain.notify_all();
-            }
-        }
-
-        fn wait_for_event_drain(&self) {
-            let mut pending = self.pending_events.lock().expect("control event drain lock");
-            while *pending != 0 && !self.worker_done.load(Ordering::Acquire) {
-                pending = self.event_drain.wait(pending).expect("control event drain wait");
-            }
-        }
-
-        fn on_worker_thread(&self) -> bool {
-            self.worker_thread
-                .lock()
-                .expect("control worker thread lock")
-                .is_some_and(|worker| worker == std::thread::current().id())
-        }
-
         fn finish_worker(&self) {
-            let _pending = self.pending_events.lock().expect("control event drain lock");
             self.worker_done.store(true, Ordering::Release);
-            self.event_drain.notify_all();
         }
     }
 
@@ -235,21 +201,15 @@ mod unix {
             dispatch_tx,
             close_signal_tx,
             queued_event_bytes: AtomicUsize::new(0),
-            pending_events: Mutex::new(0),
-            event_drain: Condvar::new(),
             worker_done: AtomicBool::new(false),
-            worker_thread: Mutex::new(None),
         });
         let worker_shared = Arc::clone(&shared);
         std::thread::Builder::new()
             .name("chatmux-relay-control-events".to_owned())
             .spawn(move || {
                 let shared = worker_shared;
-                *shared.worker_thread.lock().expect("control worker thread lock") =
-                    Some(std::thread::current().id());
                 let deliver_event = |shared: &Arc<Shared>, event: Value, bytes: usize| {
                     if !shared.release_event_bytes(bytes) {
-                        shared.finish_event();
                         shared.settle_closed();
                         return false;
                     }
@@ -257,7 +217,6 @@ mod unix {
                     if let Some(handler) = handler {
                         handler(&event);
                     }
-                    shared.finish_event();
                     true
                 };
                 let invoke_close = |shared: &Arc<Shared>| {
@@ -284,6 +243,7 @@ mod unix {
                     match dispatch {
                         Dispatch::Event { value: event, bytes } => {
                             if !deliver_event(&shared, event, bytes) {
+                                invoke_close(&shared);
                                 break;
                             }
                         }
@@ -451,16 +411,11 @@ mod unix {
                         shared.settle_closed();
                         break 'read_loop;
                     }
-                    if !shared.start_event() {
-                        let _ = shared.release_event_bytes(bytes);
-                        break 'read_loop;
-                    }
                     if shared
                         .dispatch_tx
                         .try_send(Dispatch::Event { value: parsed, bytes })
                         .is_err()
                     {
-                        shared.finish_event();
                         let _ = shared.release_event_bytes(bytes);
                         shared.settle_closed();
                         break 'read_loop;
@@ -918,22 +873,29 @@ mod tests {
             .await
             .expect("connect late-order socket");
         accepted_rx.await.expect("wait for control late-order server");
-        let entered = Arc::new(std::sync::Barrier::new(2));
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
         let release = Arc::new(std::sync::Barrier::new(2));
         let seen = Arc::new(Mutex::new(Vec::new()));
-        let entered_for_handler = Arc::clone(&entered);
+        let entered_for_handler = Arc::clone(&entered_tx);
         let release_for_handler = Arc::clone(&release);
         let seen_for_event = Arc::clone(&seen);
         control.on_event(Box::new(move |_| {
             seen_for_event.lock().expect("event order lock").push("event");
-            entered_for_handler.wait();
+            if let Some(entered_tx) = entered_for_handler.lock().expect("entry signal lock").take()
+            {
+                let _ = entered_tx.send(());
+            }
             release_for_handler.wait();
         }));
         let control_for_reader = Arc::clone(&control);
         let reader_done = tokio::spawn(async move { control_for_reader.wait_reader_done().await });
         tokio::task::yield_now().await;
         start_tx.send(()).expect("start late-order event");
-        entered.wait();
+        tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("event callback entered")
+            .expect("entry signal");
         tokio::time::timeout(Duration::from_secs(1), reader_done)
             .await
             .expect("reader sees peer close")

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -929,6 +929,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn close_registration_during_callback_is_not_stranded() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-close-race-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control close race socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept control close race socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for close race server");
+            drop(stream);
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect close race socket");
+        accepted_rx.await.expect("wait for close race server");
+        let (started_tx, started_rx) = oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        control.on_close(Box::new(move || {
+            let _ = started_tx.send(());
+            release_rx.recv().expect("release first close callback");
+        }));
+        start_tx.send(()).expect("start close race server");
+        tokio::time::timeout(Duration::from_secs(1), started_rx)
+            .await
+            .expect("first close callback entered")
+            .expect("first close callback signal");
+
+        let closed = Arc::new(Notify::new());
+        let closed_for_handler = Arc::clone(&closed);
+        control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
+        release_tx.send(()).expect("release first close callback");
+        tokio::time::timeout(Duration::from_secs(1), closed.notified())
+            .await
+            .expect("late close callback after callback race");
+
+        server.await.expect("join close race server");
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
     async fn writer_queue_preserves_complete_fifo_lines() {
         let socket_path =
             std::env::temp_dir().join(format!("chatmux-relay-control-{}.sock", std::process::id()));

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -607,6 +607,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn close_callback_survives_a_full_event_queue() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-event-overflow-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control overflow socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept control overflow socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for event handler");
+            for index in 0..=MAX_EVENT_QUEUE {
+                let line = format!("{{\"event\":\"queued-{index}\"}}\n");
+                stream.write_all(line.as_bytes()).await.expect("write queued event");
+            }
+            // EOF is the unexpected close that must still reach on_close.
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect overflow socket");
+        accepted_rx.await.expect("wait for control overflow server");
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let closed = Arc::new(Notify::new());
+        let closed_for_handler = Arc::clone(&closed);
+        control.on_event(Box::new(move |_| {
+            if entered_tx.try_send(()).is_ok() {
+                release_rx.recv().expect("release first event callback");
+            }
+        }));
+        control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
+        start_tx.send(()).expect("start control event overflow");
+        entered_rx.recv_timeout(std::time::Duration::from_secs(1)).expect("first callback entered");
+
+        let closed_wait = closed.notified();
+        tokio::pin!(closed_wait);
+        release_tx.send(()).expect("release first event callback");
+        tokio::time::timeout(Duration::from_secs(2), &mut closed_wait)
+            .await
+            .expect("close callback survives full event queue");
+        server.await.expect("join control overflow server");
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
     async fn writer_queue_preserves_complete_fifo_lines() {
         let socket_path =
             std::env::temp_dir().join(format!("chatmux-relay-control-{}.sock", std::process::id()));

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -572,14 +572,11 @@ mod unix {
                 if self.shared.deliberate.load(Ordering::SeqCst) {
                     return;
                 }
-                if self.shared.on_worker_thread()
-                    && !self.shared.worker_done.load(Ordering::Acquire)
-                {
+                if !self.shared.worker_done.load(Ordering::Acquire) {
                     *slot = Some(handler);
                     return;
                 }
                 drop(slot);
-                self.shared.wait_for_event_drain();
                 handler();
             } else {
                 *slot = Some(handler);
@@ -776,18 +773,25 @@ mod tests {
             .await
             .expect("connect overflow socket");
         accepted_rx.await.expect("wait for control overflow server");
-        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
         let closed = Arc::new(Notify::new());
         let closed_for_handler = Arc::clone(&closed);
+        let entered_for_handler = Arc::clone(&entered_tx);
         control.on_event(Box::new(move |_| {
-            if entered_tx.try_send(()).is_ok() {
+            if let Some(entered_tx) = entered_for_handler.lock().expect("entry signal lock").take()
+            {
+                let _ = entered_tx.send(());
                 release_rx.recv().expect("release first event callback");
             }
         }));
         control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
         start_tx.send(()).expect("start control event overflow");
-        entered_rx.recv_timeout(std::time::Duration::from_secs(1)).expect("first callback entered");
+        tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("first callback entered")
+            .expect("entry signal");
 
         let closed_wait = closed.notified();
         tokio::pin!(closed_wait);
@@ -816,7 +820,7 @@ mod tests {
             accepted_tx.send(()).expect("tell client that socket is accepted");
             start_rx.await.expect("wait for event handler");
             let payload = "x".repeat(MAX_CONTROL_LINE_BYTES / 2);
-            for _ in 0..3 {
+            for _ in 0..=MAX_EVENT_QUEUE_BYTES / (MAX_CONTROL_LINE_BYTES / 2) {
                 let line = format!("{{\"event\":\"{payload}\"}}\n");
                 stream.write_all(line.as_bytes()).await.expect("write byte-limited event");
             }
@@ -826,18 +830,25 @@ mod tests {
             .await
             .expect("connect byte-limited socket");
         accepted_rx.await.expect("wait for control byte server");
-        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (entered_tx, entered_rx) = oneshot::channel();
+        let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
         let closed = Arc::new(Notify::new());
         let closed_for_handler = Arc::clone(&closed);
+        let entered_for_handler = Arc::clone(&entered_tx);
         control.on_event(Box::new(move |_| {
-            if entered_tx.try_send(()).is_ok() {
+            if let Some(entered_tx) = entered_for_handler.lock().expect("entry signal lock").take()
+            {
+                let _ = entered_tx.send(());
                 release_rx.recv().expect("release first byte callback");
             }
         }));
         control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
         start_tx.send(()).expect("start control byte overflow");
-        entered_rx.recv_timeout(Duration::from_secs(1)).expect("first byte callback entered");
+        tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("first byte callback entered")
+            .expect("entry signal");
 
         let closed_wait = closed.notified();
         tokio::pin!(closed_wait);
@@ -868,9 +879,14 @@ mod tests {
             .await
             .expect("connect late-close socket");
         accepted_rx.await.expect("wait for control late-close server");
-        let reader_done = control.arm_reader_waiting();
+        let reader_control = Arc::clone(&control);
+        let reader_done = tokio::spawn(async move { reader_control.wait_reader_done().await });
+        tokio::task::yield_now().await;
         start_tx.send(()).expect("start late close");
-        reader_done.await.expect("reader observed late close");
+        tokio::time::timeout(Duration::from_secs(1), reader_done)
+            .await
+            .expect("reader observed late close")
+            .expect("reader waiter task");
         let closed = Arc::new(Notify::new());
         let closed_for_handler = Arc::clone(&closed);
         control.on_close(Box::new(move || closed_for_handler.notify_waiters()));

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -46,7 +46,7 @@ mod unix {
     use super::*;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Condvar, Mutex};
     use std::time::Duration;
 
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -78,6 +78,10 @@ mod unix {
         dispatch_tx: std::sync::mpsc::SyncSender<Dispatch>,
         close_signal_tx: std::sync::mpsc::SyncSender<()>,
         queued_event_bytes: AtomicUsize,
+        pending_events: Mutex<usize>,
+        event_drain: Condvar,
+        worker_done: AtomicBool,
+        worker_thread: Mutex<Option<std::thread::ThreadId>>,
     }
 
     enum Dispatch {
@@ -144,6 +148,43 @@ mod unix {
                 }
             }
         }
+
+        fn start_event(&self) -> bool {
+            let mut pending = self.pending_events.lock().expect("control event drain lock");
+            if self.closed.load(Ordering::Acquire) {
+                return false;
+            }
+            *pending += 1;
+            true
+        }
+
+        fn finish_event(&self) {
+            let mut pending = self.pending_events.lock().expect("control event drain lock");
+            *pending = pending.checked_sub(1).expect("control event pending count");
+            if *pending == 0 {
+                self.event_drain.notify_all();
+            }
+        }
+
+        fn wait_for_event_drain(&self) {
+            let mut pending = self.pending_events.lock().expect("control event drain lock");
+            while *pending != 0 && !self.worker_done.load(Ordering::Acquire) {
+                pending = self.event_drain.wait(pending).expect("control event drain wait");
+            }
+        }
+
+        fn on_worker_thread(&self) -> bool {
+            self.worker_thread
+                .lock()
+                .expect("control worker thread lock")
+                .is_some_and(|worker| worker == std::thread::current().id())
+        }
+
+        fn finish_worker(&self) {
+            let _pending = self.pending_events.lock().expect("control event drain lock");
+            self.worker_done.store(true, Ordering::Release);
+            self.event_drain.notify_all();
+        }
     }
 
     pub struct UnixControl {
@@ -194,12 +235,31 @@ mod unix {
             dispatch_tx,
             close_signal_tx,
             queued_event_bytes: AtomicUsize::new(0),
+            pending_events: Mutex::new(0),
+            event_drain: Condvar::new(),
+            worker_done: AtomicBool::new(false),
+            worker_thread: Mutex::new(None),
         });
         let worker_shared = Arc::clone(&shared);
         std::thread::Builder::new()
             .name("chatmux-relay-control-events".to_owned())
             .spawn(move || {
                 let shared = worker_shared;
+                *shared.worker_thread.lock().expect("control worker thread lock") =
+                    Some(std::thread::current().id());
+                let deliver_event = |shared: &Arc<Shared>, event: Value, bytes: usize| {
+                    if !shared.release_event_bytes(bytes) {
+                        shared.finish_event();
+                        shared.settle_closed();
+                        return false;
+                    }
+                    let handler = shared.event_handler.lock().expect("control event lock").clone();
+                    if let Some(handler) = handler {
+                        handler(&event);
+                    }
+                    shared.finish_event();
+                    true
+                };
                 let invoke_close = |shared: &Arc<Shared>| {
                     if !shared.deliberate.load(Ordering::SeqCst) {
                         let handler =
@@ -223,20 +283,18 @@ mod unix {
                     };
                     match dispatch {
                         Dispatch::Event { value: event, bytes } => {
-                            if !shared.release_event_bytes(bytes) {
-                                shared.settle_closed();
+                            if !deliver_event(&shared, event, bytes) {
                                 break;
-                            }
-                            // Closure is settled before the marker is queued,
-                            // but events already in the FIFO still belong to
-                            // the stream and must be delivered first.
-                            let handler =
-                                shared.event_handler.lock().expect("control event lock").clone();
-                            if let Some(handler) = handler {
-                                handler(&event);
                             }
                         }
                         Dispatch::Closed => {
+                            while let Ok(Dispatch::Event { value: event, bytes }) =
+                                dispatch_rx.try_recv()
+                            {
+                                if !deliver_event(&shared, event, bytes) {
+                                    break;
+                                }
+                            }
                             invoke_close(&shared);
                             break;
                         }
@@ -248,20 +306,15 @@ mod unix {
                         while let Ok(Dispatch::Event { value: event, bytes }) =
                             dispatch_rx.try_recv()
                         {
-                            if !shared.release_event_bytes(bytes) {
-                                shared.settle_closed();
+                            if !deliver_event(&shared, event, bytes) {
                                 break;
-                            }
-                            let handler =
-                                shared.event_handler.lock().expect("control event lock").clone();
-                            if let Some(handler) = handler {
-                                handler(&event);
                             }
                         }
                         invoke_close(&shared);
                         break;
                     }
                 }
+                shared.finish_worker();
             })
             .expect("spawn control event worker");
         // Keep one async writer for every connection. The queue makes the
@@ -398,11 +451,16 @@ mod unix {
                         shared.settle_closed();
                         break 'read_loop;
                     }
+                    if !shared.start_event() {
+                        let _ = shared.release_event_bytes(bytes);
+                        break 'read_loop;
+                    }
                     if shared
                         .dispatch_tx
                         .try_send(Dispatch::Event { value: parsed, bytes })
                         .is_err()
                     {
+                        shared.finish_event();
                         let _ = shared.release_event_bytes(bytes);
                         shared.settle_closed();
                         break 'read_loop;
@@ -514,7 +572,14 @@ mod unix {
                 if self.shared.deliberate.load(Ordering::SeqCst) {
                     return;
                 }
+                if self.shared.on_worker_thread()
+                    && !self.shared.worker_done.load(Ordering::Acquire)
+                {
+                    *slot = Some(handler);
+                    return;
+                }
                 drop(slot);
+                self.shared.wait_for_event_drain();
                 handler();
             } else {
                 *slot = Some(handler);
@@ -848,9 +913,15 @@ mod tests {
             entered_for_handler.wait();
             release_for_handler.wait();
         }));
+        let control_for_reader = Arc::clone(&control);
+        let reader_done = tokio::spawn(async move { control_for_reader.wait_reader_done().await });
+        tokio::task::yield_now().await;
         start_tx.send(()).expect("start late-order event");
         entered.wait();
-        control.wait_reader_done().await;
+        tokio::time::timeout(Duration::from_secs(1), reader_done)
+            .await
+            .expect("reader sees peer close")
+            .expect("reader waiter task");
 
         let seen_for_close = Arc::clone(&seen);
         let control_for_close = Arc::clone(&control);

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -220,12 +220,21 @@ mod unix {
                     true
                 };
                 let invoke_close = |shared: &Arc<Shared>| {
-                    if !shared.deliberate.load(Ordering::SeqCst) {
-                        let handler =
-                            shared.close_handler.lock().expect("control close lock").take();
-                        if let Some(handler) = handler {
-                            handler();
-                        }
+                    if shared.deliberate.load(Ordering::SeqCst) {
+                        return;
+                    }
+                    let handler = {
+                        let mut slot = shared.close_handler.lock().expect("control close lock");
+                        let handler = slot.take();
+                        // Publish completion before running user code. A
+                        // concurrent on_close registration can then invoke
+                        // its handler directly instead of storing it after
+                        // this worker has already taken the slot.
+                        shared.worker_done.store(true, Ordering::Release);
+                        handler
+                    };
+                    if let Some(handler) = handler {
+                        handler();
                     }
                 };
                 loop {

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -93,6 +93,11 @@ mod unix {
             // broadcast wakeup so either task can observe closure without
             // consuming the other's permit.
             self.closed_notify.notify_waiters();
+            // Serialize marker enqueue with on_close registration. The event
+            // worker may receive the marker immediately, so the handler must
+            // be either installed before enqueue or installed by on_close
+            // while the worker waits on this same mutex.
+            let _close_handler = self.close_handler.lock().expect("control close lock");
             let _ = self.dispatch_tx.try_send(Dispatch::Closed);
         }
     }
@@ -147,23 +152,40 @@ mod unix {
         std::thread::Builder::new()
             .name("chatmux-relay-control-events".to_owned())
             .spawn(move || {
-                while let Ok(dispatch) = dispatch_rx.recv() {
-                    let Some(shared) = weak_shared.upgrade() else { break };
-                    if shared.closed.load(Ordering::SeqCst) {
-                        if !shared.deliberate.load(Ordering::SeqCst) {
-                            let handler =
-                                shared.close_handler.lock().expect("control close lock").take();
-                            if let Some(handler) = handler {
-                                handler();
+                loop {
+                    let dispatch = match dispatch_rx.recv_timeout(Duration::from_millis(50)) {
+                        Ok(dispatch) => dispatch,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+                            let Some(shared) = weak_shared.upgrade() else { break };
+                            if shared.closed.load(Ordering::SeqCst) {
+                                Dispatch::Closed
+                            } else {
+                                continue;
                             }
                         }
-                        break;
-                    }
-                    if let Dispatch::Event(event) = dispatch {
-                        let handler =
-                            shared.event_handler.lock().expect("control event lock").clone();
-                        if let Some(handler) = handler {
-                            handler(&event);
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    };
+                    let Some(shared) = weak_shared.upgrade() else { break };
+                    match dispatch {
+                        Dispatch::Event(event) => {
+                            // Closure is settled before the marker is queued,
+                            // but events already in the FIFO still belong to
+                            // the stream and must be delivered first.
+                            let handler =
+                                shared.event_handler.lock().expect("control event lock").clone();
+                            if let Some(handler) = handler {
+                                handler(&event);
+                            }
+                        }
+                        Dispatch::Closed => {
+                            if !shared.deliberate.load(Ordering::SeqCst) {
+                                let handler =
+                                    shared.close_handler.lock().expect("control close lock").take();
+                                if let Some(handler) = handler {
+                                    handler();
+                                }
+                            }
+                            break;
                         }
                     }
                 }
@@ -404,11 +426,16 @@ mod unix {
         }
 
         fn on_close(&self, handler: CloseHandler) {
-            let was_closed = self.shared.closed.load(Ordering::SeqCst);
-            let deliberate = self.shared.deliberate.load(Ordering::SeqCst);
-            *self.shared.close_handler.lock().expect("control close lock") = Some(handler);
-            if was_closed && !deliberate {
+            let mut slot = self.shared.close_handler.lock().expect("control close lock");
+            if self.shared.closed.load(Ordering::SeqCst) {
+                if self.shared.deliberate.load(Ordering::SeqCst) {
+                    return;
+                }
+                *slot = Some(handler);
+                drop(slot);
                 let _ = self.shared.dispatch_tx.try_send(Dispatch::Closed);
+            } else {
+                *slot = Some(handler);
             }
         }
 

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -817,6 +817,61 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn late_close_registration_waits_for_queued_events() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-late-order-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control late-order socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) =
+                listener.accept().await.expect("accept control late-order socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for event handler");
+            stream.write_all(b"{\"event\":\"queued\"}\n").await.expect("write queued event");
+            drop(stream);
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect late-order socket");
+        accepted_rx.await.expect("wait for control late-order server");
+        let entered = Arc::new(std::sync::Barrier::new(2));
+        let release = Arc::new(std::sync::Barrier::new(2));
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let entered_for_handler = Arc::clone(&entered);
+        let release_for_handler = Arc::clone(&release);
+        let seen_for_event = Arc::clone(&seen);
+        control.on_event(Box::new(move |_| {
+            seen_for_event.lock().expect("event order lock").push("event");
+            entered_for_handler.wait();
+            release_for_handler.wait();
+        }));
+        start_tx.send(()).expect("start late-order event");
+        entered.wait();
+        control.wait_reader_done().await;
+
+        let seen_for_close = Arc::clone(&seen);
+        let control_for_close = Arc::clone(&control);
+        let close_registration = std::thread::spawn(move || {
+            control_for_close.on_close(Box::new(move || {
+                seen_for_close.lock().expect("close order lock").push("close");
+            }));
+        });
+        std::thread::yield_now();
+        assert!(!close_registration.is_finished(), "late close must wait for event drain");
+        release.wait();
+        close_registration.join().expect("late close registration");
+        assert_eq!(*seen.lock().expect("event order lock"), vec!["event", "close"]);
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("join control late-order server")
+            .expect("late-order server task");
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
     async fn writer_queue_preserves_complete_fifo_lines() {
         let socket_path =
             std::env::temp_dir().join(format!("chatmux-relay-control-{}.sock", std::process::id()));

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -13,6 +13,7 @@ const MAX_CONTROL_LINE_BYTES: usize = 1_048_576;
 const MAX_WRITER_QUEUE: usize = 256;
 const MAX_PENDING_REQUESTS: usize = 256;
 const MAX_EVENT_QUEUE: usize = 1_024;
+const MAX_EVENT_QUEUE_BYTES: usize = MAX_CONTROL_LINE_BYTES;
 
 pub type EventHandler = Box<dyn Fn(&Value) + Send + Sync>;
 pub type CloseHandler = Box<dyn Fn() + Send + Sync>;
@@ -44,7 +45,7 @@ pub use unix::connect_control;
 mod unix {
     use super::*;
     use std::collections::HashMap;
-    use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
     use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
@@ -76,10 +77,11 @@ mod unix {
         read_waiting: Mutex<Option<oneshot::Sender<()>>>,
         dispatch_tx: std::sync::mpsc::SyncSender<Dispatch>,
         close_signal_tx: std::sync::mpsc::SyncSender<()>,
+        queued_event_bytes: AtomicUsize,
     }
 
     enum Dispatch {
-        Event(Value),
+        Event { value: Value, bytes: usize },
         Closed,
     }
 
@@ -103,6 +105,44 @@ mod unix {
             // Keep closure delivery independent from the bounded event FIFO.
             // The event queue may be full while the worker is in a callback.
             let _ = self.close_signal_tx.try_send(());
+        }
+
+        fn reserve_event_bytes(&self, bytes: usize) -> bool {
+            if bytes > MAX_EVENT_QUEUE_BYTES {
+                return false;
+            }
+            let mut current = self.queued_event_bytes.load(Ordering::Acquire);
+            loop {
+                let Some(next) = current.checked_add(bytes) else { return false };
+                if next > MAX_EVENT_QUEUE_BYTES {
+                    return false;
+                }
+                match self.queued_event_bytes.compare_exchange_weak(
+                    current,
+                    next,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => return true,
+                    Err(observed) => current = observed,
+                }
+            }
+        }
+
+        fn release_event_bytes(&self, bytes: usize) -> bool {
+            let mut current = self.queued_event_bytes.load(Ordering::Acquire);
+            loop {
+                let Some(next) = current.checked_sub(bytes) else { return false };
+                match self.queued_event_bytes.compare_exchange_weak(
+                    current,
+                    next,
+                    Ordering::AcqRel,
+                    Ordering::Acquire,
+                ) {
+                    Ok(_) => return true,
+                    Err(observed) => current = observed,
+                }
+            }
         }
     }
 
@@ -153,6 +193,7 @@ mod unix {
             read_waiting: Mutex::new(None),
             dispatch_tx,
             close_signal_tx,
+            queued_event_bytes: AtomicUsize::new(0),
         });
         let worker_shared = Arc::clone(&shared);
         std::thread::Builder::new()
@@ -181,7 +222,11 @@ mod unix {
                         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
                     };
                     match dispatch {
-                        Dispatch::Event(event) => {
+                        Dispatch::Event { value: event, bytes } => {
+                            if !shared.release_event_bytes(bytes) {
+                                shared.settle_closed();
+                                break;
+                            }
                             // Closure is settled before the marker is queued,
                             // but events already in the FIFO still belong to
                             // the stream and must be delivered first.
@@ -200,7 +245,13 @@ mod unix {
                     // cannot be lost when the event FIFO is full. Drain all
                     // events accepted before EOF, then invoke close once.
                     if close_signal_rx.try_recv().is_ok() || shared.closed.load(Ordering::SeqCst) {
-                        while let Ok(Dispatch::Event(event)) = dispatch_rx.try_recv() {
+                        while let Ok(Dispatch::Event { value: event, bytes }) =
+                            dispatch_rx.try_recv()
+                        {
+                            if !shared.release_event_bytes(bytes) {
+                                shared.settle_closed();
+                                break;
+                            }
                             let handler =
                                 shared.event_handler.lock().expect("control event lock").clone();
                             if let Some(handler) = handler {
@@ -342,7 +393,17 @@ mod unix {
                 if let Some(sender) = waiting {
                     let _ = sender.send(parsed);
                 } else if parsed.get("event").and_then(Value::as_str).is_some() {
-                    if shared.dispatch_tx.try_send(Dispatch::Event(parsed)).is_err() {
+                    let bytes = line.len();
+                    if !shared.reserve_event_bytes(bytes) {
+                        shared.settle_closed();
+                        break 'read_loop;
+                    }
+                    if shared
+                        .dispatch_tx
+                        .try_send(Dispatch::Event { value: parsed, bytes })
+                        .is_err()
+                    {
+                        let _ = shared.release_event_bytes(bytes);
                         shared.settle_closed();
                         break 'read_loop;
                     }
@@ -453,9 +514,8 @@ mod unix {
                 if self.shared.deliberate.load(Ordering::SeqCst) {
                     return;
                 }
-                *slot = Some(handler);
                 drop(slot);
-                let _ = self.shared.dispatch_tx.try_send(Dispatch::Closed);
+                handler();
             } else {
                 *slot = Some(handler);
             }

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -45,7 +45,7 @@ mod unix {
     use super::*;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex, Weak};
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
 
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -75,6 +75,7 @@ mod unix {
         #[cfg(test)]
         read_waiting: Mutex<Option<oneshot::Sender<()>>>,
         dispatch_tx: std::sync::mpsc::SyncSender<Dispatch>,
+        close_signal_tx: std::sync::mpsc::SyncSender<()>,
     }
 
     enum Dispatch {
@@ -99,6 +100,9 @@ mod unix {
             // while the worker waits on this same mutex.
             let _close_handler = self.close_handler.lock().expect("control close lock");
             let _ = self.dispatch_tx.try_send(Dispatch::Closed);
+            // Keep closure delivery independent from the bounded event FIFO.
+            // The event queue may be full while the worker is in a callback.
+            let _ = self.close_signal_tx.try_send(());
         }
     }
 
@@ -133,6 +137,7 @@ mod unix {
         };
         let (read_half, write_half) = stream.into_split();
         let (dispatch_tx, dispatch_rx) = std::sync::mpsc::sync_channel(MAX_EVENT_QUEUE);
+        let (close_signal_tx, close_signal_rx) = std::sync::mpsc::sync_channel(1);
         let shared = Arc::new(Shared {
             pending: Mutex::new(HashMap::new()),
             event_handler: Mutex::new(None),
@@ -147,16 +152,26 @@ mod unix {
             #[cfg(test)]
             read_waiting: Mutex::new(None),
             dispatch_tx,
+            close_signal_tx,
         });
-        let weak_shared: Weak<Shared> = Arc::downgrade(&shared);
+        let worker_shared = Arc::clone(&shared);
         std::thread::Builder::new()
             .name("chatmux-relay-control-events".to_owned())
             .spawn(move || {
+                let shared = worker_shared;
+                let invoke_close = |shared: &Arc<Shared>| {
+                    if !shared.deliberate.load(Ordering::SeqCst) {
+                        let handler =
+                            shared.close_handler.lock().expect("control close lock").take();
+                        if let Some(handler) = handler {
+                            handler();
+                        }
+                    }
+                };
                 loop {
                     let dispatch = match dispatch_rx.recv_timeout(Duration::from_millis(50)) {
                         Ok(dispatch) => dispatch,
                         Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
-                            let Some(shared) = weak_shared.upgrade() else { break };
                             if shared.closed.load(Ordering::SeqCst) {
                                 Dispatch::Closed
                             } else {
@@ -165,7 +180,6 @@ mod unix {
                         }
                         Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
                     };
-                    let Some(shared) = weak_shared.upgrade() else { break };
                     match dispatch {
                         Dispatch::Event(event) => {
                             // Closure is settled before the marker is queued,
@@ -178,15 +192,23 @@ mod unix {
                             }
                         }
                         Dispatch::Closed => {
-                            if !shared.deliberate.load(Ordering::SeqCst) {
-                                let handler =
-                                    shared.close_handler.lock().expect("control close lock").take();
-                                if let Some(handler) = handler {
-                                    handler();
-                                }
-                            }
+                            invoke_close(&shared);
                             break;
                         }
+                    }
+                    // A close signal has its own one-slot channel, so it
+                    // cannot be lost when the event FIFO is full. Drain all
+                    // events accepted before EOF, then invoke close once.
+                    if close_signal_rx.try_recv().is_ok() || shared.closed.load(Ordering::SeqCst) {
+                        while let Ok(Dispatch::Event(event)) = dispatch_rx.try_recv() {
+                            let handler =
+                                shared.event_handler.lock().expect("control event lock").clone();
+                            if let Some(handler) = handler {
+                                handler(&event);
+                            }
+                        }
+                        invoke_close(&shared);
+                        break;
                     }
                 }
             })
@@ -644,6 +666,10 @@ mod tests {
 
         let closed_wait = closed.notified();
         tokio::pin!(closed_wait);
+        // Drop the public handle while the worker is blocked in the first
+        // callback. Closure delivery must retain its own shared state until
+        // the queued events and close notification are drained.
+        drop(control);
         release_tx.send(()).expect("release first event callback");
         tokio::time::timeout(Duration::from_secs(2), &mut closed_wait)
             .await

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -902,16 +902,24 @@ mod tests {
             .expect("reader waiter task");
 
         let seen_for_close = Arc::clone(&seen);
+        let (close_tx, close_rx) = oneshot::channel();
+        let close_tx = Arc::new(Mutex::new(Some(close_tx)));
+        let close_signal = Arc::clone(&close_tx);
         let control_for_close = Arc::clone(&control);
         let close_registration = std::thread::spawn(move || {
             control_for_close.on_close(Box::new(move || {
                 seen_for_close.lock().expect("close order lock").push("close");
+                if let Some(close_tx) = close_signal.lock().expect("close signal lock").take() {
+                    let _ = close_tx.send(());
+                }
             }));
         });
-        std::thread::yield_now();
-        assert!(!close_registration.is_finished(), "late close must wait for event drain");
-        release.wait();
         close_registration.join().expect("late close registration");
+        release.wait();
+        tokio::time::timeout(Duration::from_secs(1), close_rx)
+            .await
+            .expect("close callback after queued event")
+            .expect("close callback signal");
         assert_eq!(*seen.lock().expect("event order lock"), vec!["event", "close"]);
         tokio::time::timeout(Duration::from_secs(1), server)
             .await

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -12,6 +12,7 @@ pub const CONTROL_TIMEOUT_MS: u64 = 3_000;
 const MAX_CONTROL_LINE_BYTES: usize = 1_048_576;
 const MAX_WRITER_QUEUE: usize = 256;
 const MAX_PENDING_REQUESTS: usize = 256;
+const MAX_EVENT_QUEUE: usize = 1_024;
 
 pub type EventHandler = Box<dyn Fn(&Value) + Send + Sync>;
 pub type CloseHandler = Box<dyn Fn() + Send + Sync>;
@@ -62,7 +63,7 @@ mod unix {
 
     struct Shared {
         pending: Mutex<HashMap<u64, oneshot::Sender<Value>>>,
-        event_handler: Mutex<Option<EventHandler>>,
+        event_handler: Mutex<Option<Arc<dyn Fn(&Value) + Send + Sync>>>,
         close_handler: Mutex<Option<CloseHandler>>,
         closed: AtomicBool,
         deliberate: AtomicBool,
@@ -78,7 +79,7 @@ mod unix {
 
     enum Dispatch {
         Event(Value),
-        Close(CloseHandler),
+        Closed,
     }
 
     impl Shared {
@@ -92,12 +93,7 @@ mod unix {
             // broadcast wakeup so either task can observe closure without
             // consuming the other's permit.
             self.closed_notify.notify_waiters();
-            if self.deliberate.load(Ordering::SeqCst) {
-                return;
-            }
-            if let Some(handler) = self.close_handler.lock().expect("control close lock").take() {
-                let _ = self.dispatch_tx.try_send(Dispatch::Close(handler));
-            }
+            let _ = self.dispatch_tx.try_send(Dispatch::Closed);
         }
     }
 
@@ -131,7 +127,7 @@ mod unix {
             stream.as_raw_fd()
         };
         let (read_half, write_half) = stream.into_split();
-        let (dispatch_tx, dispatch_rx) = std::sync::mpsc::sync_channel(1024);
+        let (dispatch_tx, dispatch_rx) = std::sync::mpsc::sync_channel(MAX_EVENT_QUEUE);
         let shared = Arc::new(Shared {
             pending: Mutex::new(HashMap::new()),
             event_handler: Mutex::new(None),
@@ -152,16 +148,23 @@ mod unix {
             .name("chatmux-relay-control-events".to_owned())
             .spawn(move || {
                 while let Ok(dispatch) = dispatch_rx.recv() {
-                    match dispatch {
-                        Dispatch::Event(event) => {
-                            let Some(shared) = weak_shared.upgrade() else { break };
-                            if let Some(handler) =
-                                shared.event_handler.lock().expect("control event lock").as_ref()
-                            {
-                                handler(&event);
+                    let Some(shared) = weak_shared.upgrade() else { break };
+                    if shared.closed.load(Ordering::SeqCst) {
+                        if !shared.deliberate.load(Ordering::SeqCst) {
+                            let handler =
+                                shared.close_handler.lock().expect("control close lock").take();
+                            if let Some(handler) = handler {
+                                handler();
                             }
                         }
-                        Dispatch::Close(handler) => handler(),
+                        break;
+                    }
+                    if let Dispatch::Event(event) = dispatch {
+                        let handler =
+                            shared.event_handler.lock().expect("control event lock").clone();
+                        if let Some(handler) = handler {
+                            handler(&event);
+                        }
                     }
                 }
             })
@@ -396,11 +399,17 @@ mod unix {
         }
 
         fn on_event(&self, handler: EventHandler) {
-            *self.shared.event_handler.lock().expect("control event lock") = Some(handler);
+            *self.shared.event_handler.lock().expect("control event lock") =
+                Some(Arc::from(handler));
         }
 
         fn on_close(&self, handler: CloseHandler) {
+            let was_closed = self.shared.closed.load(Ordering::SeqCst);
+            let deliberate = self.shared.deliberate.load(Ordering::SeqCst);
             *self.shared.close_handler.lock().expect("control close lock") = Some(handler);
+            if was_closed && !deliberate {
+                let _ = self.shared.dispatch_tx.try_send(Dispatch::Closed);
+            }
         }
 
         fn pause(&self) {

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -44,7 +44,7 @@ mod unix {
     use super::*;
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-    use std::sync::{Arc, Mutex};
+    use std::sync::{Arc, Mutex, Weak};
     use std::time::Duration;
 
     use tokio::io::{AsyncReadExt as _, AsyncWriteExt as _};
@@ -73,6 +73,12 @@ mod unix {
         read_done: Notify,
         #[cfg(test)]
         read_waiting: Mutex<Option<oneshot::Sender<()>>>,
+        dispatch_tx: std::sync::mpsc::SyncSender<Dispatch>,
+    }
+
+    enum Dispatch {
+        Event(Value),
+        Close(CloseHandler),
     }
 
     impl Shared {
@@ -86,11 +92,11 @@ mod unix {
             // broadcast wakeup so either task can observe closure without
             // consuming the other's permit.
             self.closed_notify.notify_waiters();
-            if !self.deliberate.load(Ordering::SeqCst)
-                && let Some(handler) =
-                    self.close_handler.lock().expect("control close lock").as_ref()
-            {
-                handler();
+            if self.deliberate.load(Ordering::SeqCst) {
+                return;
+            }
+            if let Some(handler) = self.close_handler.lock().expect("control close lock").take() {
+                let _ = self.dispatch_tx.try_send(Dispatch::Close(handler));
             }
         }
     }
@@ -125,6 +131,7 @@ mod unix {
             stream.as_raw_fd()
         };
         let (read_half, write_half) = stream.into_split();
+        let (dispatch_tx, dispatch_rx) = std::sync::mpsc::sync_channel(1024);
         let shared = Arc::new(Shared {
             pending: Mutex::new(HashMap::new()),
             event_handler: Mutex::new(None),
@@ -138,7 +145,27 @@ mod unix {
             read_done: Notify::new(),
             #[cfg(test)]
             read_waiting: Mutex::new(None),
+            dispatch_tx,
         });
+        let weak_shared: Weak<Shared> = Arc::downgrade(&shared);
+        std::thread::Builder::new()
+            .name("chatmux-relay-control-events".to_owned())
+            .spawn(move || {
+                while let Ok(dispatch) = dispatch_rx.recv() {
+                    match dispatch {
+                        Dispatch::Event(event) => {
+                            let Some(shared) = weak_shared.upgrade() else { break };
+                            if let Some(handler) =
+                                shared.event_handler.lock().expect("control event lock").as_ref()
+                            {
+                                handler(&event);
+                            }
+                        }
+                        Dispatch::Close(handler) => handler(),
+                    }
+                }
+            })
+            .expect("spawn control event worker");
         // Keep one async writer for every connection. The queue makes the
         // synchronous `send` API safe without spawning one task per input;
         // `write_all` below waits for socket backpressure and never exposes a
@@ -267,11 +294,11 @@ mod unix {
                 });
                 if let Some(sender) = waiting {
                     let _ = sender.send(parsed);
-                } else if parsed.get("event").and_then(Value::as_str).is_some()
-                    && let Some(handler) =
-                        shared.event_handler.lock().expect("control event lock").as_ref()
-                {
-                    handler(&parsed);
+                } else if parsed.get("event").and_then(Value::as_str).is_some() {
+                    if shared.dispatch_tx.try_send(Dispatch::Event(parsed)).is_err() {
+                        shared.settle_closed();
+                        break 'read_loop;
+                    }
                 }
                 // Responses to fire-and-forget sends fall through silently.
             }
@@ -403,7 +430,7 @@ mod unix {
 mod tests {
     use super::*;
     use serde_json::json;
-    use std::sync::Arc;
+    use std::sync::{Arc, Mutex};
     use std::time::Duration;
     use tokio::io::{AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt as _};
     use tokio::net::UnixListener;
@@ -486,6 +513,61 @@ mod tests {
             .await
             .expect("second waiter wakes")
             .expect("second waiter joins");
+    }
+
+    #[tokio::test]
+    async fn event_callbacks_run_in_wire_order() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-events-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control event test socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept control event socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for event handler");
+            stream
+                .write_all(b"{\"event\":\"first\"}\n{\"event\":\"second\"}\n")
+                .await
+                .expect("write control events");
+            let mut bytes = Vec::new();
+            stream.read_to_end(&mut bytes).await.expect("read client close");
+        });
+
+        let control =
+            connect_control(&socket_path, 3_000).await.expect("connect control event test socket");
+        accepted_rx.await.expect("wait for control event server");
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let (done_tx, done_rx) = oneshot::channel();
+        let done_tx = Arc::new(Mutex::new(Some(done_tx)));
+        let seen_for_handler = Arc::clone(&seen);
+        let done_tx_for_handler = Arc::clone(&done_tx);
+        control.on_event(Box::new(move |event| {
+            let mut seen = seen_for_handler.lock().expect("event record lock");
+            seen.push(event["event"].as_str().expect("event name").to_owned());
+            if seen.len() == 2 {
+                if let Some(done_tx) = done_tx_for_handler.lock().expect("event done lock").take() {
+                    let _ = done_tx.send(());
+                }
+            }
+        }));
+        start_tx.send(()).expect("start control event stream");
+
+        tokio::time::timeout(Duration::from_secs(1), done_rx)
+            .await
+            .expect("ordered event callbacks complete")
+            .expect("ordered event callback signal");
+        assert_eq!(
+            *seen.lock().expect("event record lock"),
+            vec!["first".to_owned(), "second".to_owned()]
+        );
+        control.end();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server observes client close")
+            .expect("join control event server");
+        let _ = std::fs::remove_file(socket_path);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -679,6 +679,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn close_callback_survives_event_queue_byte_overflow() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-event-bytes-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control byte socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.expect("accept control byte socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for event handler");
+            let payload = "x".repeat(MAX_CONTROL_LINE_BYTES / 2);
+            for _ in 0..3 {
+                let line = format!("{{\"event\":\"{payload}\"}}\n");
+                stream.write_all(line.as_bytes()).await.expect("write byte-limited event");
+            }
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect byte-limited socket");
+        accepted_rx.await.expect("wait for control byte server");
+        let (entered_tx, entered_rx) = std::sync::mpsc::sync_channel(1);
+        let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let closed = Arc::new(Notify::new());
+        let closed_for_handler = Arc::clone(&closed);
+        control.on_event(Box::new(move |_| {
+            if entered_tx.try_send(()).is_ok() {
+                release_rx.recv().expect("release first byte callback");
+            }
+        }));
+        control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
+        start_tx.send(()).expect("start control byte overflow");
+        entered_rx.recv_timeout(Duration::from_secs(1)).expect("first byte callback entered");
+
+        let closed_wait = closed.notified();
+        tokio::pin!(closed_wait);
+        release_tx.send(()).expect("release first byte callback");
+        tokio::time::timeout(Duration::from_secs(2), &mut closed_wait)
+            .await
+            .expect("close callback survives byte overflow");
+        server.await.expect("join control byte server");
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
+    async fn late_close_registration_invokes_callback() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-late-close-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control late-close socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept control late-close socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for reader arm");
+            drop(stream);
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect late-close socket");
+        accepted_rx.await.expect("wait for control late-close server");
+        let reader_done = control.arm_reader_waiting();
+        start_tx.send(()).expect("start late close");
+        reader_done.await.expect("reader observed late close");
+        let closed = Arc::new(Notify::new());
+        let closed_for_handler = Arc::clone(&closed);
+        control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
+        tokio::time::timeout(Duration::from_secs(1), closed.notified())
+            .await
+            .expect("late close registration invokes callback");
+        server.await.expect("join control late-close server");
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
     async fn writer_queue_preserves_complete_fifo_lines() {
         let socket_path =
             std::env::temp_dir().join(format!("chatmux-relay-control-{}.sock", std::process::id()));

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -740,14 +740,20 @@ mod tests {
         let (entered_tx, entered_rx) = oneshot::channel();
         let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let release_rx = Arc::new(Mutex::new(release_rx));
         let closed = Arc::new(Notify::new());
         let closed_for_handler = Arc::clone(&closed);
         let entered_for_handler = Arc::clone(&entered_tx);
+        let release_rx_for_handler = Arc::clone(&release_rx);
         control.on_event(Box::new(move |_| {
             if let Some(entered_tx) = entered_for_handler.lock().expect("entry signal lock").take()
             {
                 let _ = entered_tx.send(());
-                release_rx.recv().expect("release first event callback");
+                release_rx_for_handler
+                    .lock()
+                    .expect("release receiver lock")
+                    .recv()
+                    .expect("release first event callback");
             }
         }));
         control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
@@ -797,14 +803,20 @@ mod tests {
         let (entered_tx, entered_rx) = oneshot::channel();
         let entered_tx = Arc::new(Mutex::new(Some(entered_tx)));
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let release_rx = Arc::new(Mutex::new(release_rx));
         let closed = Arc::new(Notify::new());
         let closed_for_handler = Arc::clone(&closed);
         let entered_for_handler = Arc::clone(&entered_tx);
+        let release_rx_for_handler = Arc::clone(&release_rx);
         control.on_event(Box::new(move |_| {
             if let Some(entered_tx) = entered_for_handler.lock().expect("entry signal lock").take()
             {
                 let _ = entered_tx.send(());
-                release_rx.recv().expect("release first byte callback");
+                release_rx_for_handler
+                    .lock()
+                    .expect("release receiver lock")
+                    .recv()
+                    .expect("release first byte callback");
             }
         }));
         control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
@@ -958,9 +970,15 @@ mod tests {
         accepted_rx.await.expect("wait for close race server");
         let (started_tx, started_rx) = oneshot::channel();
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
+        let release_rx = Arc::new(Mutex::new(release_rx));
+        let release_rx_for_handler = Arc::clone(&release_rx);
         control.on_close(Box::new(move || {
             let _ = started_tx.send(());
-            release_rx.recv().expect("release first close callback");
+            release_rx_for_handler
+                .lock()
+                .expect("release receiver lock")
+                .recv()
+                .expect("release first close callback");
         }));
         start_tx.send(()).expect("start close race server");
         tokio::time::timeout(Duration::from_secs(1), started_rx)

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -254,7 +254,13 @@ mod unix {
                         handler
                     };
                     if let Some(handler) = handler {
-                        handler();
+                        // `end()` can begin after the first deliberate-close
+                        // check while this worker waits for the handler lock.
+                        // Recheck at the callback boundary so an intentional
+                        // detach does not emit an unexpected-close signal.
+                        if !shared.deliberate.load(Ordering::SeqCst) {
+                            handler();
+                        }
                     }
                 };
                 loop {

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -371,17 +371,18 @@ mod unix {
                 let closed = shared.closed_notify.notified();
                 tokio::pin!(closed);
                 closed.as_mut().enable();
-                #[cfg(test)]
-                if let Some(waiting) =
-                    shared.read_waiting.lock().expect("control read waiter lock").take()
-                {
-                    let _ = waiting.send(());
-                }
                 if shared.closed.load(Ordering::SeqCst) {
                     break 'read_loop;
                 }
                 if !shared.paused.load(Ordering::SeqCst) {
                     break;
+                }
+                #[cfg(test)]
+                if let Some(waiting) =
+                    shared.read_waiting.lock().expect("control read waiter lock").take()
+                {
+                    let _ = waiting.send(());
+                    tokio::task::yield_now().await;
                 }
                 tokio::select! {
                     _ = resumed => {}
@@ -622,6 +623,53 @@ mod tests {
             .await
             .expect("server observes client close")
             .expect("join control close test server");
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn resume_wakes_reader_when_it_races_the_wait() {
+        let socket_path = std::env::temp_dir()
+            .join(format!("chatmux-relay-control-resume-{}.sock", std::process::id()));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind control resume test socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (start_tx, start_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (mut stream, _) =
+                listener.accept().await.expect("accept control resume test socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            start_rx.await.expect("wait for paused reader");
+            stream.write_all(b"{\"event\":\"resumed\"}\n").await.expect("write event");
+            let mut bytes = Vec::new();
+            stream.read_to_end(&mut bytes).await.expect("read client close");
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect control resume test socket");
+        accepted_rx.await.expect("wait for control resume test server");
+        let (event_tx, event_rx) = oneshot::channel();
+        let event_tx = Arc::new(Mutex::new(Some(event_tx)));
+        control.on_event(Box::new(move |_| {
+            if let Some(event_tx) = event_tx.lock().expect("event signal lock").take() {
+                let _ = event_tx.send(());
+            }
+        }));
+        control.pause();
+        let read_waiting = control.arm_reader_waiting();
+        start_tx.send(()).expect("send event to paused reader");
+        read_waiting.await.expect("paused reader reached wait");
+        control.resume();
+
+        tokio::time::timeout(Duration::from_secs(1), event_rx)
+            .await
+            .expect("resumed reader handles event")
+            .expect("event callback signal");
+        control.end();
+        tokio::time::timeout(Duration::from_secs(1), server)
+            .await
+            .expect("server observes client close")
+            .expect("join control resume test server");
         let _ = std::fs::remove_file(socket_path);
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -591,7 +591,9 @@ mod unix {
                     return;
                 }
                 drop(slot);
-                handler();
+                if !self.shared.deliberate.load(Ordering::SeqCst) {
+                    handler();
+                }
             } else {
                 *slot = Some(handler);
             }

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -368,6 +368,8 @@ mod unix {
             // the reader asleep after the wakeup.
             loop {
                 let resumed = shared.resume_notify.notified();
+                tokio::pin!(resumed);
+                resumed.as_mut().enable();
                 let closed = shared.closed_notify.notified();
                 tokio::pin!(closed);
                 closed.as_mut().enable();

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -77,6 +77,10 @@ mod unix {
         read_done: Notify,
         #[cfg(test)]
         read_waiting: Mutex<Option<oneshot::Sender<()>>>,
+        #[cfg(test)]
+        close_check_pause: Mutex<Option<(oneshot::Sender<()>, oneshot::Receiver<()>)>>,
+        #[cfg(test)]
+        worker_done_notify: Notify,
         dispatch_tx: std::sync::mpsc::SyncSender<Dispatch>,
         close_signal_tx: std::sync::mpsc::SyncSender<()>,
         queued_event_bytes: AtomicUsize,
@@ -150,6 +154,8 @@ mod unix {
 
         fn finish_worker(&self) {
             self.worker_done.store(true, Ordering::Release);
+            #[cfg(test)]
+            self.worker_done_notify.notify_waiters();
         }
     }
 
@@ -198,6 +204,10 @@ mod unix {
             read_done: Notify::new(),
             #[cfg(test)]
             read_waiting: Mutex::new(None),
+            #[cfg(test)]
+            close_check_pause: Mutex::new(None),
+            #[cfg(test)]
+            worker_done_notify: Notify::new(),
             dispatch_tx,
             close_signal_tx,
             queued_event_bytes: AtomicUsize::new(0),
@@ -222,6 +232,16 @@ mod unix {
                 let invoke_close = |shared: &Arc<Shared>| {
                     if shared.deliberate.load(Ordering::SeqCst) {
                         return;
+                    }
+                    #[cfg(test)]
+                    if let Some((entered, release)) = shared
+                        .close_check_pause
+                        .lock()
+                        .expect("control close check pause lock")
+                        .take()
+                    {
+                        let _ = entered.send(());
+                        let _ = release.blocking_recv();
                     }
                     let handler = {
                         let mut slot = shared.close_handler.lock().expect("control close lock");
@@ -452,6 +472,27 @@ mod unix {
             let (sender, receiver) = oneshot::channel();
             *self.shared.read_waiting.lock().expect("control read waiter lock") = Some(sender);
             receiver
+        }
+
+        #[cfg(test)]
+        pub(crate) fn pause_after_close_check(
+            &self,
+        ) -> (oneshot::Receiver<()>, oneshot::Sender<()>) {
+            let (entered_tx, entered_rx) = oneshot::channel();
+            let (release_tx, release_rx) = oneshot::channel();
+            *self.shared.close_check_pause.lock().expect("control close check pause lock") =
+                Some((entered_tx, release_rx));
+            (entered_rx, release_tx)
+        }
+
+        #[cfg(test)]
+        pub(crate) async fn wait_worker_done(&self) {
+            let done = self.shared.worker_done_notify.notified();
+            tokio::pin!(done);
+            done.as_mut().enable();
+            if !self.shared.worker_done.load(Ordering::Acquire) {
+                done.await;
+            }
         }
 
         fn encode_line(id: u64, cmd: &str, params: Value) -> Vec<u8> {
@@ -1045,6 +1086,55 @@ mod tests {
             .expect("late close callback after callback race");
 
         server.await.expect("join close race server");
+        let _ = std::fs::remove_file(socket_path);
+    }
+
+    #[tokio::test]
+    async fn deliberate_end_suppresses_close_callback_after_worker_check() {
+        let socket_path = std::env::temp_dir().join(format!(
+            "chatmux-relay-control-deliberate-close-race-{}.sock",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_file(&socket_path);
+        let listener = UnixListener::bind(&socket_path).expect("bind deliberate close race socket");
+        let (accepted_tx, accepted_rx) = oneshot::channel();
+        let (close_tx, close_rx) = oneshot::channel();
+        let server = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await.expect("accept deliberate close race socket");
+            accepted_tx.send(()).expect("tell client that socket is accepted");
+            close_rx.await.expect("start unexpected socket close");
+            drop(stream);
+        });
+
+        let control = unix::connect_control_for_test(&socket_path, 3_000)
+            .await
+            .expect("connect deliberate close race socket");
+        accepted_rx.await.expect("wait for deliberate close race server");
+        let (callback_tx, callback_rx) = oneshot::channel();
+        let callback_tx = Arc::new(Mutex::new(Some(callback_tx)));
+        control.on_close(Box::new(move || {
+            if let Some(callback_tx) = callback_tx.lock().expect("callback signal lock").take() {
+                let _ = callback_tx.send(());
+            }
+        }));
+        let (checked_rx, release_tx) = control.pause_after_close_check();
+        close_tx.send(()).expect("close server socket");
+        tokio::time::timeout(Duration::from_secs(1), checked_rx)
+            .await
+            .expect("worker passes initial deliberate-close check")
+            .expect("worker close-check signal");
+
+        control.end();
+        release_tx.send(()).expect("release close callback worker");
+        tokio::time::timeout(Duration::from_secs(1), control.wait_worker_done())
+            .await
+            .expect("close callback worker completes");
+        assert!(
+            callback_rx.await.is_err(),
+            "deliberate end must suppress the pending unexpected-close callback"
+        );
+
+        server.await.expect("join deliberate close race server");
         let _ = std::fs::remove_file(socket_path);
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -1092,10 +1092,12 @@ mod tests {
             .expect("first close callback signal");
 
         let closed = Arc::new(Notify::new());
+        let closed_wait = closed.notified();
+        tokio::pin!(closed_wait);
         let closed_for_handler = Arc::clone(&closed);
         control.on_close(Box::new(move || closed_for_handler.notify_waiters()));
         release_tx.send(()).expect("release first close callback");
-        tokio::time::timeout(Duration::from_secs(1), closed.notified())
+        tokio::time::timeout(Duration::from_secs(1), &mut closed_wait)
             .await
             .expect("late close callback after callback race");
 

--- a/cmux-tui/crates/chatmux-relay/src/control.rs
+++ b/cmux-tui/crates/chatmux-relay/src/control.rs
@@ -406,9 +406,9 @@ mod unix {
                     break;
                 }
                 #[cfg(test)]
-                if let Some(waiting) =
-                    shared.read_waiting.lock().expect("control read waiter lock").take()
-                {
+                let waiting = shared.read_waiting.lock().expect("control read waiter lock").take();
+                #[cfg(test)]
+                if let Some(waiting) = waiting {
                     let _ = waiting.send(());
                     tokio::task::yield_now().await;
                 }
@@ -1068,11 +1068,17 @@ mod tests {
             .expect("connect close race socket");
         accepted_rx.await.expect("wait for close race server");
         let (started_tx, started_rx) = oneshot::channel();
+        let started_tx = Arc::new(Mutex::new(Some(started_tx)));
+        let started_tx_for_handler = Arc::clone(&started_tx);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
         let release_rx = Arc::new(Mutex::new(release_rx));
         let release_rx_for_handler = Arc::clone(&release_rx);
         control.on_close(Box::new(move || {
-            let _ = started_tx.send(());
+            if let Some(started_tx) =
+                started_tx_for_handler.lock().expect("started sender lock").take()
+            {
+                let _ = started_tx.send(());
+            }
             release_rx_for_handler
                 .lock()
                 .expect("release receiver lock")

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1591,6 +1591,13 @@ impl Inner {
         let Some(attachment) =
             self.authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
         else {
+            // A present attachment may have failed authorization. The
+            // non-terminal error above must not fall through to the opening
+            // cancellation path, which would otherwise let a denied CLOSE
+            // retire the live attachment.
+            if self.attachments.lock().expect("attach lock").contains_key(pty_id) {
+                return;
+            }
             // A close may race the asynchronous open before its attachment
             // is published. The transport fence ran at frame dispatch, so
             // this exact owner can cancel the pending reservation now.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1355,7 +1355,7 @@ impl Inner {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            Arc::new(move |chunk: Bytes| {
+            let emit_output: DataSink = Arc::new(move |chunk: Bytes| {
                 inner.emit_output_for_generation(
                     &pty_id,
                     &chunk,
@@ -1363,7 +1363,9 @@ impl Inner {
                     generation,
                     &output_gate,
                 )
-            }) as Arc<dyn Fn(Bytes) + Send + Sync>
+            });
+            Arc::new(move |chunk: Bytes| emit_bounded_bytes(&emit_output, chunk))
+                as Arc<dyn Fn(Bytes) + Send + Sync>
         };
         let exit_gate = Arc::clone(&publication_gate);
         let on_exit = {
@@ -1937,12 +1939,11 @@ impl Inner {
 
     async fn close_authorized_async(&self, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
-        let attachment = match self
-            .authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
+        let attachment = match self.authorize_snapshot_for_close(pty_id, &auth, context, "close", 0)
         {
             Ok(attachment) => attachment,
-            Err(NonterminalAuthorizationFailure::Denied) => return,
-            Err(NonterminalAuthorizationFailure::Missing) => {
+            Err(CloseAuthorizationFailure::Denied) => return,
+            Err(CloseAuthorizationFailure::Missing) => {
                 self.close_if_transport_async(pty_id, context.transport_id.as_deref(), None).await;
                 return;
             }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2261,6 +2261,8 @@ mod tests {
         on_data: Option<DataSink>,
         on_exit: Option<ExitSink>,
         written: Vec<Vec<u8>>,
+        write_entered: Option<TestArc<Barrier>>,
+        write_release: Option<TestArc<Barrier>>,
         resized: Vec<(u16, u16)>,
         paused: bool,
         killed: bool,
@@ -2294,6 +2296,16 @@ mod tests {
 
     impl PtyControl for FakePty {
         fn write(&self, data: &[u8]) {
+            let (entered, release) = {
+                let state = self.state.lock().unwrap();
+                (state.write_entered.clone(), state.write_release.clone())
+            };
+            if let Some(entered) = entered {
+                entered.wait();
+            }
+            if let Some(release) = release {
+                release.wait();
+            }
             self.state.lock().unwrap().written.push(data.to_vec());
         }
         fn resize(&self, cols: u16, rows: u16) {
@@ -2465,12 +2477,15 @@ mod tests {
         fn context(&self, trust: &str, owner: Option<String>) -> FrameContext {
             let sent = Arc::clone(&self.sent);
             let buffered = Arc::clone(&self.buffered);
+            let live_trust = trust.to_owned();
+            let live_owner = owner.clone();
             FrameContext {
                 send: Arc::new(move |frame| sent.lock().unwrap().push(frame)),
                 buffered_amount: Arc::new(move || buffered.load(Ordering::SeqCst)),
                 trust: trust.to_owned(),
                 local_roots: None,
                 owner_user_id: owner,
+                live_auth: Arc::new(move || (live_trust.clone(), live_owner.clone())),
                 transport_id: None,
                 cancellation: CancellationToken::new(),
             }
@@ -2693,6 +2708,31 @@ mod tests {
             h.owner.clone(),
         )
         .await;
+        pty.emit("secret");
+        assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
+    }
+
+    #[tokio::test]
+    async fn output_after_live_trust_downgrade_is_not_forwarded() {
+        let h = harness(None, None);
+        let live_auth = Arc::new(StdMutex::new(("supervised".to_owned(), h.owner.clone())));
+        let mut context = h.context("supervised", h.owner.clone());
+        let live_auth_for_context = Arc::clone(&live_auth);
+        context.live_auth = Arc::new(move || live_auth_for_context.lock().unwrap().clone());
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_other",
+            "trust": "supervised",
+            "allowedRoots": Value::Null,
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        live_auth.lock().unwrap().0 = "observe".to_owned();
         pty.emit("secret");
         assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
     }
@@ -3025,17 +3065,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn denied_close_does_not_remove_attachment() {
-        let h = harness(None, None);
-        h.open_with_transport("p1", "main", "transport-a").await;
-        let denied =
-            h.context_with_transport("observe", Some("other-user".to_owned()), Some("transport-a"));
-        let close = serde_json::json!({ "version": 4, "type": "pty_close", "ptyId": "p1" });
-        h.manager.handle_frame(&close, &denied).await;
-        assert!(h.manager.has_attachment("p1"));
-    }
-
-    #[tokio::test]
     async fn detach_transport_releases_only_that_transports_attachments() {
         let h = harness(None, None);
         h.open_with_transport("p-relay", "relay-side", "transport-relay").await;
@@ -3045,6 +3074,17 @@ mod tests {
         assert!(h.manager.has_attachment("p-tunnel"), "the tunnel viewer must survive");
         h.manager.detach_all();
         assert!(!h.manager.has_attachment("p-tunnel"));
+    }
+
+    #[tokio::test]
+    async fn denied_close_does_not_remove_attachment() {
+        let h = harness(None, None);
+        h.open_with_transport("p1", "main", "transport-a").await;
+        let denied =
+            h.context_with_transport("observe", Some("other-user".to_owned()), Some("transport-a"));
+        let close = serde_json::json!({ "version": 4, "type": "pty_close", "ptyId": "p1" });
+        h.manager.handle_frame(&close, &denied).await;
+        assert!(h.manager.has_attachment("p1"));
     }
 
     #[tokio::test]
@@ -3257,5 +3297,196 @@ mod tests {
         let frame = harness.sent().pop().unwrap();
         assert_eq!(frame["type"], "pty_error");
         assert_eq!(frame["code"], "overflow");
+    }
+
+    fn blocking_terminal_context(
+        harness: &Harness,
+        entered: TestArc<Barrier>,
+        release: TestArc<Barrier>,
+    ) -> FrameContext {
+        let mut context = harness.context("supervised", harness.owner.clone());
+        let sent = TestArc::clone(&harness.sent);
+        context.send = TestArc::new(move |frame| {
+            if matches!(
+                frame.get("type").and_then(Value::as_str),
+                Some("pty_output" | "pty_exit" | "pty_error")
+            ) {
+                entered.wait();
+                release.wait();
+            }
+            sent.lock().expect("sent lock").push(frame);
+        });
+        context
+    }
+
+    #[tokio::test]
+    async fn exit_publication_retains_closing_id_until_frame_is_sent() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let exit = thread::spawn(move || pty.exit(7));
+        entered.wait();
+
+        let replacement = h.context("supervised", h.owner.clone());
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let replacement_for_task = replacement.clone();
+        let frame_for_replacement = frame.clone();
+        let replacement_task = tokio::spawn(async move {
+            manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
+        });
+        tokio::task::yield_now().await;
+        assert!(
+            !replacement_task.is_finished(),
+            "same-ID replacement must wait for the closing publication"
+        );
+        assert!(!h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+
+        release.wait();
+        exit.join().expect("exit callback");
+        replacement_task.await.expect("replacement open");
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test]
+    async fn overflow_error_publication_cannot_reach_a_same_id_replacement() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        h.buffered.store(OUTPUT_BUFFER_CAP + 1, Ordering::SeqCst);
+        let output = thread::spawn(move || pty.emit("overflow"));
+        entered.wait();
+
+        let replacement = h.context("supervised", h.owner.clone());
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert!(!h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+
+        release.wait();
+        output.join().expect("output callback");
+        h.buffered.store(0, Ordering::SeqCst);
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test]
+    async fn direct_close_waits_for_an_in_flight_publication() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let output = thread::spawn(move || pty.emit("live"));
+        entered.wait();
+
+        let close_context = h.context("supervised", h.owner.clone());
+        let manager = h.manager.inner.clone();
+        let close = thread::spawn(move || manager.close_authorized("p1", &close_context));
+        assert!(!close.is_finished(), "close must wait for the publication gate");
+
+        release.wait();
+        output.join().expect("output callback");
+        close.join().expect("close callback");
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test]
+    async fn input_operation_waits_before_close_can_retire_its_generation() {
+        let h = harness(None, None);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        let pty = h.spawned()[0].clone();
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        {
+            let mut state = pty.state.lock().unwrap();
+            state.write_entered = Some(TestArc::clone(&entered));
+            state.write_release = Some(TestArc::clone(&release));
+        }
+
+        let input = serde_json::json!({
+            "version": 4,
+            "type": "pty_input",
+            "ptyId": "p1",
+            "dataB64": b64("stale"),
+        });
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let input_context = h.context("supervised", h.owner.clone());
+        let runtime = tokio::runtime::Handle::current();
+        let input_task =
+            thread::spawn(move || runtime.block_on(manager.handle_frame(&input, &input_context)));
+        entered.wait();
+
+        let close_context = h.context("supervised", h.owner.clone());
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let close = thread::spawn(move || {
+            manager.inner.close_authorized("p1", &close_context);
+        });
+        assert!(!close.is_finished(), "close must wait for the in-flight control operation");
+
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        assert!(!h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+
+        release.wait();
+        input_task.join().expect("input operation");
+        close.join().expect("close operation");
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -944,9 +944,7 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            if action != "close" {
-                self.close(pty_id);
-            }
+            self.close(pty_id);
             send_pty_error(
                 context,
                 pty_id,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1432,9 +1432,9 @@ impl Inner {
     ) {
         let mut opening = self.opening_state.lock().expect("opening state lock");
         if let Some(entry) = opening.ids.get(pty_id) {
-            if generation.is_none_or(|expected| entry.generation == expected)
-                && entry.transport_id.as_deref() == transport_id
-            {
+            let owns_opening =
+                transport_id.is_none() || entry.transport_id.as_deref() == transport_id;
+            if generation.is_none_or(|expected| entry.generation == expected) && owns_opening {
                 opening.cancelled.insert(pty_id.to_owned(), entry.generation);
             }
             return;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1144,7 +1144,7 @@ impl Inner {
         }
         // Ownership transferred to the attachment. The guard remains on the
         // Opened value only to keep the deferred start closure alive.
-        opened.cleanup_claimed.store(true, Ordering::Release);
+        opened.cleanup.claimed.store(true, Ordering::Release);
         reservation.active = false;
         let mut opened_frame = serde_json::Map::new();
         opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
@@ -1767,13 +1767,18 @@ struct Opened {
     closing: Arc<AtomicBool>,
     generation: u64,
     publication_gate: Arc<RouteGate>,
-    cleanup_claimed: Arc<AtomicBool>,
+    cleanup: Arc<OpenedCleanup>,
     start: Box<dyn FnOnce() + Send>,
 }
 
-impl Drop for Opened {
+struct OpenedCleanup {
+    control: Arc<dyn PtyControl>,
+    claimed: AtomicBool,
+}
+
+impl Drop for OpenedCleanup {
     fn drop(&mut self) {
-        if !self.cleanup_claimed.swap(true, Ordering::AcqRel) {
+        if !self.claimed.swap(true, Ordering::AcqRel) {
             // Any open that never reaches publication still owns a live PTY.
             // Drop is the cancellation-safe fallback for every early return.
             self.control.kill();
@@ -1963,11 +1968,14 @@ impl Inner {
         Ok(Opened {
             created: ensured.created,
             surface: None,
-            control,
+            control: Arc::clone(&control),
             closing: Arc::new(AtomicBool::new(false)),
             generation,
             publication_gate,
-            cleanup_claimed: Arc::new(AtomicBool::new(false)),
+            cleanup: Arc::new(OpenedCleanup {
+                control: Arc::clone(&control),
+                claimed: AtomicBool::new(false),
+            }),
             start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
         })
     }
@@ -2152,11 +2160,14 @@ impl Inner {
         Ok(Opened {
             created,
             surface: None,
-            control: proxy,
+            control: Arc::clone(&proxy),
             closing,
             generation,
             publication_gate,
-            cleanup_claimed: Arc::new(AtomicBool::new(false)),
+            cleanup: Arc::new(OpenedCleanup {
+                control: Arc::clone(&proxy),
+                claimed: AtomicBool::new(false),
+            }),
             start,
         })
     }
@@ -2731,11 +2742,14 @@ impl Inner {
         Ok(Some(Opened {
             created: ensured.created,
             surface: Some(surface_ref.to_owned()),
-            control: proxy,
+            control: Arc::clone(&proxy),
             closing: Arc::new(AtomicBool::new(false)),
             generation,
             publication_gate,
-            cleanup_claimed: Arc::new(AtomicBool::new(false)),
+            cleanup: Arc::new(OpenedCleanup {
+                control: Arc::clone(&proxy),
+                claimed: AtomicBool::new(false),
+            }),
             start: Box::new(move || start_stream.go_live(on_data, on_exit)),
         }))
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1603,9 +1603,9 @@ impl Inner {
         }
     }
 
-    /// A CLOSE from the owning transport cannot operate after authority is
-    /// revoked. Retire that now-unauthorized attachment so it cannot retain a
-    /// resource slot or resume publication under stale authority.
+    /// A CLOSE from the owning transport cannot operate without authority.
+    /// Retire only when a newer machine-authority generation revoked the
+    /// attachment; a denied caller snapshot must leave another user's PTY.
     fn authorize_snapshot_for_close(
         &self,
         pty_id: &str,
@@ -1629,12 +1629,25 @@ impl Inner {
         }
         if self.auth_allows(auth, &attachment) {
             Ok(attachment)
-        } else {
+        } else if auth.version > attachment.auth_version {
+            // A newer machine-authority generation invalidated this existing
+            // attachment. Retire it so revoked state cannot keep a PTY slot.
             self.emit_error_for_generation(
                 context,
                 pty_id,
                 attachment.generation,
                 &attachment.publication_gate,
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
+            );
+            Err(CloseAuthorizationFailure::Denied)
+        } else {
+            // The caller's snapshot did not authorize CLOSE, but it is not a
+            // newer authority generation. Report denial without allowing a
+            // same-transport non-owner to destroy another user's PTY.
+            send_pty_error(
+                context,
+                pty_id,
                 "trust_revoked",
                 &format!("PTY {action} refused after trust change"),
             );

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -478,6 +478,14 @@ impl RouteGate {
         drop(state);
         RouteGuard { gate: self, owner }
     }
+
+    fn held_by_current_thread(&self) -> bool {
+        self.state
+            .lock()
+            .expect("route gate lock")
+            .owner
+            .is_some_and(|owner| owner == std::thread::current().id())
+    }
 }
 
 impl Drop for RouteGuard<'_> {
@@ -815,7 +823,25 @@ impl Inner {
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
         let opening_generation = self.next_opening_generation.fetch_add(1, Ordering::Relaxed);
-        let reservation_result = {
+        // Do not inspect the route gate while holding the attachment map. The
+        // normal publication path takes RouteGate -> attachments, so this
+        // preflight must run before the reservation's opening_state ->
+        // attachments critical section to preserve lock ordering.
+        let closing_attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            attachments.get(&pty_id).cloned()
+        };
+        let reentrant_replacement = closing_attachment.is_some_and(|attachment| {
+            attachment.closing.load(Ordering::SeqCst)
+                && attachment.publication_gate.held_by_current_thread()
+        });
+        let reservation_result = if reentrant_replacement {
+            // A callback may synchronously re-enter OPEN for the same id
+            // while publishing an exit/error. Reject that replacement,
+            // because allowing it to acquire the reentrant gate would
+            // publish the new generation before the old frame returns.
+            Err(("bad_request", "ptyId is still publishing".to_owned()))
+        } else {
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let attachments = self.attachments.lock().expect("attach lock");
             let attached = attachments
@@ -1502,6 +1528,34 @@ impl Inner {
         action: &str,
         generation: u64,
     ) -> Option<Attachment> {
+        self.authorize_snapshot_for_generation_mode(pty_id, auth, context, action, generation, true)
+    }
+
+    /// Authorization failures for an explicit CLOSE are non-terminal. The
+    /// caller may have a stale or downgraded trust snapshot, but it must not
+    /// be able to retire an attachment it does not own.
+    fn authorize_snapshot_for_generation_nonterminal(
+        &self,
+        pty_id: &str,
+        auth: &AuthSnapshot,
+        context: &FrameContext,
+        action: &str,
+        generation: u64,
+    ) -> Option<Attachment> {
+        self.authorize_snapshot_for_generation_mode(
+            pty_id, auth, context, action, generation, false,
+        )
+    }
+
+    fn authorize_snapshot_for_generation_mode(
+        &self,
+        pty_id: &str,
+        auth: &AuthSnapshot,
+        context: &FrameContext,
+        action: &str,
+        generation: u64,
+        retire_on_denial: bool,
+    ) -> Option<Attachment> {
         let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
         if generation != 0 && attachment.generation != generation {
             return None;
@@ -1511,6 +1565,14 @@ impl Inner {
         }
         if Self::auth_allows(auth, &attachment) {
             Some(attachment)
+        } else if !retire_on_denial {
+            send_pty_error(
+                context,
+                pty_id,
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
+            );
+            None
         } else {
             self.emit_error_for_generation(
                 context,
@@ -1527,7 +1589,7 @@ impl Inner {
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
         let Some(attachment) =
-            self.authorize_snapshot_for_generation(pty_id, &auth, context, "close", 0)
+            self.authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
         else {
             // A close may race the asynchronous open before its attachment
             // is published. The transport fence ran at frame dispatch, so

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3313,6 +3313,28 @@ mod tests {
         assert_eq!(h.manager.opening_count(), 0);
     }
 
+    #[test]
+    fn legacy_close_cancels_a_transport_owned_pending_open() {
+        let h = harness(None, None);
+        let generation = h.manager.inner.next_opening_generation.fetch_add(1, Ordering::Relaxed);
+        h.manager.inner.opening_state.lock().unwrap().ids.insert(
+            "p1".to_owned(),
+            OpeningEntry { transport_id: Some("transport-a".to_owned()), generation },
+        );
+        let started = TestArc::new(Barrier::new(2));
+        let manager = Arc::clone(&h.manager.inner);
+        let started_for_thread = TestArc::clone(&started);
+        let close = thread::spawn(move || {
+            started_for_thread.wait();
+            manager.close_if_transport("p1", None, Some(generation));
+        });
+        started.wait();
+        close.join().expect("legacy close callback");
+        let state = h.manager.inner.opening_state.lock().unwrap();
+        assert_eq!(state.cancelled.get("p1"), Some(&generation));
+        assert_eq!(state.ids.get("p1").map(|entry| entry.generation), Some(generation));
+    }
+
     #[tokio::test]
     async fn shell_open_output_input_resize_flow_round_trip() {
         let h = harness(None, None);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -25,10 +25,11 @@ use std::fs::File;
 #[cfg(unix)]
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::ThreadId;
-use tokio::sync::Notify;
+use std::time::Duration;
+use tokio::sync::{Notify, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use async_trait::async_trait;
@@ -59,6 +60,8 @@ const MAX_ALLOWED_ROOTS: usize = 32;
 const MAX_ALLOWED_ROOT_BYTES: usize = 16 * 1024;
 const MAX_ENUM_SURFACES: usize = 8;
 const RAW_ATTACH_BACKLOG_CAP: usize = 1024 * 1024;
+const MAX_OUTPUT_CHUNK_BYTES: usize = 256 * 1024;
+const CONTROL_OPERATION_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
 const PTY_INPUT_B64_CAP: usize = 4 * 1024 * 1024;
 
 /// Random lowercase-hex identity for transports and tunnel attachments.
@@ -401,11 +404,6 @@ pub struct FrameContext {
     pub cancellation: CancellationToken,
 }
 
-/// Reconciled machine authority at a single route decision.
-///
-/// The version makes a route snapshot explicit. Roots are checked again for
-/// every output/control operation, so a root rotation cannot leave an old PTY
-/// usable merely because its trust level stayed unchanged.
 #[derive(Clone, Debug, Default)]
 pub struct LiveAuth {
     pub trust: String,
@@ -463,13 +461,15 @@ struct ShellInner {
 }
 
 /// A reentrant publication gate for one attachment generation. The gate
-/// serializes route publication and control operations across threads while
-/// allowing an outbound/control callback to synchronously re-enter the same
-/// route (for example, a test sink that closes the PTY). A callback must not
-/// synchronously wait for another thread that needs this same gate.
+/// serializes route publication and control-operation admission across
+/// threads while allowing an outbound/control callback to synchronously
+/// re-enter the same route (for example, a test sink that closes the PTY).
+/// A callback must not synchronously wait for another thread that needs this
+/// same gate.
 struct RouteGate {
     state: Mutex<RouteGateState>,
     changed: Condvar,
+    async_changed: Notify,
 }
 
 #[derive(Default)]
@@ -485,7 +485,11 @@ struct RouteGuard<'a> {
 
 impl RouteGate {
     fn new() -> Self {
-        Self { state: Mutex::new(RouteGateState::default()), changed: Condvar::new() }
+        Self {
+            state: Mutex::new(RouteGateState::default()),
+            changed: Condvar::new(),
+            async_changed: Notify::new(),
+        }
     }
 
     fn lock(&self) -> RouteGuard<'_> {
@@ -498,6 +502,28 @@ impl RouteGate {
         state.depth += 1;
         drop(state);
         RouteGuard { gate: self, owner }
+    }
+
+    /// Acquire the gate without blocking a Tokio worker. The critical
+    /// sections protected by this gate never await, so the polling thread is
+    /// stable for the lifetime of the guard and can safely re-enter through a
+    /// synchronous callback.
+    async fn lock_async(&self) -> RouteGuard<'_> {
+        loop {
+            let owner = std::thread::current().id();
+            let notified = self.async_changed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            {
+                let mut state = self.state.lock().expect("route gate lock");
+                if state.owner.is_none_or(|current| current == owner) {
+                    state.owner = Some(owner);
+                    state.depth += 1;
+                    return RouteGuard { gate: self, owner };
+                }
+            }
+            notified.await;
+        }
     }
 
     fn held_by_current_thread(&self) -> bool {
@@ -517,6 +543,7 @@ impl Drop for RouteGuard<'_> {
         if state.depth == 0 {
             state.owner = None;
             self.gate.changed.notify_all();
+            self.gate.async_changed.notify_waiters();
         }
     }
 }
@@ -524,6 +551,7 @@ impl Drop for RouteGuard<'_> {
 #[derive(Clone)]
 struct Attachment {
     closing: Arc<AtomicBool>,
+    close_pending: Arc<AtomicBool>,
     /// Releases this attachment (detach a viewer, close a control stream,
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
@@ -534,6 +562,103 @@ struct Attachment {
     transport_id: Option<String>,
     generation: u64,
     publication_gate: Arc<RouteGate>,
+    control_ops: Arc<ControlOperationState>,
+}
+
+struct ControlOperationState {
+    active: AtomicUsize,
+    wait_lock: Mutex<()>,
+    owners: Mutex<HashMap<ThreadId, usize>>,
+    changed: Condvar,
+    async_changed: Notify,
+}
+
+impl ControlOperationState {
+    fn new() -> Self {
+        Self {
+            active: AtomicUsize::new(0),
+            wait_lock: Mutex::new(()),
+            owners: Mutex::new(HashMap::new()),
+            changed: Condvar::new(),
+            async_changed: Notify::new(),
+        }
+    }
+
+    fn begin(&self) {
+        let _wait = self.wait_lock.lock().expect("control operation wait lock");
+        self.active.fetch_add(1, Ordering::AcqRel);
+        let owner = std::thread::current().id();
+        *self.owners.lock().expect("control operation owners lock").entry(owner).or_default() += 1;
+    }
+
+    fn end(&self) {
+        let _wait = self.wait_lock.lock().expect("control operation wait lock");
+        let owner = std::thread::current().id();
+        let mut owners = self.owners.lock().expect("control operation owners lock");
+        if let Some(count) = owners.get_mut(&owner) {
+            *count -= 1;
+            if *count == 0 {
+                owners.remove(&owner);
+            }
+        }
+        if self.active.fetch_sub(1, Ordering::AcqRel) == 1 {
+            self.changed.notify_all();
+            self.async_changed.notify_waiters();
+        }
+    }
+
+    fn owned_by_current_thread(&self) -> bool {
+        self.owners
+            .lock()
+            .expect("control operation owners lock")
+            .contains_key(&std::thread::current().id())
+    }
+
+    fn wait_sync_timeout(&self, timeout: Option<Duration>) -> bool {
+        if self.owned_by_current_thread() {
+            return true;
+        }
+        let mut guard = self.wait_lock.lock().expect("control operation wait lock");
+        while self.active.load(Ordering::Acquire) != 0 {
+            if let Some(timeout) = timeout {
+                let (next, result) =
+                    self.changed.wait_timeout(guard, timeout).expect("control operation wait");
+                guard = next;
+                if result.timed_out() {
+                    return false;
+                }
+            } else {
+                guard = self.changed.wait(guard).expect("control operation wait");
+            }
+        }
+        true
+    }
+
+    async fn wait_async(&self) {
+        if self.owned_by_current_thread() {
+            return;
+        }
+        loop {
+            if self.active.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            let notified = self.async_changed.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+            if self.active.load(Ordering::Acquire) == 0 {
+                return;
+            }
+            notified.await;
+        }
+    }
+}
+
+struct ControlOperationLease(Arc<ControlOperationState>);
+
+impl Drop for ControlOperationLease {
+    fn drop(&mut self) {
+        self.0.end();
+    }
 }
 
 struct Inner {
@@ -667,15 +792,17 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
-                    self.inner.with_live_attachment(
-                        pty_id,
-                        &attachment,
-                        context,
-                        "input",
-                        |control| {
-                            control.write(&data);
-                        },
-                    );
+                    self.inner
+                        .with_live_attachment_async(
+                            pty_id,
+                            &attachment,
+                            context,
+                            "input",
+                            |control| {
+                                control.write(&data);
+                            },
+                        )
+                        .await;
                 }
             }
             "pty_resize" => {
@@ -689,15 +816,17 @@ impl PtyManager {
                     return;
                 };
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
-                    self.inner.with_live_attachment(
-                        pty_id,
-                        &attachment,
-                        context,
-                        "resize",
-                        |control| {
-                            control.resize(cols, rows);
-                        },
-                    );
+                    self.inner
+                        .with_live_attachment_async(
+                            pty_id,
+                            &attachment,
+                            context,
+                            "resize",
+                            |control| {
+                                control.resize(cols, rows);
+                            },
+                        )
+                        .await;
                 }
             }
             "pty_flow" => {
@@ -707,19 +836,21 @@ impl PtyManager {
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
                 if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
-                    self.inner.with_live_attachment(
-                        pty_id,
-                        &attachment,
-                        context,
-                        "flow",
-                        |control| {
-                            if pause {
-                                control.pause();
-                            } else {
-                                control.resume();
-                            }
-                        },
-                    );
+                    self.inner
+                        .with_live_attachment_async(
+                            pty_id,
+                            &attachment,
+                            context,
+                            "flow",
+                            |control| {
+                                if pause {
+                                    control.pause();
+                                } else {
+                                    control.resume();
+                                }
+                            },
+                        )
+                        .await;
                 }
             }
             "pty_close" => {
@@ -727,7 +858,7 @@ impl PtyManager {
                 if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
                     return;
                 }
-                self.inner.close_authorized(pty_id, context);
+                self.inner.close_authorized_async(pty_id, context).await;
             }
             "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
             _ => {}
@@ -770,6 +901,12 @@ impl PtyManager {
         self.detach_matching(|owner| owner == Some(transport_id));
     }
 
+    /// Async transport teardown. Gate contention yields to Tokio instead of
+    /// blocking the connection worker while a publication callback finishes.
+    pub async fn detach_transport_async(&self, transport_id: &str) {
+        self.detach_matching_async(|owner| owner == Some(transport_id)).await;
+    }
+
     fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
         // Openings first: close() records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
@@ -795,6 +932,32 @@ impl PtyManager {
         ids.extend(attachment_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())));
         for (id, owner, generation) in ids {
             self.inner.close_if_transport(&id, owner.as_deref(), Some(generation));
+        }
+    }
+
+    async fn detach_matching_async(&self, owns: impl Fn(Option<&str>) -> bool) {
+        let opening_ids: Vec<(String, Option<String>, u64)> = {
+            let opening = self.inner.opening_state.lock().expect("opening state lock");
+            opening
+                .ids
+                .iter()
+                .map(|(id, entry)| (id.clone(), entry.transport_id.clone(), entry.generation))
+                .collect()
+        };
+        let attachment_ids: Vec<(String, Option<String>, u64)> = {
+            let attachments = self.inner.attachments.lock().expect("attach lock");
+            attachments
+                .iter()
+                .map(|(id, attachment)| {
+                    (id.clone(), attachment.transport_id.clone(), attachment.generation)
+                })
+                .collect()
+        };
+        let mut ids: Vec<(String, Option<String>, u64)> =
+            opening_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())).collect();
+        ids.extend(attachment_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())));
+        for (id, owner, generation) in ids {
+            self.inner.close_if_transport_async(&id, owner.as_deref(), Some(generation)).await;
         }
     }
 }
@@ -844,9 +1007,6 @@ impl Inner {
             return;
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
-        // One monotonic domain spans reservation and attachment publication.
-        // A generation can therefore never be mistaken for a different phase
-        // of the same PTY id.
         let opening_generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         // Do not inspect the route gate while holding the attachment map. The
         // normal publication path takes RouteGate -> attachments, so this
@@ -869,18 +1029,13 @@ impl Inner {
         } else {
             let mut opening = self.opening_state.lock().expect("opening state lock");
             let attachments = self.attachments.lock().expect("attach lock");
-            let attached = attachments
-                .get(&pty_id)
-                .is_some_and(|attachment| !attachment.closing.load(Ordering::SeqCst));
+            let attached = attachments.get(&pty_id).is_some_and(|attachment| {
+                !attachment.closing.load(Ordering::SeqCst)
+                    || attachment.close_pending.load(Ordering::SeqCst)
+            });
             if attached || opening.ids.contains_key(&pty_id) {
                 Err(("bad_request", "ptyId is already attached".to_owned()))
-            } else if attachments
-                .values()
-                .filter(|attachment| !attachment.closing.load(Ordering::SeqCst))
-                .count()
-                + opening.ids.len()
-                >= self.max_ptys
-            {
+            } else if attachments.values().count() + opening.ids.len() >= self.max_ptys {
                 Err((
                     "session_limit",
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
@@ -1055,10 +1210,6 @@ impl Inner {
             }
         };
 
-        // A provider may ignore the cancellation token while opening. Never
-        // publish a PTY after its transport has gone away; `Opened::drop`
-        // closes the provider handle and `OpeningReservation::drop` releases
-        // the id reservation.
         if context.cancellation.is_cancelled() {
             return;
         }
@@ -1074,6 +1225,7 @@ impl Inner {
             opening.ids.remove(&pty_id);
             drop(opening);
             drop(attachments);
+            reservation.active = false;
             opened.closing.store(true, Ordering::SeqCst);
             opened.control.kill();
             return;
@@ -1086,7 +1238,7 @@ impl Inner {
         {
             drop(attachments);
             drop(opening);
-            let _previous_publication = previous_gate.lock();
+            let _previous_publication = previous_gate.lock_async().await;
             opening = self.opening_state.lock().expect("opening state lock");
             attachments = self.attachments.lock().expect("attach lock");
             if opening.cancelled.get(&pty_id) == Some(&opening_generation) {
@@ -1121,6 +1273,7 @@ impl Inner {
             pty_id.clone(),
             Attachment {
                 closing: opened.closing,
+                close_pending: Arc::new(AtomicBool::new(false)),
                 control: Arc::clone(&opened.control),
                 actor_id: actor.to_owned(),
                 cwd: cwd.clone(),
@@ -1128,6 +1281,7 @@ impl Inner {
                 transport_id: context.transport_id.clone(),
                 generation: opened.generation,
                 publication_gate: Arc::clone(&opened.publication_gate),
+                control_ops: Arc::new(ControlOperationState::new()),
             },
         );
         opening.ids.remove(&pty_id);
@@ -1137,8 +1291,6 @@ impl Inner {
             previous.closing.store(true, Ordering::SeqCst);
             previous.control.kill();
         }
-        // Ownership transferred to the attachment. The guard remains on the
-        // Opened value only to keep the deferred start closure alive.
         opened.cleanup.claimed.store(true, Ordering::Release);
         reservation.active = false;
         let mut opened_frame = serde_json::Map::new();
@@ -1156,7 +1308,19 @@ impl Inner {
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
-        (opened.start)();
+        let start = opened.start;
+        // Do not hold the frame handler open for the lifetime of a live PTY
+        // stream. Wait only until the sink is installed, then let the
+        // generation fence and control kill own its lifecycle.
+        let (started_tx, started_rx) = oneshot::channel();
+        let _ = std::thread::Builder::new().name("chatmux-relay-pty-start".to_owned()).spawn(
+            move || {
+                start(Box::new(move || {
+                    let _ = started_tx.send(());
+                }));
+            },
+        );
+        let _ = started_rx.await;
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
@@ -1202,18 +1366,12 @@ impl Inner {
         generation: u64,
         publication_gate: &Arc<RouteGate>,
     ) {
-        let mut auth = Self::auth_snapshot(context);
-        if self
-            .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
-            .is_none()
-        {
-            return;
-        }
         let gate = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || (context.transport_id.is_some() && current.transport_id != context.transport_id)
             {
                 return;
             }
@@ -1257,13 +1415,24 @@ impl Inner {
             );
             return;
         }
-        auth = live_auth;
         // Zero-byte chunks carry nothing and historically crashed the web
         // terminal's write path (D-R6-1); never put an empty frame on the wire.
         if chunk.is_empty() {
             return;
         }
-        let buffered = (auth.buffered_amount)();
+        if chunk.len() > MAX_OUTPUT_CHUNK_BYTES {
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                generation,
+                publication_gate,
+                "failed",
+                "pty output chunk exceeds the relay frame budget",
+            );
+            return;
+        }
+        let buffered = (live_auth.buffered_amount)();
         // Admit the complete frame before sending it. The socket may accept a
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
@@ -1282,7 +1451,7 @@ impl Inner {
             );
             return;
         }
-        (auth.send)(json!({
+        (live_auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
             "ptyId": pty_id,
@@ -1386,6 +1555,51 @@ impl Inner {
         self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
             send_pty_error(context, pty_id, code, message);
         });
+    }
+
+    async fn emit_error_for_generation_async(
+        &self,
+        context: &FrameContext,
+        pty_id: &str,
+        generation: u64,
+        publication_gate: &Arc<RouteGate>,
+        code: &str,
+        message: &str,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock_async().await;
+        let attachment = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.closing.store(true, Ordering::SeqCst);
+            current.clone()
+        };
+        send_pty_error(context, pty_id, code, message);
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        if attachments.get(pty_id).is_some_and(|current| {
+            current.generation == generation
+                && Arc::ptr_eq(&current.publication_gate, publication_gate)
+        }) {
+            attachments.remove(pty_id);
+        }
+        drop(attachments);
+        drop(_publication);
+        attachment.control.kill();
     }
 
     fn emit_terminal_for_generation(
@@ -1551,6 +1765,7 @@ impl Inner {
             if current.generation != attachment.generation
                 || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
             {
                 return;
             }
@@ -1568,6 +1783,48 @@ impl Inner {
             );
             return;
         }
+        attachment.control_ops.begin();
+        let _operation = ControlOperationLease(Arc::clone(&attachment.control_ops));
+        operation(attachment.control.as_ref());
+    }
+
+    async fn with_live_attachment_async(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        context: &FrameContext,
+        action: &str,
+        operation: impl FnOnce(&dyn PtyControl),
+    ) {
+        let _publication = attachment.publication_gate.lock_async().await;
+        {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
+            {
+                return;
+            }
+        }
+        let live_auth = Self::auth_snapshot(context);
+        if !self.auth_allows(&live_auth, attachment) {
+            drop(_publication);
+            self.emit_error_for_generation_async(
+                context,
+                pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
+            )
+            .await;
+            return;
+        }
+        attachment.control_ops.begin();
+        let _operation = ControlOperationLease(Arc::clone(&attachment.control_ops));
+        drop(_publication);
         operation(attachment.control.as_ref());
     }
 
@@ -1673,6 +1930,80 @@ impl Inner {
         self.close_exact_authorized(pty_id, &attachment, context);
     }
 
+    async fn close_authorized_async(&self, pty_id: &str, context: &FrameContext) {
+        let auth = Self::auth_snapshot(context);
+        let attachment = match self
+            .authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
+        {
+            Ok(attachment) => attachment,
+            Err(NonterminalAuthorizationFailure::Denied) => return,
+            Err(NonterminalAuthorizationFailure::Missing) => {
+                self.close_if_transport_async(pty_id, context.transport_id.as_deref(), None).await;
+                return;
+            }
+        };
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return;
+        }
+        self.close_exact_authorized_async(pty_id, &attachment, context).await;
+    }
+
+    async fn close_if_transport_async(
+        &self,
+        pty_id: &str,
+        transport_id: Option<&str>,
+        generation: Option<u64>,
+    ) {
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        if let Some(entry) = opening.ids.get(pty_id) {
+            let owns_opening =
+                transport_id.is_none() || entry.transport_id.as_deref() == transport_id;
+            if generation.is_none_or(|expected| entry.generation == expected) && owns_opening {
+                opening.cancelled.insert(pty_id.to_owned(), entry.generation);
+            }
+        }
+        drop(opening);
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if generation.is_none_or(|expected| attachment.generation == expected)
+            && attachment.transport_id.as_deref() == transport_id
+        {
+            let publication_gate = Arc::clone(&attachment.publication_gate);
+            let _publication = publication_gate.lock_async().await;
+            let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+            else {
+                return;
+            };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                || current.transport_id.as_deref() != transport_id
+            {
+                return;
+            }
+            current.close_pending.store(true, Ordering::SeqCst);
+            drop(_publication);
+            let _ = tokio::time::timeout(
+                CONTROL_OPERATION_DRAIN_TIMEOUT,
+                attachment.control_ops.wait_async(),
+            )
+            .await;
+            let _publication = publication_gate.lock_async().await;
+            let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+            else {
+                return;
+            };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                || !current.close_pending.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            self.close_exact(pty_id, generation, Some(&publication_gate));
+        }
+    }
+
     fn close_exact_authorized(
         &self,
         pty_id: &str,
@@ -1703,22 +2034,25 @@ impl Inner {
         };
         let live_auth = Self::auth_snapshot(context);
         if !self.auth_allows(&live_auth, &current) {
-            drop(_publication);
-            self.emit_error_for_generation(
+            current.close_pending.store(false, Ordering::SeqCst);
+            send_pty_error(
                 context,
                 pty_id,
-                attachment.generation,
-                &attachment.publication_gate,
                 "trust_revoked",
                 "PTY close refused after trust change",
             );
             return;
         }
+        current.close_pending.store(true, Ordering::SeqCst);
+        drop(_publication);
+        let _ = current.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
+        let _publication = gate.lock();
         let removed = {
             let mut attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != attachment.generation
                 || !Arc::ptr_eq(&current.publication_gate, &gate)
+                || !current.close_pending.load(Ordering::SeqCst)
                 || current.closing.load(Ordering::SeqCst)
             {
                 return;
@@ -1727,8 +2061,55 @@ impl Inner {
             removed.closing.store(true, Ordering::SeqCst);
             removed
         };
-        drop(_publication);
         removed.control.kill();
+    }
+
+    async fn close_exact_authorized_async(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        context: &FrameContext,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock_async().await;
+        let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if current.generation != attachment.generation
+            || !Arc::ptr_eq(&current.publication_gate, &gate)
+            || current.closing.load(Ordering::SeqCst)
+        {
+            return;
+        }
+        current.close_pending.store(true, Ordering::SeqCst);
+        drop(_publication);
+        let _ = tokio::time::timeout(
+            CONTROL_OPERATION_DRAIN_TIMEOUT,
+            attachment.control_ops.wait_async(),
+        )
+        .await;
+        let _publication = gate.lock_async().await;
+        let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if current.generation != attachment.generation
+            || !Arc::ptr_eq(&current.publication_gate, &gate)
+            || !current.close_pending.load(Ordering::SeqCst)
+        {
+            return;
+        }
+        self.close_exact_authorized(pty_id, attachment, context);
     }
 
     fn close_if_generation(&self, pty_id: &str, generation: u64) {
@@ -1771,6 +2152,7 @@ impl Inner {
             attachment.closing.store(true, Ordering::SeqCst);
             attachment
         };
+        let _ = attachment.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
         attachment.control.kill();
     }
 }
@@ -1784,7 +2166,7 @@ struct Opened {
     generation: u64,
     publication_gate: Arc<RouteGate>,
     cleanup: Arc<OpenedCleanup>,
-    start: Box<dyn FnOnce() + Send>,
+    start: Box<dyn FnOnce(Box<dyn FnOnce() + Send>) + Send>,
 }
 
 struct OpenedCleanup {
@@ -1795,8 +2177,6 @@ struct OpenedCleanup {
 impl Drop for OpenedCleanup {
     fn drop(&mut self) {
         if !self.claimed.swap(true, Ordering::AcqRel) {
-            // Any open that never reaches publication still owns a live PTY.
-            // Drop is the cancellation-safe fallback for every early return.
             self.control.kill();
         }
     }
@@ -1812,21 +2192,28 @@ impl ControlGuard {
         Self(Some(control))
     }
 
+    fn end(&mut self) {
+        if let Some(control) = self.0.take() {
+            control.end();
+        }
+    }
+
     fn disarm(&mut self) -> Arc<dyn ControlHandle> {
         self.0.take().expect("control guard owns a connection")
     }
 }
 
 async fn request_control_with_cancellation(
-    control: &Arc<dyn ControlHandle>,
+    control_guard: &mut ControlGuard,
     cmd: &str,
     params: Value,
     cancellation: &CancellationToken,
 ) -> Option<Value> {
+    let control = control_guard.0.as_ref()?.clone();
     tokio::select! {
         response = control.request(cmd, params) => response,
         _ = cancellation.cancelled() => {
-            control.end();
+            control_guard.end();
             None
         }
     }
@@ -1834,9 +2221,7 @@ async fn request_control_with_cancellation(
 
 impl Drop for ControlGuard {
     fn drop(&mut self) {
-        if let Some(control) = self.0.take() {
-            control.end();
-        }
+        self.end();
     }
 }
 
@@ -1884,59 +2269,71 @@ impl Inner {
                 .connect_control(&ensured.socket_path)
                 .await
                 .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
-            let _control_guard = ControlGuard::new(Arc::clone(&control));
-            let Some(listed) = control.request("list-workspaces", json!({})).await else {
-                control.end();
+            let mut control_guard = ControlGuard::new(Arc::clone(&control));
+            let Some(listed) = request_control_with_cancellation(
+                &mut control_guard,
+                "list-workspaces",
+                json!({}),
+                &context.cancellation,
+            )
+            .await
+            else {
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if listed.get("ok").and_then(Value::as_bool) != Some(true) {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let Some(data) = listed.get("data").and_then(Value::as_object) else {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             };
             if !data.get("workspaces").is_some_and(Value::is_array) {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             if !workspace_shape_valid(listed.get("data")) {
-                control.end();
+                control_guard.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
             }
             let tabs = match collect_pty_tabs_strict(listed.get("data")) {
                 Ok(tabs) => tabs,
                 Err(_) => {
-                    control.end();
+                    control_guard.end();
                     return Err("cannot inspect existing daemon surfaces".to_owned());
                 }
             };
             if tabs.len() > MAX_ENUM_TERMINALS || (tabs.is_empty() && !ensured.created) {
-                control.end();
+                control_guard.end();
                 return Err("cannot prove existing daemon cwd is within allowed roots".to_owned());
             }
             for tab in tabs {
-                let Some(info) =
-                    control.request("process-info", json!({ "surface": tab.surface_id })).await
+                let Some(info) = request_control_with_cancellation(
+                    &mut control_guard,
+                    "process-info",
+                    json!({ "surface": tab.surface_id }),
+                    &context.cancellation,
+                )
+                .await
                 else {
-                    control.end();
+                    control_guard.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 };
                 if info.get("ok").and_then(Value::as_bool) != Some(true) {
-                    control.end();
+                    control_guard.end();
                     return Err("cannot inspect existing surface cwd".to_owned());
                 }
                 let Some(actual) =
                     info.get("data").and_then(|v| v.get("cwd")).and_then(Value::as_str)
                 else {
-                    control.end();
+                    control_guard.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
                 };
                 if actual.is_empty() || !Path::new(actual).is_absolute() {
-                    control.end();
+                    control_guard.end();
                     return Err(
                         "cannot prove existing surface cwd is within allowed roots".to_owned()
                     );
@@ -1949,11 +2346,11 @@ impl Inner {
                 )
                 .is_err()
                 {
-                    control.end();
+                    control_guard.end();
                     return Err("existing surface cwd is outside allowed roots".to_owned());
                 }
             }
-            control.end();
+            control_guard.end();
         }
         let mut args = cmux_tui.prefix.clone();
         args.extend([
@@ -1992,7 +2389,10 @@ impl Inner {
                 control: Arc::clone(&control),
                 claimed: AtomicBool::new(false),
             }),
-            start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
+            start: Box::new(move |ready| {
+                ready();
+                drive_handle(output, banner, on_data, on_exit);
+            }),
         })
     }
 
@@ -2145,15 +2545,27 @@ impl Inner {
         });
 
         let start_session = Arc::clone(&shell_session);
-        let start: Box<dyn FnOnce() + Send> = Box::new(move || {
+        let start_gate = Arc::clone(&publication_gate);
+        let start: Box<dyn FnOnce(Box<dyn FnOnce() + Send>) + Send> = Box::new(move |ready| {
+            let _publication = start_gate.lock();
             let (banner, replay, alive) = {
-                let inner = start_session.inner.lock().expect("shell inner lock");
+                let mut inner = start_session.inner.lock().expect("shell inner lock");
                 let banner = created.then(|| start_session.banner.clone()).flatten();
                 let replay = (!created && inner.ring_size > 0).then(|| {
                     inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
                 });
+                if inner.alive && !released.load(Ordering::SeqCst) {
+                    inner.viewers.push(ViewerSink {
+                        id: viewer_id,
+                        on_data: Arc::clone(&on_data),
+                        on_exit: Arc::clone(&on_exit),
+                    });
+                }
                 (banner, replay, inner.alive)
             };
+            // The viewer is installed while the publication gate is held.
+            // Subsequent PTY output therefore waits behind replay callbacks.
+            ready();
             if let Some(banner) = banner {
                 on_data(Bytes::from(banner));
             }
@@ -2166,10 +2578,6 @@ impl Inner {
             if !alive {
                 on_exit(0);
                 return;
-            }
-            let mut inner = start_session.inner.lock().expect("shell inner lock");
-            if !released.load(Ordering::SeqCst) && inner.alive {
-                inner.viewers.push(ViewerSink { id: viewer_id, on_data, on_exit });
             }
         });
 
@@ -2370,6 +2778,15 @@ impl TerminalStream {
         on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
         on_exit: Arc<dyn Fn(i64) + Send + Sync>,
     ) {
+        self.go_live_with_ready(on_data, on_exit, || {});
+    }
+
+    fn go_live_with_ready(
+        &self,
+        on_data: Arc<dyn Fn(Bytes) + Send + Sync>,
+        on_exit: Arc<dyn Fn(i64) + Send + Sync>,
+        ready: impl FnOnce(),
+    ) {
         let should_drain = {
             let mut state = self.state.lock().expect("terminal stream lock");
             state.live_data = Some(Arc::clone(&on_data));
@@ -2377,6 +2794,7 @@ impl TerminalStream {
             state.backlog_bytes = 0;
             Self::start_delivery(&mut state)
         };
+        ready();
         if should_drain {
             self.drain();
         }
@@ -2589,7 +3007,13 @@ impl Inner {
         };
         let mut control_guard = ControlGuard::new(Arc::clone(&control));
 
-        let identify = control.request("identify", json!({})).await;
+        let identify = request_control_with_cancellation(
+            &mut control_guard,
+            "identify",
+            json!({}),
+            &context.cancellation,
+        )
+        .await;
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
         let protocol = info
             .and_then(|v| v.get("data"))
@@ -2597,7 +3021,7 @@ impl Inner {
             .and_then(Value::as_i64)
             .unwrap_or(0);
         if protocol < CONTROL_MIN_PROTOCOL {
-            control.end();
+            control_guard.end();
             return Ok(None);
         }
         let capabilities: Vec<String> = info
@@ -2615,7 +3039,13 @@ impl Inner {
             None
         };
         if surface_id.is_none() {
-            let listed = control.request("list-workspaces", json!({})).await;
+            let listed = request_control_with_cancellation(
+                &mut control_guard,
+                "list-workspaces",
+                json!({}),
+                &context.cancellation,
+            )
+            .await;
             let tabs = listed
                 .as_ref()
                 .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
@@ -2627,7 +3057,7 @@ impl Inner {
                 .map(|tab| tab.surface_id);
         }
         let Some(surface_id) = surface_id else {
-            control.end();
+            control_guard.end();
             // Typed refusal: the terminal died with its process (or its tab
             // closed) — permanent, so clients render an ended state and
             // never offer a retry.
@@ -2642,7 +3072,13 @@ impl Inner {
         let roots_scoped = context.local_roots.as_deref().is_some_and(|r| !r.is_empty())
             || server_roots.is_some_and(|r| !r.is_empty());
         if roots_scoped {
-            let info = control.request("process-info", json!({ "surface": surface_id })).await;
+            let info = request_control_with_cancellation(
+                &mut control_guard,
+                "process-info",
+                json!({ "surface": surface_id }),
+                &context.cancellation,
+            )
+            .await;
             let actual = info
                 .as_ref()
                 .filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true))
@@ -2650,14 +3086,14 @@ impl Inner {
                 .and_then(|v| v.get("cwd"))
                 .and_then(Value::as_str);
             if actual.is_none_or(|value| value.is_empty() || !Path::new(value).is_absolute()) {
-                control.end();
+                control_guard.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
                 ));
             }
             let Some(actual) = actual else {
-                control.end();
+                control_guard.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "cannot prove existing surface cwd is within allowed roots".to_owned(),
@@ -2666,7 +3102,7 @@ impl Inner {
             if scoped_cwd(Some(actual), &self.home, context.local_roots.as_deref(), server_roots)
                 .is_err()
             {
-                control.end();
+                control_guard.end();
                 return Err((
                     RelayPtyErrorCode::Failed,
                     "existing surface cwd is outside allowed roots".to_owned(),
@@ -2706,14 +3142,14 @@ impl Inner {
             json!({ "surface": surface_id })
         };
         let attached = request_control_with_cancellation(
-            &control,
+            &mut control_guard,
             "attach-surface",
             attach_params,
             &context.cancellation,
         )
         .await;
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
-            control.end();
+            control_guard.end();
             let reason = attached
                 .as_ref()
                 .and_then(|v| v.get("error"))
@@ -2766,7 +3202,7 @@ impl Inner {
                 control: Arc::clone(&proxy),
                 claimed: AtomicBool::new(false),
             }),
-            start: Box::new(move || start_stream.go_live(on_data, on_exit)),
+            start: Box::new(move |ready| start_stream.go_live_with_ready(on_data, on_exit, ready)),
         }))
     }
 
@@ -3160,6 +3596,20 @@ mod tests {
         ensure_socket_path: Option<PathBuf>,
         control: Option<Arc<dyn ControlHandle>>,
     ) -> Harness {
+        harness_with_control_and_max_ptys(resolve, read_dir, ensure_socket_path, control, MAX_PTYS)
+    }
+
+    fn harness_with_max_ptys(max_ptys: usize) -> Harness {
+        harness_with_control_and_max_ptys(None, None, None, None, max_ptys)
+    }
+
+    fn harness_with_control_and_max_ptys(
+        resolve: Option<CmuxTui>,
+        read_dir: Option<Vec<String>>,
+        ensure_socket_path: Option<PathBuf>,
+        control: Option<Arc<dyn ControlHandle>>,
+        max_ptys: usize,
+    ) -> Harness {
         let home = TestDirectory::new("harness");
         let home_path = home.path.clone();
         let env = env_map(&home_path);
@@ -3178,7 +3628,7 @@ mod tests {
             deps,
             home_path.clone(),
             env,
-            MAX_PTYS,
+            max_ptys,
             SCROLLBACK_LIMIT,
             OUTPUT_BUFFER_CAP,
         );
@@ -3883,6 +4333,44 @@ mod tests {
         fn end(&self) {}
     }
 
+    struct HangingControl {
+        ended: Arc<AtomicUsize>,
+    }
+
+    impl ControlHandle for HangingControl {
+        fn request(
+            &self,
+            _cmd: &str,
+            _params: Value,
+        ) -> std::pin::Pin<Box<dyn Future<Output = Option<Value>> + Send + '_>> {
+            Box::pin(std::future::pending())
+        }
+        fn send(&self, _cmd: &str, _params: Value) {}
+        fn on_event(&self, _handler: EventHandler) {}
+        fn on_close(&self, _handler: CloseHandler) {}
+        fn pause(&self) {}
+        fn resume(&self) {}
+        fn end(&self) {
+            self.ended.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    #[tokio::test]
+    async fn cancelled_control_request_ends_guard_once() {
+        let ended = Arc::new(AtomicUsize::new(0));
+        let control: Arc<dyn ControlHandle> =
+            Arc::new(HangingControl { ended: Arc::clone(&ended) });
+        let mut guard = ControlGuard::new(control);
+        let cancellation = CancellationToken::new();
+        cancellation.cancel();
+        assert!(
+            request_control_with_cancellation(&mut guard, "identify", Value::Null, &cancellation)
+                .await
+                .is_none()
+        );
+        assert_eq!(ended.load(Ordering::SeqCst), 1);
+    }
+
     #[tokio::test]
     async fn missing_surface_refuses_with_typed_terminal_gone() {
         let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
@@ -3982,6 +4470,12 @@ mod tests {
         let close = serde_json::json!({ "version": 4, "type": "pty_close", "ptyId": "p1" });
         h.manager.handle_frame(&close, &denied).await;
         assert!(h.manager.has_attachment("p1"));
+        assert!(!h.spawned()[0].state.lock().unwrap().killed);
+        assert!(
+            h.sent()
+                .iter()
+                .any(|frame| { frame["type"] == "pty_error" && frame["code"] == "trust_revoked" })
+        );
     }
 
     #[tokio::test]
@@ -4263,6 +4757,45 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn closing_attachment_counts_toward_capacity_until_publication_returns() {
+        let h = harness_with_max_ptys(1);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let exit = thread::spawn(move || pty.exit(7));
+        entered.wait();
+
+        let replacement = h.context("supervised", h.owner.clone());
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert_eq!(h.manager.attachment_count(), 1);
+        assert!(
+            h.sent()
+                .iter()
+                .any(|frame| { frame["type"] == "pty_error" && frame["code"] == "session_limit" })
+        );
+
+        release.wait();
+        exit.join().expect("exit callback");
+        h.manager.handle_frame(&frame, &replacement).await;
+        assert_eq!(h.manager.attachment_count(), 1);
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test]
     async fn overflow_error_publication_cannot_reach_a_same_id_replacement() {
         let h = harness(None, None);
         let entered = TestArc::new(Barrier::new(2));
@@ -4285,13 +4818,21 @@ mod tests {
         entered.wait();
 
         let replacement = h.context("supervised", h.owner.clone());
-        h.manager.handle_frame(&frame, &replacement).await;
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let replacement_for_task = replacement.clone();
+        let frame_for_replacement = frame.clone();
+        let replacement_task = tokio::spawn(async move {
+            manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!replacement_task.is_finished());
         assert!(!h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
         }));
 
         release.wait();
         output.join().expect("output callback");
+        replacement_task.await.expect("replacement open");
         h.buffered.store(0, Ordering::SeqCst);
         h.manager.handle_frame(&frame, &replacement).await;
         assert!(h.sent().iter().any(|frame| {
@@ -4461,6 +5002,182 @@ mod tests {
         h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
         assert!(h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn async_close_waits_for_control_operation_across_workers() {
+        let h = harness(None, None);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        let pty = h.spawned()[0].clone();
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        {
+            let mut state = pty.state.lock().unwrap();
+            state.write_entered = Some(TestArc::clone(&entered));
+            state.write_release = Some(TestArc::clone(&release));
+        }
+        let input = serde_json::json!({
+            "version": 4,
+            "type": "pty_input",
+            "ptyId": "p1",
+            "dataB64": b64("held"),
+        });
+        let input_task = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = h.context("supervised", h.owner.clone());
+            async move { manager.handle_frame(&input, &context).await }
+        });
+        entered.wait();
+        let close_task = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = h.context("supervised", h.owner.clone());
+            async move {
+                manager
+                    .handle_frame(
+                        &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
+                        &context,
+                    )
+                    .await;
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(!close_task.is_finished(), "close waits for the in-flight control operation");
+        release.wait();
+        input_task.await.expect("input operation");
+        close_task.await.expect("close operation");
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_route_gate_wait_does_not_block_unrelated_tasks() {
+        let gate = Arc::new(RouteGate::new());
+        let (entered_tx, entered_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let held_gate = Arc::clone(&gate);
+        let owner = thread::spawn(move || {
+            let _guard = held_gate.lock();
+            entered_tx.send(()).expect("gate owner entered");
+            release_rx.recv().expect("gate owner released");
+        });
+        entered_rx.recv().expect("gate owner entered");
+
+        let waiter_gate = Arc::clone(&gate);
+        let waiter = tokio::spawn(async move {
+            let _guard = waiter_gate.lock_async().await;
+        });
+        let tick = tokio::spawn(async { 17_u8 });
+        assert_eq!(tick.await.expect("unrelated task"), 17);
+        release_tx.send(()).expect("release gate owner");
+        waiter.await.expect("async gate waiter");
+        owner.join().expect("gate owner");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_transport_detach_does_not_block_unrelated_tasks() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let mut context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        context.transport_id = Some("transport-a".to_owned());
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let output = thread::spawn(move || pty.emit("live"));
+        entered.wait();
+
+        let manager = h.manager.clone();
+        let detach = tokio::spawn(async move {
+            manager.detach_transport_async("transport-a").await;
+        });
+        tokio::task::yield_now().await;
+        assert!(!detach.is_finished(), "detach must wait for the publication gate");
+
+        let tick = tokio::spawn(async { 17_u8 });
+        assert_eq!(tick.await.expect("unrelated task"), 17);
+
+        release.wait();
+        output.join().expect("output callback");
+        detach.await.expect("transport detach");
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn long_lived_start_does_not_block_close_or_subsequent_frames() {
+        let h = harness(None, None);
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
+        let shell = h.spawned()[0].clone();
+        shell.emit("replay");
+        h.manager
+            .handle_frame(
+                &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
+                &h.context("supervised", h.owner.clone()),
+            )
+            .await;
+
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        let open = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = context.clone();
+            let frame = frame.clone();
+            async move { manager.handle_frame(&frame, &context).await }
+        });
+        open.await.expect("replacement open");
+        entered.wait();
+        let output_during_start = thread::spawn(move || shell.emit("during-start"));
+
+        let close = tokio::spawn({
+            let manager = h.manager.clone();
+            let context = h.context("supervised", h.owner.clone());
+            async move {
+                manager
+                    .handle_frame(
+                        &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
+                        &context,
+                    )
+                    .await;
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(!close.is_finished(), "close must wait for the replay callback");
+
+        release.wait();
+        output_during_start.join().expect("output during start");
+        close.await.expect("close after replay");
+        assert!(!h.manager.has_attachment("p1"));
+        assert!(h.sent().iter().any(|frame| {
+            frame["type"] == "pty_output"
+                && from_b64(frame["dataB64"].as_str().unwrap_or_default()) == "during-start"
         }));
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::ThreadId;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 use tokio::sync::{Notify, oneshot};
 use tokio_util::sync::CancellationToken;
 
@@ -618,11 +618,16 @@ impl ControlOperationState {
         if self.owned_by_current_thread() {
             return true;
         }
+        let deadline = timeout.map(|duration| Instant::now() + duration);
         let mut guard = self.wait_lock.lock().expect("control operation wait lock");
         while self.active.load(Ordering::Acquire) != 0 {
-            if let Some(timeout) = timeout {
+            if let Some(deadline) = deadline {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return false;
+                }
                 let (next, result) =
-                    self.changed.wait_timeout(guard, timeout).expect("control operation wait");
+                    self.changed.wait_timeout(guard, remaining).expect("control operation wait");
                 guard = next;
                 if result.timed_out() {
                     return false;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2911,6 +2911,16 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn denied_close_does_not_remove_attachment() {
+        let h = harness(None, None);
+        h.open_with_transport("p1", "main", "transport-a").await;
+        let denied = h.context_with_transport("observe", Some("other-user".to_owned()), Some("transport-a"));
+        let close = serde_json::json!({ "version": 4, "type": "pty_close", "ptyId": "p1" });
+        h.manager.handle_frame(&close, &denied).await;
+        assert!(h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test]
     async fn detach_transport_releases_only_that_transports_attachments() {
         let h = harness(None, None);
         h.open_with_transport("p-relay", "relay-side", "transport-relay").await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -944,9 +944,7 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            if action != "close" {
-                self.close(pty_id);
-            }
+            self.close(pty_id);
             send_pty_error(
                 context,
                 pty_id,
@@ -1034,7 +1032,9 @@ impl Inner {
         if allowed {
             Some(attachment)
         } else {
-            self.close(pty_id);
+            if action != "close" {
+                self.close(pty_id);
+            }
             send_pty_error(
                 context,
                 pty_id,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1043,9 +1043,6 @@ impl Inner {
         }
     }
 
-    fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
-        self.close(pty_id);
-    }
 }
 
 /// A resolved open: what to echo, plus a deferred `start` that begins output.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1067,10 +1067,13 @@ impl Inner {
         }
         // This is the publication linearization point. Read the live
         // authority only after waiting for any prior generation's publication
-        // gate, while the opening and attachment state are still held. A
-        // downgrade that races the slow OPEN path therefore cannot publish a
-        // newly attached PTY.
+        // gate and while the opening state is held. Do not invoke the public
+        // live-auth callback while the attachment map mutex is held. The
+        // opening lock serializes competing reservations; reacquiring the
+        // attachment map after the read keeps callbacks outside map locks.
+        drop(attachments);
         let live_auth = Self::auth_snapshot(context);
+        attachments = self.attachments.lock().expect("attach lock");
         if live_auth.trust.is_empty()
             || (live_auth.trust == "observe"
                 && (live_auth.owner_user_id.is_none()
@@ -1587,6 +1590,11 @@ impl Inner {
     }
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
+        // Capture presence before authorization. If this request is denied,
+        // the attachment may be removed and replaced while the error callback
+        // runs; remembering that it targeted a present attachment prevents
+        // the fallback cancellation path from touching that replacement.
+        let had_attachment = self.attachments.lock().expect("attach lock").contains_key(pty_id);
         let auth = Self::auth_snapshot(context);
         let Some(attachment) =
             self.authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
@@ -1595,7 +1603,7 @@ impl Inner {
             // non-terminal error above must not fall through to the opening
             // cancellation path, which would otherwise let a denied CLOSE
             // retire the live attachment.
-            if self.attachments.lock().expect("attach lock").contains_key(pty_id) {
+            if had_attachment {
                 return;
             }
             // A close may race the asynchronous open before its attachment

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3589,7 +3589,17 @@ mod tests {
     async fn close_requires_current_trust() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
-        h.frame_as(serde_json::json!({"type":"pty_close","ptyId":"p1"}), "", h.owner.clone()).await;
+        let mut revoked = h.context("", h.owner.clone());
+        let owner = h.owner.clone();
+        revoked.live_auth = Arc::new(move || LiveAuth {
+            trust: String::new(),
+            owner_user_id: owner.clone(),
+            version: 1,
+            ..Default::default()
+        });
+        h.manager
+            .handle_frame(&serde_json::json!({"type":"pty_close","ptyId":"p1"}), &revoked)
+            .await;
         assert!(h.sent().iter().any(|f| f["code"] == "trust_revoked"));
         assert!(!h.manager.has_attachment("p1"));
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -389,7 +389,7 @@ pub struct FrameContext {
     pub owner_user_id: Option<String>,
     /// Read current trust and owner for an attachment. Session transports
     /// update this closure's backing state after trust acknowledgements.
-    pub live_auth: Arc<dyn Fn() -> (String, Option<String>) + Send + Sync>,
+    pub live_auth: Arc<dyn Fn() -> LiveAuth + Send + Sync>,
     /// Identity of the transport this frame arrived on. The PtyManager is
     /// shared between the relay WebSocket and the managed tunnel listener;
     /// an attachment may only be written to, resized, flow-controlled, or
@@ -401,10 +401,25 @@ pub struct FrameContext {
     pub cancellation: CancellationToken,
 }
 
+/// Reconciled machine authority at a single route decision.
+///
+/// The version makes a route snapshot explicit. Roots are checked again for
+/// every output/control operation, so a root rotation cannot leave an old PTY
+/// usable merely because its trust level stayed unchanged.
+#[derive(Clone, Debug, Default)]
+pub struct LiveAuth {
+    pub trust: String,
+    pub roots: Option<Vec<String>>,
+    pub owner_user_id: Option<String>,
+    pub version: u64,
+}
+
 #[derive(Clone)]
 struct AuthSnapshot {
     trust: String,
+    roots: Option<Vec<String>>,
     owner_user_id: Option<String>,
+    version: u64,
     send: Arc<dyn Fn(Value) + Send + Sync>,
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
 }
@@ -513,6 +528,8 @@ struct Attachment {
     /// kill a viewer PTY) — never kills a shared session.
     control: Arc<dyn PtyControl>,
     actor_id: String,
+    cwd: PathBuf,
+    auth_version: u64,
     /// Transport that opened this attachment (see FrameContext::transport_id).
     transport_id: Option<String>,
     generation: u64,
@@ -533,7 +550,6 @@ struct Inner {
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
     next_generation: AtomicU64,
-    next_opening_generation: AtomicU64,
 }
 
 #[derive(Default)]
@@ -603,7 +619,6 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 next_generation: AtomicU64::new(1),
-                next_opening_generation: AtomicU64::new(1),
             }),
         }
     }
@@ -629,7 +644,6 @@ impl PtyManager {
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
                 next_generation: AtomicU64::new(1),
-                next_opening_generation: AtomicU64::new(1),
             }),
         }
     }
@@ -813,10 +827,12 @@ fn send_typed_pty_error(
 
 impl Inner {
     fn auth_snapshot(context: &FrameContext) -> AuthSnapshot {
-        let (trust, owner_user_id) = (context.live_auth)();
+        let live = (context.live_auth)();
         AuthSnapshot {
-            trust,
-            owner_user_id,
+            trust: live.trust,
+            roots: live.roots,
+            owner_user_id: live.owner_user_id,
+            version: live.version,
             send: Arc::clone(&context.send),
             buffered_amount: Arc::clone(&context.buffered_amount),
         }
@@ -828,7 +844,10 @@ impl Inner {
             return;
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
-        let opening_generation = self.next_opening_generation.fetch_add(1, Ordering::Relaxed);
+        // One monotonic domain spans reservation and attachment publication.
+        // A generation can therefore never be mistaken for a different phase
+        // of the same PTY id.
+        let opening_generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         // Do not inspect the route gate while holding the attachment map. The
         // normal publication path takes RouteGate -> attachments, so this
         // preflight must run before the reservation's opening_state ->
@@ -978,6 +997,7 @@ impl Inner {
                     &env,
                     &pty_id,
                     server_roots.as_deref(),
+                    opening_generation,
                     context,
                 )
                 .await
@@ -1006,6 +1026,7 @@ impl Inner {
                             &env,
                             &pty_id,
                             server_roots.as_deref(),
+                            opening_generation,
                             context,
                         )
                         .await
@@ -1019,6 +1040,7 @@ impl Inner {
                             &env,
                             &pty_id,
                             server_roots.as_deref(),
+                            opening_generation,
                             context,
                         )
                         .await
@@ -1033,6 +1055,14 @@ impl Inner {
             }
         };
 
+        // A provider may ignore the cancellation token while opening. Never
+        // publish a PTY after its transport has gone away; `Opened::drop`
+        // closes the provider handle and `OpeningReservation::drop` releases
+        // the id reservation.
+        if context.cancellation.is_cancelled() {
+            return;
+        }
+
         // Keep both locks held until the attachment is installed. `close`
         // takes opening_state first, so it cannot observe a gap between
         // removing the opening marker and inserting the attachment.
@@ -1044,7 +1074,6 @@ impl Inner {
             opening.ids.remove(&pty_id);
             drop(opening);
             drop(attachments);
-            reservation.active = false;
             opened.closing.store(true, Ordering::SeqCst);
             opened.control.kill();
             return;
@@ -1085,10 +1114,6 @@ impl Inner {
                 && (live_auth.owner_user_id.is_none()
                     || Some(actor) != live_auth.owner_user_id.as_deref()))
         {
-            opening.ids.remove(&pty_id);
-            if opening.cancelled.get(&pty_id) == Some(&opening_generation) {
-                opening.cancelled.remove(&pty_id);
-            }
             drop(opening);
             drop(attachments);
             reservation.active = false;
@@ -1101,8 +1126,10 @@ impl Inner {
             pty_id.clone(),
             Attachment {
                 closing: opened.closing,
-                control: opened.control,
+                control: Arc::clone(&opened.control),
                 actor_id: actor.to_owned(),
+                cwd: cwd.clone(),
+                auth_version: live_auth.version,
                 transport_id: context.transport_id.clone(),
                 generation: opened.generation,
                 publication_gate: Arc::clone(&opened.publication_gate),
@@ -1115,6 +1142,9 @@ impl Inner {
             previous.closing.store(true, Ordering::SeqCst);
             previous.control.kill();
         }
+        // Ownership transferred to the attachment. The guard remains on the
+        // Opened value only to keep the deferred start closure alive.
+        opened.cleanup_claimed.store(true, Ordering::Release);
         reservation.active = false;
         let mut opened_frame = serde_json::Map::new();
         opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
@@ -1220,7 +1250,7 @@ impl Inner {
             }
             current.clone()
         };
-        if !Self::auth_allows(&live_auth, &attachment) {
+        if !self.auth_allows(&live_auth, &attachment) {
             drop(_publication);
             self.emit_error_for_generation(
                 context,
@@ -1307,7 +1337,7 @@ impl Inner {
         // after acquiring the generation gate, then publish using this live
         // snapshot. The trust read is the exit frame's linearization point.
         let live_auth = Self::auth_snapshot(context);
-        if !Self::auth_allows(&live_auth, &attachment) {
+        if !self.auth_allows(&live_auth, &attachment) {
             drop(_publication);
             self.emit_error_for_generation(
                 context,
@@ -1481,9 +1511,15 @@ impl Inner {
         self.authorize_snapshot(pty_id, &auth, context, action)
     }
 
-    fn auth_allows(auth: &AuthSnapshot, attachment: &Attachment) -> bool {
+    fn auth_allows(&self, auth: &AuthSnapshot, attachment: &Attachment) -> bool {
         let owner = auth.owner_user_id.as_deref();
-        !auth.trust.is_empty()
+        let roots_allow_cwd = auth.roots.as_deref().is_none_or(|roots| {
+            roots.is_empty()
+                || scoped_cwd(attachment.cwd.to_str(), &self.home, Some(roots), None).is_ok()
+        });
+        auth.version >= attachment.auth_version
+            && roots_allow_cwd
+            && !auth.trust.is_empty()
             && (auth.trust != "observe"
                 || (owner.is_some() && owner == Some(attachment.actor_id.as_str())))
     }
@@ -1518,7 +1554,7 @@ impl Inner {
             }
         }
         let live_auth = Self::auth_snapshot(context);
-        if !Self::auth_allows(&live_auth, attachment) {
+        if !self.auth_allows(&live_auth, attachment) {
             drop(_publication);
             self.emit_error_for_generation(
                 context,
@@ -1541,7 +1577,26 @@ impl Inner {
         action: &str,
         generation: u64,
     ) -> Option<Attachment> {
-        self.authorize_snapshot_for_generation_mode(pty_id, auth, context, action, generation, true)
+        let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
+        if generation != 0 && attachment.generation != generation {
+            return None;
+        }
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return None;
+        }
+        if self.auth_allows(auth, &attachment) {
+            Some(attachment)
+        } else {
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
+            );
+            None
+        }
     }
 
     /// Authorization failures for an explicit CLOSE are non-terminal. The
@@ -1568,7 +1623,7 @@ impl Inner {
         if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
             return Err(NonterminalAuthorizationFailure::Missing);
         }
-        if Self::auth_allows(auth, &attachment) {
+        if self.auth_allows(auth, &attachment) {
             Ok(attachment)
         } else {
             send_pty_error(
@@ -1578,45 +1633,6 @@ impl Inner {
                 &format!("PTY {action} refused after trust change"),
             );
             Err(NonterminalAuthorizationFailure::Denied)
-        }
-    }
-
-    fn authorize_snapshot_for_generation_mode(
-        &self,
-        pty_id: &str,
-        auth: &AuthSnapshot,
-        context: &FrameContext,
-        action: &str,
-        generation: u64,
-        retire_on_denial: bool,
-    ) -> Option<Attachment> {
-        let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
-        if generation != 0 && attachment.generation != generation {
-            return None;
-        }
-        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
-            return None;
-        }
-        if Self::auth_allows(auth, &attachment) {
-            Some(attachment)
-        } else if !retire_on_denial {
-            send_pty_error(
-                context,
-                pty_id,
-                "trust_revoked",
-                &format!("PTY {action} refused after trust change"),
-            );
-            None
-        } else {
-            self.emit_error_for_generation(
-                context,
-                pty_id,
-                attachment.generation,
-                &attachment.publication_gate,
-                "trust_revoked",
-                &format!("PTY {action} refused after trust change"),
-            );
-            None
         }
     }
 
@@ -1670,7 +1686,7 @@ impl Inner {
             current.clone()
         };
         let live_auth = Self::auth_snapshot(context);
-        if !Self::auth_allows(&live_auth, &current) {
+        if !self.auth_allows(&live_auth, &current) {
             drop(_publication);
             self.emit_error_for_generation(
                 context,
@@ -1751,7 +1767,18 @@ struct Opened {
     closing: Arc<AtomicBool>,
     generation: u64,
     publication_gate: Arc<RouteGate>,
+    cleanup_claimed: Arc<AtomicBool>,
     start: Box<dyn FnOnce() + Send>,
+}
+
+impl Drop for Opened {
+    fn drop(&mut self) {
+        if !self.cleanup_claimed.swap(true, Ordering::AcqRel) {
+            // Any open that never reaches publication still owns a live PTY.
+            // Drop is the cancellation-safe fallback for every early return.
+            self.control.kill();
+        }
+    }
 }
 
 /// Own a control connection while an OPEN operation performs cancellable
@@ -1823,6 +1850,7 @@ impl Inner {
         env: &HashMap<String, String>,
         pty_id: &str,
         server_roots: Option<&[String]>,
+        generation: u64,
         context: &FrameContext,
     ) -> Result<Opened, String> {
         let socket_dir = self.deps.socket_dir();
@@ -1929,7 +1957,6 @@ impl Inner {
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
-        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let publication_gate = Arc::new(RouteGate::new());
         let (on_data, on_exit) =
             self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
@@ -1940,6 +1967,7 @@ impl Inner {
             closing: Arc::new(AtomicBool::new(false)),
             generation,
             publication_gate,
+            cleanup_claimed: Arc::new(AtomicBool::new(false)),
             start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
         })
     }
@@ -1956,6 +1984,7 @@ impl Inner {
         env: &HashMap<String, String>,
         pty_id: &str,
         server_roots: Option<&[String]>,
+        generation: u64,
         context: &FrameContext,
     ) -> Result<Opened, String> {
         let mut created = false;
@@ -2079,7 +2108,6 @@ impl Inner {
         let viewer_id = next_viewer_id();
         let released = Arc::new(AtomicBool::new(false));
         let closing = Arc::new(AtomicBool::new(false));
-        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let publication_gate = Arc::new(RouteGate::new());
         let (on_data, on_exit) =
             self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
@@ -2128,6 +2156,7 @@ impl Inner {
             closing,
             generation,
             publication_gate,
+            cleanup_claimed: Arc::new(AtomicBool::new(false)),
             start,
         })
     }
@@ -2518,6 +2547,7 @@ impl Inner {
         env: &HashMap<String, String>,
         pty_id: &str,
         server_roots: Option<&[String]>,
+        generation: u64,
         context: &FrameContext,
     ) -> Result<Option<Opened>, (RelayPtyErrorCode, String)> {
         let socket_dir = self.deps.socket_dir();
@@ -2670,7 +2700,6 @@ impl Inner {
 
         let proxy =
             Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
-        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
         let publication_gate = Arc::new(RouteGate::new());
         let (on_data, _) = self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
         let relay = Arc::clone(&self);
@@ -2706,6 +2735,7 @@ impl Inner {
             closing: Arc::new(AtomicBool::new(false)),
             generation,
             publication_gate,
+            cleanup_claimed: Arc::new(AtomicBool::new(false)),
             start: Box::new(move || start_stream.go_live(on_data, on_exit)),
         }))
     }
@@ -3145,7 +3175,11 @@ mod tests {
                 trust: trust.to_owned(),
                 local_roots: None,
                 owner_user_id: owner,
-                live_auth: Arc::new(move || (live_trust.clone(), live_owner.clone())),
+                live_auth: Arc::new(move || LiveAuth {
+                    trust: live_trust.clone(),
+                    owner_user_id: live_owner.clone(),
+                    ..Default::default()
+                }),
                 transport_id: None,
                 cancellation: CancellationToken::new(),
             }
@@ -3299,8 +3333,7 @@ mod tests {
     #[tokio::test]
     async fn stale_cancellation_marker_cannot_cancel_a_reused_open_generation() {
         let h = harness(None, None);
-        let stale_generation =
-            h.manager.inner.next_opening_generation.fetch_add(1, Ordering::Relaxed);
+        let stale_generation = h.manager.inner.next_generation.fetch_add(1, Ordering::Relaxed);
         h.manager
             .inner
             .opening_state
@@ -3316,7 +3349,7 @@ mod tests {
     #[test]
     fn legacy_close_cancels_a_transport_owned_pending_open() {
         let h = harness(None, None);
-        let generation = h.manager.inner.next_opening_generation.fetch_add(1, Ordering::Relaxed);
+        let generation = h.manager.inner.next_generation.fetch_add(1, Ordering::Relaxed);
         h.manager.inner.opening_state.lock().unwrap().ids.insert(
             "p1".to_owned(),
             OpeningEntry { transport_id: Some("transport-a".to_owned()), generation },
@@ -3414,7 +3447,11 @@ mod tests {
     #[tokio::test]
     async fn output_after_live_trust_downgrade_is_not_forwarded() {
         let h = harness(None, None);
-        let live_auth = Arc::new(StdMutex::new(("supervised".to_owned(), h.owner.clone())));
+        let live_auth = Arc::new(StdMutex::new(LiveAuth {
+            trust: "supervised".to_owned(),
+            owner_user_id: h.owner.clone(),
+            ..Default::default()
+        }));
         let mut context = h.context("supervised", h.owner.clone());
         let live_auth_for_context = Arc::clone(&live_auth);
         context.live_auth = Arc::new(move || live_auth_for_context.lock().unwrap().clone());
@@ -3446,9 +3483,17 @@ mod tests {
         context.live_auth = Arc::new(move || {
             let call = calls_for_context.fetch_add(1, Ordering::SeqCst);
             if call >= 2 {
-                ("observe".to_owned(), owner.clone())
+                LiveAuth {
+                    trust: "observe".to_owned(),
+                    owner_user_id: owner.clone(),
+                    ..Default::default()
+                }
             } else {
-                ("supervised".to_owned(), owner.clone())
+                LiveAuth {
+                    trust: "supervised".to_owned(),
+                    owner_user_id: owner.clone(),
+                    ..Default::default()
+                }
             }
         });
         let frame = serde_json::json!({
@@ -3471,7 +3516,11 @@ mod tests {
     async fn live_trust_rejection_clears_open_reservation() {
         let h = harness(None, None);
         let mut context = h.context("supervised", h.owner.clone());
-        context.live_auth = Arc::new(|| ("observe".to_owned(), Some("user_owner".to_owned())));
+        context.live_auth = Arc::new(|| LiveAuth {
+            trust: "observe".to_owned(),
+            owner_user_id: Some("user_owner".to_owned()),
+            ..Default::default()
+        });
         let frame = serde_json::json!({
             "version": 4,
             "type": "pty_open",

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -447,6 +447,11 @@ struct Attachment {
     actor_id: String,
     /// Transport that opened this attachment (see FrameContext::transport_id).
     transport_id: Option<String>,
+    /// Monotonic identity for the callback route associated with this
+    /// attachment. A PTY source can outlive a detach and later invoke its old
+    /// sink after the same `ptyId` has been reopened; the route prevents that
+    /// stale callback from addressing the replacement attachment.
+    route_id: u64,
 }
 
 struct Inner {
@@ -565,7 +570,9 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) = self.inner.authorize_snapshot(pty_id, &auth, context, "input") {
+                if let Some(attachment) =
+                    self.inner.authorize_snapshot(pty_id, &auth, context, "input", None)
+                {
                     attachment.control.write(&data);
                 }
             }
@@ -579,7 +586,9 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) = self.inner.authorize_snapshot(pty_id, &auth, context, "resize") {
+                if let Some(attachment) =
+                    self.inner.authorize_snapshot(pty_id, &auth, context, "resize", None)
+                {
                     attachment.control.resize(cols, rows);
                 }
             }
@@ -589,7 +598,9 @@ impl PtyManager {
                     return;
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
-                if let Some(attachment) = self.inner.authorize_snapshot(pty_id, &auth, context, "flow") {
+                if let Some(attachment) =
+                    self.inner.authorize_snapshot(pty_id, &auth, context, "flow", None)
+                {
                     if pause {
                         attachment.control.pause();
                     } else {
@@ -602,7 +613,7 @@ impl PtyManager {
                 if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
                     return;
                 }
-                if self.inner.authorize_snapshot(pty_id, &auth, context, "close").is_some() {
+                if self.inner.authorize_snapshot(pty_id, &auth, context, "close", None).is_some() {
                     self.inner.close(pty_id);
                 }
             }
@@ -882,6 +893,7 @@ impl Inner {
                 control: opened.control,
                 actor_id: actor.to_owned(),
                 transport_id: context.transport_id.clone(),
+                route_id: opened.route_id,
             },
         );
         if let Some(previous) = previous {
@@ -910,28 +922,50 @@ impl Inner {
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
-    fn sinks(self: &Arc<Self>, pty_id: &str, context: &FrameContext) -> (DataSink, ExitSink) {
+    fn sinks(self: &Arc<Self>, pty_id: &str, context: &FrameContext) -> (DataSink, ExitSink, u64) {
+        let route_id = next_attachment_route_id();
         let on_data = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            let auth = AuthSnapshot { trust: context.trust.clone(), owner_user_id: context.owner_user_id.clone(), send: Arc::clone(&context.send), buffered_amount: Arc::clone(&context.buffered_amount) };
-            Arc::new(move |chunk: Bytes| inner.emit_output(&pty_id, &chunk, &context, &auth))
-                as Arc<dyn Fn(Bytes) + Send + Sync>
+            let auth = AuthSnapshot {
+                trust: context.trust.clone(),
+                owner_user_id: context.owner_user_id.clone(),
+                send: Arc::clone(&context.send),
+                buffered_amount: Arc::clone(&context.buffered_amount),
+            };
+            Arc::new(move |chunk: Bytes| {
+                inner.emit_output(&pty_id, &chunk, &context, &auth, route_id)
+            }) as Arc<dyn Fn(Bytes) + Send + Sync>
         };
         let on_exit = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            let auth = AuthSnapshot { trust: context.trust.clone(), owner_user_id: context.owner_user_id.clone(), send: Arc::clone(&context.send), buffered_amount: Arc::clone(&context.buffered_amount) };
-            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context, &auth))
+            let auth = AuthSnapshot {
+                trust: context.trust.clone(),
+                owner_user_id: context.owner_user_id.clone(),
+                send: Arc::clone(&context.send),
+                buffered_amount: Arc::clone(&context.buffered_amount),
+            };
+            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context, &auth, route_id))
                 as Arc<dyn Fn(i64) + Send + Sync>
         };
-        (on_data, on_exit)
+        (on_data, on_exit, route_id)
     }
 
-    fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext, auth: &AuthSnapshot) {
-        if self.authorize_snapshot(pty_id, auth, context, "output").is_none() {
+    fn emit_output(
+        &self,
+        pty_id: &str,
+        chunk: &Bytes,
+        context: &FrameContext,
+        auth: &AuthSnapshot,
+        route_id: u64,
+    ) {
+        if !self.route_is_current(pty_id, route_id) {
+            return;
+        }
+        if self.authorize_snapshot(pty_id, auth, context, "output", Some(route_id)).is_none() {
             return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
@@ -944,16 +978,22 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            self.close(pty_id);
-            send_pty_error(
-                context,
-                pty_id,
-                "failed",
-                &format!(
-                    "dropped: {buffered} bytes buffered toward the server (cap {})",
-                    self.output_cap
-                ),
-            );
+            if self.close_route(pty_id, route_id) {
+                send_pty_error(
+                    context,
+                    pty_id,
+                    "failed",
+                    &format!(
+                        "dropped: {buffered} bytes buffered toward the server (cap {})",
+                        self.output_cap
+                    ),
+                );
+            }
+            return;
+        }
+        // Re-check after the backpressure probe. A concurrent replacement may
+        // have invalidated this route while the probe ran.
+        if !self.route_is_current(pty_id, route_id) {
             return;
         }
         (auth.send)(json!({
@@ -964,13 +1004,25 @@ impl Inner {
         }));
     }
 
-    fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext, auth: &AuthSnapshot) {
-        if self.authorize_snapshot(pty_id, auth, context, "exit").is_none() {
+    fn emit_exit(
+        &self,
+        pty_id: &str,
+        code: i64,
+        context: &FrameContext,
+        auth: &AuthSnapshot,
+        route_id: u64,
+    ) {
+        if !self.route_is_current(pty_id, route_id) {
+            return;
+        }
+        if self.authorize_snapshot(pty_id, auth, context, "exit", Some(route_id)).is_none() {
             return;
         }
         let mut attachments = self.attachments.lock().expect("attach lock");
         match attachments.get(pty_id) {
-            Some(attachment) if !attachment.closing.load(Ordering::SeqCst) => {}
+            Some(attachment)
+                if attachment.route_id == route_id
+                    && !attachment.closing.load(Ordering::SeqCst) => {}
             _ => return,
         }
         attachments.remove(pty_id);
@@ -1003,6 +1055,33 @@ impl Inner {
         }
     }
 
+    /// Remove and release an attachment only when the caller still owns its
+    /// callback route. This keeps an old PTY source from closing a replacement
+    /// that reused the same protocol id.
+    fn close_route(&self, pty_id: &str, route_id: u64) -> bool {
+        let attachment = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            if attachments.get(pty_id).is_some_and(|attachment| attachment.route_id == route_id) {
+                attachments.remove(pty_id)
+            } else {
+                None
+            }
+        };
+        if let Some(attachment) = attachment {
+            attachment.closing.store(true, Ordering::SeqCst);
+            attachment.control.kill();
+            true
+        } else {
+            false
+        }
+    }
+
+    fn route_is_current(&self, pty_id: &str, route_id: u64) -> bool {
+        self.attachments.lock().expect("attach lock").get(pty_id).is_some_and(|attachment| {
+            attachment.route_id == route_id && !attachment.closing.load(Ordering::SeqCst)
+        })
+    }
+
     /// Frame-level transport fence. Unknown ids retain the protocol's silent
     /// no-op behavior; once an id is reserved or attached, a different
     /// transport may not act on it. A `None` caller owns everything (legacy).
@@ -1023,8 +1102,14 @@ impl Inner {
         auth: &AuthSnapshot,
         context: &FrameContext,
         action: &str,
+        route_id: Option<u64>,
     ) -> Option<Attachment> {
         let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
+        if route_id.is_some_and(|route_id| attachment.route_id != route_id) {
+            // A callback from a detached source is stale. It must not emit an
+            // error through its old transport or touch the replacement.
+            return None;
+        }
         let owner = auth.owner_user_id.as_deref();
         let allowed = !auth.trust.is_empty()
             && (auth.trust != "observe"
@@ -1033,7 +1118,11 @@ impl Inner {
             Some(attachment)
         } else {
             if action != "close" {
-                self.close(pty_id);
+                if let Some(route_id) = route_id {
+                    self.close_route(pty_id, route_id);
+                } else {
+                    self.close(pty_id);
+                }
             }
             send_pty_error(
                 context,
@@ -1044,7 +1133,6 @@ impl Inner {
             None
         }
     }
-
 }
 
 /// A resolved open: what to echo, plus a deferred `start` that begins output.
@@ -1053,6 +1141,7 @@ struct Opened {
     surface: Option<String>,
     control: Arc<dyn PtyControl>,
     closing: Arc<AtomicBool>,
+    route_id: u64,
     start: Box<dyn FnOnce() + Send>,
 }
 
@@ -1192,12 +1281,13 @@ impl Inner {
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
-        let (on_data, on_exit) = self.sinks(pty_id, context);
+        let (on_data, on_exit, route_id) = self.sinks(pty_id, context);
         Ok(Opened {
             created: ensured.created,
             surface: None,
             control,
             closing: Arc::new(AtomicBool::new(false)),
+            route_id,
             start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
         })
     }
@@ -1337,7 +1427,7 @@ impl Inner {
         let viewer_id = next_viewer_id();
         let released = Arc::new(AtomicBool::new(false));
         let closing = Arc::new(AtomicBool::new(false));
-        let (on_data, on_exit) = self.sinks(pty_id, context);
+        let (on_data, on_exit, route_id) = self.sinks(pty_id, context);
 
         // The per-attachment control proxies onto the session pty but its
         // kill() only unhooks this viewer (release), never the session.
@@ -1376,7 +1466,7 @@ impl Inner {
             }
         });
 
-        Ok(Opened { created, surface: None, control: proxy, closing, start })
+        Ok(Opened { created, surface: None, control: proxy, closing, route_id, start })
     }
 }
 
@@ -1413,6 +1503,11 @@ impl PtyControl for ShellViewerControl {
 }
 
 fn next_viewer_id() -> u64 {
+    static NEXT: AtomicU64 = AtomicU64::new(1);
+    NEXT.fetch_add(1, Ordering::Relaxed)
+}
+
+fn next_attachment_route_id() -> u64 {
     static NEXT: AtomicU64 = AtomicU64::new(1);
     NEXT.fetch_add(1, Ordering::Relaxed)
 }
@@ -1909,22 +2004,36 @@ impl Inner {
         }
 
         let proxy = Arc::new(ControlTerminalControl { control, surface_id });
-        let (on_data, _) = self.sinks(pty_id, context);
+        let (on_data, _, route_id) = self.sinks(pty_id, context);
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
         let pty_id_for_exit = pty_id.to_owned();
         let stream_for_exit = Arc::clone(&stream);
+        let route_id_for_exit = route_id;
         let on_exit: ExitSink = Arc::new(move |code| {
             if stream_for_exit.overflowed() {
-                relay.close(&pty_id_for_exit);
-                send_pty_error(
-                    &context_for_exit,
-                    &pty_id_for_exit,
-                    "overflow",
-                    "pty output backlog overflowed; reattach to continue receiving output",
-                );
+                if relay.close_route(&pty_id_for_exit, route_id_for_exit) {
+                    send_pty_error(
+                        &context_for_exit,
+                        &pty_id_for_exit,
+                        "overflow",
+                        "pty output backlog overflowed; reattach to continue receiving output",
+                    );
+                }
             } else {
-                relay.emit_exit(&pty_id_for_exit, code, &context_for_exit);
+                let auth = AuthSnapshot {
+                    trust: context_for_exit.trust.clone(),
+                    owner_user_id: context_for_exit.owner_user_id.clone(),
+                    send: Arc::clone(&context_for_exit.send),
+                    buffered_amount: Arc::clone(&context_for_exit.buffered_amount),
+                };
+                relay.emit_exit(
+                    &pty_id_for_exit,
+                    code,
+                    &context_for_exit,
+                    &auth,
+                    route_id_for_exit,
+                );
             }
         });
         let start_stream = Arc::clone(&stream);
@@ -1933,6 +2042,7 @@ impl Inner {
             surface: Some(surface_ref.to_owned()),
             control: proxy,
             closing: Arc::new(AtomicBool::new(false)),
+            route_id,
             start: Box::new(move || start_stream.go_live(on_data, on_exit)),
         }))
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2299,11 +2299,16 @@ fn drive_handle(
     banner: Option<Vec<u8>>,
     on_data: DataSink,
     on_exit: ExitSink,
+    ready: impl FnOnce(),
 ) {
     if let Some(banner) = banner {
         emit_bounded_bytes(&on_data, Bytes::from(banner));
     }
     output.subscribe(on_data, on_exit);
+    // Signal readiness only after the output source owns both callbacks. A
+    // fast PTY can emit output or exit during subscribe, so signaling before
+    // this point lets the OPEN response race those first events.
+    ready();
 }
 
 fn emit_bounded_bytes(on_data: &DataSink, bytes: Bytes) {
@@ -2462,8 +2467,7 @@ impl Inner {
                 claimed: AtomicBool::new(false),
             }),
             start: Box::new(move |ready| {
-                ready();
-                drive_handle(output, banner, on_data, on_exit);
+                drive_handle(output, banner, on_data, on_exit, ready);
             }),
         })
     }
@@ -3492,6 +3496,8 @@ mod tests {
     struct FakeState {
         on_data: Option<DataSink>,
         on_exit: Option<ExitSink>,
+        subscribe_output: Option<Bytes>,
+        subscribe_exit: Option<i64>,
         written: Vec<Vec<u8>>,
         write_entered: Option<TestArc<Barrier>>,
         write_release: Option<TestArc<Barrier>>,
@@ -3556,9 +3562,18 @@ mod tests {
 
     impl PtyOutput for FakePty {
         fn subscribe(&self, on_data: DataSink, on_exit: ExitSink) {
-            let mut state = self.state.lock().unwrap();
-            state.on_data = Some(on_data);
-            state.on_exit = Some(on_exit);
+            let (subscribe_output, subscribe_exit) = {
+                let mut state = self.state.lock().unwrap();
+                state.on_data = Some(on_data.clone());
+                state.on_exit = Some(on_exit.clone());
+                (state.subscribe_output.take(), state.subscribe_exit.take())
+            };
+            if let Some(output) = subscribe_output {
+                on_data(output);
+            }
+            if let Some(code) = subscribe_exit {
+                on_exit(code);
+            }
         }
     }
 
@@ -3567,6 +3582,8 @@ mod tests {
         spawned: Vec<FakePty>,
         daemons: Vec<(String, PathBuf)>,
         connected: Vec<PathBuf>,
+        subscribe_output: Option<Bytes>,
+        subscribe_exit: Option<i64>,
     }
 
     struct FakeDeps {
@@ -3582,8 +3599,16 @@ mod tests {
     #[async_trait]
     impl PtyDeps for FakeDeps {
         async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle {
+            let (subscribe_output, subscribe_exit) = {
+                let mut recorded = self.recorded.lock().unwrap();
+                (recorded.subscribe_output.take(), recorded.subscribe_exit.take())
+            };
             let pty = FakePty {
-                state: Arc::new(StdMutex::new(FakeState::default())),
+                state: Arc::new(StdMutex::new(FakeState {
+                    subscribe_output,
+                    subscribe_exit,
+                    ..FakeState::default()
+                })),
                 spawn_file: spec.file.clone(),
                 spawn_cwd: spec.cwd.path.clone(),
                 spawn_term: spec.env.get("TERM").cloned().unwrap_or_default(),
@@ -3817,6 +3842,13 @@ mod tests {
         }
         fn connected(&self) -> Vec<PathBuf> {
             self.recorded.lock().unwrap().connected.clone()
+        }
+
+        fn configure_subscribe_race(&self, output: Option<&str>, exit: Option<i64>) {
+            let mut recorded = self.recorded.lock().unwrap();
+            recorded.subscribe_output =
+                output.map(|value| Bytes::copy_from_slice(value.as_bytes()));
+            recorded.subscribe_exit = exit;
         }
     }
 
@@ -4436,6 +4468,24 @@ mod tests {
         let viewer = h.spawned()[0].clone();
         h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
         assert!(viewer.state.lock().unwrap().killed);
+    }
+
+    #[tokio::test]
+    async fn cmux_open_readiness_waits_for_fast_output_and_exit_subscriptions() {
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let h = harness(Some(cmux), None);
+        h.configure_subscribe_race(Some("fast output"), Some(0));
+
+        h.open("p1", "work", Value::Null, "supervised", h.owner.clone()).await;
+
+        let sent = h.sent();
+        assert_eq!(sent.first().map(ty), Some("pty_opened"));
+        assert!(sent.iter().any(|frame| {
+            ty(frame) == "pty_output"
+                && from_b64(frame["dataB64"].as_str().unwrap_or_default()) == "fast output"
+        }));
+        assert!(sent.iter().any(|frame| ty(frame) == "pty_exit" && frame["code"] == 0));
+        assert!(!h.manager.has_attachment("p1"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1112,7 +1112,6 @@ impl Inner {
         if !self.auth_allows_claim(&live_auth, actor, &cwd, 0) {
             drop(opening);
             drop(attachments);
-            reservation.active = false;
             opened.closing.store(true, Ordering::SeqCst);
             opened.control.kill();
             fail("trust_revoked", "terminal trust changed while opening");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -462,7 +462,6 @@ struct Inner {
     cancelled_openings: Mutex<std::collections::HashSet<String>>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
-    auth: Mutex<Option<AuthSnapshot>>,
 }
 
 struct ShellStartReservation {
@@ -513,7 +512,6 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
             }),
         }
     }
@@ -539,19 +537,18 @@ impl PtyManager {
                 cancelled_openings: Mutex::new(std::collections::HashSet::new()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
-                auth: Mutex::new(None),
             }),
         }
     }
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        *self.inner.auth.lock().expect("auth lock") = Some(AuthSnapshot {
+        let auth = AuthSnapshot {
             trust: context.trust.clone(),
             owner_user_id: context.owner_user_id.clone(),
             send: Arc::clone(&context.send),
             buffered_amount: Arc::clone(&context.buffered_amount),
-        });
+        };
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,
@@ -568,7 +565,7 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
+                if let Some(attachment) = self.inner.authorize_snapshot(pty_id, &auth, context, "input") {
                     attachment.control.write(&data);
                 }
             }
@@ -582,7 +579,7 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
+                if let Some(attachment) = self.inner.authorize_snapshot(pty_id, &auth, context, "resize") {
                     attachment.control.resize(cols, rows);
                 }
             }
@@ -592,7 +589,7 @@ impl PtyManager {
                     return;
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
-                if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
+                if let Some(attachment) = self.inner.authorize_snapshot(pty_id, &auth, context, "flow") {
                     if pause {
                         attachment.control.pause();
                     } else {
@@ -605,7 +602,8 @@ impl PtyManager {
                 if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
                     return;
                 }
-                self.inner.close_authorized(pty_id, context);
+                let _ = self.inner.authorize_snapshot(pty_id, &auth, context, "close");
+                self.inner.close(pty_id);
             }
             "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
             _ => {}
@@ -916,22 +914,23 @@ impl Inner {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            Arc::new(move |chunk: Bytes| inner.emit_output(&pty_id, &chunk, &context))
+            let auth = AuthSnapshot { trust: context.trust.clone(), owner_user_id: context.owner_user_id.clone(), send: Arc::clone(&context.send), buffered_amount: Arc::clone(&context.buffered_amount) };
+            Arc::new(move |chunk: Bytes| inner.emit_output(&pty_id, &chunk, &context, &auth))
                 as Arc<dyn Fn(Bytes) + Send + Sync>
         };
         let on_exit = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context))
+            let auth = AuthSnapshot { trust: context.trust.clone(), owner_user_id: context.owner_user_id.clone(), send: Arc::clone(&context.send), buffered_amount: Arc::clone(&context.buffered_amount) };
+            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context, &auth))
                 as Arc<dyn Fn(i64) + Send + Sync>
         };
         (on_data, on_exit)
     }
 
-    fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
-        if self.authorize_snapshot(pty_id, &auth, context, "output").is_none() {
+    fn emit_output(&self, pty_id: &str, chunk: &Bytes, context: &FrameContext, auth: &AuthSnapshot) {
+        if self.authorize_snapshot(pty_id, auth, context, "output").is_none() {
             return;
         }
         // Zero-byte chunks carry nothing and historically crashed the web
@@ -964,9 +963,8 @@ impl Inner {
         }));
     }
 
-    fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext) {
-        let Some(auth) = self.auth.lock().expect("auth lock").clone() else { return };
-        if self.authorize_snapshot(pty_id, &auth, context, "exit").is_none() {
+    fn emit_exit(&self, pty_id: &str, code: i64, context: &FrameContext, auth: &AuthSnapshot) {
+        if self.authorize_snapshot(pty_id, auth, context, "exit").is_none() {
             return;
         }
         let mut attachments = self.attachments.lock().expect("attach lock");
@@ -1018,11 +1016,6 @@ impl Inner {
         true
     }
 
-    fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
-        let auth = self.auth.lock().expect("auth lock").clone()?;
-        self.authorize_snapshot(pty_id, &auth, context, action)
-    }
-
     fn authorize_snapshot(
         &self,
         pty_id: &str,
@@ -1050,7 +1043,6 @@ impl Inner {
     }
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
-        let _ = self.authorize(pty_id, context, "close");
         self.close(pty_id);
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2278,9 +2278,18 @@ fn drive_handle(
     on_exit: ExitSink,
 ) {
     if let Some(banner) = banner {
-        on_data(Bytes::from(banner));
+        emit_bounded_bytes(&on_data, Bytes::from(banner));
     }
     output.subscribe(on_data, on_exit);
+}
+
+fn emit_bounded_bytes(on_data: &DataSink, bytes: Bytes) {
+    let mut offset = 0;
+    while offset < bytes.len() {
+        let end = (offset + MAX_OUTPUT_CHUNK_BYTES).min(bytes.len());
+        on_data(bytes.slice(offset..end));
+        offset = end;
+    }
 }
 
 impl Inner {
@@ -2607,10 +2616,10 @@ impl Inner {
             // Subsequent PTY output therefore waits behind replay callbacks.
             ready();
             if let Some(banner) = banner {
-                on_data(Bytes::from(banner));
+                emit_bounded_bytes(&on_data, Bytes::from(banner));
             }
             if let Some(replay) = replay {
-                on_data(Bytes::from(replay));
+                emit_bounded_bytes(&on_data, Bytes::from(replay));
             }
             if released.load(Ordering::SeqCst) {
                 return;
@@ -4232,6 +4241,59 @@ mod tests {
         assert!(replay.len() <= 32 + 20);
         assert!(replay.contains("chunk-9"));
         assert!(!replay.contains("chunk-0"));
+    }
+
+    #[tokio::test]
+    async fn large_scrollback_replay_is_split_into_bounded_frames() {
+        let home = TestDirectory::new("large-scrollback");
+        let home_path = home.path.clone();
+        let env = env_map(&home_path);
+        let recorded = Arc::new(StdMutex::new(Recorded::default()));
+        let deps = Arc::new(FakeDeps {
+            env: env.clone(),
+            recorded: Arc::clone(&recorded),
+            resolve: None,
+            socket_dir: PathBuf::from("/run/cmux-tui-501"),
+            read_dir: None,
+            ensure_socket_path: None,
+            control: None,
+        });
+        let manager = PtyManager::with_limits(
+            deps,
+            home_path.clone(),
+            env,
+            MAX_PTYS,
+            MAX_OUTPUT_CHUNK_BYTES * 2 + 5,
+            OUTPUT_BUFFER_CAP,
+        );
+        let h = Harness {
+            manager,
+            recorded,
+            sent: Arc::new(StdMutex::new(Vec::new())),
+            buffered: Arc::new(AtomicU64::new(0)),
+            owner: Some("user_owner".to_owned()),
+            home: home_path,
+            _home: home,
+        };
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        pty.emit(&"x".repeat(MAX_OUTPUT_CHUNK_BYTES * 2 + 5));
+        let before = h.sent().len();
+        h.open("p2", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let frames: Vec<Value> = h.sent()[before..]
+            .iter()
+            .filter(|frame| frame["type"] == "pty_output")
+            .cloned()
+            .collect();
+        assert!(frames.len() >= 2);
+        assert!(frames.iter().all(|frame| {
+            BASE64
+                .decode(frame["dataB64"].as_str().unwrap_or_default())
+                .map(|bytes| bytes.len() <= MAX_OUTPUT_CHUNK_BYTES)
+                .unwrap_or(false)
+        }));
+        assert!(!h.sent().iter().any(|frame| frame["code"] == "failed"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3442,6 +3442,26 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_trust_rejection_clears_open_reservation() {
+        let h = harness(None, None);
+        let mut context = h.context("supervised", h.owner.clone());
+        context.live_auth = Arc::new(|| ("observe".to_owned(), Some("user_owner".to_owned())));
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_other",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        assert_eq!(h.manager.opening_count(), 0);
+        assert!(!h.manager.has_attachment("p1"));
+        assert!(h.sent().iter().any(|frame| frame["code"] == "trust_revoked"));
+    }
+
+    #[tokio::test]
     async fn close_requires_current_trust() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1308,18 +1308,32 @@ impl Inner {
 
         // Output only AFTER pty_opened (ordering): banner, then scrollback
         // replay, then live bytes.
+        let generation = opened.generation;
+        let publication_gate = Arc::clone(&opened.publication_gate);
         let start = opened.start;
         // Do not hold the frame handler open for the lifetime of a live PTY
         // stream. Wait only until the sink is installed, then let the
         // generation fence and control kill own its lifecycle.
         let (started_tx, started_rx) = oneshot::channel();
-        let _ = std::thread::Builder::new().name("chatmux-relay-pty-start".to_owned()).spawn(
-            move || {
+        let start_result = std::thread::Builder::new()
+            .name("chatmux-relay-pty-start".to_owned())
+            .spawn(move || {
                 start(Box::new(move || {
                     let _ = started_tx.send(());
                 }));
-            },
-        );
+            });
+        if start_result.is_err() {
+            self.emit_error_for_generation_async(
+                context,
+                &pty_id,
+                generation,
+                &publication_gate,
+                "failed",
+                "PTY output start could not be scheduled",
+            )
+            .await;
+            return;
+        }
         let _ = started_rx.await;
     }
 
@@ -1647,20 +1661,6 @@ impl Inner {
         // Terminal publication retires the viewer. Killing is idempotent for
         // an already-exited PTY and releases an overflowed or revoked one.
         attachment.control.kill();
-    }
-
-    /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
-    fn close(&self, pty_id: &str) {
-        // Match `open`'s lock order. If opening still owns the reservation,
-        // record cancellation and let it dispose the newly opened PTY.
-        let mut opening = self.opening_state.lock().expect("opening state lock");
-        if opening.ids.contains_key(pty_id) {
-            let generation = opening.ids.get(pty_id).expect("opening entry").generation;
-            opening.cancelled.insert(pty_id.to_owned(), generation);
-            return;
-        }
-        drop(opening);
-        self.close_exact(pty_id, None, None);
     }
 
     fn close_if_transport(
@@ -2110,16 +2110,6 @@ impl Inner {
             return;
         }
         self.close_exact_authorized(pty_id, attachment, context);
-    }
-
-    fn close_if_generation(&self, pty_id: &str, generation: u64) {
-        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
-            return;
-        };
-        if attachment.generation == generation {
-            self.close_exact(pty_id, Some(generation), Some(&attachment.publication_gate));
-        }
     }
 
     fn close_exact(
@@ -4735,10 +4725,12 @@ mod tests {
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
         let replacement_for_task = replacement.clone();
         let frame_for_replacement = frame.clone();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let replacement_task = tokio::spawn(async move {
+            let _ = started.send(());
             manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("replacement task started");
         assert!(
             !replacement_task.is_finished(),
             "same-ID replacement must wait for the closing publication"
@@ -4821,10 +4813,12 @@ mod tests {
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
         let replacement_for_task = replacement.clone();
         let frame_for_replacement = frame.clone();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let replacement_task = tokio::spawn(async move {
+            let _ = started.send(());
             manager.handle_frame(&frame_for_replacement, &replacement_for_task).await;
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("replacement task started");
         assert!(!replacement_task.is_finished());
         assert!(!h.sent().iter().any(|frame| {
             frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
@@ -4863,7 +4857,13 @@ mod tests {
 
         let close_context = h.context("supervised", h.owner.clone());
         let manager = h.manager.inner.clone();
-        let close = thread::spawn(move || manager.close_authorized("p1", &close_context));
+        let started = TestArc::new(Barrier::new(2));
+        let close_started = TestArc::clone(&started);
+        let close = thread::spawn(move || {
+            close_started.wait();
+            manager.close_authorized("p1", &close_context);
+        });
+        started.wait();
         assert!(!close.is_finished(), "close must wait for the publication gate");
 
         release.wait();
@@ -4986,9 +4986,13 @@ mod tests {
 
         let close_context = h.context("supervised", h.owner.clone());
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let close_started = TestArc::new(Barrier::new(2));
+        let close_started_in_thread = TestArc::clone(&close_started);
         let close = thread::spawn(move || {
+            close_started_in_thread.wait();
             manager.inner.close_authorized("p1", &close_context);
         });
+        close_started.wait();
         assert!(!close.is_finished(), "close must wait for the in-flight control operation");
 
         h.manager.handle_frame(&frame, &h.context("supervised", h.owner.clone())).await;
@@ -5038,10 +5042,13 @@ mod tests {
             async move { manager.handle_frame(&input, &context).await }
         });
         entered.wait();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let close_task = tokio::spawn({
             let manager = h.manager.clone();
             let context = h.context("supervised", h.owner.clone());
+            let started = started;
             async move {
+                let _ = started.send(());
                 manager
                     .handle_frame(
                         &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
@@ -5050,7 +5057,7 @@ mod tests {
                     .await;
             }
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("close task started");
         assert!(!close_task.is_finished(), "close waits for the in-flight control operation");
         release.wait();
         input_task.await.expect("input operation");
@@ -5105,10 +5112,12 @@ mod tests {
         entered.wait();
 
         let manager = h.manager.clone();
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let detach = tokio::spawn(async move {
+            let _ = started.send(());
             manager.detach_transport_async("transport-a").await;
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("detach task started");
         assert!(!detach.is_finished(), "detach must wait for the publication gate");
 
         let tick = tokio::spawn(async { 17_u8 });
@@ -5156,10 +5165,12 @@ mod tests {
         entered.wait();
         let output_during_start = thread::spawn(move || shell.emit("during-start"));
 
+        let (started, started_rx) = tokio::sync::oneshot::channel();
         let close = tokio::spawn({
             let manager = h.manager.clone();
             let context = h.context("supervised", h.owner.clone());
             async move {
+                let _ = started.send(());
                 manager
                     .handle_frame(
                         &serde_json::json!({ "type": "pty_close", "ptyId": "p1" }),
@@ -5168,7 +5179,7 @@ mod tests {
                     .await;
             }
         });
-        tokio::task::yield_now().await;
+        started_rx.await.expect("close task started");
         assert!(!close.is_finished(), "close must wait for the replay callback");
 
         release.wait();

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -26,7 +26,8 @@ use std::fs::File;
 use std::os::fd::AsRawFd;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Condvar, Mutex};
+use std::thread::ThreadId;
 use tokio::sync::Notify;
 use tokio_util::sync::CancellationToken;
 
@@ -441,6 +442,56 @@ struct ShellInner {
     viewers: Vec<ViewerSink>,
 }
 
+/// A reentrant publication gate for one attachment generation. The gate
+/// serializes route publication and control operations across threads while
+/// allowing an outbound/control callback to synchronously re-enter the same
+/// route (for example, a test sink that closes the PTY).
+struct RouteGate {
+    state: Mutex<RouteGateState>,
+    changed: Condvar,
+}
+
+#[derive(Default)]
+struct RouteGateState {
+    owner: Option<ThreadId>,
+    depth: usize,
+}
+
+struct RouteGuard<'a> {
+    gate: &'a RouteGate,
+    owner: ThreadId,
+}
+
+impl RouteGate {
+    fn new() -> Self {
+        Self { state: Mutex::new(RouteGateState::default()), changed: Condvar::new() }
+    }
+
+    fn lock(&self) -> RouteGuard<'_> {
+        let owner = std::thread::current().id();
+        let mut state = self.state.lock().expect("route gate lock");
+        while state.owner.is_some_and(|current| current != owner) {
+            state = self.changed.wait(state).expect("route gate wait");
+        }
+        state.owner = Some(owner);
+        state.depth += 1;
+        drop(state);
+        RouteGuard { gate: self, owner }
+    }
+}
+
+impl Drop for RouteGuard<'_> {
+    fn drop(&mut self) {
+        let mut state = self.gate.state.lock().expect("route gate lock");
+        debug_assert_eq!(state.owner, Some(self.owner));
+        state.depth = state.depth.saturating_sub(1);
+        if state.depth == 0 {
+            state.owner = None;
+            self.gate.changed.notify_all();
+        }
+    }
+}
+
 #[derive(Clone)]
 struct Attachment {
     closing: Arc<AtomicBool>,
@@ -451,7 +502,7 @@ struct Attachment {
     /// Transport that opened this attachment (see FrameContext::transport_id).
     transport_id: Option<String>,
     generation: u64,
-    publication_gate: Arc<Mutex<()>>,
+    publication_gate: Arc<RouteGate>,
 }
 
 struct Inner {
@@ -950,21 +1001,6 @@ impl Inner {
             }
         };
 
-        // Re-read authority after slow daemon/PTY work. A trust downgrade can
-        // arrive while OPEN is pending, so the original frame context is not
-        // sufficient to admit the attachment.
-        let live_auth = Self::auth_snapshot(context);
-        if live_auth.trust.is_empty()
-            || (live_auth.trust == "observe"
-                && (live_auth.owner_user_id.is_none()
-                    || Some(actor) != live_auth.owner_user_id.as_deref()))
-        {
-            opened.closing.store(true, Ordering::SeqCst);
-            opened.control.kill();
-            fail("trust_revoked", "terminal trust changed while opening");
-            return;
-        }
-
         // Keep both locks held until the attachment is installed. `close`
         // takes opening_state first, so it cannot observe a gap between
         // removing the opening marker and inserting the attachment.
@@ -989,7 +1025,7 @@ impl Inner {
         {
             drop(attachments);
             drop(opening);
-            let _previous_publication = previous_gate.lock().expect("attachment publication lock");
+            let _previous_publication = previous_gate.lock();
             opening = self.opening_state.lock().expect("opening state lock");
             attachments = self.attachments.lock().expect("attach lock");
             if opening.cancelled.get(&pty_id) == Some(&opening_generation) {
@@ -1002,6 +1038,25 @@ impl Inner {
                 opened.control.kill();
                 return;
             }
+        }
+        // This is the publication linearization point. Read the live
+        // authority only after waiting for any prior generation's publication
+        // gate, while the opening and attachment state are still held. A
+        // downgrade that races the slow OPEN path therefore cannot publish a
+        // newly attached PTY.
+        let live_auth = Self::auth_snapshot(context);
+        if live_auth.trust.is_empty()
+            || (live_auth.trust == "observe"
+                && (live_auth.owner_user_id.is_none()
+                    || Some(actor) != live_auth.owner_user_id.as_deref()))
+        {
+            drop(opening);
+            drop(attachments);
+            reservation.active = false;
+            opened.closing.store(true, Ordering::SeqCst);
+            opened.control.kill();
+            fail("trust_revoked", "terminal trust changed while opening");
+            return;
         }
         let previous = attachments.insert(
             pty_id.clone(),
@@ -1046,7 +1101,7 @@ impl Inner {
         pty_id: &str,
         context: &FrameContext,
         generation: u64,
-        publication_gate: Arc<Mutex<()>>,
+        publication_gate: Arc<RouteGate>,
     ) -> (DataSink, ExitSink) {
         let output_gate = Arc::clone(&publication_gate);
         let on_data = {
@@ -1081,7 +1136,7 @@ impl Inner {
         chunk: &Bytes,
         context: &FrameContext,
         generation: u64,
-        publication_gate: &Arc<Mutex<()>>,
+        publication_gate: &Arc<RouteGate>,
     ) {
         let mut auth = Self::auth_snapshot(context);
         if self
@@ -1100,7 +1155,7 @@ impl Inner {
             }
             Arc::clone(&current.publication_gate)
         };
-        let _publication = gate.lock().expect("attachment publication lock");
+        let _publication = gate.lock();
         {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
@@ -1177,23 +1232,82 @@ impl Inner {
         code: i64,
         context: &FrameContext,
         generation: u64,
-        publication_gate: &Arc<Mutex<()>>,
+        publication_gate: &Arc<RouteGate>,
     ) {
-        let auth = Self::auth_snapshot(context);
+        let initial_auth = Self::auth_snapshot(context);
         if self
-            .authorize_snapshot_for_generation(pty_id, &auth, context, "exit", generation)
+            .authorize_snapshot_for_generation(pty_id, &initial_auth, context, "exit", generation)
             .is_none()
         {
             return;
         }
-        self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
-            (auth.send)(json!({
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock();
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.clone()
+        };
+        // A trust downgrade can race the first route check. Re-read authority
+        // after acquiring the generation gate, then publish using this live
+        // snapshot. The trust read is the exit frame's linearization point.
+        let live_auth = Self::auth_snapshot(context);
+        if !Self::auth_allows(&live_auth, &attachment) {
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                generation,
+                publication_gate,
+                "trust_revoked",
+                "PTY exit refused after trust change",
+            );
+            return;
+        }
+        let attachment = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.closing.store(true, Ordering::SeqCst);
+            current.clone()
+        };
+        (live_auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
             "ptyId": pty_id,
             "code": code,
-            }));
-        });
+        }));
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        if attachments.get(pty_id).is_some_and(|current| {
+            current.generation == generation
+                && Arc::ptr_eq(&current.publication_gate, publication_gate)
+        }) {
+            attachments.remove(pty_id);
+        }
+        drop(attachments);
+        drop(_publication);
+        attachment.control.kill();
     }
 
     fn emit_error_for_generation(
@@ -1201,7 +1315,7 @@ impl Inner {
         context: &FrameContext,
         pty_id: &str,
         generation: u64,
-        publication_gate: &Arc<Mutex<()>>,
+        publication_gate: &Arc<RouteGate>,
         code: &str,
         message: &str,
     ) {
@@ -1214,7 +1328,7 @@ impl Inner {
         &self,
         pty_id: &str,
         generation: u64,
-        publication_gate: &Arc<Mutex<()>>,
+        publication_gate: &Arc<RouteGate>,
         publish: impl FnOnce(),
     ) {
         let gate = {
@@ -1227,7 +1341,7 @@ impl Inner {
             }
             Arc::clone(&current.publication_gate)
         };
-        let _publication = gate.lock().expect("attachment publication lock");
+        let _publication = gate.lock();
         let attachment = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
@@ -1353,7 +1467,7 @@ impl Inner {
         action: &str,
         operation: impl FnOnce(&dyn PtyControl),
     ) {
-        let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
+        let _publication = attachment.publication_gate.lock();
         {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
@@ -1443,7 +1557,7 @@ impl Inner {
             }
             Arc::clone(&current.publication_gate)
         };
-        let _publication = gate.lock().expect("attachment publication lock");
+        let _publication = gate.lock();
         let current = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
@@ -1499,7 +1613,7 @@ impl Inner {
         &self,
         pty_id: &str,
         generation: Option<u64>,
-        publication_gate: Option<&Arc<Mutex<()>>>,
+        publication_gate: Option<&Arc<RouteGate>>,
     ) {
         let gate = {
             let attachments = self.attachments.lock().expect("attach lock");
@@ -1512,7 +1626,7 @@ impl Inner {
             }
             Arc::clone(&current.publication_gate)
         };
-        let _publication = gate.lock().expect("attachment publication lock");
+        let _publication = gate.lock();
         let attachment = {
             let mut attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
@@ -1536,7 +1650,7 @@ struct Opened {
     control: Arc<dyn PtyControl>,
     closing: Arc<AtomicBool>,
     generation: u64,
-    publication_gate: Arc<Mutex<()>>,
+    publication_gate: Arc<RouteGate>,
     start: Box<dyn FnOnce() + Send>,
 }
 
@@ -1716,7 +1830,7 @@ impl Inner {
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let publication_gate = Arc::new(Mutex::new(()));
+        let publication_gate = Arc::new(RouteGate::new());
         let (on_data, on_exit) =
             self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
         Ok(Opened {
@@ -1866,7 +1980,7 @@ impl Inner {
         let released = Arc::new(AtomicBool::new(false));
         let closing = Arc::new(AtomicBool::new(false));
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let publication_gate = Arc::new(Mutex::new(()));
+        let publication_gate = Arc::new(RouteGate::new());
         let (on_data, on_exit) =
             self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
 
@@ -2457,7 +2571,7 @@ impl Inner {
         let proxy =
             Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
         let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
-        let publication_gate = Arc::new(Mutex::new(()));
+        let publication_gate = Arc::new(RouteGate::new());
         let (on_data, _) = self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
@@ -2667,6 +2781,7 @@ mod tests {
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as StdMutex};
     use std::thread;
+    use std::time::Duration;
 
     static NEXT_TEST_DIRECTORY: AtomicU64 = AtomicU64::new(0);
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1085,6 +1085,10 @@ impl Inner {
                 && (live_auth.owner_user_id.is_none()
                     || Some(actor) != live_auth.owner_user_id.as_deref()))
         {
+            opening.ids.remove(&pty_id);
+            if opening.cancelled.get(&pty_id) == Some(&opening_generation) {
+                opening.cancelled.remove(&pty_id);
+            }
             drop(opening);
             drop(attachments);
             reservation.active = false;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3482,7 +3482,7 @@ mod tests {
         });
         h.manager.handle_frame(&frame, &context).await;
         let pty = h.spawned()[0].clone();
-        live_auth.lock().unwrap().0 = "observe".to_owned();
+        live_auth.lock().unwrap().trust = "observe".to_owned();
         pty.emit("secret");
         assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
     }
@@ -3551,11 +3551,42 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn live_root_restriction_rejects_open_before_publication() {
+        let h = harness(None, None);
+        let allowed = h.home.join("allowed");
+        std::fs::create_dir(&allowed).expect("create allowed root");
+        let mut context = h.context("supervised", h.owner.clone());
+        let owner = h.owner.clone();
+        context.live_auth = Arc::new(move || LiveAuth {
+            trust: "supervised".to_owned(),
+            roots: Some(vec![allowed.to_string_lossy().into_owned()]),
+            owner_user_id: owner.clone(),
+            version: 1,
+        });
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+
+        h.manager.handle_frame(&frame, &context).await;
+
+        assert_eq!(h.manager.opening_count(), 0);
+        assert!(!h.manager.has_attachment("p1"));
+        assert!(h.sent().iter().any(|frame| frame["code"] == "trust_revoked"));
+    }
+
+    #[tokio::test]
     async fn close_requires_current_trust() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
         h.frame_as(serde_json::json!({"type":"pty_close","ptyId":"p1"}), "", h.owner.clone()).await;
         assert!(h.sent().iter().any(|f| f["code"] == "trust_revoked"));
+        assert!(!h.manager.has_attachment("p1"));
     }
 
     #[tokio::test]
@@ -4299,10 +4330,11 @@ mod tests {
             "actorId": "user_owner",
         });
         let sent = Arc::clone(&h.sent);
+        let nested_frame_for_callback = nested_frame.clone();
         let reentered_for_send = Arc::clone(&reentered);
         context.send = TestArc::new(move |frame| {
             if frame["type"] == "pty_exit" && !reentered_for_send.swap(true, Ordering::SeqCst) {
-                runtime.block_on(manager.handle_frame(&nested_frame, &nested_context));
+                runtime.block_on(manager.handle_frame(&nested_frame_for_callback, &nested_context));
                 done.send(()).expect("nested open completion");
             }
             sent.lock().unwrap().push(frame);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2180,20 +2180,42 @@ impl Inner {
         };
         let _publication = gate.lock();
         let attachment = {
-            let mut attachments = self.attachments.lock().expect("attach lock");
+            let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if generation.is_some_and(|expected| current.generation != expected)
                 || !Arc::ptr_eq(&current.publication_gate, &gate)
             {
                 return;
             }
-            let attachment = attachments.remove(pty_id).expect("attachment still present");
-            attachment.closing.store(true, Ordering::SeqCst);
-            attachment
+            current.close_pending.store(true, Ordering::SeqCst);
+            current.clone()
         };
         let _ = attachment.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+                || !current.close_pending.load(Ordering::SeqCst)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.closing.store(true, Ordering::SeqCst);
+            current.clone()
+        };
         drop(_publication);
         attachment.control.kill();
+        let _publication = gate.lock();
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        if attachments.get(pty_id).is_some_and(|current| {
+            generation.is_none_or(|expected| current.generation == expected)
+                && Arc::ptr_eq(&current.publication_gate, &gate)
+                && current.close_pending.load(Ordering::SeqCst)
+                && current.closing.load(Ordering::SeqCst)
+        }) {
+            attachments.remove(pty_id);
+        }
     }
 }
 
@@ -5153,18 +5175,19 @@ mod tests {
 
         let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
         let detach = thread::spawn(move || manager.detach_transport("transport-a"));
-        for _ in 0..100 {
-            if h.manager
+        loop {
+            let close_state = h
+                .manager
                 .inner
                 .attachments
                 .lock()
                 .unwrap()
                 .get("p1")
-                .is_some_and(|attachment| attachment.close_pending.load(Ordering::SeqCst))
-            {
-                break;
+                .map(|attachment| attachment.close_pending.load(Ordering::SeqCst));
+            match close_state {
+                None | Some(true) => break,
+                Some(false) => thread::yield_now(),
             }
-            thread::yield_now();
         }
         assert!(
             h.manager

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -602,8 +602,9 @@ impl PtyManager {
                 if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
                     return;
                 }
-                let _ = self.inner.authorize_snapshot(pty_id, &auth, context, "close");
-                self.inner.close(pty_id);
+                if self.inner.authorize_snapshot(pty_id, &auth, context, "close").is_some() {
+                    self.inner.close(pty_id);
+                }
             }
             "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
             _ => {}

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -991,10 +991,15 @@ impl Inner {
             }
             return;
         }
-        // Re-check after the backpressure probe. A concurrent replacement may
-        // have invalidated this route while the probe ran.
-        if !self.route_is_current(pty_id, route_id) {
-            return;
+        // Keep route validation and delivery under the attachment-map lock.
+        // Close and replacement use the same lock, so they cannot invalidate
+        // this route between the check and the socket handoff.
+        let attachments = self.attachments.lock().expect("attach lock");
+        match attachments.get(pty_id) {
+            Some(attachment)
+                if attachment.route_id == route_id
+                    && !attachment.closing.load(Ordering::SeqCst) => {}
+            _ => return,
         }
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
@@ -1025,14 +1030,13 @@ impl Inner {
                     && !attachment.closing.load(Ordering::SeqCst) => {}
             _ => return,
         }
-        attachments.remove(pty_id);
-        drop(attachments);
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
             "ptyId": pty_id,
             "code": code,
         }));
+        attachments.remove(pty_id);
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
@@ -3024,7 +3028,8 @@ mod tests {
     async fn denied_close_does_not_remove_attachment() {
         let h = harness(None, None);
         h.open_with_transport("p1", "main", "transport-a").await;
-        let denied = h.context_with_transport("observe", Some("other-user".to_owned()), Some("transport-a"));
+        let denied =
+            h.context_with_transport("observe", Some("other-user".to_owned()), Some("transport-a"));
         let close = serde_json::json!({ "version": 4, "type": "pty_close", "ptyId": "p1" });
         h.manager.handle_frame(&close, &denied).await;
         assert!(h.manager.has_attachment("p1"));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3401,6 +3401,33 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn transport_close_checks_matching_attachment_after_other_open_reservation() {
+        let h = harness(None, None);
+        h.open_with_transport("p1", "main", "transport-a").await;
+        let attachment_generation =
+            h.manager.inner.attachments.lock().unwrap().get("p1").expect("attachment").generation;
+        let replacement_generation =
+            h.manager.inner.next_generation.fetch_add(1, Ordering::Relaxed);
+        h.manager.inner.opening_state.lock().unwrap().ids.insert(
+            "p1".to_owned(),
+            OpeningEntry {
+                transport_id: Some("transport-b".to_owned()),
+                generation: replacement_generation,
+            },
+        );
+
+        h.manager.inner.close_if_transport("p1", Some("transport-a"), Some(attachment_generation));
+
+        assert!(!h.manager.has_attachment("p1"));
+        let opening = h.manager.inner.opening_state.lock().unwrap();
+        assert!(!opening.cancelled.contains_key("p1"));
+        assert_eq!(
+            opening.ids.get("p1").map(|entry| entry.generation),
+            Some(replacement_generation)
+        );
+    }
+
+    #[tokio::test]
     async fn shell_open_output_input_resize_flow_round_trip() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4076,6 +4076,49 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn reentrant_same_id_open_is_rejected_until_exit_publication_finishes() {
+        let h = harness(None, None);
+        let mut context = h.context("supervised", h.owner.clone());
+        let nested_context = h.context("supervised", h.owner.clone());
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let runtime = tokio::runtime::Handle::current();
+        let reentered = Arc::new(AtomicBool::new(false));
+        let (done, completed) = std::sync::mpsc::channel();
+        let nested_frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        let sent = Arc::clone(&h.sent);
+        let reentered_for_send = Arc::clone(&reentered);
+        context.send = TestArc::new(move |frame| {
+            if frame["type"] == "pty_exit" && !reentered_for_send.swap(true, Ordering::SeqCst) {
+                runtime.block_on(manager.handle_frame(&nested_frame, &nested_context));
+                done.send(()).expect("nested open completion");
+            }
+            sent.lock().unwrap().push(frame);
+        });
+        let frame = nested_frame.clone();
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let exit = thread::spawn(move || pty.exit(7));
+        assert!(
+            completed.recv_timeout(Duration::from_secs(1)).is_ok(),
+            "reentrant open must return while the exit callback owns the route gate"
+        );
+        exit.join().expect("exit callback");
+        assert!(!h.manager.has_attachment("p1"));
+        assert!(!h.sent().iter().any(|frame| {
+            frame["type"] == "pty_opened" && frame["ptyId"] == "p1" && frame["created"] == false
+        }));
+        assert!(h.sent().iter().any(|frame| frame["code"] == "bad_request"));
+    }
+
+    #[tokio::test]
     async fn input_operation_waits_before_close_can_retire_its_generation() {
         let h = harness(None, None);
         let frame = serde_json::json!({

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -944,7 +944,9 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            self.close(pty_id);
+            if action != "close" {
+                self.close(pty_id);
+            }
             send_pty_error(
                 context,
                 pty_id,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -5125,6 +5125,82 @@ mod tests {
         }));
     }
 
+    #[tokio::test]
+    async fn detach_close_keeps_generation_reserved_until_control_drain() {
+        let h = harness(None, None);
+        h.open_with_transport("p1", "main", "transport-a").await;
+        let pty = h.spawned()[0].clone();
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        {
+            let mut state = pty.state.lock().unwrap();
+            state.write_entered = Some(TestArc::clone(&entered));
+            state.write_release = Some(TestArc::clone(&release));
+        }
+        let input = serde_json::json!({
+            "version": 4,
+            "type": "pty_input",
+            "ptyId": "p1",
+            "dataB64": b64("held"),
+        });
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let input_context =
+            h.context_with_transport("supervised", h.owner.clone(), Some("transport-a"));
+        let runtime = tokio::runtime::Handle::current();
+        let input_task =
+            thread::spawn(move || runtime.block_on(manager.handle_frame(&input, &input_context)));
+        entered.wait();
+
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let detach = thread::spawn(move || manager.detach_transport("transport-a"));
+        for _ in 0..100 {
+            if h.manager
+                .inner
+                .attachments
+                .lock()
+                .unwrap()
+                .get("p1")
+                .is_some_and(|attachment| attachment.close_pending.load(Ordering::SeqCst))
+            {
+                break;
+            }
+            thread::yield_now();
+        }
+        assert!(
+            h.manager
+                .inner
+                .attachments
+                .lock()
+                .unwrap()
+                .get("p1")
+                .is_some_and(|attachment| attachment.close_pending.load(Ordering::SeqCst)),
+            "detach must mark the generation as closing before draining control operations"
+        );
+
+        let replacement = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&replacement, &h.context("supervised", h.owner.clone())).await;
+        assert_eq!(h.spawned().len(), 1, "same-ID open must wait for old control drain");
+        assert!(
+            h.sent()
+                .iter()
+                .any(|frame| { frame["type"] == "pty_error" && frame["code"] == "bad_request" })
+        );
+
+        release.wait();
+        input_task.join().expect("input operation");
+        detach.join().expect("detach operation");
+        h.manager.handle_frame(&replacement, &h.context("supervised", h.owner.clone())).await;
+        assert_eq!(h.spawned().len(), 2, "same-ID open succeeds after old control kill");
+    }
+
     #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
     async fn async_close_waits_for_control_operation_across_workers() {
         let h = harness(None, None);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -409,6 +409,11 @@ struct AuthSnapshot {
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
 }
 
+enum NonterminalAuthorizationFailure {
+    Missing,
+    Denied,
+}
+
 /// Scrubbed env for interactive PTYs (actions.mjs base, real TERM).
 pub fn pty_env(base: &HashMap<String, String>) -> HashMap<String, String> {
     let mut env = scrubbed_env(base);
@@ -1545,10 +1550,31 @@ impl Inner {
         context: &FrameContext,
         action: &str,
         generation: u64,
-    ) -> Option<Attachment> {
-        self.authorize_snapshot_for_generation_mode(
-            pty_id, auth, context, action, generation, false,
-        )
+    ) -> Result<Attachment, NonterminalAuthorizationFailure> {
+        let attachment = self
+            .attachments
+            .lock()
+            .expect("attach lock")
+            .get(pty_id)
+            .cloned()
+            .ok_or(NonterminalAuthorizationFailure::Missing)?;
+        if generation != 0 && attachment.generation != generation {
+            return Err(NonterminalAuthorizationFailure::Missing);
+        }
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return Err(NonterminalAuthorizationFailure::Missing);
+        }
+        if Self::auth_allows(auth, &attachment) {
+            Ok(attachment)
+        } else {
+            send_pty_error(
+                context,
+                pty_id,
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
+            );
+            Err(NonterminalAuthorizationFailure::Denied)
+        }
     }
 
     fn authorize_snapshot_for_generation_mode(
@@ -1591,27 +1617,19 @@ impl Inner {
     }
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
-        // Capture presence before authorization. If this request is denied,
-        // the attachment may be removed and replaced while the error callback
-        // runs; remembering that it targeted a present attachment prevents
-        // the fallback cancellation path from touching that replacement.
-        let had_attachment = self.attachments.lock().expect("attach lock").contains_key(pty_id);
         let auth = Self::auth_snapshot(context);
-        let Some(attachment) =
-            self.authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
-        else {
-            // A present attachment may have failed authorization. The
-            // non-terminal error above must not fall through to the opening
-            // cancellation path, which would otherwise let a denied CLOSE
-            // retire the live attachment.
-            if had_attachment {
+        let attachment = match self
+            .authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
+        {
+            Ok(attachment) => attachment,
+            Err(NonterminalAuthorizationFailure::Denied) => return,
+            Err(NonterminalAuthorizationFailure::Missing) => {
+                // A close may race the asynchronous open before its attachment
+                // is published. The transport fence ran at frame dispatch, so
+                // this exact owner can cancel the pending reservation now.
+                self.close_if_transport(pty_id, context.transport_id.as_deref(), None);
                 return;
             }
-            // A close may race the asynchronous open before its attachment
-            // is published. The transport fence ran at frame dispatch, so
-            // this exact owner can cancel the pending reservation now.
-            self.close_if_transport(pty_id, context.transport_id.as_deref(), None);
-            return;
         };
         if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
             return;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3928,6 +3928,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn output_sink_can_reenter_detach_without_deadlock() {
+        let h = harness(None, None);
+        let mut context = h.context("supervised", h.owner.clone());
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        context.send = TestArc::new(move |frame| {
+            if frame["type"] == "pty_output" {
+                manager.detach_all();
+            }
+        });
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        let (done, completed) = std::sync::mpsc::channel();
+        thread::spawn(move || {
+            pty.emit("reentrant");
+            done.send(()).expect("reentrant output completion");
+        });
+        assert!(
+            completed.recv_timeout(Duration::from_secs(1)).is_ok(),
+            "a reentrant output sink must not deadlock on the publication gate"
+        );
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test]
     async fn input_operation_waits_before_close_can_retire_its_generation() {
         let h = harness(None, None);
         let frame = serde_json::json!({

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2050,6 +2050,7 @@ impl Inner {
         let live_auth = Self::auth_snapshot(context);
         if !self.auth_allows(&live_auth, &current) {
             current.close_pending.store(false, Ordering::SeqCst);
+            drop(_publication);
             send_pty_error(
                 context,
                 pty_id,
@@ -2076,6 +2077,7 @@ impl Inner {
             removed.closing.store(true, Ordering::SeqCst);
             removed
         };
+        drop(_publication);
         removed.control.kill();
     }
 
@@ -2185,6 +2187,7 @@ impl Inner {
             attachment
         };
         let _ = attachment.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
+        drop(_publication);
         attachment.control.kill();
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -424,7 +424,7 @@ struct AuthSnapshot {
     buffered_amount: Arc<dyn Fn() -> u64 + Send + Sync>,
 }
 
-enum NonterminalAuthorizationFailure {
+enum CloseAuthorizationFailure {
     Missing,
     Denied,
 }
@@ -1109,11 +1109,7 @@ impl Inner {
         drop(attachments);
         let live_auth = Self::auth_snapshot(context);
         attachments = self.attachments.lock().expect("attach lock");
-        if live_auth.trust.is_empty()
-            || (live_auth.trust == "observe"
-                && (live_auth.owner_user_id.is_none()
-                    || Some(actor) != live_auth.owner_user_id.as_deref()))
-        {
+        if !self.auth_allows_claim(&live_auth, actor, &cwd, 0) {
             drop(opening);
             drop(attachments);
             reservation.active = false;
@@ -1512,16 +1508,24 @@ impl Inner {
     }
 
     fn auth_allows(&self, auth: &AuthSnapshot, attachment: &Attachment) -> bool {
+        self.auth_allows_claim(auth, &attachment.actor_id, &attachment.cwd, attachment.auth_version)
+    }
+
+    fn auth_allows_claim(
+        &self,
+        auth: &AuthSnapshot,
+        actor_id: &str,
+        cwd: &Path,
+        minimum_version: u64,
+    ) -> bool {
         let owner = auth.owner_user_id.as_deref();
         let roots_allow_cwd = auth.roots.as_deref().is_none_or(|roots| {
-            roots.is_empty()
-                || scoped_cwd(attachment.cwd.to_str(), &self.home, Some(roots), None).is_ok()
+            roots.is_empty() || scoped_cwd(cwd.to_str(), &self.home, Some(roots), None).is_ok()
         });
-        auth.version >= attachment.auth_version
+        auth.version >= minimum_version
             && roots_allow_cwd
             && !auth.trust.is_empty()
-            && (auth.trust != "observe"
-                || (owner.is_some() && owner == Some(attachment.actor_id.as_str())))
+            && (auth.trust != "observe" || (owner.is_some() && owner == Some(actor_id)))
     }
 
     fn authorize_snapshot(
@@ -1599,51 +1603,52 @@ impl Inner {
         }
     }
 
-    /// Authorization failures for an explicit CLOSE are non-terminal. The
-    /// caller may have a stale or downgraded trust snapshot, but it must not
-    /// be able to retire an attachment it does not own.
-    fn authorize_snapshot_for_generation_nonterminal(
+    /// A CLOSE from the owning transport cannot operate after authority is
+    /// revoked. Retire that now-unauthorized attachment so it cannot retain a
+    /// resource slot or resume publication under stale authority.
+    fn authorize_snapshot_for_close(
         &self,
         pty_id: &str,
         auth: &AuthSnapshot,
         context: &FrameContext,
         action: &str,
         generation: u64,
-    ) -> Result<Attachment, NonterminalAuthorizationFailure> {
+    ) -> Result<Attachment, CloseAuthorizationFailure> {
         let attachment = self
             .attachments
             .lock()
             .expect("attach lock")
             .get(pty_id)
             .cloned()
-            .ok_or(NonterminalAuthorizationFailure::Missing)?;
+            .ok_or(CloseAuthorizationFailure::Missing)?;
         if generation != 0 && attachment.generation != generation {
-            return Err(NonterminalAuthorizationFailure::Missing);
+            return Err(CloseAuthorizationFailure::Missing);
         }
         if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
-            return Err(NonterminalAuthorizationFailure::Missing);
+            return Err(CloseAuthorizationFailure::Missing);
         }
         if self.auth_allows(auth, &attachment) {
             Ok(attachment)
         } else {
-            send_pty_error(
+            self.emit_error_for_generation(
                 context,
                 pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
                 "trust_revoked",
                 &format!("PTY {action} refused after trust change"),
             );
-            Err(NonterminalAuthorizationFailure::Denied)
+            Err(CloseAuthorizationFailure::Denied)
         }
     }
 
     fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
-        let attachment = match self
-            .authorize_snapshot_for_generation_nonterminal(pty_id, &auth, context, "close", 0)
+        let attachment = match self.authorize_snapshot_for_close(pty_id, &auth, context, "close", 0)
         {
             Ok(attachment) => attachment,
-            Err(NonterminalAuthorizationFailure::Denied) => return,
-            Err(NonterminalAuthorizationFailure::Missing) => {
+            Err(CloseAuthorizationFailure::Denied) => return,
+            Err(CloseAuthorizationFailure::Missing) => {
                 // A close may race the asynchronous open before its attachment
                 // is published. The transport fence ran at frame dispatch, so
                 // this exact owner can cancel the pending reservation now.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -445,7 +445,8 @@ struct ShellInner {
 /// A reentrant publication gate for one attachment generation. The gate
 /// serializes route publication and control operations across threads while
 /// allowing an outbound/control callback to synchronously re-enter the same
-/// route (for example, a test sink that closes the PTY).
+/// route (for example, a test sink that closes the PTY). A callback must not
+/// synchronously wait for another thread that needs this same gate.
 struct RouteGate {
     state: Mutex<RouteGateState>,
     changed: Condvar,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2600,9 +2600,11 @@ impl Inner {
             let (banner, replay, alive) = {
                 let mut inner = start_session.inner.lock().expect("shell inner lock");
                 let banner = created.then(|| start_session.banner.clone()).flatten();
-                let replay = (!created && inner.ring_size > 0).then(|| {
-                    inner.ring.iter().flat_map(|c| c.iter().copied()).collect::<Vec<u8>>()
-                });
+                // Clone the retained chunks, not their bytes. `Bytes` clones
+                // share the backing storage, so a large scrollback replay
+                // does not allocate one contiguous buffer before framing.
+                let replay = (!created && inner.ring_size > 0)
+                    .then(|| inner.ring.iter().cloned().collect::<Vec<Bytes>>());
                 if inner.alive && !released.load(Ordering::SeqCst) {
                     inner.viewers.push(ViewerSink {
                         id: viewer_id,
@@ -2619,7 +2621,9 @@ impl Inner {
                 emit_bounded_bytes(&on_data, Bytes::from(banner));
             }
             if let Some(replay) = replay {
-                emit_bounded_bytes(&on_data, Bytes::from(replay));
+                for chunk in replay {
+                    emit_bounded_bytes(&on_data, chunk);
+                }
             }
             if released.load(Ordering::SeqCst) {
                 return;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4323,6 +4323,36 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn large_live_output_is_split_into_bounded_frames() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let pty = h.spawned()[0].clone();
+        let before = h.sent().len();
+        pty.emit(&"x".repeat(MAX_OUTPUT_CHUNK_BYTES * 2 + 5));
+        let frames: Vec<Value> = h.sent()[before..]
+            .iter()
+            .filter(|frame| frame["type"] == "pty_output")
+            .cloned()
+            .collect();
+        assert!(frames.len() >= 2);
+        assert!(frames.iter().all(|frame| {
+            BASE64
+                .decode(frame["dataB64"].as_str().unwrap_or_default())
+                .map(|bytes| bytes.len() <= MAX_OUTPUT_CHUNK_BYTES)
+                .unwrap_or(false)
+        }));
+        assert!(!h.sent().iter().any(|frame| frame["code"] == "failed"));
+    }
+
+    #[tokio::test]
+    async fn async_close_authorized_path_is_callable() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test]
     async fn second_open_adds_a_viewer_output_fans_out_to_both() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2000,7 +2000,22 @@ impl Inner {
             {
                 return;
             }
-            self.close_exact(pty_id, generation, Some(&publication_gate));
+            let removed = {
+                let mut attachments = self.attachments.lock().expect("attach lock");
+                let Some(current) = attachments.get(pty_id) else { return };
+                if generation.is_some_and(|expected| current.generation != expected)
+                    || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                    || !current.close_pending.load(Ordering::SeqCst)
+                    || current.closing.load(Ordering::SeqCst)
+                {
+                    return;
+                }
+                let removed = attachments.remove(pty_id).expect("attachment still present");
+                removed.closing.store(true, Ordering::SeqCst);
+                removed
+            };
+            drop(_publication);
+            removed.control.kill();
         }
     }
 
@@ -2109,7 +2124,34 @@ impl Inner {
         {
             return;
         }
-        self.close_exact_authorized(pty_id, attachment, context);
+        let live_auth = Self::auth_snapshot(context);
+        if !self.auth_allows(&live_auth, &current) {
+            current.close_pending.store(false, Ordering::SeqCst);
+            drop(_publication);
+            send_pty_error(
+                context,
+                pty_id,
+                "trust_revoked",
+                "PTY close refused after trust change",
+            );
+            return;
+        }
+        let removed = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+                || !current.close_pending.load(Ordering::SeqCst)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            let removed = attachments.remove(pty_id).expect("attachment still present");
+            removed.closing.store(true, Ordering::SeqCst);
+            removed
+        };
+        drop(_publication);
+        removed.control.kill();
     }
 
     fn close_exact(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -386,6 +386,9 @@ pub struct FrameContext {
     pub trust: String,
     pub local_roots: Option<Vec<String>>,
     pub owner_user_id: Option<String>,
+    /// Read current trust and owner for an attachment. Session transports
+    /// update this closure's backing state after trust acknowledgements.
+    pub live_auth: Arc<dyn Fn() -> (String, Option<String>) + Send + Sync>,
     /// Identity of the transport this frame arrived on. The PtyManager is
     /// shared between the relay WebSocket and the managed tunnel listener;
     /// an attachment may only be written to, resized, flow-controlled, or
@@ -447,11 +450,8 @@ struct Attachment {
     actor_id: String,
     /// Transport that opened this attachment (see FrameContext::transport_id).
     transport_id: Option<String>,
-    /// Monotonic identity for the callback route associated with this
-    /// attachment. A PTY source can outlive a detach and later invoke its old
-    /// sink after the same `ptyId` has been reopened; the route prevents that
-    /// stale callback from addressing the replacement attachment.
-    route_id: u64,
+    generation: u64,
+    publication_gate: Arc<Mutex<()>>,
 }
 
 struct Inner {
@@ -462,11 +462,25 @@ struct Inner {
     scrollback_limit: usize,
     output_cap: u64,
     attachments: Mutex<HashMap<String, Attachment>>,
-    /// ptyId -> transport that reserved it (None = legacy whole-manager owner).
-    opening_ids: Mutex<HashMap<String, Option<String>>>,
-    cancelled_openings: Mutex<std::collections::HashSet<String>>,
+    /// Reservation state is one lock so close/open/drop cannot leave a stale
+    /// cancellation marker between the id and marker updates.
+    opening_state: Mutex<OpeningState>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
+    next_generation: AtomicU64,
+    next_opening_generation: AtomicU64,
+}
+
+#[derive(Default)]
+struct OpeningState {
+    ids: HashMap<String, OpeningEntry>,
+    cancelled: HashMap<String, u64>,
+}
+
+#[derive(Clone)]
+struct OpeningEntry {
+    transport_id: Option<String>,
+    generation: u64,
 }
 
 struct ShellStartReservation {
@@ -488,12 +502,19 @@ impl Drop for ShellStartReservation {
 struct OpeningReservation {
     inner: Arc<Inner>,
     id: String,
+    generation: u64,
     active: bool,
 }
 impl Drop for OpeningReservation {
     fn drop(&mut self) {
         if self.active {
-            self.inner.opening_ids.lock().expect("opening lock").remove(&self.id);
+            let mut state = self.inner.opening_state.lock().expect("opening state lock");
+            if state.ids.get(&self.id).is_some_and(|entry| entry.generation == self.generation) {
+                state.ids.remove(&self.id);
+            }
+            if state.cancelled.get(&self.id) == Some(&self.generation) {
+                state.cancelled.remove(&self.id);
+            }
         }
     }
 }
@@ -513,10 +534,11 @@ impl PtyManager {
                 scrollback_limit: SCROLLBACK_LIMIT,
                 output_cap: OUTPUT_BUFFER_CAP,
                 attachments: Mutex::new(HashMap::new()),
-                opening_ids: Mutex::new(HashMap::new()),
-                cancelled_openings: Mutex::new(std::collections::HashSet::new()),
+                opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
+                next_generation: AtomicU64::new(1),
+                next_opening_generation: AtomicU64::new(1),
             }),
         }
     }
@@ -538,22 +560,17 @@ impl PtyManager {
                 scrollback_limit,
                 output_cap,
                 attachments: Mutex::new(HashMap::new()),
-                opening_ids: Mutex::new(HashMap::new()),
-                cancelled_openings: Mutex::new(std::collections::HashSet::new()),
+                opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
+                next_generation: AtomicU64::new(1),
+                next_opening_generation: AtomicU64::new(1),
             }),
         }
     }
 
     /// Handle one Worker -> relay PTY frame.
     pub async fn handle_frame(&self, frame: &Value, context: &FrameContext) {
-        let auth = AuthSnapshot {
-            trust: context.trust.clone(),
-            owner_user_id: context.owner_user_id.clone(),
-            send: Arc::clone(&context.send),
-            buffered_amount: Arc::clone(&context.buffered_amount),
-        };
         let frame_type = frame.get("type").and_then(Value::as_str).unwrap_or_default();
         match frame_type {
             "pty_open" => self.inner.clone().open(frame, context).await,
@@ -570,10 +587,16 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) =
-                    self.inner.authorize_snapshot(pty_id, &auth, context, "input", None)
-                {
-                    attachment.control.write(&data);
+                if let Some(attachment) = self.inner.authorize(pty_id, context, "input") {
+                    self.inner.with_live_attachment(
+                        pty_id,
+                        &attachment,
+                        context,
+                        "input",
+                        |control| {
+                            control.write(&data);
+                        },
+                    );
                 }
             }
             "pty_resize" => {
@@ -586,10 +609,16 @@ impl PtyManager {
                 else {
                     return;
                 };
-                if let Some(attachment) =
-                    self.inner.authorize_snapshot(pty_id, &auth, context, "resize", None)
-                {
-                    attachment.control.resize(cols, rows);
+                if let Some(attachment) = self.inner.authorize(pty_id, context, "resize") {
+                    self.inner.with_live_attachment(
+                        pty_id,
+                        &attachment,
+                        context,
+                        "resize",
+                        |control| {
+                            control.resize(cols, rows);
+                        },
+                    );
                 }
             }
             "pty_flow" => {
@@ -598,14 +627,20 @@ impl PtyManager {
                     return;
                 }
                 let pause = frame.get("pause").and_then(Value::as_bool).unwrap_or(false);
-                if let Some(attachment) =
-                    self.inner.authorize_snapshot(pty_id, &auth, context, "flow", None)
-                {
-                    if pause {
-                        attachment.control.pause();
-                    } else {
-                        attachment.control.resume();
-                    }
+                if let Some(attachment) = self.inner.authorize(pty_id, context, "flow") {
+                    self.inner.with_live_attachment(
+                        pty_id,
+                        &attachment,
+                        context,
+                        "flow",
+                        |control| {
+                            if pause {
+                                control.pause();
+                            } else {
+                                control.resume();
+                            }
+                        },
+                    );
                 }
             }
             "pty_close" => {
@@ -613,9 +648,7 @@ impl PtyManager {
                 if !self.inner.transport_owns(pty_id, context.transport_id.as_deref()) {
                     return;
                 }
-                if self.inner.authorize_snapshot(pty_id, &auth, context, "close", None).is_some() {
-                    self.inner.close(pty_id);
-                }
+                self.inner.close_authorized(pty_id, context);
             }
             "surface_list" => self.inner.clone().list_surfaces(frame, context).await,
             _ => {}
@@ -626,12 +659,22 @@ impl PtyManager {
     /// this after a pty_error reply to tell a fatal refusal (attachment gone,
     /// connection ends) from a non-fatal one (oversized input, stream lives).
     pub fn has_attachment(&self, pty_id: &str) -> bool {
-        self.inner.attachments.lock().expect("attach lock").contains_key(pty_id)
+        self.inner
+            .attachments
+            .lock()
+            .expect("attach lock")
+            .get(pty_id)
+            .is_some_and(|attachment| !attachment.closing.load(Ordering::SeqCst))
     }
 
     /// Live attachment count (viewers, not sessions). Diagnostics and tests.
     pub fn attachment_count(&self) -> usize {
         self.inner.attachments.lock().expect("attach lock").len()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn opening_count(&self) -> usize {
+        self.inner.opening_state.lock().expect("opening state lock").ids.len()
     }
 
     /// The relay socket dropped: release every attachment (sessions live on).
@@ -651,25 +694,28 @@ impl PtyManager {
     fn detach_matching(&self, owns: impl Fn(Option<&str>) -> bool) {
         // Openings first: close() records cancellation for a reserved id, so
         // a late open cannot install an attachment after its transport died.
-        let mut ids: Vec<String> = {
-            let opening = self.inner.opening_ids.lock().expect("opening lock");
+        let opening_ids: Vec<(String, Option<String>, u64)> = {
+            let opening = self.inner.opening_state.lock().expect("opening state lock");
             opening
+                .ids
                 .iter()
-                .filter(|(_, owner)| owns(owner.as_deref()))
-                .map(|(id, _)| id.clone())
+                .map(|(id, entry)| (id.clone(), entry.transport_id.clone(), entry.generation))
                 .collect()
         };
-        {
+        let attachment_ids: Vec<(String, Option<String>, u64)> = {
             let attachments = self.inner.attachments.lock().expect("attach lock");
-            ids.extend(
-                attachments
-                    .iter()
-                    .filter(|(_, attachment)| owns(attachment.transport_id.as_deref()))
-                    .map(|(id, _)| id.clone()),
-            );
-        }
-        for id in ids {
-            self.inner.close(&id);
+            attachments
+                .iter()
+                .map(|(id, attachment)| {
+                    (id.clone(), attachment.transport_id.clone(), attachment.generation)
+                })
+                .collect()
+        };
+        let mut ids: Vec<(String, Option<String>, u64)> =
+            opening_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())).collect();
+        ids.extend(attachment_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())));
+        for (id, owner, generation) in ids {
+            self.inner.close_if_transport(&id, owner.as_deref(), Some(generation));
         }
     }
 }
@@ -701,18 +747,36 @@ fn send_typed_pty_error(
 }
 
 impl Inner {
+    fn auth_snapshot(context: &FrameContext) -> AuthSnapshot {
+        let (trust, owner_user_id) = (context.live_auth)();
+        AuthSnapshot {
+            trust,
+            owner_user_id,
+            send: Arc::clone(&context.send),
+            buffered_amount: Arc::clone(&context.buffered_amount),
+        }
+    }
+
     async fn open(self: Arc<Self>, frame: &Value, context: &FrameContext) {
         let pty_id = frame.get("ptyId").and_then(Value::as_str).unwrap_or_default().to_owned();
         if pty_id.is_empty() {
             return;
         }
         let fail = |code: &str, message: &str| send_pty_error(context, &pty_id, code, message);
+        let opening_generation = self.next_opening_generation.fetch_add(1, Ordering::Relaxed);
         let reservation_result = {
-            let mut opening = self.opening_ids.lock().expect("opening lock");
-            let attached = self.attachments.lock().expect("attach lock").contains_key(&pty_id);
-            if attached || opening.contains_key(&pty_id) {
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            let attachments = self.attachments.lock().expect("attach lock");
+            let attached = attachments
+                .get(&pty_id)
+                .is_some_and(|attachment| !attachment.closing.load(Ordering::SeqCst));
+            if attached || opening.ids.contains_key(&pty_id) {
                 Err(("bad_request", "ptyId is already attached".to_owned()))
-            } else if self.attachments.lock().expect("attach lock").len() + opening.len()
+            } else if attachments
+                .values()
+                .filter(|attachment| !attachment.closing.load(Ordering::SeqCst))
+                .count()
+                + opening.ids.len()
                 >= self.max_ptys
             {
                 Err((
@@ -720,7 +784,17 @@ impl Inner {
                     format!("this relay caps concurrent terminals at {}", self.max_ptys),
                 ))
             } else {
-                opening.insert(pty_id.clone(), context.transport_id.clone());
+                // A prior generation may have left a cancellation marker
+                // after its reservation was dropped. It cannot cancel this
+                // fresh generation and is discarded while claiming the id.
+                opening.cancelled.remove(&pty_id);
+                opening.ids.insert(
+                    pty_id.clone(),
+                    OpeningEntry {
+                        transport_id: context.transport_id.clone(),
+                        generation: opening_generation,
+                    },
+                );
                 Ok(())
             }
         };
@@ -728,8 +802,12 @@ impl Inner {
             fail(code, &message);
             return;
         }
-        let mut reservation =
-            OpeningReservation { inner: Arc::clone(&self), id: pty_id.clone(), active: true };
+        let mut reservation = OpeningReservation {
+            inner: Arc::clone(&self),
+            id: pty_id.clone(),
+            generation: opening_generation,
+            active: true,
+        };
 
         let session = frame.get("session").and_then(Value::as_str).unwrap_or_default().to_owned();
         let (Some(cols), Some(rows)) = (clamp_dim(frame.get("cols")), clamp_dim(frame.get("rows")))
@@ -872,36 +950,77 @@ impl Inner {
             }
         };
 
-        // Keep the opening reservation held until the attachment is installed.
-        // `close` takes this lock first, so it cannot observe a gap between
+        // Re-read authority after slow daemon/PTY work. A trust downgrade can
+        // arrive while OPEN is pending, so the original frame context is not
+        // sufficient to admit the attachment.
+        let live_auth = Self::auth_snapshot(context);
+        if live_auth.trust.is_empty()
+            || (live_auth.trust == "observe"
+                && (live_auth.owner_user_id.is_none()
+                    || Some(actor) != live_auth.owner_user_id.as_deref()))
+        {
+            opened.closing.store(true, Ordering::SeqCst);
+            opened.control.kill();
+            fail("trust_revoked", "terminal trust changed while opening");
+            return;
+        }
+
+        // Keep both locks held until the attachment is installed. `close`
+        // takes opening_state first, so it cannot observe a gap between
         // removing the opening marker and inserting the attachment.
-        let mut opening = self.opening_ids.lock().expect("opening lock");
-        let cancelled =
-            self.cancelled_openings.lock().expect("cancelled openings lock").remove(&pty_id);
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        let cancelled = opening.cancelled.get(&pty_id) == Some(&opening_generation);
         if cancelled {
-            opening.remove(&pty_id);
+            opening.cancelled.remove(&pty_id);
+            opening.ids.remove(&pty_id);
             drop(opening);
+            drop(attachments);
             reservation.active = false;
             opened.closing.store(true, Ordering::SeqCst);
             opened.control.kill();
             return;
         }
-        let previous = self.attachments.lock().expect("attach lock").insert(
+        // A terminal callback locks its publication gate before it rechecks
+        // the attachment map. Acquire the previous generation's gate before
+        // replacing it, otherwise a same-ID open can overtake a blocked exit.
+        if let Some(previous_gate) =
+            attachments.get(&pty_id).map(|previous| Arc::clone(&previous.publication_gate))
+        {
+            drop(attachments);
+            drop(opening);
+            let _previous_publication = previous_gate.lock().expect("attachment publication lock");
+            opening = self.opening_state.lock().expect("opening state lock");
+            attachments = self.attachments.lock().expect("attach lock");
+            if opening.cancelled.get(&pty_id) == Some(&opening_generation) {
+                opening.cancelled.remove(&pty_id);
+                opening.ids.remove(&pty_id);
+                drop(opening);
+                drop(attachments);
+                reservation.active = false;
+                opened.closing.store(true, Ordering::SeqCst);
+                opened.control.kill();
+                return;
+            }
+        }
+        let previous = attachments.insert(
             pty_id.clone(),
             Attachment {
                 closing: opened.closing,
                 control: opened.control,
                 actor_id: actor.to_owned(),
                 transport_id: context.transport_id.clone(),
-                route_id: opened.route_id,
+                generation: opened.generation,
+                publication_gate: Arc::clone(&opened.publication_gate),
             },
         );
+        opening.ids.remove(&pty_id);
+        drop(opening);
+        drop(attachments);
         if let Some(previous) = previous {
             previous.closing.store(true, Ordering::SeqCst);
             previous.control.kill();
         }
-        opening.remove(&pty_id);
-        drop(opening);
         reservation.active = false;
         let mut opened_frame = serde_json::Map::new();
         opened_frame.insert("version".to_owned(), Value::from(PTY_PROTOCOL_VERSION));
@@ -922,52 +1041,104 @@ impl Inner {
     }
 
     /// Build the per-attachment emit closures (output + exit framing).
-    fn sinks(self: &Arc<Self>, pty_id: &str, context: &FrameContext) -> (DataSink, ExitSink, u64) {
-        let route_id = next_attachment_route_id();
+    fn sinks(
+        self: &Arc<Self>,
+        pty_id: &str,
+        context: &FrameContext,
+        generation: u64,
+        publication_gate: Arc<Mutex<()>>,
+    ) -> (DataSink, ExitSink) {
+        let output_gate = Arc::clone(&publication_gate);
         let on_data = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            let auth = AuthSnapshot {
-                trust: context.trust.clone(),
-                owner_user_id: context.owner_user_id.clone(),
-                send: Arc::clone(&context.send),
-                buffered_amount: Arc::clone(&context.buffered_amount),
-            };
             Arc::new(move |chunk: Bytes| {
-                inner.emit_output(&pty_id, &chunk, &context, &auth, route_id)
+                inner.emit_output_for_generation(
+                    &pty_id,
+                    &chunk,
+                    &context,
+                    generation,
+                    &output_gate,
+                )
             }) as Arc<dyn Fn(Bytes) + Send + Sync>
         };
+        let exit_gate = Arc::clone(&publication_gate);
         let on_exit = {
             let inner = Arc::clone(self);
             let context = context.clone();
             let pty_id = pty_id.to_owned();
-            let auth = AuthSnapshot {
-                trust: context.trust.clone(),
-                owner_user_id: context.owner_user_id.clone(),
-                send: Arc::clone(&context.send),
-                buffered_amount: Arc::clone(&context.buffered_amount),
-            };
-            Arc::new(move |code: i64| inner.emit_exit(&pty_id, code, &context, &auth, route_id))
-                as Arc<dyn Fn(i64) + Send + Sync>
+            Arc::new(move |code: i64| {
+                inner.emit_exit_for_generation(&pty_id, code, &context, generation, &exit_gate)
+            }) as Arc<dyn Fn(i64) + Send + Sync>
         };
-        (on_data, on_exit, route_id)
+        (on_data, on_exit)
     }
 
-    fn emit_output(
+    fn emit_output_for_generation(
         &self,
         pty_id: &str,
         chunk: &Bytes,
         context: &FrameContext,
-        auth: &AuthSnapshot,
-        route_id: u64,
+        generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
     ) {
-        if !self.route_is_current(pty_id, route_id) {
+        let mut auth = Self::auth_snapshot(context);
+        if self
+            .authorize_snapshot_for_generation(pty_id, &auth, context, "output", generation)
+            .is_none()
+        {
             return;
         }
-        if self.authorize_snapshot(pty_id, auth, context, "output", Some(route_id)).is_none() {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock().expect("attachment publication lock");
+        {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+        }
+        // Trust can change after the first route check and before this
+        // callback reaches the socket. Re-read authority while the generation
+        // publication gate is held, then publish using that fresh snapshot.
+        let live_auth = Self::auth_snapshot(context);
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.clone()
+        };
+        if !Self::auth_allows(&live_auth, &attachment) {
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                generation,
+                publication_gate,
+                "trust_revoked",
+                "PTY output refused after trust change",
+            );
             return;
         }
+        auth = live_auth;
         // Zero-byte chunks carry nothing and historically crashed the web
         // terminal's write path (D-R6-1); never put an empty frame on the wire.
         if chunk.is_empty() {
@@ -978,28 +1149,19 @@ impl Inner {
         // frame exactly at the cap, but must reject one that would push the
         // buffered amount over the cap.
         if buffered.saturating_add(chunk.len() as u64) > self.output_cap {
-            if self.close_route(pty_id, route_id) {
-                send_pty_error(
-                    context,
-                    pty_id,
-                    "failed",
-                    &format!(
-                        "dropped: {buffered} bytes buffered toward the server (cap {})",
-                        self.output_cap
-                    ),
-                );
-            }
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                generation,
+                publication_gate,
+                "failed",
+                &format!(
+                    "dropped: {buffered} bytes buffered toward the server (cap {})",
+                    self.output_cap
+                ),
+            );
             return;
-        }
-        // Keep route validation and delivery under the attachment-map lock.
-        // Close and replacement use the same lock, so they cannot invalidate
-        // this route between the check and the socket handoff.
-        let attachments = self.attachments.lock().expect("attach lock");
-        match attachments.get(pty_id) {
-            Some(attachment)
-                if attachment.route_id == route_id
-                    && !attachment.closing.load(Ordering::SeqCst) => {}
-            _ => return,
         }
         (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
@@ -1009,81 +1171,135 @@ impl Inner {
         }));
     }
 
-    fn emit_exit(
+    fn emit_exit_for_generation(
         &self,
         pty_id: &str,
         code: i64,
         context: &FrameContext,
-        auth: &AuthSnapshot,
-        route_id: u64,
+        generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
     ) {
-        if !self.route_is_current(pty_id, route_id) {
+        let auth = Self::auth_snapshot(context);
+        if self
+            .authorize_snapshot_for_generation(pty_id, &auth, context, "exit", generation)
+            .is_none()
+        {
             return;
         }
-        if self.authorize_snapshot(pty_id, auth, context, "exit", Some(route_id)).is_none() {
-            return;
-        }
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        match attachments.get(pty_id) {
-            Some(attachment)
-                if attachment.route_id == route_id
-                    && !attachment.closing.load(Ordering::SeqCst) => {}
-            _ => return,
-        }
-        (auth.send)(json!({
+        self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
+            (auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
             "ptyId": pty_id,
             "code": code,
-        }));
-        attachments.remove(pty_id);
+            }));
+        });
+    }
+
+    fn emit_error_for_generation(
+        &self,
+        context: &FrameContext,
+        pty_id: &str,
+        generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
+        code: &str,
+        message: &str,
+    ) {
+        self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
+            send_pty_error(context, pty_id, code, message);
+        });
+    }
+
+    fn emit_terminal_for_generation(
+        &self,
+        pty_id: &str,
+        generation: u64,
+        publication_gate: &Arc<Mutex<()>>,
+        publish: impl FnOnce(),
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock().expect("attachment publication lock");
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.closing.store(true, Ordering::SeqCst);
+            current.clone()
+        };
+        // Keep the closing attachment in the map while the terminal frame is
+        // published. A same-ID open therefore cannot overtake this callback.
+        publish();
+        let mut attachments = self.attachments.lock().expect("attach lock");
+        if attachments.get(pty_id).is_some_and(|current| {
+            current.generation == generation
+                && Arc::ptr_eq(&current.publication_gate, publication_gate)
+        }) {
+            attachments.remove(pty_id);
+        }
+        drop(attachments);
+        drop(_publication);
+        // Terminal publication retires the viewer. Killing is idempotent for
+        // an already-exited PTY and releases an overflowed or revoked one.
+        attachment.control.kill();
     }
 
     /// Detach, NOT kill: idempotent, unknown ptyId tolerated.
     fn close(&self, pty_id: &str) {
         // Match `open`'s lock order. If opening still owns the reservation,
         // record cancellation and let it dispose the newly opened PTY.
-        let opening = self.opening_ids.lock().expect("opening lock");
-        if opening.contains_key(pty_id) {
-            self.cancelled_openings
-                .lock()
-                .expect("cancelled openings lock")
-                .insert(pty_id.to_owned());
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        if opening.ids.contains_key(pty_id) {
+            let generation = opening.ids.get(pty_id).expect("opening entry").generation;
+            opening.cancelled.insert(pty_id.to_owned(), generation);
             return;
         }
         drop(opening);
-        let attachment = self.attachments.lock().expect("attach lock").remove(pty_id);
-        if let Some(attachment) = attachment {
-            attachment.closing.store(true, Ordering::SeqCst);
-            attachment.control.kill();
-        }
+        self.close_exact(pty_id, None, None);
     }
 
-    /// Remove and release an attachment only when the caller still owns its
-    /// callback route. This keeps an old PTY source from closing a replacement
-    /// that reused the same protocol id.
-    fn close_route(&self, pty_id: &str, route_id: u64) -> bool {
-        let attachment = {
-            let mut attachments = self.attachments.lock().expect("attach lock");
-            if attachments.get(pty_id).is_some_and(|attachment| attachment.route_id == route_id) {
-                attachments.remove(pty_id)
-            } else {
-                None
+    fn close_if_transport(
+        &self,
+        pty_id: &str,
+        transport_id: Option<&str>,
+        generation: Option<u64>,
+    ) {
+        let mut opening = self.opening_state.lock().expect("opening state lock");
+        if let Some(entry) = opening.ids.get(pty_id) {
+            if generation.is_none_or(|expected| entry.generation == expected)
+                && entry.transport_id.as_deref() == transport_id
+            {
+                opening.cancelled.insert(pty_id.to_owned(), entry.generation);
             }
-        };
-        if let Some(attachment) = attachment {
-            attachment.closing.store(true, Ordering::SeqCst);
-            attachment.control.kill();
-            true
-        } else {
-            false
+            return;
         }
-    }
-
-    fn route_is_current(&self, pty_id: &str, route_id: u64) -> bool {
-        self.attachments.lock().expect("attach lock").get(pty_id).is_some_and(|attachment| {
-            attachment.route_id == route_id && !attachment.closing.load(Ordering::SeqCst)
-        })
+        drop(opening);
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if generation.is_none_or(|expected| attachment.generation == expected)
+            && attachment.transport_id.as_deref() == transport_id
+        {
+            self.close_exact(
+                pty_id,
+                Some(attachment.generation),
+                Some(&attachment.publication_gate),
+            );
+        }
     }
 
     /// Frame-level transport fence. Unknown ids retain the protocol's silent
@@ -1091,13 +1307,32 @@ impl Inner {
     /// transport may not act on it. A `None` caller owns everything (legacy).
     fn transport_owns(&self, pty_id: &str, transport_id: Option<&str>) -> bool {
         let Some(transport_id) = transport_id else { return true };
+        if let Some(owner) = self
+            .opening_state
+            .lock()
+            .expect("opening state lock")
+            .ids
+            .get(pty_id)
+            .map(|entry| entry.transport_id.clone())
+        {
+            return owner.as_deref() == Some(transport_id);
+        }
         if let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id) {
             return attachment.transport_id.as_deref() == Some(transport_id);
         }
-        if let Some(owner) = self.opening_ids.lock().expect("opening lock").get(pty_id) {
-            return owner.as_deref() == Some(transport_id);
-        }
         true
+    }
+
+    fn authorize(&self, pty_id: &str, context: &FrameContext, action: &str) -> Option<Attachment> {
+        let auth = Self::auth_snapshot(context);
+        self.authorize_snapshot(pty_id, &auth, context, action)
+    }
+
+    fn auth_allows(auth: &AuthSnapshot, attachment: &Attachment) -> bool {
+        let owner = auth.owner_user_id.as_deref();
+        !auth.trust.is_empty()
+            && (auth.trust != "observe"
+                || (owner.is_some() && owner == Some(attachment.actor_id.as_str())))
     }
 
     fn authorize_snapshot(
@@ -1106,36 +1341,191 @@ impl Inner {
         auth: &AuthSnapshot,
         context: &FrameContext,
         action: &str,
-        route_id: Option<u64>,
     ) -> Option<Attachment> {
-        let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
-        if route_id.is_some_and(|route_id| attachment.route_id != route_id) {
-            // A callback from a detached source is stale. It must not emit an
-            // error through its old transport or touch the replacement.
-            return None;
-        }
-        let owner = auth.owner_user_id.as_deref();
-        let allowed = !auth.trust.is_empty()
-            && (auth.trust != "observe"
-                || (owner.is_some() && owner == Some(attachment.actor_id.as_str())));
-        if allowed {
-            Some(attachment)
-        } else {
-            if action != "close" {
-                if let Some(route_id) = route_id {
-                    self.close_route(pty_id, route_id);
-                } else {
-                    self.close(pty_id);
-                }
+        self.authorize_snapshot_for_generation(pty_id, auth, context, action, 0)
+    }
+
+    fn with_live_attachment(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        context: &FrameContext,
+        action: &str,
+        operation: impl FnOnce(&dyn PtyControl),
+    ) {
+        let _publication = attachment.publication_gate.lock().expect("attachment publication lock");
+        {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
             }
-            send_pty_error(
+        }
+        let live_auth = Self::auth_snapshot(context);
+        if !Self::auth_allows(&live_auth, attachment) {
+            drop(_publication);
+            self.emit_error_for_generation(
                 context,
                 pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
+                "trust_revoked",
+                &format!("PTY {action} refused after trust change"),
+            );
+            return;
+        }
+        operation(attachment.control.as_ref());
+    }
+
+    fn authorize_snapshot_for_generation(
+        &self,
+        pty_id: &str,
+        auth: &AuthSnapshot,
+        context: &FrameContext,
+        action: &str,
+        generation: u64,
+    ) -> Option<Attachment> {
+        let attachment = self.attachments.lock().expect("attach lock").get(pty_id)?.clone();
+        if generation != 0 && attachment.generation != generation {
+            return None;
+        }
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return None;
+        }
+        if Self::auth_allows(auth, &attachment) {
+            Some(attachment)
+        } else {
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
                 "trust_revoked",
                 &format!("PTY {action} refused after trust change"),
             );
             None
         }
+    }
+
+    fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
+        let auth = Self::auth_snapshot(context);
+        let Some(attachment) =
+            self.authorize_snapshot_for_generation(pty_id, &auth, context, "close", 0)
+        else {
+            // A close may race the asynchronous open before its attachment
+            // is published. The transport fence ran at frame dispatch, so
+            // this exact owner can cancel the pending reservation now.
+            self.close_if_transport(pty_id, context.transport_id.as_deref(), None);
+            return;
+        };
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return;
+        }
+        self.close_exact_authorized(pty_id, &attachment, context);
+    }
+
+    fn close_exact_authorized(
+        &self,
+        pty_id: &str,
+        attachment: &Attachment,
+        context: &FrameContext,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &attachment.publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock().expect("attachment publication lock");
+        let current = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            current.clone()
+        };
+        let live_auth = Self::auth_snapshot(context);
+        if !Self::auth_allows(&live_auth, &current) {
+            drop(_publication);
+            self.emit_error_for_generation(
+                context,
+                pty_id,
+                attachment.generation,
+                &attachment.publication_gate,
+                "trust_revoked",
+                "PTY close refused after trust change",
+            );
+            return;
+        }
+        let removed = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != attachment.generation
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+                || current.closing.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            let removed = attachments.remove(pty_id).expect("attachment still present");
+            removed.closing.store(true, Ordering::SeqCst);
+            removed
+        };
+        drop(_publication);
+        removed.control.kill();
+    }
+
+    fn close_if_generation(&self, pty_id: &str, generation: u64) {
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            return;
+        };
+        if attachment.generation == generation {
+            self.close_exact(pty_id, Some(generation), Some(&attachment.publication_gate));
+        }
+    }
+
+    fn close_exact(
+        &self,
+        pty_id: &str,
+        generation: Option<u64>,
+        publication_gate: Option<&Arc<Mutex<()>>>,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || publication_gate
+                    .is_some_and(|expected| !Arc::ptr_eq(&current.publication_gate, expected))
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock().expect("attachment publication lock");
+        let attachment = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+            {
+                return;
+            }
+            let attachment = attachments.remove(pty_id).expect("attachment still present");
+            attachment.closing.store(true, Ordering::SeqCst);
+            attachment
+        };
+        attachment.control.kill();
     }
 }
 
@@ -1145,8 +1535,47 @@ struct Opened {
     surface: Option<String>,
     control: Arc<dyn PtyControl>,
     closing: Arc<AtomicBool>,
-    route_id: u64,
+    generation: u64,
+    publication_gate: Arc<Mutex<()>>,
     start: Box<dyn FnOnce() + Send>,
+}
+
+/// Own a control connection while an OPEN operation performs cancellable
+/// discovery and attach requests. Dropping the request must close the socket
+/// even when no `Opened` value has been returned yet.
+struct ControlGuard(Option<Arc<dyn ControlHandle>>);
+
+impl ControlGuard {
+    fn new(control: Arc<dyn ControlHandle>) -> Self {
+        Self(Some(control))
+    }
+
+    fn disarm(&mut self) -> Arc<dyn ControlHandle> {
+        self.0.take().expect("control guard owns a connection")
+    }
+}
+
+async fn request_control_with_cancellation(
+    control: &Arc<dyn ControlHandle>,
+    cmd: &str,
+    params: Value,
+    cancellation: &CancellationToken,
+) -> Option<Value> {
+    tokio::select! {
+        response = control.request(cmd, params) => response,
+        _ = cancellation.cancelled() => {
+            control.end();
+            None
+        }
+    }
+}
+
+impl Drop for ControlGuard {
+    fn drop(&mut self) {
+        if let Some(control) = self.0.take() {
+            control.end();
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1192,6 +1621,7 @@ impl Inner {
                 .connect_control(&ensured.socket_path)
                 .await
                 .map_err(|_| "cannot inspect existing daemon cwd".to_owned())?;
+            let _control_guard = ControlGuard::new(Arc::clone(&control));
             let Some(listed) = control.request("list-workspaces", json!({})).await else {
                 control.end();
                 return Err("cannot inspect existing daemon surfaces".to_owned());
@@ -1285,13 +1715,17 @@ impl Inner {
         let control = Arc::clone(&handle.control);
         let output = Arc::clone(&handle.output);
         let banner = handle.banner.clone();
-        let (on_data, on_exit, route_id) = self.sinks(pty_id, context);
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let publication_gate = Arc::new(Mutex::new(()));
+        let (on_data, on_exit) =
+            self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
         Ok(Opened {
             created: ensured.created,
             surface: None,
             control,
             closing: Arc::new(AtomicBool::new(false)),
-            route_id,
+            generation,
+            publication_gate,
             start: Box::new(move || drive_handle(output, banner, on_data, on_exit)),
         })
     }
@@ -1431,7 +1865,10 @@ impl Inner {
         let viewer_id = next_viewer_id();
         let released = Arc::new(AtomicBool::new(false));
         let closing = Arc::new(AtomicBool::new(false));
-        let (on_data, on_exit, route_id) = self.sinks(pty_id, context);
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let publication_gate = Arc::new(Mutex::new(()));
+        let (on_data, on_exit) =
+            self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
 
         // The per-attachment control proxies onto the session pty but its
         // kill() only unhooks this viewer (release), never the session.
@@ -1470,7 +1907,15 @@ impl Inner {
             }
         });
 
-        Ok(Opened { created, surface: None, control: proxy, closing, route_id, start })
+        Ok(Opened {
+            created,
+            surface: None,
+            control: proxy,
+            closing,
+            generation,
+            publication_gate,
+            start,
+        })
     }
 }
 
@@ -1507,11 +1952,6 @@ impl PtyControl for ShellViewerControl {
 }
 
 fn next_viewer_id() -> u64 {
-    static NEXT: AtomicU64 = AtomicU64::new(1);
-    NEXT.fetch_add(1, Ordering::Relaxed)
-}
-
-fn next_attachment_route_id() -> u64 {
     static NEXT: AtomicU64 = AtomicU64::new(1);
     NEXT.fetch_add(1, Ordering::Relaxed)
 }
@@ -1876,6 +2316,7 @@ impl Inner {
             Ok(control) => control,
             Err(_) => return Ok(None), // degrade to the whole-session attach
         };
+        let mut control_guard = ControlGuard::new(Arc::clone(&control));
 
         let identify = control.request("identify", json!({})).await;
         let info = identify.as_ref().filter(|v| v.get("ok").and_then(Value::as_bool) == Some(true));
@@ -1993,7 +2434,13 @@ impl Inner {
         } else {
             json!({ "surface": surface_id })
         };
-        let attached = control.request("attach-surface", attach_params).await;
+        let attached = request_control_with_cancellation(
+            &control,
+            "attach-surface",
+            attach_params,
+            &context.cancellation,
+        )
+        .await;
         if attached.as_ref().and_then(|v| v.get("ok")).and_then(Value::as_bool) != Some(true) {
             control.end();
             let reason = attached
@@ -2007,36 +2454,33 @@ impl Inner {
             ));
         }
 
-        let proxy = Arc::new(ControlTerminalControl { control, surface_id });
-        let (on_data, _, route_id) = self.sinks(pty_id, context);
+        let proxy =
+            Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
+        let generation = self.next_generation.fetch_add(1, Ordering::Relaxed);
+        let publication_gate = Arc::new(Mutex::new(()));
+        let (on_data, _) = self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));
         let relay = Arc::clone(&self);
         let context_for_exit = context.clone();
         let pty_id_for_exit = pty_id.to_owned();
         let stream_for_exit = Arc::clone(&stream);
-        let route_id_for_exit = route_id;
+        let exit_gate = Arc::clone(&publication_gate);
         let on_exit: ExitSink = Arc::new(move |code| {
             if stream_for_exit.overflowed() {
-                if relay.close_route(&pty_id_for_exit, route_id_for_exit) {
-                    send_pty_error(
-                        &context_for_exit,
-                        &pty_id_for_exit,
-                        "overflow",
-                        "pty output backlog overflowed; reattach to continue receiving output",
-                    );
-                }
+                relay.emit_error_for_generation(
+                    &context_for_exit,
+                    &pty_id_for_exit,
+                    generation,
+                    &exit_gate,
+                    "overflow",
+                    "pty output backlog overflowed; reattach to continue receiving output",
+                );
             } else {
-                let auth = AuthSnapshot {
-                    trust: context_for_exit.trust.clone(),
-                    owner_user_id: context_for_exit.owner_user_id.clone(),
-                    send: Arc::clone(&context_for_exit.send),
-                    buffered_amount: Arc::clone(&context_for_exit.buffered_amount),
-                };
-                relay.emit_exit(
+                relay.emit_exit_for_generation(
                     &pty_id_for_exit,
                     code,
                     &context_for_exit,
-                    &auth,
-                    route_id_for_exit,
+                    generation,
+                    &exit_gate,
                 );
             }
         });
@@ -2046,7 +2490,8 @@ impl Inner {
             surface: Some(surface_ref.to_owned()),
             control: proxy,
             closing: Arc::new(AtomicBool::new(false)),
-            route_id,
+            generation,
+            publication_gate,
             start: Box::new(move || start_stream.go_live(on_data, on_exit)),
         }))
     }
@@ -2637,6 +3082,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn stale_cancellation_marker_cannot_cancel_a_reused_open_generation() {
+        let h = harness(None, None);
+        let stale_generation =
+            h.manager.inner.next_opening_generation.fetch_add(1, Ordering::Relaxed);
+        h.manager
+            .inner
+            .opening_state
+            .lock()
+            .unwrap()
+            .cancelled
+            .insert("p1".to_owned(), stale_generation);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        assert_eq!(h.sent()[0]["type"], "pty_opened");
+        assert_eq!(h.manager.opening_count(), 0);
+    }
+
+    #[tokio::test]
     async fn shell_open_output_input_resize_flow_round_trip() {
         let h = harness(None, None);
         h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
@@ -2735,6 +3197,37 @@ mod tests {
         live_auth.lock().unwrap().0 = "observe".to_owned();
         pty.emit("secret");
         assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
+    }
+
+    #[tokio::test]
+    async fn output_rechecks_live_auth_after_route_admission() {
+        let h = harness(None, None);
+        let calls = Arc::new(AtomicUsize::new(0));
+        let mut context = h.context("supervised", h.owner.clone());
+        let calls_for_context = Arc::clone(&calls);
+        let owner = h.owner.clone();
+        context.live_auth = Arc::new(move || {
+            let call = calls_for_context.fetch_add(1, Ordering::SeqCst);
+            if call >= 2 {
+                ("observe".to_owned(), owner.clone())
+            } else {
+                ("supervised".to_owned(), owner.clone())
+            }
+        });
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_other",
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let pty = h.spawned()[0].clone();
+        pty.emit("secret");
+        assert!(!h.sent().iter().any(|f| f["type"] == "pty_output"));
+        assert!(h.sent().iter().any(|f| f["code"] == "trust_revoked"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1463,7 +1463,6 @@ impl Inner {
             if generation.is_none_or(|expected| entry.generation == expected) && owns_opening {
                 opening.cancelled.insert(pty_id.to_owned(), entry.generation);
             }
-            return;
         }
         drop(opening);
         let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2932,6 +2932,23 @@ mod tests {
         assert!(!h.manager.has_attachment("p-tunnel"));
     }
 
+    #[tokio::test]
+    async fn stale_viewer_output_cannot_reach_a_replacement_attachment() {
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let h = harness(Some(cmux), None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let stale_viewer = h.spawned()[0].clone();
+
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let before = h.sent().len();
+
+        stale_viewer.emit("stale output");
+
+        assert_eq!(h.sent().len(), before, "a detached viewer must not write to its replacement");
+        assert!(h.manager.has_attachment("p1"), "the replacement attachment must remain live");
+    }
+
     #[test]
     fn pty_env_scrubs_secrets_but_keeps_a_real_term() {
         let home = TestDirectory::new("env");

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1352,25 +1352,18 @@ impl Inner {
         }
         tokio::select! {
             _ = context.cancellation.cancelled() => {
-                self.emit_error_for_generation_async(
-                    context,
-                    &pty_id,
-                    generation,
-                    &publication_gate,
-                    "failed",
-                    "PTY output start cancelled",
-                ).await;
+                // Do not wait for the publication gate here. The start owner
+                // drops below and retires the attachment from its detached
+                // cleanup thread, while this request must finish promptly on
+                // transport cancellation.
+                send_pty_error(context, &pty_id, "failed", "PTY output start cancelled");
             }
             result = tokio::time::timeout(PTY_START_TIMEOUT, started_rx) => {
                 if result.is_err() {
-                    self.emit_error_for_generation_async(
-                        context,
-                        &pty_id,
-                        generation,
-                        &publication_gate,
-                        "failed",
-                        "PTY output start timed out",
-                    ).await;
+                    // The cleanup owner handles the gated retirement. Keep
+                    // the timeout path independent from that gate so a stuck
+                    // output callback cannot strand the opening request.
+                    send_pty_error(context, &pty_id, "failed", "PTY output start timed out");
                 }
             }
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1423,6 +1423,7 @@ impl Inner {
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.close_pending.load(Ordering::SeqCst)
                 || (context.transport_id.is_some() && current.transport_id != context.transport_id)
             {
                 return;
@@ -1436,6 +1437,7 @@ impl Inner {
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
             {
                 return;
             }
@@ -1450,6 +1452,7 @@ impl Inner {
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
             {
                 return;
             }
@@ -1532,6 +1535,7 @@ impl Inner {
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
             {
                 return;
             }
@@ -1544,6 +1548,7 @@ impl Inner {
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
             {
                 return;
             }
@@ -1571,6 +1576,7 @@ impl Inner {
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
                 || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
             {
                 return;
             }
@@ -5481,6 +5487,13 @@ mod tests {
                 .get("p1")
                 .is_some_and(|attachment| attachment.close_pending.load(Ordering::SeqCst)),
             "detach must mark the generation as closing before draining control operations"
+        );
+        let sent_before_late_output = h.sent().len();
+        pty.emit("late output");
+        assert_eq!(
+            h.sent().len(),
+            sent_before_late_output,
+            "a pending-close attachment must not publish stale output"
         );
 
         let replacement = serde_json::json!({

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -505,6 +505,18 @@ impl RouteGate {
         RouteGuard { gate: self, owner }
     }
 
+    fn try_lock(&self) -> Option<RouteGuard<'_>> {
+        let owner = std::thread::current().id();
+        let mut state = self.state.lock().expect("route gate lock");
+        if state.owner.is_some_and(|current| current != owner) {
+            return None;
+        }
+        state.owner = Some(owner);
+        state.depth += 1;
+        drop(state);
+        Some(RouteGuard { gate: self, owner })
+    }
+
     /// Acquire the gate without blocking a Tokio worker. The critical
     /// sections protected by this gate never await, so the polling thread is
     /// stable for the lifetime of the guard and can safely re-enter through a
@@ -1362,7 +1374,13 @@ impl Inner {
                 // drops below and retires the attachment from its detached
                 // cleanup thread, while this request must finish promptly on
                 // transport cancellation.
-                send_pty_error(context, &pty_id, "failed", "PTY output start cancelled");
+                self.send_start_error_if_current(
+                    context,
+                    &pty_id,
+                    generation,
+                    &publication_gate,
+                    "PTY output start cancelled",
+                );
             }
             result = tokio::time::timeout(PTY_START_TIMEOUT, started_rx) => {
                 if result.is_ok() {
@@ -1375,7 +1393,13 @@ impl Inner {
                     // The cleanup owner handles the gated retirement. Keep
                     // the timeout path independent from that gate so a stuck
                     // output callback cannot strand the opening request.
-                    send_pty_error(context, &pty_id, "failed", "PTY output start timed out");
+                    self.send_start_error_if_current(
+                        context,
+                        &pty_id,
+                        generation,
+                        &publication_gate,
+                        "PTY output start timed out",
+                    );
                 }
             }
         }
@@ -1621,6 +1645,38 @@ impl Inner {
         self.emit_terminal_for_generation(pty_id, generation, publication_gate, || {
             send_pty_error(context, pty_id, code, message);
         });
+    }
+
+    fn send_start_error_if_current(
+        &self,
+        context: &FrameContext,
+        pty_id: &str,
+        generation: u64,
+        publication_gate: &Arc<RouteGate>,
+        message: &str,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            {
+                return;
+            }
+            Arc::clone(&current.publication_gate)
+        };
+        let Some(_publication) = gate.try_lock() else { return };
+        let attachments = self.attachments.lock().expect("attach lock");
+        let Some(current) = attachments.get(pty_id) else { return };
+        if current.generation != generation
+            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+            || current.closing.load(Ordering::SeqCst)
+            || current.close_pending.load(Ordering::SeqCst)
+        {
+            return;
+        }
+        drop(attachments);
+        send_pty_error(context, pty_id, "failed", message);
     }
 
     async fn emit_error_for_generation_async(
@@ -2344,9 +2400,34 @@ impl StartCleanup {
         let pty_id = self.pty_id.clone();
         let generation = self.generation;
         let publication_gate = Arc::clone(&self.publication_gate);
-        std::thread::spawn(move || {
-            inner.close_exact(&pty_id, Some(generation), Some(&publication_gate));
-        });
+        if let Ok(handle) = tokio::runtime::Handle::try_current() {
+            // Keep the cleanup task owned by Tokio. The blocking section uses
+            // its bounded executor, so repeated cancelled starts cannot spawn
+            // one untracked OS thread each.
+            handle.spawn(async move {
+                let _ = tokio::task::spawn_blocking(move || {
+                    inner.close_exact(&pty_id, Some(generation), Some(&publication_gate));
+                })
+                .await;
+            });
+        } else {
+            // StartOwner normally drops on a Tokio worker. Keep a fallback for
+            // teardown paths that run after the runtime has shut down.
+            let fallback_inner = Arc::clone(&self.inner);
+            let fallback_gate = Arc::clone(&self.publication_gate);
+            let fallback_pty_id = self.pty_id.clone();
+            let fallback_generation = self.generation;
+            let cleanup = std::thread::Builder::new().name("chatmux-relay-pty-cleanup".to_owned());
+            if let Err(error) = cleanup.spawn(move || {
+                fallback_inner.close_exact(
+                    &fallback_pty_id,
+                    Some(fallback_generation),
+                    Some(&fallback_gate),
+                );
+            }) {
+                eprintln!("PTY cleanup thread could not be created: {error}");
+            }
+        }
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -62,6 +62,7 @@ const MAX_ENUM_SURFACES: usize = 8;
 const RAW_ATTACH_BACKLOG_CAP: usize = 1024 * 1024;
 const MAX_OUTPUT_CHUNK_BYTES: usize = 256 * 1024;
 const CONTROL_OPERATION_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
+const PTY_START_TIMEOUT: Duration = Duration::from_secs(5);
 const PTY_INPUT_B64_CAP: usize = 4 * 1024 * 1024;
 
 /// Random lowercase-hex identity for transports and tunnel attachments.
@@ -1349,7 +1350,30 @@ impl Inner {
             .await;
             return;
         }
-        let _ = started_rx.await;
+        tokio::select! {
+            _ = context.cancellation.cancelled() => {
+                self.emit_error_for_generation_async(
+                    context,
+                    &pty_id,
+                    generation,
+                    &publication_gate,
+                    "failed",
+                    "PTY output start cancelled",
+                ).await;
+            }
+            result = tokio::time::timeout(PTY_START_TIMEOUT, started_rx) => {
+                if result.is_err() {
+                    self.emit_error_for_generation_async(
+                        context,
+                        &pty_id,
+                        generation,
+                        &publication_gate,
+                        "failed",
+                        "PTY output start timed out",
+                    ).await;
+                }
+            }
+        }
     }
 
     /// Build the per-attachment emit closures (output + exit framing).

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1654,7 +1654,24 @@ impl Inner {
             }
             Arc::clone(&current.publication_gate)
         };
-        let Some(_publication) = gate.try_lock() else { return };
+        let Some(_publication) = gate.try_lock() else {
+            // A live output callback may own the gate while waiting on the
+            // socket. Send the terminal error directly in that case. The
+            // attachment cannot be replaced until the callback releases its
+            // gate, so this remains generation-scoped without another wait.
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if current.generation != generation
+                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
+                || current.closing.load(Ordering::SeqCst)
+                || current.close_pending.load(Ordering::SeqCst)
+            {
+                return;
+            }
+            drop(attachments);
+            send_pty_error(context, pty_id, "failed", message);
+            return;
+        };
         let attachments = self.attachments.lock().expect("attach lock");
         let Some(current) = attachments.get(pty_id) else { return };
         if current.generation != generation
@@ -2253,21 +2270,11 @@ impl Inner {
         }
         current.close_pending.store(true, Ordering::SeqCst);
         drop(_publication);
-        let drained = tokio::time::timeout(
-            CONTROL_OPERATION_DRAIN_TIMEOUT,
-            attachment.control_ops.wait_async(),
-        )
-        .await;
-        if drained.is_err() {
-            let manager = Arc::clone(self);
-            let pty_id = pty_id.to_owned();
-            let attachment = attachment.clone();
-            let context = context.clone();
-            tokio::spawn(async move {
-                manager.close_exact_authorized_async(&pty_id, &attachment, &context).await;
-            });
-            return;
-        }
+        // Keep the generation reserved until every in-flight control call
+        // completes. The transport teardown owns a separate cleanup task, so
+        // cancellation cannot create a retry loop or expose a replacement ID
+        // while the old operation is still running.
+        attachment.control_ops.wait_async().await;
         let _publication = gate.lock_async().await;
         let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
         else {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1372,7 +1372,7 @@ impl Inner {
                 );
             }
             result = tokio::time::timeout(PTY_START_TIMEOUT, started_rx) => {
-                if result.is_ok() {
+                if matches!(result, Ok(Ok(()))) {
                     // Commit readiness only after this task receives the
                     // signal. If cancellation wins before that point,
                     // StartOwner::drop retains ownership and retires the
@@ -2108,11 +2108,27 @@ impl Inner {
             if drained.is_err() {
                 let manager = Arc::clone(self);
                 let pty_id = pty_id.to_owned();
-                let transport_id = transport_id.map(str::to_owned);
+                let publication_gate = Arc::clone(&publication_gate);
                 tokio::spawn(async move {
-                    manager
-                        .close_if_transport_async(&pty_id, transport_id.as_deref(), generation)
-                        .await;
+                    attachment.control_ops.wait_async().await;
+                    let _publication = publication_gate.lock_async().await;
+                    let removed = {
+                        let mut attachments = manager.attachments.lock().expect("attach lock");
+                        let Some(current) = attachments.get(&pty_id) else { return };
+                        if generation.is_some_and(|expected| current.generation != expected)
+                            || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
+                            || !current.close_pending.load(Ordering::SeqCst)
+                            || current.closing.load(Ordering::SeqCst)
+                        {
+                            return;
+                        }
+                        let removed =
+                            attachments.remove(&pty_id).expect("attachment still present");
+                        removed.closing.store(true, Ordering::SeqCst);
+                        removed
+                    };
+                    drop(_publication);
+                    removed.control.kill();
                 });
                 return;
             }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -963,7 +963,15 @@ impl PtyManager {
             opening_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())).collect();
         ids.extend(attachment_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())));
         for (id, owner, generation) in ids {
-            self.inner.close_if_transport_async(&id, owner.as_deref(), Some(generation)).await;
+            // Keep retirement owned by Tokio even if the connection teardown
+            // timeout drops this waiter. Dropping a JoinHandle detaches the
+            // cleanup task, so a close_pending marker cannot strand the slot.
+            let manager = Arc::clone(&self.inner);
+            let owner = owner.clone();
+            let cleanup = tokio::spawn(async move {
+                manager.close_if_transport_async(&id, owner.as_deref(), Some(generation)).await;
+            });
+            let _ = cleanup.await;
         }
     }
 }
@@ -2191,14 +2199,32 @@ impl Inner {
         }
         let live_auth = Self::auth_snapshot(context);
         if !self.auth_allows(&live_auth, &current) {
-            current.close_pending.store(false, Ordering::SeqCst);
-            drop(_publication);
-            send_pty_error(
-                context,
-                pty_id,
-                "trust_revoked",
-                "PTY close refused after trust change",
-            );
+            if live_auth.version > current.auth_version {
+                let removed = {
+                    let mut attachments = self.attachments.lock().expect("attach lock");
+                    let Some(current) = attachments.get(pty_id) else { return };
+                    if current.generation != attachment.generation
+                        || !Arc::ptr_eq(&current.publication_gate, &gate)
+                        || !current.close_pending.load(Ordering::SeqCst)
+                    {
+                        return;
+                    }
+                    let removed = attachments.remove(pty_id).expect("attachment still present");
+                    removed.closing.store(true, Ordering::SeqCst);
+                    removed
+                };
+                drop(_publication);
+                removed.control.kill();
+            } else {
+                current.close_pending.store(false, Ordering::SeqCst);
+                drop(_publication);
+                send_pty_error(
+                    context,
+                    pty_id,
+                    "trust_revoked",
+                    "PTY close refused after trust change",
+                );
+            }
             return;
         }
         let removed = {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4320,6 +4320,51 @@ mod tests {
         assert!(!h.manager.has_attachment("p1"));
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn async_close_auth_denial_does_not_block_tokio_worker() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let publication_gate = {
+            let attachments = h.manager.inner.attachments.lock().expect("attach lock");
+            Arc::clone(&attachments.get("p1").expect("opened attachment").publication_gate)
+        };
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let gate_owner = std::thread::spawn(move || {
+            let _publication = publication_gate.lock();
+            entered_tx.send(()).expect("gate owner entered");
+            release_rx.recv().expect("gate owner released");
+        });
+        entered_rx.await.expect("gate owner entered");
+
+        let mut revoked = h.context("", h.owner.clone());
+        let owner = h.owner.clone();
+        revoked.live_auth = Arc::new(move || LiveAuth {
+            trust: String::new(),
+            owner_user_id: owner.clone(),
+            version: 1,
+            ..Default::default()
+        });
+        let close = tokio::spawn({
+            let manager = h.manager.clone();
+            async move {
+                manager
+                    .handle_frame(&serde_json::json!({"type":"pty_close","ptyId":"p1"}), &revoked)
+                    .await;
+            }
+        });
+        tokio::task::yield_now().await;
+        assert!(!close.is_finished(), "close waits asynchronously for the publication gate");
+        let tick = tokio::spawn(async { 17_u8 });
+        assert_eq!(tick.await.expect("unrelated task"), 17);
+
+        release_tx.send(()).expect("release gate owner");
+        close.await.expect("close task");
+        gate_owner.join().expect("gate owner");
+        assert!(h.sent().iter().any(|frame| frame["code"] == "trust_revoked"));
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
     #[tokio::test]
     async fn close_detaches_without_killing_reattach_replays_scrollback() {
         let h = harness(None, None);
@@ -4631,7 +4676,10 @@ mod tests {
         tokio::task::spawn_blocking(move || entered.wait()).await.expect("subscribe entered");
 
         cancellation.cancel();
-        open.abort();
+        tokio::time::timeout(Duration::from_secs(1), open)
+            .await
+            .expect("cancelled open returns without waiting for the publication gate")
+            .expect("cancelled open task");
         tokio::task::spawn_blocking(move || release.wait()).await.expect("subscribe released");
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1349,25 +1349,14 @@ impl Inner {
             state: AtomicUsize::new(0),
         });
         let _start_owner = StartOwner(Arc::clone(&start_cleanup));
-        let start_result = std::thread::Builder::new()
-            .name("chatmux-relay-pty-start".to_owned())
-            .spawn(move || {
-                start(Box::new(move || {
-                    let _ = started_tx.send(());
-                }));
-            });
-        if start_result.is_err() {
-            self.emit_error_for_generation_async(
-                context,
-                &pty_id,
-                generation,
-                &publication_gate,
-                "failed",
-                "PTY output start could not be scheduled",
-            )
-            .await;
-            return;
-        }
+        // Use Tokio's bounded blocking executor. A PTY source may block while
+        // installing callbacks, but repeated cancellations cannot create one
+        // untracked OS thread per opening.
+        let _start_task = tokio::task::spawn_blocking(move || {
+            start(Box::new(move || {
+                let _ = started_tx.send(());
+            }));
+        });
         tokio::select! {
             _ = context.cancellation.cancelled() => {
                 // Do not wait for the publication gate here. The start owner
@@ -2038,7 +2027,7 @@ impl Inner {
         self.close_exact_authorized(pty_id, &attachment, context);
     }
 
-    async fn close_authorized_async(&self, pty_id: &str, context: &FrameContext) {
+    async fn close_authorized_async(self: &Arc<Self>, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
         let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
         else {
@@ -2076,7 +2065,7 @@ impl Inner {
     }
 
     async fn close_if_transport_async(
-        &self,
+        self: &Arc<Self>,
         pty_id: &str,
         transport_id: Option<&str>,
         generation: Option<u64>,
@@ -2111,11 +2100,22 @@ impl Inner {
             }
             current.close_pending.store(true, Ordering::SeqCst);
             drop(_publication);
-            let _ = tokio::time::timeout(
+            let drained = tokio::time::timeout(
                 CONTROL_OPERATION_DRAIN_TIMEOUT,
                 attachment.control_ops.wait_async(),
             )
             .await;
+            if drained.is_err() {
+                let manager = Arc::clone(self);
+                let pty_id = pty_id.to_owned();
+                let transport_id = transport_id.map(str::to_owned);
+                tokio::spawn(async move {
+                    manager
+                        .close_if_transport_async(&pty_id, transport_id.as_deref(), generation)
+                        .await;
+                });
+                return;
+            }
             let _publication = publication_gate.lock_async().await;
             let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
             else {
@@ -2209,7 +2209,7 @@ impl Inner {
     }
 
     async fn close_exact_authorized_async(
-        &self,
+        self: &Arc<Self>,
         pty_id: &str,
         attachment: &Attachment,
         context: &FrameContext,
@@ -2237,11 +2237,21 @@ impl Inner {
         }
         current.close_pending.store(true, Ordering::SeqCst);
         drop(_publication);
-        let _ = tokio::time::timeout(
+        let drained = tokio::time::timeout(
             CONTROL_OPERATION_DRAIN_TIMEOUT,
             attachment.control_ops.wait_async(),
         )
         .await;
+        if drained.is_err() {
+            let manager = Arc::clone(self);
+            let pty_id = pty_id.to_owned();
+            let attachment = attachment.clone();
+            let context = context.clone();
+            tokio::spawn(async move {
+                manager.close_exact_authorized_async(&pty_id, &attachment, &context).await;
+            });
+            return;
+        }
         let _publication = gate.lock_async().await;
         let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
         else {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1973,15 +1973,35 @@ impl Inner {
 
     async fn close_authorized_async(&self, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
-        let attachment = match self.authorize_snapshot_for_close(pty_id, &auth, context, "close", 0)
-        {
-            Ok(attachment) => attachment,
-            Err(CloseAuthorizationFailure::Denied) => return,
-            Err(CloseAuthorizationFailure::Missing) => {
-                self.close_if_transport_async(pty_id, context.transport_id.as_deref(), None).await;
-                return;
-            }
+        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
+        else {
+            self.close_if_transport_async(pty_id, context.transport_id.as_deref(), None).await;
+            return;
         };
+        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
+            return;
+        }
+        if !self.auth_allows(&auth, &attachment) {
+            if auth.version > attachment.auth_version {
+                self.emit_error_for_generation_async(
+                    context,
+                    pty_id,
+                    attachment.generation,
+                    &attachment.publication_gate,
+                    "trust_revoked",
+                    "PTY close refused after trust change",
+                )
+                .await;
+            } else {
+                send_pty_error(
+                    context,
+                    pty_id,
+                    "trust_revoked",
+                    "PTY close refused after trust change",
+                );
+            }
+            return;
+        }
         if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
             return;
         }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3496,6 +3496,8 @@ mod tests {
     struct FakeState {
         on_data: Option<DataSink>,
         on_exit: Option<ExitSink>,
+        subscribe_entered: Option<TestArc<Barrier>>,
+        subscribe_release: Option<TestArc<Barrier>>,
         subscribe_output: Option<Bytes>,
         subscribe_exit: Option<i64>,
         written: Vec<Vec<u8>>,
@@ -3562,12 +3564,23 @@ mod tests {
 
     impl PtyOutput for FakePty {
         fn subscribe(&self, on_data: DataSink, on_exit: ExitSink) {
-            let (subscribe_output, subscribe_exit) = {
+            let (subscribe_entered, subscribe_release, subscribe_output, subscribe_exit) = {
                 let mut state = self.state.lock().unwrap();
                 state.on_data = Some(on_data.clone());
                 state.on_exit = Some(on_exit.clone());
-                (state.subscribe_output.take(), state.subscribe_exit.take())
+                (
+                    state.subscribe_entered.clone(),
+                    state.subscribe_release.clone(),
+                    state.subscribe_output.take(),
+                    state.subscribe_exit.take(),
+                )
             };
+            if let Some(entered) = subscribe_entered {
+                entered.wait();
+            }
+            if let Some(release) = subscribe_release {
+                release.wait();
+            }
             if let Some(output) = subscribe_output {
                 on_data(output);
             }
@@ -3584,6 +3597,8 @@ mod tests {
         connected: Vec<PathBuf>,
         subscribe_output: Option<Bytes>,
         subscribe_exit: Option<i64>,
+        subscribe_entered: Option<TestArc<Barrier>>,
+        subscribe_release: Option<TestArc<Barrier>>,
     }
 
     struct FakeDeps {
@@ -3599,14 +3614,21 @@ mod tests {
     #[async_trait]
     impl PtyDeps for FakeDeps {
         async fn spawn_pty(&self, spec: SpawnSpec) -> PtyHandle {
-            let (subscribe_output, subscribe_exit) = {
+            let (subscribe_output, subscribe_exit, subscribe_entered, subscribe_release) = {
                 let mut recorded = self.recorded.lock().unwrap();
-                (recorded.subscribe_output.take(), recorded.subscribe_exit.take())
+                (
+                    recorded.subscribe_output.take(),
+                    recorded.subscribe_exit.take(),
+                    recorded.subscribe_entered.clone(),
+                    recorded.subscribe_release.clone(),
+                )
             };
             let pty = FakePty {
                 state: Arc::new(StdMutex::new(FakeState {
                     subscribe_output,
                     subscribe_exit,
+                    subscribe_entered,
+                    subscribe_release,
                     ..FakeState::default()
                 })),
                 spawn_file: spec.file.clone(),
@@ -3849,6 +3871,12 @@ mod tests {
             recorded.subscribe_output =
                 output.map(|value| Bytes::copy_from_slice(value.as_bytes()));
             recorded.subscribe_exit = exit;
+        }
+
+        fn configure_subscribe_block(&self, entered: TestArc<Barrier>, release: TestArc<Barrier>) {
+            let mut recorded = self.recorded.lock().unwrap();
+            recorded.subscribe_entered = Some(entered);
+            recorded.subscribe_release = Some(release);
         }
     }
 
@@ -4486,6 +4514,43 @@ mod tests {
         }));
         assert!(sent.iter().any(|frame| ty(frame) == "pty_exit" && frame["code"] == 0));
         assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test]
+    async fn cancelled_open_before_readiness_releases_attachment() {
+        let cmux = CmuxTui { file: "/opt/cmux-tui".to_owned(), prefix: Vec::new() };
+        let h = harness(Some(cmux), None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        h.configure_subscribe_block(TestArc::clone(&entered), TestArc::clone(&release));
+        let context = h.context("supervised", h.owner.clone());
+        let cancellation = context.cancellation.clone();
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "work",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        let manager = h.manager.clone();
+        let open = tokio::spawn(async move { manager.handle_frame(&frame, &context).await });
+        tokio::task::spawn_blocking(move || entered.wait()).await.expect("subscribe entered");
+
+        cancellation.cancel();
+        open.abort();
+        tokio::task::spawn_blocking(move || release.wait()).await.expect("subscribe released");
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if h.manager.attachment_count() == 0 {
+                    break;
+                }
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+        })
+        .await
+        .expect("cancelled open releases attachment");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2100,6 +2100,28 @@ impl Inner {
         self.close_exact_authorized_async(pty_id, &attachment, context).await;
     }
 
+    fn force_retire(
+        &self,
+        pty_id: &str,
+        generation: Option<u64>,
+        publication_gate: Option<&Arc<RouteGate>>,
+    ) {
+        let removed = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || publication_gate
+                    .is_some_and(|expected| !Arc::ptr_eq(&current.publication_gate, expected))
+            {
+                return;
+            }
+            let removed = attachments.remove(pty_id).expect("attachment still present");
+            removed.closing.store(true, Ordering::SeqCst);
+            removed
+        };
+        removed.control.kill();
+    }
+
     async fn close_if_transport_async(
         self: &Arc<Self>,
         pty_id: &str,
@@ -2142,30 +2164,7 @@ impl Inner {
             )
             .await;
             if drained.is_err() {
-                let manager = Arc::clone(self);
-                let pty_id = pty_id.to_owned();
-                let publication_gate = Arc::clone(&publication_gate);
-                tokio::spawn(async move {
-                    attachment.control_ops.wait_async().await;
-                    let _publication = publication_gate.lock_async().await;
-                    let removed = {
-                        let mut attachments = manager.attachments.lock().expect("attach lock");
-                        let Some(current) = attachments.get(&pty_id) else { return };
-                        if generation.is_some_and(|expected| current.generation != expected)
-                            || !Arc::ptr_eq(&current.publication_gate, &publication_gate)
-                            || !current.close_pending.load(Ordering::SeqCst)
-                            || current.closing.load(Ordering::SeqCst)
-                        {
-                            return;
-                        }
-                        let removed =
-                            attachments.remove(&pty_id).expect("attachment still present");
-                        removed.closing.store(true, Ordering::SeqCst);
-                        removed
-                    };
-                    drop(_publication);
-                    removed.control.kill();
-                });
+                self.force_retire(pty_id, generation, Some(&publication_gate));
                 return;
             }
             let _publication = publication_gate.lock_async().await;
@@ -2289,11 +2288,15 @@ impl Inner {
         }
         current.close_pending.store(true, Ordering::SeqCst);
         drop(_publication);
-        // Keep the generation reserved until every in-flight control call
-        // completes. The transport teardown owns a separate cleanup task, so
-        // cancellation cannot create a retry loop or expose a replacement ID
-        // while the old operation is still running.
-        attachment.control_ops.wait_async().await;
+        let drained = tokio::time::timeout(
+            CONTROL_OPERATION_DRAIN_TIMEOUT,
+            attachment.control_ops.wait_async(),
+        )
+        .await;
+        if drained.is_err() {
+            self.force_retire(pty_id, Some(attachment.generation), Some(&gate));
+            return;
+        }
         let _publication = gate.lock_async().await;
         let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
         else {
@@ -2429,8 +2432,8 @@ struct OpenedCleanup {
 }
 
 /// Own the attachment until the start thread proves that both output sinks
-/// are installed. Cancellation while waiting for readiness releases the slot
-/// from a detached cleanup thread, so the async runtime is never blocked.
+/// are installed. Cancellation while waiting for readiness retires the exact
+/// generation without waiting for a blocked output callback.
 struct StartCleanup {
     inner: Arc<Inner>,
     pty_id: String,
@@ -2448,38 +2451,10 @@ impl StartCleanup {
         if self.state.compare_exchange(0, 2, Ordering::AcqRel, Ordering::Acquire).is_err() {
             return;
         }
-        let inner = Arc::clone(&self.inner);
-        let pty_id = self.pty_id.clone();
-        let generation = self.generation;
-        let publication_gate = Arc::clone(&self.publication_gate);
-        if let Ok(handle) = tokio::runtime::Handle::try_current() {
-            // Keep the cleanup task owned by Tokio. The blocking section uses
-            // its bounded executor, so repeated cancelled starts cannot spawn
-            // one untracked OS thread each.
-            handle.spawn(async move {
-                let _ = tokio::task::spawn_blocking(move || {
-                    inner.close_exact(&pty_id, Some(generation), Some(&publication_gate));
-                })
-                .await;
-            });
-        } else {
-            // StartOwner normally drops on a Tokio worker. Keep a fallback for
-            // teardown paths that run after the runtime has shut down.
-            let fallback_inner = Arc::clone(&self.inner);
-            let fallback_gate = Arc::clone(&self.publication_gate);
-            let fallback_pty_id = self.pty_id.clone();
-            let fallback_generation = self.generation;
-            let cleanup = std::thread::Builder::new().name("chatmux-relay-pty-cleanup".to_owned());
-            if let Err(error) = cleanup.spawn(move || {
-                fallback_inner.close_exact(
-                    &fallback_pty_id,
-                    Some(fallback_generation),
-                    Some(&fallback_gate),
-                );
-            }) {
-                eprintln!("PTY cleanup thread could not be created: {error}");
-            }
-        }
+        // Retire without waiting for the publication gate. The start task may
+        // be blocked in subscribe, but generation checks reject its late
+        // callbacks once this map entry is removed.
+        self.inner.force_retire(&self.pty_id, Some(self.generation), Some(&self.publication_gate));
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -29,7 +29,7 @@ use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex};
 use std::thread::ThreadId;
 use std::time::{Duration, Instant};
-use tokio::sync::{Notify, oneshot};
+use tokio::sync::{Notify, Semaphore, oneshot};
 use tokio_util::sync::CancellationToken;
 
 use async_trait::async_trait;
@@ -692,6 +692,7 @@ struct Inner {
     opening_state: Mutex<OpeningState>,
     shell_sessions: Mutex<HashMap<String, Arc<ShellSession>>>,
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
+    start_slots: Arc<Semaphore>,
     next_generation: AtomicU64,
 }
 
@@ -761,6 +762,7 @@ impl PtyManager {
                 opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
+                start_slots: Arc::new(Semaphore::new(MAX_PTYS)),
                 next_generation: AtomicU64::new(1),
             }),
         }
@@ -786,6 +788,7 @@ impl PtyManager {
                 opening_state: Mutex::new(OpeningState::default()),
                 shell_sessions: Mutex::new(HashMap::new()),
                 shell_starting: Mutex::new(HashMap::new()),
+                start_slots: Arc::new(Semaphore::new(max_ptys.max(1))),
                 next_generation: AtomicU64::new(1),
             }),
         }
@@ -1349,10 +1352,26 @@ impl Inner {
             state: AtomicUsize::new(0),
         });
         let _start_owner = StartOwner(Arc::clone(&start_cleanup));
+        let start_permit = tokio::select! {
+            _ = context.cancellation.cancelled() => {
+                self.send_start_error_if_current(
+                    context,
+                    &pty_id,
+                    generation,
+                    &publication_gate,
+                    "PTY output start cancelled",
+                );
+                return;
+            }
+            permit = self.start_slots.clone().acquire_owned() => {
+                permit.expect("PTY start semaphore remains open")
+            }
+        };
         // Use Tokio's bounded blocking executor. A PTY source may block while
         // installing callbacks, but repeated cancellations cannot create one
         // untracked OS thread per opening.
         let _start_task = tokio::task::spawn_blocking(move || {
+            let _start_permit = start_permit;
             start(Box::new(move || {
                 let _ = started_tx.send(());
             }));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1328,13 +1328,11 @@ impl Inner {
             publication_gate: Arc::clone(&publication_gate),
             state: AtomicUsize::new(0),
         });
-        let start_cleanup_for_thread = Arc::clone(&start_cleanup);
         let _start_owner = StartOwner(Arc::clone(&start_cleanup));
         let start_result = std::thread::Builder::new()
             .name("chatmux-relay-pty-start".to_owned())
             .spawn(move || {
                 start(Box::new(move || {
-                    start_cleanup_for_thread.mark_ready();
                     let _ = started_tx.send(());
                 }));
             });
@@ -1359,7 +1357,13 @@ impl Inner {
                 send_pty_error(context, &pty_id, "failed", "PTY output start cancelled");
             }
             result = tokio::time::timeout(PTY_START_TIMEOUT, started_rx) => {
-                if result.is_err() {
+                if result.is_ok() {
+                    // Commit readiness only after this task receives the
+                    // signal. If cancellation wins before that point,
+                    // StartOwner::drop retains ownership and retires the
+                    // attachment instead of accepting a late signal.
+                    start_cleanup.mark_ready();
+                } else {
                     // The cleanup owner handles the gated retirement. Keep
                     // the timeout path independent from that gate so a stuck
                     // output callback cannot strand the opening request.

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1320,10 +1320,20 @@ impl Inner {
         // stream. Wait only until the sink is installed, then let the
         // generation fence and control kill own its lifecycle.
         let (started_tx, started_rx) = oneshot::channel();
+        let start_cleanup = Arc::new(StartCleanup {
+            inner: Arc::clone(&self),
+            pty_id: pty_id.clone(),
+            generation,
+            publication_gate: Arc::clone(&publication_gate),
+            state: AtomicUsize::new(0),
+        });
+        let start_cleanup_for_thread = Arc::clone(&start_cleanup);
+        let _start_owner = StartOwner(Arc::clone(&start_cleanup));
         let start_result = std::thread::Builder::new()
             .name("chatmux-relay-pty-start".to_owned())
             .spawn(move || {
                 start(Box::new(move || {
+                    start_cleanup_for_thread.mark_ready();
                     let _ = started_tx.send(());
                 }));
             });
@@ -2235,6 +2245,44 @@ struct Opened {
 struct OpenedCleanup {
     control: Arc<dyn PtyControl>,
     claimed: AtomicBool,
+}
+
+/// Own the attachment until the start thread proves that both output sinks
+/// are installed. Cancellation while waiting for readiness releases the slot
+/// from a detached cleanup thread, so the async runtime is never blocked.
+struct StartCleanup {
+    inner: Arc<Inner>,
+    pty_id: String,
+    generation: u64,
+    publication_gate: Arc<RouteGate>,
+    state: AtomicUsize,
+}
+
+impl StartCleanup {
+    fn mark_ready(&self) {
+        let _ = self.state.compare_exchange(0, 1, Ordering::AcqRel, Ordering::Acquire);
+    }
+
+    fn cancel(&self) {
+        if self.state.compare_exchange(0, 2, Ordering::AcqRel, Ordering::Acquire).is_err() {
+            return;
+        }
+        let inner = Arc::clone(&self.inner);
+        let pty_id = self.pty_id.clone();
+        let generation = self.generation;
+        let publication_gate = Arc::clone(&self.publication_gate);
+        std::thread::spawn(move || {
+            inner.close_exact(&pty_id, Some(generation), Some(&publication_gate));
+        });
+    }
+}
+
+struct StartOwner(Arc<StartCleanup>);
+
+impl Drop for StartOwner {
+    fn drop(&mut self) {
+        self.0.cancel();
+    }
 }
 
 impl Drop for OpenedCleanup {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4556,6 +4556,62 @@ mod tests {
         assert!(!h.manager.has_attachment("p1"));
     }
 
+    #[tokio::test(flavor = "current_thread")]
+    async fn publication_timeout_retires_before_reporting_error() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let (generation, publication_gate) = {
+            let attachments = h.manager.inner.attachments.lock().expect("attach lock");
+            let attachment = attachments.get("p1").expect("opened attachment");
+            (attachment.generation, Arc::clone(&attachment.publication_gate))
+        };
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let gate_for_thread = Arc::clone(&publication_gate);
+        let gate_owner = thread::spawn(move || {
+            let _publication = gate_for_thread.lock();
+            entered_tx.send(()).expect("publication gate owner entered");
+            let _ = release_rx.blocking_recv();
+        });
+        entered_rx.await.expect("publication gate owner entered");
+
+        let error_seen = Arc::new(AtomicBool::new(false));
+        let attachment_visible_on_error = Arc::new(AtomicBool::new(false));
+        let error_seen_for_send = Arc::clone(&error_seen);
+        let attachment_visible_for_send = Arc::clone(&attachment_visible_on_error);
+        let manager_for_send = h.manager.clone();
+        let sent = Arc::clone(&h.sent);
+        let mut context = h.context("supervised", h.owner.clone());
+        context.send = Arc::new(move |frame| {
+            if frame["type"] == "pty_error" {
+                error_seen_for_send.store(true, Ordering::SeqCst);
+                attachment_visible_for_send
+                    .store(manager_for_send.has_attachment("p1"), Ordering::SeqCst);
+            }
+            sent.lock().expect("sent lock").push(frame);
+        });
+        h.manager
+            .inner
+            .emit_error_for_generation_async(
+                &context,
+                "p1",
+                generation,
+                &publication_gate,
+                "failed",
+                "publication gate timed out",
+            )
+            .await;
+        assert!(error_seen.load(Ordering::SeqCst), "publication timeout reports an error");
+        assert!(
+            !attachment_visible_on_error.load(Ordering::SeqCst),
+            "publication timeout must retire before publishing its error"
+        );
+        assert!(!h.manager.has_attachment("p1"));
+
+        release_tx.send(()).expect("release publication gate owner");
+        gate_owner.join().expect("publication gate owner");
+    }
+
     #[tokio::test]
     async fn close_detaches_without_killing_reattach_replays_scrollback() {
         let h = harness(None, None);

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1296,7 +1296,7 @@ impl Inner {
         drop(attachments);
         let live_auth = Self::auth_snapshot(context);
         attachments = self.attachments.lock().expect("attach lock");
-        if !self.auth_allows_claim(&live_auth, actor, &cwd, 0) {
+        if !self.auth_allows_claim(&live_auth, actor, &cwd.path, 0) {
             drop(opening);
             drop(attachments);
             opened.closing.store(true, Ordering::SeqCst);
@@ -1311,7 +1311,7 @@ impl Inner {
                 close_pending: Arc::new(AtomicBool::new(false)),
                 control: Arc::clone(&opened.control),
                 actor_id: actor.to_owned(),
-                cwd: cwd.clone(),
+                cwd: cwd.path.clone(),
                 auth_version: live_auth.version,
                 transport_id: context.transport_id.clone(),
                 generation: opened.generation,
@@ -1617,7 +1617,7 @@ impl Inner {
             return;
         }
         let attachment = {
-            let mut attachments = self.attachments.lock().expect("attach lock");
+            let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
@@ -1739,7 +1739,7 @@ impl Inner {
                 }
             };
         let attachment = {
-            let mut attachments = self.attachments.lock().expect("attach lock");
+            let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
@@ -1817,12 +1817,15 @@ impl Inner {
         generation: Option<u64>,
     ) {
         let mut opening = self.opening_state.lock().expect("opening state lock");
-        if let Some(entry) = opening.ids.get(pty_id) {
-            let owns_opening =
-                transport_id.is_none() || entry.transport_id.as_deref() == transport_id;
-            if generation.is_none_or(|expected| entry.generation == expected) && owns_opening {
-                opening.cancelled.insert(pty_id.to_owned(), entry.generation);
-            }
+        if let Some((entry_generation, owns_opening)) = opening.ids.get(pty_id).map(|entry| {
+            (
+                entry.generation,
+                transport_id.is_none() || entry.transport_id.as_deref() == transport_id,
+            )
+        }) && generation.is_none_or(|expected| entry_generation == expected)
+            && owns_opening
+        {
+            opening.cancelled.insert(pty_id.to_owned(), entry_generation);
         }
         drop(opening);
         let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
@@ -2140,12 +2143,15 @@ impl Inner {
         generation: Option<u64>,
     ) {
         let mut opening = self.opening_state.lock().expect("opening state lock");
-        if let Some(entry) = opening.ids.get(pty_id) {
-            let owns_opening =
-                transport_id.is_none() || entry.transport_id.as_deref() == transport_id;
-            if generation.is_none_or(|expected| entry.generation == expected) && owns_opening {
-                opening.cancelled.insert(pty_id.to_owned(), entry.generation);
-            }
+        if let Some((entry_generation, owns_opening)) = opening.ids.get(pty_id).map(|entry| {
+            (
+                entry.generation,
+                transport_id.is_none() || entry.transport_id.as_deref() == transport_id,
+            )
+        }) && generation.is_none_or(|expected| entry_generation == expected)
+            && owns_opening
+        {
+            opening.cancelled.insert(pty_id.to_owned(), entry_generation);
         }
         drop(opening);
         let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
@@ -2886,7 +2892,7 @@ impl Inner {
 
         // The per-attachment control proxies onto the session pty but its
         // kill() only unhooks this viewer (release), never the session.
-        let proxy = Arc::new(ShellViewerControl {
+        let proxy: Arc<dyn PtyControl> = Arc::new(ShellViewerControl {
             session: Arc::clone(&shell_session),
             viewer_id,
             released: Arc::clone(&released),
@@ -3513,7 +3519,7 @@ impl Inner {
             ));
         }
 
-        let proxy =
+        let proxy: Arc<dyn PtyControl> =
             Arc::new(ControlTerminalControl { control: control_guard.disarm(), surface_id });
         let publication_gate = Arc::new(RouteGate::new());
         let (on_data, _) = self.sinks(pty_id, context, generation, Arc::clone(&publication_gate));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1766,6 +1766,7 @@ impl Inner {
                 Err(_) => {
                     let send = Arc::clone(&context.send);
                     let pty_id = pty_id.to_owned();
+                    let error_pty_id = pty_id.clone();
                     let code = code.to_owned();
                     let message = message.to_owned();
                     self.force_retire_with_completion(
@@ -1776,7 +1777,7 @@ impl Inner {
                             send(json!({
                                 "version": PTY_PROTOCOL_VERSION,
                                 "type": "pty_error",
-                                "ptyId": pty_id,
+                                "ptyId": error_pty_id,
                                 "code": code,
                                 "message": message,
                             }));
@@ -1990,7 +1991,7 @@ impl Inner {
     }
 
     async fn with_live_attachment_async(
-        &self,
+        self: &Arc<Self>,
         pty_id: &str,
         attachment: &Attachment,
         context: &FrameContext,

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1287,41 +1287,40 @@ impl Inner {
                 return;
             }
         }
-        let mut opening = self.opening_state.lock().expect("opening state lock");
         // This is the publication linearization point. Read the live
         // authority only after waiting for any prior generation's publication
         // gate and while the opening state is held. Do not invoke the public
         // live-auth callback while the attachment map mutex is held. The
         // opening lock serializes competing reservations; reacquiring the
         // attachment map after the read keeps callbacks outside map locks.
-        let live_auth = Self::auth_snapshot(context);
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        if !self.auth_allows_claim(&live_auth, actor, &cwd.path, 0) {
-            drop(opening);
-            drop(attachments);
-            opened.closing.store(true, Ordering::SeqCst);
-            opened.control.kill();
-            fail("trust_revoked", "terminal trust changed while opening");
-            return;
-        }
-        let previous = attachments.insert(
-            pty_id.clone(),
-            Attachment {
-                closing: opened.closing,
-                close_pending: Arc::new(AtomicBool::new(false)),
-                control: Arc::clone(&opened.control),
-                actor_id: actor.to_owned(),
-                cwd: cwd.path.clone(),
-                auth_version: live_auth.version,
-                transport_id: context.transport_id.clone(),
-                generation: opened.generation,
-                publication_gate: Arc::clone(&opened.publication_gate),
-                control_ops: Arc::new(ControlOperationState::new()),
-            },
-        );
-        opening.ids.remove(&pty_id);
-        drop(opening);
-        drop(attachments);
+        let previous = {
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            let live_auth = Self::auth_snapshot(context);
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            if !self.auth_allows_claim(&live_auth, actor, &cwd.path, 0) {
+                opened.closing.store(true, Ordering::SeqCst);
+                opened.control.kill();
+                fail("trust_revoked", "terminal trust changed while opening");
+                return;
+            }
+            let previous = attachments.insert(
+                pty_id.clone(),
+                Attachment {
+                    closing: opened.closing,
+                    close_pending: Arc::new(AtomicBool::new(false)),
+                    control: Arc::clone(&opened.control),
+                    actor_id: actor.to_owned(),
+                    cwd: cwd.path.clone(),
+                    auth_version: live_auth.version,
+                    transport_id: context.transport_id.clone(),
+                    generation: opened.generation,
+                    publication_gate: Arc::clone(&opened.publication_gate),
+                    control_ops: Arc::new(ControlOperationState::new()),
+                },
+            );
+            opening.ids.remove(&pty_id);
+            previous
+        };
         if let Some(previous) = previous {
             previous.closing.store(true, Ordering::SeqCst);
             previous.control.kill();
@@ -1816,18 +1815,19 @@ impl Inner {
         transport_id: Option<&str>,
         generation: Option<u64>,
     ) {
-        let mut opening = self.opening_state.lock().expect("opening state lock");
-        if let Some((entry_generation, owns_opening)) = opening.ids.get(pty_id).map(|entry| {
-            (
-                entry.generation,
-                transport_id.is_none() || entry.transport_id.as_deref() == transport_id,
-            )
-        }) && generation.is_none_or(|expected| entry_generation == expected)
-            && owns_opening
         {
-            opening.cancelled.insert(pty_id.to_owned(), entry_generation);
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            if let Some((entry_generation, owns_opening)) = opening.ids.get(pty_id).map(|entry| {
+                (
+                    entry.generation,
+                    transport_id.is_none() || entry.transport_id.as_deref() == transport_id,
+                )
+            }) && generation.is_none_or(|expected| entry_generation == expected)
+                && owns_opening
+            {
+                opening.cancelled.insert(pty_id.to_owned(), entry_generation);
+            }
         }
-        drop(opening);
         let attachment = {
             let attachments = self.attachments.lock().expect("attach lock");
             attachments.get(pty_id).cloned()
@@ -2181,8 +2181,11 @@ impl Inner {
                         return;
                     }
                 };
-            let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-            else {
+            let current = {
+                let attachments = self.attachments.lock().expect("attach lock");
+                attachments.get(pty_id).cloned()
+            };
+            let Some(current) = current else {
                 return;
             };
             if generation.is_some_and(|expected| current.generation != expected)
@@ -2212,8 +2215,11 @@ impl Inner {
                         return;
                     }
                 };
-            let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-            else {
+            let current = {
+                let attachments = self.attachments.lock().expect("attach lock");
+                attachments.get(pty_id).cloned()
+            };
+            let Some(current) = current else {
                 return;
             };
             if generation.is_some_and(|expected| current.generation != expected)
@@ -2327,8 +2333,11 @@ impl Inner {
                     return;
                 }
             };
-        let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
+        let current = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            attachments.get(pty_id).cloned()
+        };
+        let Some(current) = current else {
             return;
         };
         if current.generation != attachment.generation
@@ -2356,8 +2365,11 @@ impl Inner {
                     return;
                 }
             };
-        let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
+        let current = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            attachments.get(pty_id).cloned()
+        };
+        let Some(current) = current else {
             return;
         };
         if current.generation != attachment.generation

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -755,6 +755,7 @@ impl Drop for OpeningReservation {
     }
 }
 
+#[derive(Clone)]
 pub struct PtyManager {
     inner: Arc<Inner>,
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1668,22 +1668,12 @@ impl Inner {
         publication_gate: &Arc<RouteGate>,
         message: &str,
     ) {
-        let gate = {
-            let attachments = self.attachments.lock().expect("attach lock");
-            let Some(current) = attachments.get(pty_id) else { return };
-            if current.generation != generation
-                || !Arc::ptr_eq(&current.publication_gate, publication_gate)
-            {
-                return;
-            }
-            Arc::clone(&current.publication_gate)
-        };
-        let Some(_publication) = gate.try_lock() else {
-            // A live output callback may own the gate while waiting on the
-            // socket. Send the terminal error directly in that case. The
-            // attachment cannot be replaced until the callback releases its
-            // gate, so this remains generation-scoped without another wait.
-            let attachments = self.attachments.lock().expect("attach lock");
+        // Start failure must retire the route before publishing its terminal
+        // error. The tunnel sink classifies an error as fatal by checking the
+        // attachment map synchronously. Do not wait for the publication gate:
+        // a stalled subscribe or replay callback can own it indefinitely.
+        let attachment = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if current.generation != generation
                 || !Arc::ptr_eq(&current.publication_gate, publication_gate)
@@ -1692,21 +1682,12 @@ impl Inner {
             {
                 return;
             }
-            drop(attachments);
-            send_pty_error(context, pty_id, "failed", message);
-            return;
+            let attachment = attachments.remove(pty_id).expect("attachment still present");
+            attachment.closing.store(true, Ordering::SeqCst);
+            attachment
         };
-        let attachments = self.attachments.lock().expect("attach lock");
-        let Some(current) = attachments.get(pty_id) else { return };
-        if current.generation != generation
-            || !Arc::ptr_eq(&current.publication_gate, publication_gate)
-            || current.closing.load(Ordering::SeqCst)
-            || current.close_pending.load(Ordering::SeqCst)
-        {
-            return;
-        }
-        drop(attachments);
         send_pty_error(context, pty_id, "failed", message);
+        attachment.control.kill();
     }
 
     async fn emit_error_for_generation_async(

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -5772,6 +5772,46 @@ mod tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
+    async fn transport_detach_retires_attachment_when_publication_stalls() {
+        let h = harness(None, None);
+        let entered = TestArc::new(Barrier::new(2));
+        let release = TestArc::new(Barrier::new(2));
+        let mut context =
+            blocking_terminal_context(&h, TestArc::clone(&entered), TestArc::clone(&release));
+        context.transport_id = Some("transport-a".to_owned());
+        h.manager
+            .handle_frame(
+                &serde_json::json!({
+                    "version": 4,
+                    "type": "pty_open",
+                    "ptyId": "p1",
+                    "session": "main",
+                    "cols": 80,
+                    "rows": 24,
+                    "actorId": "user_owner",
+                }),
+                &context,
+            )
+            .await;
+        let pty = h.spawned()[0].clone();
+        let output = thread::spawn(move || pty.emit("blocked"));
+        entered.wait();
+
+        let manager = h.manager.clone();
+        let mut detach =
+            tokio::spawn(async move { manager.detach_transport_async("transport-a").await });
+        let completed = tokio::time::timeout(Duration::from_secs(1), &mut detach).await;
+
+        release.wait();
+        output.join().expect("output callback");
+        if completed.is_err() {
+            detach.await.expect("transport detach after gate release");
+        }
+        assert!(completed.is_ok(), "transport detach has a bounded publication wait");
+        assert!(!h.manager.has_attachment("p1"));
+    }
+
+    #[tokio::test(flavor = "current_thread")]
     async fn long_lived_start_does_not_block_close_or_subsequent_frames() {
         let h = harness(None, None);
         let frame = serde_json::json!({

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -30,6 +30,7 @@ use std::sync::{Arc, Condvar, Mutex};
 use std::thread::ThreadId;
 use std::time::{Duration, Instant};
 use tokio::sync::{Notify, Semaphore, oneshot};
+use tokio::task::JoinSet;
 use tokio_util::sync::CancellationToken;
 
 use async_trait::async_trait;
@@ -62,6 +63,7 @@ const MAX_ENUM_SURFACES: usize = 8;
 const RAW_ATTACH_BACKLOG_CAP: usize = 1024 * 1024;
 const MAX_OUTPUT_CHUNK_BYTES: usize = 256 * 1024;
 const CONTROL_OPERATION_DRAIN_TIMEOUT: Duration = Duration::from_millis(250);
+const PUBLICATION_GATE_TIMEOUT: Duration = Duration::from_millis(250);
 const PTY_START_TIMEOUT: Duration = Duration::from_secs(5);
 const PTY_INPUT_B64_CAP: usize = 4 * 1024 * 1024;
 
@@ -977,16 +979,20 @@ impl PtyManager {
         let mut ids: Vec<(String, Option<String>, u64)> =
             opening_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())).collect();
         ids.extend(attachment_ids.into_iter().filter(|(_, owner, _)| owns(owner.as_deref())));
+        let mut cleanups = JoinSet::new();
         for (id, owner, generation) in ids {
-            // Keep retirement owned by Tokio even if the connection teardown
-            // timeout drops this waiter. Dropping a JoinHandle detaches the
-            // cleanup task, so a close_pending marker cannot strand the slot.
+            // Retire all attachments concurrently, but retain every task until
+            // it finishes so this cleanup does not create detached work.
             let manager = Arc::clone(&self.inner);
             let owner = owner.clone();
-            let cleanup = tokio::spawn(async move {
+            cleanups.spawn(async move {
                 manager.close_if_transport_async(&id, owner.as_deref(), Some(generation)).await;
             });
-            let _ = cleanup.await;
+        }
+        while let Some(result) = cleanups.join_next().await {
+            if let Err(error) = result {
+                eprintln!("PTY transport cleanup task failed: {error}");
+            }
         }
     }
 }
@@ -1723,7 +1729,15 @@ impl Inner {
             }
             Arc::clone(&current.publication_gate)
         };
-        let _publication = gate.lock_async().await;
+        let _publication =
+            match tokio::time::timeout(PUBLICATION_GATE_TIMEOUT, gate.lock_async()).await {
+                Ok(guard) => guard,
+                Err(_) => {
+                    send_pty_error(context, pty_id, code, message);
+                    self.force_retire(pty_id, Some(generation), Some(publication_gate));
+                    return;
+                }
+            };
         let attachment = {
             let mut attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
@@ -2142,7 +2156,16 @@ impl Inner {
             && attachment.transport_id.as_deref() == transport_id
         {
             let publication_gate = Arc::clone(&attachment.publication_gate);
-            let _publication = publication_gate.lock_async().await;
+            let _publication =
+                match tokio::time::timeout(PUBLICATION_GATE_TIMEOUT, publication_gate.lock_async())
+                    .await
+                {
+                    Ok(guard) => guard,
+                    Err(_) => {
+                        self.force_retire(pty_id, generation, Some(&publication_gate));
+                        return;
+                    }
+                };
             let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
             else {
                 return;
@@ -2164,7 +2187,16 @@ impl Inner {
                 self.force_retire(pty_id, generation, Some(&publication_gate));
                 return;
             }
-            let _publication = publication_gate.lock_async().await;
+            let _publication =
+                match tokio::time::timeout(PUBLICATION_GATE_TIMEOUT, publication_gate.lock_async())
+                    .await
+                {
+                    Ok(guard) => guard,
+                    Err(_) => {
+                        self.force_retire(pty_id, generation, Some(&publication_gate));
+                        return;
+                    }
+                };
             let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
             else {
                 return;
@@ -2272,7 +2304,14 @@ impl Inner {
             }
             Arc::clone(&current.publication_gate)
         };
-        let _publication = gate.lock_async().await;
+        let _publication =
+            match tokio::time::timeout(PUBLICATION_GATE_TIMEOUT, gate.lock_async()).await {
+                Ok(guard) => guard,
+                Err(_) => {
+                    self.force_retire(pty_id, Some(attachment.generation), Some(&gate));
+                    return;
+                }
+            };
         let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
         else {
             return;
@@ -2294,7 +2333,14 @@ impl Inner {
             self.force_retire(pty_id, Some(attachment.generation), Some(&gate));
             return;
         }
-        let _publication = gate.lock_async().await;
+        let _publication =
+            match tokio::time::timeout(PUBLICATION_GATE_TIMEOUT, gate.lock_async()).await {
+                Ok(guard) => guard,
+                Err(_) => {
+                    self.force_retire(pty_id, Some(attachment.generation), Some(&gate));
+                    return;
+                }
+            };
         let Some(current) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
         else {
             return;
@@ -5807,7 +5853,7 @@ mod tests {
         if completed.is_err() {
             detach.await.expect("transport detach after gate release");
         }
-        assert!(completed.is_ok(), "transport detach has a bounded publication wait");
+        assert!(matches!(completed, Ok(Ok(()))), "transport detach has a bounded publication wait");
         assert!(!h.manager.has_attachment("p1"));
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -790,7 +790,6 @@ impl PtyManager {
                 if retired {
                     eprintln!("retire worker retired {}", request.pty_id);
                     if let Some(completion) = request.completion {
-                        eprintln!("retire worker completion {}", request.pty_id);
                         completion();
                     }
                 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1551,6 +1551,11 @@ impl Inner {
             );
             return;
         }
+        // Forced retirement can mark the generation pending while a callback
+        // is between its map check and this send boundary.
+        if attachment.close_pending.load(Ordering::SeqCst) {
+            return;
+        }
         (live_auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_output",
@@ -1628,6 +1633,11 @@ impl Inner {
             current.closing.store(true, Ordering::SeqCst);
             current.clone()
         };
+        // Forced retirement can mark the generation pending while a callback
+        // is between its map check and this send boundary.
+        if attachment.close_pending.load(Ordering::SeqCst) {
+            return;
+        }
         (live_auth.send)(json!({
             "version": PTY_PROTOCOL_VERSION,
             "type": "pty_exit",
@@ -1683,6 +1693,7 @@ impl Inner {
                 return;
             }
             let attachment = attachments.remove(pty_id).expect("attachment still present");
+            attachment.close_pending.store(true, Ordering::SeqCst);
             attachment.closing.store(true, Ordering::SeqCst);
             attachment
         };
@@ -2117,6 +2128,7 @@ impl Inner {
                 return;
             }
             let removed = attachments.remove(pty_id).expect("attachment still present");
+            removed.close_pending.store(true, Ordering::SeqCst);
             removed.closing.store(true, Ordering::SeqCst);
             removed
         };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -790,6 +790,7 @@ impl PtyManager {
                 if retired {
                     eprintln!("retire worker retired {}", request.pty_id);
                     if let Some(completion) = request.completion {
+                        eprintln!("retire worker completion {}", request.pty_id);
                         completion();
                     }
                 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -781,12 +781,14 @@ impl PtyManager {
         });
         std::thread::spawn(move || {
             while let Ok(request) = retire_rx.recv() {
+                eprintln!("retire worker request {}", request.pty_id);
                 let retired = request.inner.retire_after_gate(
                     &request.pty_id,
                     request.generation,
                     request.publication_gate.as_ref(),
                 );
                 if retired {
+                    eprintln!("retire worker retired {}", request.pty_id);
                     if let Some(completion) = request.completion {
                         completion();
                     }
@@ -823,12 +825,14 @@ impl PtyManager {
         });
         std::thread::spawn(move || {
             while let Ok(request) = retire_rx.recv() {
+                eprintln!("retire worker request {}", request.pty_id);
                 let retired = request.inner.retire_after_gate(
                     &request.pty_id,
                     request.generation,
                     request.publication_gate.as_ref(),
                 );
                 if retired {
+                    eprintln!("retire worker retired {}", request.pty_id);
                     if let Some(completion) = request.completion {
                         completion();
                     }
@@ -2247,6 +2251,7 @@ impl Inner {
             publication_gate: Some(gate),
             completion,
         };
+        eprintln!("queue retire {pty_id}");
         if let Err(std::sync::mpsc::TrySendError::Full(request)) = self.retire_tx.try_send(request)
         {
             std::thread::spawn(move || {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2094,9 +2094,6 @@ impl Inner {
             }
             return;
         }
-        if context.transport_id.is_some() && attachment.transport_id != context.transport_id {
-            return;
-        }
         self.close_exact_authorized_async(pty_id, &attachment, context).await;
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -5281,6 +5281,34 @@ mod tests {
     }
 
     #[test]
+    fn go_live_ready_waits_for_backlog_replay() {
+        let stream = TerminalStream::new();
+        stream.push_output(Bytes::from_static(b"buffered"));
+
+        let seen = Arc::new(Mutex::new(Vec::new()));
+        let data_seen = Arc::clone(&seen);
+        let exit_seen = Arc::clone(&seen);
+        let ready_seen = Arc::clone(&seen);
+        stream.go_live_with_ready(
+            Arc::new(move |chunk| {
+                data_seen
+                    .lock()
+                    .expect("ready order data lock")
+                    .push(String::from_utf8_lossy(&chunk).into_owned());
+            }),
+            Arc::new(move |code| {
+                exit_seen.lock().expect("ready order exit lock").push(format!("exit:{code}"));
+            }),
+            move || ready_seen.lock().expect("ready order lock").push("ready".to_owned()),
+        );
+
+        assert_eq!(
+            *seen.lock().expect("ready order lock"),
+            vec!["buffered".to_owned(), "ready".to_owned()]
+        );
+    }
+
+    #[test]
     fn backlog_overflow_ends_after_accepted_bytes_and_marks_overflow() {
         let stream = TerminalStream::new();
         stream.push_output(Bytes::from(vec![b'x'; RAW_ATTACH_BACKLOG_CAP]));

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1249,53 +1249,53 @@ impl Inner {
             return;
         }
 
-        // Keep both locks held until the attachment is installed. `close`
-        // takes opening_state first, so it cannot observe a gap between
-        // removing the opening marker and inserting the attachment.
-        let mut opening = self.opening_state.lock().expect("opening state lock");
-        let mut attachments = self.attachments.lock().expect("attach lock");
-        let cancelled = opening.cancelled.get(&pty_id) == Some(&opening_generation);
-        if cancelled {
-            opening.cancelled.remove(&pty_id);
-            opening.ids.remove(&pty_id);
-            drop(opening);
-            drop(attachments);
-            reservation.active = false;
-            opened.closing.store(true, Ordering::SeqCst);
-            opened.control.kill();
-            return;
-        }
-        // A terminal callback locks its publication gate before it rechecks
-        // the attachment map. Acquire the previous generation's gate before
-        // replacing it, otherwise a same-ID open can overtake a blocked exit.
-        if let Some(previous_gate) =
-            attachments.get(&pty_id).map(|previous| Arc::clone(&previous.publication_gate))
-        {
-            drop(attachments);
-            drop(opening);
-            let _previous_publication = previous_gate.lock_async().await;
-            opening = self.opening_state.lock().expect("opening state lock");
-            attachments = self.attachments.lock().expect("attach lock");
+        // `close` takes opening_state first, so keep that lock across the
+        // publication decision. Never keep either std mutex guard across an
+        // await, because this handler runs in Tokio's Send task pool.
+        let previous_gate = {
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            let attachments = self.attachments.lock().expect("attach lock");
             if opening.cancelled.get(&pty_id) == Some(&opening_generation) {
                 opening.cancelled.remove(&pty_id);
                 opening.ids.remove(&pty_id);
-                drop(opening);
                 drop(attachments);
                 reservation.active = false;
                 opened.closing.store(true, Ordering::SeqCst);
                 opened.control.kill();
                 return;
             }
+            attachments.get(&pty_id).map(|previous| Arc::clone(&previous.publication_gate))
+        };
+        // A terminal callback locks its publication gate before it rechecks
+        // the attachment map. Acquire the previous generation's gate before
+        // replacing it, otherwise a same-ID open can overtake a blocked exit.
+        if let Some(previous_gate) = previous_gate {
+            let _previous_publication = previous_gate.lock_async().await;
+            let cancelled = {
+                let mut opening = self.opening_state.lock().expect("opening state lock");
+                let cancelled = opening.cancelled.get(&pty_id) == Some(&opening_generation);
+                if cancelled {
+                    opening.cancelled.remove(&pty_id);
+                    opening.ids.remove(&pty_id);
+                }
+                cancelled
+            };
+            if cancelled {
+                reservation.active = false;
+                opened.closing.store(true, Ordering::SeqCst);
+                opened.control.kill();
+                return;
+            }
         }
+        let mut opening = self.opening_state.lock().expect("opening state lock");
         // This is the publication linearization point. Read the live
         // authority only after waiting for any prior generation's publication
         // gate and while the opening state is held. Do not invoke the public
         // live-auth callback while the attachment map mutex is held. The
         // opening lock serializes competing reservations; reacquiring the
         // attachment map after the read keeps callbacks outside map locks.
-        drop(attachments);
         let live_auth = Self::auth_snapshot(context);
-        attachments = self.attachments.lock().expect("attach lock");
+        let mut attachments = self.attachments.lock().expect("attach lock");
         if !self.auth_allows_claim(&live_auth, actor, &cwd.path, 0) {
             drop(opening);
             drop(attachments);
@@ -1828,8 +1828,11 @@ impl Inner {
             opening.cancelled.insert(pty_id.to_owned(), entry_generation);
         }
         drop(opening);
-        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            attachments.get(pty_id).cloned()
+        };
+        let Some(attachment) = attachment else {
             return;
         };
         if generation.is_none_or(|expected| attachment.generation == expected)
@@ -2082,8 +2085,11 @@ impl Inner {
 
     async fn close_authorized_async(self: &Arc<Self>, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
-        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            attachments.get(pty_id).cloned()
+        };
+        let Some(attachment) = attachment else {
             self.close_if_transport_async(pty_id, context.transport_id.as_deref(), None).await;
             return;
         };
@@ -2154,8 +2160,11 @@ impl Inner {
             opening.cancelled.insert(pty_id.to_owned(), entry_generation);
         }
         drop(opening);
-        let Some(attachment) = self.attachments.lock().expect("attach lock").get(pty_id).cloned()
-        else {
+        let attachment = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            attachments.get(pty_id).cloned()
+        };
+        let Some(attachment) = attachment else {
             return;
         };
         if generation.is_none_or(|expected| attachment.generation == expected)

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4744,26 +4744,34 @@ mod tests {
             }
             sent.lock().expect("sent lock").push(frame);
         });
-        h.manager
-            .inner
-            .emit_error_for_generation_async(
-                &context,
-                "p1",
-                generation,
-                &publication_gate,
-                "failed",
-                "publication gate timed out",
-            )
-            .await;
+        let manager = h.manager.clone();
+        let context_for_error = context.clone();
+        let gate_for_error = Arc::clone(&publication_gate);
+        let error = tokio::spawn(async move {
+            manager
+                .inner
+                .emit_error_for_generation_async(
+                    &context_for_error,
+                    "p1",
+                    generation,
+                    &gate_for_error,
+                    "failed",
+                    "publication gate timed out",
+                )
+                .await;
+        });
+        tokio::time::sleep(PUBLICATION_GATE_TIMEOUT + Duration::from_millis(50)).await;
+        assert!(!error_seen.load(Ordering::SeqCst), "error waits for gated retirement");
+
+        release_tx.send(()).expect("release publication gate owner");
+        gate_owner.join().expect("publication gate owner");
+        error.await.expect("publication timeout task");
         assert!(error_seen.load(Ordering::SeqCst), "publication timeout reports an error");
         assert!(
             !attachment_visible_on_error.load(Ordering::SeqCst),
             "publication timeout must retire before publishing its error"
         );
         assert!(!h.manager.has_attachment("p1"));
-
-        release_tx.send(()).expect("release publication gate owner");
-        gate_owner.join().expect("publication gate owner");
     }
 
     #[tokio::test(flavor = "current_thread")]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2943,7 +2943,6 @@ impl Inner {
             };
             // The viewer is installed while the publication gate is held.
             // Subsequent PTY output therefore waits behind replay callbacks.
-            ready();
             if let Some(banner) = banner {
                 emit_bounded_bytes(&on_data, Bytes::from(banner));
             }
@@ -2952,13 +2951,13 @@ impl Inner {
                     emit_bounded_bytes(&on_data, chunk);
                 }
             }
-            if released.load(Ordering::SeqCst) {
-                return;
-            }
-            if !alive {
+            if !released.load(Ordering::SeqCst) && !alive {
                 on_exit(0);
-                return;
             }
+            // Publish readiness only after the complete banner and replay
+            // handoff. Cancellation after readiness can retire this
+            // generation, so signalling first could discard terminal state.
+            ready();
         });
 
         Ok(Opened {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -4870,7 +4870,21 @@ mod tests {
         let entered = TestArc::new(Barrier::new(2));
         let release = TestArc::new(Barrier::new(2));
         h.configure_subscribe_block(TestArc::clone(&entered), TestArc::clone(&release));
-        let context = h.context("supervised", h.owner.clone());
+        let error_seen = Arc::new(AtomicBool::new(false));
+        let attachment_visible_on_error = Arc::new(AtomicBool::new(false));
+        let error_seen_for_send = Arc::clone(&error_seen);
+        let attachment_visible_for_send = Arc::clone(&attachment_visible_on_error);
+        let manager_for_send = h.manager.clone();
+        let sent = Arc::clone(&h.sent);
+        let mut context = h.context("supervised", h.owner.clone());
+        context.send = Arc::new(move |frame| {
+            if frame["type"] == "pty_error" {
+                error_seen_for_send.store(true, Ordering::SeqCst);
+                attachment_visible_for_send
+                    .store(manager_for_send.has_attachment("p1"), Ordering::SeqCst);
+            }
+            sent.lock().expect("sent lock").push(frame);
+        });
         let cancellation = context.cancellation.clone();
         let frame = serde_json::json!({
             "version": 4,
@@ -4890,6 +4904,11 @@ mod tests {
             .await
             .expect("cancelled open returns without waiting for the publication gate")
             .expect("cancelled open task");
+        assert!(error_seen.load(Ordering::SeqCst), "cancelled open reports a terminal error");
+        assert!(
+            !attachment_visible_on_error.load(Ordering::SeqCst),
+            "start failure must retire the attachment before publishing its error"
+        );
         tokio::task::spawn_blocking(move || release.wait()).await.expect("subscribe released");
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -1713,8 +1713,8 @@ impl Inner {
             match tokio::time::timeout(PUBLICATION_GATE_TIMEOUT, gate.lock_async()).await {
                 Ok(guard) => guard,
                 Err(_) => {
-                    send_pty_error(context, pty_id, code, message);
                     self.force_retire(pty_id, Some(generation), Some(publication_gate));
+                    send_pty_error(context, pty_id, code, message);
                     return;
                 }
             };

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -704,6 +704,7 @@ struct RetireRequest {
     pty_id: String,
     generation: Option<u64>,
     publication_gate: Option<Arc<RouteGate>>,
+    completion: Option<Box<dyn FnOnce() + Send + 'static>>,
 }
 
 #[derive(Default)]
@@ -779,11 +780,16 @@ impl PtyManager {
         });
         std::thread::spawn(move || {
             while let Ok(request) = retire_rx.recv() {
-                request.inner.retire_after_gate(
+                let retired = request.inner.retire_after_gate(
                     &request.pty_id,
                     request.generation,
                     request.publication_gate.as_ref(),
                 );
+                if retired {
+                    if let Some(completion) = request.completion {
+                        completion();
+                    }
+                }
             }
         });
         PtyManager { inner }
@@ -816,11 +822,16 @@ impl PtyManager {
         });
         std::thread::spawn(move || {
             while let Ok(request) = retire_rx.recv() {
-                request.inner.retire_after_gate(
+                let retired = request.inner.retire_after_gate(
                     &request.pty_id,
                     request.generation,
                     request.publication_gate.as_ref(),
                 );
+                if retired {
+                    if let Some(completion) = request.completion {
+                        completion();
+                    }
+                }
             }
         });
         PtyManager { inner }
@@ -1752,8 +1763,24 @@ impl Inner {
             match tokio::time::timeout(PUBLICATION_GATE_TIMEOUT, gate.lock_async()).await {
                 Ok(guard) => guard,
                 Err(_) => {
-                    self.force_retire(pty_id, Some(generation), Some(publication_gate));
-                    send_pty_error(context, pty_id, code, message);
+                    let send = Arc::clone(&context.send);
+                    let pty_id = pty_id.to_owned();
+                    let code = code.to_owned();
+                    let message = message.to_owned();
+                    self.force_retire_with_completion(
+                        &pty_id,
+                        Some(generation),
+                        Some(publication_gate),
+                        Some(Box::new(move || {
+                            send(json!({
+                                "version": PTY_PROTOCOL_VERSION,
+                                "type": "pty_error",
+                                "ptyId": pty_id,
+                                "code": code,
+                                "message": message,
+                            }));
+                        })),
+                    );
                     return;
                 }
             };
@@ -2145,26 +2172,26 @@ impl Inner {
         pty_id: &str,
         generation: Option<u64>,
         publication_gate: Option<&Arc<RouteGate>>,
-    ) {
+    ) -> bool {
         let gate = {
             let attachments = self.attachments.lock().expect("attach lock");
-            let Some(current) = attachments.get(pty_id) else { return };
+            let Some(current) = attachments.get(pty_id) else { return false };
             if generation.is_some_and(|expected| current.generation != expected)
                 || publication_gate
                     .is_some_and(|expected| !Arc::ptr_eq(&current.publication_gate, expected))
             {
-                return;
+                return false;
             }
             Arc::clone(&current.publication_gate)
         };
         let _publication = gate.lock();
         let removed = {
             let mut attachments = self.attachments.lock().expect("attach lock");
-            let Some(current) = attachments.get(pty_id) else { return };
+            let Some(current) = attachments.get(pty_id) else { return false };
             if generation.is_some_and(|expected| current.generation != expected)
                 || !Arc::ptr_eq(&current.publication_gate, &gate)
             {
-                return;
+                return false;
             }
             let removed = attachments.remove(pty_id).expect("attachment still present");
             removed.closing.store(true, Ordering::SeqCst);
@@ -2172,6 +2199,7 @@ impl Inner {
         };
         drop(_publication);
         removed.control.kill();
+        true
     }
 
     fn force_retire(
@@ -2179,6 +2207,16 @@ impl Inner {
         pty_id: &str,
         generation: Option<u64>,
         publication_gate: Option<&Arc<RouteGate>>,
+    ) {
+        self.force_retire_with_completion(pty_id, generation, publication_gate, None);
+    }
+
+    fn force_retire_with_completion(
+        self: &Arc<Self>,
+        pty_id: &str,
+        generation: Option<u64>,
+        publication_gate: Option<&Arc<RouteGate>>,
+        completion: Option<Box<dyn FnOnce() + Send + 'static>>,
     ) {
         let gate = {
             let attachments = self.attachments.lock().expect("attach lock");
@@ -2193,7 +2231,11 @@ impl Inner {
             Arc::clone(&current.publication_gate)
         };
         if let Some(_publication) = gate.try_lock() {
-            self.retire_after_gate(pty_id, generation, Some(&gate));
+            if self.retire_after_gate(pty_id, generation, Some(&gate)) {
+                if let Some(completion) = completion {
+                    completion();
+                }
+            }
             return;
         }
         let request = RetireRequest {
@@ -2201,15 +2243,21 @@ impl Inner {
             pty_id: pty_id.to_owned(),
             generation,
             publication_gate: Some(gate),
+            completion,
         };
         if let Err(std::sync::mpsc::TrySendError::Full(request)) = self.retire_tx.try_send(request)
         {
             std::thread::spawn(move || {
-                request.inner.retire_after_gate(
+                let retired = request.inner.retire_after_gate(
                     &request.pty_id,
                     request.generation,
                     request.publication_gate.as_ref(),
                 );
+                if retired {
+                    if let Some(completion) = request.completion {
+                        completion();
+                    }
+                }
             });
         }
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -781,14 +781,12 @@ impl PtyManager {
         });
         std::thread::spawn(move || {
             while let Ok(request) = retire_rx.recv() {
-                eprintln!("retire worker request {}", request.pty_id);
                 let retired = request.inner.retire_after_gate(
                     &request.pty_id,
                     request.generation,
                     request.publication_gate.as_ref(),
                 );
                 if retired {
-                    eprintln!("retire worker retired {}", request.pty_id);
                     if let Some(completion) = request.completion {
                         completion();
                     }
@@ -825,14 +823,12 @@ impl PtyManager {
         });
         std::thread::spawn(move || {
             while let Ok(request) = retire_rx.recv() {
-                eprintln!("retire worker request {}", request.pty_id);
                 let retired = request.inner.retire_after_gate(
                     &request.pty_id,
                     request.generation,
                     request.publication_gate.as_ref(),
                 );
                 if retired {
-                    eprintln!("retire worker retired {}", request.pty_id);
                     if let Some(completion) = request.completion {
                         completion();
                     }
@@ -2251,7 +2247,6 @@ impl Inner {
             publication_gate: Some(gate),
             completion,
         };
-        eprintln!("queue retire {pty_id}");
         if let Err(std::sync::mpsc::TrySendError::Full(request)) = self.retire_tx.try_send(request)
         {
             std::thread::spawn(move || {

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -5978,4 +5978,57 @@ mod tests {
                 && from_b64(frame["dataB64"].as_str().unwrap_or_default()) == "during-start"
         }));
     }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn shell_start_publishes_readiness_after_backlog_replay() {
+        let h = harness(None, None);
+        h.open("p1", "main", Value::Null, "supervised", h.owner.clone()).await;
+        let shell = h.spawned()[0].clone();
+        shell.emit("replay");
+        h.frame(serde_json::json!({ "type": "pty_close", "ptyId": "p1" })).await;
+
+        let (entered_tx, entered_rx) = tokio::sync::oneshot::channel();
+        let entered_tx = Arc::new(StdMutex::new(Some(entered_tx)));
+        let (release_tx, release_rx) = tokio::sync::oneshot::channel();
+        let release_rx = Arc::new(StdMutex::new(Some(release_rx)));
+        let sent = Arc::clone(&h.sent);
+        let mut context = h.context("supervised", h.owner.clone());
+        context.send = Arc::new(move |frame| {
+            if matches!(
+                frame.get("type").and_then(Value::as_str),
+                Some("pty_output" | "pty_exit" | "pty_error")
+            ) {
+                if let Some(entered_tx) =
+                    entered_tx.lock().expect("replay entry signal lock").take()
+                {
+                    let _ = entered_tx.send(());
+                }
+                if let Some(release_rx) = release_rx.lock().expect("replay release lock").take() {
+                    let _ = release_rx.blocking_recv();
+                }
+            }
+            sent.lock().expect("sent lock").push(frame);
+        });
+
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+        });
+        let manager = h.manager.clone();
+        let open = tokio::spawn(async move { manager.handle_frame(&frame, &context).await });
+        tokio::time::timeout(Duration::from_secs(1), entered_rx)
+            .await
+            .expect("replay callback entered")
+            .expect("replay entry signal");
+        assert!(!open.is_finished(), "shell OPEN must wait for replay before publishing readiness");
+
+        release_tx.send(()).expect("release replay callback");
+        open.await.expect("shell replacement open");
+        assert!(h.sent().iter().any(|frame| frame["type"] == "pty_output"));
+    }
 }

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -3174,10 +3174,13 @@ impl TerminalStream {
             state.backlog_bytes = 0;
             Self::start_delivery(&mut state)
         };
-        ready();
         if should_drain {
             self.drain();
         }
+        // Keep OPEN readiness behind the complete backlog handoff. A close
+        // or replacement can retire this generation as soon as readiness is
+        // published, so signaling first could discard replay callbacks.
+        ready();
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2148,18 +2148,19 @@ impl Inner {
         transport_id: Option<&str>,
         generation: Option<u64>,
     ) {
-        let mut opening = self.opening_state.lock().expect("opening state lock");
-        if let Some((entry_generation, owns_opening)) = opening.ids.get(pty_id).map(|entry| {
-            (
-                entry.generation,
-                transport_id.is_none() || entry.transport_id.as_deref() == transport_id,
-            )
-        }) && generation.is_none_or(|expected| entry_generation == expected)
-            && owns_opening
         {
-            opening.cancelled.insert(pty_id.to_owned(), entry_generation);
+            let mut opening = self.opening_state.lock().expect("opening state lock");
+            if let Some((entry_generation, owns_opening)) = opening.ids.get(pty_id).map(|entry| {
+                (
+                    entry.generation,
+                    transport_id.is_none() || entry.transport_id.as_deref() == transport_id,
+                )
+            }) && generation.is_none_or(|expected| entry_generation == expected)
+                && owns_opening
+            {
+                opening.cancelled.insert(pty_id.to_owned(), entry_generation);
+            }
         }
-        drop(opening);
         let attachment = {
             let attachments = self.attachments.lock().expect("attach lock");
             attachments.get(pty_id).cloned()

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -696,6 +696,14 @@ struct Inner {
     shell_starting: Mutex<HashMap<String, Arc<Notify>>>,
     start_slots: Arc<Semaphore>,
     next_generation: AtomicU64,
+    retire_tx: std::sync::mpsc::SyncSender<RetireRequest>,
+}
+
+struct RetireRequest {
+    inner: Arc<Inner>,
+    pty_id: String,
+    generation: Option<u64>,
+    publication_gate: Option<Arc<RouteGate>>,
 }
 
 #[derive(Default)]
@@ -752,22 +760,33 @@ pub struct PtyManager {
 
 impl PtyManager {
     pub fn new(deps: Arc<dyn PtyDeps>, home: PathBuf, env: HashMap<String, String>) -> PtyManager {
-        PtyManager {
-            inner: Arc::new(Inner {
-                deps,
-                home,
-                env,
-                max_ptys: MAX_PTYS,
-                scrollback_limit: SCROLLBACK_LIMIT,
-                output_cap: OUTPUT_BUFFER_CAP,
-                attachments: Mutex::new(HashMap::new()),
-                opening_state: Mutex::new(OpeningState::default()),
-                shell_sessions: Mutex::new(HashMap::new()),
-                shell_starting: Mutex::new(HashMap::new()),
-                start_slots: Arc::new(Semaphore::new(MAX_PTYS)),
-                next_generation: AtomicU64::new(1),
-            }),
-        }
+        let (retire_tx, retire_rx) =
+            std::sync::mpsc::sync_channel(MAX_PTYS.saturating_mul(2).max(1));
+        let inner = Arc::new(Inner {
+            deps,
+            home,
+            env,
+            max_ptys: MAX_PTYS,
+            scrollback_limit: SCROLLBACK_LIMIT,
+            output_cap: OUTPUT_BUFFER_CAP,
+            attachments: Mutex::new(HashMap::new()),
+            opening_state: Mutex::new(OpeningState::default()),
+            shell_sessions: Mutex::new(HashMap::new()),
+            shell_starting: Mutex::new(HashMap::new()),
+            start_slots: Arc::new(Semaphore::new(MAX_PTYS)),
+            next_generation: AtomicU64::new(1),
+            retire_tx,
+        });
+        std::thread::spawn(move || {
+            while let Ok(request) = retire_rx.recv() {
+                request.inner.retire_after_gate(
+                    &request.pty_id,
+                    request.generation,
+                    request.publication_gate.as_ref(),
+                );
+            }
+        });
+        PtyManager { inner }
     }
 
     pub fn with_limits(
@@ -778,22 +797,33 @@ impl PtyManager {
         scrollback_limit: usize,
         output_cap: u64,
     ) -> PtyManager {
-        PtyManager {
-            inner: Arc::new(Inner {
-                deps,
-                home,
-                env,
-                max_ptys,
-                scrollback_limit,
-                output_cap,
-                attachments: Mutex::new(HashMap::new()),
-                opening_state: Mutex::new(OpeningState::default()),
-                shell_sessions: Mutex::new(HashMap::new()),
-                shell_starting: Mutex::new(HashMap::new()),
-                start_slots: Arc::new(Semaphore::new(max_ptys.max(1))),
-                next_generation: AtomicU64::new(1),
-            }),
-        }
+        let (retire_tx, retire_rx) =
+            std::sync::mpsc::sync_channel(max_ptys.max(1).saturating_mul(2));
+        let inner = Arc::new(Inner {
+            deps,
+            home,
+            env,
+            max_ptys,
+            scrollback_limit,
+            output_cap,
+            attachments: Mutex::new(HashMap::new()),
+            opening_state: Mutex::new(OpeningState::default()),
+            shell_sessions: Mutex::new(HashMap::new()),
+            shell_starting: Mutex::new(HashMap::new()),
+            start_slots: Arc::new(Semaphore::new(max_ptys.max(1))),
+            next_generation: AtomicU64::new(1),
+            retire_tx,
+        });
+        std::thread::spawn(move || {
+            while let Ok(request) = retire_rx.recv() {
+                request.inner.retire_after_gate(
+                    &request.pty_id,
+                    request.generation,
+                    request.publication_gate.as_ref(),
+                );
+            }
+        });
+        PtyManager { inner }
     }
 
     /// Handle one Worker -> relay PTY frame.
@@ -892,12 +922,10 @@ impl PtyManager {
     /// this after a pty_error reply to tell a fatal refusal (attachment gone,
     /// connection ends) from a non-fatal one (oversized input, stream lives).
     pub fn has_attachment(&self, pty_id: &str) -> bool {
-        self.inner
-            .attachments
-            .lock()
-            .expect("attach lock")
-            .get(pty_id)
-            .is_some_and(|attachment| !attachment.closing.load(Ordering::SeqCst))
+        self.inner.attachments.lock().expect("attach lock").get(pty_id).is_some_and(|attachment| {
+            !attachment.closing.load(Ordering::SeqCst)
+                && !attachment.close_pending.load(Ordering::SeqCst)
+        })
     }
 
     /// Live attachment count (viewers, not sessions). Diagnostics and tests.
@@ -1702,7 +1730,7 @@ impl Inner {
     }
 
     async fn emit_error_for_generation_async(
-        &self,
+        self: &Arc<Self>,
         context: &FrameContext,
         pty_id: &str,
         generation: u64,
@@ -1802,7 +1830,7 @@ impl Inner {
     }
 
     fn close_if_transport(
-        &self,
+        self: &Arc<Self>,
         pty_id: &str,
         transport_id: Option<&str>,
         generation: Option<u64>,
@@ -2055,7 +2083,7 @@ impl Inner {
         }
     }
 
-    fn close_authorized(&self, pty_id: &str, context: &FrameContext) {
+    fn close_authorized(self: &Arc<Self>, pty_id: &str, context: &FrameContext) {
         let auth = Self::auth_snapshot(context);
         let attachment = match self.authorize_snapshot_for_close(pty_id, &auth, context, "close", 0)
         {
@@ -2112,14 +2140,14 @@ impl Inner {
         self.close_exact_authorized_async(pty_id, &attachment, context).await;
     }
 
-    fn force_retire(
+    fn retire_after_gate(
         &self,
         pty_id: &str,
         generation: Option<u64>,
         publication_gate: Option<&Arc<RouteGate>>,
     ) {
-        let removed = {
-            let mut attachments = self.attachments.lock().expect("attach lock");
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };
             if generation.is_some_and(|expected| current.generation != expected)
                 || publication_gate
@@ -2127,12 +2155,63 @@ impl Inner {
             {
                 return;
             }
+            Arc::clone(&current.publication_gate)
+        };
+        let _publication = gate.lock();
+        let removed = {
+            let mut attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || !Arc::ptr_eq(&current.publication_gate, &gate)
+            {
+                return;
+            }
             let removed = attachments.remove(pty_id).expect("attachment still present");
-            removed.close_pending.store(true, Ordering::SeqCst);
             removed.closing.store(true, Ordering::SeqCst);
             removed
         };
+        drop(_publication);
         removed.control.kill();
+    }
+
+    fn force_retire(
+        self: &Arc<Self>,
+        pty_id: &str,
+        generation: Option<u64>,
+        publication_gate: Option<&Arc<RouteGate>>,
+    ) {
+        let gate = {
+            let attachments = self.attachments.lock().expect("attach lock");
+            let Some(current) = attachments.get(pty_id) else { return };
+            if generation.is_some_and(|expected| current.generation != expected)
+                || publication_gate
+                    .is_some_and(|expected| !Arc::ptr_eq(&current.publication_gate, expected))
+            {
+                return;
+            }
+            current.close_pending.store(true, Ordering::SeqCst);
+            Arc::clone(&current.publication_gate)
+        };
+        if let Some(_publication) = gate.try_lock() {
+            self.retire_after_gate(pty_id, generation, Some(&gate));
+            return;
+        }
+        let request = RetireRequest {
+            inner: Arc::clone(self),
+            pty_id: pty_id.to_owned(),
+            generation,
+            publication_gate: Some(gate),
+        };
+        if let Err(std::sync::mpsc::TrySendError::Full(request)) = self.retire_tx.try_send(request)
+        {
+            std::thread::spawn(move || {
+                request.inner.retire_after_gate(
+                    &request.pty_id,
+                    request.generation,
+                    request.publication_gate.as_ref(),
+                );
+            });
+        }
     }
 
     async fn close_if_transport_async(
@@ -2242,7 +2321,7 @@ impl Inner {
     }
 
     fn close_exact_authorized(
-        &self,
+        self: &Arc<Self>,
         pty_id: &str,
         attachment: &Attachment,
         context: &FrameContext,
@@ -2427,7 +2506,7 @@ impl Inner {
     }
 
     fn close_exact(
-        &self,
+        self: &Arc<Self>,
         pty_id: &str,
         generation: Option<u64>,
         publication_gate: Option<&Arc<RouteGate>>,
@@ -4635,6 +4714,70 @@ mod tests {
 
         release_tx.send(()).expect("release publication gate owner");
         gate_owner.join().expect("publication gate owner");
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn forced_retirement_waits_for_inflight_publication() {
+        let h = harness(None, None);
+        let entered = Arc::new(Barrier::new(2));
+        let release = Arc::new(Barrier::new(2));
+        let sent = Arc::clone(&h.sent);
+        let entered_for_send = Arc::clone(&entered);
+        let release_for_send = Arc::clone(&release);
+        let mut context = h.context("supervised", h.owner.clone());
+        context.send = Arc::new(move |frame| {
+            if frame["type"] == "pty_output" {
+                entered_for_send.wait();
+                release_for_send.wait();
+            }
+            sent.lock().expect("sent lock").push(frame);
+        });
+        let frame = serde_json::json!({
+            "version": 4,
+            "type": "pty_open",
+            "ptyId": "p1",
+            "session": "main",
+            "cols": 80,
+            "rows": 24,
+            "actorId": "user_owner",
+            "trust": "supervised",
+            "allowedRoots": Value::Null,
+        });
+        h.manager.handle_frame(&frame, &context).await;
+        let (generation, publication_gate) = {
+            let attachments = h.manager.inner.attachments.lock().expect("attach lock");
+            let attachment = attachments.get("p1").expect("opened attachment");
+            (attachment.generation, Arc::clone(&attachment.publication_gate))
+        };
+        let pty = h.spawned()[0].clone();
+        let emit = thread::spawn(move || pty.emit("in flight"));
+        entered.wait();
+
+        let manager = PtyManager { inner: Arc::clone(&h.manager.inner) };
+        let retire = thread::spawn(move || {
+            manager.inner.force_retire("p1", Some(generation), Some(&publication_gate));
+        });
+        retire.join().expect("forced retirement request");
+        assert!(
+            h.manager
+                .inner
+                .attachments
+                .lock()
+                .expect("attach lock")
+                .get("p1")
+                .is_some_and(|attachment| attachment.close_pending.load(Ordering::SeqCst)),
+            "retirement marks the generation pending while publication is in flight"
+        );
+
+        release.wait();
+        emit.join().expect("output publication");
+        for _ in 0..100 {
+            if !h.manager.inner.attachments.lock().expect("attach lock").contains_key("p1") {
+                break;
+            }
+            thread::yield_now();
+        }
+        assert!(!h.manager.inner.attachments.lock().expect("attach lock").contains_key("p1"));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/pty.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty.rs
@@ -2271,7 +2271,13 @@ impl Inner {
         }
         current.close_pending.store(true, Ordering::SeqCst);
         drop(_publication);
-        let _ = current.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
+        if !current.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT)) {
+            // A control callback can outlive the synchronous close budget.
+            // Retire this generation explicitly instead of treating the
+            // still-active operation as drained.
+            self.force_retire(pty_id, Some(attachment.generation), Some(&gate));
+            return;
+        }
         let _publication = gate.lock();
         let removed = {
             let mut attachments = self.attachments.lock().expect("attach lock");
@@ -2437,7 +2443,14 @@ impl Inner {
             current.close_pending.store(true, Ordering::SeqCst);
             current.clone()
         };
-        let _ = attachment.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT));
+        if !attachment.control_ops.wait_sync_timeout(Some(CONTROL_OPERATION_DRAIN_TIMEOUT)) {
+            // A control callback can outlive the synchronous close budget.
+            // Retire this generation explicitly instead of treating the
+            // still-active operation as drained.
+            drop(_publication);
+            self.force_retire(pty_id, generation, Some(&gate));
+            return;
+        }
         let attachment = {
             let attachments = self.attachments.lock().expect("attach lock");
             let Some(current) = attachments.get(pty_id) else { return };

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -95,6 +95,7 @@ struct AuthSnapshot {
     trust: String,
     roots: Option<Vec<String>>,
     owner: Option<String>,
+    version: u64,
 }
 
 pub(crate) struct OutboundFrame {
@@ -587,7 +588,12 @@ fn make_context(
         owner_user_id: auth.owner.clone(),
         live_auth: Arc::new(move || {
             let snapshot = live_auth.lock().expect("auth lock");
-            (snapshot.trust.clone(), snapshot.owner.clone())
+            crate::pty::LiveAuth {
+                trust: snapshot.trust.clone(),
+                roots: snapshot.roots.clone(),
+                owner_user_id: snapshot.owner.clone(),
+                version: snapshot.version,
+            }
         }),
         transport_id: Some(transport_id.to_owned()),
         cancellation: cancellation.clone(),
@@ -975,6 +981,7 @@ async fn relay_session(
                             snapshot.trust = effective_trust;
                             snapshot.roots = local_roots.clone();
                             snapshot.owner = config.owner_user_id.clone();
+                            snapshot.version = snapshot.version.wrapping_add(1);
                             workspace.set_local_observe(local_observe);
                         }
                         let cadence = Duration::from_millis(hello.heartbeat_interval_ms);
@@ -1034,7 +1041,9 @@ async fn relay_session(
                         if !state.managed {
                             save(config, config_path);
                         }
-                        auth.lock().expect("auth lock").trust = ack.as_str().to_owned();
+                        let mut auth = auth.lock().expect("auth lock");
+                        auth.trust = ack.as_str().to_owned();
+                        auth.version = auth.version.wrapping_add(1);
                         workspace.set_local_observe(ack == Trust::Observe);
                         println!("Trust level set to {ack}.");
                     }

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -64,6 +64,7 @@ const MAX_PTY_INGRESS_FRAMES: usize = 64;
 const MAX_INBOUND_FRAME_BYTES: usize = 4 << 20;
 const CONNECTION_TASK_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const CONNECTION_TASK_ABORT_TIMEOUT: Duration = Duration::from_secs(1);
+const PTY_DETACH_TIMEOUT: Duration = Duration::from_secs(2);
 /// One suspend/read-liveness sample per period while a socket is open.
 const LIVENESS_CHECK_INTERVAL: Duration = Duration::from_secs(5);
 /// Wall clock moving more than this relative to the monotonic clock between
@@ -1289,7 +1290,12 @@ async fn relay_session(
     // managed tunnel listener's attachments are another transport's — a
     // reconnect must never detach them (docs/TERMINAL.md).
     #[cfg(unix)]
-    runtime.pty.detach_transport_async(&transport_id).await;
+    if timeout(PTY_DETACH_TIMEOUT, runtime.pty.detach_transport_async(&transport_id)).await.is_err()
+    {
+        eprintln!(
+            "PTY transport cleanup exceeded its safety deadline; some attachments may remain."
+        );
+    }
     result
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1289,7 +1289,7 @@ async fn relay_session(
     // managed tunnel listener's attachments are another transport's — a
     // reconnect must never detach them (docs/TERMINAL.md).
     #[cfg(unix)]
-    runtime.pty.detach_transport(&transport_id);
+    runtime.pty.detach_transport_async(&transport_id).await;
     result
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -16,6 +16,7 @@
 //! the server-directed backpressure the JS relay read from `ws.bufferedAmount`.
 
 use std::collections::{HashMap, HashSet, VecDeque};
+use std::future::Future;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
@@ -1290,13 +1291,40 @@ async fn relay_session(
     // managed tunnel listener's attachments are another transport's — a
     // reconnect must never detach them (docs/TERMINAL.md).
     #[cfg(unix)]
-    if timeout(PTY_DETACH_TIMEOUT, runtime.pty.detach_transport_async(&transport_id)).await.is_err()
     {
-        eprintln!(
-            "PTY transport cleanup exceeded its safety deadline; some attachments may remain."
-        );
+        let manager = Arc::clone(&runtime.pty);
+        let transport = transport_id.clone();
+        if !run_owned_cleanup(
+            async move { manager.detach_transport_async(&transport).await },
+            PTY_DETACH_TIMEOUT,
+        )
+        .await
+        {
+            eprintln!(
+                "PTY transport cleanup exceeded its safety deadline; cleanup continues in the background."
+            );
+        }
     }
     result
+}
+
+/// Run teardown in an owned task. A timeout only limits how long connection
+/// shutdown waits. Dropping a Tokio JoinHandle does not cancel its task, so a
+/// publication gate or control operation that finishes later can still
+/// release its attachment and capacity slot.
+async fn run_owned_cleanup<F>(cleanup: F, deadline: Duration) -> bool
+where
+    F: Future<Output = ()> + Send + 'static,
+{
+    let task = tokio::spawn(cleanup);
+    match timeout(deadline, task).await {
+        Ok(Ok(())) => true,
+        Ok(Err(error)) => {
+            eprintln!("Owned PTY cleanup task failed: {error}");
+            false
+        }
+        Err(_) => false,
+    }
 }
 
 #[cfg(all(test, not(unix)))]
@@ -1385,7 +1413,9 @@ mod liveness_tests {
 
 #[cfg(test)]
 mod cancellation_tests {
-    use super::{send_socket_text, shutdown_connection_tasks, wait_for_reconnect};
+    use super::{
+        run_owned_cleanup, send_socket_text, shutdown_connection_tasks, wait_for_reconnect,
+    };
     use futures_util::Sink;
     use std::pin::Pin;
     use std::sync::Arc;
@@ -1502,6 +1532,24 @@ mod cancellation_tests {
         process_cancellation.cancel();
         assert!(send.await.expect("send task joined").is_err());
         assert!(!connection_cancellation.is_cancelled());
+    }
+
+    #[tokio::test(flavor = "current_thread")]
+    async fn timed_out_cleanup_continues_and_completes_late() {
+        let completed = Arc::new(AtomicBool::new(false));
+        let task_completed = Arc::clone(&completed);
+        assert!(
+            !run_owned_cleanup(
+                async move {
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    task_completed.store(true, Ordering::Release);
+                },
+                Duration::from_millis(1),
+            )
+            .await
+        );
+        tokio::time::sleep(Duration::from_millis(40)).await;
+        assert!(completed.load(Ordering::Acquire));
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -550,12 +550,14 @@ fn make_context(
     out: &OutboundSink,
     pending: &Arc<AtomicU64>,
     auth: &AuthSnapshot,
+    live_auth: &Arc<std::sync::Mutex<AuthSnapshot>>,
     transport_id: &str,
     cancellation: &CancellationToken,
 ) -> FrameContext {
     let sender = out.clone();
     let pending_send = Arc::clone(pending);
     let pending_probe = Arc::clone(pending);
+    let live_auth = Arc::clone(live_auth);
     FrameContext {
         send: Arc::new(move |frame: Value| {
             let size = serde_json::to_string(&frame).map(|text| text.len() as u64).unwrap_or(0);
@@ -583,6 +585,10 @@ fn make_context(
         trust: auth.trust.clone(),
         local_roots: auth.roots.clone(),
         owner_user_id: auth.owner.clone(),
+        live_auth: Arc::new(move || {
+            let snapshot = live_auth.lock().expect("auth lock");
+            (snapshot.trust.clone(), snapshot.owner.clone())
+        }),
         transport_id: Some(transport_id.to_owned()),
         cancellation: cancellation.clone(),
     }
@@ -677,7 +683,7 @@ async fn relay_session(
                 };
                 let snapshot = auth.lock().expect("auth lock").clone();
                 let context =
-                    make_context(&out, &pending, &snapshot, &transport, &connection_token);
+                    make_context(&out, &pending, &snapshot, &auth, &transport, &connection_token);
                 tokio::select! {
                     biased;
                     _ = connection_token.cancelled() => break,
@@ -1146,6 +1152,7 @@ async fn relay_session(
                                     &out_tx,
                                     &pending,
                                     &snapshot,
+                                    &auth_direct,
                                     &transport_id,
                                     &connection_cancellation,
                                 );

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1535,21 +1535,32 @@ mod cancellation_tests {
     }
 
     #[tokio::test(flavor = "current_thread")]
-    async fn timed_out_cleanup_continues_and_completes_late() {
-        let completed = Arc::new(AtomicBool::new(false));
-        let task_completed = Arc::clone(&completed);
+    async fn timed_out_cleanup_is_cancelled_and_reaped() {
+        struct DropSignal(Arc<AtomicBool>);
+
+        impl Drop for DropSignal {
+            fn drop(&mut self) {
+                self.0.store(true, Ordering::Release);
+            }
+        }
+
+        let started = Arc::new(AtomicBool::new(false));
+        let dropped = Arc::new(AtomicBool::new(false));
+        let task_started = Arc::clone(&started);
+        let task_dropped = Arc::clone(&dropped);
         assert!(
             !run_owned_cleanup(
                 async move {
-                    tokio::time::sleep(Duration::from_millis(20)).await;
-                    task_completed.store(true, Ordering::Release);
+                    let _drop_signal = DropSignal(task_dropped);
+                    task_started.store(true, Ordering::Release);
+                    std::future::pending::<()>().await;
                 },
-                Duration::from_millis(1),
+                Duration::from_millis(20),
             )
             .await
         );
-        tokio::time::sleep(Duration::from_millis(40)).await;
-        assert!(completed.load(Ordering::Acquire));
+        assert!(started.load(Ordering::Acquire));
+        assert!(dropped.load(Ordering::Acquire));
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1300,7 +1300,7 @@ async fn relay_session(
         )
         .await
         {
-            eprintln!("PTY transport cleanup exceeded its safety deadline and was cancelled.");
+            eprintln!("Some terminal sessions did not close. Reconnect to the relay and retry.");
         }
     }
     result

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1300,30 +1300,30 @@ async fn relay_session(
         )
         .await
         {
-            eprintln!(
-                "PTY transport cleanup exceeded its safety deadline; cleanup continues in the background."
-            );
+            eprintln!("PTY transport cleanup exceeded its safety deadline and was cancelled.");
         }
     }
     result
 }
 
-/// Run teardown in an owned task. A timeout only limits how long connection
-/// shutdown waits. Dropping a Tokio JoinHandle does not cancel its task, so a
-/// publication gate or control operation that finishes later can still
-/// release its attachment and capacity slot.
+/// Run teardown in an owned task. On timeout, abort and collect the task so
+/// connection shutdown does not leave untracked cleanup work behind.
 async fn run_owned_cleanup<F>(cleanup: F, deadline: Duration) -> bool
 where
     F: Future<Output = ()> + Send + 'static,
 {
-    let task = tokio::spawn(cleanup);
-    match timeout(deadline, task).await {
+    let mut task = tokio::spawn(cleanup);
+    match timeout(deadline, &mut task).await {
         Ok(Ok(())) => true,
         Ok(Err(error)) => {
             eprintln!("Owned PTY cleanup task failed: {error}");
             false
         }
-        Err(_) => false,
+        Err(_) => {
+            task.abort();
+            let _ = task.await;
+            false
+        }
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -393,6 +393,7 @@ impl Connection {
             trust: "supervised".to_owned(),
             local_roots: None,
             owner_user_id: None,
+            live_auth: Arc::new(|| ("supervised".to_owned(), None)),
             transport_id: Some(self.pty_id.clone()),
             cancellation: self.done.clone(),
         }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -393,7 +393,10 @@ impl Connection {
             trust: "supervised".to_owned(),
             local_roots: None,
             owner_user_id: None,
-            live_auth: Arc::new(|| ("supervised".to_owned(), None)),
+            live_auth: Arc::new(|| crate::pty::LiveAuth {
+                trust: "supervised".to_owned(),
+                ..Default::default()
+            }),
             transport_id: Some(self.pty_id.clone()),
             cancellation: self.done.clone(),
         }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -545,7 +545,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
     let open_deadline = tokio::time::sleep(OPEN_TIMEOUT);
     tokio::pin!(open_deadline);
-    loop {
+    'reader: loop {
         tokio::select! {
             biased;
             _ = parent.cancelled() => {
@@ -570,7 +570,14 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                 match decoder.push(&buffer[..count]) {
                     Ok(frames) => {
                         for frame in frames {
-                            handle_client_frame(&connection, &context, frame).await;
+                            tokio::select! {
+                                biased;
+                                _ = &mut open_deadline, if !connection.opened_seen.load(Ordering::SeqCst) => {
+                                    connection.protocol_error("bad_request", "open timed out");
+                                    break 'reader;
+                                }
+                                _ = handle_client_frame(&connection, &context, frame) => {}
+                            }
                         }
                     }
                     Err(_) => {
@@ -1051,7 +1058,8 @@ mod tests {
 
     #[tokio::test]
     async fn open_deadline_cancels_a_slow_manager_open() {
-        let rig = rig_with_limits_and_spawn_delay(8, OPEN_TIMEOUT + Duration::from_millis(50)).await;
+        let rig =
+            rig_with_limits_and_spawn_delay(8, OPEN_TIMEOUT + Duration::from_millis(50)).await;
         let stream = connect(&rig).await;
         let (mut read, mut write) = stream.into_split();
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -68,7 +68,10 @@ pub const FRAME_KIND_PTY: u8 = 1;
 /// u32 length + u8 kind.
 const HEADER_BYTES: usize = 5;
 /// The opened (or refused) reply must arrive within this budget.
+#[cfg(not(test))]
 const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
+#[cfg(test)]
+const OPEN_TIMEOUT: Duration = Duration::from_millis(100);
 /// Writer flow control: pause the PTY source above the high-water mark of
 /// bytes queued toward the socket, resume below the low-water mark. The
 /// manager's own 1 MiB output cap stays the hard boundary above this.
@@ -706,11 +709,15 @@ mod tests {
 
     struct FakeDeps {
         spawned: Arc<StdMutex<Vec<FakePty>>>,
+        spawn_delay: Duration,
     }
 
     #[async_trait]
     impl PtyDeps for FakeDeps {
         async fn spawn_pty(&self, _spec: SpawnSpec) -> PtyHandle {
+            if !self.spawn_delay.is_zero() {
+                tokio::time::sleep(self.spawn_delay).await;
+            }
             let pty = FakePty { state: Arc::new(StdMutex::new(FakeState::default())) };
             self.spawned.lock().unwrap().push(pty.clone());
             PtyHandle { control: Arc::new(pty.clone()), output: Arc::new(pty), banner: None }
@@ -753,8 +760,12 @@ mod tests {
     }
 
     async fn rig_with_limits(max_ptys: usize) -> Rig {
+        rig_with_limits_and_spawn_delay(max_ptys, Duration::ZERO).await
+    }
+
+    async fn rig_with_limits_and_spawn_delay(max_ptys: usize, spawn_delay: Duration) -> Rig {
         let spawned = Arc::new(StdMutex::new(Vec::new()));
-        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned) });
+        let deps = Arc::new(FakeDeps { spawned: Arc::clone(&spawned), spawn_delay });
         let env = HashMap::from([
             ("SHELL".to_owned(), "/bin/fakesh".to_owned()),
             ("HOME".to_owned(), std::env::temp_dir().to_string_lossy().into_owned()),
@@ -1035,6 +1046,33 @@ mod tests {
         let reopened = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
         assert_eq!(reopened["t"], "opened");
         assert_eq!(reopened["created"], false);
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn open_deadline_cancels_a_slow_manager_open() {
+        let rig = rig_with_limits_and_spawn_delay(8, OPEN_TIMEOUT + Duration::from_millis(50)).await;
+        let stream = connect(&rig).await;
+        let (mut read, mut write) = stream.into_split();
+        let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
+        let mut queue = Vec::new();
+
+        write
+            .write_all(&encode_control_frame(&json!({
+                "t": "open",
+                "session": "slow",
+                "cols": 80,
+                "rows": 24,
+            })))
+            .await
+            .expect("send slow open");
+        let error = control_json(&next_frame(&mut read, &mut decoder, &mut queue).await);
+        assert_eq!(error["t"], "error");
+        assert_eq!(error["code"], "bad_request");
+        read_eof(&mut read).await;
+
+        tokio::time::sleep(OPEN_TIMEOUT + Duration::from_millis(100)).await;
+        assert_eq!(rig.manager.attachment_count(), 0);
         rig.cancel.cancel();
     }
 


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11526.

The bounded control-event FIFO can fill while its callback worker is busy. The old close marker then used the same full FIFO and could be dropped. Add a regression test that writes MAX_EVENT_QUEUE+1 events before EOF, then deliver closure through a dedicated one-slot signal and drain accepted events before invoking on_close.

Commits are test-first: a22199c930 adds the behavior coverage, then 4e587f301a adds the close signal.

Static checks: rustfmt --edition 2024 --check cmux-tui/crates/chatmux-relay/src/control.rs; git diff --check. Cargo checks were not run because the local disk guard blocks cmux-tui artifact producers.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790952945&installation_model_id=21920&pr_number=11694&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11694&signature=3f99af006b760064861e93a42f1edd390ec96cc5073d156981c69c3a87be3879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relay lifecycle races could drop close callbacks, leak PTY reservations or attachments, and deliver stale terminal output. Control and PTY lifecycle handling now use bounded, ordered close delivery plus live authorization and generation fencing, while slow operations are cancelled or retired at their deadlines.

**Control events**
- Queued events have independent count and byte limits; EOF drains accepted events in wire order.
- Late or concurrent `on_close` registration stays reliable, deliberate `end()` stays silent, and paused readers no longer miss resume wakeups.

**PTY lifecycle**
- Authorization uses current per-transport trust, roots, and owner data; denied closes fail closed without removing caller-owned attachments, while authority revocation retires affected attachments.
- Route and publication gates reject stale, reentrant, and replacement callbacks; readiness waits for backlog and shell replay, and output stops when close begins.
- Rejected, cancelled, or timed-out opens release reservations, bound concurrent starts, and cancel slow tunnel opens at the deadline; legacy close also cancels pending opens.
- Publication timeouts and forced retirement retire callbacks before emitting errors and serialize retirement with publication, including deferred errors.
- Transport detach cleanup runs in owned tasks, aborts and reaps on timeout, continues past other reservations, and retires blocked lifecycle work during close.

<sup>Written for commit d168030b9e4ee0b545d7b719ccdcefea9b6c2976. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event delivery reliability and preserved callback ordering during high event volume.
  * Ensured close callbacks are delivered even when event or data capacity is reached, including for late-registered handlers.
  * Closed connections cleanly when event or data limits are exceeded.
  * Updated authentication state handling so live authorization information refreshes when trust changes.
  * Improved terminal-session cleanup when operations take longer than expected.
  * Cancelled slow terminal opens when the connection deadline expires, preventing incomplete attachments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->