### PR TITLE
Fix hosted TUI artifact retention safety

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -371,6 +371,9 @@ jobs:
           EXACT_COMMIT: ${{ inputs.commit }}
         run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
 
+      - name: Hosted artifact retention tests
+        run: ./scripts/test-hosted-retention.sh
+
       - name: Use short temporary directory for macOS socket tests
         if: runner.os == 'macOS'
         run: echo "TMPDIR=/tmp" >> "$GITHUB_ENV"

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
 # Shared by verify-cmux-tui-hosted.sh and the behavior-level retention tests.
-# The function runs in a subshell so its EXIT trap cannot change the caller's
-# cleanup policy.
+# The public wrapper captures the caller PID before entering a subshell. Bash
+# 3.2 keeps $$ bound to the parent shell in a subshell, so capturing it inside
+# the implementation would make stale-lock recovery observe the wrong owner.
 
 cmux_hosted_retention_cleanup_scratch_dir=""
 cmux_hosted_retention_cleanup_quarantine_root=""
@@ -81,6 +82,142 @@ cmux_hosted_retention_hash_file() {
   printf '%s\n' "$digest"
 }
 
+cmux_hosted_retention_pid_state() {
+  local pid="$1"
+  local ps_output
+
+  if kill -0 "$pid" 2>/dev/null; then
+    return 0
+  fi
+  if ! cmux_hosted_retention_command_available ps; then
+    return 2
+  fi
+  ps_output="$(ps -p "$pid" -o pid= 2>/dev/null || true)"
+  if [[ "$ps_output" =~ (^|[[:space:]])$pid([[:space:]]|$) ]]; then
+    return 0
+  fi
+  if [[ -n "$ps_output" ]]; then
+    return 2
+  fi
+  return 1
+}
+
+cmux_hosted_retention_reclaim_lock() {
+  local lock_dir="$1"
+  local lock_marker="$2"
+  local now="$3"
+  local stale_after="$4"
+  local lock_line
+  local lock_pid
+  local lock_timestamp
+  local lock_token
+  local lock_extra
+  local lock_age
+  local owner_state
+  local recovery_dir
+
+  if [[ ! -d "$lock_dir" || -L "$lock_dir" || ! -O "$lock_dir" ||
+    ! -f "$lock_marker" || -L "$lock_marker" || ! -O "$lock_marker" ]]; then
+    return 1
+  fi
+  lock_line="$(<"$lock_marker")" || return 1
+  lock_pid=""
+  lock_timestamp=""
+  lock_token=""
+  lock_extra=""
+  IFS=$'\t' read -r lock_pid lock_timestamp lock_token lock_extra <<< "$lock_line"
+  if [[ "$lock_line" != "$lock_pid"$'\t'"$lock_timestamp"$'\t'"$lock_token" ||
+    -z "$lock_token" || -n "$lock_extra" ||
+    ! "$lock_pid" =~ ^[1-9][0-9]*$ || ! "$lock_timestamp" =~ ^[0-9]+$ ]]; then
+    return 1
+  fi
+  if ! lock_age="$(awk -v now="$now" -v timestamp="$lock_timestamp" \
+    'BEGIN { if (timestamp > now) exit 2; print now - timestamp }')"; then
+    return 1
+  fi
+  [[ "$lock_age" =~ ^[0-9]+$ ]] || return 1
+  if (( lock_age < stale_after )); then
+    return 1
+  fi
+  if cmux_hosted_retention_pid_state "$lock_pid"; then
+    owner_state=0
+  else
+    owner_state=$?
+  fi
+  [[ "$owner_state" -eq 1 ]] || return 1
+
+  recovery_dir="$lock_dir.$$.$RANDOM.reclaim"
+  if [[ -e "$recovery_dir" || -L "$recovery_dir" ]]; then
+    return 2
+  fi
+  if ! mv -- "$lock_dir" "$recovery_dir"; then
+    return 2
+  fi
+  if [[ ! -d "$recovery_dir" || -L "$recovery_dir" || ! -O "$recovery_dir" ||
+    ! -f "$recovery_dir/owner" || -L "$recovery_dir/owner" ||
+    ! -O "$recovery_dir/owner" ||
+    "$(<"$recovery_dir/owner")" != "$lock_line" ]]; then
+    if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
+      -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
+      mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+    fi
+    return 2
+  fi
+  if ! rm -f -- "$recovery_dir/owner" >/dev/null 2>&1; then
+    if [[ ! -e "$lock_dir" && ! -L "$lock_dir" ]]; then
+      mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+    fi
+    return 2
+  fi
+  if ! rmdir -- "$recovery_dir" >/dev/null 2>&1; then
+    if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
+      -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
+      mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+    fi
+    return 2
+  fi
+  return 0
+}
+
+cmux_hosted_retention_recover_quarantines() {
+  local artifact_root="$1"
+  local now="$2"
+  local stale_after="$3"
+  local quarantine_root
+  local quarantine_mtime
+  local quarantine_age
+  local candidate_dir
+  local candidate_commit
+  local restore_dir
+  local root_count=0
+  local entry_count=0
+  local max_entries=10000
+
+  shopt -s nullglob
+  for quarantine_root in "$artifact_root"/.retention-quarantine.*; do
+    root_count=$((root_count + 1))
+    (( root_count <= max_entries )) || break
+    [[ -d "$quarantine_root" && ! -L "$quarantine_root" && -O "$quarantine_root" ]] || continue
+    quarantine_mtime="$(cmux_hosted_retention_mtime "$quarantine_root")" || continue
+    [[ "$quarantine_mtime" =~ ^[0-9]+$ && "$quarantine_mtime" -le "$now" ]] || continue
+    quarantine_age=$((now - quarantine_mtime))
+    (( quarantine_age >= stale_after )) || continue
+    for candidate_dir in "$quarantine_root"/*; do
+      entry_count=$((entry_count + 1))
+      (( entry_count <= max_entries )) || break
+      [[ -d "$candidate_dir" && ! -L "$candidate_dir" && -O "$candidate_dir" ]] || continue
+      candidate_commit="${candidate_dir##*/}"
+      [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
+      [[ -f "$candidate_dir/cmux-tui" && ! -L "$candidate_dir/cmux-tui" && -O "$candidate_dir/cmux-tui" ]] || continue
+      restore_dir="$artifact_root/$candidate_commit"
+      [[ ! -e "$restore_dir" && ! -L "$restore_dir" ]] || continue
+      mv -- "$candidate_dir" "$restore_dir" >/dev/null 2>&1 || true
+    done
+    rmdir -- "$quarantine_root" >/dev/null 2>&1 || true
+  done
+  shopt -u nullglob
+}
+
 cmux_hosted_retention_lsof_state() {
   local lsof_command="$1"
   local target_path="$2"
@@ -90,6 +227,7 @@ cmux_hosted_retention_lsof_state() {
   local lsof_record
   local lsof_name
   local saw_name=0
+  local record_count=0
 
   if "$lsof_command" -F n -- "$target_path" > "$output_file" 2> "$error_file"; then
     lsof_status=0
@@ -101,6 +239,8 @@ cmux_hosted_retention_lsof_state() {
   fi
 
   while IFS= read -r lsof_record; do
+    record_count=$((record_count + 1))
+    (( record_count <= 1024 )) || return 2
     case "$lsof_record" in
       n*)
         saw_name=1
@@ -129,7 +269,13 @@ cmux_hosted_retention_lsof_state() {
   return 1
 }
 
-cmux_hosted_retention_run() (
+cmux_hosted_retention_run() {
+  local owner_pid="$$"
+  CMUX_TUI_HOSTED_RETENTION_OWNER_PID="$owner_pid" \
+    cmux_hosted_retention_run_impl "$@"
+}
+
+cmux_hosted_retention_run_impl() (
   if [[ $# -ne 2 ]]; then
     cmux_hosted_retention_error "expected current artifact directory and current commit"
     exit $?
@@ -143,11 +289,17 @@ cmux_hosted_retention_run() (
   local retention_confirmed="${CMUX_TUI_HOSTED_RETENTION_CONFIRM:-0}"
   local max_candidates_limit=10000
   local max_candidates="${CMUX_TUI_HOSTED_RETENTION_MAX_CANDIDATES:-$max_candidates_limit}"
-  local uid
   local scratch_dir
   local preview_file
   local preview_tmp
   local candidate_paths_file
+  local candidate_scan_error_file
+  local candidate_scan_status_file
+  local candidate_scan_find_status
+  local candidate_scan_filter_status
+  local candidate_scan_limit
+  local candidate_relative
+  local candidate_scan_error=0
   local candidate_order_file
   local plan_file
   local preview_hash
@@ -158,7 +310,6 @@ cmux_hosted_retention_run() (
   local candidate_dir
   local candidate_commit
   local candidate_mtime
-  local candidate_count=0
   local candidate_action
   local retained=0
   local lsof_command="${CMUX_TUI_HOSTED_RETENTION_LSOF:-lsof}"
@@ -169,6 +320,7 @@ cmux_hosted_retention_run() (
   local lsof_target_count=0
   local lsof_output_file
   local lsof_error_file
+  local lsof_record_count=0
   local active_commits_file
   local cleanup_commits_file
   local decision_file
@@ -180,6 +332,12 @@ cmux_hosted_retention_run() (
   local lock_dir=""
   local lock_marker=""
   local lock_token=""
+  # A dead owner is reclaimable only after one day. This bounds crash residue
+  # while protecting a long-running cleanup from a premature takeover.
+  local lock_stale_after_seconds=86400
+  local lock_owner_pid="${CMUX_TUI_HOSTED_RETENTION_OWNER_PID:-$$}"
+  local lock_reclaim_status
+  local lock_timestamp
   local quarantine_root=""
   local quarantine_dir=""
   local quarantine_binary=""
@@ -192,6 +350,10 @@ cmux_hosted_retention_run() (
   if [[ -z "$retention_count" ]]; then
     echo "Hosted artifact retention disabled (set a positive retention count to enable)" >&2
     exit 0
+  fi
+  if [[ ! "$lock_owner_pid" =~ ^[1-9][0-9]*$ ]]; then
+    cmux_hosted_retention_error "retention cleanup owner is invalid"
+    exit $?
   fi
   if ! cmux_hosted_retention_bounded_integer "$max_candidates" "$max_candidates_limit"; then
     cmux_hosted_retention_error "candidate scan limit must be a positive integer no greater than $max_candidates_limit"
@@ -236,11 +398,6 @@ cmux_hosted_retention_run() (
     cmux_hosted_retention_error "artifact root is not owned by the current user"
     exit $?
   fi
-  if ! uid="$(id -u)"; then
-    cmux_hosted_retention_error "cannot resolve the current user"
-    exit $?
-  fi
-
   old_umask="$(umask)"
   umask 077
   if ! scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/cmux-hosted-retention.XXXXXX")"; then
@@ -257,6 +414,10 @@ cmux_hosted_retention_run() (
   cmux_hosted_retention_cleanup_lock_acquired=0
   # shellcheck disable=SC2329 # invoked by the EXIT trap below
   cmux_hosted_retention_cleanup() {
+    if [[ -n "$quarantine_dir" && -d "$quarantine_dir" && ! -L "$quarantine_dir" && -O "$quarantine_dir" &&
+      -n "$candidate_dir" && ! -e "$candidate_dir" && ! -L "$candidate_dir" ]]; then
+      mv -- "$quarantine_dir" "$candidate_dir" >/dev/null 2>&1 || true
+    fi
     if [[ -n "$cmux_hosted_retention_cleanup_quarantine_root" && -d "$cmux_hosted_retention_cleanup_quarantine_root" && ! -L "$cmux_hosted_retention_cleanup_quarantine_root" ]]; then
       rmdir -- "$cmux_hosted_retention_cleanup_quarantine_root" >/dev/null 2>&1 || true
     fi
@@ -272,32 +433,99 @@ cmux_hosted_retention_run() (
   }
   trap cmux_hosted_retention_cleanup EXIT
 
+  now="$(date +%s)" || {
+    cmux_hosted_retention_error "cannot read the current time"
+    exit $?
+  }
+  cmux_hosted_retention_recover_quarantines "$artifact_root" "$now" 86400
+
   preview_file="$artifact_root/.retention-preview"
   candidate_paths_file="$scratch_dir/candidate-paths"
+  candidate_scan_error_file="$scratch_dir/candidate-find-error"
+  candidate_scan_status_file="$scratch_dir/candidate-find-status"
   candidate_order_file="$scratch_dir/candidate-order"
   plan_file="$scratch_dir/plan"
 
-  if ! find "$artifact_root" \
-    -mindepth 1 -maxdepth 1 -type d -user "$uid" -print0 > "$candidate_paths_file"; then
+  if ! cmux_hosted_retention_command_available find; then
+    cmux_hosted_retention_error "cannot enumerate artifact directories because find is unavailable"
+    exit $?
+  fi
+  if ! cmux_hosted_retention_command_available awk; then
+    cmux_hosted_retention_error "cannot enumerate artifact directories because awk is unavailable"
+    exit $?
+  fi
+  candidate_scan_limit=$((max_candidates + 1))
+  (
+    if ! cd "$artifact_root"; then
+      exit 1
+    fi
+    set +e
+    find . -type d \( -name . -o -prune -print \) 2> "$candidate_scan_error_file" \
+      | awk -v limit="$candidate_scan_limit" \
+        'substr($0, 1, 2) == "./" {
+           candidate = substr($0, 3)
+           if (length(candidate) == 40 && candidate !~ /[^0-9a-f]/) {
+             count++
+             if (count <= limit) print
+           }
+         }
+         END { if (count >= limit) exit 3 }' > "$candidate_paths_file"
+    candidate_scan_pipeline_status=("${PIPESTATUS[@]}")
+    candidate_scan_find_status="${candidate_scan_pipeline_status[0]}"
+    candidate_scan_filter_status="${candidate_scan_pipeline_status[1]}"
+    set -e
+    printf '%s\t%s\n' "$candidate_scan_find_status" "$candidate_scan_filter_status" > "$candidate_scan_status_file"
+  ) || {
+    cmux_hosted_retention_error "cannot enumerate artifact directories"
+    exit $?
+  }
+
+  hosted_artifact_order=()
+  while IFS= read -r candidate_relative; do
+    [[ "$candidate_relative" == ./* ]] || continue
+    candidate_commit="${candidate_relative#./}"
+    [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
+    candidate_dir="$artifact_root/$candidate_commit"
+    [[ -d "$candidate_dir" && ! -L "$candidate_dir" && -O "$candidate_dir" ]] || continue
+    if ! candidate_mtime="$(cmux_hosted_retention_mtime "$candidate_dir")"; then
+      candidate_scan_error=1
+      continue
+    fi
+    hosted_artifact_order+=("$candidate_mtime"$'\t'"$candidate_commit")
+  done < "$candidate_paths_file"
+  if [[ ! -f "$candidate_scan_status_file" ]]; then
     cmux_hosted_retention_error "cannot enumerate artifact directories"
     exit $?
   fi
-
-  hosted_artifact_order=()
-  while IFS= read -r -d '' candidate_dir; do
-    candidate_commit="${candidate_dir##*/}"
-    [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
-    candidate_count=$((candidate_count + 1))
-    if (( candidate_count > max_candidates )); then
-      cmux_hosted_retention_error "candidate scan exceeded the bounded limit of $max_candidates"
-      exit $?
-    fi
-    candidate_mtime="$(cmux_hosted_retention_mtime "$artifact_root/$candidate_commit")" || {
-      cmux_hosted_retention_error "cannot read an artifact modification time"
-      exit $?
-    }
-    hosted_artifact_order+=("$candidate_mtime"$'\t'"$candidate_commit")
-  done < "$candidate_paths_file"
+  IFS=$'\t' read -r candidate_scan_find_status candidate_scan_filter_status < "$candidate_scan_status_file" || {
+    cmux_hosted_retention_error "cannot enumerate artifact directories"
+    exit $?
+  }
+  if [[ ! "$candidate_scan_find_status" =~ ^[0-9]+$ ||
+    ! "$candidate_scan_filter_status" =~ ^[0-9]+$ ]]; then
+    cmux_hosted_retention_error "cannot enumerate artifact directories"
+    exit $?
+  fi
+  if [[ -s "$candidate_scan_error_file" ]]; then
+    cmux_hosted_retention_error "cannot enumerate artifact directories"
+    exit $?
+  fi
+  if [[ "$candidate_scan_filter_status" -eq 3 ]]; then
+    cmux_hosted_retention_error "candidate scan exceeded the bounded limit of $max_candidates"
+    exit $?
+  fi
+  if [[ "$candidate_scan_filter_status" -ne 0 ]]; then
+    cmux_hosted_retention_error "cannot enumerate artifact directories"
+    exit $?
+  fi
+  if [[ "$candidate_scan_find_status" -ne 0 ]]; then
+    cmux_hosted_retention_error "cannot enumerate artifact directories"
+    exit $?
+  fi
+  if (( candidate_scan_error )); then
+    cmux_hosted_retention_error "cannot read an artifact modification time"
+    exit $?
+  fi
 
   hosted_artifact_commits=()
   if ((${#hosted_artifact_order[@]} > 0)); then
@@ -438,11 +666,25 @@ cmux_hosted_retention_run() (
 
   lock_dir="$artifact_root/.retention.lock"
   lock_marker="$lock_dir/owner"
-  lock_token="$(printf '%s:%s' "$$" "$scratch_dir")"
+  lock_timestamp="$now"
+  lock_token="$(printf '%s\t%s\t%s' "$lock_owner_pid" "$lock_timestamp" "$scratch_dir")"
   cmux_hosted_retention_cleanup_lock_dir="$lock_dir"
   cmux_hosted_retention_cleanup_lock_marker="$lock_marker"
   cmux_hosted_retention_cleanup_lock_token="$lock_token"
-  if [[ -e "$lock_dir" || -L "$lock_dir" ]] || ! (umask 077 && mkdir "$lock_dir"); then
+  if [[ -e "$lock_dir" || -L "$lock_dir" ]]; then
+    if cmux_hosted_retention_reclaim_lock "$lock_dir" "$lock_marker" "$now" "$lock_stale_after_seconds"; then
+      :
+    else
+      lock_reclaim_status=$?
+      if [[ "$lock_reclaim_status" -eq 1 ]]; then
+        cmux_hosted_retention_error "another retention cleanup is already running"
+      else
+        cmux_hosted_retention_error "cannot recover the previous retention cleanup lock"
+      fi
+      exit $?
+    fi
+  fi
+  if ! (umask 077 && mkdir "$lock_dir"); then
     cmux_hosted_retention_error "another retention cleanup is already running"
     exit $?
   fi
@@ -489,6 +731,11 @@ cmux_hosted_retention_run() (
       exit $?
     fi
     while IFS= read -r lsof_record; do
+      lsof_record_count=$((lsof_record_count + 1))
+      (( lsof_record_count <= max_candidates * 4 )) || {
+        cmux_hosted_retention_error "lsof returned too many activity records"
+        exit $?
+      }
       case "$lsof_record" in
         n*)
           active_path="${lsof_record#n}"

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -1,0 +1,450 @@
+#!/usr/bin/env bash
+
+# Shared by verify-cmux-tui-hosted.sh and the behavior-level retention tests.
+# The function runs in a subshell so its EXIT trap cannot change the caller's
+# cleanup policy.
+
+cmux_hosted_retention_error() {
+  echo "error: hosted artifact retention: $*" >&2
+  return 2
+}
+
+cmux_hosted_retention_command_available() {
+  local command_name="$1"
+  if [[ "$command_name" == */* ]]; then
+    [[ -x "$command_name" ]]
+  else
+    command -v "$command_name" >/dev/null 2>&1
+  fi
+}
+
+cmux_hosted_retention_bounded_integer() {
+  local value="$1"
+  local maximum="$2"
+
+  [[ "$value" =~ ^[1-9][0-9]*$ ]] || return 1
+  # The length check keeps the arithmetic comparison below within the shell's
+  # integer range. Both values are at most five digits in this function.
+  if (( ${#value} > ${#maximum} )); then
+    return 1
+  fi
+  if (( ${#value} == ${#maximum} )) && (( value > maximum )); then
+    return 1
+  fi
+}
+
+cmux_hosted_retention_mtime() {
+  local candidate_path="$1"
+  local stat_command="${CMUX_TUI_HOSTED_RETENTION_STAT:-stat}"
+  local output
+
+  if ! cmux_hosted_retention_command_available "$stat_command"; then
+    return 1
+  fi
+
+  # GNU stat uses -c for file fields. BSD/macOS stat uses -f. Probe the GNU
+  # form first because GNU -f means filesystem status and can succeed while
+  # returning a mount point instead of a file timestamp.
+  if output="$("$stat_command" -c '%Y' "$candidate_path" 2>/dev/null)"; then
+    [[ "$output" =~ ^-?[0-9]+$ ]] || return 1
+    printf '%s\n' "$output"
+    return 0
+  fi
+  if output="$("$stat_command" -f '%m' "$candidate_path" 2>/dev/null)"; then
+    [[ "$output" =~ ^-?[0-9]+$ ]] || return 1
+    printf '%s\n' "$output"
+    return 0
+  fi
+  return 1
+}
+
+cmux_hosted_retention_hash_file() {
+  local input_file="$1"
+  local digest
+
+  if command -v shasum >/dev/null 2>&1; then
+    digest="$(shasum -a 256 "$input_file" | awk 'NR == 1 { print $1 }')" || return 1
+  elif command -v sha256sum >/dev/null 2>&1; then
+    digest="$(sha256sum "$input_file" | awk 'NR == 1 { print $1 }')" || return 1
+  else
+    return 1
+  fi
+
+  [[ "$digest" =~ ^[0-9a-f]{64}$ ]] || return 1
+  printf '%s\n' "$digest"
+}
+
+cmux_hosted_retention_run() (
+  if [[ $# -ne 2 ]]; then
+    cmux_hosted_retention_error "expected artifact root and current commit"
+    exit $?
+  fi
+
+  local artifact_root="$1"
+  local current_commit="$2"
+  local retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-}"
+  local retention_dry_run="${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}"
+  local retention_confirmed="${CMUX_TUI_HOSTED_RETENTION_CONFIRM:-0}"
+  local max_candidates_limit=10000
+  local max_candidates="${CMUX_TUI_HOSTED_RETENTION_MAX_CANDIDATES:-$max_candidates_limit}"
+  local uid
+  local scratch_dir
+  local preview_file
+  local preview_tmp
+  local candidate_paths_file
+  local candidate_order_file
+  local plan_file
+  local preview_hash
+  local preview_timestamp
+  local preview_line_count
+  local preview_line
+  local now
+  local candidate_dir
+  local candidate_commit
+  local candidate_mtime
+  local candidate_count=0
+  local candidate_action
+  local retained=0
+  local lsof_command="${CMUX_TUI_HOSTED_RETENTION_LSOF:-lsof}"
+  local lsof_status
+  local lsof_record
+  local active_path
+  local active_commit
+  local lsof_target_count=0
+  local lsof_output_file
+  local lsof_error_file
+  local active_commits_file
+  local cleanup_commits_file
+  local decision_file
+  local candidate_index
+  local decision
+  local decision_commit
+  local old_umask
+
+  # Retention is opt-in. Keep the existing verification path unchanged when
+  # no retention count is supplied.
+  if [[ -z "$retention_count" ]]; then
+    echo "Hosted artifact retention disabled (set a positive retention count to enable)" >&2
+    exit 0
+  fi
+  if ! cmux_hosted_retention_bounded_integer "$max_candidates" "$max_candidates_limit"; then
+    cmux_hosted_retention_error "candidate scan limit must be a positive integer no greater than $max_candidates_limit"
+    exit $?
+  fi
+  if ! cmux_hosted_retention_bounded_integer "$retention_count" "$max_candidates"; then
+    cmux_hosted_retention_error "retention count must be a positive integer no greater than $max_candidates"
+    exit $?
+  fi
+  case "$retention_dry_run" in
+    0|1) ;;
+    *)
+      cmux_hosted_retention_error "dry-run mode must be 0 or 1"
+      exit $?
+      ;;
+  esac
+  if [[ "$retention_dry_run" == 0 && "$retention_confirmed" != 1 ]]; then
+    cmux_hosted_retention_error "destructive cleanup requires a confirmation after a dry-run preview"
+    exit $?
+  fi
+  if [[ ! "$current_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    cmux_hosted_retention_error "current commit is not a lowercase 40-character SHA"
+    exit $?
+  fi
+  if [[ ! -d "$artifact_root" ]]; then
+    cmux_hosted_retention_error "artifact root does not exist"
+    exit $?
+  fi
+  if ! artifact_root="$(cd "$artifact_root" && pwd -P)"; then
+    cmux_hosted_retention_error "cannot resolve artifact root"
+    exit $?
+  fi
+  if [[ ! -O "$artifact_root" ]]; then
+    cmux_hosted_retention_error "artifact root is not owned by the current user"
+    exit $?
+  fi
+  if [[ ! -d "$artifact_root/$current_commit" || -L "$artifact_root/$current_commit" || \
+    ! -O "$artifact_root/$current_commit" ]]; then
+    cmux_hosted_retention_error "current artifact is missing or is not owned by the current user"
+    exit $?
+  fi
+  if ! uid="$(id -u)"; then
+    cmux_hosted_retention_error "cannot resolve the current user"
+    exit $?
+  fi
+
+  old_umask="$(umask)"
+  umask 077
+  if ! scratch_dir="$(mktemp -d "${TMPDIR:-/tmp}/cmux-hosted-retention.XXXXXX")"; then
+    umask "$old_umask"
+    cmux_hosted_retention_error "cannot create retention scratch space"
+    exit $?
+  fi
+  umask "$old_umask"
+  # shellcheck disable=SC2329 # invoked by the EXIT trap below
+  cmux_hosted_retention_cleanup() {
+    rm -rf -- "$scratch_dir"
+  }
+  trap cmux_hosted_retention_cleanup EXIT
+
+  preview_file="$artifact_root/.retention-preview"
+  candidate_paths_file="$scratch_dir/candidate-paths"
+  candidate_order_file="$scratch_dir/candidate-order"
+  plan_file="$scratch_dir/plan"
+
+  if ! find "$artifact_root" \
+    -mindepth 1 -maxdepth 1 -type d -user "$uid" -print0 > "$candidate_paths_file"; then
+    cmux_hosted_retention_error "cannot enumerate artifact directories"
+    exit $?
+  fi
+
+  hosted_artifact_order=()
+  while IFS= read -r -d '' candidate_dir; do
+    candidate_commit="${candidate_dir##*/}"
+    [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
+    candidate_count=$((candidate_count + 1))
+    if (( candidate_count > max_candidates )); then
+      cmux_hosted_retention_error "candidate scan exceeded the bounded limit of $max_candidates"
+      exit $?
+    fi
+    candidate_mtime="$(cmux_hosted_retention_mtime "$artifact_root/$candidate_commit")" || {
+      cmux_hosted_retention_error "cannot read an artifact modification time"
+      exit $?
+    }
+    hosted_artifact_order+=("$candidate_mtime"$'\t'"$candidate_commit")
+  done < "$candidate_paths_file"
+
+  hosted_artifact_commits=()
+  if ((${#hosted_artifact_order[@]} > 0)); then
+    if ! printf '%s\n' "${hosted_artifact_order[@]}" \
+      | LC_ALL=C sort -t $'\t' -k1,1nr -k2,2r > "$candidate_order_file"; then
+      cmux_hosted_retention_error "cannot order artifact directories"
+      exit $?
+    fi
+    while IFS=$'\t' read -r candidate_mtime candidate_commit; do
+      [[ "$candidate_mtime" =~ ^-?[0-9]+$ ]] || {
+        cmux_hosted_retention_error "artifact ordering returned an invalid timestamp"
+        exit $?
+      }
+      [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || {
+        cmux_hosted_retention_error "artifact ordering returned an invalid commit"
+        exit $?
+      }
+      hosted_artifact_commits+=("$candidate_commit")
+    done < "$candidate_order_file"
+  fi
+
+  hosted_artifact_actions=()
+  for candidate_commit in "${hosted_artifact_commits[@]}"; do
+    if [[ "$candidate_commit" == "$current_commit" ]]; then
+      candidate_action="keep-current"
+    elif (( retained < retention_count )); then
+      retained=$((retained + 1))
+      candidate_action="keep-recent"
+    else
+      candidate_action="delete"
+    fi
+    hosted_artifact_actions+=("$candidate_action")
+  done
+
+  {
+    printf 'cmux-hosted-retention-plan-v1\n'
+    printf 'current-commit\t%s\n' "$current_commit"
+    printf 'retention-count\t%s\n' "$retention_count"
+    printf 'candidate-limit\t%s\n' "$max_candidates"
+    for candidate_index in "${!hosted_artifact_commits[@]}"; do
+      printf 'candidate\t%s\t%s\n' \
+        "${hosted_artifact_commits[$candidate_index]}" \
+        "${hosted_artifact_actions[$candidate_index]}"
+    done
+  } > "$plan_file" || {
+    cmux_hosted_retention_error "cannot build the retention plan"
+    exit $?
+  }
+  preview_hash="$(cmux_hosted_retention_hash_file "$plan_file")" || {
+    cmux_hosted_retention_error "cannot hash the retention plan"
+    exit $?
+  }
+
+  if [[ "$retention_dry_run" == 1 ]]; then
+    now="$(date +%s)" || {
+      cmux_hosted_retention_error "cannot create a preview timestamp"
+      exit $?
+    }
+    [[ "$now" =~ ^[0-9]+$ ]] || {
+      cmux_hosted_retention_error "preview timestamp is invalid"
+      exit $?
+    }
+    if [[ -L "$preview_file" ]]; then
+      cmux_hosted_retention_error "preview path is a symbolic link"
+      exit $?
+    fi
+    if [[ -e "$preview_file" && ! -O "$preview_file" ]]; then
+      cmux_hosted_retention_error "preview path is not owned by the current user"
+      exit $?
+    fi
+    preview_tmp="$scratch_dir/preview"
+    if ! (umask 077 && printf '%s\t%s\n' "$preview_hash" "$now" > "$preview_tmp"); then
+      cmux_hosted_retention_error "cannot write the retention preview"
+      exit $?
+    fi
+    if ! mv -f -- "$preview_tmp" "$preview_file"; then
+      cmux_hosted_retention_error "cannot publish the retention preview"
+      exit $?
+    fi
+  else
+    if [[ ! -f "$preview_file" || -L "$preview_file" || ! -O "$preview_file" ]]; then
+      cmux_hosted_retention_error "a fresh retention preview is required"
+      exit $?
+    fi
+    preview_line_count="$(wc -l < "$preview_file" | tr -d '[:space:]')" || {
+      cmux_hosted_retention_error "cannot read the retention preview"
+      exit $?
+    }
+    if [[ "$preview_line_count" != 1 ]]; then
+      cmux_hosted_retention_error "retention preview format is invalid"
+      exit $?
+    fi
+    preview_line="$(<"$preview_file")" || {
+      cmux_hosted_retention_error "cannot read the retention preview"
+      exit $?
+    }
+    if [[ "$preview_line" != "$preview_hash"$'\t'* ]]; then
+      cmux_hosted_retention_error "retention preview does not match the current deletion plan"
+      exit $?
+    fi
+    preview_timestamp="${preview_line#*$'\t'}"
+    if [[ -z "$preview_timestamp" || "$preview_timestamp" == *$'\t'* || ! "$preview_timestamp" =~ ^[0-9]+$ ]]; then
+      cmux_hosted_retention_error "retention preview timestamp is invalid"
+      exit $?
+    fi
+    now="$(date +%s)" || {
+      cmux_hosted_retention_error "cannot read the current time"
+      exit $?
+    }
+    if [[ ! "$now" =~ ^[0-9]+$ ]] || ! awk -v now="$now" -v timestamp="$preview_timestamp" \
+      'BEGIN { exit !(timestamp <= now && now - timestamp <= 600) }'; then
+      cmux_hosted_retention_error "retention preview is expired or from the future"
+      exit $?
+    fi
+  fi
+
+  cleanup_commits=()
+  for candidate_index in "${!hosted_artifact_commits[@]}"; do
+    if [[ "${hosted_artifact_actions[$candidate_index]}" == delete ]]; then
+      cleanup_commits+=("${hosted_artifact_commits[$candidate_index]}")
+    fi
+  done
+
+  if ((${#cleanup_commits[@]} == 0)); then
+    exit 0
+  fi
+  if [[ "$retention_dry_run" == 1 ]]; then
+    for candidate_commit in "${cleanup_commits[@]}"; do
+      echo "Would remove hosted artifact: $artifact_root/$candidate_commit" >&2
+    done
+    exit 0
+  fi
+
+  if ! cmux_hosted_retention_command_available "$lsof_command"; then
+    cmux_hosted_retention_error "cannot prove artifacts are inactive because lsof is unavailable"
+    exit $?
+  fi
+
+  lsof_targets=()
+  for candidate_commit in "${cleanup_commits[@]}"; do
+    candidate_dir="$artifact_root/$candidate_commit/cmux-tui"
+    if [[ -f "$candidate_dir" ]]; then
+      lsof_targets+=("$candidate_dir")
+      lsof_target_count=$((lsof_target_count + 1))
+    fi
+  done
+
+  active_commits_file="$scratch_dir/active-commits"
+  : > "$active_commits_file"
+  if (( lsof_target_count > 0 )); then
+    lsof_output_file="$scratch_dir/lsof-output"
+    lsof_error_file="$scratch_dir/lsof-error"
+    if "$lsof_command" -F n -- "${lsof_targets[@]}" > "$lsof_output_file" 2> "$lsof_error_file"; then
+      lsof_status=0
+    else
+      lsof_status=$?
+    fi
+    if [[ -s "$lsof_error_file" || "$lsof_status" -gt 1 ]]; then
+      cmux_hosted_retention_error "lsof could not establish artifact activity"
+      exit $?
+    fi
+    while IFS= read -r lsof_record; do
+      case "$lsof_record" in
+        n*)
+          active_path="${lsof_record#n}"
+          if [[ "$active_path" != "$artifact_root"/*/cmux-tui ]]; then
+            continue
+          fi
+          active_commit="${active_path%/cmux-tui}"
+          active_commit="${active_commit##*/}"
+          [[ "$active_commit" =~ ^[0-9a-f]{40}$ ]] || {
+            cmux_hosted_retention_error "lsof returned an unexpected artifact path"
+            exit $?
+          }
+          printf '%s\n' "$active_commit" >> "$active_commits_file"
+          ;;
+        p*|f*)
+          # lsof always emits the PID field, and versions 4.88 through 4.93.2
+          # also emit a file-descriptor field even when only names are asked.
+          ;;
+        *)
+          cmux_hosted_retention_error "lsof returned an invalid activity record"
+          exit $?
+          ;;
+      esac
+    done < "$lsof_output_file"
+    if [[ -s "$lsof_output_file" && ! -s "$active_commits_file" ]]; then
+      cmux_hosted_retention_error "lsof returned no usable artifact names"
+      exit $?
+    fi
+    if (( lsof_status == 0 )) && [[ ! -s "$lsof_output_file" ]]; then
+      cmux_hosted_retention_error "lsof returned no activity records"
+      exit $?
+    fi
+  fi
+  LC_ALL=C sort -u "$active_commits_file" -o "$active_commits_file" || {
+    cmux_hosted_retention_error "cannot normalize lsof activity records"
+    exit $?
+  }
+
+  cleanup_commits_file="$scratch_dir/cleanup-commits"
+  decision_file="$scratch_dir/decisions"
+  printf '%s\n' "${cleanup_commits[@]}" > "$cleanup_commits_file"
+  if ! awk '
+    FILENAME == ARGV[1] { active[$0] = 1; next }
+    { print (($0 in active) ? "active" : "inactive") "\t" $0 }
+  ' "$active_commits_file" "$cleanup_commits_file" > "$decision_file"; then
+    cmux_hosted_retention_error "cannot build the activity decision"
+    exit $?
+  fi
+
+  while IFS=$'\t' read -r decision decision_commit; do
+    case "$decision" in
+      active)
+        echo "Keeping active hosted artifact: $artifact_root/$decision_commit/cmux-tui" >&2
+        ;;
+      inactive)
+        candidate_dir="$artifact_root/$decision_commit"
+        if [[ ! -d "$candidate_dir" || -L "$candidate_dir" || ! -O "$candidate_dir" ]]; then
+          cmux_hosted_retention_error "artifact changed before deletion"
+          exit $?
+        fi
+        if ! rm -rf -- "$candidate_dir"; then
+          cmux_hosted_retention_error "cannot remove an inactive artifact"
+          exit $?
+        fi
+        echo "Removed hosted artifact: $candidate_dir" >&2
+        ;;
+      *)
+        cmux_hosted_retention_error "activity decision is invalid"
+        exit $?
+        ;;
+    esac
+  done < "$decision_file"
+  exit 0
+)

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -4,6 +4,13 @@
 # The function runs in a subshell so its EXIT trap cannot change the caller's
 # cleanup policy.
 
+cmux_hosted_retention_cleanup_scratch_dir=""
+cmux_hosted_retention_cleanup_quarantine_root=""
+cmux_hosted_retention_cleanup_lock_dir=""
+cmux_hosted_retention_cleanup_lock_marker=""
+cmux_hosted_retention_cleanup_lock_token=""
+cmux_hosted_retention_cleanup_lock_acquired=0
+
 cmux_hosted_retention_error() {
   echo "error: hosted artifact retention: $*" >&2
   return 2
@@ -74,6 +81,54 @@ cmux_hosted_retention_hash_file() {
   printf '%s\n' "$digest"
 }
 
+cmux_hosted_retention_lsof_state() {
+  local lsof_command="$1"
+  local target_path="$2"
+  local output_file="$3"
+  local error_file="$4"
+  local lsof_status
+  local lsof_record
+  local lsof_name
+  local saw_name=0
+
+  if "$lsof_command" -F n -- "$target_path" > "$output_file" 2> "$error_file"; then
+    lsof_status=0
+  else
+    lsof_status=$?
+  fi
+  if [[ -s "$error_file" || "$lsof_status" -gt 1 ]]; then
+    return 2
+  fi
+
+  while IFS= read -r lsof_record; do
+    case "$lsof_record" in
+      n*)
+        saw_name=1
+        lsof_name="${lsof_record#n}"
+        [[ "$lsof_name" == "$target_path" ]] || return 2
+        ;;
+      p*|f*)
+        # lsof always emits the PID field, and versions 4.88 through 4.93.2
+        # also emit a file-descriptor field even when only names are asked.
+        ;;
+      *)
+        return 2
+        ;;
+    esac
+  done < "$output_file"
+
+  if [[ -s "$output_file" && "$saw_name" -eq 0 ]]; then
+    return 2
+  fi
+  if (( lsof_status == 0 )) && [[ ! -s "$output_file" ]]; then
+    return 2
+  fi
+  if [[ "$saw_name" -eq 1 ]]; then
+    return 0
+  fi
+  return 1
+}
+
 cmux_hosted_retention_run() (
   if [[ $# -ne 2 ]]; then
     cmux_hosted_retention_error "expected current artifact directory and current commit"
@@ -121,6 +176,16 @@ cmux_hosted_retention_run() (
   local decision
   local decision_commit
   local old_umask
+  local candidate_binary
+  local lock_dir=""
+  local lock_marker=""
+  local lock_token=""
+  local quarantine_root=""
+  local quarantine_dir=""
+  local quarantine_binary=""
+  local recheck_output_file
+  local recheck_error_file
+  local recheck_status
 
   # Retention is opt-in. Keep the existing verification path unchanged when
   # no retention count is supplied.
@@ -184,9 +249,26 @@ cmux_hosted_retention_run() (
     exit $?
   fi
   umask "$old_umask"
+  cmux_hosted_retention_cleanup_scratch_dir="$scratch_dir"
+  cmux_hosted_retention_cleanup_quarantine_root=""
+  cmux_hosted_retention_cleanup_lock_dir=""
+  cmux_hosted_retention_cleanup_lock_marker=""
+  cmux_hosted_retention_cleanup_lock_token=""
+  cmux_hosted_retention_cleanup_lock_acquired=0
   # shellcheck disable=SC2329 # invoked by the EXIT trap below
   cmux_hosted_retention_cleanup() {
-    rm -rf -- "$scratch_dir"
+    if [[ -n "$cmux_hosted_retention_cleanup_quarantine_root" && -d "$cmux_hosted_retention_cleanup_quarantine_root" && ! -L "$cmux_hosted_retention_cleanup_quarantine_root" ]]; then
+      rmdir -- "$cmux_hosted_retention_cleanup_quarantine_root" >/dev/null 2>&1 || true
+    fi
+    if [[ "$cmux_hosted_retention_cleanup_lock_acquired" -eq 1 && -n "$cmux_hosted_retention_cleanup_lock_dir" && -d "$cmux_hosted_retention_cleanup_lock_dir" && ! -L "$cmux_hosted_retention_cleanup_lock_dir" && -f "$cmux_hosted_retention_cleanup_lock_marker" && ! -L "$cmux_hosted_retention_cleanup_lock_marker" && -O "$cmux_hosted_retention_cleanup_lock_marker" ]]; then
+      if [[ "$(<"$cmux_hosted_retention_cleanup_lock_marker")" == "$cmux_hosted_retention_cleanup_lock_token" ]]; then
+        rm -f -- "$cmux_hosted_retention_cleanup_lock_marker" >/dev/null 2>&1 || true
+        rmdir -- "$cmux_hosted_retention_cleanup_lock_dir" >/dev/null 2>&1 || true
+      fi
+    fi
+    if [[ -n "$cmux_hosted_retention_cleanup_scratch_dir" ]]; then
+      rm -rf -- "$cmux_hosted_retention_cleanup_scratch_dir"
+    fi
   }
   trap cmux_hosted_retention_cleanup EXIT
 
@@ -354,6 +436,33 @@ cmux_hosted_retention_run() (
     exit $?
   fi
 
+  lock_dir="$artifact_root/.retention.lock"
+  lock_marker="$lock_dir/owner"
+  lock_token="$(printf '%s:%s' "$$" "$scratch_dir")"
+  cmux_hosted_retention_cleanup_lock_dir="$lock_dir"
+  cmux_hosted_retention_cleanup_lock_marker="$lock_marker"
+  cmux_hosted_retention_cleanup_lock_token="$lock_token"
+  if [[ -e "$lock_dir" || -L "$lock_dir" ]] || ! (umask 077 && mkdir "$lock_dir"); then
+    cmux_hosted_retention_error "another retention cleanup is already running"
+    exit $?
+  fi
+  if ! (umask 077 && printf '%s\n' "$lock_token" > "$lock_marker"); then
+    rmdir -- "$lock_dir" >/dev/null 2>&1 || true
+    cmux_hosted_retention_error "cannot initialize the retention cleanup lock"
+    exit $?
+  fi
+  cmux_hosted_retention_cleanup_lock_acquired=1
+
+  if ! quarantine_root="$(umask 077 && mktemp -d "$artifact_root/.retention-quarantine.XXXXXX")"; then
+    cmux_hosted_retention_error "cannot create the retention quarantine"
+    exit $?
+  fi
+  if [[ ! -d "$quarantine_root" || -L "$quarantine_root" || ! -O "$quarantine_root" ]]; then
+    cmux_hosted_retention_error "retention quarantine is not owned by the current user"
+    exit $?
+  fi
+  cmux_hosted_retention_cleanup_quarantine_root="$quarantine_root"
+
   lsof_targets=()
   for candidate_commit in "${cleanup_commits[@]}"; do
     candidate_binary="$artifact_root/$candidate_commit/cmux-tui"
@@ -429,6 +538,8 @@ cmux_hosted_retention_run() (
     exit $?
   fi
 
+  recheck_output_file="$scratch_dir/recheck-output"
+  recheck_error_file="$scratch_dir/recheck-error"
   while IFS=$'\t' read -r decision decision_commit; do
     case "$decision" in
       active)
@@ -436,15 +547,70 @@ cmux_hosted_retention_run() (
         ;;
       inactive)
         candidate_dir="$artifact_root/$decision_commit"
-        if [[ ! -d "$candidate_dir" || -L "$candidate_dir" || ! -O "$candidate_dir" ]]; then
-          cmux_hosted_retention_error "artifact changed before deletion"
+        candidate_binary="$candidate_dir/cmux-tui"
+        if [[ ! -d "$candidate_dir" || -L "$candidate_dir" || ! -O "$candidate_dir" || ! -f "$candidate_binary" || -L "$candidate_binary" || ! -O "$candidate_binary" ]]; then
+          cmux_hosted_retention_error "artifact changed before entering quarantine"
           exit $?
         fi
-        if ! rm -rf -- "$candidate_dir"; then
-          cmux_hosted_retention_error "cannot remove an inactive artifact"
+        quarantine_dir="$quarantine_root/$decision_commit"
+        if [[ -e "$quarantine_dir" || -L "$quarantine_dir" ]]; then
+          cmux_hosted_retention_error "retention quarantine path already exists"
           exit $?
         fi
-        echo "Removed hosted artifact: $candidate_dir" >&2
+        if ! mv -- "$candidate_dir" "$quarantine_dir"; then
+          cmux_hosted_retention_error "cannot quarantine an inactive artifact"
+          exit $?
+        fi
+        quarantine_binary="$quarantine_dir/cmux-tui"
+        if [[ ! -d "$quarantine_dir" || -L "$quarantine_dir" || ! -O "$quarantine_dir" || ! -f "$quarantine_binary" || -L "$quarantine_binary" || ! -O "$quarantine_binary" ]]; then
+          if [[ ! -e "$candidate_dir" && ! -L "$candidate_dir" && -d "$quarantine_dir" && ! -L "$quarantine_dir" ]]; then
+            mv -- "$quarantine_dir" "$candidate_dir" >/dev/null 2>&1 || true
+          fi
+          cmux_hosted_retention_error "artifact changed after entering quarantine"
+          exit $?
+        fi
+
+        if cmux_hosted_retention_lsof_state \
+          "$lsof_command" "$quarantine_binary" "$recheck_output_file" "$recheck_error_file"; then
+          recheck_status=0
+        else
+          recheck_status=$?
+        fi
+        case "$recheck_status" in
+          0)
+            if [[ -e "$candidate_dir" || -L "$candidate_dir" ]]; then
+              cmux_hosted_retention_error "artifact path was recreated while checking activity"
+              exit $?
+            fi
+            if ! mv -- "$quarantine_dir" "$candidate_dir"; then
+              cmux_hosted_retention_error "cannot restore an active artifact"
+              exit $?
+            fi
+            echo "Keeping active hosted artifact: $candidate_dir/cmux-tui" >&2
+            ;;
+          1)
+            if [[ -e "$candidate_dir" || -L "$candidate_dir" ]]; then
+              cmux_hosted_retention_error "artifact path was recreated while checking activity"
+              exit $?
+            fi
+            if [[ ! -d "$quarantine_dir" || -L "$quarantine_dir" || ! -O "$quarantine_dir" || ! -f "$quarantine_binary" || -L "$quarantine_binary" || ! -O "$quarantine_binary" ]]; then
+              cmux_hosted_retention_error "artifact changed after activity check"
+              exit $?
+            fi
+            if ! rm -rf -- "$quarantine_dir"; then
+              cmux_hosted_retention_error "cannot remove an inactive artifact"
+              exit $?
+            fi
+            echo "Removed hosted artifact: $candidate_dir" >&2
+            ;;
+          *)
+            if [[ ! -e "$candidate_dir" && ! -L "$candidate_dir" && -d "$quarantine_dir" && ! -L "$quarantine_dir" && -O "$quarantine_dir" ]]; then
+              mv -- "$quarantine_dir" "$candidate_dir" >/dev/null 2>&1 || true
+            fi
+            cmux_hosted_retention_error "lsof could not establish quarantined artifact activity"
+            exit $?
+            ;;
+        esac
         ;;
       *)
         cmux_hosted_retention_error "activity decision is invalid"

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -76,7 +76,7 @@ cmux_hosted_retention_hash_file() {
 
 cmux_hosted_retention_run() (
   if [[ $# -ne 2 ]]; then
-    cmux_hosted_retention_error "expected artifact root and current commit"
+    cmux_hosted_retention_error "expected current artifact directory and current commit"
     exit $?
   fi
 

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -80,7 +80,8 @@ cmux_hosted_retention_run() (
     exit $?
   fi
 
-  local artifact_root="$1"
+  local current_artifact_dir="$1"
+  local artifact_root
   local current_commit="$2"
   local retention_count="${CMUX_TUI_HOSTED_RETENTION_COUNT:-}"
   local retention_dry_run="${CMUX_TUI_HOSTED_RETENTION_DRY_RUN:-0}"
@@ -150,21 +151,24 @@ cmux_hosted_retention_run() (
     cmux_hosted_retention_error "current commit is not a lowercase 40-character SHA"
     exit $?
   fi
-  if [[ ! -d "$artifact_root" ]]; then
-    cmux_hosted_retention_error "artifact root does not exist"
+  if [[ ! -d "$current_artifact_dir" || -L "$current_artifact_dir" ]]; then
+    cmux_hosted_retention_error "current artifact directory is missing or is a symbolic link"
     exit $?
   fi
-  if ! artifact_root="$(cd "$artifact_root" && pwd -P)"; then
+  if ! current_artifact_dir="$(cd "$current_artifact_dir" && pwd -P)"; then
+    cmux_hosted_retention_error "cannot resolve current artifact directory"
+    exit $?
+  fi
+  if [[ "${current_artifact_dir##*/}" != "$current_commit" || ! -O "$current_artifact_dir" ]]; then
+    cmux_hosted_retention_error "current artifact directory does not match the current commit"
+    exit $?
+  fi
+  if ! artifact_root="$(cd "$current_artifact_dir/.." && pwd -P)"; then
     cmux_hosted_retention_error "cannot resolve artifact root"
     exit $?
   fi
-  if [[ ! -O "$artifact_root" ]]; then
+  if [[ ! -d "$artifact_root" || ! -O "$artifact_root" ]]; then
     cmux_hosted_retention_error "artifact root is not owned by the current user"
-    exit $?
-  fi
-  if [[ ! -d "$artifact_root/$current_commit" || -L "$artifact_root/$current_commit" || \
-    ! -O "$artifact_root/$current_commit" ]]; then
-    cmux_hosted_retention_error "current artifact is missing or is not owned by the current user"
     exit $?
   fi
   if ! uid="$(id -u)"; then
@@ -352,11 +356,13 @@ cmux_hosted_retention_run() (
 
   lsof_targets=()
   for candidate_commit in "${cleanup_commits[@]}"; do
-    candidate_dir="$artifact_root/$candidate_commit/cmux-tui"
-    if [[ -f "$candidate_dir" ]]; then
-      lsof_targets+=("$candidate_dir")
-      lsof_target_count=$((lsof_target_count + 1))
+    candidate_binary="$artifact_root/$candidate_commit/cmux-tui"
+    if [[ ! -f "$candidate_binary" || -L "$candidate_binary" ]]; then
+      cmux_hosted_retention_error "artifact binary changed before activity check"
+      exit $?
     fi
+    lsof_targets+=("$candidate_binary")
+    lsof_target_count=$((lsof_target_count + 1))
   done
 
   active_commits_file="$scratch_dir/active-commits"

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -372,6 +372,64 @@ cmux_hosted_retention_lsof_state() {
   return 1
 }
 
+cmux_hosted_retention_collect_lsof_batch() {
+  local lsof_command="$1"
+  local artifact_root="$2"
+  local active_commits_file="$3"
+  local output_file="$4"
+  local error_file="$5"
+  shift 5
+  local lsof_status
+  local lsof_record
+  local active_path
+  local active_commit
+  local record_count=0
+  local saw_usable_name=0
+
+  if "$lsof_command" -F n -- "$@" > "$output_file" 2> "$error_file"; then
+    lsof_status=0
+  else
+    lsof_status=$?
+  fi
+  if [[ -s "$error_file" || "$lsof_status" -gt 1 ]]; then
+    return 2
+  fi
+  while IFS= read -r lsof_record; do
+    record_count=$((record_count + 1))
+    (( record_count <= 512 )) || return 2
+    case "$lsof_record" in
+      n*)
+        active_path="${lsof_record#n}"
+        if [[ "$active_path" != "$artifact_root"/*/cmux-tui ]]; then
+          continue
+        fi
+        active_commit="${active_path%/cmux-tui}"
+        active_commit="${active_commit##*/}"
+        [[ "$active_commit" =~ ^[0-9a-f]{40}$ ]] || return 2
+        printf '%s\n' "$active_commit" >> "$active_commits_file"
+        saw_usable_name=1
+        ;;
+      p*|f*)
+        # lsof always emits the PID field, and versions 4.88 through 4.93.2
+        # also emit a file-descriptor field even when only names are asked.
+        ;;
+      *)
+        return 2
+        ;;
+    esac
+  done < "$output_file"
+  if [[ -s "$output_file" && "$saw_usable_name" -eq 0 ]]; then
+    return 2
+  fi
+  if [[ -s "$output_file" && "$lsof_status" -ne 0 ]]; then
+    return 2
+  fi
+  if (( lsof_status == 0 )) && [[ ! -s "$output_file" ]]; then
+    return 2
+  fi
+  return 0
+}
+
 cmux_hosted_retention_run() {
   local owner_pid="$$"
   CMUX_TUI_HOSTED_RETENTION_OWNER_PID="$owner_pid" \
@@ -415,14 +473,13 @@ cmux_hosted_retention_run_impl() (
   local candidate_action
   local retained=0
   local lsof_command="${CMUX_TUI_HOSTED_RETENTION_LSOF:-lsof}"
-  local lsof_status
-  local lsof_record
-  local active_path
-  local active_commit
   local lsof_target_count=0
   local lsof_output_file
   local lsof_error_file
-  local lsof_record_count=0
+  local lsof_batch_size=128
+  local lsof_batch_targets=()
+  local lsof_batch_count=0
+  local lsof_batch_index=0
   local active_commits_file
   local cleanup_commits_file
   local decision_file
@@ -574,7 +631,9 @@ cmux_hosted_retention_run_impl() (
   fi
   cmux_hosted_retention_cleanup_lock_acquired=1
 
-  cmux_hosted_retention_recover_quarantines "$artifact_root" "$now" 86400 "$scratch_dir"
+  if [[ "$retention_dry_run" == 0 ]]; then
+    cmux_hosted_retention_recover_quarantines "$artifact_root" "$now" 86400 "$scratch_dir"
+  fi
 
   preview_file="$artifact_root/.retention-preview"
   candidate_paths_file="$scratch_dir/candidate-paths"
@@ -805,58 +864,36 @@ cmux_hosted_retention_run_impl() (
   active_commits_file="$scratch_dir/active-commits"
   : > "$active_commits_file"
   if (( lsof_target_count > 0 )); then
-    lsof_output_file="$scratch_dir/lsof-output"
-    lsof_error_file="$scratch_dir/lsof-error"
-    if "$lsof_command" -F n -- "${lsof_targets[@]}" > "$lsof_output_file" 2> "$lsof_error_file"; then
-      lsof_status=0
-    else
-      lsof_status=$?
-    fi
-    if [[ -s "$lsof_error_file" || "$lsof_status" -gt 1 ]]; then
-      cmux_hosted_retention_error "lsof could not establish artifact activity"
-      exit $?
-    fi
-    while IFS= read -r lsof_record; do
-      lsof_record_count=$((lsof_record_count + 1))
-      (( lsof_record_count <= max_candidates * 4 )) || {
-        cmux_hosted_retention_error "lsof returned too many activity records"
+    lsof_batch_targets=()
+    lsof_batch_count=0
+    lsof_batch_index=0
+    for candidate_binary in "${lsof_targets[@]}"; do
+      lsof_batch_targets+=("$candidate_binary")
+      lsof_batch_count=$((lsof_batch_count + 1))
+      if (( lsof_batch_count < lsof_batch_size )); then
+        continue
+      fi
+      lsof_output_file="$scratch_dir/lsof-output-$lsof_batch_index"
+      lsof_error_file="$scratch_dir/lsof-error-$lsof_batch_index"
+      if ! cmux_hosted_retention_collect_lsof_batch \
+        "$lsof_command" "$artifact_root" "$active_commits_file" \
+        "$lsof_output_file" "$lsof_error_file" "${lsof_batch_targets[@]}"; then
+        cmux_hosted_retention_error "lsof could not establish artifact activity"
         exit $?
-      }
-      case "$lsof_record" in
-        n*)
-          active_path="${lsof_record#n}"
-          if [[ "$active_path" != "$artifact_root"/*/cmux-tui ]]; then
-            continue
-          fi
-          active_commit="${active_path%/cmux-tui}"
-          active_commit="${active_commit##*/}"
-          [[ "$active_commit" =~ ^[0-9a-f]{40}$ ]] || {
-            cmux_hosted_retention_error "lsof returned an unexpected artifact path"
-            exit $?
-          }
-          printf '%s\n' "$active_commit" >> "$active_commits_file"
-          ;;
-        p*|f*)
-          # lsof always emits the PID field, and versions 4.88 through 4.93.2
-          # also emit a file-descriptor field even when only names are asked.
-          ;;
-        *)
-          cmux_hosted_retention_error "lsof returned an invalid activity record"
-          exit $?
-          ;;
-      esac
-    done < "$lsof_output_file"
-    if [[ -s "$lsof_output_file" && ! -s "$active_commits_file" ]]; then
-      cmux_hosted_retention_error "lsof returned no usable artifact names"
-      exit $?
-    fi
-    if [[ -s "$lsof_output_file" && "$lsof_status" -ne 0 ]]; then
-      cmux_hosted_retention_error "lsof returned a partial activity result"
-      exit $?
-    fi
-    if (( lsof_status == 0 )) && [[ ! -s "$lsof_output_file" ]]; then
-      cmux_hosted_retention_error "lsof returned no activity records"
-      exit $?
+      fi
+      lsof_batch_targets=()
+      lsof_batch_count=0
+      lsof_batch_index=$((lsof_batch_index + 1))
+    done
+    if (( lsof_batch_count > 0 )); then
+      lsof_output_file="$scratch_dir/lsof-output-$lsof_batch_index"
+      lsof_error_file="$scratch_dir/lsof-error-$lsof_batch_index"
+      if ! cmux_hosted_retention_collect_lsof_batch \
+        "$lsof_command" "$artifact_root" "$active_commits_file" \
+        "$lsof_output_file" "$lsof_error_file" "${lsof_batch_targets[@]}"; then
+        cmux_hosted_retention_error "lsof could not establish artifact activity"
+        exit $?
+      fi
     fi
   fi
   LC_ALL=C sort -u "$active_commits_file" -o "$active_commits_file" || {

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -377,7 +377,6 @@ cmux_hosted_retention_run_impl() (
   local candidate_scan_status_file
   local candidate_scan_find_status
   local candidate_scan_filter_status
-  local candidate_scan_limit
   local candidate_relative
   local candidate_scan_error=0
   local candidate_order_file

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -66,6 +66,31 @@ cmux_hosted_retention_mtime() {
   return 1
 }
 
+cmux_hosted_retention_scan_direct_dirs() {
+  local scan_root="$1"
+  local scan_output_file="$2"
+  local scan_error_file="$3"
+  local scan_status_file="$4"
+  local scan_limit="$5"
+  local scan_pipeline_status
+
+  (
+    if ! cd "$scan_root"; then
+      exit 1
+    fi
+    set +e
+    find . -type d \( -name . -o -prune -print \) 2> "$scan_error_file" \
+      | awk -v limit="$((scan_limit + 1))" \
+        'substr($0, 1, 2) == "./" {
+           count++
+           if (count <= limit) print
+           if (count >= limit) exit 3
+         }' > "$scan_output_file"
+    scan_pipeline_status=("${PIPESTATUS[@]}")
+    printf '%s\t%s\n' "${scan_pipeline_status[0]}" "${scan_pipeline_status[1]}" > "$scan_status_file"
+  )
+}
+
 cmux_hosted_retention_hash_file() {
   local input_file="$1"
   local digest
@@ -113,38 +138,47 @@ cmux_hosted_retention_reclaim_lock() {
   local lock_token
   local lock_extra
   local lock_age
+  local lock_valid=0
+  local lock_mtime
   local owner_state
   local recovery_dir
 
-  if [[ ! -d "$lock_dir" || -L "$lock_dir" || ! -O "$lock_dir" ||
-    ! -f "$lock_marker" || -L "$lock_marker" || ! -O "$lock_marker" ]]; then
+  if [[ ! -d "$lock_dir" || -L "$lock_dir" || ! -O "$lock_dir" ]]; then
     return 1
   fi
-  lock_line="$(<"$lock_marker")" || return 1
-  lock_pid=""
-  lock_timestamp=""
-  lock_token=""
-  lock_extra=""
-  IFS=$'\t' read -r lock_pid lock_timestamp lock_token lock_extra <<< "$lock_line"
-  if [[ "$lock_line" != "$lock_pid"$'\t'"$lock_timestamp"$'\t'"$lock_token" ||
-    -z "$lock_token" || -n "$lock_extra" ||
-    ! "$lock_pid" =~ ^[1-9][0-9]*$ || ! "$lock_timestamp" =~ ^[0-9]+$ ]]; then
-    return 1
+  if [[ -f "$lock_marker" && ! -L "$lock_marker" && -O "$lock_marker" ]]; then
+    lock_line="$(<"$lock_marker")" || return 1
+    lock_pid=""
+    lock_timestamp=""
+    lock_token=""
+    lock_extra=""
+    IFS=$'\t' read -r lock_pid lock_timestamp lock_token lock_extra <<< "$lock_line"
+    if [[ "$lock_line" == "$lock_pid"$'\t'"$lock_timestamp"$'\t'"$lock_token" &&
+      -n "$lock_token" && -z "$lock_extra" &&
+      "$lock_pid" =~ ^[1-9][0-9]*$ && "$lock_timestamp" =~ ^[0-9]+$ ]]; then
+      lock_valid=1
+    fi
   fi
-  if ! lock_age="$(awk -v now="$now" -v timestamp="$lock_timestamp" \
-    'BEGIN { if (timestamp > now) exit 2; print now - timestamp }')"; then
-    return 1
+  if (( lock_valid )); then
+    lock_age="$(awk -v now="$now" -v timestamp="$lock_timestamp" \
+      'BEGIN { if (timestamp > now) exit 2; print now - timestamp }')" || return 1
+  else
+    lock_mtime="$(cmux_hosted_retention_mtime "$lock_dir")" || return 1
+    [[ "$lock_mtime" =~ ^[0-9]+$ && "$lock_mtime" -le "$now" ]] || return 1
+    lock_age=$((now - lock_mtime))
   fi
   [[ "$lock_age" =~ ^[0-9]+$ ]] || return 1
   if (( lock_age < stale_after )); then
     return 1
   fi
-  if cmux_hosted_retention_pid_state "$lock_pid"; then
-    owner_state=0
-  else
-    owner_state=$?
+  if (( lock_valid )); then
+    if cmux_hosted_retention_pid_state "$lock_pid"; then
+      owner_state=0
+    else
+      owner_state=$?
+    fi
+    [[ "$owner_state" -eq 1 ]] || return 1
   fi
-  [[ "$owner_state" -eq 1 ]] || return 1
 
   recovery_dir="$lock_dir.$$.$RANDOM.reclaim"
   if [[ -e "$recovery_dir" || -L "$recovery_dir" ]]; then
@@ -153,17 +187,34 @@ cmux_hosted_retention_reclaim_lock() {
   if ! mv -- "$lock_dir" "$recovery_dir"; then
     return 2
   fi
-  if [[ ! -d "$recovery_dir" || -L "$recovery_dir" || ! -O "$recovery_dir" ||
-    ! -f "$recovery_dir/owner" || -L "$recovery_dir/owner" ||
-    ! -O "$recovery_dir/owner" ||
-    "$(<"$recovery_dir/owner")" != "$lock_line" ]]; then
+  if [[ ! -d "$recovery_dir" || -L "$recovery_dir" || ! -O "$recovery_dir" ]]; then
     if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
       -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
       mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
     fi
     return 2
   fi
-  if ! rm -f -- "$recovery_dir/owner" >/dev/null 2>&1; then
+  if (( lock_valid )); then
+    if [[ ! -f "$recovery_dir/owner" || -L "$recovery_dir/owner" ||
+      ! -O "$recovery_dir/owner" || "$(<"$recovery_dir/owner")" != "$lock_line" ]]; then
+      if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
+        -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
+        mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+      fi
+      return 2
+    fi
+  elif [[ -e "$recovery_dir/owner" || -L "$recovery_dir/owner" ]]; then
+    if [[ ! -f "$recovery_dir/owner" || -L "$recovery_dir/owner" ||
+      ! -O "$recovery_dir/owner" ]]; then
+      if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
+        -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
+        mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+      fi
+      return 2
+    fi
+  fi
+  if [[ -e "$recovery_dir/owner" || -L "$recovery_dir/owner" ]] &&
+    ! rm -f -- "$recovery_dir/owner" >/dev/null 2>&1; then
     if [[ ! -e "$lock_dir" && ! -L "$lock_dir" ]]; then
       mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
     fi
@@ -183,28 +234,54 @@ cmux_hosted_retention_recover_quarantines() {
   local artifact_root="$1"
   local now="$2"
   local stale_after="$3"
+  local scratch_dir="$4"
   local quarantine_root
   local quarantine_mtime
   local quarantine_age
   local candidate_dir
   local candidate_commit
   local restore_dir
-  local root_count=0
   local entry_count=0
   local max_entries=10000
+  local root_scan_file="$scratch_dir/quarantine-roots"
+  local root_scan_error_file="$scratch_dir/quarantine-roots-error"
+  local root_scan_status_file="$scratch_dir/quarantine-roots-status"
+  local entry_scan_file="$scratch_dir/quarantine-entries"
+  local entry_scan_error_file="$scratch_dir/quarantine-entries-error"
+  local entry_scan_status_file="$scratch_dir/quarantine-entries-status"
+  local scan_find_status
+  local scan_filter_status
+  local scan_relative
+  local scan_limit
 
-  shopt -s nullglob
-  for quarantine_root in "$artifact_root"/.retention-quarantine.*; do
-    root_count=$((root_count + 1))
-    (( root_count <= max_entries )) || break
+  cmux_hosted_retention_scan_direct_dirs "$artifact_root" \
+    "$root_scan_file" "$root_scan_error_file" "$root_scan_status_file" "$max_entries" || return 0
+  IFS=$'\t' read -r scan_find_status scan_filter_status < "$root_scan_status_file" || return 0
+  [[ "$scan_find_status" =~ ^[0-9]+$ && "$scan_filter_status" =~ ^[0-9]+$ ]] || return 0
+  [[ ! -s "$root_scan_error_file" && "$scan_find_status" -eq 0 && "$scan_filter_status" -eq 0 ]] || return 0
+
+  while IFS= read -r scan_relative; do
+    [[ "$scan_relative" == ./.retention-quarantine.* ]] || continue
+    quarantine_root="$artifact_root/${scan_relative#./}"
     [[ -d "$quarantine_root" && ! -L "$quarantine_root" && -O "$quarantine_root" ]] || continue
     quarantine_mtime="$(cmux_hosted_retention_mtime "$quarantine_root")" || continue
     [[ "$quarantine_mtime" =~ ^[0-9]+$ && "$quarantine_mtime" -le "$now" ]] || continue
     quarantine_age=$((now - quarantine_mtime))
     (( quarantine_age >= stale_after )) || continue
-    for candidate_dir in "$quarantine_root"/*; do
+
+    scan_limit=$((max_entries - entry_count))
+    (( scan_limit > 0 )) || break
+    cmux_hosted_retention_scan_direct_dirs "$quarantine_root" \
+      "$entry_scan_file" "$entry_scan_error_file" "$entry_scan_status_file" "$scan_limit" || break
+    IFS=$'\t' read -r scan_find_status scan_filter_status < "$entry_scan_status_file" || break
+    [[ "$scan_find_status" =~ ^[0-9]+$ && "$scan_filter_status" =~ ^[0-9]+$ ]] || break
+    [[ ! -s "$entry_scan_error_file" && "$scan_find_status" -eq 0 ]] || break
+    while IFS= read -r scan_relative; do
       entry_count=$((entry_count + 1))
-      (( entry_count <= max_entries )) || break
+      (( entry_count <= max_entries )) || break 2
+      [[ "$scan_relative" == ./* ]] || continue
+      candidate_dir="$quarantine_root/${scan_relative#./}"
+      [[ "$candidate_dir" == "$quarantine_root"/* ]] || continue
       [[ -d "$candidate_dir" && ! -L "$candidate_dir" && -O "$candidate_dir" ]] || continue
       candidate_commit="${candidate_dir##*/}"
       [[ "$candidate_commit" =~ ^[0-9a-f]{40}$ ]] || continue
@@ -212,10 +289,10 @@ cmux_hosted_retention_recover_quarantines() {
       restore_dir="$artifact_root/$candidate_commit"
       [[ ! -e "$restore_dir" && ! -L "$restore_dir" ]] || continue
       mv -- "$candidate_dir" "$restore_dir" >/dev/null 2>&1 || true
-    done
+    done < "$entry_scan_file"
+    [[ "$scan_filter_status" -eq 0 ]] || break
     rmdir -- "$quarantine_root" >/dev/null 2>&1 || true
-  done
-  shopt -u nullglob
+  done < "$root_scan_file"
 }
 
 cmux_hosted_retention_lsof_state() {
@@ -258,6 +335,9 @@ cmux_hosted_retention_lsof_state() {
   done < "$output_file"
 
   if [[ -s "$output_file" && "$saw_name" -eq 0 ]]; then
+    return 2
+  fi
+  if [[ -s "$output_file" && "$lsof_status" -ne 0 ]]; then
     return 2
   fi
   if (( lsof_status == 0 )) && [[ ! -s "$output_file" ]]; then
@@ -437,7 +517,39 @@ cmux_hosted_retention_run_impl() (
     cmux_hosted_retention_error "cannot read the current time"
     exit $?
   }
-  cmux_hosted_retention_recover_quarantines "$artifact_root" "$now" 86400
+
+  lock_dir="$artifact_root/.retention.lock"
+  lock_marker="$lock_dir/owner"
+  lock_timestamp="$now"
+  lock_token="$(printf '%s\t%s\t%s' "$lock_owner_pid" "$lock_timestamp" "$scratch_dir")"
+  cmux_hosted_retention_cleanup_lock_dir="$lock_dir"
+  cmux_hosted_retention_cleanup_lock_marker="$lock_marker"
+  cmux_hosted_retention_cleanup_lock_token="$lock_token"
+  if [[ -e "$lock_dir" || -L "$lock_dir" ]]; then
+    if cmux_hosted_retention_reclaim_lock "$lock_dir" "$lock_marker" "$now" "$lock_stale_after_seconds"; then
+      :
+    else
+      lock_reclaim_status=$?
+      if [[ "$lock_reclaim_status" -eq 1 ]]; then
+        cmux_hosted_retention_error "another retention cleanup is already running"
+      else
+        cmux_hosted_retention_error "cannot recover the previous retention cleanup lock"
+      fi
+      exit $?
+    fi
+  fi
+  if ! (umask 077 && mkdir "$lock_dir"); then
+    cmux_hosted_retention_error "another retention cleanup is already running"
+    exit $?
+  fi
+  if ! (umask 077 && printf '%s\n' "$lock_token" > "$lock_marker"); then
+    rmdir -- "$lock_dir" >/dev/null 2>&1 || true
+    cmux_hosted_retention_error "cannot initialize the retention cleanup lock"
+    exit $?
+  fi
+  cmux_hosted_retention_cleanup_lock_acquired=1
+
+  cmux_hosted_retention_recover_quarantines "$artifact_root" "$now" 86400 "$scratch_dir"
 
   preview_file="$artifact_root/.retention-preview"
   candidate_paths_file="$scratch_dir/candidate-paths"
@@ -454,28 +566,8 @@ cmux_hosted_retention_run_impl() (
     cmux_hosted_retention_error "cannot enumerate artifact directories because awk is unavailable"
     exit $?
   fi
-  candidate_scan_limit=$((max_candidates + 1))
-  (
-    if ! cd "$artifact_root"; then
-      exit 1
-    fi
-    set +e
-    find . -type d \( -name . -o -prune -print \) 2> "$candidate_scan_error_file" \
-      | awk -v limit="$candidate_scan_limit" \
-        'substr($0, 1, 2) == "./" {
-           candidate = substr($0, 3)
-           if (length(candidate) == 40 && candidate !~ /[^0-9a-f]/) {
-             count++
-             if (count <= limit) print
-           }
-         }
-         END { if (count >= limit) exit 3 }' > "$candidate_paths_file"
-    candidate_scan_pipeline_status=("${PIPESTATUS[@]}")
-    candidate_scan_find_status="${candidate_scan_pipeline_status[0]}"
-    candidate_scan_filter_status="${candidate_scan_pipeline_status[1]}"
-    set -e
-    printf '%s\t%s\n' "$candidate_scan_find_status" "$candidate_scan_filter_status" > "$candidate_scan_status_file"
-  ) || {
+  cmux_hosted_retention_scan_direct_dirs "$artifact_root" \
+    "$candidate_paths_file" "$candidate_scan_error_file" "$candidate_scan_status_file" "$max_candidates" || {
     cmux_hosted_retention_error "cannot enumerate artifact directories"
     exit $?
   }
@@ -588,8 +680,8 @@ cmux_hosted_retention_run_impl() (
       cmux_hosted_retention_error "preview timestamp is invalid"
       exit $?
     }
-    if [[ -L "$preview_file" ]]; then
-      cmux_hosted_retention_error "preview path is a symbolic link"
+    if [[ -e "$preview_file" && ( ! -f "$preview_file" || -L "$preview_file" ) ]]; then
+      cmux_hosted_retention_error "preview path is not a regular file"
       exit $?
     fi
     if [[ -e "$preview_file" && ! -O "$preview_file" ]]; then
@@ -664,37 +756,6 @@ cmux_hosted_retention_run_impl() (
     exit $?
   fi
 
-  lock_dir="$artifact_root/.retention.lock"
-  lock_marker="$lock_dir/owner"
-  lock_timestamp="$now"
-  lock_token="$(printf '%s\t%s\t%s' "$lock_owner_pid" "$lock_timestamp" "$scratch_dir")"
-  cmux_hosted_retention_cleanup_lock_dir="$lock_dir"
-  cmux_hosted_retention_cleanup_lock_marker="$lock_marker"
-  cmux_hosted_retention_cleanup_lock_token="$lock_token"
-  if [[ -e "$lock_dir" || -L "$lock_dir" ]]; then
-    if cmux_hosted_retention_reclaim_lock "$lock_dir" "$lock_marker" "$now" "$lock_stale_after_seconds"; then
-      :
-    else
-      lock_reclaim_status=$?
-      if [[ "$lock_reclaim_status" -eq 1 ]]; then
-        cmux_hosted_retention_error "another retention cleanup is already running"
-      else
-        cmux_hosted_retention_error "cannot recover the previous retention cleanup lock"
-      fi
-      exit $?
-    fi
-  fi
-  if ! (umask 077 && mkdir "$lock_dir"); then
-    cmux_hosted_retention_error "another retention cleanup is already running"
-    exit $?
-  fi
-  if ! (umask 077 && printf '%s\n' "$lock_token" > "$lock_marker"); then
-    rmdir -- "$lock_dir" >/dev/null 2>&1 || true
-    cmux_hosted_retention_error "cannot initialize the retention cleanup lock"
-    exit $?
-  fi
-  cmux_hosted_retention_cleanup_lock_acquired=1
-
   if ! quarantine_root="$(umask 077 && mktemp -d "$artifact_root/.retention-quarantine.XXXXXX")"; then
     cmux_hosted_retention_error "cannot create the retention quarantine"
     exit $?
@@ -762,6 +823,10 @@ cmux_hosted_retention_run_impl() (
     done < "$lsof_output_file"
     if [[ -s "$lsof_output_file" && ! -s "$active_commits_file" ]]; then
       cmux_hosted_retention_error "lsof returned no usable artifact names"
+      exit $?
+    fi
+    if [[ -s "$lsof_output_file" && "$lsof_status" -ne 0 ]]; then
+      cmux_hosted_retention_error "lsof returned a partial activity result"
       exit $?
     fi
     if (( lsof_status == 0 )) && [[ ! -s "$lsof_output_file" ]]; then

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -79,7 +79,7 @@ cmux_hosted_retention_scan_direct_dirs() {
       exit 1
     fi
     set +e
-    find . -type d \( -name . -o -prune -print \) 2> "$scan_error_file" \
+    find . \( -name . -o -prune -print \) 2> "$scan_error_file" \
       | awk -v limit="$((scan_limit + 1))" \
         'substr($0, 1, 2) == "./" {
            count++

--- a/scripts/hosted-retention.sh
+++ b/scripts/hosted-retention.sh
@@ -139,12 +139,17 @@ cmux_hosted_retention_reclaim_lock() {
   local lock_extra
   local lock_age
   local lock_valid=0
+  local lock_marker_present=0
   local lock_mtime
   local owner_state
   local recovery_dir
+  local owner_backup
 
   if [[ ! -d "$lock_dir" || -L "$lock_dir" || ! -O "$lock_dir" ]]; then
     return 1
+  fi
+  if [[ -e "$lock_marker" || -L "$lock_marker" ]]; then
+    lock_marker_present=1
   fi
   if [[ -f "$lock_marker" && ! -L "$lock_marker" && -O "$lock_marker" ]]; then
     lock_line="$(<"$lock_marker")" || return 1
@@ -194,7 +199,7 @@ cmux_hosted_retention_reclaim_lock() {
     fi
     return 2
   fi
-  if (( lock_valid )); then
+  if [[ "$lock_marker_present" -eq 1 ]]; then
     if [[ ! -f "$recovery_dir/owner" || -L "$recovery_dir/owner" ||
       ! -O "$recovery_dir/owner" || "$(<"$recovery_dir/owner")" != "$lock_line" ]]; then
       if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
@@ -212,21 +217,39 @@ cmux_hosted_retention_reclaim_lock() {
       fi
       return 2
     fi
-  fi
-  if [[ -e "$recovery_dir/owner" || -L "$recovery_dir/owner" ]] &&
-    ! rm -f -- "$recovery_dir/owner" >/dev/null 2>&1; then
-    if [[ ! -e "$lock_dir" && ! -L "$lock_dir" ]]; then
-      mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
-    fi
-    return 2
-  fi
-  if ! rmdir -- "$recovery_dir" >/dev/null 2>&1; then
     if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
       -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
       mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
     fi
     return 2
   fi
+  owner_backup="$lock_dir.$$.$RANDOM.owner-backup"
+  if [[ -e "$owner_backup" || -L "$owner_backup" ]]; then
+    if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
+      -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
+      mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+    fi
+    return 2
+  fi
+  if [[ -e "$recovery_dir/owner" || -L "$recovery_dir/owner" ]]; then
+    if ! mv -- "$recovery_dir/owner" "$owner_backup" >/dev/null 2>&1; then
+      if [[ ! -e "$lock_dir" && ! -L "$lock_dir" ]]; then
+        mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+      fi
+      return 2
+    fi
+  fi
+  if ! rmdir -- "$recovery_dir" >/dev/null 2>&1; then
+    if [[ -e "$owner_backup" || -L "$owner_backup" ]]; then
+      mv -- "$owner_backup" "$recovery_dir/owner" >/dev/null 2>&1 || true
+    fi
+    if [[ ! -e "$lock_dir" && ! -L "$lock_dir" &&
+      -d "$recovery_dir" && ! -L "$recovery_dir" ]]; then
+      mv -- "$recovery_dir" "$lock_dir" >/dev/null 2>&1 || true
+    fi
+    return 2
+  fi
+  rm -f -- "$owner_backup" >/dev/null 2>&1 || true
   return 0
 }
 
@@ -410,6 +433,7 @@ cmux_hosted_retention_run_impl() (
   local candidate_binary
   local lock_dir=""
   local lock_marker=""
+  local lock_marker_tmp=""
   local lock_token=""
   # A dead owner is reclaimable only after one day. This bounds crash residue
   # while protecting a long-running cleanup from a premature takeover.
@@ -541,7 +565,9 @@ cmux_hosted_retention_run_impl() (
     cmux_hosted_retention_error "another retention cleanup is already running"
     exit $?
   fi
-  if ! (umask 077 && printf '%s\n' "$lock_token" > "$lock_marker"); then
+  lock_marker_tmp="$lock_dir/.owner.$$.$RANDOM.tmp"
+  if ! (umask 077 && printf '%s\n' "$lock_token" > "$lock_marker_tmp" && mv -- "$lock_marker_tmp" "$lock_marker"); then
+    rm -f -- "$lock_marker_tmp" >/dev/null 2>&1 || true
     rmdir -- "$lock_dir" >/dev/null 2>&1 || true
     cmux_hosted_retention_error "cannot initialize the retention cleanup lock"
     exit $?

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=hosted-retention.sh
+source "$ROOT/scripts/hosted-retention.sh"
+
+tmp="$(mktemp -d "${TMPDIR:-/tmp}/cmux-hosted-retention-test.XXXXXX")"
+trap 'rm -rf -- "$tmp"' EXIT
+
+current_commit="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+new_commit="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+active_commit="cccccccccccccccccccccccccccccccccccccccc"
+old_commit="dddddddddddddddddddddddddddddddddddddddd"
+
+fake_lsof="$tmp/lsof"
+cat > "$fake_lsof" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == error ]]; then
+  echo 'simulated lsof failure' >&2
+  exit 1
+fi
+
+[[ "${CMUX_TEST_LSOF_MODE:-inactive}" == active ]] || exit 1
+for argument in "$@"; do
+  if [[ "$argument" == /*/cmux-tui ]]; then
+    if [[ "${argument##*/}" == cmux-tui && "$argument" == *"/${CMUX_TEST_ACTIVE_COMMIT:-}"/* ]]; then
+      printf 'n%s\n' "$argument"
+    fi
+  fi
+done
+exit 1
+EOF
+chmod 0755 "$fake_lsof"
+
+fake_stat="$tmp/stat"
+cat > "$fake_stat" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+format="${1:-}"
+case "${CMUX_TEST_STAT_MODE:-gnu}:$format" in
+  gnu:-c|bsd:-f)
+    shift 2
+    ;;
+  gnu:-f|bsd:-c)
+    # GNU stat's -f is filesystem status, not file modification time. Return
+    # a successful non-numeric value to catch callers that accept that result.
+    printf '/mounted\n'
+    exit 0
+    ;;
+  *)
+    exit 1
+    ;;
+esac
+
+candidate="${1##*/}"
+awk -F '\t' -v candidate="$candidate" '$1 == candidate { print $2; found = 1 } END { exit(found ? 0 : 1) }' \
+  "$CMUX_TEST_STAT_MAP"
+EOF
+chmod 0755 "$fake_stat"
+
+make_root() {
+  test_root="$tmp/root-$RANDOM"
+  mkdir -p "$test_root"
+}
+
+make_artifact() {
+  local commit="$1"
+  mkdir -p "$test_root/$commit"
+  printf '%s\n' "$commit" > "$test_root/$commit/cmux-tui"
+}
+
+write_stat_map() {
+  : > "$tmp/stat-map"
+  for entry in "$@"; do
+    printf '%s\n' "$entry" >> "$tmp/stat-map"
+  done
+  export CMUX_TEST_STAT_MAP="$tmp/stat-map"
+}
+
+run_retention() {
+  CMUX_TUI_HOSTED_RETENTION_COUNT="$test_count" \
+  CMUX_TUI_HOSTED_RETENTION_DRY_RUN="$test_dry_run" \
+  CMUX_TUI_HOSTED_RETENTION_CONFIRM="$test_confirm" \
+  CMUX_TUI_HOSTED_RETENTION_LSOF="$fake_lsof" \
+  CMUX_TUI_HOSTED_RETENTION_STAT="$fake_stat" \
+  CMUX_TEST_LSOF_MODE="${test_lsof_mode:-inactive}" \
+  CMUX_TEST_ACTIVE_COMMIT="${test_active_commit:-}" \
+  CMUX_TEST_STAT_MODE="${test_stat_mode:-gnu}" \
+  cmux_hosted_retention_run "$test_root" "$test_current_commit"
+}
+
+expect_success() {
+  if ! run_retention >"$tmp/stdout" 2>"$tmp/stderr"; then
+    echo "expected success" >&2
+    cat "$tmp/stderr" >&2
+    exit 1
+  fi
+}
+
+expect_failure() {
+  local expected_status="$1"
+  local actual_status
+  if run_retention >"$tmp/stdout" 2>"$tmp/stderr"; then
+    echo "expected failure with status $expected_status" >&2
+    exit 1
+  else
+    actual_status=$?
+  fi
+  if [[ "$actual_status" -ne "$expected_status" ]]; then
+    echo "expected status $expected_status, got $actual_status" >&2
+    cat "$tmp/stderr" >&2
+    exit 1
+  fi
+}
+
+assert_exists() {
+  [[ -e "$test_root/$1" ]] || { echo "missing expected path: $1" >&2; exit 1; }
+}
+
+assert_missing() {
+  [[ ! -e "$test_root/$1" ]] || { echo "unexpected path: $1" >&2; exit 1; }
+}
+
+make_baseline() {
+  make_root
+  make_artifact "$current_commit"
+  make_artifact "$new_commit"
+  make_artifact "$active_commit"
+  make_artifact "$old_commit"
+  write_stat_map \
+    "$current_commit\t400" \
+    "$new_commit\t300" \
+    "$active_commit\t200" \
+    "$old_commit\t100"
+  test_current_commit="$current_commit"
+  test_count=1
+  test_dry_run=1
+  test_confirm=0
+  test_lsof_mode=inactive
+  test_active_commit=""
+  test_stat_mode=gnu
+}
+
+# A dry run creates the preview. A destructive run with the same plan removes
+# only the inactive tail, while retaining the current and newest prior item.
+make_baseline
+expect_success
+assert_exists .retention-preview
+test_dry_run=0
+test_confirm=1
+expect_success
+assert_exists "$current_commit"
+assert_exists "$new_commit"
+assert_missing "$active_commit"
+assert_missing "$old_commit"
+
+# The preview binds the retention policy. Changing the count cannot reuse it.
+make_baseline
+expect_success
+test_dry_run=0
+test_count=2
+test_confirm=1
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
+
+# The preview binds the current commit. A different current artifact cannot
+# reuse a prior preview even when the candidate directory set is unchanged.
+make_baseline
+expect_success
+test_dry_run=0
+test_current_commit="$new_commit"
+test_confirm=1
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
+
+# Malformed, expired, and future timestamps are all rejected before cleanup.
+make_baseline
+expect_success
+preview="$test_root/.retention-preview"
+preview_hash="$(cut -f1 "$preview")"
+printf '%s\tnot-a-timestamp\n' "$preview_hash" > "$preview"
+test_dry_run=0
+test_confirm=1
+expect_failure 2
+assert_exists "$old_commit"
+
+make_baseline
+expect_success
+preview="$test_root/.retention-preview"
+preview_hash="$(cut -f1 "$preview")"
+printf '%s\t%s\n' "$preview_hash" "$(( $(date +%s) + 1 ))" > "$preview"
+test_dry_run=0
+test_confirm=1
+expect_failure 2
+assert_exists "$old_commit"
+
+make_baseline
+expect_success
+preview="$test_root/.retention-preview"
+preview_hash="$(cut -f1 "$preview")"
+printf '%s\t%s\n' "$preview_hash" "$(( $(date +%s) - 601 ))" > "$preview"
+test_dry_run=0
+test_confirm=1
+expect_failure 2
+assert_exists "$old_commit"
+
+# An lsof error is not the same as an empty match. Cleanup must fail closed.
+make_baseline
+expect_success
+test_dry_run=0
+test_confirm=1
+test_lsof_mode=error
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
+
+# An active binary is retained while a confirmed inactive binary is removed.
+make_baseline
+expect_success
+test_dry_run=0
+test_confirm=1
+test_lsof_mode=active
+test_active_commit="$active_commit"
+expect_success
+assert_exists "$active_commit"
+assert_missing "$old_commit"
+
+# Exercise both documented stat interfaces. The GNU form must be tried first
+# on GNU systems, while the BSD form remains a valid fallback on macOS.
+make_baseline
+test_stat_mode=bsd
+test_dry_run=1
+expect_success
+make_baseline
+test_stat_mode=gnu
+test_dry_run=1
+expect_success
+
+echo 'hosted retention behavior passed'

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -91,7 +91,7 @@ run_retention() {
   CMUX_TEST_LSOF_MODE="${test_lsof_mode:-inactive}" \
   CMUX_TEST_ACTIVE_COMMIT="${test_active_commit:-}" \
   CMUX_TEST_STAT_MODE="${test_stat_mode:-gnu}" \
-  cmux_hosted_retention_run "$test_root" "$test_current_commit"
+  cmux_hosted_retention_run "$test_root/$test_current_commit" "$test_current_commit"
 }
 
 expect_success() {
@@ -254,6 +254,21 @@ test_active_commit="$active_commit"
 expect_success
 assert_exists "$active_commit"
 assert_missing "$old_commit"
+
+# A symlinked cleanup binary can make lsof report its target outside the
+# artifact tree. Fail closed instead of deleting that artifact when another
+# candidate produces a valid activity record.
+make_baseline
+mv "$test_root/$old_commit/cmux-tui" "$tmp/external-binary"
+ln -s "$tmp/external-binary" "$test_root/$old_commit/cmux-tui"
+expect_success
+test_dry_run=0
+test_confirm=1
+test_lsof_mode=active
+test_active_commit="$active_commit"
+expect_failure 2
+assert_exists "$old_commit"
+assert_exists "$active_commit"
 
 # The candidate scan has a hard upper bound, so sorting cannot grow without
 # limit when a cache was never cleaned by an older script.

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -12,6 +12,7 @@ current_commit="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 new_commit="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 active_commit="cccccccccccccccccccccccccccccccccccccccc"
 old_commit="dddddddddddddddddddddddddddddddddddddddd"
+extra_commit="eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee"
 
 fake_lsof="$tmp/lsof"
 cat > "$fake_lsof" <<'EOF'
@@ -45,7 +46,7 @@ case "${CMUX_TEST_STAT_MODE:-gnu}:$format" in
   gnu:-c|bsd:-f)
     shift 2
     ;;
-  gnu:-f|bsd:-c)
+  gnu:-f)
     # GNU stat's -f is filesystem status, not file modification time. Return
     # a successful non-numeric value to catch callers that accept that result.
     printf '/mounted\n'
@@ -63,8 +64,7 @@ EOF
 chmod 0755 "$fake_stat"
 
 make_root() {
-  test_root="$tmp/root-$RANDOM"
-  mkdir -p "$test_root"
+  test_root="$(mktemp -d "$tmp/root.XXXXXX")"
 }
 
 make_artifact() {
@@ -76,7 +76,7 @@ make_artifact() {
 write_stat_map() {
   : > "$tmp/stat-map"
   for entry in "$@"; do
-    printf '%s\n' "$entry" >> "$tmp/stat-map"
+    printf '%s\t%s\n' "${entry%%:*}" "${entry#*:}" >> "$tmp/stat-map"
   done
   export CMUX_TEST_STAT_MAP="$tmp/stat-map"
 }
@@ -85,7 +85,8 @@ run_retention() {
   CMUX_TUI_HOSTED_RETENTION_COUNT="$test_count" \
   CMUX_TUI_HOSTED_RETENTION_DRY_RUN="$test_dry_run" \
   CMUX_TUI_HOSTED_RETENTION_CONFIRM="$test_confirm" \
-  CMUX_TUI_HOSTED_RETENTION_LSOF="$fake_lsof" \
+  CMUX_TUI_HOSTED_RETENTION_MAX_CANDIDATES="${test_max_candidates:-10000}" \
+  CMUX_TUI_HOSTED_RETENTION_LSOF="${test_lsof_command:-$fake_lsof}" \
   CMUX_TUI_HOSTED_RETENTION_STAT="$fake_stat" \
   CMUX_TEST_LSOF_MODE="${test_lsof_mode:-inactive}" \
   CMUX_TEST_ACTIVE_COMMIT="${test_active_commit:-}" \
@@ -132,10 +133,10 @@ make_baseline() {
   make_artifact "$active_commit"
   make_artifact "$old_commit"
   write_stat_map \
-    "$current_commit\t400" \
-    "$new_commit\t300" \
-    "$active_commit\t200" \
-    "$old_commit\t100"
+    "$current_commit:400" \
+    "$new_commit:300" \
+    "$active_commit:200" \
+    "$old_commit:100"
   test_current_commit="$current_commit"
   test_count=1
   test_dry_run=1
@@ -143,6 +144,8 @@ make_baseline() {
   test_lsof_mode=inactive
   test_active_commit=""
   test_stat_mode=gnu
+  test_max_candidates=10000
+  test_lsof_command="$fake_lsof"
 }
 
 # A dry run creates the preview. A destructive run with the same plan removes
@@ -179,6 +182,17 @@ expect_failure 2
 assert_exists "$active_commit"
 assert_exists "$old_commit"
 
+# Adding a candidate after the preview invalidates the exact deletion plan.
+make_baseline
+expect_success
+make_artifact "$extra_commit"
+printf '%s\t%s\n' "$extra_commit" 500 >> "$tmp/stat-map"
+test_dry_run=0
+test_confirm=1
+expect_failure 2
+assert_exists "$extra_commit"
+assert_exists "$old_commit"
+
 # Malformed, expired, and future timestamps are all rejected before cleanup.
 make_baseline
 expect_success
@@ -194,7 +208,7 @@ make_baseline
 expect_success
 preview="$test_root/.retention-preview"
 preview_hash="$(cut -f1 "$preview")"
-printf '%s\t%s\n' "$preview_hash" "$(( $(date +%s) + 1 ))" > "$preview"
+printf '%s\t%s\n' "$preview_hash" "$(( $(date +%s) + 3600 ))" > "$preview"
 test_dry_run=0
 test_confirm=1
 expect_failure 2
@@ -220,6 +234,16 @@ expect_failure 2
 assert_exists "$active_commit"
 assert_exists "$old_commit"
 
+# Cleanup also fails closed when the activity tool is not available.
+make_baseline
+expect_success
+test_dry_run=0
+test_confirm=1
+test_lsof_command="$tmp/missing-lsof"
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
+
 # An active binary is retained while a confirmed inactive binary is removed.
 make_baseline
 expect_success
@@ -230,6 +254,13 @@ test_active_commit="$active_commit"
 expect_success
 assert_exists "$active_commit"
 assert_missing "$old_commit"
+
+# The candidate scan has a hard upper bound, so sorting cannot grow without
+# limit when a cache was never cleaned by an older script.
+make_baseline
+test_max_candidates=3
+expect_failure 2
+assert_exists "$old_commit"
 
 # Exercise both documented stat interfaces. The GNU form must be tried first
 # on GNU systems, while the BSD form remains a valid fallback on macOS.

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -6,7 +6,18 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "$ROOT/scripts/hosted-retention.sh"
 
 tmp="$(mktemp -d "${TMPDIR:-/tmp}/cmux-hosted-retention-test.XXXXXX")"
-trap 'rm -rf -- "$tmp"' EXIT
+stop_race_process() {
+  local race_pid
+  if [[ -f "$tmp/race-pid" ]] && race_pid="$(<"$tmp/race-pid")" && [[ "$race_pid" =~ ^[0-9]+$ ]]; then
+    kill "$race_pid" 2>/dev/null || true
+  fi
+  rm -f "$tmp/race-pid"
+}
+cleanup_test_processes() {
+  stop_race_process
+  rm -rf -- "$tmp"
+}
+trap cleanup_test_processes EXIT
 
 current_commit="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
 new_commit="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
@@ -21,6 +32,29 @@ set -euo pipefail
 
 if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == error ]]; then
   echo 'simulated lsof failure' >&2
+  exit 1
+fi
+
+if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == race ]]; then
+  if [[ ! -e "${CMUX_TEST_LSOF_STATE:-}" ]]; then
+    : > "$CMUX_TEST_LSOF_STATE"
+    (
+      exec 9<"$CMUX_TEST_RACE_BINARY"
+      exec tail -f /dev/null
+    ) &
+    printf '%s\n' "$!" > "$CMUX_TEST_RACE_PID_FILE"
+    exit 1
+  fi
+  race_match=0
+  for argument in "$@"; do
+    if [[ "$argument" == *"/${CMUX_TEST_RACE_COMMIT:-}/cmux-tui" ]]; then
+      printf 'n%s\n' "$argument"
+      race_match=1
+    fi
+  done
+  if (( race_match )); then
+    exit 0
+  fi
   exit 1
 fi
 
@@ -90,6 +124,10 @@ run_retention() {
   CMUX_TUI_HOSTED_RETENTION_STAT="$fake_stat" \
   CMUX_TEST_LSOF_MODE="${test_lsof_mode:-inactive}" \
   CMUX_TEST_ACTIVE_COMMIT="${test_active_commit:-}" \
+  CMUX_TEST_LSOF_STATE="${test_lsof_state:-$tmp/lsof-state}" \
+  CMUX_TEST_RACE_BINARY="${test_race_binary:-}" \
+  CMUX_TEST_RACE_COMMIT="${test_race_commit:-}" \
+  CMUX_TEST_RACE_PID_FILE="$tmp/race-pid" \
   CMUX_TEST_STAT_MODE="${test_stat_mode:-gnu}" \
   cmux_hosted_retention_run "$test_root/$test_current_commit" "$test_current_commit"
 }
@@ -127,6 +165,8 @@ assert_missing() {
 }
 
 make_baseline() {
+  stop_race_process
+  rm -f "$tmp/lsof-state"
   make_root
   make_artifact "$current_commit"
   make_artifact "$new_commit"
@@ -146,6 +186,9 @@ make_baseline() {
   test_stat_mode=gnu
   test_max_candidates=10000
   test_lsof_command="$fake_lsof"
+  test_lsof_state="$tmp/lsof-state"
+  test_race_binary=""
+  test_race_commit=""
 }
 
 # A dry run creates the preview. A destructive run with the same plan removes
@@ -160,6 +203,19 @@ assert_exists "$current_commit"
 assert_exists "$new_commit"
 assert_missing "$active_commit"
 assert_missing "$old_commit"
+assert_missing .retention.lock
+
+# The helper is also called directly by production scripts. Its EXIT cleanup
+# must remove private state when the caller does not wrap it in a conditional.
+make_baseline
+run_retention >"$tmp/stdout" 2>"$tmp/stderr"
+assert_exists .retention-preview
+test_dry_run=0
+test_confirm=1
+run_retention >"$tmp/stdout" 2>"$tmp/stderr"
+assert_missing "$active_commit"
+assert_missing "$old_commit"
+assert_missing .retention.lock
 
 # The preview binds the retention policy. Changing the count cannot reuse it.
 make_baseline
@@ -254,6 +310,31 @@ test_active_commit="$active_commit"
 expect_success
 assert_exists "$active_commit"
 assert_missing "$old_commit"
+assert_missing .retention.lock
+
+# A process can start using an artifact after the initial batch lsof check.
+# The cleanup must quarantine the directory and recheck the quarantined binary
+# before deleting it, then restore an artifact that became active.
+make_baseline
+expect_success
+test_dry_run=0
+test_confirm=1
+test_lsof_mode=race
+test_race_binary="$test_root/$active_commit/cmux-tui"
+test_race_commit="$active_commit"
+expect_success
+assert_exists "$active_commit"
+assert_missing "$old_commit"
+
+# A second retention process must not run concurrently with a destructive one.
+make_baseline
+expect_success
+mkdir "$test_root/.retention.lock"
+test_dry_run=0
+test_confirm=1
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
 
 # A symlinked cleanup binary can make lsof report its target outside the
 # artifact tree. Fail closed instead of deleting that artifact when another

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -70,6 +70,24 @@ exit 1
 EOF
 chmod 0755 "$fake_lsof"
 
+fake_find="$tmp/find"
+cat > "$fake_find" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+printf '%s\n' "$*" >> "$CMUX_TEST_FIND_ARGS_FILE"
+for argument in "$@"; do
+  case "$argument" in
+    -mindepth|-maxdepth)
+      echo "simulated BSD find rejected GNU depth predicate: $argument" >&2
+      exit 2
+      ;;
+  esac
+done
+exec /usr/bin/find "$@"
+EOF
+chmod 0755 "$fake_find"
+
 fake_stat="$tmp/stat"
 cat > "$fake_stat" <<'EOF'
 #!/usr/bin/env bash
@@ -116,6 +134,7 @@ write_stat_map() {
 }
 
 run_retention() {
+  PATH="$tmp:$PATH" \
   CMUX_TUI_HOSTED_RETENTION_COUNT="$test_count" \
   CMUX_TUI_HOSTED_RETENTION_DRY_RUN="$test_dry_run" \
   CMUX_TUI_HOSTED_RETENTION_CONFIRM="$test_confirm" \
@@ -128,6 +147,7 @@ run_retention() {
   CMUX_TEST_RACE_BINARY="${test_race_binary:-}" \
   CMUX_TEST_RACE_COMMIT="${test_race_commit:-}" \
   CMUX_TEST_RACE_PID_FILE="$tmp/race-pid" \
+  CMUX_TEST_FIND_ARGS_FILE="$tmp/find-args" \
   CMUX_TEST_STAT_MODE="${test_stat_mode:-gnu}" \
   cmux_hosted_retention_run "$test_root/$test_current_commit" "$test_current_commit"
 }
@@ -190,6 +210,16 @@ make_baseline() {
   test_race_binary=""
   test_race_commit=""
 }
+
+# The scan uses only the POSIX direct-child expression. BSD find does not
+# accept GNU's -mindepth or -maxdepth predicates.
+make_baseline
+expect_success
+[[ -s "$tmp/find-args" ]] || { echo "portable scan did not invoke find" >&2; exit 1; }
+if grep -Eq '(^|[[:space:]])-(mindepth|maxdepth)([[:space:]]|$)' "$tmp/find-args"; then
+  echo "portable scan passed GNU-only depth predicates" >&2
+  exit 1
+fi
 
 # A dry run creates the preview. A destructive run with the same plan removes
 # only the inactive tail, while retaining the current and newest prior item.
@@ -330,6 +360,50 @@ assert_missing "$old_commit"
 make_baseline
 expect_success
 mkdir "$test_root/.retention.lock"
+test_dry_run=0
+test_confirm=1
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
+
+# A dead owner lock older than the recovery age is reclaimed before cleanup.
+make_baseline
+expect_success
+(
+  exit 0
+) &
+dead_lock_pid=$!
+wait "$dead_lock_pid"
+mkdir "$test_root/.retention.lock"
+printf '%s\t%s\tstale-owner\n' "$dead_lock_pid" "$(( $(date +%s) - 90000 ))" > "$test_root/.retention.lock/owner"
+test_dry_run=0
+test_confirm=1
+expect_success
+assert_missing "$active_commit"
+assert_missing "$old_commit"
+assert_missing .retention.lock
+
+# A live owner remains exclusive even when its lock is old.
+make_baseline
+expect_success
+mkdir "$test_root/.retention.lock"
+printf '%s\t%s\tlive-owner\n' "$$" "$(( $(date +%s) - 90000 ))" > "$test_root/.retention.lock/owner"
+test_dry_run=0
+test_confirm=1
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
+
+# A dead but recent owner is not reclaimed before the recovery age.
+make_baseline
+expect_success
+(
+  exit 0
+) &
+dead_lock_pid=$!
+wait "$dead_lock_pid"
+mkdir "$test_root/.retention.lock"
+printf '%s\t%s\trecent-owner\n' "$dead_lock_pid" "$(date +%s)" > "$test_root/.retention.lock/owner"
 test_dry_run=0
 test_confirm=1
 expect_failure 2

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -69,14 +69,17 @@ if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == partial ]]; then
 fi
 
 [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == active ]] || exit 1
+active_match=0
 for argument in "$@"; do
   if [[ "$argument" == /*/cmux-tui ]]; then
     if [[ "${argument##*/}" == cmux-tui && "$argument" == *"/${CMUX_TEST_ACTIVE_COMMIT:-}"/* ]]; then
       printf 'n%s\n' "$argument"
+      active_match=1
     fi
   fi
 done
-exit 0
+(( active_match )) && exit 0
+exit 1
 EOF
 chmod 0755 "$fake_lsof"
 
@@ -146,10 +149,10 @@ write_stat_map() {
 set_old_mtime() {
   local path="$1"
   local old_timestamp
-  if old_timestamp="$(date -v-25H +%m%d%H%M%Y 2>/dev/null)"; then
+  if old_timestamp="$(date -v-25H +%Y%m%d%H%M 2>/dev/null)"; then
     :
   else
-    old_timestamp="$(date -d '25 hours ago' +%m%d%H%M%Y)"
+    old_timestamp="$(date -d '25 hours ago' +%Y%m%d%H%M)"
   fi
   touch -t "$old_timestamp" "$path"
 }
@@ -433,6 +436,7 @@ make_baseline
 expect_success
 mkdir "$test_root/.retention.lock"
 set_old_mtime "$test_root/.retention.lock"
+printf '.retention.lock\t100\n' >> "$tmp/stat-map"
 test_dry_run=0
 test_confirm=1
 expect_success
@@ -446,6 +450,7 @@ expect_success
 mkdir "$test_root/.retention.lock"
 printf 'malformed\n' > "$test_root/.retention.lock/owner"
 set_old_mtime "$test_root/.retention.lock"
+printf '.retention.lock\t100\n' >> "$tmp/stat-map"
 test_dry_run=0
 test_confirm=1
 expect_success

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -128,6 +128,22 @@ awk -F '\t' -v candidate="$candidate" '$1 == candidate { print $2; found = 1 } E
 EOF
 chmod 0755 "$fake_stat"
 
+fake_mv="$tmp/mv"
+cat > "$fake_mv" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+/bin/mv "$@"
+destination=""
+for argument in "$@"; do
+  destination="$argument"
+done
+if [[ "${CMUX_TEST_MV_MODE:-normal}" == publish-marker && "$destination" == *.reclaim ]]; then
+  printf 'published-after-move\n' > "$destination/owner"
+fi
+EOF
+chmod 0755 "$fake_mv"
+
 make_root() {
   test_root="$(mktemp -d "$tmp/root.XXXXXX")"
 }
@@ -165,6 +181,7 @@ run_retention() {
   CMUX_TUI_HOSTED_RETENTION_MAX_CANDIDATES="${test_max_candidates:-10000}" \
   CMUX_TUI_HOSTED_RETENTION_LSOF="${test_lsof_command:-$fake_lsof}" \
   CMUX_TUI_HOSTED_RETENTION_STAT="$fake_stat" \
+  CMUX_TEST_MV_MODE="${test_mv_mode:-normal}" \
   CMUX_TEST_LSOF_MODE="${test_lsof_mode:-inactive}" \
   CMUX_TEST_ACTIVE_COMMIT="${test_active_commit:-}" \
   CMUX_TEST_LSOF_STATE="${test_lsof_state:-$tmp/lsof-state}" \
@@ -457,6 +474,40 @@ expect_success
 assert_missing "$active_commit"
 assert_missing "$old_commit"
 assert_missing .retention.lock
+
+# Reclaim must not delete a marker published after the atomic move. Restore the
+# moved lock and fail closed when publication races with stale recovery.
+make_baseline
+mkdir "$test_root/.retention.lock"
+set_old_mtime "$test_root/.retention.lock"
+printf '.retention.lock\t100\n' >> "$tmp/stat-map"
+test_dry_run=0
+test_confirm=1
+test_mv_mode=publish-marker
+expect_failure 2
+assert_exists .retention.lock
+[[ "$(<"$test_root/.retention.lock/owner")" == published-after-move ]] || {
+  echo "concurrent owner marker was not preserved" >&2
+  exit 1
+}
+
+# A stale lock with unexpected contents must retain its owner marker when
+# quarantine cleanup cannot remove the extra entry.
+make_baseline
+mkdir "$test_root/.retention.lock"
+printf '999999\t1\told-token\n' > "$test_root/.retention.lock/owner"
+printf x > "$test_root/.retention.lock/extra"
+set_old_mtime "$test_root/.retention.lock"
+printf '.retention.lock\t100\n' >> "$tmp/stat-map"
+test_dry_run=0
+test_confirm=1
+test_mv_mode=normal
+expect_failure 2
+assert_exists .retention.lock
+[[ "$(<"$test_root/.retention.lock/owner")" == $'999999\t1\told-token' ]] || {
+  echo "stale lock owner marker was lost" >&2
+  exit 1
+}
 
 # A live owner remains exclusive even when its lock is old.
 make_baseline

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -58,6 +58,16 @@ if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == race ]]; then
   exit 1
 fi
 
+if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == partial ]]; then
+  for argument in "$@"; do
+    if [[ "$argument" == *"/${CMUX_TEST_ACTIVE_COMMIT:-}/cmux-tui" ]]; then
+      printf 'n%s\n' "$argument"
+      exit 1
+    fi
+  done
+  exit 1
+fi
+
 [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == active ]] || exit 1
 for argument in "$@"; do
   if [[ "$argument" == /*/cmux-tui ]]; then
@@ -66,7 +76,7 @@ for argument in "$@"; do
     fi
   fi
 done
-exit 1
+exit 0
 EOF
 chmod 0755 "$fake_lsof"
 
@@ -131,6 +141,17 @@ write_stat_map() {
     printf '%s\t%s\n' "${entry%%:*}" "${entry#*:}" >> "$tmp/stat-map"
   done
   export CMUX_TEST_STAT_MAP="$tmp/stat-map"
+}
+
+set_old_mtime() {
+  local path="$1"
+  local old_timestamp
+  if old_timestamp="$(date -v-25H +%m%d%H%M%Y 2>/dev/null)"; then
+    :
+  else
+    old_timestamp="$(date -d '25 hours ago' +%m%d%H%M%Y)"
+  fi
+  touch -t "$old_timestamp" "$path"
 }
 
 run_retention() {
@@ -320,6 +341,18 @@ expect_failure 2
 assert_exists "$active_commit"
 assert_exists "$old_commit"
 
+# A partial lsof result is not a valid inactive decision. Preserve every
+# candidate when lsof emits a name and exits nonzero.
+make_baseline
+expect_success
+test_dry_run=0
+test_confirm=1
+test_lsof_mode=partial
+test_active_commit="$active_commit"
+expect_failure 2
+assert_exists "$active_commit"
+assert_exists "$old_commit"
+
 # Cleanup also fails closed when the activity tool is not available.
 make_baseline
 expect_success
@@ -340,6 +373,17 @@ test_active_commit="$active_commit"
 expect_success
 assert_exists "$active_commit"
 assert_missing "$old_commit"
+
+# A preview path must be a regular file. An owned directory must not receive
+# the temporary preview as a child and report success.
+make_baseline
+mkdir "$test_root/.retention-preview"
+expect_failure 2
+assert_exists .retention-preview
+[[ ! -e "$test_root/.retention-preview/preview" ]] || {
+  echo "preview was written inside a directory" >&2
+  exit 1
+}
 assert_missing .retention.lock
 
 # A process can start using an artifact after the initial batch lsof check.
@@ -376,6 +420,32 @@ dead_lock_pid=$!
 wait "$dead_lock_pid"
 mkdir "$test_root/.retention.lock"
 printf '%s\t%s\tstale-owner\n' "$dead_lock_pid" "$(( $(date +%s) - 90000 ))" > "$test_root/.retention.lock/owner"
+test_dry_run=0
+test_confirm=1
+expect_success
+assert_missing "$active_commit"
+assert_missing "$old_commit"
+assert_missing .retention.lock
+
+# A crash between lock-directory creation and owner-marker publication leaves
+# an empty stale directory. It must be reclaimable by age and ownership.
+make_baseline
+expect_success
+mkdir "$test_root/.retention.lock"
+set_old_mtime "$test_root/.retention.lock"
+test_dry_run=0
+test_confirm=1
+expect_success
+assert_missing "$active_commit"
+assert_missing "$old_commit"
+assert_missing .retention.lock
+
+# A malformed stale marker with no extra lock contents is also recoverable.
+make_baseline
+expect_success
+mkdir "$test_root/.retention.lock"
+printf 'malformed\n' > "$test_root/.retention.lock/owner"
+set_old_mtime "$test_root/.retention.lock"
 test_dry_run=0
 test_confirm=1
 expect_success

--- a/scripts/test-hosted-retention.sh
+++ b/scripts/test-hosted-retention.sh
@@ -68,6 +68,20 @@ if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == partial ]]; then
   exit 1
 fi
 
+if [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == arg-limit ]]; then
+  lsof_target_count=0
+  for argument in "$@"; do
+    if [[ "$argument" == /*/cmux-tui ]]; then
+      lsof_target_count=$((lsof_target_count + 1))
+    fi
+  done
+  if (( lsof_target_count > 128 )); then
+    echo 'simulated lsof argument limit' >&2
+    exit 2
+  fi
+  exit 1
+fi
+
 [[ "${CMUX_TEST_LSOF_MODE:-inactive}" == active ]] || exit 1
 active_match=0
 for argument in "$@"; do
@@ -406,6 +420,19 @@ assert_exists .retention-preview
 }
 assert_missing .retention.lock
 
+# A dry run must not recover stale quarantine entries or otherwise mutate the
+# artifact tree. Recovery is reserved for destructive execution.
+make_baseline
+quarantine_root="$test_root/.retention-quarantine.test"
+mkdir "$quarantine_root"
+mv "$test_root/$old_commit" "$quarantine_root/$old_commit"
+set_old_mtime "$quarantine_root"
+printf '.retention-quarantine.test\t100\n' >> "$tmp/stat-map"
+expect_success
+assert_exists ".retention-quarantine.test/$old_commit"
+assert_missing "$old_commit"
+assert_missing .retention.lock
+
 # A process can start using an artifact after the initial batch lsof check.
 # The cleanup must quarantine the directory and recheck the quarantined binary
 # before deleting it, then restore an artifact that became active.
@@ -557,6 +584,25 @@ make_baseline
 test_max_candidates=3
 expect_failure 2
 assert_exists "$old_commit"
+
+# lsof receives bounded batches. A single invocation over 128 targets must
+# fail, while cleanup with 130 candidates succeeds through multiple batches.
+make_baseline
+batch_index=1
+while (( batch_index <= 130 )); do
+  batch_commit="$(printf '%040x' "$((batch_index + 1000))")"
+  make_artifact "$batch_commit"
+  printf '%s\t%s\n' "$batch_commit" "$((1000 - batch_index))" >> "$tmp/stat-map"
+  batch_index=$((batch_index + 1))
+done
+test_count=1
+test_dry_run=1
+expect_success
+test_dry_run=0
+test_confirm=1
+test_lsof_mode=arg-limit
+expect_success
+assert_missing "$old_commit"
 
 # Exercise both documented stat interfaces. The GNU form must be tried first
 # on GNU systems, while the BSD form remains a valid fallback on macOS.

--- a/scripts/verify-cmux-tui-hosted.sh
+++ b/scripts/verify-cmux-tui-hosted.sh
@@ -18,6 +18,12 @@ Cargo test names do not include their package name, so a plain test-name filter
 cannot select that crate.
 --full runs the cross-platform merge gate, including real Windows execution.
 Both modes build and download a macOS arm64 cmux-tui artifact from the exact pushed HEAD.
+
+Optional retention is enabled with CMUX_TUI_HOSTED_RETENTION_COUNT. Run once
+with CMUX_TUI_HOSTED_RETENTION_DRY_RUN=1, then run with
+CMUX_TUI_HOSTED_RETENTION_CONFIRM=1 to remove confirmed inactive artifacts.
+The candidate scan is capped at 10,000 directories; use
+CMUX_TUI_HOSTED_RETENTION_MAX_CANDIDATES to choose a lower cap.
 EOF
 }
 
@@ -61,6 +67,8 @@ if [[ ! "$timeout_seconds" =~ ^[1-9][0-9]*$ ]]; then
 fi
 
 script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=hosted-retention.sh
+source "$script_dir/hosted-retention.sh"
 repo_root="$(git -C "$script_dir" rev-parse --show-toplevel)"
 cd "$repo_root"
 
@@ -341,6 +349,8 @@ artifact_dir="cmux-tui/target/hosted/$commit"
 artifact_binary="$artifact_dir/cmux-tui"
 mkdir -p "$artifact_dir"
 install -m 0755 "$downloaded_binary" "$artifact_binary"
+
+cmux_hosted_retention_run "$artifact_dir" "$commit"
 
 echo "Hosted verification passed: $run_url"
 echo "Artifact: $artifact_binary"


### PR DESCRIPTION
Fixes the unsafe hosted artifact retention path from #11620.

The first commit adds behavior-level tests and wires them into the cmux-tui workflow. The second commit binds destructive cleanup to a canonical plan hash, current commit, retention policy, exact candidate set, and a fresh timestamp. It rejects malformed or future previews, uses portable GNU/BSD stat mtime forms, bounds candidate collection, revalidates ownership and symlink state before deletion, and fails closed when lsof cannot establish activity. A single lsof scan records active binaries before cleanup.

The follow-up test/fix pair covers the production artifact-root contract and rejects symlinked cleanup binaries. The helper receives the installed current artifact directory and derives its parent cache root, matching the production call.

Checks:
- Bash 3.2 syntax and behavior tests on macOS
- Bash 5.2 behavior tests in Docker
- Real macOS lsof active/inactive cleanup checks
- shellcheck with warning severity
- git diff --check

References:
- https://man7.org/linux/man-pages/man8/lsof.8.html
- https://github.com/apple-oss-distributions/file_cmds/blob/main/stat/stat.1
- https://www.gnu.org/software/coreutils/manual/html_node/stat-invocation.html

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790956780&installation_model_id=21920&pr_number=11699&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11699&signature=4caa9dad76bdd7a3a15ffb124f333eabdb28011239a958baee0241c89d816e9c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the unsafe hosted artifact retention path with opt-in cleanup in `verify-cmux-tui-hosted.sh`. The default verification path is unchanged; when enabled, cleanup keeps the current and configured recent artifacts, then removes only confirmed inactive older artifacts.

**Usage**
- Set `CMUX_TUI_HOSTED_RETENTION_COUNT`, run with `CMUX_TUI_HOSTED_RETENTION_DRY_RUN=1`, then rerun with `CMUX_TUI_HOSTED_RETENTION_CONFIRM=1`.
- Lower the default 10,000-directory scan cap with `CMUX_TUI_HOSTED_RETENTION_MAX_CANDIDATES`.

**Safety and tests**
- Preview plans bind the current commit, retention policy, exact candidate set, and a timestamp valid for 10 minutes.
- Dry runs stay read-only; destructive runs batch `lsof` checks into bounded groups, quarantine-recheck before deletion, recover stale locks and quarantines, and fail closed on any activity, ownership, symlink, scan, or lock safety failure.
- Behavior tests cover direct callers, activity races, lock recovery, stat portability, lsof batching, and the production artifact-root and binary contracts in the `cmux-tui` workflow.

<sup>Written for commit 0eead036e8b23e9f625e859f491715522f74359b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional cleanup for hosted build artifacts, retaining current and recent artifacts while safely removing eligible inactive artifacts.
  * Added a dry-run preview and confirmation step before cleanup.
  * Added safeguards for active artifacts, interrupted cleanup, stale locks, and concurrent processes.
  * Added configuration for limiting scanned candidates.
  * Updated hosted verification guidance for the retention workflow.

* **Tests**
  * Added automated coverage for platform variations, locking, safety checks, and race conditions.
  * Integrated hosted artifact retention tests into continuous integration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->