### PR TITLE
Fix TUI grapheme cell width handling

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -564,4 +564,14 @@ mod tests {
         assert_eq!(shown, "界");
         assert_eq!(cursor, 2);
     }
+
+    #[test]
+    fn visible_cursor_counts_halfwidth_sound_marks_as_terminal_cells() {
+        let mut input = text_input("ｶﾞa");
+
+        let (shown, cursor) = input.visible_text_and_cursor(4);
+
+        assert_eq!(shown, "ｶﾞa");
+        assert_eq!(cursor, 3);
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use unicode_segmentation::UnicodeSegmentation;
-use unicode_width::UnicodeWidthStr;
+use ratatui::buffer::CellWidth;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputEvent {
@@ -112,7 +112,7 @@ impl TextInput {
         let mut used = 0;
         let mut end = scroll;
         for (offset, grapheme) in self.buffer[scroll..].grapheme_indices(true) {
-            let grapheme_width = UnicodeWidthStr::width(grapheme);
+            let grapheme_width = grapheme.cell_width() as usize;
             if used + grapheme_width > width {
                 break;
             }
@@ -143,7 +143,7 @@ impl TextInput {
         for (offset, grapheme) in self.buffer[self.scroll..].grapheme_indices(true) {
             let start = self.scroll + offset;
             let end = start + grapheme.len();
-            let grapheme_width = UnicodeWidthStr::width(grapheme);
+            let grapheme_width = grapheme.cell_width() as usize;
             if used + grapheme_width > width {
                 break;
             }
@@ -354,7 +354,7 @@ impl TextInput {
         // Recomputing widths from `scroll` on every iteration makes long inputs quadratic.
         let mut cursor_col = 0;
         for grapheme in self.buffer[scroll..cursor].graphemes(true) {
-            cursor_col += UnicodeWidthStr::width(grapheme);
+            cursor_col += grapheme.cell_width() as usize;
         }
         if cursor_col >= width {
             let viewport_start = scroll;

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -363,7 +363,7 @@ impl TextInput {
                 if next > cursor {
                     break;
                 }
-                cursor_col = cursor_col.saturating_sub(UnicodeWidthStr::width(grapheme));
+                cursor_col = cursor_col.saturating_sub(grapheme.cell_width() as usize);
                 scroll = next;
                 if cursor_col < width {
                     break;


### PR DESCRIPTION
Use ratatui CellWidth for TextInput cursor/viewport calculations and UI text layout. This accounts for terminal-specific halfwidth Katakana sound marks while preserving existing Ghostty VtCell behavior.

Tests: static git diff --check only; Rust tests were not run locally per cmux-tui instructions.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11703"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790958500&installation_model_id=21920&pr_number=11703&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11703&signature=e4355afe8edbde93bd562c8314fc3f62c4335d7460181a98634565878878bb76"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates TUI text input to use ratatui cell widths instead of Unicode widths, so cursor positioning and viewport scanning match terminal rendering for halfwidth Katakana sound-mark sequences.

- Applies cell widths to visible text, viewport, and cursor calculations.
- Adds regression coverage for `ｶﾞa`.

<sup>Written for commit ad07c6fd733d25f446515a01428afa2e9be046d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text input cursor positioning and display for halfwidth sound-mark characters, ensuring they occupy the correct number of terminal cells.

* **Tests**
  * Added coverage to verify accurate cursor placement for these characters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->