### PR TITLE
Bound TUI grapheme truncation work

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -747,8 +747,9 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
 }
 
 pub(crate) fn middle_truncate(input: &str, max_chars: usize) -> String {
-    let chars = input.chars().collect::<Vec<_>>();
-    if chars.len() <= max_chars {
+    let graphemes = input.graphemes(true);
+    let prefix = graphemes.clone().take(max_chars.saturating_add(1)).count();
+    if prefix <= max_chars {
         return input.to_string();
     }
     if max_chars == 0 {
@@ -760,9 +761,9 @@ pub(crate) fn middle_truncate(input: &str, max_chars: usize) -> String {
     let keep = max_chars - 3;
     let front = keep.div_ceil(2);
     let back = keep / 2;
-    let mut output = chars[..front].iter().collect::<String>();
+    let mut output = input.graphemes(true).take(front).collect::<String>();
     output.push_str("...");
-    output.extend(&chars[chars.len() - back..]);
+    output.extend(input.graphemes(true).rev().take(back).collect::<Vec<_>>().into_iter().rev());
     output
 }
 
@@ -783,6 +784,7 @@ mod tests {
         assert_eq!(middle_truncate("abcdefghi", 3), "...");
         assert_eq!(middle_truncate("abc", 3), "abc");
         assert_eq!(middle_truncate("abc", 0), "");
+        assert_eq!(middle_truncate("e\u{301}clair", 5), "e\u{301}...r");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -9,6 +9,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Position;
 use ratatui::style::{Modifier, Style};
 use unicode_width::UnicodeWidthStr;
+use unicode_segmentation::UnicodeSegmentation;
 
 use crate::app::{App, ContextMenu, MenuItem};
 use crate::localization::catalog;
@@ -339,9 +340,13 @@ fn wrapped_message_lines(message: &str, width: usize, limit: usize) -> Vec<Strin
     let mut lines = Vec::new();
     let mut remaining = sanitized.as_str();
     while !remaining.is_empty() && lines.len() < limit {
-        let mut end = remaining.len();
-        while end > 0 && remaining[..end].width() > width {
-            end = remaining[..end].char_indices().next_back().map_or(0, |(index, _)| index);
+        let mut end = 0;
+        let mut used = 0;
+        for grapheme in remaining.graphemes(true) {
+            let next = used.saturating_add(grapheme.width());
+            if next > width { break; }
+            used = next;
+            end += grapheme.len();
         }
         if end == 0 {
             break;
@@ -358,7 +363,8 @@ fn wrapped_message_lines(message: &str, width: usize, limit: usize) -> Vec<Strin
         && let Some(last) = lines.last_mut()
     {
         while format!("{last}…").width() > width && !last.is_empty() {
-            last.pop();
+            let end = last.grapheme_indices(true).next_back().map_or(0, |(i, _)| i);
+            last.truncate(end);
         }
         last.push('…');
     }
@@ -703,7 +709,7 @@ fn label_width(label: &str) -> u16 {
 mod tests {
     use cmux_tui_core::Rect;
 
-    use super::toast_rect_for_label;
+    use super::{toast_rect_for_label, wrapped_message_lines};
     use crate::localization::catalog_for_locale;
 
     #[test]
@@ -718,5 +724,11 @@ mod tests {
             toast_rect_for_label(Rect { x: 10, y: 2, width: 10, height: 5 }, " 界 "),
             Some(Rect { x: 16, y: 5, width: 3, height: 1 })
         );
+    }
+
+    #[test]
+    fn wrapping_does_not_split_combining_graphemes() {
+        let lines = wrapped_message_lines("e\u{301}clair", 3, 2);
+        assert_eq!(lines, vec!["e\u{301}c", "lair"]);
     }
 }


### PR DESCRIPTION
Cap Unicode truncation and wrapping scans by the requested display budget while preserving grapheme boundaries. Add regression coverage for combining-mark input.

Static validation: git diff --check passed. cargo fmt --check was blocked by the repository 250 GiB free-space guard (146.9 GiB available). No local Rust tests or builds run per policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11702"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790958458&installation_model_id=21920&pr_number=11702&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11702&signature=0940f3e0ce9dfd390214083b92a3e92fdf3a8856c1d7875f5c170b8d34ecd168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes TUI truncation and wrapping preserve grapheme boundaries and stop scanning at the requested display budget. Toast wrapping now measures by grapheme width instead of trimming bytes, and `middle_truncate` no longer collects the whole string before deciding whether to truncate. Adds regression tests for combining-mark input.

<sup>Written for commit a09b8a7bf80f7b207a8ec397024e07a4bdc77d4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

