### PR TITLE
fix(relay): supervise process actions through session lifetime

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -22,8 +22,9 @@
 //! - all output is truncated to bounded sizes before it goes on the wire.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use serde_json::{Map, Value, json};
 
@@ -43,6 +44,7 @@ const MAX_RUNTIME_ENVIRONMENT_ENTRIES: usize = 64;
 const MAX_RUNTIME_ENVIRONMENT_BYTES: usize = 256_000;
 const MAX_RUNTIME_FILES: usize = 8;
 pub(crate) const MAX_BLOCKING_FILE_ACTIONS: usize = 8;
+const MAX_LIVE_PROCESSES: usize = 8;
 
 // ---------------------------------------------------------------------------
 // Path policy (pure)
@@ -997,6 +999,126 @@ enum RunOutcome {
     Failed { message: String },
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SupervisorState {
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum WaitState {
+    Retry,
+    AlreadyReaped,
+}
+
+impl WaitState {
+    fn from_wait_error(already_reaped: bool) -> Self {
+        if already_reaped { Self::AlreadyReaped } else { Self::Retry }
+    }
+}
+
+pub(crate) struct ProcessSupervisor {
+    lifecycle: Mutex<SupervisorLifecycle>,
+    slots: Arc<tokio::sync::Semaphore>,
+    shutdown_gate: tokio::sync::Mutex<()>,
+}
+
+struct SupervisorLifecycle {
+    state: SupervisorState,
+    tasks: Vec<SupervisedTask>,
+}
+
+struct SupervisedTask {
+    handle: tokio::task::JoinHandle<()>,
+    cancellation: tokio_util::sync::CancellationToken,
+}
+
+struct CancelOnDrop(Option<tokio_util::sync::CancellationToken>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if let Some(token) = self.0.take() {
+            token.cancel();
+        }
+    }
+}
+
+async fn await_supervised(
+    receiver: tokio::sync::oneshot::Receiver<RunOutcome>,
+    cancellation: tokio_util::sync::CancellationToken,
+) -> RunOutcome {
+    let mut cancel_on_drop = CancelOnDrop(Some(cancellation));
+    let outcome = receiver
+        .await
+        .unwrap_or(RunOutcome::Failed { message: "process failed to start".to_owned() });
+    cancel_on_drop.0 = None;
+    outcome
+}
+
+impl ProcessSupervisor {
+    pub(crate) fn new() -> Self {
+        Self {
+            lifecycle: Mutex::new(SupervisorLifecycle {
+                state: SupervisorState::Open,
+                tasks: Vec::new(),
+            }),
+            slots: Arc::new(tokio::sync::Semaphore::new(MAX_LIVE_PROCESSES)),
+            shutdown_gate: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    fn state(&self) -> SupervisorState {
+        self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner).state
+    }
+
+    fn spawn<F, Fut>(
+        &self,
+        task: F,
+    ) -> Option<(tokio::sync::oneshot::Receiver<RunOutcome>, tokio_util::sync::CancellationToken)>
+    where
+        F: FnOnce(tokio_util::sync::CancellationToken) -> Fut + Send + 'static,
+        Fut: Future<Output = RunOutcome> + Send + 'static,
+    {
+        let permit = Arc::clone(&self.slots).try_acquire_owned().ok()?;
+        let mut lifecycle =
+            self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if lifecycle.state != SupervisorState::Open {
+            return None;
+        }
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let task_cancellation = cancellation.clone();
+        let handle = tokio::spawn(async move {
+            let _permit = permit;
+            let outcome = task(task_cancellation).await;
+            let _ = sender.send(outcome);
+        });
+        lifecycle.tasks.retain(|task| !task.handle.is_finished());
+        lifecycle.tasks.push(SupervisedTask { handle, cancellation: cancellation.clone() });
+        Some((receiver, cancellation))
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let _shutdown_gate = self.shutdown_gate.lock().await;
+        let tasks = {
+            let mut lifecycle =
+                self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if lifecycle.state == SupervisorState::Closed {
+                return;
+            }
+            lifecycle.state = SupervisorState::Closing;
+            std::mem::take(&mut lifecycle.tasks)
+        };
+        for task in tasks {
+            task.cancellation.cancel();
+            let _ = task.handle.await;
+        }
+        self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner).state =
+            SupervisorState::Closed;
+    }
+}
+
 #[cfg(unix)]
 struct ProcessGroupGuard {
     pid: Option<u32>,
@@ -1026,6 +1148,7 @@ async fn run_spec(
     cwd_fd: Option<ScopedCwdFd>,
     timeout_ms: u64,
     env: &HashMap<String, String>,
+    cancellation: Option<tokio_util::sync::CancellationToken>,
 ) -> RunOutcome {
     use tokio::io::AsyncReadExt as _;
     let mut command = match &spec {
@@ -1086,6 +1209,7 @@ async fn run_spec(
         Ok(job) => Some(job),
         Err(_) => {
             let _ = child.start_kill();
+            let _ = child.wait().await;
             return RunOutcome::Failed { message: "process failed to start".to_owned() };
         }
     };
@@ -1098,6 +1222,7 @@ async fn run_spec(
     let mut stderr = child.stderr.take();
     let mut output: Vec<u8> = Vec::new();
     let mut timed_out = false;
+    let mut cancelled = false;
     let deadline = tokio::time::sleep(std::time::Duration::from_millis(timeout_ms));
     tokio::pin!(deadline);
     let mut stdout_buf = [0_u8; 8_192];
@@ -1108,6 +1233,7 @@ async fn run_spec(
     let mut kill_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut drain_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut final_wait_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+    let mut wait_retry_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     loop {
         // A timed-out process group still needs its escalation pass even when
         // the shell leader has already exited. Otherwise closing inherited
@@ -1121,6 +1247,23 @@ async fn run_spec(
             break;
         }
         tokio::select! {
+            () = async {
+                match cancellation.as_ref() {
+                    Some(token) => token.cancelled().await,
+                    None => std::future::pending().await,
+                }
+            }, if !cancelled => {
+                cancelled = true;
+                #[cfg(unix)]
+                if !signal_process_tree(pid, false) {
+                    let _ = child.start_kill();
+                }
+                #[cfg(not(unix))]
+                signal_process_tree(pid, false);
+                kill_deadline = Some(Box::pin(tokio::time::sleep(
+                    std::time::Duration::from_millis(250),
+                )));
+            }
             read = async {
                 match stdout.as_mut() {
                     Some(stream) => stream.read(&mut stdout_buf).await,
@@ -1151,7 +1294,8 @@ async fn run_spec(
                     }
                 }
             }
-            status = child.wait(), if exited.is_none() => {
+            status = child.wait(),
+                if exited.is_none() && wait_retry_deadline.is_none() && kill_deadline.is_none() => {
                 // The child is gone, but descendants may still own the output
                 // pipes. Preserve a timeout escalation that is already in
                 // flight, and bound the remaining drain after a timeout.
@@ -1171,7 +1315,24 @@ async fn run_spec(
                             process_group_guard.armed = false;
                         }
                     }
-                    Err(_) => exited = Some(1),
+                    Err(error) => {
+                        #[cfg(unix)]
+                        if error.raw_os_error() == Some(libc::ECHILD) {
+                            exited = Some(1);
+                            process_group_guard.armed = false;
+                        } else {
+                            wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                std::time::Duration::from_millis(10),
+                            )));
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            let _ = error;
+                            wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                std::time::Duration::from_millis(10),
+                            )));
+                        }
+                    }
                 }
             }
             () = &mut deadline, if !timed_out => {
@@ -1180,9 +1341,7 @@ async fn run_spec(
                 // inherited stdout/stderr. Kill the whole POSIX process group
                 // so the supervisor gets its EXIT cleanup, then enforce a
                 // hard bound for processes that ignore TERM.
-                if exited.is_some() {
-                    signal_process_group(pid, false);
-                } else {
+                if exited.is_none() {
                     // The process group is the authoritative target. If the
                     // group disappeared before we could signal it, use the
                     // live Child handle instead of the numeric PID. A PID
@@ -1217,9 +1376,7 @@ async fn run_spec(
                     None => std::future::pending().await,
                 }
             }, if kill_deadline.is_some() => {
-                if exited.is_some() {
-                    signal_process_group(pid, true);
-                } else {
+                if exited.is_none() {
                     // See the timeout branch above: never fall back to a
                     // numeric PID after a process-group signal fails.
                     #[cfg(unix)]
@@ -1256,14 +1413,21 @@ async fn run_spec(
                     None => std::future::pending().await,
                 }
             }, if final_wait_deadline.is_some() && exited.is_none() => {
-                let _ = child.start_kill();
                 final_wait_deadline = None;
-                exited = Some(1);
+                wait_retry_deadline = None;
                 if stdout_open || stderr_open {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
                     )));
                 }
+            }
+            () = async {
+                match wait_retry_deadline.as_mut() {
+                    Some(timer) => timer.as_mut().await,
+                    None => std::future::pending().await,
+                }
+            }, if wait_retry_deadline.is_some() => {
+                wait_retry_deadline = None;
             }
         }
     }
@@ -1275,6 +1439,9 @@ async fn run_spec(
     }
     if timed_out {
         return RunOutcome::TimedOut;
+    }
+    if cancelled {
+        return RunOutcome::Failed { message: "process cancelled".to_owned() };
     }
     let text = String::from_utf8_lossy(&output);
     RunOutcome::Done { exit_code: exited.unwrap_or(0), output: text.into_owned() }
@@ -1400,6 +1567,7 @@ pub struct ActionContext {
     pub env: HashMap<String, String>,
     /// Process-owned capacity retained by file work that outlives a socket.
     pub file_slots: Arc<tokio::sync::Semaphore>,
+    pub(crate) process_supervisor: Arc<ProcessSupervisor>,
     #[cfg(test)]
     pub(crate) test_file_operation_barrier: Option<Arc<std::sync::Barrier>>,
 }
@@ -1806,7 +1974,8 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             };
             #[cfg(not(unix))]
             let command_cwd_fd = None;
-            let outcome = tokio::spawn(async move {
+            let process_supervisor = Arc::clone(&context.process_supervisor);
+            let outcome = match process_supervisor.spawn(move |cancellation| async move {
                 let _file_permit = file_permit;
                 #[cfg(unix)]
                 let _path_guard = _path_guard;
@@ -1829,11 +1998,13 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                     command_cwd_fd,
                     timeout_ms,
                     &env,
+                    Some(cancellation),
                 )
                 .await
-            })
-            .await
-            .unwrap_or(RunOutcome::Failed { message: "process failed to start".to_owned() });
+            }) {
+                Some((receiver, cancellation)) => await_supervised(receiver, cancellation).await,
+                None => RunOutcome::Failed { message: "relay process capacity is busy".to_owned() },
+            };
             run_reply(version, &action_id, outcome, args.get("limit"), Some(200), timeout_ms)
         }
         "find" => {
@@ -1897,14 +2068,25 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                 find_args.push("-name".to_owned());
                 find_args.push(pattern.to_owned());
             }
-            let outcome = run_spec(
-                RunSpec::Argv { file: "find", args: find_args },
-                Path::new(&command_cwd_path),
-                command_cwd_fd,
-                timeout_ms,
-                &env,
-            )
-            .await;
+            let process_supervisor = Arc::clone(&context.process_supervisor);
+            let outcome = match process_supervisor.spawn(move |cancellation| async move {
+                #[cfg(unix)]
+                let _path_guard = _path_guard;
+                #[cfg(unix)]
+                let _cwd_guard = _cwd_guard;
+                run_spec(
+                    RunSpec::Argv { file: "find", args: find_args },
+                    Path::new(&command_cwd_path),
+                    command_cwd_fd,
+                    timeout_ms,
+                    &env,
+                    Some(cancellation),
+                )
+                .await
+            }) {
+                Some((receiver, cancellation)) => await_supervised(receiver, cancellation).await,
+                None => RunOutcome::Failed { message: "relay process capacity is busy".to_owned() },
+            };
             run_reply(version, &action_id, outcome, args.get("limit"), Some(500), timeout_ms)
         }
         "exec" => {
@@ -1938,14 +2120,23 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             #[cfg(not(unix))]
             let scoped_cwd_fd = None;
             let prepared = command_with_process_files(command, &runtime.files);
-            let outcome = run_spec(
-                RunSpec::Shell { command: &prepared },
-                Path::new(&scoped_cwd_path),
-                scoped_cwd_fd,
-                timeout_ms,
-                &env,
-            )
-            .await;
+            let process_supervisor = Arc::clone(&context.process_supervisor);
+            let outcome = match process_supervisor.spawn(move |cancellation| async move {
+                #[cfg(unix)]
+                let _cwd_guard = _cwd_guard;
+                run_spec(
+                    RunSpec::Shell { command: &prepared },
+                    Path::new(&scoped_cwd_path),
+                    scoped_cwd_fd,
+                    timeout_ms,
+                    &env,
+                    Some(cancellation),
+                )
+                .await
+            }) {
+                Some((receiver, cancellation)) => await_supervised(receiver, cancellation).await,
+                None => RunOutcome::Failed { message: "relay process capacity is busy".to_owned() },
+            };
             run_reply(version, &action_id, outcome, None, None, timeout_ms)
         }
         _ => fail("unsupported_verb", &format!("verb \"{verb}\" fell through")),
@@ -1972,6 +2163,7 @@ mod tests {
             home,
             env: HashMap::new(),
             file_slots: Arc::new(tokio::sync::Semaphore::new(MAX_BLOCKING_FILE_ACTIONS)),
+            process_supervisor: Arc::new(ProcessSupervisor::new()),
             test_file_operation_barrier: None,
         }
     }
@@ -2066,12 +2258,13 @@ mod tests {
         let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let task_completed = Arc::clone(&completed);
         let outcome = supervisor
-            .spawn(async move {
+            .spawn(move |_| async move {
                 tokio::time::sleep(std::time::Duration::from_millis(5)).await;
                 task_completed.store(true, std::sync::atomic::Ordering::Release);
                 RunOutcome::Done { exit_code: 0, output: String::new() }
             })
             .expect("open supervisor admits process");
+        let (outcome, _) = outcome;
         supervisor.shutdown().await;
         assert!(completed.load(std::sync::atomic::Ordering::Acquire));
         assert!(matches!(outcome.await, Ok(RunOutcome::Done { exit_code: 0, .. })));
@@ -2082,9 +2275,11 @@ mod tests {
     async fn process_supervisor_rejects_new_tasks_after_close() {
         let supervisor = Arc::new(ProcessSupervisor::new());
         supervisor.shutdown().await;
-        assert!(supervisor
-            .spawn(async { RunOutcome::Done { exit_code: 0, output: String::new() } })
-            .is_none());
+        assert!(
+            supervisor
+                .spawn(|_| async { RunOutcome::Done { exit_code: 0, output: String::new() } })
+                .is_none()
+        );
     }
 
     #[test]
@@ -2537,7 +2732,7 @@ mod tests {
         let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
         let outcome = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env),
+            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env, None),
         )
         .await
         .expect("timeout cleanup must not wait for a descendant pipe");

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1140,7 +1140,7 @@ impl ProcessSupervisor {
             lifecycle.state = SupervisorState::Closing;
             std::mem::take(&mut lifecycle.tasks)
         };
-        for task in tasks {
+        for task in &tasks {
             task.cancellation.cancel();
         }
         for task in tasks {
@@ -1267,6 +1267,7 @@ async fn run_spec(
     let mut final_wait_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut wait_retry_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut group_kill_confirmed = false;
+    let mut scope_settled = false;
     let mut phase = ProcessPhase::Running;
     loop {
         // A timed-out process group still needs its escalation pass even when
@@ -1299,6 +1300,10 @@ async fn run_spec(
                     #[cfg(not(unix))]
                     signal_process_tree(pid, false);
                     kill_deadline = Some(Box::pin(tokio::time::sleep(
+                        std::time::Duration::from_millis(250),
+                    )));
+                } else if (stdout_open || stderr_open) && drain_deadline.is_none() {
+                    drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
                     )));
                 }
@@ -1337,12 +1342,13 @@ async fn run_spec(
                 if exited.is_none()
                     && wait_retry_deadline.is_none()
                     && kill_deadline.is_none()
-                    && phase.may_wait(timed_out, cancelled, stdout_open, stderr_open) => {
+                    && phase.may_wait(timed_out, cancelled, stdout_open, stderr_open)
+                    && (phase != ProcessPhase::Waiting || scope_settled) => {
                 // The child is gone, but descendants may still own the output
                 // pipes. Preserve a timeout escalation that is already in
                 // flight, and bound the remaining drain after a timeout.
                 final_wait_deadline = None;
-                if timed_out && (stdout_open || stderr_open) && drain_deadline.is_none() {
+                if (timed_out || cancelled) && (stdout_open || stderr_open) && drain_deadline.is_none() {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
                     )));
@@ -1430,11 +1436,20 @@ async fn run_spec(
                         if !group_kill_confirmed {
                             group_kill_confirmed = child.start_kill().is_ok();
                         }
+                        scope_settled = group_kill_confirmed;
                     }
                     #[cfg(not(unix))]
                     {
                         signal_process_tree(pid, true);
-                        group_kill_confirmed = true;
+                        #[cfg(windows)]
+                        {
+                            scope_settled = job.as_ref().map(WindowsJob::is_signaled).unwrap_or(true);
+                        }
+                        #[cfg(not(windows))]
+                        {
+                            scope_settled = true;
+                        }
+                        group_kill_confirmed = scope_settled;
                     }
                     phase = ProcessPhase::Waiting;
                 }
@@ -1590,6 +1605,17 @@ impl WindowsJob {
                 1,
             )
         };
+    }
+
+    fn is_signaled(&self) -> bool {
+        use std::os::windows::io::AsRawHandle;
+        const WAIT_OBJECT_0: u32 = 0;
+        unsafe {
+            windows_sys::Win32::System::Threading::WaitForSingleObject(
+                self.handle.as_raw_handle(),
+                0,
+            ) == WAIT_OBJECT_0
+        }
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1000,6 +1000,36 @@ enum RunOutcome {
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum ProcessPhase {
+    Running,
+    StopRequested,
+    Waiting,
+    Reaped,
+    AlreadyReaped,
+}
+
+impl ProcessPhase {
+    fn may_wait(
+        self,
+        timed_out: bool,
+        cancelled: bool,
+        stdout_open: bool,
+        stderr_open: bool,
+    ) -> bool {
+        matches!(self, Self::Waiting)
+            || (matches!(self, Self::Running)
+                && !timed_out
+                && !cancelled
+                && !stdout_open
+                && !stderr_open)
+    }
+
+    fn may_signal(self) -> bool {
+        matches!(self, Self::Running | Self::StopRequested)
+    }
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub(crate) enum SupervisorState {
     Open,
     Closing,
@@ -1235,6 +1265,7 @@ async fn run_spec(
     let mut final_wait_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut wait_retry_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut group_kill_confirmed = false;
+    let mut phase = ProcessPhase::Running;
     loop {
         // A timed-out process group still needs its escalation pass even when
         // the shell leader has already exited. Otherwise closing inherited
@@ -1255,6 +1286,7 @@ async fn run_spec(
                 }
             }, if !cancelled => {
                 cancelled = true;
+                phase = ProcessPhase::StopRequested;
                 #[cfg(unix)]
                 if !signal_process_tree(pid, false) {
                     let _ = child.start_kill();
@@ -1299,7 +1331,7 @@ async fn run_spec(
                 if exited.is_none()
                     && wait_retry_deadline.is_none()
                     && kill_deadline.is_none()
-                    && (group_kill_confirmed || (!timed_out && !cancelled && !stdout_open && !stderr_open)) => {
+                    && phase.may_wait(timed_out, cancelled, stdout_open, stderr_open) => {
                 // The child is gone, but descendants may still own the output
                 // pipes. Preserve a timeout escalation that is already in
                 // flight, and bound the remaining drain after a timeout.
@@ -1312,6 +1344,7 @@ async fn run_spec(
                 match status {
                     Ok(status) => {
                         exited = Some(status.code().map(i64::from).unwrap_or(1));
+                        phase = ProcessPhase::Reaped;
                         // `wait` has reaped the leader. Disarm before any
                         // subsequent cancellation can target a reused PID.
                         #[cfg(unix)]
@@ -1323,6 +1356,7 @@ async fn run_spec(
                         #[cfg(unix)]
                         if error.raw_os_error() == Some(libc::ECHILD) {
                             exited = Some(1);
+                            phase = ProcessPhase::AlreadyReaped;
                             process_group_guard.armed = false;
                         } else {
                             wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
@@ -1341,11 +1375,12 @@ async fn run_spec(
             }
             () = &mut deadline, if !timed_out => {
                 timed_out = true;
+                phase = ProcessPhase::StopRequested;
                 // Commands run below a shell and may have descendants that
                 // inherited stdout/stderr. Kill the whole POSIX process group
                 // so the supervisor gets its EXIT cleanup, then enforce a
                 // hard bound for processes that ignore TERM.
-                if exited.is_none() {
+                if phase.may_signal() {
                     // The process group is the authoritative target. If the
                     // group disappeared before we could signal it, use the
                     // live Child handle instead of the numeric PID. A PID
@@ -1380,7 +1415,7 @@ async fn run_spec(
                     None => std::future::pending().await,
                 }
             }, if kill_deadline.is_some() => {
-                if exited.is_none() {
+                if phase.may_signal() {
                     // See the timeout branch above: never fall back to a
                     // numeric PID after a process-group signal fails.
                     #[cfg(unix)]
@@ -1395,6 +1430,7 @@ async fn run_spec(
                         signal_process_tree(pid, true);
                         group_kill_confirmed = true;
                     }
+                    phase = ProcessPhase::Waiting;
                 }
                 #[cfg(windows)]
                 if let Some(job) = job.as_ref() {
@@ -1422,7 +1458,7 @@ async fn run_spec(
                     Some(timer) => timer.as_mut().await,
                     None => std::future::pending().await,
                 }
-            }, if final_wait_deadline.is_some() && exited.is_none() => {
+            }, if final_wait_deadline.is_some() && phase == ProcessPhase::Waiting => {
                 final_wait_deadline = None;
                 wait_retry_deadline = None;
                 if stdout_open || stderr_open {
@@ -2299,6 +2335,15 @@ mod tests {
     }
 
     #[test]
+    fn process_phase_blocks_wait_until_scope_kill() {
+        assert!(!ProcessPhase::Running.may_wait(true, false, false, false));
+        assert!(!ProcessPhase::StopRequested.may_wait(true, true, false, false));
+        assert!(ProcessPhase::Waiting.may_wait(true, true, true, true));
+        assert!(!ProcessPhase::Reaped.may_signal());
+        assert!(!ProcessPhase::AlreadyReaped.may_signal());
+    }
+
+    #[test]
     fn scoped_file_capability_refusal_is_typed_and_fail_closed() {
         let roots = vec!["/srv/work".to_owned()];
         let scoped: RootLists<'_> = [Some(roots.as_slice()), None];
@@ -2740,13 +2785,28 @@ mod tests {
     #[tokio::test]
     async fn timeout_escalates_after_shell_exits_with_open_descendant_pipe() {
         let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let pid_file =
+            std::env::temp_dir().join(format!("chatmux-timeout-pid-{}", std::process::id()));
+        let command = format!("sleep 5 & echo $! > {}", pid_file.display());
         let outcome = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env, None),
+            run_spec(RunSpec::Shell { command: &command }, Path::new("/"), None, 20, &env, None),
         )
         .await
         .expect("timeout cleanup must not wait for a descendant pipe");
         assert!(matches!(outcome, RunOutcome::TimedOut));
+        let pid = std::fs::read_to_string(&pid_file)
+            .ok()
+            .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
+            .expect("descendant pid marker");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while unsafe { libc::kill(pid, 0) } == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("descendant must be gone after timeout escalation");
+        std::fs::remove_file(pid_file).ok();
     }
     #[tokio::test]
     async fn exec_receives_scoped_process_environment_values() {

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1418,6 +1418,10 @@ async fn run_spec(
                     kill_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
                     )));
+                } else if exited.is_none() && phase == ProcessPhase::WaitUncertain {
+                    // The process-group identity is no longer trusted after
+                    // a wait error. Kill only through the owned Child handle.
+                    let _ = child.start_kill();
                 }
                 #[cfg(windows)]
                 if let Some(job) = job.as_ref() {

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1142,6 +1142,8 @@ impl ProcessSupervisor {
         };
         for task in tasks {
             task.cancellation.cancel();
+        }
+        for task in tasks {
             let _ = task.handle.await;
         }
         self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner).state =
@@ -1286,18 +1288,20 @@ async fn run_spec(
                 }
             }, if !cancelled => {
                 cancelled = true;
-                phase = ProcessPhase::StopRequested;
-                if exited.is_none() && phase.may_signal() {
+                let was_live = exited.is_none()
+                    && matches!(phase, ProcessPhase::Running | ProcessPhase::StopRequested);
+                if was_live {
+                    phase = ProcessPhase::StopRequested;
                     #[cfg(unix)]
                     if !signal_process_tree(pid, false) {
                         let _ = child.start_kill();
                     }
                     #[cfg(not(unix))]
                     signal_process_tree(pid, false);
+                    kill_deadline = Some(Box::pin(tokio::time::sleep(
+                        std::time::Duration::from_millis(250),
+                    )));
                 }
-                kill_deadline = Some(Box::pin(tokio::time::sleep(
-                    std::time::Duration::from_millis(250),
-                )));
             }
             read = async {
                 match stdout.as_mut() {
@@ -1377,12 +1381,12 @@ async fn run_spec(
             }
             () = &mut deadline, if !timed_out => {
                 timed_out = true;
-                phase = ProcessPhase::StopRequested;
                 // Commands run below a shell and may have descendants that
                 // inherited stdout/stderr. Kill the whole POSIX process group
                 // so the supervisor gets its EXIT cleanup, then enforce a
                 // hard bound for processes that ignore TERM.
-                if phase.may_signal() {
+                if exited.is_none() && phase.may_signal() {
+                    phase = ProcessPhase::StopRequested;
                     // The process group is the authoritative target. If the
                     // group disappeared before we could signal it, use the
                     // live Child handle instead of the numeric PID. A PID
@@ -1394,6 +1398,9 @@ async fn run_spec(
                     }
                     #[cfg(not(unix))]
                     signal_process_tree(pid, false);
+                    kill_deadline = Some(Box::pin(tokio::time::sleep(
+                        std::time::Duration::from_millis(250),
+                    )));
                 }
                 #[cfg(windows)]
                 if let Some(job) = job.as_ref() {
@@ -1402,9 +1409,6 @@ async fn run_spec(
                 // Keep the escalation timer owned by this invocation. A
                 // detached task could fire after the process exits and its
                 // PID is reused by an unrelated process.
-                kill_deadline = Some(Box::pin(tokio::time::sleep(
-                    std::time::Duration::from_millis(250),
-                )));
                 if exited.is_some() && (stdout_open || stderr_open) && drain_deadline.is_none() {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1287,12 +1287,14 @@ async fn run_spec(
             }, if !cancelled => {
                 cancelled = true;
                 phase = ProcessPhase::StopRequested;
-                #[cfg(unix)]
-                if !signal_process_tree(pid, false) {
-                    let _ = child.start_kill();
+                if exited.is_none() && phase.may_signal() {
+                    #[cfg(unix)]
+                    if !signal_process_tree(pid, false) {
+                        let _ = child.start_kill();
+                    }
+                    #[cfg(not(unix))]
+                    signal_process_tree(pid, false);
                 }
-                #[cfg(not(unix))]
-                signal_process_tree(pid, false);
                 kill_deadline = Some(Box::pin(tokio::time::sleep(
                     std::time::Duration::from_millis(250),
                 )));

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1003,6 +1003,7 @@ enum RunOutcome {
 enum ProcessPhase {
     Running,
     StopRequested,
+    WaitUncertain,
     Waiting,
     Reaped,
     AlreadyReaped,
@@ -1016,7 +1017,7 @@ impl ProcessPhase {
         stdout_open: bool,
         stderr_open: bool,
     ) -> bool {
-        matches!(self, Self::Waiting)
+        matches!(self, Self::Waiting | Self::WaitUncertain)
             || (matches!(self, Self::Running)
                 && !timed_out
                 && !cancelled
@@ -1304,6 +1305,8 @@ async fn run_spec(
                     kill_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
                     )));
+                } else if exited.is_none() && phase == ProcessPhase::WaitUncertain {
+                    let _ = child.start_kill();
                 } else if (stdout_open || stderr_open) && drain_deadline.is_none() {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
@@ -1373,6 +1376,11 @@ async fn run_spec(
                             phase = ProcessPhase::AlreadyReaped;
                             process_group_guard.armed = false;
                         } else {
+                            phase = ProcessPhase::WaitUncertain;
+                            #[cfg(unix)]
+                            {
+                                process_group_guard.armed = false;
+                            }
                             wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
                                 std::time::Duration::from_millis(10),
                             )));
@@ -1380,6 +1388,7 @@ async fn run_spec(
                         #[cfg(not(unix))]
                         {
                             let _ = error;
+                            phase = ProcessPhase::WaitUncertain;
                             wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
                                 std::time::Duration::from_millis(10),
                             )));
@@ -2398,6 +2407,8 @@ mod tests {
         assert!(!ProcessPhase::Running.may_wait(true, false, false, false));
         assert!(!ProcessPhase::StopRequested.may_wait(true, true, false, false));
         assert!(ProcessPhase::Waiting.may_wait(true, true, true, true));
+        assert!(ProcessPhase::WaitUncertain.may_wait(true, true, true, true));
+        assert!(!ProcessPhase::WaitUncertain.may_signal());
         assert!(!ProcessPhase::Reaped.may_signal());
         assert!(!ProcessPhase::AlreadyReaped.may_signal());
     }

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1269,6 +1269,8 @@ async fn run_spec(
     let mut group_kill_confirmed = false;
     let mut scope_settled = false;
     let mut phase = ProcessPhase::Running;
+    #[cfg(windows)]
+    let mut job_settle_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     loop {
         // A timed-out process group still needs its escalation pass even when
         // the shell leader has already exited. Otherwise closing inherited
@@ -1343,7 +1345,7 @@ async fn run_spec(
                     && wait_retry_deadline.is_none()
                     && kill_deadline.is_none()
                     && phase.may_wait(timed_out, cancelled, stdout_open, stderr_open)
-                    && (phase != ProcessPhase::Waiting || scope_settled) => {
+                    && (!cfg!(windows) || phase != ProcessPhase::Waiting || scope_settled) => {
                 // The child is gone, but descendants may still own the output
                 // pipes. Preserve a timeout escalation that is already in
                 // flight, and bound the remaining drain after a timeout.
@@ -1436,7 +1438,11 @@ async fn run_spec(
                         if !group_kill_confirmed {
                             group_kill_confirmed = child.start_kill().is_ok();
                         }
-                        scope_settled = group_kill_confirmed;
+                        // Unix PGID signaling cannot prove descendant settlement;
+                        // the owned Child can still be waited safely after the
+                        // escalation attempt, while descendants remain scoped
+                        // by the process-group guard until owner shutdown.
+                        scope_settled = true;
                     }
                     #[cfg(not(unix))]
                     {
@@ -1444,6 +1450,11 @@ async fn run_spec(
                         #[cfg(windows)]
                         {
                             scope_settled = job.as_ref().map(WindowsJob::is_signaled).unwrap_or(true);
+                            if !scope_settled {
+                                job_settle_deadline = Some(Box::pin(tokio::time::sleep(
+                                    std::time::Duration::from_millis(10),
+                                )));
+                            }
                         }
                         #[cfg(not(windows))]
                         {
@@ -1485,6 +1496,22 @@ async fn run_spec(
                 if stdout_open || stderr_open {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
+                    )));
+                }
+            }
+            #[cfg(windows)]
+            () = async {
+                match job_settle_deadline.as_mut() {
+                    Some(timer) => timer.as_mut().await,
+                    None => std::future::pending().await,
+                }
+            }, if job_settle_deadline.is_some() && !scope_settled => {
+                if job.as_ref().map(WindowsJob::is_signaled).unwrap_or(true) {
+                    scope_settled = true;
+                    job_settle_deadline = None;
+                } else {
+                    job_settle_deadline = Some(Box::pin(tokio::time::sleep(
+                        std::time::Duration::from_millis(10),
                     )));
                 }
             }

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1234,6 +1234,7 @@ async fn run_spec(
     let mut drain_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut final_wait_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut wait_retry_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+    let mut group_kill_confirmed = false;
     loop {
         // A timed-out process group still needs its escalation pass even when
         // the shell leader has already exited. Otherwise closing inherited
@@ -1295,7 +1296,10 @@ async fn run_spec(
                 }
             }
             status = child.wait(),
-                if exited.is_none() && wait_retry_deadline.is_none() && kill_deadline.is_none() => {
+                if exited.is_none()
+                    && wait_retry_deadline.is_none()
+                    && kill_deadline.is_none()
+                    && (group_kill_confirmed || (!timed_out && !cancelled && !stdout_open && !stderr_open)) => {
                 // The child is gone, but descendants may still own the output
                 // pipes. Preserve a timeout escalation that is already in
                 // flight, and bound the remaining drain after a timeout.
@@ -1380,11 +1384,17 @@ async fn run_spec(
                     // See the timeout branch above: never fall back to a
                     // numeric PID after a process-group signal fails.
                     #[cfg(unix)]
-                    if !signal_process_tree(pid, true) {
-                        let _ = child.start_kill();
+                    {
+                        group_kill_confirmed = signal_process_tree(pid, true);
+                        if !group_kill_confirmed {
+                            group_kill_confirmed = child.start_kill().is_ok();
+                        }
                     }
                     #[cfg(not(unix))]
-                    signal_process_tree(pid, true);
+                    {
+                        signal_process_tree(pid, true);
+                        group_kill_confirmed = true;
+                    }
                 }
                 #[cfg(windows)]
                 if let Some(job) = job.as_ref() {

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2060,6 +2060,39 @@ mod tests {
         assert_eq!(clamp_timeout(Some(&json!(-5))), DEFAULT_TIMEOUT_MS);
     }
 
+    #[tokio::test]
+    async fn process_supervisor_closes_after_owned_task_finishes() {
+        let supervisor = Arc::new(ProcessSupervisor::new());
+        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_completed = Arc::clone(&completed);
+        let outcome = supervisor
+            .spawn(async move {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                task_completed.store(true, std::sync::atomic::Ordering::Release);
+                RunOutcome::Done { exit_code: 0, output: String::new() }
+            })
+            .expect("open supervisor admits process");
+        supervisor.shutdown().await;
+        assert!(completed.load(std::sync::atomic::Ordering::Acquire));
+        assert!(matches!(outcome.await, Ok(RunOutcome::Done { exit_code: 0, .. })));
+        assert_eq!(supervisor.state(), SupervisorState::Closed);
+    }
+
+    #[tokio::test]
+    async fn process_supervisor_rejects_new_tasks_after_close() {
+        let supervisor = Arc::new(ProcessSupervisor::new());
+        supervisor.shutdown().await;
+        assert!(supervisor
+            .spawn(async { RunOutcome::Done { exit_code: 0, output: String::new() } })
+            .is_none());
+    }
+
+    #[test]
+    fn wait_error_state_distinguishes_already_reaped() {
+        assert_eq!(WaitState::from_wait_error(true), WaitState::AlreadyReaped);
+        assert_eq!(WaitState::from_wait_error(false), WaitState::Retry);
+    }
+
     #[test]
     fn scoped_file_capability_refusal_is_typed_and_fail_closed() {
         let roots = vec!["/srv/work".to_owned()];

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -33,7 +33,8 @@ use tokio_tungstenite::tungstenite::{Error as TungsteniteError, Message};
 use tokio_util::sync::CancellationToken;
 
 use crate::actions::{
-    ActionContext, MAX_BLOCKING_FILE_ACTIONS, perform_action, process_env_snapshot, scrubbed_env,
+    ActionContext, MAX_BLOCKING_FILE_ACTIONS, ProcessSupervisor, perform_action,
+    process_env_snapshot, scrubbed_env,
 };
 use crate::config::{Config, save_config};
 use crate::error::RelayError;
@@ -325,6 +326,7 @@ pub struct SessionRuntime {
     home: PathBuf,
     base_env: HashMap<String, String>,
     file_action_slots: Arc<Semaphore>,
+    pub(crate) process_supervisor: Arc<ProcessSupervisor>,
     pub(crate) workspace: Arc<crate::workspace::SharedRuntime>,
     #[cfg(unix)]
     pty: Arc<PtyManager>,
@@ -347,6 +349,7 @@ impl SessionRuntime {
             home,
             base_env,
             file_action_slots: Arc::new(Semaphore::new(MAX_BLOCKING_FILE_ACTIONS)),
+            process_supervisor: Arc::new(ProcessSupervisor::new()),
             workspace: Arc::new(crate::workspace::SharedRuntime::new(local_roots)),
             #[cfg(unix)]
             pty,
@@ -474,9 +477,9 @@ pub async fn stay_online(
         }
     }
     let mut attempt: u32 = 0;
-    loop {
+    let result = loop {
         if cancellation.is_cancelled() {
-            return Ok(());
+            break Ok(());
         }
         match relay_session(&mut config, config_path, &mut state, &runtime, &cancellation).await {
             Ok(was_connected) => {
@@ -485,7 +488,7 @@ pub async fn stay_online(
                 }
             }
             Err(RelayError::Fatal { message, exit_code }) => {
-                return Err(RelayError::Fatal { message, exit_code });
+                break Err(RelayError::Fatal { message, exit_code });
             }
             Err(RelayError::WakeRedial { message }) => {
                 // The socket died silently (host suspend, or a peer that
@@ -501,15 +504,17 @@ pub async fn stay_online(
             }
         }
         if cancellation.is_cancelled() {
-            return Ok(());
+            break Ok(());
         }
         let ceiling = 500_u64.saturating_mul(1_u64 << attempt.min(10)).min(30_000);
         attempt = attempt.saturating_add(1);
         let delay = (ceiling as f64 * jitter()).round().max(0.0) as u64;
         if !wait_for_reconnect(&cancellation, Duration::from_millis(delay)).await {
-            return Ok(());
+            break Ok(());
         }
-    }
+    };
+    runtime.process_supervisor.shutdown().await;
+    result
 }
 
 fn save(config: &Config, config_path: &Path) {
@@ -1045,6 +1050,7 @@ async fn relay_session(
                             home: runtime.home.clone(),
                             env: scrubbed_env(&runtime.base_env),
                             file_slots: Arc::clone(&runtime.file_action_slots),
+                            process_supervisor: Arc::clone(&runtime.process_supervisor),
                             #[cfg(test)]
                             test_file_operation_barrier: None,
                         };


### PR DESCRIPTION
Supersedes https://github.com/manaflow-ai/cmux/pull/11629.

Introduces a per-session async process supervisor with Open, Closing, and Closed admission states. It retains Child ownership through successful wait or ECHILD, gates scope signals by explicit process phase, bounds process admission, cancels and drains tracked tasks during runtime shutdown, and waits for Windows Job settlement before releasing ownership.

Test-first commits cover supervisor closure, reap states, and descendant cleanup after leader exit. Static checks pass. No local Cargo or Rust tests were run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790956673&installation_model_id=21920&pr_number=11698&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11698&signature=29ef5399907805113d958c26b673bd2ec542d442d3b4be9259322bde69862ffe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Relay process actions previously ran outside a session-owned lifecycle and could leave child processes behind. They now run under a per-session supervisor that cancels and drains them during shutdown, including descendants after cancellation or timeout.

- Limits live process actions to eight; new actions fail with a capacity error when all slots are in use.
- Tracks Open, Closing, and Closed admission states and rejects work after shutdown begins.
- Gates signals and waits by process phase, treats `ECHILD` as already reaped, and retries transient wait errors.
- Kills an uncertain child through its owned handle on timeout instead of reusing an untrusted process-group identity.
- Waits for Windows Job settlement and covers closure, reap states, and descendant cleanup with tests.

<sup>Written for commit 74f8cbdb0e84d7985a3f3b90cbdd67acc08270fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved command execution reliability by limiting the number of simultaneously running processes.
  - Added more consistent handling of cancelled and timed-out commands, including termination of descendant processes.
  - Ensured process cleanup completes during session shutdown, including when sessions end because of cancellation or errors.
  - Improved handling of lingering output streams after a process is stopped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->