### PR TITLE
fix(cmux-tui): clear agent cache on surface retirement

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -296,9 +296,6 @@ struct RemoteTreeCache {
     title_updates: HashMap<SurfaceId, TitleUpdate>,
     agent_generation: u64,
     agent_updates: HashMap<SurfaceId, AgentUpdate>,
-    // Surface IDs are monotonic. Keep a tombstone so a stale roster snapshot
-    // received after retirement cannot restore the agent row.
-    retired_agents: HashSet<SurfaceId>,
 }
 
 #[derive(Clone, Copy)]
@@ -386,13 +383,17 @@ impl RemoteTreeCache {
         self.title_generation
     }
 
-    fn replace_agents(&mut self, agents: Vec<AgentInfo>, refresh_generation: u64) {
-        let retired_agents = &self.retired_agents;
+    fn replace_agents(
+        &mut self,
+        agents: Vec<AgentInfo>,
+        refresh_generation: u64,
+        retired_surfaces: &HashSet<SurfaceId>,
+    ) {
         self.agents =
-            agents.into_iter().filter(|agent| !retired_agents.contains(&agent.surface)).collect();
+            agents.into_iter().filter(|agent| !retired_surfaces.contains(&agent.surface)).collect();
         let updates = std::mem::take(&mut self.agent_updates);
         for (surface, update) in updates {
-            if self.retired_agents.contains(&surface) {
+            if retired_surfaces.contains(&surface) {
                 continue;
             }
             if self.surface_tabs.contains_key(&surface) {
@@ -415,8 +416,8 @@ impl RemoteTreeCache {
         }
     }
 
-    fn update_agent(&mut self, agent: AgentInfo) {
-        if self.retired_agents.contains(&agent.surface) {
+    fn update_agent(&mut self, agent: AgentInfo, retired_surfaces: &HashSet<SurfaceId>) {
+        if retired_surfaces.contains(&agent.surface) {
             return;
         }
         self.agent_generation = self.agent_generation.saturating_add(1);
@@ -436,7 +437,6 @@ impl RemoteTreeCache {
     }
 
     fn remove_agent(&mut self, surface: SurfaceId) {
-        self.retired_agents.insert(surface);
         self.agents.retain(|agent| agent.surface != surface);
         self.agent_updates.remove(&surface);
     }
@@ -2382,7 +2382,7 @@ impl RemoteSession {
                     if retired_surfaces.contains(&surface) {
                         return;
                     }
-                    self.tree.lock().unwrap().update_agent(agent);
+                    self.tree.lock().unwrap().update_agent(agent, &retired_surfaces);
                 }
                 self.emit(event);
             }
@@ -3476,10 +3476,7 @@ impl RemoteSession {
             let mut cache = self.tree.lock().unwrap();
             tree.retain_not_retired(&retired_surfaces);
             cache.replace(tree, title_refresh_generation);
-            cache.replace_agents(agents, agent_refresh_generation);
-            for &surface in retired_surfaces.iter() {
-                cache.remove_agent(surface);
-            }
+            cache.replace_agents(agents, agent_refresh_generation, &retired_surfaces);
             cache.view.clone()
         };
         drop(retired_surfaces);
@@ -7620,13 +7617,9 @@ mod tests {
         let agents = (0..4096_u64).map(agent).collect::<Vec<_>>();
         for surface in 0..4096_u64 {
             let agent = agents[surface as usize].clone();
-            cache.agent_updates.insert(
-                surface,
-                AgentUpdate {
-                    generation: surface,
-                    agent,
-                },
-            );
+            cache
+                .agent_updates
+                .insert(surface, AgentUpdate { generation: surface.saturating_add(1), agent });
         }
         let retired = (0..4096_u64).step_by(2).collect::<HashSet<_>>();
 
@@ -7907,18 +7900,22 @@ mod tests {
         }));
         let mut cache = RemoteTreeCache::default();
         cache.replace(tree, 0);
+        let retired = HashSet::new();
         let refresh_generation = cache.agent_generation();
-        cache.update_agent(AgentInfo {
-            surface: 4,
-            state: "working".into(),
-            source: "hook".into(),
-            session: Some("review".into()),
-            updated_at_ms: 41,
-        });
+        cache.update_agent(
+            AgentInfo {
+                surface: 4,
+                state: "working".into(),
+                source: "hook".into(),
+                session: Some("review".into()),
+                updated_at_ms: 41,
+            },
+            &retired,
+        );
 
         let title_generation = cache.title_generation();
         cache.replace(TreeView::default(), title_generation);
-        cache.replace_agents(Vec::new(), refresh_generation);
+        cache.replace_agents(Vec::new(), refresh_generation, &retired);
 
         assert!(cache.agents.is_empty());
     }
@@ -7940,25 +7937,29 @@ mod tests {
         }));
         let mut cache = RemoteTreeCache::default();
         cache.replace(tree.clone(), 0);
+        let retired = HashSet::new();
 
         // The event races the first refresh and is retained while the
         // topology omits the surface.
         let refresh_generation = cache.agent_generation();
-        cache.update_agent(AgentInfo {
-            surface: 4,
-            state: "working".into(),
-            source: "hook".into(),
-            session: Some("review".into()),
-            updated_at_ms: 41,
-        });
+        cache.update_agent(
+            AgentInfo {
+                surface: 4,
+                state: "working".into(),
+                source: "hook".into(),
+                session: Some("review".into()),
+                updated_at_ms: 41,
+            },
+            &retired,
+        );
         cache.replace(TreeView::default(), cache.title_generation());
-        cache.replace_agents(Vec::new(), refresh_generation);
+        cache.replace_agents(Vec::new(), refresh_generation, &retired);
 
         // A later refresh confirms the agent is absent. A stale topology may
         // briefly show the surface again, but the old event must not return.
         let confirmed_generation = cache.agent_generation();
         cache.replace(tree, cache.title_generation());
-        cache.replace_agents(Vec::new(), confirmed_generation);
+        cache.replace_agents(Vec::new(), confirmed_generation, &retired);
 
         assert!(cache.agents.is_empty());
         assert!(cache.agent_updates.is_empty());
@@ -7981,6 +7982,7 @@ mod tests {
         }));
         let mut cache = RemoteTreeCache::default();
         cache.replace(tree.clone(), 0);
+        let retired = HashSet::new();
         let refresh_generation = cache.agent_generation();
         let update = AgentInfo {
             surface: 4,
@@ -7989,17 +7991,17 @@ mod tests {
             session: Some("review".into()),
             updated_at_ms: 41,
         };
-        cache.update_agent(update.clone());
+        cache.update_agent(update.clone(), &retired);
 
         // The tree response can lag the event stream and omit a live surface.
         cache.replace(TreeView::default(), cache.title_generation());
-        cache.replace_agents(Vec::new(), refresh_generation);
+        cache.replace_agents(Vec::new(), refresh_generation, &retired);
 
         assert_eq!(cache.agent_updates.get(&4).map(|pending| &pending.agent), Some(&update));
 
         // A later topology response makes the pending event visible again.
         cache.replace(tree, cache.title_generation());
-        cache.replace_agents(Vec::new(), refresh_generation);
+        cache.replace_agents(Vec::new(), refresh_generation, &retired);
 
         assert_eq!(cache.agents, vec![update]);
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7522,6 +7522,7 @@ mod tests {
 
         // A stale topology response can briefly show the exited surface again.
         // A stale agent snapshot must not resurrect the exited agent row.
+        let retired_surfaces = session.retired_surfaces.lock().unwrap().clone();
         let mut cache = session.tree.lock().unwrap();
         let title_generation = cache.title_generation();
         cache.replace(tree(), title_generation);
@@ -7534,6 +7535,7 @@ mod tests {
                 updated_at_ms: 41,
             }],
             0,
+            &retired_surfaces,
         );
         assert!(cache.agents.is_empty());
     }
@@ -7600,6 +7602,61 @@ mod tests {
         update_thread.join().unwrap();
 
         assert!(session.cached_agents().is_empty());
+    }
+
+    #[test]
+    fn agent_refresh_filters_retired_surfaces_in_one_authoritative_pass() {
+        fn agent(surface: SurfaceId) -> AgentInfo {
+            AgentInfo {
+                surface,
+                state: "working".into(),
+                source: "hook".into(),
+                session: Some("review".into()),
+                updated_at_ms: surface,
+            }
+        }
+
+        let mut cache = RemoteTreeCache::default();
+        let agents = (0..4096_u64).map(agent).collect::<Vec<_>>();
+        for surface in 0..4096_u64 {
+            let agent = agents[surface as usize].clone();
+            cache.agent_updates.insert(
+                surface,
+                AgentUpdate {
+                    generation: surface,
+                    agent,
+                },
+            );
+        }
+        let retired = (0..4096_u64).step_by(2).collect::<HashSet<_>>();
+
+        cache.replace_agents(agents, 0, &retired);
+
+        assert_eq!(cache.agents.len(), 2048);
+        assert!(cache.agents.iter().all(|agent| !retired.contains(&agent.surface)));
+        assert_eq!(cache.agent_updates.len(), 2048);
+        assert!(cache.agent_updates.keys().all(|surface| !retired.contains(surface)));
+        assert!(cache.agents.iter().all(|agent| cache.agent_updates.contains_key(&agent.surface)));
+    }
+
+    #[test]
+    fn agent_cache_does_not_keep_permanent_retirement_tombstones() {
+        let agent = AgentInfo {
+            surface: 7,
+            state: "working".into(),
+            source: "hook".into(),
+            session: Some("review".into()),
+            updated_at_ms: 41,
+        };
+        let mut cache = RemoteTreeCache::default();
+        cache.replace_agent(agent.clone());
+        cache.remove_agent(agent.surface);
+
+        let retired = HashSet::new();
+        cache.update_agent(agent.clone(), &retired);
+
+        assert_eq!(cache.agents, vec![agent]);
+        assert_eq!(cache.agent_updates.len(), 1);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -424,6 +424,11 @@ impl RemoteTreeCache {
         }
     }
 
+    fn remove_agent(&mut self, surface: SurfaceId) {
+        self.agents.retain(|agent| agent.surface != surface);
+        self.agent_updates.remove(&surface);
+    }
+
     fn agent_generation(&self) -> u64 {
         self.agent_generation
     }
@@ -3328,6 +3333,7 @@ impl RemoteSession {
     }
 
     pub fn retire_surface(&self, id: SurfaceId) {
+        self.tree.lock().unwrap().remove_agent(id);
         let _cell_pixel_lifecycle = self.cell_pixel_lifecycle.lock().unwrap();
         self.retired_surfaces.lock().unwrap().insert(id);
         let surface = self.surfaces.lock().unwrap().remove(&id);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2365,7 +2365,13 @@ impl RemoteSession {
                     session: agent.session.as_deref().map(Arc::from),
                     updated_at_ms,
                 };
-                self.tree.lock().unwrap().update_agent(agent);
+                {
+                    let retired_surfaces = self.retired_surfaces.lock().unwrap();
+                    if retired_surfaces.contains(&surface) {
+                        return;
+                    }
+                    self.tree.lock().unwrap().update_agent(agent);
+                }
                 self.emit(event);
             }
             Some("layout-changed") => {
@@ -3337,13 +3343,13 @@ impl RemoteSession {
     }
 
     pub fn retire_surface(&self, id: SurfaceId) {
-        self.tree.lock().unwrap().remove_agent(id);
         let mut retired_surfaces = self.retired_surfaces.lock().unwrap();
         retired_surfaces.insert(id);
         #[cfg(test)]
         if let Some(sender) = self.retire_surface_test_marker.lock().unwrap().clone() {
             let _ = sender.send(id);
         }
+        self.tree.lock().unwrap().remove_agent(id);
         drop(retired_surfaces);
         let _cell_pixel_lifecycle = self.cell_pixel_lifecycle.lock().unwrap();
         let surface = self.surfaces.lock().unwrap().remove(&id);
@@ -3453,14 +3459,18 @@ impl RemoteSession {
             .lock()
             .unwrap()
             .retain(|surface_id, _| live_surface_ids.contains(surface_id));
+        let retired_surfaces = self.retired_surfaces.lock().unwrap();
         let tree = {
             let mut cache = self.tree.lock().unwrap();
-            let retired = self.retired_surfaces.lock().unwrap().clone();
-            tree.retain_not_retired(&retired);
+            tree.retain_not_retired(&retired_surfaces);
             cache.replace(tree, title_refresh_generation);
             cache.replace_agents(agents, agent_refresh_generation);
+            for &surface in retired_surfaces.iter() {
+                cache.remove_agent(surface);
+            }
             cache.view.clone()
         };
+        drop(retired_surfaces);
         let browser_sources = browser_sources_from_tree(&tree);
         *self.browser_sources.lock().unwrap() = browser_sources.clone();
         let surfaces = self.surfaces.lock().unwrap().clone();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1515,6 +1515,8 @@ pub struct RemoteSession {
     exited_surfaces: Mutex<ExitedSurfaceState>,
     surface_leases: Mutex<HashMap<SurfaceId, String>>,
     retired_surfaces: Mutex<HashSet<SurfaceId>>,
+    #[cfg(test)]
+    retire_surface_test_marker: Mutex<Option<Sender<SurfaceId>>>,
     tree: Mutex<RemoteTreeCache>,
     browser_sources: Mutex<HashMap<SurfaceId, BrowserSource>>,
     tree_refresh: Mutex<()>,
@@ -1871,6 +1873,8 @@ impl RemoteSession {
             exited_surfaces: Mutex::new(ExitedSurfaceState::default()),
             surface_leases: Mutex::new(HashMap::new()),
             retired_surfaces: Mutex::new(HashSet::new()),
+            #[cfg(test)]
+            retire_surface_test_marker: Mutex::new(None),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
             tree_refresh: Mutex::new(()),
@@ -3334,8 +3338,14 @@ impl RemoteSession {
 
     pub fn retire_surface(&self, id: SurfaceId) {
         self.tree.lock().unwrap().remove_agent(id);
+        let mut retired_surfaces = self.retired_surfaces.lock().unwrap();
+        retired_surfaces.insert(id);
+        #[cfg(test)]
+        if let Some(sender) = self.retire_surface_test_marker.lock().unwrap().clone() {
+            let _ = sender.send(id);
+        }
+        drop(retired_surfaces);
         let _cell_pixel_lifecycle = self.cell_pixel_lifecycle.lock().unwrap();
-        self.retired_surfaces.lock().unwrap().insert(id);
         let surface = self.surfaces.lock().unwrap().remove(&id);
         let mut exited = self.exited_surfaces.lock().unwrap();
         exited.ids.insert(id);
@@ -3830,6 +3840,7 @@ fn test_session_with_writer(
         exited_surfaces: Mutex::new(ExitedSurfaceState::default()),
         surface_leases: Mutex::new(HashMap::new()),
         retired_surfaces: Mutex::new(HashSet::new()),
+        retire_surface_test_marker: Mutex::new(None),
         tree: Mutex::new(RemoteTreeCache::default()),
         browser_sources: Mutex::new(HashMap::new()),
         tree_refresh: Mutex::new(()),
@@ -5071,6 +5082,7 @@ mod tests {
             exited_surfaces: Mutex::new(ExitedSurfaceState::default()),
             surface_leases: Mutex::new(HashMap::new()),
             retired_surfaces: Mutex::new(HashSet::new()),
+            retire_surface_test_marker: Mutex::new(None),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
             tree_refresh: Mutex::new(()),
@@ -7493,6 +7505,70 @@ mod tests {
         cache.replace(tree(), title_generation);
         cache.replace_agents(Vec::new(), 0);
         assert!(cache.agents.is_empty());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn surface_exit_serializes_agent_updates_after_retirement_marker() {
+        let tree = || {
+            parse_tree(&json!({
+                "workspaces": [{
+                    "id": 1,
+                    "screens": [{
+                        "id": 2,
+                        "layout": {"type": "leaf", "pane": 3},
+                        "panes": [{
+                            "id": 3,
+                            "tabs": [{"surface": 7, "title": "agent terminal"}],
+                        }],
+                    }],
+                }],
+            }))
+        };
+        let (client, _server) = UnixStream::pair().unwrap();
+        let session = socket_test_session(client);
+        session.tree.lock().unwrap().replace(tree(), 0);
+        session.handle_line(json!({
+            "event": "agent-changed",
+            "surface": 7,
+            "state": "working",
+            "source": "hook",
+            "session": "review",
+            "updated_at_ms": 41,
+        }));
+
+        let (marker_tx, marker_rx) = channel();
+        *session.retire_surface_test_marker.lock().unwrap() = Some(marker_tx);
+
+        // Hold the cache lock. The retirement must publish its marker before
+        // waiting for this lock, so a concurrent agent update cannot slip in.
+        let tree_guard = session.tree.lock().unwrap();
+        let retiring = session.clone();
+        let retire_thread = std::thread::spawn(move || {
+            retiring.handle_line(json!({"event": "surface-exited", "surface": 7}));
+        });
+        if marker_rx.recv_timeout(Duration::from_secs(1)).is_err() {
+            drop(tree_guard);
+            retire_thread.join().unwrap();
+            panic!("surface retirement did not publish its marker before cache cleanup");
+        }
+
+        let updating = session.clone();
+        let update_thread = std::thread::spawn(move || {
+            updating.handle_line(json!({
+                "event": "agent-changed",
+                "surface": 7,
+                "state": "needsInput",
+                "source": "hook",
+                "session": "review",
+                "updated_at_ms": 42,
+            }));
+        });
+        drop(tree_guard);
+        retire_thread.join().unwrap();
+        update_thread.join().unwrap();
+
+        assert!(session.cached_agents().is_empty());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7445,6 +7445,50 @@ mod tests {
         assert!(events.try_iter().next().is_none());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn surface_exit_drops_cached_agent_before_a_stale_topology_can_restore_it() {
+        let tree = || {
+            parse_tree(&json!({
+                "workspaces": [{
+                    "id": 1,
+                    "screens": [{
+                        "id": 2,
+                        "layout": {"type": "leaf", "pane": 3},
+                        "panes": [{
+                            "id": 3,
+                            "tabs": [{"surface": 7, "title": "agent terminal"}],
+                        }],
+                    }],
+                }],
+            }))
+        };
+        let (client, _server) = UnixStream::pair().unwrap();
+        let session = socket_test_session(client);
+        session.tree.lock().unwrap().replace(tree(), 0);
+
+        session.handle_line(json!({
+            "event": "agent-changed",
+            "surface": 7,
+            "state": "working",
+            "source": "hook",
+            "session": "review",
+            "updated_at_ms": 41,
+        }));
+        assert_eq!(session.cached_agents().len(), 1);
+
+        session.handle_line(json!({"event": "surface-exited", "surface": 7}));
+        assert!(session.cached_agents().is_empty());
+
+        // A stale topology response can briefly show the exited surface again.
+        // The event seen before exit must not resurrect its agent row.
+        let mut cache = session.tree.lock().unwrap();
+        let title_generation = cache.title_generation();
+        cache.replace(tree(), title_generation);
+        cache.replace_agents(Vec::new(), 0);
+        assert!(cache.agents.is_empty());
+    }
+
     #[test]
     fn surface_event_scope_filters_before_remote_cache_invalidation() {
         let (session, _requests) = recording_acknowledging_session();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -296,6 +296,9 @@ struct RemoteTreeCache {
     title_updates: HashMap<SurfaceId, TitleUpdate>,
     agent_generation: u64,
     agent_updates: HashMap<SurfaceId, AgentUpdate>,
+    // Surface IDs are monotonic. Keep a tombstone so a stale roster snapshot
+    // received after retirement cannot restore the agent row.
+    retired_agents: HashSet<SurfaceId>,
 }
 
 #[derive(Clone, Copy)]
@@ -384,9 +387,14 @@ impl RemoteTreeCache {
     }
 
     fn replace_agents(&mut self, agents: Vec<AgentInfo>, refresh_generation: u64) {
-        self.agents = agents;
+        let retired_agents = &self.retired_agents;
+        self.agents =
+            agents.into_iter().filter(|agent| !retired_agents.contains(&agent.surface)).collect();
         let updates = std::mem::take(&mut self.agent_updates);
         for (surface, update) in updates {
+            if self.retired_agents.contains(&surface) {
+                continue;
+            }
             if self.surface_tabs.contains_key(&surface) {
                 // A pending update may have been observed during an earlier
                 // refresh whose topology omitted this surface. Reapply it
@@ -408,6 +416,9 @@ impl RemoteTreeCache {
     }
 
     fn update_agent(&mut self, agent: AgentInfo) {
+        if self.retired_agents.contains(&agent.surface) {
+            return;
+        }
         self.agent_generation = self.agent_generation.saturating_add(1);
         self.agent_updates.insert(
             agent.surface,
@@ -425,6 +436,7 @@ impl RemoteTreeCache {
     }
 
     fn remove_agent(&mut self, surface: SurfaceId) {
+        self.retired_agents.insert(surface);
         self.agents.retain(|agent| agent.surface != surface);
         self.agent_updates.remove(&surface);
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7509,11 +7509,20 @@ mod tests {
         assert!(session.cached_agents().is_empty());
 
         // A stale topology response can briefly show the exited surface again.
-        // The event seen before exit must not resurrect its agent row.
+        // A stale agent snapshot must not resurrect the exited agent row.
         let mut cache = session.tree.lock().unwrap();
         let title_generation = cache.title_generation();
         cache.replace(tree(), title_generation);
-        cache.replace_agents(Vec::new(), 0);
+        cache.replace_agents(
+            vec![AgentInfo {
+                surface: 7,
+                state: "working".into(),
+                source: "hook".into(),
+                session: Some("review".into()),
+                updated_at_ms: 41,
+            }],
+            0,
+        );
         assert!(cache.agents.is_empty());
     }
 


### PR DESCRIPTION
## Summary

Remove cached agent records and pending agent updates when a remote surface retires. This prevents a stale topology refresh from restoring an agent row after `surface-exited`.

Related: https://github.com/manaflow-ai/cmux/issues/9863

The broader lifecycle reconciliation work remains out of scope.

## Commits

1. Add the behavior regression test.
2. Add the cache cleanup.

## Checks

- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/session/remote.rs`
- `git diff --check`
- Cargo and Rust tests were not run locally, per cmux-tui Testbox policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790955620&installation_model_id=21920&pr_number=11695&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11695&signature=bfa2f4f21ea6810d5b2e70bd344451e79246a75ecefb1d440b0c4b8816dea6aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes races where a stale topology refresh or concurrent agent update could restore an agent row after `surface-exited`. On retirement, cached agents and pending updates are cleared, agent updates are serialized against retirement, and agent refreshes filter out retired surfaces so no stale row survives. Addresses issue 9863; broader lifecycle reconciliation remains out of scope.

<sup>Written for commit 90c9985d5bf6280270207c4a93a0aef8d2d9591e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where agents from exited surfaces could reappear after a stale topology update.
  * Cached agent entries and pending updates are now cleared when a surface exits.
  * Prevented delayed, outdated refresh results from overwriting newer session state.
  * Ignored updates for surfaces that have already been retired.

* **Tests**
  * Added coverage for stale topology responses, delayed refresh handling, retirement state preservation, and batch agent removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->