### PR TITLE
feat(pipe-io): land rendererless relay milestone on main

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -26,6 +26,7 @@ mod machine_provider_client;
 #[cfg(unix)]
 mod machine_provider_runtime;
 mod machine_runtime;
+mod pipe_io;
 mod plugin_manager;
 mod process_diagnostics;
 #[cfg(target_os = "linux")]
@@ -428,6 +429,13 @@ START OPTIONS
   --session <name>   Session name (default: main). Determines the socket path.
   --socket <path>    Explicit control socket path.
   --terminal <id>    With attach, show only this terminal (use `cmux terminal list`).
+  --pipe-io          With attach --terminal, relay raw bytes over stdio for an
+                     embedder that parses them itself instead of rendering
+                     (stdout = replay then live output, stdin = JSON
+                     input/resize lines, exit 0 = terminal ended, exit 2 =
+                     daemon connection lost).
+  --cols <n>         Initial viewer columns for --pipe-io (default 80).
+  --rows <n>         Initial viewer rows for --pipe-io (default 24).
   --state <path>     Durable session-state root (default: platform state dir).
   --ephemeral        Keep workspace state in memory for this run only.
   --machine-provider <path>
@@ -491,6 +499,9 @@ struct Args {
     session: String,
     socket: Option<PathBuf>,
     terminal: Option<String>,
+    pipe_io: bool,
+    pipe_io_cols: Option<u16>,
+    pipe_io_rows: Option<u16>,
     state: Option<PathBuf>,
     ephemeral: bool,
     machine_provider: Option<PathBuf>,
@@ -565,6 +576,9 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
         session: "main".to_string(),
         socket: None,
         terminal: None,
+        pipe_io: false,
+        pipe_io_cols: None,
+        pipe_io_rows: None,
         state: None,
         ephemeral: false,
         machine_provider: None,
@@ -617,6 +631,19 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
             "--terminal" => {
                 out.terminal =
                     Some(args.next().ok_or_else(|| "--terminal needs a value".to_string())?);
+            }
+            "--pipe-io" => {
+                out.pipe_io = true;
+            }
+            "--cols" => {
+                let value = args.next().ok_or_else(|| "--cols needs a value".to_string())?;
+                out.pipe_io_cols =
+                    Some(value.parse().map_err(|_| "--cols needs a number".to_string())?);
+            }
+            "--rows" => {
+                let value = args.next().ok_or_else(|| "--rows needs a value".to_string())?;
+                out.pipe_io_rows =
+                    Some(value.parse().map_err(|_| "--rows needs a number".to_string())?);
             }
             "--machine-provider" => {
                 if out.machine_provider.is_some() {
@@ -811,6 +838,12 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
     }
     if out.terminal.is_some() && !out.attach {
         return Err("--terminal requires `cmux attach`".to_string());
+    }
+    if out.pipe_io && out.terminal.is_none() {
+        return Err("--pipe-io requires `cmux attach --terminal`".to_string());
+    }
+    if (out.pipe_io_cols.is_some() || out.pipe_io_rows.is_some()) && !out.pipe_io {
+        return Err("--cols/--rows require --pipe-io".to_string());
     }
     #[cfg(not(unix))]
     if out.agent_browser_provider {
@@ -1252,6 +1285,8 @@ const STARTUP_VALUE_OPTIONS: &[&str] = &[
     "--session",
     "--machine",
     "--terminal",
+    "--cols",
+    "--rows",
     "--state",
     "--machine-provider",
     "--cloud-host",
@@ -1626,6 +1661,18 @@ fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
     cmux_tui_core::terminal_host_runtime::serve_terminal_host_stdio(args, &mut reader, &mut writer)
 }
 
+/// Ends a `--pipe-io` relay: the machine-readable exit reason is the final
+/// stderr line (the embedder localizes what it shows) and the exit code
+/// carries the respawn decision.
+fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
+    {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{}", serde_json::json!({"exit": {"reason": reason.as_str()}}));
+        let _ = stderr.flush();
+    }
+    client_log::exit(reason.exit_code());
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
@@ -1641,27 +1688,69 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         })
         .transpose()?;
     let remote = if terminal.is_some() {
-        RemoteSession::connect_for_terminal_attach(&socket_path)?
+        match RemoteSession::connect_for_terminal_attach(&socket_path) {
+            Ok(remote) => remote,
+            // A pipe-io embedder retries daemon-lost forever (a daemon
+            // restart window looks exactly like this) but gives up on
+            // unexplained failures; a connect failure is the former.
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        }
     } else {
         RemoteSession::connect(&socket_path)?
     };
     let surface_only = if let Some(terminal) = terminal.as_ref() {
-        let tree = remote.refresh_tree()?;
-        let surface = tree
-            .resolve_terminal(terminal)
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        };
+        let resolved = tree.resolve_terminal(terminal);
+        // A pipe-io embedder respawns on daemon loss; a terminal that no
+        // longer exists must read as terminal-ended (do not respawn), not
+        // as a startup failure it would retry forever.
+        if args.pipe_io && resolved.is_none() {
+            exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+        }
+        let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
-        remote.scope_events_to_surface(surface)?;
-        let tree = remote.refresh_tree()?;
+        if let Err(error) = remote.scope_events_to_surface(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+            }
+            return Err(error);
+        }
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        };
         if tree.resolve_terminal(terminal) != Some(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+            }
             anyhow::bail!(messages.unknown_terminal(terminal.as_str()));
         }
         Some(surface)
     } else {
         None
     };
+    if args.pipe_io {
+        let surface = surface_only.expect("--pipe-io is validated to carry --terminal");
+        let terminal = terminal.as_ref().expect("--pipe-io is validated to carry --terminal");
+        let reason = pipe_io::run(
+            &remote,
+            &socket_path,
+            terminal,
+            surface,
+            args.pipe_io_cols.unwrap_or(80),
+            args.pipe_io_rows.unwrap_or(24),
+        )?;
+        exit_pipe_io(reason);
+    }
     run_connected_session_client(
         socket_path,
         args.session,

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1715,6 +1715,14 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
+            // A pipe-IO embedder needs a machine-readable terminal result for
+            // every startup path. Without the scoped subscription filter, the
+            // relay cannot safely distinguish this surface's bytes, so treat
+            // it as a retryable daemon capability loss instead of returning a
+            // plain CLI error (which would omit the final exit record).
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+            }
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -3018,6 +3018,25 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_startup_errors_distinguish_transport_loss_from_setup_failure() {
+        let transport_loss = anyhow::Error::new(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "daemon is restarting",
+        ));
+        assert_eq!(
+            pipe_io_startup_exit_reason(&transport_loss),
+            pipe_io::PipeIoExitReason::DaemonLost
+        );
+
+        let setup_failure =
+            anyhow::anyhow!("remote server does not support filtered subscriptions");
+        assert_eq!(
+            pipe_io_startup_exit_reason(&setup_failure),
+            pipe_io::PipeIoExitReason::SetupFailed
+        );
+    }
+
+    #[test]
     fn remote_normalization_preserves_leading_globals_for_direct_commands() {
         let mut json_connect = ["--json", "connect"].map(str::to_string).to_vec();
         normalize_remote_resource_args(&mut json_connect).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1673,6 +1673,14 @@ fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
     client_log::exit(reason.exit_code());
 }
 
+fn pipe_io_startup_exit_reason(error: &anyhow::Error) -> pipe_io::PipeIoExitReason {
+    if session::is_pipe_io_retryable_error(error) {
+        pipe_io::PipeIoExitReason::DaemonLost
+    } else {
+        pipe_io::PipeIoExitReason::SetupFailed
+    }
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
@@ -1693,7 +1701,7 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
             // A pipe-io embedder retries daemon-lost forever (a daemon
             // restart window looks exactly like this) but gives up on
             // unexplained failures; a connect failure is the former.
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
             Err(error) => return Err(error),
         }
     } else {
@@ -1702,7 +1710,7 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
     let surface_only = if let Some(terminal) = terminal.as_ref() {
         let tree = match remote.refresh_tree() {
             Ok(tree) => tree,
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
             Err(error) => return Err(error),
         };
         let resolved = tree.resolve_terminal(terminal);
@@ -1721,19 +1729,19 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
             // it as a retryable daemon capability loss instead of returning a
             // plain CLI error (which would omit the final exit record).
             if args.pipe_io {
-                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+                exit_pipe_io(pipe_io::PipeIoExitReason::SetupFailed);
             }
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {
             if args.pipe_io {
-                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+                exit_pipe_io(pipe_io_startup_exit_reason(&error));
             }
             return Err(error);
         }
         let tree = match remote.refresh_tree() {
             Ok(tree) => tree,
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
             Err(error) => return Err(error),
         };
         if tree.resolve_terminal(terminal) != Some(surface) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1,0 +1,656 @@
+//! Renderer-less byte relay for embedder-fed (manual-IO) surfaces.
+//!
+//! `cmux attach --terminal <id> --pipe-io` is the scoped attach client minus
+//! the renderer: the embedder (the macOS GUI's manual-mirror Ghostty
+//! surface) parses the byte stream itself, so this process only relays.
+//!
+//! Contract:
+//! - stdout: raw VT bytes — the daemon replay first, then live PTY output.
+//!   A replay that is not the relay's first output is prefixed with a full
+//!   reset (`ESC c` + erase-scrollback) because a daemon replay REPLACES
+//!   terminal state while a byte stream can only append.
+//! - stdin: JSON lines — `{"input":"<base64>"}` forwards raw bytes to the
+//!   daemon terminal's PTY; `{"resize":{"cols":N,"rows":N}}` drives the
+//!   daemon-side viewer size; `{"claim":{"geometry":true}}` re-asserts this
+//!   relay's geometry authority (last claim wins across attachments; the
+//!   embedder sends it when its pane receives user input). Unknown keys are
+//!   ignored (forward compat); stdin EOF means the embedder is gone and
+//!   ends the relay cleanly.
+//! - stderr: one final JSON line `{"exit":{"reason":...}}`.
+//! - exit code: 0 when the terminal ended or the embedder closed stdin (do
+//!   not respawn), 2 when the daemon connection was lost (respawning
+//!   reattaches and resyncs from a fresh replay).
+
+use std::borrow::Cow;
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use cmux_tui_core::SurfaceId;
+use cmux_tui_core::resource::TerminalPublicId;
+use crossbeam_channel::{Receiver, Sender};
+use serde::Deserialize;
+
+use crate::session::{
+    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
+    is_remote_surface_unavailable,
+};
+
+/// The terminal ended, or the embedder walked away: respawning is wrong.
+pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
+/// The daemon connection was lost: the embedder may respawn to resync.
+pub const EXIT_DAEMON_LOST: i32 = 2;
+
+/// Bounded event queue between the session reader thread and the stdout
+/// pump. A full queue means the embedder stopped reading; the session
+/// treats that as a lost transport rather than wedging its reader thread.
+const EVENT_QUEUE_CAPACITY: usize = 4096;
+const EVENT_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+const MAX_PIPE_IO_INPUT_BYTES: usize = crate::pty_input::PTY_INPUT_MAX_BYTES;
+const MAX_PIPE_IO_BASE64_BYTES: usize = MAX_PIPE_IO_INPUT_BYTES.div_ceil(3) * 4;
+const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
+
+/// Emitted before any replay that is not the relay's first output: full
+/// reset plus erase-scrollback, so the replacement replay does not stack on
+/// top of the embedder's previous terminal state.
+const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
+const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipeIoExitReason {
+    TerminalEnded,
+    DaemonLost,
+    ParentClosed,
+}
+
+impl PipeIoExitReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TerminalEnded => "terminal-ended",
+            Self::DaemonLost => "daemon-lost",
+            Self::ParentClosed => "parent-closed",
+        }
+    }
+
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
+            Self::DaemonLost => EXIT_DAEMON_LOST,
+        }
+    }
+}
+
+/// One parsed stdin line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoRequest {
+    Input(Vec<u8>),
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    /// Re-assert this relay's geometry authority over the terminal. Sent by
+    /// the embedder when its pane receives user input: authority is
+    /// last-claim-wins across attachments, so with several panes (or stale
+    /// restored panes) viewing one terminal, the pane the user actually
+    /// types in must own the PTY size.
+    ClaimGeometry,
+    /// A well-formed line carrying no verb this relay knows: ignored, so a
+    /// newer embedder can talk to an older relay.
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct PipeIoWireRequest<'a> {
+    #[serde(borrow)]
+    input: Option<Cow<'a, str>>,
+    resize: Option<PipeIoWireResize>,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    claim: bool,
+}
+
+#[derive(Deserialize)]
+struct PipeIoWireResize {
+    cols: Option<u64>,
+    rows: Option<u64>,
+}
+
+fn deserialize_present<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::de::IgnoredAny::deserialize(deserializer).map(|_| true)
+}
+
+pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
+    if line.len() > MAX_PIPE_IO_LINE_BYTES {
+        anyhow::bail!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes");
+    }
+    let request: PipeIoWireRequest<'_> = serde_json::from_str(line)?;
+    if let Some(encoded) = request.input {
+        let encoded = encoded.as_ref();
+        if encoded.len() > MAX_PIPE_IO_BASE64_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        if encoded.len() % 4 == 0 {
+            let padding = encoded.bytes().rev().take_while(|byte| *byte == b'=').count();
+            let decoded_len = encoded
+                .len()
+                .checked_div(4)
+                .and_then(|quads| quads.checked_mul(3))
+                .and_then(|bytes| bytes.checked_sub(padding))
+                .unwrap_or(usize::MAX);
+            if decoded_len > MAX_PIPE_IO_INPUT_BYTES {
+                anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+            }
+        } else if base64::decoded_len_estimate(encoded.len()) > MAX_PIPE_IO_INPUT_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        let bytes = base64::engine::general_purpose::STANDARD.decode(encoded)?;
+        if bytes.len() > MAX_PIPE_IO_INPUT_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        return Ok(PipeIoRequest::Input(bytes));
+    }
+    if let Some(resize) = request.resize {
+        let cols = resize.cols;
+        let rows = resize.rows;
+        let (Some(cols), Some(rows)) = (cols, rows) else {
+            anyhow::bail!("resize needs numeric cols and rows");
+        };
+        let (cols, rows) = (u16::try_from(cols)?, u16::try_from(rows)?);
+        return Ok(PipeIoRequest::Resize { cols: cols.max(1), rows: rows.max(1) });
+    }
+    if request.claim {
+        return Ok(PipeIoRequest::ClaimGeometry);
+    }
+    Ok(PipeIoRequest::Unknown)
+}
+
+pub fn run(
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+    surface: SurfaceId,
+    cols: u16,
+    rows: u16,
+) -> anyhow::Result<PipeIoExitReason> {
+    let (sender, receiver) = crossbeam_channel::bounded(EVENT_QUEUE_CAPACITY);
+    // Lifecycle events have their own reserved signal path. A stalled
+    // embedder can fill the byte queue, but it must never be able to hide the
+    // transport-loss event that tells the embedder to respawn.
+    let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+    let byte_budget = Arc::new(PipeIoByteBudget::new(EVENT_QUEUE_MAX_BYTES));
+    // Install before attach so the initial replay cannot be missed.
+    let tap_token = remote.install_pipe_io_tap(
+        surface,
+        sender.clone(),
+        lifecycle_sender.clone(),
+        byte_budget.clone(),
+    );
+    let tap_guard = PipeIoTapGuard { remote: remote.as_ref(), token: tap_token };
+    let handle = match remote.try_attach_pipe_io(surface, Some((cols.max(1), rows.max(1)))) {
+        Ok(PipeIoSurfaceAttach::Attached) => {
+            PipeIoSurfaceHandle { remote: remote.clone(), surface }
+        }
+        Ok(PipeIoSurfaceAttach::Retired) => {
+            return Ok(PipeIoExitReason::TerminalEnded);
+        }
+        Ok(PipeIoSurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
+        Err(error) => return Ok(attach_failure_exit_reason(&error, surface)),
+    };
+    // The daemon resizes a terminal's PTY only for its geometry-authority
+    // client (the full TUI client claims this for its active surface). The
+    // relay is the embedder's only viewer of this terminal, so claim the
+    // authority or every embedder resize is recorded but never applied.
+    if let Err(error) = remote.notify_claim_terminal_geometry(surface) {
+        eprintln!(
+            "{}",
+            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
+        );
+    }
+    spawn_stdin_pump(handle, lifecycle_sender);
+    let reason = pump_events_to_stdout(
+        &receiver,
+        &lifecycle_receiver,
+        &byte_budget,
+        &mut std::io::stdout().lock(),
+    )?;
+    // Stop forwarding while the daemon probe runs. The probe has its own
+    // request path, and events for the finished relay must not fill the data
+    // queue or tear down a replacement transport.
+    drop(tap_guard);
+    if reason == PipeIoExitReason::DaemonLost {
+        return Ok(classify_daemon_loss(remote, socket_path, terminal));
+    }
+    Ok(reason)
+}
+
+/// The pipe-IO relay needs only the remote request path. Keeping this handle
+/// separate from `SurfaceHandle::Remote` prevents the normal local VT mirror
+/// from being created or mutated for a renderer-less attachment.
+#[derive(Clone)]
+struct PipeIoSurfaceHandle {
+    remote: Arc<RemoteSession>,
+    surface: SurfaceId,
+}
+
+impl PipeIoSurfaceHandle {
+    fn write_bytes(&self, bytes: &[u8]) -> anyhow::Result<()> {
+        self.remote.send_bytes(self.surface, bytes)
+    }
+
+    fn resize(&self, cols: u16, rows: u16) -> anyhow::Result<bool> {
+        self.remote.resize_pipe_io(self.surface, cols, rows)
+    }
+}
+
+struct PipeIoTapGuard<'a> {
+    remote: &'a RemoteSession,
+    token: Arc<u8>,
+}
+
+impl Drop for PipeIoTapGuard<'_> {
+    fn drop(&mut self) {
+        self.remote.clear_pipe_io_tap(&self.token);
+    }
+}
+
+fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
+    // A rejected attach naming this exact surface means the terminal ended
+    // between the tree lookup and the attach request. Every other failure is
+    // reported as retryable daemon loss so the embedder receives the normal
+    // final JSON record and exit code.
+    if is_remote_surface_unavailable(error, surface) {
+        PipeIoExitReason::TerminalEnded
+    } else {
+        PipeIoExitReason::DaemonLost
+    }
+}
+
+/// The stream ended without a terminal-exit event, but "stream lost" covers
+/// two situations the embedder must tell apart: the daemon really is
+/// unreachable (respawn until it returns), or the terminal was closed and
+/// the daemon tore the scoped stream down before the exit event reached us
+/// (never respawn). One bounded probe of the daemon resolves it: prefer the
+/// existing connection, and fall back to a fresh connect when the socket
+/// died with the stream.
+fn classify_daemon_loss(
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+) -> PipeIoExitReason {
+    let deadline = Instant::now() + DAEMON_LOSS_PROBE_TIMEOUT;
+    let terminal_still_exists = remote
+        .refresh_tree_until(deadline)
+        .ok()
+        .map(|tree| tree.resolve_terminal(terminal).is_some())
+        .or_else(|| {
+            let probe =
+                RemoteSession::connect_for_terminal_attach_until(socket_path, deadline).ok()?;
+            let tree = probe.refresh_tree_until(deadline).ok()?;
+            Some(tree.resolve_terminal(terminal).is_some())
+        });
+    match terminal_still_exists {
+        Some(false) => PipeIoExitReason::TerminalEnded,
+        Some(true) | None => PipeIoExitReason::DaemonLost,
+    }
+}
+
+fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::Result<usize> {
+    line.clear();
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(line.len());
+        }
+        let (chunk_len, has_newline) = match available.iter().position(|byte| *byte == b'\n') {
+            Some(index) => (index + 1, true),
+            None => (available.len(), false),
+        };
+        if line.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes"),
+            ));
+        }
+        let chunk = &available[..chunk_len];
+        let text = std::str::from_utf8(chunk)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        line.push_str(text);
+        reader.consume(chunk_len);
+        if has_newline {
+            return Ok(line.len());
+        }
+    }
+}
+
+/// Forwards embedder requests from stdin until EOF, then reports the closed
+/// parent through the shared event queue.
+fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+    std::thread::Builder::new()
+        .name("pipe-io-stdin".into())
+        .spawn(move || {
+            let stdin = std::io::stdin();
+            let mut reader = stdin.lock();
+            let mut line = String::new();
+            loop {
+                let Ok(bytes_read) = read_pipe_io_line(&mut reader, &mut line) else { break };
+                if bytes_read == 0 {
+                    break;
+                }
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_request(&line) {
+                    Ok(PipeIoRequest::Input(bytes)) => {
+                        if handle.write_bytes(&bytes).is_err() {
+                            // The transport owns loss reporting; input can
+                            // only stop early.
+                            break;
+                        }
+                    }
+                    Ok(PipeIoRequest::Resize { cols, rows }) => {
+                        // Diagnostics only; the exit JSON stays the final
+                        // stderr line and embedders skip lines without an
+                        // "exit" key.
+                        match handle.resize(cols, rows) {
+                            Ok(accepted) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                                })
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::ClaimGeometry) => {
+                        // Claims only establish ownership. Enqueue them on
+                        // the same ordered writer as input so a claim cannot
+                        // overtake the keystroke that follows it, and avoid a
+                        // new blocking thread for every claim.
+                        match handle.remote.notify_claim_terminal_geometry(handle.surface) {
+                            Ok(()) => eprintln!(
+                                "{}",
+                                serde_json::json!({"diag": {"claim": {"accepted": true}}})
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"claim": {"error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::Unknown) => {}
+                    // A malformed line means the embedder side is broken;
+                    // stop consuming rather than misinterpreting input.
+                    Err(_) => break,
+                }
+            }
+            // Lifecycle has its own one-slot channel, so a full byte queue
+            // cannot delay the parent-close signal.
+            let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+        })
+        .expect("spawn pipe-io stdin pump");
+}
+
+fn pump_events_to_stdout(
+    receiver: &Receiver<PipeIoEvent>,
+    lifecycle_receiver: &Receiver<PipeIoEvent>,
+    byte_budget: &PipeIoByteBudget,
+    stdout: &mut impl Write,
+) -> anyhow::Result<PipeIoExitReason> {
+    let mut emitted_output = false;
+    loop {
+        // Lifecycle signals have a separate bounded channel, so a full byte
+        // queue cannot delay or drop a transport-loss notification.
+        let event = crossbeam_channel::select_biased! {
+            recv(lifecycle_receiver) -> event => {
+                match event {
+                    Ok(PipeIoEvent::SurfaceExited) => {
+                        // Lifecycle signals use a separate channel, so a
+                        // surface-exit notification can overtake bytes that
+                        // the reader already queued. Drain those committed
+                        // bytes before preserving the terminal's final frame.
+                        // Transport loss has different semantics: queued
+                        // bytes are stale and must be discarded.
+                        while let Ok(event) = receiver.try_recv() {
+                            byte_budget.release(event.retained_bytes());
+                            match event {
+                                PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+                                    if write_pipe_io_data(
+                                        &event,
+                                        &mut emitted_output,
+                                        stdout,
+                                    )
+                                    .is_err()
+                                    {
+                                        return Ok(PipeIoExitReason::ParentClosed);
+                                    }
+                                }
+                                PipeIoEvent::SurfaceExited => {
+                                    break;
+                                }
+                                PipeIoEvent::TransportLost => {
+                                    return Ok(PipeIoExitReason::DaemonLost);
+                                }
+                                PipeIoEvent::StdinClosed => {
+                                    return Ok(PipeIoExitReason::ParentClosed);
+                                }
+                            }
+                        }
+                        return Ok(PipeIoExitReason::TerminalEnded);
+                    }
+                    Ok(PipeIoEvent::TransportLost) => {
+                        return Ok(PipeIoExitReason::DaemonLost);
+                    }
+                    Ok(PipeIoEvent::StdinClosed) => {
+                        return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                    Ok(PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_)) => {
+                        // Lifecycle senders never carry byte events. Ignore a
+                        // malformed producer rather than violating framing.
+                        continue;
+                    }
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
+            recv(receiver) -> event => {
+                match event {
+                    Ok(event) => event,
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
+        };
+        byte_budget.release(event.retained_bytes());
+        let write_result = match &event {
+            PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+                write_pipe_io_data(&event, &mut emitted_output, stdout)
+            }
+            PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
+            PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
+            PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
+        };
+        if write_result.is_err() {
+            // stdout is the embedder; a failed write means it is gone.
+            return Ok(PipeIoExitReason::ParentClosed);
+        }
+    }
+}
+
+fn write_pipe_io_data(
+    event: &PipeIoEvent,
+    emitted_output: &mut bool,
+    stdout: &mut impl Write,
+) -> std::io::Result<()> {
+    match event {
+        PipeIoEvent::Replay { bytes } => {
+            if *emitted_output {
+                stdout.write_all(REPLAY_RESET)?;
+            }
+            stdout.write_all(bytes)?;
+            stdout.flush()?;
+        }
+        PipeIoEvent::Output(bytes) => {
+            stdout.write_all(bytes)?;
+            stdout.flush()?;
+        }
+        PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost | PipeIoEvent::StdinClosed => {
+            debug_assert!(false, "lifecycle event passed to byte writer");
+        }
+    }
+    *emitted_output = true;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn replay(bytes: &[u8]) -> PipeIoEvent {
+        PipeIoEvent::Replay { bytes: bytes.to_vec() }
+    }
+
+    #[test]
+    fn parse_request_decodes_input_resize_and_ignores_unknown_verbs() {
+        assert_eq!(
+            parse_request(r#"{"input":"aGk="}"#).unwrap(),
+            PipeIoRequest::Input(b"hi".to_vec())
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":100,"rows":30}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 100, rows: 30 }
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":0,"rows":0}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 1, rows: 1 }
+        );
+        assert_eq!(parse_request(r#"{"future-verb":true}"#).unwrap(), PipeIoRequest::Unknown);
+        assert!(parse_request("not json").is_err());
+        assert!(parse_request(r#"{"input":"@@not-base64@@"}"#).is_err());
+        assert!(parse_request(r#"{"resize":{"cols":100}}"#).is_err());
+    }
+
+    #[test]
+    fn parse_request_rejects_oversized_lines_and_input_before_decoding() {
+        let oversized_line = " ".repeat(MAX_PIPE_IO_LINE_BYTES + 1);
+        let error = parse_request(&oversized_line).unwrap_err().to_string();
+        assert!(error.contains("request line exceeds"), "{error}");
+
+        let oversized_base64 = "A".repeat(MAX_PIPE_IO_BASE64_BYTES + 4);
+        let line = format!(r#"{{"input":"{oversized_base64}"}}"#);
+        let error = parse_request(&line).unwrap_err().to_string();
+        assert!(error.contains("input exceeds"), "{error}");
+    }
+
+    #[test]
+    fn exit_reasons_map_to_the_respawn_contract() {
+        assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
+        assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
+        assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
+        assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+    }
+
+    #[test]
+    fn stdout_pump_prefixes_only_non_initial_replays_with_a_full_reset() {
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        sender.send(replay(b"FIRST")).unwrap();
+        sender.send(PipeIoEvent::Output(b"live".to_vec())).unwrap();
+        sender.send(replay(b"SECOND")).unwrap();
+        sender.send(PipeIoEvent::SurfaceExited).unwrap();
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        let reason =
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        let mut expected = b"FIRSTlive".to_vec();
+        expected.extend_from_slice(REPLAY_RESET);
+        expected.extend_from_slice(b"SECOND");
+        assert_eq!(stdout, expected);
+    }
+
+    #[test]
+    fn stdout_pump_maps_lifecycle_events_to_exit_reasons() {
+        for (event, expected) in [
+            (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
+            (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
+        ] {
+            let (sender, receiver) = crossbeam_channel::bounded(8);
+            let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            sender.send(event).unwrap();
+            let mut stdout = Vec::new();
+            let budget = PipeIoByteBudget::new(1024);
+            assert_eq!(
+                pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout)
+                    .unwrap(),
+                expected
+            );
+            assert!(stdout.is_empty());
+        }
+        // Sender dropped without any event: the session vanished wholesale.
+        let (sender, receiver) = crossbeam_channel::bounded::<PipeIoEvent>(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        drop(sender);
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+    }
+
+    #[test]
+    fn stdout_pump_prioritizes_a_transport_loss_over_queued_bytes() {
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        sender.send(PipeIoEvent::Output(b"stale".to_vec())).unwrap();
+        lifecycle_sender.send(PipeIoEvent::TransportLost).unwrap();
+
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+        assert!(stdout.is_empty(), "stale bytes must not be emitted after transport loss");
+    }
+
+    #[test]
+    fn stdout_pump_drains_committed_bytes_before_surface_exit() {
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let budget = PipeIoByteBudget::new(1024);
+        assert!(budget.try_reserve(5));
+        sender.send(replay(b"FINAL")).unwrap();
+        lifecycle_sender.send(PipeIoEvent::SurfaceExited).unwrap();
+
+        let mut stdout = Vec::new();
+        let reason =
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        assert_eq!(stdout, b"FINAL");
+    }
+
+    #[test]
+    fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
+        let terminal_ended =
+            crate::session::test_remote_rejected_error_with_message("unknown surface 7");
+        assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
+
+        let daemon_lost = crate::session::test_remote_transport_error();
+        assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
+
+        let unexpected = anyhow::anyhow!("attach capability negotiation failed");
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -209,6 +209,11 @@ pub fn run(
             "{}",
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
         );
+        // Continuing without geometry authority would make later resize
+        // requests look accepted while the daemon keeps the wrong PTY size.
+        // Classify the startup failure so the embedder can either stop for a
+        // retired terminal or reconnect after a lost daemon transport.
+        return Ok(attach_failure_exit_reason(&error, surface));
     }
     spawn_stdin_pump(handle, lifecycle_sender);
     let reason = pump_events_to_stdout(

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -57,29 +57,6 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Serializes diagnostics with the final exit record. The stdin pump can be
-/// blocked in a read when the relay ends, so joining it is not a safe way to
-/// establish ordering. Closing this gate makes later diagnostics no-ops while
-/// allowing an in-flight diagnostic to finish before the final record is
-/// written by the parent.
-#[derive(Default)]
-struct StderrGate(Mutex<bool>);
-
-impl StderrGate {
-    fn close(&self) {
-        *self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
-    }
-
-    fn diag(&self, value: serde_json::Value) {
-        let closed = self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        if *closed {
-            return;
-        }
-        eprintln!("{value}");
-        let _ = std::io::stderr().flush();
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -229,7 +206,7 @@ pub fn run(
     // client (the full TUI client claims this for its active surface). The
     // relay is the embedder's only viewer of this terminal, so claim the
     // authority or every embedder resize is recorded but never applied.
-    if let Err(error) = remote.notify_claim_terminal_geometry(surface) {
+    if let Err(error) = remote.claim_terminal_geometry(surface) {
         eprintln!(
             "{}",
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
@@ -248,8 +225,7 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let stderr_gate = Arc::new(StderrGate::default());
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -266,10 +242,6 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
-    // The stdin pump may still be blocked in read(2). Close the diagnostic
-    // gate before returning so the parent can write the final exit record
-    // without a late resize/claim diagnostic racing it.
-    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -386,7 +358,6 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
-    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -395,7 +366,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -405,7 +376,6 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
-    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -446,12 +416,8 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                    })),
+                    Ok(_accepted) => {}
+                    Err(_error) => {}
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -464,12 +430,8 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => {
-                        stderr_gate.diag(serde_json::json!({"diag": {"claim": {"accepted": true}}}))
-                    }
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"error": error.to_string()}}
-                    })),
+                    Ok(()) => (),
+                    Err(_error) => (),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -747,9 +709,8 @@ mod tests {
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
-        let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -761,8 +722,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            let stderr_gate = StderrGate::default();
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -327,9 +327,15 @@ fn classify_daemon_loss(
 
 fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::Result<usize> {
     line.clear();
+    let mut bytes = Vec::new();
     loop {
         let available = reader.fill_buf()?;
         if available.is_empty() {
+            if bytes.is_empty() {
+                return Ok(0);
+            }
+            *line = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
         let (chunk_len, has_newline) = match available.iter().position(|byte| *byte == b'\n') {
@@ -343,11 +349,11 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
             ));
         }
         let chunk = &available[..chunk_len];
-        let text = std::str::from_utf8(chunk)
-            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
-        line.push_str(text);
+        bytes.extend_from_slice(chunk);
         reader.consume(chunk_len);
         if has_newline {
+            *line = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -63,6 +63,7 @@ pub enum PipeIoExitReason {
     TerminalEnded,
     DaemonLost,
     ParentClosed,
+    SetupFailed,
 }
 
 impl PipeIoExitReason {
@@ -71,12 +72,13 @@ impl PipeIoExitReason {
             Self::TerminalEnded => "terminal-ended",
             Self::DaemonLost => "daemon-lost",
             Self::ParentClosed => "parent-closed",
+            Self::SetupFailed => "setup-failed",
         }
     }
 
     pub fn exit_code(self) -> i32 {
         match self {
-            Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
+            Self::TerminalEnded | Self::ParentClosed | Self::SetupFailed => EXIT_DO_NOT_RESPAWN,
             Self::DaemonLost => EXIT_DAEMON_LOST,
         }
     }
@@ -215,7 +217,17 @@ pub fn run(
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
     }
-    spawn_stdin_pump(handle, lifecycle_sender);
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+        Ok(pump) => pump,
+        Err(error) => {
+            eprintln!(
+                "{}",
+                serde_json::json!({"diag": {"stdin-pump": {"error": error.to_string()}}})
+            );
+            drop(tap_guard);
+            return Ok(PipeIoExitReason::SetupFailed);
+        }
+    };
     let reason = pump_events_to_stdout(
         &receiver,
         &lifecycle_receiver,
@@ -264,13 +276,15 @@ impl Drop for PipeIoTapGuard<'_> {
 
 fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
     // A rejected attach naming this exact surface means the terminal ended
-    // between the tree lookup and the attach request. Every other failure is
-    // reported as retryable daemon loss so the embedder receives the normal
-    // final JSON record and exit code.
+    // between the tree lookup and the attach request. Only confirmed
+    // transport failures are retryable; capability and protocol failures
+    // must stop without asking the embedder to respawn forever.
     if is_remote_surface_unavailable(error, surface) {
         PipeIoExitReason::TerminalEnded
-    } else {
+    } else if crate::session::is_pipe_io_retryable_error(error) {
         PipeIoExitReason::DaemonLost
+    } else {
+        PipeIoExitReason::SetupFailed
     }
 }
 
@@ -333,7 +347,10 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 
 /// Forwards embedder requests from stdin until EOF, then reports the closed
 /// parent through the shared event queue.
-fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+fn spawn_stdin_pump(
+    handle: PipeIoSurfaceHandle,
+    lifecycle_sender: Sender<PipeIoEvent>,
+) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
     std::thread::Builder::new()
@@ -343,7 +360,7 @@ fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIo
             let mut reader = stdin.lock();
             run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
-        .expect("spawn pipe-io stdin pump");
+        .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
 
 fn run_stdin_pump(
@@ -576,10 +593,12 @@ mod tests {
     fn exit_reasons_map_to_the_respawn_contract() {
         assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::SetupFailed.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
         assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
         assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
         assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+        assert_eq!(PipeIoExitReason::SetupFailed.as_str(), "setup-failed");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -28,14 +28,14 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
-use cmux_tui_core::resource::TerminalPublicId;
 use cmux_tui_core::SurfaceId;
+use cmux_tui_core::resource::TerminalPublicId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
 use crate::session::{
-    is_remote_surface_unavailable, PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach,
-    RemoteSession,
+    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
+    is_remote_surface_unavailable,
 };
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
@@ -239,6 +239,14 @@ pub fn run(
         // Classify the startup failure so the embedder can either stop for a
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
+    }
+    // Older daemons do not accept geometry in the attach request. Apply the
+    // requested initial size explicitly after claiming authority so the
+    // first replay uses the embedder's dimensions on that compatibility path.
+    if !remote.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY) {
+        if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
+            return Ok(attach_failure_exit_reason(&error, surface));
+        }
     }
     let stderr_gate = Arc::new(StderrGate::default());
     let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -517,6 +517,9 @@ fn write_pipe_io_data(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+    use std::sync::{Weak, mpsc};
+
     use super::*;
 
     fn replay(bytes: &[u8]) -> PipeIoEvent {
@@ -644,6 +647,16 @@ mod tests {
             pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
         assert_eq!(reason, PipeIoExitReason::TerminalEnded);
         assert_eq!(stdout, b"FINAL");
+    }
+
+    #[test]
+    fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
+        let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
+        let mut input = Cursor::new(br#"{"input":"aGk="}\n"#.to_vec());
+
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -334,76 +334,90 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 /// Forwards embedder requests from stdin until EOF, then reports the closed
 /// parent through the shared event queue.
 fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+    let remote = Arc::downgrade(&handle.remote);
+    let surface = handle.surface;
     std::thread::Builder::new()
         .name("pipe-io-stdin".into())
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            let mut line = String::new();
-            loop {
-                let Ok(bytes_read) = read_pipe_io_line(&mut reader, &mut line) else { break };
-                if bytes_read == 0 {
-                    break;
-                }
-                if line.trim().is_empty() {
-                    continue;
-                }
-                match parse_request(&line) {
-                    Ok(PipeIoRequest::Input(bytes)) => {
-                        if handle.write_bytes(&bytes).is_err() {
-                            // The transport owns loss reporting; input can
-                            // only stop early.
-                            break;
-                        }
-                    }
-                    Ok(PipeIoRequest::Resize { cols, rows }) => {
-                        // Diagnostics only; the exit JSON stays the final
-                        // stderr line and embedders skip lines without an
-                        // "exit" key.
-                        match handle.resize(cols, rows) {
-                            Ok(accepted) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                                })
-                            ),
-                            Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                                })
-                            ),
-                        }
-                    }
-                    Ok(PipeIoRequest::ClaimGeometry) => {
-                        // Claims only establish ownership. Enqueue them on
-                        // the same ordered writer as input so a claim cannot
-                        // overtake the keystroke that follows it, and avoid a
-                        // new blocking thread for every claim.
-                        match handle.remote.notify_claim_terminal_geometry(handle.surface) {
-                            Ok(()) => eprintln!(
-                                "{}",
-                                serde_json::json!({"diag": {"claim": {"accepted": true}}})
-                            ),
-                            Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"claim": {"error": error.to_string()}}
-                                })
-                            ),
-                        }
-                    }
-                    Ok(PipeIoRequest::Unknown) => {}
-                    // A malformed line means the embedder side is broken;
-                    // stop consuming rather than misinterpreting input.
-                    Err(_) => break,
-                }
-            }
-            // Lifecycle has its own one-slot channel, so a full byte queue
-            // cannot delay the parent-close signal.
-            let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .expect("spawn pipe-io stdin pump");
+}
+
+fn run_stdin_pump(
+    reader: &mut impl BufRead,
+    remote: &Weak<RemoteSession>,
+    surface: SurfaceId,
+    lifecycle_sender: &Sender<PipeIoEvent>,
+) {
+    let mut line = String::new();
+    loop {
+        let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
+        if bytes_read == 0 {
+            break;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        match parse_request(&line) {
+            Ok(PipeIoRequest::Input(bytes)) => {
+                let Some(remote) = remote.upgrade() else { break };
+                let handle = PipeIoSurfaceHandle { remote, surface };
+                if handle.write_bytes(&bytes).is_err() {
+                    // The transport owns loss reporting; input can only stop
+                    // early.
+                    break;
+                }
+            }
+            Ok(PipeIoRequest::Resize { cols, rows }) => {
+                let Some(remote) = remote.upgrade() else { break };
+                let handle = PipeIoSurfaceHandle { remote, surface };
+                // Diagnostics only; the exit JSON stays the final stderr line
+                // and embedders skip lines without an "exit" key.
+                match handle.resize(cols, rows) {
+                    Ok(accepted) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                        })
+                    ),
+                    Err(error) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                        })
+                    ),
+                }
+            }
+            Ok(PipeIoRequest::ClaimGeometry) => {
+                let Some(remote) = remote.upgrade() else { break };
+                // Claims only establish ownership. Enqueue them on the same
+                // ordered writer as input so a claim cannot overtake the
+                // keystroke that follows it, and avoid a new blocking thread
+                // for every claim.
+                match remote.notify_claim_terminal_geometry(surface) {
+                    Ok(()) => {
+                        eprintln!("{}", serde_json::json!({"diag": {"claim": {"accepted": true}}}))
+                    }
+                    Err(error) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"claim": {"error": error.to_string()}}
+                        })
+                    ),
+                }
+            }
+            Ok(PipeIoRequest::Unknown) => {}
+            // A malformed line means the embedder side is broken; stop
+            // consuming rather than misinterpreting input.
+            Err(_) => break,
+        }
+    }
+    // Lifecycle has its own one-slot channel, so a full byte queue cannot
+    // delay the parent-close signal.
+    let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
 }
 
 fn pump_events_to_stdout(
@@ -652,7 +666,7 @@ mod tests {
     #[test]
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
-        let mut input = Cursor::new(br#"{"input":"aGk="}\n"#.to_vec());
+        let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
         run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,10 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Weak};
+use std::sync::{
+    Arc, Mutex, Weak,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -57,6 +60,38 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Diagnostics are best-effort. A blocked stderr pipe must never hold relay
+/// finalization, so writers use a non-blocking lock and drop the record when
+/// another diagnostic is still being written.
+struct StderrGate {
+    closed: AtomicBool,
+    writer: Mutex<()>,
+}
+
+impl Default for StderrGate {
+    fn default() -> Self {
+        Self { closed: AtomicBool::new(false), writer: Mutex::new(()) }
+    }
+}
+
+impl StderrGate {
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    fn diag(&self, value: serde_json::Value) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        let Ok(_guard) = self.writer.try_lock() else { return };
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        eprintln!("{value}");
+        let _ = std::io::stderr().flush();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -225,7 +260,8 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+    let stderr_gate = Arc::new(StderrGate::default());
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -242,6 +278,7 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
+    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -342,7 +379,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
             Some(index) => (index + 1, true),
             None => (available.len(), false),
         };
-        if line.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
+        if bytes.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes"),
@@ -364,6 +401,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -372,7 +410,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -382,6 +420,7 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -422,8 +461,12 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(_accepted) => {}
-                    Err(_error) => {}
+                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -436,8 +479,12 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => (),
-                    Err(_error) => (),
+                    Ok(()) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"accepted": true}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -716,7 +763,7 @@ mod tests {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -728,7 +775,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -370,6 +370,7 @@ fn run_stdin_pump(
     lifecycle_sender: &Sender<PipeIoEvent>,
 ) {
     let mut line = String::new();
+    let mut stop_event = None;
     loop {
         let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
         if bytes_read == 0 {
@@ -380,16 +381,23 @@ fn run_stdin_pump(
         }
         match parse_request(&line) {
             Ok(PipeIoRequest::Input(bytes)) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 let handle = PipeIoSurfaceHandle { remote, surface };
                 if handle.write_bytes(&bytes).is_err() {
                     // The transport owns loss reporting; input can only stop
                     // early.
+                    stop_event = Some(PipeIoEvent::TransportLost);
                     break;
                 }
             }
             Ok(PipeIoRequest::Resize { cols, rows }) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 let handle = PipeIoSurfaceHandle { remote, surface };
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
@@ -409,7 +417,10 @@ fn run_stdin_pump(
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 // Claims only establish ownership. Enqueue them on the same
                 // ordered writer as input so a claim cannot overtake the
                 // keystroke that follows it, and avoid a new blocking thread
@@ -429,12 +440,16 @@ fn run_stdin_pump(
             Ok(PipeIoRequest::Unknown) => {}
             // A malformed line means the embedder side is broken; stop
             // consuming rather than misinterpreting input.
-            Err(_) => break,
+            Err(_) => {
+                stop_event = Some(PipeIoEvent::StdinError);
+                break;
+            }
         }
     }
     // Lifecycle has its own one-slot channel, so a full byte queue cannot
-    // delay the parent-close signal.
-    let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+    // delay the parent-close or failure signal. Only actual stdin EOF maps to
+    // StdinClosed; transport and protocol failures keep their own reason.
+    let _ = lifecycle_sender.send(stop_event.unwrap_or(PipeIoEvent::StdinClosed));
 }
 
 fn pump_events_to_stdout(
@@ -480,6 +495,9 @@ fn pump_events_to_stdout(
                                 PipeIoEvent::StdinClosed => {
                                     return Ok(PipeIoExitReason::ParentClosed);
                                 }
+                                PipeIoEvent::StdinError => {
+                                    return Ok(PipeIoExitReason::SetupFailed);
+                                }
                             }
                         }
                         return Ok(PipeIoExitReason::TerminalEnded);
@@ -489,6 +507,9 @@ fn pump_events_to_stdout(
                     }
                     Ok(PipeIoEvent::StdinClosed) => {
                         return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                    Ok(PipeIoEvent::StdinError) => {
+                        return Ok(PipeIoExitReason::SetupFailed);
                     }
                     Ok(PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_)) => {
                         // Lifecycle senders never carry byte events. Ignore a
@@ -513,6 +534,7 @@ fn pump_events_to_stdout(
             PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
             PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
             PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
+            PipeIoEvent::StdinError => return Ok(PipeIoExitReason::SetupFailed),
         };
         if write_result.is_err() {
             // stdout is the embedder; a failed write means it is gone.
@@ -538,7 +560,10 @@ fn write_pipe_io_data(
             stdout.write_all(bytes)?;
             stdout.flush()?;
         }
-        PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost | PipeIoEvent::StdinClosed => {
+        PipeIoEvent::SurfaceExited
+        | PipeIoEvent::TransportLost
+        | PipeIoEvent::StdinClosed
+        | PipeIoEvent::StdinError => {
             debug_assert!(false, "lifecycle event passed to byte writer");
         }
     }
@@ -549,7 +574,7 @@ fn write_pipe_io_data(
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
-    use std::sync::{Weak, mpsc};
+    use std::sync::Weak;
 
     use super::*;
 
@@ -625,6 +650,7 @@ mod tests {
         for (event, expected) in [
             (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
             (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
+            (PipeIoEvent::StdinError, PipeIoExitReason::SetupFailed),
         ] {
             let (sender, receiver) = crossbeam_channel::bounded(8);
             let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
@@ -684,12 +710,12 @@ mod tests {
 
     #[test]
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
-        let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
         run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
-        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
 
     #[test]
@@ -702,6 +728,6 @@ mod tests {
         assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
 
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
-        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::SetupFailed);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,10 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{
-    Arc, Mutex, Weak,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -60,38 +57,6 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Diagnostics are best-effort. A blocked stderr pipe must never hold relay
-/// finalization, so writers use a non-blocking lock and drop the record when
-/// another diagnostic is still being written.
-struct StderrGate {
-    closed: AtomicBool,
-    writer: Mutex<()>,
-}
-
-impl Default for StderrGate {
-    fn default() -> Self {
-        Self { closed: AtomicBool::new(false), writer: Mutex::new(()) }
-    }
-}
-
-impl StderrGate {
-    fn close(&self) {
-        self.closed.store(true, Ordering::Release);
-    }
-
-    fn diag(&self, value: serde_json::Value) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        let Ok(_guard) = self.writer.try_lock() else { return };
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        eprintln!("{value}");
-        let _ = std::io::stderr().flush();
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -260,8 +225,7 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let stderr_gate = Arc::new(StderrGate::default());
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -278,7 +242,6 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
-    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -401,7 +364,6 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
-    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -410,7 +372,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -420,7 +382,6 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
-    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -461,12 +422,8 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                    })),
+                    Ok(_accepted) => {}
+                    Err(_error) => {}
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -479,12 +436,8 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"accepted": true}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"error": error.to_string()}}
-                    })),
+                    Ok(()) => (),
+                    Err(_error) => (),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -763,7 +716,7 @@ mod tests {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -775,7 +728,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,18 +24,18 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
-use cmux_tui_core::SurfaceId;
 use cmux_tui_core::resource::TerminalPublicId;
+use cmux_tui_core::SurfaceId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
 use crate::session::{
-    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
-    is_remote_surface_unavailable,
+    is_remote_surface_unavailable, PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach,
+    RemoteSession,
 };
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
@@ -57,6 +57,29 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Serializes diagnostics with the final exit record. The stdin pump can be
+/// blocked in a read when the relay ends, so joining it is not a safe way to
+/// establish ordering. Closing this gate makes later diagnostics no-ops while
+/// allowing an in-flight diagnostic to finish before the final record is
+/// written by the parent.
+#[derive(Default)]
+struct StderrGate(Mutex<bool>);
+
+impl StderrGate {
+    fn close(&self) {
+        *self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+    }
+
+    fn diag(&self, value: serde_json::Value) {
+        let closed = self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *closed {
+            return;
+        }
+        eprintln!("{value}");
+        let _ = std::io::stderr().flush();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -217,7 +240,8 @@ pub fn run(
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
     }
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+    let stderr_gate = Arc::new(StderrGate::default());
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -234,6 +258,10 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
+    // The stdin pump may still be blocked in read(2). Close the diagnostic
+    // gate before returning so the parent can write the final exit record
+    // without a late resize/claim diagnostic racing it.
+    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -350,6 +378,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -358,7 +387,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -368,11 +397,18 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
     loop {
-        let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
+        let bytes_read = match read_pipe_io_line(reader, &mut line) {
+            Ok(bytes_read) => bytes_read,
+            Err(_) => {
+                stop_event = Some(PipeIoEvent::StdinError);
+                break;
+            }
+        };
         if bytes_read == 0 {
             break;
         }
@@ -402,18 +438,12 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                        })
-                    ),
-                    Err(error) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                        })
-                    ),
+                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -427,14 +457,11 @@ fn run_stdin_pump(
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
                     Ok(()) => {
-                        eprintln!("{}", serde_json::json!({"diag": {"claim": {"accepted": true}}}))
+                        stderr_gate.diag(serde_json::json!({"diag": {"claim": {"accepted": true}}}))
                     }
-                    Err(error) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"claim": {"error": error.to_string()}}
-                        })
-                    ),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -712,10 +739,24 @@ mod tests {
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
+        let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
+    }
+
+    #[test]
+    fn stdin_pump_reports_line_read_errors_as_stdin_errors() {
+        let inputs =
+            vec![b"{\"input\":\"aGk=\"}\n\xff".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
+        for input in inputs {
+            let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            let mut input = Cursor::new(input.to_vec());
+            let stderr_gate = StderrGate::default();
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+            assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pty_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/pty_input.rs
@@ -19,7 +19,8 @@ use crate::session::{SurfaceHandle, is_remote_timeout, is_remote_transport_failu
 
 pub(crate) const PTY_OPERATION_QUEUE_CAPACITY: usize = 512;
 pub(crate) const TERMINAL_EXITED_LABEL: &str = "terminal exited";
-const MAX_QUEUED_BYTES: usize = 4 * 1024 * 1024;
+pub(crate) const PTY_INPUT_MAX_BYTES: usize = 4 * 1024 * 1024;
+const MAX_QUEUED_BYTES: usize = PTY_INPUT_MAX_BYTES;
 const MAX_CONCURRENT_SURFACE_OPERATIONS: usize = 32;
 const RESERVED_RELEASE_BYTES: usize = 64;
 const REMOTE_RELEASE_MAX_ATTEMPTS: u8 = 3;

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -35,9 +35,10 @@ use ghostty_vt::{
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
+pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach};
 pub use remote::{
-    RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface, RemoteTransport,
-    RemoteTransportAbort,
+    PipeIoEvent, RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface,
+    RemoteTransport, RemoteTransportAbort,
 };
 pub use tree::{TabNotificationView, TreeView, WorkspaceView};
 

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -35,7 +35,7 @@ use ghostty_vt::{
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
-pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach};
+pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach, is_pipe_io_retryable_error};
 pub use remote::{
     PipeIoEvent, RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface,
     RemoteTransport, RemoteTransportAbort,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8,7 +8,7 @@ use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
-use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -1279,6 +1279,51 @@ impl WorkerCompletion {
         }
         *done
     }
+
+    fn is_done(&self) -> bool {
+        *self.done.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn wait_forever(&self) {
+        let mut done = self.done.lock().unwrap_or_else(|poison| poison.into_inner());
+        while !*done {
+            done = self.changed.wait(done).unwrap_or_else(|poison| poison.into_inner());
+        }
+    }
+}
+
+fn enqueue_worker_reap(
+    handle: std::thread::JoinHandle<()>,
+    completion: Arc<WorkerCompletion>,
+) -> Result<(), std::thread::JoinHandle<()>> {
+    type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
+    static REAPER: OnceLock<std::sync::mpsc::SyncSender<ReapRequest>> = OnceLock::new();
+    let sender = REAPER.get_or_init(|| {
+        let (sender, receiver) = std::sync::mpsc::sync_channel::<ReapRequest>(64);
+        let Ok(_) =
+            std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
+                while let Ok((handle, completion)) = receiver.recv() {
+                    completion.wait_forever();
+                    let _ = handle.join();
+                }
+            })
+        else {
+            return sender;
+        };
+        sender
+    });
+    try_enqueue_worker_reap(sender, handle, completion)
+}
+
+fn try_enqueue_worker_reap(
+    sender: &std::sync::mpsc::SyncSender<(std::thread::JoinHandle<()>, Arc<WorkerCompletion>)>,
+    handle: std::thread::JoinHandle<()>,
+    completion: Arc<WorkerCompletion>,
+) -> Result<(), std::thread::JoinHandle<()>> {
+    sender.try_send((handle, completion)).map_err(|error| match error {
+        std::sync::mpsc::TrySendError::Full((handle, _))
+        | std::sync::mpsc::TrySendError::Disconnected((handle, _)) => handle,
+    })
 }
 
 struct WorkerCompletionGuard(Arc<WorkerCompletion>);
@@ -1473,9 +1518,36 @@ impl InteractiveWriter {
         if let Some(handle) = handle {
             if self.shared.worker_completion.wait(remote_write_timeout()) {
                 let _ = handle.join();
-            } else {
+            } else if let Err(handle) =
+                enqueue_worker_reap(handle, self.shared.worker_completion.clone())
+            {
                 *self.worker.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(handle);
             }
+        }
+    }
+
+    fn join_worker_if_done(&self) {
+        let current = std::thread::current().id();
+        let handle = {
+            let mut worker = self.worker.lock().unwrap_or_else(|poison| poison.into_inner());
+            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                return;
+            }
+            let Some(handle) = worker.take() else {
+                return;
+            };
+            if !self.shared.worker_completion.is_done() {
+                if let Err(handle) =
+                    enqueue_worker_reap(handle, self.shared.worker_completion.clone())
+                {
+                    *worker = Some(handle);
+                }
+                return;
+            }
+            Some(handle)
+        };
+        if let Some(handle) = handle {
+            let _ = handle.join();
         }
     }
 
@@ -1506,7 +1578,6 @@ impl InteractiveWriter {
                 "remote writer did not close before its deadline",
             ));
         }
-        self.join_worker();
     }
 }
 
@@ -1521,7 +1592,7 @@ impl Drop for InteractiveWriter {
                 "remote writer owner was dropped",
             ));
         }
-        self.join_worker();
+        self.join_worker_if_done();
     }
 }
 
@@ -3067,6 +3138,7 @@ impl RemoteSession {
         self.begin_shutdown();
         self.interactive_writer.close();
         self.interactive_writer.abort_transport();
+        self.interactive_writer.join_worker();
         self.join_reader_worker();
     }
 
@@ -3075,6 +3147,7 @@ impl RemoteSession {
         let handle = {
             let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
             if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                worker.take();
                 return;
             }
             worker.take()
@@ -3082,7 +3155,8 @@ impl RemoteSession {
         if let Some(handle) = handle {
             if self.reader_completion.wait(remote_write_timeout()) {
                 let _ = handle.join();
-            } else {
+            } else if let Err(handle) = enqueue_worker_reap(handle, self.reader_completion.clone())
+            {
                 *self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner()) =
                     Some(handle);
             }
@@ -3694,7 +3768,9 @@ fn local_hostname() -> Option<String> {
 
 impl Drop for RemoteSession {
     fn drop(&mut self) {
-        self.disconnect_transport();
+        self.interactive_writer.request_close();
+        self.interactive_writer.abort_transport();
+        self.interactive_writer.join_worker_if_done();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;
         };
@@ -6534,6 +6610,28 @@ mod tests {
         writer_exited_rx
             .recv_timeout(Duration::from_millis(100))
             .expect("transport shutdown must join the writer");
+    }
+
+    #[test]
+    fn worker_reaper_returns_ownership_when_queue_is_saturated() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(0);
+        let completion = Arc::new(WorkerCompletion::new());
+        let handle = std::thread::spawn(|| {});
+        let returned = try_enqueue_worker_reap(&sender, handle, completion)
+            .expect_err("a zero-capacity queue must return the handle");
+        drop(receiver);
+        returned.join().expect("returned worker handle remains joinable");
+    }
+
+    #[test]
+    fn worker_reaper_returns_ownership_when_queue_is_disconnected() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        drop(receiver);
+        let completion = Arc::new(WorkerCompletion::new());
+        let handle = std::thread::spawn(|| {});
+        let returned = try_enqueue_worker_reap(&sender, handle, completion)
+            .expect_err("a disconnected queue must return the handle");
+        returned.join().expect("returned worker handle remains joinable");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7336,6 +7336,21 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_forward_does_not_build_payload_without_matching_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let built = Arc::new(AtomicBool::new(false));
+        let built_by_event = built.clone();
+
+        assert!(!session.pipe_io_forward(7, || {
+            built_by_event.store(true, Ordering::Release);
+            PipeIoEvent::Output(vec![0; 1024])
+        }));
+        assert!(!built.load(Ordering::Acquire));
+    }
+
+    #[test]
     fn stale_pipe_io_tap_cleanup_cannot_remove_a_replacement() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1240,8 +1240,53 @@ struct InteractiveWriterShared {
     state: Mutex<InteractiveWriteQueueState>,
     changed: Condvar,
     metrics: InteractiveWriteMetrics,
+    worker_completion: Arc<WorkerCompletion>,
     #[cfg(test)]
     wait_until_written_gate: Mutex<Option<InteractiveWaitUntilWrittenGate>>,
+}
+
+struct WorkerCompletion {
+    done: Mutex<bool>,
+    changed: Condvar,
+}
+
+impl WorkerCompletion {
+    fn new() -> Self {
+        Self { done: Mutex::new(false), changed: Condvar::new() }
+    }
+
+    fn mark_done(&self) {
+        *self.done.lock().unwrap_or_else(|poison| poison.into_inner()) = true;
+        self.changed.notify_all();
+    }
+
+    fn wait(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut done = self.done.lock().unwrap_or_else(|poison| poison.into_inner());
+        while !*done {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            let (next, timeout) = self
+                .changed
+                .wait_timeout(done, remaining)
+                .unwrap_or_else(|poison| poison.into_inner());
+            done = next;
+            if timeout.timed_out() {
+                break;
+            }
+        }
+        *done
+    }
+}
+
+struct WorkerCompletionGuard(Arc<WorkerCompletion>);
+
+impl Drop for WorkerCompletionGuard {
+    fn drop(&mut self) {
+        self.0.mark_done();
+    }
 }
 
 #[cfg(test)]
@@ -1267,13 +1312,15 @@ impl InteractiveWriter {
             state: Mutex::new(InteractiveWriteQueueState::default()),
             changed: Condvar::new(),
             metrics: InteractiveWriteMetrics::default(),
+            worker_completion: Arc::new(WorkerCompletion::new()),
             #[cfg(test)]
             wait_until_written_gate: Mutex::new(None),
         });
         let worker_shared = shared.clone();
+        let worker_completion = shared.worker_completion.clone();
         let worker = std::thread::Builder::new()
             .name("remote-input-writer".into())
-            .spawn(move || interactive_writer_worker(worker_shared, writer))?;
+            .spawn(move || interactive_writer_worker(worker_shared, writer, worker_completion))?;
         Ok(Self { shared, abort, worker: Mutex::new(Some(worker)) })
     }
 
@@ -1424,7 +1471,11 @@ impl InteractiveWriter {
             worker.take()
         };
         if let Some(handle) = handle {
-            let _ = handle.join();
+            if self.shared.worker_completion.wait(remote_write_timeout()) {
+                let _ = handle.join();
+            } else {
+                *self.worker.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(handle);
+            }
         }
     }
 
@@ -1477,7 +1528,9 @@ impl Drop for InteractiveWriter {
 fn interactive_writer_worker(
     shared: Arc<InteractiveWriterShared>,
     mut writer: Box<dyn RemoteMessageWriter>,
+    worker_completion: Arc<WorkerCompletion>,
 ) {
+    let _completion = WorkerCompletionGuard(worker_completion);
     loop {
         let write = {
             let mut state = shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
@@ -1589,6 +1642,7 @@ enum DisconnectState {
 pub struct RemoteSession {
     interactive_writer: InteractiveWriter,
     reader_worker: Mutex<Option<std::thread::JoinHandle<()>>>,
+    reader_completion: Arc<WorkerCompletion>,
     /// The first terminal state wins. Local shutdown is kept separate from a
     /// reader failure so closing our own transport does not report a fake
     /// remote diagnostic.
@@ -1951,6 +2005,7 @@ impl RemoteSession {
         let session = Arc::new(RemoteSession {
             interactive_writer,
             reader_worker: Mutex::new(None),
+            reader_completion: Arc::new(WorkerCompletion::new()),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
@@ -1983,8 +2038,10 @@ impl RemoteSession {
         });
 
         let reader_session = Arc::downgrade(&session);
+        let reader_completion = session.reader_completion.clone();
         let reader_worker =
             std::thread::Builder::new().name("remote-reader".into()).spawn(move || {
+                let _completion = WorkerCompletionGuard(reader_completion);
                 let mut report_progress = |partial: &[u8]| {
                     if let Some(session) = reader_session.upgrade() {
                         session.report_read_progress(partial);
@@ -3023,7 +3080,12 @@ impl RemoteSession {
             worker.take()
         };
         if let Some(handle) = handle {
-            let _ = handle.join();
+            if self.reader_completion.wait(remote_write_timeout()) {
+                let _ = handle.join();
+            } else {
+                *self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner()) =
+                    Some(handle);
+            }
         }
     }
 
@@ -3940,6 +4002,7 @@ fn test_session_with_writer(
     Arc::new(RemoteSession {
         interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
         reader_worker: Mutex::new(None),
+        reader_completion: Arc::new(WorkerCompletion::new()),
         disconnect_state: Mutex::new(DisconnectState::default()),
         pending: Mutex::new(PendingRemoteRequests::default()),
         next_id: AtomicU64::new(1),
@@ -5183,6 +5246,7 @@ mod tests {
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
             reader_worker: Mutex::new(None),
+            reader_completion: Arc::new(WorkerCompletion::new()),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel}
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use cmux_tui_core::server::{VIEWPORT_COLUMN_RESIZE_CAPABILITY, VIEWPORT_SPLITS_CAPABILITY};
 use cmux_tui_core::{
@@ -236,6 +237,28 @@ impl RemoteRequestError {
             _ => None,
         }
     }
+}
+
+pub(crate) fn is_pipe_io_retryable_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        if let Some(remote_error) = cause.downcast_ref::<RemoteRequestError>() {
+            return remote_error.is_transport_failure() || remote_error.is_timeout();
+        }
+        cause.downcast_ref::<io::Error>().is_some_and(|io_error| {
+            matches!(
+                io_error.kind(),
+                io::ErrorKind::ConnectionRefused
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::UnexpectedEof
+                    | io::ErrorKind::TimedOut
+                    | io::ErrorKind::NotConnected
+                    | io::ErrorKind::WouldBlock
+                    | io::ErrorKind::Interrupted
+                    | io::ErrorKind::NotFound
+            )
+        })
+    })
 }
 
 impl std::fmt::Display for RemoteRequestError {
@@ -2156,9 +2179,8 @@ impl RemoteSession {
     }
 
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
-        let stream = transport::connect(path).map_err(|e| {
-            anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
-        })?;
+        let stream = transport::connect(path)
+            .with_context(|| format!("cannot connect to session socket {}", path.display()))?;
         Self::connect_stream_with_subscription(stream, subscribe)
     }
 
@@ -2178,9 +2200,7 @@ impl RemoteSession {
         {
             Ok(result) => {
                 let _ = connector.join();
-                result.map_err(|error| {
-                    anyhow::anyhow!("cannot connect to session socket {display}: {error}")
-                })?
+                result.with_context(|| format!("cannot connect to session socket {display}"))?
             }
             Err(RecvTimeoutError::Disconnected) => {
                 let _ = connector.join();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6981,6 +6981,25 @@ mod tests {
     }
 
     #[test]
+    fn json_line_reader_preserves_utf8_across_buffer_boundaries() {
+        let input = b"{\"text\":\"\xC3\xA9\"}\n".to_vec();
+        let mut reader = BufReader::with_capacity(1, io::Cursor::new(input));
+        let mut progress = Vec::new();
+
+        let line = read_json_line_with_progress_bounded(
+            &mut reader,
+            &mut |partial| progress.push(partial.to_vec()),
+            64,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(line.as_bytes(), b"{\"text\":\"\xC3\xA9\"}");
+        assert!(progress.iter().any(|partial| partial.ends_with(&[0xC3])));
+        assert_eq!(progress.last().unwrap(), b"{\"text\":\"\xC3\xA9\"}");
+    }
+
+    #[test]
     fn remote_reader_end_reason_distinguishes_eof_from_read_failure() {
         let eof: io::Result<Option<String>> = Ok(None);
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3770,6 +3770,7 @@ impl Drop for RemoteSession {
     fn drop(&mut self) {
         self.interactive_writer.request_close();
         self.interactive_writer.abort_transport();
+        self.join_reader_worker();
         self.interactive_writer.join_worker_if_done();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2802,7 +2802,7 @@ impl RemoteSession {
                     // overflow) ends the byte feed without ending the
                     // terminal. The relay reports a lost connection so its
                     // embedder respawns and resyncs from a fresh replay.
-                    self.pipe_io_forward(id, || PipeIoEvent::TransportLost);
+                    self.signal_pipe_io_event(Some(id), None, PipeIoEvent::TransportLost);
                     self.surfaces.lock().unwrap().remove(&id);
                     self.emit(MuxEvent::SurfaceOutput(id));
                 }
@@ -2852,7 +2852,7 @@ impl RemoteSession {
             }
             Some("surface-exited") => {
                 if let Some(id) = surface_id() {
-                    self.pipe_io_forward(id, || PipeIoEvent::SurfaceExited);
+                    self.signal_pipe_io_event(Some(id), None, PipeIoEvent::SurfaceExited);
                     // Retire the mirror immediately. The authoritative tree
                     // refresh may lag this event, but input and reattach must
                     // already fail closed for a known-exited surface.
@@ -3540,16 +3540,16 @@ impl RemoteSession {
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
         use crossbeam_channel::TrySendError;
-        let event = event();
-        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
-            return self.signal_pipe_io_event(Some(surface), None, event);
-        }
         let (stalled_token, pipe_io_owned) = {
             let tap = self.pipe_io_tap.lock().unwrap();
             let Some(tap) = tap.as_ref() else { return false };
             if tap.surface != surface {
                 return false;
             }
+            // Resolve ownership before invoking the closure. Output and
+            // replay call sites capture a payload clone in the closure, and
+            // sessions without a matching tap must not pay that allocation.
+            let event = event();
             let retained_bytes = event.retained_bytes();
             if !tap.byte_budget.try_reserve(retained_bytes) {
                 (Some(tap.token.clone()), true)

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1253,6 +1253,7 @@ struct InteractiveWaitUntilWrittenGate {
 struct InteractiveWriter {
     shared: Arc<InteractiveWriterShared>,
     abort: Arc<dyn RemoteTransportAbort>,
+    worker: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
 impl InteractiveWriter {
@@ -1270,10 +1271,10 @@ impl InteractiveWriter {
             wait_until_written_gate: Mutex::new(None),
         });
         let worker_shared = shared.clone();
-        std::thread::Builder::new()
+        let worker = std::thread::Builder::new()
             .name("remote-input-writer".into())
             .spawn(move || interactive_writer_worker(worker_shared, writer))?;
-        Ok(Self { shared, abort })
+        Ok(Self { shared, abort, worker: Mutex::new(Some(worker)) })
     }
 
     fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
@@ -1409,6 +1410,24 @@ impl InteractiveWriter {
         let _ = self.abort.abort();
     }
 
+    fn abort_transport(&self) {
+        let _ = self.abort.abort();
+    }
+
+    fn join_worker(&self) {
+        let current = std::thread::current().id();
+        let handle = {
+            let mut worker = self.worker.lock().unwrap_or_else(|poison| poison.into_inner());
+            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                return;
+            }
+            worker.take()
+        };
+        if let Some(handle) = handle {
+            let _ = handle.join();
+        }
+    }
+
     fn close(&self) {
         self.request_close();
         let deadline = Instant::now() + remote_write_timeout();
@@ -1436,6 +1455,7 @@ impl InteractiveWriter {
                 "remote writer did not close before its deadline",
             ));
         }
+        self.join_worker();
     }
 }
 
@@ -1450,6 +1470,7 @@ impl Drop for InteractiveWriter {
                 "remote writer owner was dropped",
             ));
         }
+        self.join_worker();
     }
 }
 
@@ -1567,6 +1588,7 @@ enum DisconnectState {
 
 pub struct RemoteSession {
     interactive_writer: InteractiveWriter,
+    reader_worker: Mutex<Option<std::thread::JoinHandle<()>>>,
     /// The first terminal state wins. Local shutdown is kept separate from a
     /// reader failure so closing our own transport does not report a fake
     /// remote diagnostic.
@@ -1928,6 +1950,7 @@ impl RemoteSession {
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
         let session = Arc::new(RemoteSession {
             interactive_writer,
+            reader_worker: Mutex::new(None),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
@@ -1960,39 +1983,43 @@ impl RemoteSession {
         });
 
         let reader_session = Arc::downgrade(&session);
-        std::thread::Builder::new().name("remote-reader".into()).spawn(move || {
-            let mut report_progress = |partial: &[u8]| {
-                if let Some(session) = reader_session.upgrade() {
-                    session.report_read_progress(partial);
-                }
-            };
-            let reason = loop {
-                let received = reader.receive_with_progress(&mut report_progress);
-                if let Some(reason) = remote_reader_end_reason(&received) {
-                    break Some(reason);
-                }
-                let Ok(Some(mut message)) = received else { unreachable!("end reason handled") };
-                if message.len() > REMOTE_SESSION_MESSAGE_MAX_BYTES {
-                    break Some(remote_reader_message_too_large(&mut message));
-                }
-                let value = match serde_json::from_str::<Value>(&message) {
-                    Ok(value) => value,
-                    Err(error) => {
-                        let reason = format!("remote JSON decode failed: {error}");
-                        zeroize_string(&mut message);
-                        break Some(reason);
+        let reader_worker =
+            std::thread::Builder::new().name("remote-reader".into()).spawn(move || {
+                let mut report_progress = |partial: &[u8]| {
+                    if let Some(session) = reader_session.upgrade() {
+                        session.report_read_progress(partial);
                     }
                 };
-                zeroize_string(&mut message);
-                let Some(session) = reader_session.upgrade() else { break None };
-                session.handle_line(value);
-            };
-            // Connection lost: retain the reason before telling the app to quit.
-            if let Some(session) = reader_session.upgrade() {
-                session.disconnect_transport_with_reason(reason);
-                session.emit(MuxEvent::Empty);
-            }
-        })?;
+                let reason = loop {
+                    let received = reader.receive_with_progress(&mut report_progress);
+                    if let Some(reason) = remote_reader_end_reason(&received) {
+                        break Some(reason);
+                    }
+                    let Ok(Some(mut message)) = received else {
+                        unreachable!("end reason handled")
+                    };
+                    if message.len() > REMOTE_SESSION_MESSAGE_MAX_BYTES {
+                        break Some(remote_reader_message_too_large(&mut message));
+                    }
+                    let value = match serde_json::from_str::<Value>(&message) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            let reason = format!("remote JSON decode failed: {error}");
+                            zeroize_string(&mut message);
+                            break Some(reason);
+                        }
+                    };
+                    zeroize_string(&mut message);
+                    let Some(session) = reader_session.upgrade() else { break None };
+                    session.handle_line(value);
+                };
+                // Connection lost: retain the reason before telling the app to quit.
+                if let Some(session) = reader_session.upgrade() {
+                    session.disconnect_transport_with_reason(reason);
+                    session.emit(MuxEvent::Empty);
+                }
+            })?;
+        *session.reader_worker.lock().unwrap() = Some(reader_worker);
 
         if let Err(error) = session.initialize(subscribe) {
             session.disconnect_transport();
@@ -2982,6 +3009,22 @@ impl RemoteSession {
         drop(state);
         self.begin_shutdown();
         self.interactive_writer.close();
+        self.interactive_writer.abort_transport();
+        self.join_reader_worker();
+    }
+
+    fn join_reader_worker(&self) {
+        let current = std::thread::current().id();
+        let handle = {
+            let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
+            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                return;
+            }
+            worker.take()
+        };
+        if let Some(handle) = handle {
+            let _ = handle.join();
+        }
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -3589,6 +3632,7 @@ fn local_hostname() -> Option<String> {
 
 impl Drop for RemoteSession {
     fn drop(&mut self) {
+        self.disconnect_transport();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;
         };
@@ -3895,6 +3939,7 @@ fn test_session_with_writer(
 ) -> Arc<RemoteSession> {
     Arc::new(RemoteSession {
         interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
+        reader_worker: Mutex::new(None),
         disconnect_state: Mutex::new(DisconnectState::default()),
         pending: Mutex::new(PendingRemoteRequests::default()),
         next_id: AtomicU64::new(1),
@@ -5137,6 +5182,7 @@ mod tests {
     ) -> Arc<RemoteSession> {
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
+            reader_worker: Mutex::new(None),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
@@ -6426,6 +6472,81 @@ mod tests {
             .expect("transport shutdown must join the writer");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn malformed_json_cancels_a_pending_request_and_preserves_decode_reason() {
+        let (client, server) = UnixStream::pair().unwrap();
+        let (release_tx, release_rx) = channel();
+        let peer = std::thread::spawn(move || {
+            let mut peer = BufReader::new(server);
+            for expected_command in ["identify", "set-client-info", "subscribe"] {
+                let mut line = String::new();
+                peer.read_line(&mut line).unwrap();
+                let request: Value = serde_json::from_str(&line).unwrap();
+                assert_eq!(request["cmd"], expected_command);
+                let data = if expected_command == "identify" {
+                    json!({
+                        "app": "cmux-tui",
+                        "protocol": SUPPORTED_PROTOCOL_VERSION,
+                        "capabilities": ["browser-pointer-frame-guard-v1"],
+                    })
+                } else {
+                    Value::Null
+                };
+                writeln!(
+                    peer.get_mut(),
+                    "{}",
+                    json!({"id": request["id"], "ok": true, "data": data})
+                )
+                .unwrap();
+            }
+
+            let mut line = String::new();
+            peer.read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(&line).unwrap();
+            assert_eq!(request["cmd"], "wait-for-malformed");
+            peer.get_mut().write_all(b"not-json\n").unwrap();
+            release_rx.recv().unwrap();
+        });
+        let session = RemoteSession::connect_stream(Box::new(client)).unwrap();
+        let request_session = session.clone();
+        let (done_tx, done_rx) = channel();
+        let request = std::thread::spawn(move || {
+            done_tx.send(request_session.request(json!({"cmd": "wait-for-malformed"}))).unwrap();
+        });
+
+        let result = match done_rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(error) => {
+                session.begin_shutdown();
+                request.join().unwrap();
+                release_tx.send(()).unwrap();
+                peer.join().unwrap();
+                panic!("malformed JSON did not cancel the request promptly: {error}");
+            }
+        };
+        request.join().unwrap();
+        release_tx.send(()).unwrap();
+        peer.join().unwrap();
+
+        let error = result.unwrap_err();
+        assert!(
+            matches!(
+                error.downcast_ref::<RemoteRequestError>(),
+                Some(RemoteRequestError::Shutdown)
+            ),
+            "expected shutdown after malformed JSON canceled the request, got {error:?}"
+        );
+        assert!(
+            session
+                .transport_disconnect_reason()
+                .is_some_and(|reason| reason.starts_with("remote JSON decode failed:")),
+            "malformed JSON decode reason was not preserved: {:?}",
+            session.transport_disconnect_reason()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
     #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {
@@ -7055,81 +7176,6 @@ mod tests {
         );
         assert!(started.elapsed() < Duration::from_secs(2));
         assert!(session.shutdown.load(Ordering::Acquire));
-        assert!(session.pending.lock().unwrap().is_empty());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn malformed_json_cancels_a_pending_request_and_preserves_decode_reason() {
-        let (client, server) = UnixStream::pair().unwrap();
-        let (release_tx, release_rx) = channel();
-        let peer = std::thread::spawn(move || {
-            let mut peer = BufReader::new(server);
-            for expected_command in ["identify", "set-client-info", "subscribe"] {
-                let mut line = String::new();
-                peer.read_line(&mut line).unwrap();
-                let request: Value = serde_json::from_str(&line).unwrap();
-                assert_eq!(request["cmd"], expected_command);
-                let data = if expected_command == "identify" {
-                    json!({
-                        "app": "cmux-tui",
-                        "protocol": SUPPORTED_PROTOCOL_VERSION,
-                        "capabilities": ["browser-pointer-frame-guard-v1"],
-                    })
-                } else {
-                    Value::Null
-                };
-                writeln!(
-                    peer.get_mut(),
-                    "{}",
-                    json!({"id": request["id"], "ok": true, "data": data})
-                )
-                .unwrap();
-            }
-
-            let mut line = String::new();
-            peer.read_line(&mut line).unwrap();
-            let request: Value = serde_json::from_str(&line).unwrap();
-            assert_eq!(request["cmd"], "wait-for-malformed");
-            peer.get_mut().write_all(b"not-json\n").unwrap();
-            release_rx.recv().unwrap();
-        });
-        let session = RemoteSession::connect_stream(Box::new(client)).unwrap();
-        let request_session = session.clone();
-        let (done_tx, done_rx) = channel();
-        let request = std::thread::spawn(move || {
-            done_tx.send(request_session.request(json!({"cmd": "wait-for-malformed"}))).unwrap();
-        });
-
-        let result = match done_rx.recv_timeout(Duration::from_secs(2)) {
-            Ok(result) => result,
-            Err(error) => {
-                session.begin_shutdown();
-                request.join().unwrap();
-                release_tx.send(()).unwrap();
-                peer.join().unwrap();
-                panic!("malformed JSON did not cancel the request promptly: {error}");
-            }
-        };
-        request.join().unwrap();
-        release_tx.send(()).unwrap();
-        peer.join().unwrap();
-
-        let error = result.unwrap_err();
-        assert!(
-            matches!(
-                error.downcast_ref::<RemoteRequestError>(),
-                Some(RemoteRequestError::Shutdown)
-            ),
-            "expected shutdown after malformed JSON canceled the request, got {error:?}"
-        );
-        assert!(
-            session
-                .transport_disconnect_reason()
-                .is_some_and(|reason| reason.starts_with("remote JSON decode failed:")),
-            "malformed JSON decode reason was not preserved: {:?}",
-            session.transport_disconnect_reason()
-        );
         assert!(session.pending.lock().unwrap().is_empty());
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,8 +6,8 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -27,11 +27,13 @@ use cmux_tui_core::{
     },
 };
 use cmux_tui_machine_protocol::BearerToken;
+use crossbeam_channel::Sender as EventSender;
 use ghostty_vt::{
     Callbacks, CursorShape, KeyInput, KittyGraphicsLimits, KittyImageIdCursors, KittyReplayState,
     MouseEncoders, MouseInput, RenderState, Terminal, TerminalColorOverrides,
     TerminalPointerSemanticSnapshot, parse_color,
 };
+use parking_lot::Mutex as ParkingMutex;
 use serde_json::{Value, json};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -981,6 +983,25 @@ enum RequestDeadline {
     Standard,
     Attach,
     Fixed(Duration),
+    /// A deadline shared by a sequence of requests, such as reconnect
+    /// classification. Each phase consumes only the time that remains.
+    Until(Instant),
+}
+
+impl RequestDeadline {
+    fn remaining(self) -> Result<Duration, RemoteRequestError> {
+        match self {
+            Self::Standard => Ok(REMOTE_REQUEST_TIMEOUT),
+            Self::Fixed(timeout) => Ok(timeout),
+            Self::Until(deadline) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() { Err(RemoteRequestError::Timeout) } else { Ok(remaining) }
+            }
+            // Attach has its own progress-aware response deadline, but its
+            // enqueue/write phase still needs the normal bounded write wait.
+            Self::Attach => Ok(remote_write_timeout()),
+        }
+    }
 }
 
 struct AttachResponseDeadline {
@@ -1730,7 +1751,7 @@ pub struct RemoteSession {
     retire_surface_test_marker: Mutex<Option<Sender<SurfaceId>>>,
     tree: Mutex<RemoteTreeCache>,
     browser_sources: Mutex<HashMap<SurfaceId, BrowserSource>>,
-    tree_refresh: Mutex<()>,
+    tree_refresh: ParkingMutex<()>,
     tree_stale: AtomicBool,
     subscription_started: AtomicBool,
     event_surface_filter: AtomicU64,
@@ -1746,10 +1767,108 @@ pub struct RemoteSession {
     capabilities: Mutex<HashSet<String>>,
     provider_workspace_authority: Option<BearerToken>,
     provider_workspaces_guarded: AtomicBool,
+    pipe_io_tap: Mutex<Option<PipeIoTap>>,
+}
+
+/// One event on the raw byte stream a `--pipe-io` relay serves to its
+/// embedder. `Replay` REPLACES all prior terminal state (the relay must
+/// emit a full reset before any replay that is not its first output);
+/// `Output` appends live PTY bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoEvent {
+    Replay { bytes: Vec<u8> },
+    Output(Vec<u8>),
+    SurfaceExited,
+    TransportLost,
+    StdinClosed,
+}
+
+impl PipeIoEvent {
+    /// Bytes retained by the relay's bounded data queue. Lifecycle signals
+    /// have a separate one-slot channel and carry no retained payload.
+    pub(crate) fn retained_bytes(&self) -> usize {
+        match self {
+            Self::Replay { bytes } | Self::Output(bytes) => bytes.len(),
+            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed => 0,
+        }
+    }
+}
+
+/// Shared byte budget for one pipe-IO relay. A count-only bounded channel can
+/// retain megabytes per event when a replay is large; this budget makes the
+/// memory bound explicit and turns an overrun into the same transport-loss
+/// path as a full channel.
+pub(crate) struct PipeIoByteBudget {
+    retained: AtomicUsize,
+    limit: usize,
+}
+
+impl PipeIoByteBudget {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self { retained: AtomicUsize::new(0), limit: limit.max(1) }
+    }
+
+    pub(crate) fn try_reserve(&self, bytes: usize) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+        let mut current = self.retained.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(bytes) else { return false };
+            if next > self.limit {
+                return false;
+            }
+            match self.retained.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    pub(crate) fn release(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        let mut current = self.retained.load(Ordering::Acquire);
+        loop {
+            let next = current.saturating_sub(bytes);
+            match self.retained.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+struct PipeIoTap {
+    surface: SurfaceId,
+    sender: EventSender<PipeIoEvent>,
+    lifecycle_sender: EventSender<PipeIoEvent>,
+    byte_budget: Arc<PipeIoByteBudget>,
+    token: Arc<u8>,
 }
 
 pub(super) enum RemoteSurfaceAttach {
     Attached(Arc<RemoteSurface>),
+    Retired,
+    Deferred,
+}
+
+/// Result of registering a renderer-less pipe-IO attachment. Unlike
+/// `RemoteSurfaceAttach`, this path deliberately does not allocate a local VT
+/// parser. The relay receives the server's raw byte stream and owns parsing.
+pub(crate) enum PipeIoSurfaceAttach {
+    Attached,
     Retired,
     Deferred,
 }
@@ -1828,6 +1947,19 @@ impl RemoteTransport {
 
     pub fn json_lines(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         stream.set_write_timeout(Some(remote_write_timeout()))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_with_timeout(
+        stream: Box<dyn transport::Stream>,
+        timeout: Duration,
+    ) -> io::Result<Self> {
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_parts(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         let read_half = stream.try_clone_box()?;
         let abort_stream = stream.try_clone_box()?;
         Ok(Self {
@@ -2016,15 +2148,52 @@ impl RemoteSession {
         Self::connect_path(path, false)
     }
 
+    pub(crate) fn connect_for_terminal_attach_until(
+        path: &Path,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_path_until(path, false, deadline)
+    }
+
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
         let stream = transport::connect(path).map_err(|e| {
             anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
         })?;
-        if subscribe {
-            Self::connect_stream(stream)
-        } else {
-            Self::connect_stream_with_subscription(stream, false)
-        }
+        Self::connect_stream_with_subscription(stream, subscribe)
+    }
+
+    fn connect_path_until(
+        path: &Path,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let path_for_thread = path.to_path_buf();
+        let display = path.display().to_string();
+        let (sender, receiver) = sync_channel(1);
+        let connector =
+            std::thread::Builder::new().name("remote-probe-connect".into()).spawn(move || {
+                let _ = sender.send(transport::connect(&path_for_thread));
+            })?;
+        let stream = match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        {
+            Ok(result) => {
+                let _ = connector.join();
+                result.map_err(|error| {
+                    anyhow::anyhow!("cannot connect to session socket {display}: {error}")
+                })?
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let _ = connector.join();
+                anyhow::bail!("remote probe connector stopped without a result")
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                // The pipe-io process exits after classification. Dropping the
+                // connector lets that process terminate any blocked connect.
+                drop(connector);
+                anyhow::bail!(RemoteRequestError::Timeout)
+            }
+        };
+        Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
     }
 
     /// Connect over an already-established full-duplex byte stream.
@@ -2045,6 +2214,27 @@ impl RemoteSession {
             anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
         })?;
         Self::connect_transport_with_initial_subscription(transport, subscribe)
+    }
+
+    fn connect_stream_with_subscription_until(
+        stream: Box<dyn transport::Stream>,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let timeout = deadline.saturating_duration_since(Instant::now());
+        if timeout.is_zero() {
+            anyhow::bail!(RemoteRequestError::Timeout);
+        }
+        let transport =
+            RemoteTransport::json_lines_with_timeout(stream, timeout).map_err(|error| {
+                anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
+            })?;
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            None,
+            subscribe,
+            Some(deadline),
+        )
     }
 
     pub fn connect_transport(transport: RemoteTransport) -> anyhow::Result<Arc<Self>> {
@@ -2070,6 +2260,20 @@ impl RemoteSession {
         provider_workspace_authority: Option<BearerToken>,
         subscribe: bool,
     ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            provider_workspace_authority,
+            subscribe,
+            None,
+        )
+    }
+
+    fn connect_transport_with_provider_authority_until(
+        transport: RemoteTransport,
+        provider_workspace_authority: Option<BearerToken>,
+        subscribe: bool,
+        deadline: Option<Instant>,
+    ) -> anyhow::Result<Arc<Self>> {
         let RemoteTransport { mut reader, writer, abort } = transport;
         let interactive_writer = InteractiveWriter::spawn(writer, abort)
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
@@ -2090,7 +2294,7 @@ impl RemoteSession {
             retire_surface_test_marker: Mutex::new(None),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -2106,6 +2310,7 @@ impl RemoteSession {
             capabilities: Mutex::new(HashSet::new()),
             provider_workspace_authority,
             provider_workspaces_guarded: AtomicBool::new(false),
+            pipe_io_tap: Mutex::new(None),
         });
 
         let reader_session = Arc::downgrade(&session);
@@ -2149,7 +2354,11 @@ impl RemoteSession {
             })?;
         *session.reader_worker.lock().unwrap() = Some(reader_worker);
 
-        if let Err(error) = session.initialize(subscribe) {
+        let initialization = deadline.map_or_else(
+            || session.initialize(subscribe),
+            |deadline| session.initialize_until(subscribe, deadline),
+        );
+        if let Err(error) = initialization {
             session.disconnect_transport();
             return Err(error);
         }
@@ -2157,8 +2366,20 @@ impl RemoteSession {
     }
 
     fn initialize(&self, subscribe: bool) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Standard)
+    }
+
+    fn initialize_until(&self, subscribe: bool, deadline: Instant) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Until(deadline))
+    }
+
+    fn initialize_with_deadline(
+        &self,
+        subscribe: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<()> {
         // Identify the endpoint and register this connection before any optional subscription.
-        let ident = self.request(json!({"cmd": "identify"}))?;
+        let ident = self.request_with_deadline(json!({"cmd": "identify"}), deadline)?;
         validate_remote_identity(&ident)?;
         *self.capabilities.lock().unwrap() = identity_capabilities(&ident);
         let mut client_info = json!({"cmd": "set-client-info", "kind": "tui"});
@@ -2184,10 +2405,10 @@ impl RemoteSession {
         if !negotiated.is_empty() {
             client_info["capabilities"] = json!(negotiated);
         }
-        self.request(client_info)?;
+        self.request_with_deadline(client_info, deadline)?;
         if subscribe {
             self.prime_local_subscription();
-            if let Err(error) = self.request(self.subscription_request()) {
+            if let Err(error) = self.request_with_deadline(self.subscription_request(), deadline) {
                 self.primed_subscription.lock().unwrap().take();
                 return Err(error);
             }
@@ -2340,6 +2561,12 @@ impl RemoteSession {
     }
 
     fn handle_line(self: &Arc<Self>, value: Value) {
+        // The reader can have one buffered JSON line after the transport has
+        // been closed. Do not let that late event mutate a replacement relay
+        // or resurrect a mirror during local shutdown.
+        if self.shutdown.load(Ordering::Acquire) {
+            return;
+        }
         let surface_id = || value.get("surface").and_then(|v| v.as_u64());
         let event = value.get("event").and_then(Value::as_str);
         if event.is_some_and(|event| !self.accepts_event_in_surface_scope(event, &value)) {
@@ -2360,11 +2587,20 @@ impl RemoteSession {
                 let Ok(replay) = base64::engine::general_purpose::STANDARD.decode(data) else {
                     return;
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 self.log_frame(
                     id,
                     format_args!("vt-state cols={cols} rows={rows} bytes={}", replay.len()),
                 );
+                let pipe_io_owned =
+                    self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() });
+                // A pipe-IO relay consumes the authoritative VT byte stream
+                // itself. Do not also parse the same replay into a local
+                // `RemoteSurface`: that duplicate parser can fail or mutate
+                // state even though the embedder never reads it.
+                if pipe_io_owned {
+                    return;
+                }
+                let colors = value.get("colors").and_then(parse_terminal_colors);
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
                     return;
@@ -2427,8 +2663,12 @@ impl RemoteSession {
                 let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data) else {
                     return;
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 self.log_frame(id, format_args!("output bytes={}", bytes.len()));
+                let pipe_io_owned = self.pipe_io_forward(id, || PipeIoEvent::Output(bytes.clone()));
+                if pipe_io_owned {
+                    return;
+                }
+                let colors = value.get("colors").and_then(parse_terminal_colors);
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     surface.scan_cursor_provenance(&bytes);
                     let mut term = surface.term.lock().unwrap();
@@ -2462,6 +2702,21 @@ impl RemoteSession {
                     }
                     None => None,
                 };
+                self.log_frame(
+                    id,
+                    format_args!(
+                        "resized cols={cols} rows={rows} bytes={}",
+                        replay.as_ref().map(|bytes| bytes.len()).unwrap_or(0)
+                    ),
+                );
+                let pipe_io_owned = if let Some(replay) = replay.as_ref() {
+                    self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() })
+                } else {
+                    self.pipe_io_owns_surface(id)
+                };
+                if pipe_io_owned {
+                    return;
+                }
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
                     return;
@@ -2471,13 +2726,6 @@ impl RemoteSession {
                     return;
                 };
                 let colors = value.get("colors").and_then(parse_terminal_colors);
-                self.log_frame(
-                    id,
-                    format_args!(
-                        "resized cols={cols} rows={rows} bytes={}",
-                        replay.as_ref().map(|bytes| bytes.len()).unwrap_or(0)
-                    ),
-                );
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     if surface
                         .apply_stream_resize_with_colors(
@@ -2505,6 +2753,9 @@ impl RemoteSession {
             }
             Some("colors-changed") => {
                 let Some(id) = surface_id() else { return };
+                if self.pipe_io_owns_surface(id) {
+                    return;
+                }
                 let Some(colors) = parse_terminal_colors(&value) else { return };
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     let mut term = surface.term.lock().unwrap();
@@ -2547,6 +2798,11 @@ impl RemoteSession {
             }
             Some("detached") => {
                 if let Some(id) = surface_id() {
+                    // A server-side stream detach (e.g. backpressure
+                    // overflow) ends the byte feed without ending the
+                    // terminal. The relay reports a lost connection so its
+                    // embedder respawns and resyncs from a fresh replay.
+                    self.pipe_io_forward(id, || PipeIoEvent::TransportLost);
                     self.surfaces.lock().unwrap().remove(&id);
                     self.emit(MuxEvent::SurfaceOutput(id));
                 }
@@ -2596,6 +2852,7 @@ impl RemoteSession {
             }
             Some("surface-exited") => {
                 if let Some(id) = surface_id() {
+                    self.pipe_io_forward(id, || PipeIoEvent::SurfaceExited);
                     // Retire the mirror immediately. The authoritative tree
                     // refresh may lag this event, but input and reattach must
                     // already fail closed for a known-exited surface.
@@ -2845,6 +3102,12 @@ impl RemoteSession {
         mut cmd: Value,
         deadline: RequestDeadline,
     ) -> anyhow::Result<Value> {
+        // A shared deadline must cover enqueueing, the ordered write, and the
+        // response wait. Check it before creating a pending request so an
+        // expired reconnect probe cannot add work to the relay.
+        if let Err(error) = deadline.remaining() {
+            return Err(error.into());
+        }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let progress = Arc::new(AtomicU64::new(0));
         let attach_progress = matches!(deadline, RequestDeadline::Attach)
@@ -2872,7 +3135,14 @@ impl RemoteSession {
                 return Err(RemoteRequestError::Transport(error).into());
             }
         };
-        if let Err(error) = self.wait_for_ordered_write(sequence) {
+        let write_timeout = match deadline.remaining() {
+            Ok(timeout) => timeout,
+            Err(error) => {
+                self.pending.lock().unwrap().remove(&id);
+                return Err(error.into());
+            }
+        };
+        if let Err(error) = self.wait_for_ordered_write_with_timeout(sequence, write_timeout) {
             self.pending.lock().unwrap().remove(&id);
             return Err(RemoteRequestError::Transport(error).into());
         }
@@ -2916,12 +3186,10 @@ impl RemoteSession {
         progress: Arc<AtomicU64>,
         attach_progress: Option<u64>,
     ) -> Result<Value, RemoteRequestError> {
-        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) = deadline {
-            let timeout = match deadline {
-                RequestDeadline::Standard => REMOTE_REQUEST_TIMEOUT,
-                RequestDeadline::Fixed(timeout) => timeout,
-                RequestDeadline::Attach => unreachable!(),
-            };
+        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) | RequestDeadline::Until(_) =
+            deadline
+        {
+            let timeout = deadline.remaining().map_err(|_| RemoteRequestError::Timeout)?;
             return match rx.recv_timeout(timeout) {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
@@ -3013,6 +3281,32 @@ impl RemoteSession {
     pub fn send_bytes(&self, surface: SurfaceId, bytes: &[u8]) -> anyhow::Result<()> {
         let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
         self.request_no_wait(json!({"cmd": "send", "surface": surface, "bytes": encoded}))
+    }
+
+    /// Claims exclusive terminal geometry for a renderer-less pipe-IO
+    /// attachment. This mirrors `Session::claim_terminal_geometry` without
+    /// requiring a local `RemoteSurface` mirror.
+    pub(crate) fn claim_terminal_geometry(&self, surface: SurfaceId) -> anyhow::Result<()> {
+        self.request(json!({
+            "cmd": "set-client-sizing",
+            "surface": surface,
+            "enabled": true,
+            "exclusive": true,
+        }))
+        .map(|_| ())
+    }
+
+    /// Enqueues a geometry claim without waiting for its acknowledgement.
+    /// Claims only establish ownership; input and resize requests already use
+    /// the same ordered writer, so a fire-and-forget claim cannot overtake the
+    /// keystroke that follows it.
+    pub(crate) fn notify_claim_terminal_geometry(&self, surface: SurfaceId) -> anyhow::Result<()> {
+        self.notify(json!({
+            "cmd": "set-client-sizing",
+            "surface": surface,
+            "enabled": true,
+            "exclusive": true,
+        }))
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -3111,7 +3405,15 @@ impl RemoteSession {
     }
 
     fn wait_for_ordered_write(&self, sequence: u64) -> io::Result<()> {
-        match self.interactive_writer.wait_until_written(sequence, remote_write_timeout()) {
+        self.wait_for_ordered_write_with_timeout(sequence, remote_write_timeout())
+    }
+
+    fn wait_for_ordered_write_with_timeout(
+        &self,
+        sequence: u64,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        match self.interactive_writer.wait_until_written(sequence, timeout) {
             Ok(()) => Ok(()),
             Err(error) => {
                 if error.kind() == io::ErrorKind::TimedOut {
@@ -3135,6 +3437,10 @@ impl RemoteSession {
             };
         }
         drop(state);
+        // Signal the pipe-io relay before shutdown waits on any in-flight
+        // writer. The lifecycle channel is separate from the bounded byte
+        // queue, so this wake cannot be dropped behind queued output.
+        self.signal_pipe_io_event(None, None, PipeIoEvent::TransportLost);
         self.begin_shutdown();
         self.interactive_writer.close();
         self.interactive_writer.abort_transport();
@@ -3161,6 +3467,115 @@ impl RemoteSession {
                     Some(handle);
             }
         }
+    }
+
+    /// Routes one scoped surface's raw byte stream to a `--pipe-io` relay.
+    /// Install before `attach-surface` so the initial replay is not missed.
+    pub(crate) fn install_pipe_io_tap(
+        &self,
+        surface: SurfaceId,
+        sender: EventSender<PipeIoEvent>,
+        lifecycle_sender: EventSender<PipeIoEvent>,
+        byte_budget: Arc<PipeIoByteBudget>,
+    ) -> Arc<u8> {
+        // A non-zero-sized allocation gives each tap a stable identity. A
+        // zero-sized Arc token could share the allocator's dangling pointer.
+        let token = Arc::new(0u8);
+        *self.pipe_io_tap.lock().unwrap() = Some(PipeIoTap {
+            surface,
+            sender,
+            lifecycle_sender,
+            byte_budget,
+            token: token.clone(),
+        });
+        token
+    }
+
+    pub(crate) fn clear_pipe_io_tap(&self, token: &Arc<u8>) {
+        let mut slot = self.pipe_io_tap.lock().unwrap();
+        if slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token)) {
+            slot.take();
+        }
+    }
+
+    fn signal_pipe_io_event(
+        &self,
+        surface: Option<SurfaceId>,
+        token: Option<&Arc<u8>>,
+        event: PipeIoEvent,
+    ) -> bool {
+        let tap = {
+            let mut slot = self.pipe_io_tap.lock().unwrap();
+            if (surface.is_none() || slot.as_ref().is_some_and(|tap| Some(tap.surface) == surface))
+                && token.is_none_or(|token| {
+                    slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token))
+                })
+            {
+                slot.take()
+            } else {
+                None
+            }
+        };
+        if let Some(tap) = tap {
+            // A second lifecycle event is redundant. If the one-slot signal
+            // channel is already occupied, the first event remains the
+            // authoritative reason and still wakes the relay.
+            let _ = tap.lifecycle_sender.try_send(event);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns true while this connection has a raw pipe-IO tap for
+    /// `surface`. The event reader uses this fence to avoid feeding the same
+    /// bytes into the normal local mirror parser as well as the relay.
+    fn pipe_io_owns_surface(&self, surface: SurfaceId) -> bool {
+        self.pipe_io_tap.lock().unwrap().as_ref().is_some_and(|tap| tap.surface == surface)
+    }
+
+    /// Forwards one tap event, treating a full or dropped queue as a lost
+    /// transport: the relay's reader stalled, and silently dropping bytes
+    /// would corrupt the embedder's terminal state (bounded-backpressure
+    /// policy; never wedge the session reader thread).
+    fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
+        use crossbeam_channel::TrySendError;
+        let event = event();
+        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
+            return self.signal_pipe_io_event(Some(surface), None, event);
+        }
+        let (stalled_token, pipe_io_owned) = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return false };
+            if tap.surface != surface {
+                return false;
+            }
+            let retained_bytes = event.retained_bytes();
+            if !tap.byte_budget.try_reserve(retained_bytes) {
+                (Some(tap.token.clone()), true)
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => (None, true),
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        tap.byte_budget.release(retained_bytes);
+                        (Some(tap.token.clone()), true)
+                    }
+                }
+            }
+        };
+        if let Some(token) = stalled_token {
+            // Signal only the tap that observed the stall. A replacement tap
+            // may have been installed while this reader thread released the
+            // mutex; it must not be torn down by an older relay.
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
+        }
+        // Capture ownership while holding the tap lock. A concurrent relay
+        // teardown can remove the tap before the caller reaches its parser
+        // fence; returning this snapshot prevents one raw event from being
+        // parsed twice during that handoff.
+        pipe_io_owned
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -3396,6 +3811,114 @@ impl RemoteSession {
         })
     }
 
+    /// Registers one renderer-less attachment for a pipe-IO relay. The
+    /// normal `try_ensure_surface` path creates a local `RemoteSurface` and
+    /// parses every VT event. A raw relay must only register the server stream
+    /// and preserve those bytes for the embedder's parser.
+    pub(crate) fn try_attach_pipe_io(
+        &self,
+        id: SurfaceId,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<PipeIoSurfaceAttach> {
+        if self.retired_surfaces.lock().unwrap().contains(&id) {
+            return Ok(PipeIoSurfaceAttach::Retired);
+        }
+        if !self.can_attach_after_overflow(id) {
+            return Ok(PipeIoSurfaceAttach::Deferred);
+        }
+        let initial_size = size.map(|(cols, rows)| (cols.max(1), rows.max(1))).filter(|_| {
+            self.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY)
+        });
+        let mut request = json!({"cmd": "attach-surface", "surface": id, "mode": "bytes"});
+        if let Some((cols, rows)) = initial_size {
+            request["cols"] = json!(cols);
+            request["rows"] = json!(rows);
+        }
+        let response = match self.request_with_deadline(request, RequestDeadline::Attach) {
+            Ok(response) => response,
+            Err(error) => {
+                if error
+                    .downcast_ref::<RemoteRequestError>()
+                    .is_some_and(RemoteRequestError::is_timeout)
+                {
+                    // The server registers the stream before it queues the
+                    // attach response. Closing the connection is the only
+                    // protocol cancellation that guarantees cleanup.
+                    self.disconnect_transport();
+                }
+                return Err(error);
+            }
+        };
+        let attachment_lease = if self.supports_capability(VIEW_ATTACHMENT_LEASE_CAPABILITY) {
+            let Some(lease) = response.get("lease").and_then(Value::as_str) else {
+                self.disconnect_transport();
+                anyhow::bail!(
+                    "server advertised {VIEW_ATTACHMENT_LEASE_CAPABILITY} but pipe-IO attach returned no lease"
+                );
+            };
+            Some(lease.to_string())
+        } else {
+            None
+        };
+        // Retirement can race the attach response. Do not start a relay for
+        // a terminal that already emitted `surface-exited`; closing this
+        // connection releases the server-side pending stream.
+        if self.retired_surfaces.lock().unwrap().contains(&id) {
+            self.disconnect_transport();
+            return Ok(PipeIoSurfaceAttach::Retired);
+        }
+        if let Some(lease) = attachment_lease {
+            self.surface_leases.lock().unwrap().insert(id, lease);
+        }
+        // Mark a successful raw attachment as stable for the same overflow
+        // recovery budget used by the normal mirror path. Without this
+        // commit, every reconnect would remain in the pre-stability window
+        // and consume another backoff slot forever.
+        if let Some(recovery) = self.surface_overflow_recovery.lock().unwrap().get_mut(&id) {
+            recovery.attached_at = Some(Instant::now());
+            recovery.retry_after = None;
+        }
+        Ok(PipeIoSurfaceAttach::Attached)
+    }
+
+    /// Sends a resize for a renderer-less attachment. There is no local
+    /// `RemoteSurface` to hold a reported size, so every accepted sample is
+    /// sent; the Swift pump already coalesces samples and bounds traffic.
+    pub(crate) fn resize_pipe_io(
+        &self,
+        surface: SurfaceId,
+        cols: u16,
+        rows: u16,
+    ) -> anyhow::Result<bool> {
+        let desired = (cols.max(1), rows.max(1));
+        let mut request = json!({
+            "cmd": "resize-surface",
+            "surface": surface,
+            "cols": desired.0,
+            "rows": desired.1,
+        });
+        if self.supports_capability(VIEW_ATTACHMENT_LEASE_CAPABILITY) {
+            let Some(lease) = self.attachment_lease(surface) else {
+                anyhow::bail!("pipe-IO attachment lease is no longer active");
+            };
+            request = json!({
+                "cmd": "resize-attached-view",
+                "surface": surface,
+                "lease": lease,
+                "cols": desired.0,
+                "rows": desired.1,
+            });
+        }
+        let response = self.request(request)?;
+        match response.get("outcome").and_then(Value::as_str) {
+            Some("superseded") | Some("passive") => Ok(false),
+            Some("applied") | None => {
+                Ok(response.get("accepted").and_then(Value::as_bool).unwrap_or(true))
+            }
+            Some(other) => anyhow::bail!("unknown pipe-IO resize outcome {other}"),
+        }
+    }
+
     /// Mirror for a surface, attaching on first use. Servers advertising
     /// initial attach sizing receive the first viewer claim atomically with
     /// the attach, so the initial replay already has its final geometry.
@@ -3622,12 +4145,37 @@ impl RemoteSession {
         self.refresh_tree_inner(true)
     }
 
+    /// Refresh the workspace tree with a bounded request deadline. Used by
+    /// reconnect classification, where a stale daemon must not hold the relay.
+    pub fn refresh_tree_with_timeout(&self, timeout: Duration) -> anyhow::Result<TreeView> {
+        self.refresh_tree_until(Instant::now() + timeout)
+    }
+
+    pub(crate) fn refresh_tree_until(&self, deadline: Instant) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Until(deadline))
+    }
+
     pub fn refresh_tree_background(&self) -> anyhow::Result<TreeView> {
         self.refresh_tree_inner(false)
     }
 
     fn refresh_tree_inner(&self, identity_refresh: bool) -> anyhow::Result<TreeView> {
-        let _refresh = self.tree_refresh.lock().unwrap();
+        self.refresh_tree_inner_with_deadline(identity_refresh, RequestDeadline::Standard)
+    }
+
+    fn refresh_tree_inner_with_deadline(
+        &self,
+        identity_refresh: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<TreeView> {
+        let refresh_timeout = match deadline {
+            RequestDeadline::Standard => REMOTE_REQUEST_TIMEOUT,
+            RequestDeadline::Attach => remote_write_timeout(),
+            RequestDeadline::Fixed(timeout) => timeout,
+            RequestDeadline::Until(deadline) => deadline.saturating_duration_since(Instant::now()),
+        };
+        let _refresh =
+            self.tree_refresh.try_lock_for(refresh_timeout).ok_or(RemoteRequestError::Timeout)?;
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
         }
@@ -3635,7 +4183,7 @@ impl RemoteSession {
             let cache = self.tree.lock().unwrap();
             (cache.title_generation(), cache.agent_generation())
         };
-        let data = match self.request(json!({"cmd": "list-workspaces"})) {
+        let data = match self.request_with_deadline(json!({"cmd": "list-workspaces"}), deadline) {
             Ok(data) => data,
             Err(e) => {
                 if identity_refresh {
@@ -3646,7 +4194,7 @@ impl RemoteSession {
             }
         };
         let agents = self
-            .request(json!({"cmd": "list-agents"}))
+            .request_with_deadline(json!({"cmd": "list-agents"}), deadline)
             .ok()
             .and_then(|data| {
                 data.get("agents")
@@ -4092,7 +4640,7 @@ fn test_session_with_writer(
         retire_surface_test_marker: Mutex::new(None),
         tree: Mutex::new(RemoteTreeCache::default()),
         browser_sources: Mutex::new(HashMap::new()),
-        tree_refresh: Mutex::new(()),
+        tree_refresh: ParkingMutex::new(()),
         tree_stale: AtomicBool::new(true),
         subscription_started: AtomicBool::new(false),
         event_surface_filter: AtomicU64::new(0),
@@ -4108,6 +4656,7 @@ fn test_session_with_writer(
         capabilities: Mutex::new(capabilities),
         provider_workspace_authority,
         provider_workspaces_guarded: AtomicBool::new(false),
+        pipe_io_tap: Mutex::new(None),
     })
 }
 
@@ -5336,7 +5885,7 @@ mod tests {
             retire_surface_test_marker: Mutex::new(None),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -5352,6 +5901,7 @@ mod tests {
             capabilities: Mutex::new(capabilities),
             provider_workspace_authority,
             provider_workspaces_guarded: AtomicBool::new(false),
+            pipe_io_tap: Mutex::new(None),
         })
     }
 
@@ -6757,6 +7307,71 @@ mod tests {
     }
 
     #[test]
+    fn full_pipe_io_queue_signals_loss_on_the_reserved_lifecycle_channel() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"first".to_vec()));
+        // The byte queue is full. The second event must force a transport
+        // loss, and that lifecycle signal must remain observable even though
+        // no byte-queue slot is available.
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"second".to_vec()));
+
+        assert_eq!(
+            lifecycle_receiver.recv_timeout(Duration::from_secs(1)).unwrap(),
+            PipeIoEvent::TransportLost
+        );
+        assert!(session.pipe_io_tap.lock().unwrap().is_none());
+        assert!(session.shutdown.load(Ordering::Acquire));
+        assert_eq!(receiver.try_recv().unwrap(), PipeIoEvent::Output(b"first".to_vec()));
+    }
+
+    #[test]
+    fn stale_pipe_io_tap_cleanup_cannot_remove_a_replacement() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (first_sender, _first_receiver) = crossbeam_channel::bounded(1);
+        let (first_lifecycle_sender, _first_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let first_token = session.install_pipe_io_tap(
+            7,
+            first_sender,
+            first_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        let (second_sender, second_receiver) = crossbeam_channel::bounded(1);
+        let (second_lifecycle_sender, _second_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let second_token = session.install_pipe_io_tap(
+            7,
+            second_sender,
+            second_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.clear_pipe_io_tap(&first_token);
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"replacement".to_vec()));
+
+        assert!(Arc::ptr_eq(
+            &session.pipe_io_tap.lock().unwrap().as_ref().unwrap().token,
+            &second_token
+        ));
+        assert_eq!(
+            second_receiver.try_recv().unwrap(),
+            PipeIoEvent::Output(b"replacement".to_vec())
+        );
+    }
+
+    #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),
@@ -7320,6 +7935,103 @@ mod tests {
         assert!(session.pending.lock().unwrap().is_empty());
         assert!(session.shutdown.load(Ordering::Acquire));
         assert!(closed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn bounded_tree_refresh_times_out_and_clears_pending_probe() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let started = Instant::now();
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a silent probe unexpectedly completed"),
+        };
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms probe deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_does_not_wait_for_another_refresh_lock() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let _refresh = session.tree_refresh.lock();
+        let started = Instant::now();
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a contended refresh lock unexpectedly completed"),
+        };
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms lock deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn standard_tree_refresh_does_not_wait_indefinitely_for_another_refresh_lock() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let _refresh = session.tree_refresh.lock();
+        let started = Instant::now();
+        let error = match session.refresh_tree() {
+            Err(error) => error,
+            Ok(_) => panic!("a contended refresh lock unexpectedly completed"),
+        };
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < REMOTE_REQUEST_TIMEOUT + Duration::from_millis(100),
+            "refresh lock deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_aborts_a_blocked_ordered_write() {
+        let (stream, control) = BlockingWriteStream::new();
+        let session = blocking_test_session(stream);
+        session.send_bytes(7, b"blocked").unwrap();
+        control.wait_until_entered();
+
+        let started = Instant::now();
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a blocked probe write unexpectedly completed"),
+        };
+
+        assert!(error.downcast_ref::<RemoteRequestError>().is_some_and(|error| {
+            matches!(error, RemoteRequestError::Transport(io_error)
+                if io_error.kind() == io::ErrorKind::TimedOut)
+        }));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms write deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(control.state.0.lock().unwrap().aborted);
+        assert!(session.pending.lock().unwrap().is_empty());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6324,6 +6324,108 @@ mod tests {
         assert!(closed.load(Ordering::Acquire));
     }
 
+    struct LifecycleReader {
+        responses: Receiver<String>,
+        remaining_responses: usize,
+        release: Arc<(Mutex<bool>, Condvar)>,
+        exited: Sender<()>,
+    }
+
+    impl RemoteMessageReader for LifecycleReader {
+        fn receive(&mut self) -> io::Result<Option<String>> {
+            if self.remaining_responses > 0 {
+                self.remaining_responses -= 1;
+                return self.responses.recv().map(Some).map_err(|_| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "lifecycle response channel closed")
+                });
+            }
+
+            let (released, changed) = &*self.release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = changed.wait(released).unwrap();
+            }
+            self.exited.send(()).unwrap();
+            Ok(None)
+        }
+    }
+
+    struct LifecycleWriter {
+        responses: Sender<String>,
+        closed: Arc<AtomicBool>,
+        exited: Sender<()>,
+    }
+
+    impl RemoteMessageWriter for LifecycleWriter {
+        fn send(&mut self, message: &str) -> io::Result<()> {
+            let request: Value = serde_json::from_str(message).map_err(io::Error::other)?;
+            let id = request
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| io::Error::other("lifecycle request omitted its id"))?;
+            let data = (request.get("cmd").and_then(Value::as_str) == Some("identify"))
+                .then(|| json!({"app": "cmux-tui", "protocol": SUPPORTED_PROTOCOL_VERSION}))
+                .unwrap_or(Value::Null);
+            self.responses
+                .send(json!({"id": id, "ok": true, "data": data}).to_string())
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "lifecycle reader exited"))
+        }
+
+        fn close(&mut self) -> io::Result<()> {
+            self.closed.store(true, Ordering::Release);
+            Ok(())
+        }
+    }
+
+    impl Drop for LifecycleWriter {
+        fn drop(&mut self) {
+            let _ = self.exited.send(());
+        }
+    }
+
+    struct LifecycleAbort {
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl RemoteTransportAbort for LifecycleAbort {
+        fn abort(&self) -> io::Result<()> {
+            let (released, changed) = &*self.release;
+            *released.lock().unwrap() = true;
+            changed.notify_all();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn transport_disconnect_cancels_and_joins_reader_and_writer_workers() {
+        let (responses, response_rx) = channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (reader_exited, reader_exited_rx) = channel();
+        let (writer_exited, writer_exited_rx) = channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let session = RemoteSession::connect_transport(RemoteTransport::new(
+            Box::new(LifecycleReader {
+                responses: response_rx,
+                remaining_responses: 3,
+                release: release.clone(),
+                exited: reader_exited,
+            }),
+            Box::new(LifecycleWriter { responses, closed: closed.clone(), exited: writer_exited }),
+            Arc::new(LifecycleAbort { release }),
+        ))
+        .unwrap();
+
+        session.disconnect_transport();
+
+        assert!(closed.load(Ordering::Acquire));
+        reader_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("transport shutdown must cancel the blocked reader");
+        writer_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("transport shutdown must join the writer");
+    }
+
     #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -205,8 +205,15 @@ pub(crate) enum RemoteRequestError {
     Encode(serde_json::Error),
     Transport(io::Error),
     Timeout,
-    Rejected { error: String, code: Option<String>, delivery: Option<ClearHistoryDelivery> },
+    Rejected {
+        error: String,
+        code: Option<String>,
+        delivery: Option<ClearHistoryDelivery>,
+    },
     Shutdown,
+    /// The peer closed the transport. This is retryable for pipe-IO startup,
+    /// unlike a local shutdown initiated by this process.
+    RemoteShutdown,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -242,7 +249,9 @@ impl RemoteRequestError {
 pub(crate) fn is_pipe_io_retryable_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
         if let Some(remote_error) = cause.downcast_ref::<RemoteRequestError>() {
-            return remote_error.is_transport_failure() || remote_error.is_timeout();
+            return remote_error.is_transport_failure()
+                || remote_error.is_timeout()
+                || matches!(remote_error, RemoteRequestError::RemoteShutdown);
         }
         cause.downcast_ref::<io::Error>().is_some_and(|io_error| {
             matches!(
@@ -269,6 +278,9 @@ impl std::fmt::Display for RemoteRequestError {
             Self::Timeout => write!(formatter, "remote session did not respond"),
             Self::Rejected { error, .. } => write!(formatter, "remote command rejected: {error}"),
             Self::Shutdown => write!(formatter, "remote response wait canceled for shutdown"),
+            Self::RemoteShutdown => {
+                write!(formatter, "remote response wait canceled after peer disconnect")
+            }
         }
     }
 }
@@ -2685,10 +2697,11 @@ impl RemoteSession {
                     return;
                 };
                 self.log_frame(id, format_args!("output bytes={}", bytes.len()));
-                let pipe_io_owned = self.pipe_io_forward(id, || PipeIoEvent::Output(bytes.clone()));
-                if pipe_io_owned {
-                    return;
-                }
+                let bytes = match self.pipe_io_forward_owned(id, PipeIoEvent::Output(bytes)) {
+                    Ok(()) => return,
+                    Err(PipeIoEvent::Output(bytes)) => bytes,
+                    Err(_) => return,
+                };
                 let colors = value.get("colors").and_then(parse_terminal_colors);
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     surface.scan_cursor_provenance(&bytes);
@@ -3112,6 +3125,14 @@ impl RemoteSession {
         self.request_with_deadline(cmd, RequestDeadline::Standard)
     }
 
+    fn shutdown_request_error(&self) -> RemoteRequestError {
+        if matches!(&*self.disconnect_state.lock().unwrap(), DisconnectState::Remote(_)) {
+            RemoteRequestError::RemoteShutdown
+        } else {
+            RemoteRequestError::Shutdown
+        }
+    }
+
     /// Fire-and-forget command: enqueued in order with interactive traffic,
     /// never awaited. Used for best-effort reporting such as client focus.
     pub(crate) fn notify(&self, cmd: Value) -> anyhow::Result<()> {
@@ -3170,7 +3191,7 @@ impl RemoteSession {
 
         if self.shutdown.load(Ordering::Acquire) {
             self.pending.lock().unwrap().remove(&id);
-            return Err(RemoteRequestError::Shutdown.into());
+            return Err(self.shutdown_request_error().into());
         }
 
         let response = match self.wait_for_response(rx, deadline, progress, attach_progress) {
@@ -3215,7 +3236,7 @@ impl RemoteSession {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
                 Err(RecvTimeoutError::Disconnected) if self.shutdown.load(Ordering::Acquire) => {
-                    Err(RemoteRequestError::Shutdown)
+                    Err(self.shutdown_request_error())
                 }
                 Err(RecvTimeoutError::Disconnected) => Err(RemoteRequestError::Timeout),
             };
@@ -3241,13 +3262,13 @@ impl RemoteSession {
             match rx.recv_timeout(wait) {
                 Ok(response) => return Ok(response),
                 Err(RecvTimeoutError::Disconnected) if self.shutdown.load(Ordering::Acquire) => {
-                    return Err(RemoteRequestError::Shutdown);
+                    return Err(self.shutdown_request_error());
                 }
                 Err(RecvTimeoutError::Disconnected) => return Err(RemoteRequestError::Timeout),
                 Err(RecvTimeoutError::Timeout) => {}
             }
             if self.shutdown.load(Ordering::Acquire) {
-                return Err(RemoteRequestError::Shutdown);
+                return Err(self.shutdown_request_error());
             }
         }
     }
@@ -3272,7 +3293,7 @@ impl RemoteSession {
             .map_err(RemoteRequestError::Transport)?;
         if self.shutdown.load(Ordering::Acquire) {
             self.wait_for_ordered_write(sequence).map_err(RemoteRequestError::Transport)?;
-            return Err(RemoteRequestError::Shutdown.into());
+            return Err(self.shutdown_request_error().into());
         }
         Ok(())
     }
@@ -3560,26 +3581,34 @@ impl RemoteSession {
     /// would corrupt the embedder's terminal state (bounded-backpressure
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
+        self.pipe_io_forward_owned(surface, event()).is_ok()
+    }
+
+    /// Forwards an already-owned event without cloning its payload. If no
+    /// matching tap exists, the event is returned to the caller for normal
+    /// terminal parsing. Once a tap owns the event, queue overflow consumes it
+    /// and tears down that relay, so the caller must not parse it locally.
+    fn pipe_io_forward_owned(
+        &self,
+        surface: SurfaceId,
+        event: PipeIoEvent,
+    ) -> Result<(), PipeIoEvent> {
         use crossbeam_channel::TrySendError;
-        let (stalled_token, pipe_io_owned) = {
+        let stalled_token = {
             let tap = self.pipe_io_tap.lock().unwrap();
-            let Some(tap) = tap.as_ref() else { return false };
+            let Some(tap) = tap.as_ref() else { return Err(event) };
             if tap.surface != surface {
-                return false;
+                return Err(event);
             }
-            // Resolve ownership before invoking the closure. Output and
-            // replay call sites capture a payload clone in the closure, and
-            // sessions without a matching tap must not pay that allocation.
-            let event = event();
             let retained_bytes = event.retained_bytes();
             if !tap.byte_budget.try_reserve(retained_bytes) {
-                (Some(tap.token.clone()), true)
+                Some(tap.token.clone())
             } else {
                 match tap.sender.try_send(event) {
-                    Ok(()) => (None, true),
+                    Ok(()) => None,
                     Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
                         tap.byte_budget.release(retained_bytes);
-                        (Some(tap.token.clone()), true)
+                        Some(tap.token.clone())
                     }
                 }
             }
@@ -3592,11 +3621,7 @@ impl RemoteSession {
                 self.disconnect_transport();
             }
         }
-        // Capture ownership while holding the tap lock. A concurrent relay
-        // teardown can remove the tap before the caller reaches its parser
-        // fence; returning this snapshot prevents one raw event from being
-        // parsed twice during that handoff.
-        pipe_io_owned
+        Ok(())
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -7332,7 +7357,7 @@ mod tests {
         assert!(
             matches!(
                 error.downcast_ref::<RemoteRequestError>(),
-                Some(RemoteRequestError::Shutdown)
+                Some(RemoteRequestError::RemoteShutdown)
             ),
             "expected shutdown after malformed JSON canceled the request, got {error:?}"
         );
@@ -8146,7 +8171,7 @@ mod tests {
         assert!(
             matches!(
                 error.downcast_ref::<RemoteRequestError>(),
-                Some(RemoteRequestError::Shutdown)
+                Some(RemoteRequestError::RemoteShutdown)
             ),
             "expected shutdown after EOF canceled the request, got {error:?}"
         );

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6515,6 +6515,8 @@ mod tests {
         remaining_responses: usize,
         release: Arc<(Mutex<bool>, Condvar)>,
         exited: Sender<()>,
+        entered: Option<Sender<()>>,
+        exit_delay: Duration,
     }
 
     impl RemoteMessageReader for LifecycleReader {
@@ -6527,9 +6529,15 @@ mod tests {
             }
 
             let (released, changed) = &*self.release;
+            if let Some(entered) = self.entered.take() {
+                let _ = entered.send(());
+            }
             let mut released = released.lock().unwrap();
             while !*released {
                 released = changed.wait(released).unwrap();
+            }
+            if !self.exit_delay.is_zero() {
+                std::thread::sleep(self.exit_delay);
             }
             self.exited.send(()).unwrap();
             Ok(None)
@@ -6595,6 +6603,8 @@ mod tests {
                 remaining_responses: 3,
                 release: release.clone(),
                 exited: reader_exited,
+                entered: None,
+                exit_delay: Duration::ZERO,
             }),
             Box::new(LifecycleWriter { responses, closed: closed.clone(), exited: writer_exited }),
             Arc::new(LifecycleAbort { release }),
@@ -6610,6 +6620,42 @@ mod tests {
         writer_exited_rx
             .recv_timeout(Duration::from_millis(100))
             .expect("transport shutdown must join the writer");
+    }
+
+    #[test]
+    fn dropping_session_waits_for_blocked_reader_worker() {
+        let (responses, response_rx) = channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (reader_entered, reader_entered_rx) = channel();
+        let (reader_exited, reader_exited_rx) = channel();
+        let (writer_exited, _writer_exited_rx) = channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let session = RemoteSession::connect_transport(RemoteTransport::new(
+            Box::new(LifecycleReader {
+                responses: response_rx,
+                remaining_responses: 3,
+                release: release.clone(),
+                exited: reader_exited,
+                entered: Some(reader_entered),
+                exit_delay: Duration::from_millis(50),
+            }),
+            Box::new(LifecycleWriter { responses, closed, exited: writer_exited }),
+            Arc::new(LifecycleAbort { release }),
+        ))
+        .unwrap();
+        reader_entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("reader did not reach its blocked receive");
+
+        let started = Instant::now();
+        drop(session);
+        assert!(
+            started.elapsed() >= Duration::from_millis(40),
+            "dropping the session returned before the reader worker exited"
+        );
+        reader_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("reader worker did not exit before session drop returned");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3581,7 +3581,33 @@ impl RemoteSession {
     /// would corrupt the embedder's terminal state (bounded-backpressure
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
-        self.pipe_io_forward_owned(surface, event()).is_ok()
+        use crossbeam_channel::TrySendError;
+        let stalled_token = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return false };
+            if tap.surface != surface {
+                return false;
+            }
+            let event = event();
+            let retained_bytes = event.retained_bytes();
+            if !tap.byte_budget.try_reserve(retained_bytes) {
+                Some(tap.token.clone())
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => None,
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        tap.byte_budget.release(retained_bytes);
+                        Some(tap.token.clone())
+                    }
+                }
+            }
+        };
+        if let Some(token) = stalled_token {
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
+        }
+        true
     }
 
     /// Forwards an already-owned event without cloning its payload. If no

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1804,6 +1804,7 @@ pub enum PipeIoEvent {
     SurfaceExited,
     TransportLost,
     StdinClosed,
+    StdinError,
 }
 
 impl PipeIoEvent {
@@ -1812,7 +1813,7 @@ impl PipeIoEvent {
     pub(crate) fn retained_bytes(&self) -> usize {
         match self {
             Self::Replay { bytes } | Self::Output(bytes) => bytes.len(),
-            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed => 0,
+            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed | Self::StdinError => 0,
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4263,3 +4263,380 @@ fn unique_temp_dir(name: &str) -> PathBuf {
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_cmux-tui")
 }
+
+// ---------------------------------------------------------------------------
+// `attach --pipe-io`: renderer-less byte relay for embedder-fed surfaces.
+//
+// Contract under test (GUI-frontend migration, manual-IO surface):
+//   stdout  = raw VT bytes (daemon replay first, then live output),
+//   stdin   = JSON lines ({"input":"<b64>"} | {"resize":{"cols":N,"rows":N}}),
+//   stderr  = one final JSON line {"exit":{"reason":...}},
+//   exit 0  = terminal ended (or parent closed stdin) — do not respawn,
+//   exit 2  = daemon connection lost — the embedder may respawn to resync.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+struct PipeIoRelay {
+    child: Child,
+    stdin: Option<std::process::ChildStdin>,
+    stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+#[cfg(unix)]
+impl PipeIoRelay {
+    fn start(server: &HeadlessServer, terminal: &str, cols: u16, rows: u16) -> Self {
+        let mut child = Command::new(bin())
+            .args(["attach", "--socket"])
+            .arg(&server.socket)
+            .args([
+                "--terminal",
+                terminal,
+                "--pipe-io",
+                "--cols",
+                &cols.to_string(),
+                "--rows",
+                &rows.to_string(),
+            ])
+            .env_remove("CMUX_TUI_SOCKET")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take();
+        let stdout = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let stderr = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let out = child.stdout.take().unwrap();
+        let err = child.stderr.take().unwrap();
+        let stdout_sink = stdout.clone();
+        std::thread::spawn(move || drain_into(out, stdout_sink));
+        let stderr_sink = stderr.clone();
+        std::thread::spawn(move || drain_into(err, stderr_sink));
+        Self { child, stdin, stdout, stderr }
+    }
+
+    fn send_input(&mut self, bytes: &[u8]) {
+        use base64::Engine as _;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        let line = format!("{}\n", serde_json::json!({ "input": encoded }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn send_resize(&mut self, cols: u16, rows: u16) {
+        let line = format!("{}\n", serde_json::json!({ "resize": { "cols": cols, "rows": rows } }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn send_claim(&mut self) {
+        let line = format!("{}\n", serde_json::json!({ "claim": { "geometry": true } }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn stdout_text(&self) -> String {
+        String::from_utf8_lossy(&self.stdout.lock().unwrap()).into_owned()
+    }
+
+    fn stderr_text(&self) -> String {
+        String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned()
+    }
+
+    fn wait_for_stdout(&mut self, needle: &str, what: &str) {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            if self.stdout_text().contains(needle) {
+                return;
+            }
+            if let Some(status) = self.child.try_wait().unwrap() {
+                panic!(
+                    "pipe-io relay exited ({status}) before {what}\nstdout:\n{}\nstderr:\n{}",
+                    self.stdout_text(),
+                    String::from_utf8_lossy(&self.stderr.lock().unwrap())
+                );
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("timed out waiting for {what}\nstdout:\n{}", self.stdout_text());
+    }
+
+    fn wait_for_exit(&mut self) -> (i32, serde_json::Value) {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                // Let the drain threads observe EOF.
+                std::thread::sleep(Duration::from_millis(100));
+                let stderr_text =
+                    String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
+                let exit_line = stderr_text
+                    .lines()
+                    .rev()
+                    .find(|line| line.trim_start().starts_with('{'))
+                    .unwrap_or_else(|| {
+                        panic!("pipe-io relay printed no JSON exit line\nstderr:\n{stderr_text}")
+                    })
+                    .to_string();
+                let value: serde_json::Value = serde_json::from_str(&exit_line).unwrap();
+                return (status.code().unwrap_or(-1), value);
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("pipe-io relay did not exit\nstdout:\n{}", self.stdout_text());
+    }
+}
+
+#[cfg(unix)]
+fn drain_into(mut source: impl Read, sink: std::sync::Arc<std::sync::Mutex<Vec<u8>>>) {
+    let mut buffer = [0u8; 4096];
+    loop {
+        match source.read(&mut buffer) {
+            Ok(0) | Err(_) => return,
+            Ok(count) => sink.lock().unwrap().extend_from_slice(&buffer[..count]),
+        }
+    }
+}
+
+/// Reaps the adoptable terminal hosts a deliberate daemon SIGKILL leaves
+/// behind. The fixture's Drop treats any surviving host as a leak, but this
+/// test kills the daemon on purpose (host adoption after a daemon death is
+/// covered elsewhere); the orphaned hosts are part of the arranged scene.
+#[cfg(unix)]
+fn reap_orphaned_hosts_after_daemon_kill(server: &HeadlessServer) {
+    let host_root = cmux_tui_core::terminal_host_runtime::terminal_host_root(&server.state, "main");
+    for pid in terminal_host_pids(&host_root) {
+        if let Ok(pid) = libc::pid_t::try_from(pid) {
+            // SAFETY: terminating a test-owned child process group member.
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+    }
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while terminal_host_pids(&host_root).iter().any(|pid| process_exists(*pid)) {
+        assert!(Instant::now() < deadline, "orphaned terminal hosts survived SIGKILL");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    let _ = fs::remove_dir_all(&host_root);
+}
+
+#[cfg(unix)]
+fn pipe_io_terminal(server: &HeadlessServer) -> String {
+    let created = json_cli(server, &["workspace", "create", "--name", "pipe-io"]);
+    assert_success(&created);
+    json_output(&created)["value"]["terminal_id"].as_str().unwrap().to_string()
+}
+
+/// Count literal `^[[<digits>;<digits>R` runs, the form `cat -v` uses to
+/// render a cursor-position report that reached the inner process.
+#[cfg(unix)]
+fn visible_cursor_position_reports(text: &str) -> usize {
+    let bytes = text.as_bytes();
+    let mut count = 0;
+    let mut index = 0;
+    while let Some(offset) = text[index..].find("^[[") {
+        let mut cursor = index + offset + 3;
+        let mut digits_then_semicolon = false;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+            cursor += 1;
+        }
+        if cursor < bytes.len() && bytes[cursor] == b';' {
+            cursor += 1;
+            let row_end = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            digits_then_semicolon = cursor > row_end;
+        }
+        if digits_then_semicolon && cursor < bytes.len() && bytes[cursor] == b'R' {
+            count += 1;
+        }
+        index += offset + 3;
+    }
+    count
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_attach_streams_output_and_replays_on_reconnect() {
+    let server = HeadlessServer::start("pipe-io-basic");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut first = PipeIoRelay::start(&server, &terminal, 80, 24);
+    first.send_input(b"printf 'PIPEIO-%s\\n' FIRST\n");
+    first.wait_for_stdout("PIPEIO-FIRST", "live output of the typed marker");
+
+    // Dropping stdin tells the relay its embedder is gone: clean exit 0.
+    first.stdin = None;
+    let (code, exit) = first.wait_for_exit();
+    assert_eq!(code, 0, "stdin EOF must be a clean detach, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "parent-closed");
+
+    // A fresh relay must serve the daemon replay before live bytes: the
+    // marker typed through the first relay is visible without retyping.
+    let mut second = PipeIoRelay::start(&server, &terminal, 80, 24);
+    second.wait_for_stdout("PIPEIO-FIRST", "replayed marker after reconnect");
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_exit_distinguishes_terminal_end_from_daemon_loss() {
+    let mut server = HeadlessServer::start("pipe-io-exits");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    relay.send_input(b"printf 'PIPEIO-%s\\n' READY\n");
+    relay.wait_for_stdout("PIPEIO-READY", "shell readiness marker");
+    let closed = json_cli(&server, &["terminal", &terminal, "close"]);
+    assert_success(&closed);
+    let (code, exit) = relay.wait_for_exit();
+    assert_eq!(code, 0, "terminal close must exit 0, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "terminal-ended");
+
+    let second_terminal = pipe_io_terminal(&server);
+    let mut survivor = PipeIoRelay::start(&server, &second_terminal, 80, 24);
+    survivor.send_input(b"printf 'PIPEIO-%s\\n' TWO\n");
+    survivor.wait_for_stdout("PIPEIO-TWO", "second shell readiness marker");
+    server.child.kill().unwrap();
+    let (code, exit) = survivor.wait_for_exit();
+    assert_eq!(code, 2, "daemon loss must exit 2, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "daemon-lost");
+    reap_orphaned_hosts_after_daemon_kill(&server);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_startup_connect_failure_reports_daemon_lost() {
+    // A daemon restart window (dead socket) must read as daemon-lost so
+    // the embedder keeps retrying; only unexplained failures make it stop.
+    let dir = unique_temp_dir("pipe-io-dead-socket");
+    fs::create_dir_all(&dir).unwrap();
+    let dead_socket = dir.join("mux.sock");
+    let output = Command::new(bin())
+        .args(["attach", "--socket"])
+        .arg(&dead_socket)
+        .args(["--terminal", "term_0123456789abcdef0123456789abcdef", "--pipe-io"])
+        .env_remove("CMUX_TUI_SOCKET")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let exit_line = stderr.lines().rev().find(|line| line.trim_start().starts_with('{')).unwrap();
+    let value: serde_json::Value = serde_json::from_str(exit_line).unwrap();
+    assert_eq!(value["exit"]["reason"], "daemon-lost");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_resize_reaches_the_daemon_pty() {
+    let server = HeadlessServer::start("pipe-io-resize");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    relay.send_input(b"printf 'PIPEIO-%s\\n' SIZED\n");
+    relay.wait_for_stdout("PIPEIO-SIZED", "shell readiness marker");
+    relay.send_resize(100, 30);
+    // The daemon acknowledges the resize before the PTY winsize necessarily
+    // lands; poll stty until the new geometry is visible.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        relay.send_input(b"stty size\n");
+        let poll_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < poll_deadline {
+            if relay.stdout_text().contains("30 100") {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for stty to report the resized PTY\nstdout:\n{}\nstderr:\n{}",
+            relay.stdout_text(),
+            relay.stderr_text()
+        );
+    }
+}
+
+/// Polls `stty size` through `relay` until `needle` (e.g. "30 100") shows,
+/// panicking with both streams on timeout. The daemon acknowledges resizes
+/// before the PTY winsize necessarily lands, hence the poll.
+#[cfg(unix)]
+fn wait_for_stty(relay: &mut PipeIoRelay, needle: &str, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        relay.send_input(b"stty size\n");
+        let poll_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < poll_deadline {
+            if relay.stdout_text().contains(needle) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {what}\nstdout:\n{}\nstderr:\n{}",
+            relay.stdout_text(),
+            relay.stderr_text()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_claim_line_reclaims_geometry_authority() {
+    let server = HeadlessServer::start("pipe-io-claim");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut first = PipeIoRelay::start(&server, &terminal, 80, 24);
+    first.send_input(b"printf 'PIPEIO-%s\\n' CLAIM\n");
+    first.wait_for_stdout("PIPEIO-CLAIM", "shell readiness marker");
+
+    // A later attachment claims geometry authority (last claim wins), so
+    // the PTY follows the second relay's smaller grid.
+    let mut second = PipeIoRelay::start(&server, &terminal, 60, 20);
+    second.wait_for_stdout("PIPEIO-CLAIM", "replay on the second relay");
+    wait_for_stty(&mut first, "20 60", "the second attach claim to resize the PTY");
+
+    // The claim line is how an embedder re-asserts authority when its pane
+    // receives user input; the first relay's sizes apply again.
+    first.send_claim();
+    wait_for_stty(&mut first, "24 80", "the reclaim to restore the first relay's grid");
+    first.send_resize(100, 30);
+    wait_for_stty(&mut first, "30 100", "a post-reclaim resize to apply");
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_inner_query_is_answered_exactly_once() {
+    let server = HeadlessServer::start("pipe-io-reply-authority");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    // The inner program emits a DSR cursor-position query and then renders
+    // its own stdin visibly. Exactly one authority (the daemon-side
+    // terminal) must answer; the relay and any embedder mirror stay silent.
+    relay.send_input(b"sh -c 'printf \"\\033[6n\"; exec cat -v'\n");
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut seen = 0;
+    while Instant::now() < deadline {
+        seen = visible_cursor_position_reports(&relay.stdout_text());
+        if seen >= 1 {
+            // Give a duplicated reply time to surface before asserting.
+            std::thread::sleep(Duration::from_millis(500));
+            seen = visible_cursor_position_reports(&relay.stdout_text());
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert_eq!(
+        seen,
+        1,
+        "inner DSR query must be answered exactly once\nstdout:\n{}",
+        relay.stdout_text()
+    );
+}

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4286,6 +4286,16 @@ struct PipeIoRelay {
 #[cfg(unix)]
 impl PipeIoRelay {
     fn start(server: &HeadlessServer, terminal: &str, cols: u16, rows: u16) -> Self {
+        Self::start_with_stderr_delay(server, terminal, cols, rows, Duration::ZERO)
+    }
+
+    fn start_with_stderr_delay(
+        server: &HeadlessServer,
+        terminal: &str,
+        cols: u16,
+        rows: u16,
+        stderr_delay: Duration,
+    ) -> Self {
         let mut child = Command::new(bin())
             .args(["attach", "--socket"])
             .arg(&server.socket)
@@ -4312,7 +4322,12 @@ impl PipeIoRelay {
         let stdout_sink = stdout.clone();
         std::thread::spawn(move || drain_into(out, stdout_sink));
         let stderr_sink = stderr.clone();
-        std::thread::spawn(move || drain_into(err, stderr_sink));
+        std::thread::spawn(move || {
+            if !stderr_delay.is_zero() {
+                std::thread::sleep(stderr_delay);
+            }
+            drain_into(err, stderr_sink);
+        });
         Self { child, stdin, stdout, stderr }
     }
 
@@ -4529,6 +4544,25 @@ fn pipe_io_startup_connect_failure_reports_daemon_lost() {
     let value: serde_json::Value = serde_json::from_str(exit_line).unwrap();
     assert_eq!(value["exit"]["reason"], "daemon-lost");
     let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_wait_for_exit_waits_for_delayed_stderr_drain() {
+    let server = HeadlessServer::start("pipe-io-drain-join");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start_with_stderr_delay(
+        &server,
+        &terminal,
+        80,
+        24,
+        Duration::from_millis(500),
+    );
+    relay.stdin = None;
+    let (code, exit) = relay.wait_for_exit();
+    assert_eq!(code, 0, "stdin EOF must be a clean detach, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "parent-closed");
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4281,6 +4281,8 @@ struct PipeIoRelay {
     stdin: Option<std::process::ChildStdin>,
     stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
     stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    stdout_drain: Option<std::thread::JoinHandle<()>>,
+    stderr_drain: Option<std::thread::JoinHandle<()>>,
 }
 
 #[cfg(unix)]
@@ -4320,15 +4322,22 @@ impl PipeIoRelay {
         let out = child.stdout.take().unwrap();
         let err = child.stderr.take().unwrap();
         let stdout_sink = stdout.clone();
-        std::thread::spawn(move || drain_into(out, stdout_sink));
+        let stdout_drain = std::thread::spawn(move || drain_into(out, stdout_sink));
         let stderr_sink = stderr.clone();
-        std::thread::spawn(move || {
+        let stderr_drain = std::thread::spawn(move || {
             if !stderr_delay.is_zero() {
                 std::thread::sleep(stderr_delay);
             }
             drain_into(err, stderr_sink);
         });
-        Self { child, stdin, stdout, stderr }
+        Self {
+            child,
+            stdin,
+            stdout,
+            stderr,
+            stdout_drain: Some(stdout_drain),
+            stderr_drain: Some(stderr_drain),
+        }
     }
 
     fn send_input(&mut self, bytes: &[u8]) {
@@ -4378,8 +4387,15 @@ impl PipeIoRelay {
         let deadline = Instant::now() + Duration::from_secs(20);
         while Instant::now() < deadline {
             if let Some(status) = self.child.try_wait().unwrap() {
-                // Let the drain threads observe EOF.
-                std::thread::sleep(Duration::from_millis(100));
+                // Child EOF is the completion signal for both drain threads.
+                // Join them before reading stderr so the final exit record
+                // cannot race the test's parser.
+                if let Some(drain) = self.stdout_drain.take() {
+                    drain.join().expect("stdout drain thread panicked");
+                }
+                if let Some(drain) = self.stderr_drain.take() {
+                    drain.join().expect("stderr drain thread panicked");
+                }
                 let stderr_text =
                     String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
                 let exit_line = stderr_text

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -13,7 +13,7 @@ request:
 ```text
 cmux [START OPTIONS]
 cmux server start [START OPTIONS]
-cmux attach [START OPTIONS] [--terminal <terminal-id>]
+cmux attach [START OPTIONS] [--terminal <terminal-id>] [--pipe-io [--cols <n> --rows <n>]]
 cmux relay [ROUTING OPTIONS]
 cmux machine-agent [OPTIONS]
 ```
@@ -24,6 +24,25 @@ complete session TUI. `attach --terminal <terminal-id>` resolves an exact ID
 from `cmux terminal list` and renders only that terminal, without session
 chrome or unrelated event traffic. Startup attach does not accept internal
 runtime identifiers, abbreviated identifiers, names, or `current`.
+
+`attach --terminal <terminal-id> --pipe-io` is the same scoped attach without
+a renderer, for an embedder that parses terminal bytes itself. stdout carries
+raw bytes: the daemon replay first, then live output, with a full reset
+(`ESC c` plus erase-scrollback) before any replay that is not the relay's
+first output, because a replay replaces state while a byte stream appends.
+stdin takes one JSON object per line: `{"input":"<base64>"}` forwards bytes to
+the terminal, `{"resize":{"cols":N,"rows":N}}` drives the attached viewer
+size, and `{"claim":{"geometry":true}}` re-asserts this relay's geometry
+authority (authority is last-claim-wins across a terminal's attachments; an
+embedder sends it when its pane receives user input, so the typed-in pane
+owns the PTY size). Each applied resize and claim is reported as one
+`{"diag":...}` stderr line; unknown keys are ignored. stderr ends with one
+JSON line
+`{"exit":{"reason":"terminal-ended"|"daemon-lost"|"parent-closed"}}`. Exit
+code 0 means the terminal ended or the embedder closed stdin (do not
+respawn); exit code 2 means the daemon connection was lost and a respawn
+reattaches and resyncs from a fresh replay. `--cols` and `--rows` set the
+initial viewer size (default 80x24). `--pipe-io` requires `--terminal`.
 
 Interactive and headless ownership are intentionally separate:
 


### PR DESCRIPTION
## Summary

Ports the still-tracked `cmux-tui attach --terminal <id> --pipe-io` milestone onto current `main` without the obsolete Swift Process relay or cloud pane wiring.

- Adds the bounded raw VT relay, JSON input and resize protocol, scoped event tap, replay reset, geometry claim, and daemon-loss classification.
- Preserves PTY input bounds, ordered writer deadlines, transport-loss fencing, and CLI integration tests.
- Adds regression coverage for tap ownership and deterministic stderr/stdout drain completion.
- Emits the final JSON exit record for unsupported scoped subscriptions and classifies initial geometry claim failures.

Commit order is feature port, failing regression tests, then fixes. Rust tests were not run locally because repository policy requires hosted Rust verification. Static `rustfmt --edition 2024 --check` and `git diff --check` pass.

This PR is based directly on current `main` and supersedes only the Rust relay portion of [#11443](https://github.com/manaflow-ai/cmux/pull/11443), [#11553](https://github.com/manaflow-ai/cmux/pull/11553), and [#11700](https://github.com/manaflow-ai/cmux/pull/11700). Keep [#11523](https://github.com/manaflow-ai/cmux/pull/11523) as the owner of native cloud manual-mirror UI. The old stacked PRs should be closed after this replacement is reviewed.

## Verification

- Base: `main` at `857b5f249c3099ac0523e8c966406a9a9107c250`
- Head: `341ea50b02d025780a3634d46d7a8d3e48a2f184`
- Changed paths are limited to `cmux-tui` Rust sources, tests, and CLI spec.
- No cargo, rustc, or local Rust tests run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790959651&installation_model_id=21920&pr_number=11705&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11705&signature=f6a820d490ec8d9ec71b1007ebc78bdd178ff8e6ef9bdab9529955a3c2d10a5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `cmux attach --terminal <id> --pipe-io` as a rendererless relay for embedders that parse raw terminal bytes. Normal attach renders; pipe mode streams replay and live VT output over stdout, accepts JSON commands on stdin, and reports completion, daemon loss, and stdin read failures through a final JSON exit record.

- Replays after the first start with a full terminal reset; `--cols` and `--rows` set initial geometry (default 80×24), and the startup geometry claim is acknowledged.
- Checks remote capabilities before attaching and classifies unsupported or retryable daemon errors accordingly.
- Remote workers own cancellation, abort transports before waiting, join readers during session drop, and use bounded joins for deterministic shutdown.
- The stdin pump does not retain the remote session and preserves UTF-8 frames across input chunks, so the relay can release it cleanly on exit.
- Startup failures preserve distinct classifications and reasons, while stdin diagnostics are serialized to avoid blocking and interleaved output.
- Regression tests cover tap ownership, UTF-8 frame boundaries, stream draining, startup failures, worker shutdown, reader cleanup, and stdin read failures before remote input delivery.

<sup>Written for commit 21941b991504bdd388c37d1129937005efd331af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added `cmux attach --pipe-io` for embedding terminal sessions through standard input and output.
  - Streams terminal replay and live output, and accepts input, resize, and geometry-claim commands.
  - Added configurable initial dimensions with `--cols` and `--rows` (default: 80×24).
  - Reports terminal completion and connection loss through machine-readable status messages and exit codes.

- **Documentation**
  - Documented pipe-IO usage, supported commands, output behavior, and exit statuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

