### PR TITLE
fix(pipe-io): make relay startup and drain failures deterministic

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1713,6 +1713,14 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
+            // A pipe-IO embedder needs a machine-readable terminal result for
+            // every startup path. Without the scoped subscription filter, the
+            // relay cannot safely distinguish this surface's bytes, so treat
+            // it as a retryable daemon capability loss instead of returning a
+            // plain CLI error (which would omit the final exit record).
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+            }
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -209,6 +209,11 @@ pub fn run(
             "{}",
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
         );
+        // Continuing without geometry authority would make later resize
+        // requests look accepted while the daemon keeps the wrong PTY size.
+        // Classify the startup failure so the embedder can either stop for a
+        // retired terminal or reconnect after a lost daemon transport.
+        return Ok(attach_failure_exit_reason(&error, surface));
     }
     spawn_stdin_pump(handle, lifecycle_sender);
     let reason = pump_events_to_stdout(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2563,7 +2563,7 @@ impl RemoteSession {
                     // overflow) ends the byte feed without ending the
                     // terminal. The relay reports a lost connection so its
                     // embedder respawns and resyncs from a fresh replay.
-                    self.pipe_io_forward(id, || PipeIoEvent::TransportLost);
+                    self.signal_pipe_io_event(Some(id), None, PipeIoEvent::TransportLost);
                     self.surfaces.lock().unwrap().remove(&id);
                     self.emit(MuxEvent::SurfaceOutput(id));
                 }
@@ -2607,7 +2607,7 @@ impl RemoteSession {
             }
             Some("surface-exited") => {
                 if let Some(id) = surface_id() {
-                    self.pipe_io_forward(id, || PipeIoEvent::SurfaceExited);
+                    self.signal_pipe_io_event(Some(id), None, PipeIoEvent::SurfaceExited);
                     // Retire the mirror immediately. The authoritative tree
                     // refresh may lag this event, but input and reattach must
                     // already fail closed for a known-exited surface.
@@ -3271,16 +3271,16 @@ impl RemoteSession {
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
         use crossbeam_channel::TrySendError;
-        let event = event();
-        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
-            return self.signal_pipe_io_event(Some(surface), None, event);
-        }
         let (stalled_token, pipe_io_owned) = {
             let tap = self.pipe_io_tap.lock().unwrap();
             let Some(tap) = tap.as_ref() else { return false };
             if tap.surface != surface {
                 return false;
             }
+            // Resolve ownership before invoking the closure. Output and
+            // replay call sites capture a payload clone in the closure, and
+            // sessions without a matching tap must not pay that allocation.
+            let event = event();
             let retained_bytes = event.retained_bytes();
             if !tap.byte_budget.try_reserve(retained_bytes) {
                 (Some(tap.token.clone()), true)

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6804,6 +6804,21 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_forward_does_not_build_payload_without_matching_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let built = Arc::new(AtomicBool::new(false));
+        let built_by_event = built.clone();
+
+        assert!(!session.pipe_io_forward(7, || {
+            built_by_event.store(true, Ordering::Release);
+            PipeIoEvent::Output(vec![0; 1024])
+        }));
+        assert!(!built.load(Ordering::Acquire));
+    }
+
+    #[test]
     fn stale_pipe_io_tap_cleanup_cannot_remove_a_replacement() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4106,6 +4106,8 @@ struct PipeIoRelay {
     stdin: Option<std::process::ChildStdin>,
     stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
     stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    stdout_drain: Option<std::thread::JoinHandle<()>>,
+    stderr_drain: Option<std::thread::JoinHandle<()>>,
 }
 
 #[cfg(unix)]
@@ -4145,15 +4147,22 @@ impl PipeIoRelay {
         let out = child.stdout.take().unwrap();
         let err = child.stderr.take().unwrap();
         let stdout_sink = stdout.clone();
-        std::thread::spawn(move || drain_into(out, stdout_sink));
+        let stdout_drain = std::thread::spawn(move || drain_into(out, stdout_sink));
         let stderr_sink = stderr.clone();
-        std::thread::spawn(move || {
+        let stderr_drain = std::thread::spawn(move || {
             if !stderr_delay.is_zero() {
                 std::thread::sleep(stderr_delay);
             }
             drain_into(err, stderr_sink);
         });
-        Self { child, stdin, stdout, stderr }
+        Self {
+            child,
+            stdin,
+            stdout,
+            stderr,
+            stdout_drain: Some(stdout_drain),
+            stderr_drain: Some(stderr_drain),
+        }
     }
 
     fn send_input(&mut self, bytes: &[u8]) {
@@ -4203,8 +4212,15 @@ impl PipeIoRelay {
         let deadline = Instant::now() + Duration::from_secs(20);
         while Instant::now() < deadline {
             if let Some(status) = self.child.try_wait().unwrap() {
-                // Let the drain threads observe EOF.
-                std::thread::sleep(Duration::from_millis(100));
+                // Child EOF is the completion signal for both drain threads.
+                // Join them before reading stderr so the final exit record
+                // cannot race the test's parser.
+                if let Some(drain) = self.stdout_drain.take() {
+                    drain.join().expect("stdout drain thread panicked");
+                }
+                if let Some(drain) = self.stderr_drain.take() {
+                    drain.join().expect("stderr drain thread panicked");
+                }
                 let stderr_text =
                     String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
                 let exit_line = stderr_text

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4111,6 +4111,16 @@ struct PipeIoRelay {
 #[cfg(unix)]
 impl PipeIoRelay {
     fn start(server: &HeadlessServer, terminal: &str, cols: u16, rows: u16) -> Self {
+        Self::start_with_stderr_delay(server, terminal, cols, rows, Duration::ZERO)
+    }
+
+    fn start_with_stderr_delay(
+        server: &HeadlessServer,
+        terminal: &str,
+        cols: u16,
+        rows: u16,
+        stderr_delay: Duration,
+    ) -> Self {
         let mut child = Command::new(bin())
             .args(["attach", "--socket"])
             .arg(&server.socket)
@@ -4137,7 +4147,12 @@ impl PipeIoRelay {
         let stdout_sink = stdout.clone();
         std::thread::spawn(move || drain_into(out, stdout_sink));
         let stderr_sink = stderr.clone();
-        std::thread::spawn(move || drain_into(err, stderr_sink));
+        std::thread::spawn(move || {
+            if !stderr_delay.is_zero() {
+                std::thread::sleep(stderr_delay);
+            }
+            drain_into(err, stderr_sink);
+        });
         Self { child, stdin, stdout, stderr }
     }
 
@@ -4354,6 +4369,25 @@ fn pipe_io_startup_connect_failure_reports_daemon_lost() {
     let value: serde_json::Value = serde_json::from_str(exit_line).unwrap();
     assert_eq!(value["exit"]["reason"], "daemon-lost");
     let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_wait_for_exit_waits_for_delayed_stderr_drain() {
+    let server = HeadlessServer::start("pipe-io-drain-join");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start_with_stderr_delay(
+        &server,
+        &terminal,
+        80,
+        24,
+        Duration::from_millis(500),
+    );
+    relay.stdin = None;
+    let (code, exit) = relay.wait_for_exit();
+    assert_eq!(code, 0, "stdin EOF must be a clean detach, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "parent-closed");
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
## Summary
- emit the machine-readable `daemon-lost` exit record when pipe-IO attach cannot use filtered subscriptions
- classify initial geometry-claim transport failures and stop before accepting bytes without geometry authority
- resolve tap ownership before constructing replay/output payloads
- retain and join stdout/stderr drain threads before parsing the final exit record

The first commit adds behavior tests for tap ownership and delayed stderr draining. The second commit applies the relay fixes.

## Verification
- `git diff --check`
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/main.rs cmux-tui/crates/cmux-tui/src/pipe_io.rs cmux-tui/crates/cmux-tui/src/session/remote.rs cmux-tui/crates/cmux-tui/tests/cli.rs`

Rust tests were not run locally because cmux-tui builds and tests must run on the hosted Testbox.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790956820&installation_model_id=21920&pr_number=11700&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11700&signature=b8e218d6184c94f10584f2d4bca23696f6f2fa2054f1ef4c4b256378c476f20e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes pipe-IO relay startup and drain failures so embedders get deterministic, machine-readable exit records instead of plain CLI errors or missing final records.

- Emits a `daemon-lost` exit record when pipe-IO attach cannot use filtered subscriptions.
- Stops pipe-IO startup when the initial geometry-claim transport fails, before accepting bytes without geometry authority.
- Resolves tap ownership before constructing replay/output payloads so sessions without a matching tap don't allocate them.
- Joins stdout and stderr drain threads before parsing the final exit record in tests.
- Adds behavior tests for tap ownership and delayed stderr draining.

<sup>Written for commit fe13a41e7f8392dc551ff810fbfc2c972d1a80c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

