### PR TITLE
fix(cmux-tui): preserve Ghostty wide-cell render semantics

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -442,7 +442,7 @@ fn renderable_cell_text(text: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ghostty_vt::{Callbacks, CursorInfo, CursorShape, RenderState, Terminal};
+    use ghostty_vt::{Callbacks, CursorShape, RenderState, Terminal};
     use ratatui::Terminal as RatatuiTerminal;
     use ratatui::backend::TestBackend;
 

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use cmux_tui_core::{Rect, SurfaceRenderFrame};
-use ghostty_vt::{Cell as VtCell, CellWidth, ColorSpec, Rgb};
+use ghostty_vt::{Cell as VtCell, CellWidth, ColorSpec, CursorInfo, Rgb};
 use ratatui::Frame;
 use ratatui::buffer::Buffer;
 use ratatui::layout::Rect as RatatuiRect;
@@ -127,15 +127,45 @@ fn draw_render_frame_with_catalog(
         );
     }
 
-    render
-        .frame
-        .cursor
-        .filter(|cursor| {
-            cursor.x >= source_x
-                && usize::from(cursor.x - source_x) < live_cols
-                && (cursor.y as usize) < live_rows
-        })
-        .map(|cursor| (rect.x + cursor.x - source_x, rect.y + cursor.y))
+    render.frame.cursor.and_then(|cursor| {
+        cropped_cursor_position(
+            cursor,
+            render.frame.styled_rows(),
+            source_x,
+            live_cols,
+            live_rows,
+        )
+        .map(|(x, y)| (rect.x + x, rect.y + y))
+    })
+}
+
+/// Return a cursor position that is drawable in a horizontally cropped frame.
+/// Ghostty can report a cursor on a wide grapheme's trailing spacer. That
+/// spacer is not an independent drawable cell, so place the cursor on the
+/// grapheme lead before applying crop bounds.
+fn cropped_cursor_position(
+    cursor: CursorInfo,
+    rows: &[Vec<VtCell>],
+    source_x: u16,
+    live_cols: usize,
+    live_rows: usize,
+) -> Option<(u16, u16)> {
+    let mut x = cursor.x;
+    if x > 0
+        && rows
+            .get(cursor.y as usize)
+            .and_then(|row| row.get(x as usize))
+            .is_some_and(|cell| cell.width == CellWidth::SpacerTail)
+        && rows
+            .get(cursor.y as usize)
+            .and_then(|row| row.get((x - 1) as usize))
+            .is_some_and(|cell| cell.width == CellWidth::Wide)
+    {
+        x -= 1;
+    }
+
+    (x >= source_x && usize::from(x - source_x) < live_cols && (cursor.y as usize) < live_rows)
+        .then_some((x - source_x, cursor.y))
 }
 
 fn partial_wide_cell(

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -688,6 +688,28 @@ mod tests {
                     crate::localization::catalog_for_locale("en_US.UTF-8"),
                     |_, _| false,
                 );
+        })
+            .unwrap();
+        assert_eq!(cursor, None);
+
+        // A lead at the right crop edge is also blanked because its spacer
+        // falls outside the live width, so it must not receive a cursor.
+        let mut output = RatatuiTerminal::new(TestBackend::new(1, 1)).unwrap();
+        let mut cursor = None;
+        output
+            .draw(|frame| {
+                cursor = draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 1, height: 1 },
+                        source_x: 1,
+                    },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    |_, _| false,
+                );
             })
             .unwrap();
         assert_eq!(cursor, None);

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -412,7 +412,7 @@ fn renderable_cell_text(text: &str) -> Cow<'_, str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ghostty_vt::{Callbacks, RenderState, Terminal};
+    use ghostty_vt::{Callbacks, CursorInfo, CursorShape, RenderState, Terminal};
     use ratatui::Terminal as RatatuiTerminal;
     use ratatui::backend::TestBackend;
 
@@ -545,6 +545,68 @@ mod tests {
 
         let clipped_tail = draw_crop(2);
         assert_eq!(row_text(clipped_tail.backend().buffer(), 0, 0, 2), " b");
+    }
+
+    #[test]
+    fn cropped_grid_places_a_wide_cell_cursor_on_the_lead_cell() {
+        let mut terminal = Terminal::new(6, 1, 0, Callbacks::default()).unwrap();
+        terminal.vt_write("a界bc".as_bytes());
+        let mut state = RenderState::new().unwrap();
+        state.update(&mut terminal).unwrap();
+        let mut render = SurfaceRenderFrame {
+            frame: state.build_frame().unwrap(),
+            content_generation: 1,
+            scrollback_rows: 0,
+            history_epoch: terminal.history_epoch(),
+            pointer_semantics: terminal.pointer_semantic_snapshot(),
+            palette_colors: std::array::from_fn(|idx| state.palette_color(idx as u8)),
+            palette_overridden: std::array::from_fn(|idx| state.palette_overridden(idx as u8)),
+        };
+        // A terminal cursor may be reported on the trailing spacer of a wide
+        // grapheme. The renderer must use the lead column for its placement.
+        render.frame.cursor = Some(CursorInfo {
+            x: 2,
+            y: 0,
+            shape: CursorShape::Block,
+            blinking: false,
+        });
+
+        let mut output = RatatuiTerminal::new(TestBackend::new(3, 1)).unwrap();
+        let mut cursor = None;
+        output
+            .draw(|frame| {
+                cursor = draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 3, height: 1 }, source_x: 1 },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    |_, _| false,
+                );
+            })
+            .unwrap();
+
+        assert_eq!(cursor, Some((0, 0)));
+
+        // Cropping from the spacer itself must not leave a cursor on a blank
+        // partial-glyph cell.
+        let mut output = RatatuiTerminal::new(TestBackend::new(2, 1)).unwrap();
+        let mut cursor = None;
+        output
+            .draw(|frame| {
+                cursor = draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 2, height: 1 }, source_x: 2 },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    |_, _| false,
+                );
+            })
+            .unwrap();
+        assert_eq!(cursor, None);
     }
 
     fn row_text(buffer: &Buffer, y: u16, x: u16, width: u16) -> String {

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -1,9 +1,10 @@
 use std::borrow::Cow;
+use std::num::NonZeroU16;
 
 use cmux_tui_core::{Rect, SurfaceRenderFrame};
 use ghostty_vt::{Cell as VtCell, CellWidth, ColorSpec, CursorInfo, Rgb};
 use ratatui::Frame;
-use ratatui::buffer::Buffer;
+use ratatui::buffer::{Buffer, CellDiffOption, CellWidth as RatatuiCellWidth};
 use ratatui::layout::Rect as RatatuiRect;
 use ratatui::style::{Color, Modifier, Style};
 
@@ -107,16 +108,23 @@ fn draw_render_frame_with_catalog(
         for col in 0..available {
             let source_col = source_x + col;
             let x = rect.x + col as u16;
-            let selected = selected(source_col as u16, row as u16);
             let cell = &cells[source_col];
-            apply_cell(&mut buf[(x, y)], cell, &colors, selected.then_some(theme));
-            if partial_wide_cell(cells, source_x, source_end, source_col) {
-                buf[(x, y)].set_symbol(" ");
+            let partial = partial_wide_cell(cells, source_x, source_end, source_col);
+            let selected = selected_cell(cells, source_col, row, &selected);
+            let target = &mut buf[(x, y)];
+            apply_cell(target, cell, &colors, selected.then_some(theme));
+            if partial {
+                // A clipped half of a wide grapheme is rendered as a normal
+                // blank cell. Clear the forced width applied above so Ratatui
+                // does not skip the adjacent column during diffing.
+                target.set_symbol(" ").set_diff_option(CellDiffOption::None);
             }
         }
         for col in available..live_cols {
             let x = rect.x + col as u16;
-            buf[(x, y)].set_symbol(" ").set_style(blank_style);
+            let target = &mut buf[(x, y)];
+            target.reset();
+            target.set_symbol(" ").set_style(blank_style);
         }
     }
 
@@ -137,6 +145,38 @@ fn draw_render_frame_with_catalog(
         )
         .map(|(x, y)| (rect.x + x, rect.y + y))
     })
+}
+
+/// Return whether a grid cell is selected, treating both columns of a wide
+/// grapheme as one selectable unit. Selection ranges are normally normalized
+/// to the lead cell, but checking the paired coordinate also keeps rendering
+/// correct for callers that still provide a raw spacer-tail endpoint.
+fn selected_cell(
+    cells: &[VtCell],
+    source_col: usize,
+    row: usize,
+    selected: &impl Fn(u16, u16) -> bool,
+) -> bool {
+    let selected_here = selected(source_col as u16, row as u16);
+    let paired_col = match cells[source_col].width {
+        CellWidth::Wide
+            if cells
+                .get(source_col.saturating_add(1))
+                .is_some_and(|next| next.width == CellWidth::SpacerTail) =>
+        {
+            Some(source_col + 1)
+        }
+        CellWidth::SpacerTail
+            if source_col > 0
+                && cells
+                    .get(source_col - 1)
+                    .is_some_and(|previous| previous.width == CellWidth::Wide) =>
+        {
+            Some(source_col - 1)
+        }
+        CellWidth::Narrow | CellWidth::SpacerHead | CellWidth::Wide | CellWidth::SpacerTail => None,
+    };
+    selected_here || paired_col.is_some_and(|col| selected(col as u16, row as u16))
 }
 
 /// Return a cursor position that is drawable in a horizontally cropped frame.
@@ -387,7 +427,17 @@ fn apply_cell(
     selected: Option<&Theme>,
 ) {
     target.reset();
-    target.set_symbol(&renderable_cell_text(&cell.text));
+    let text = renderable_cell_text(&cell.text);
+    target.set_symbol(&text);
+    let columns = match cell.width {
+        CellWidth::Wide => 2,
+        CellWidth::Narrow | CellWidth::SpacerTail | CellWidth::SpacerHead => 1,
+    };
+    if text.cell_width() != columns {
+        target.set_diff_option(CellDiffOption::ForcedWidth(
+            NonZeroU16::new(columns).expect("Ghostty cells always occupy at least one column"),
+        ));
+    }
 
     let mut style = Style::default();
     style = style.fg(colors.resolve_fg(cell.fg));

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -445,6 +445,8 @@ mod tests {
     use ghostty_vt::{Callbacks, CursorShape, RenderState, Terminal};
     use ratatui::Terminal as RatatuiTerminal;
     use ratatui::backend::TestBackend;
+    use ratatui::buffer::{CellDiffOption, CellWidth as RatatuiCellWidth};
+    use std::num::NonZeroU16;
 
     #[test]
     fn terminal_cells_drop_control_characters_before_ratatui_diffing() {
@@ -568,6 +570,7 @@ mod tests {
 
         let clipped_lead = draw_crop(0);
         assert_eq!(row_text(clipped_lead.backend().buffer(), 0, 0, 2), "a ");
+        assert_eq!(clipped_lead.backend().buffer()[(1, 0)].diff_option, CellDiffOption::None);
 
         let complete_glyph = draw_crop(1);
         assert_eq!(complete_glyph.backend().buffer()[(0, 0)].symbol(), "界");
@@ -575,6 +578,7 @@ mod tests {
 
         let clipped_tail = draw_crop(2);
         assert_eq!(row_text(clipped_tail.backend().buffer(), 0, 0, 2), " b");
+        assert_eq!(clipped_tail.backend().buffer()[(0, 0)].diff_option, CellDiffOption::None);
     }
 
     #[test]
@@ -764,6 +768,66 @@ mod tests {
             apply_cell(&mut target, &cell, &resolver, None);
             assert_eq!(target.symbol(), " ");
         }
+    }
+
+    #[test]
+    fn terminal_cells_keep_ghostty_width_for_ratatui_diffing() {
+        let colors = [Rgb::default(); 256];
+        let overridden = [false; 256];
+        let resolver = resolver(&colors, &overridden);
+        let cases = [
+            (CellWidth::Narrow, 1, "ｶﾞ", true),
+            (CellWidth::Wide, 2, "x", true),
+            (CellWidth::Wide, 2, "界", false),
+            (CellWidth::SpacerTail, 1, "", false),
+            (CellWidth::SpacerHead, 1, "", false),
+        ];
+
+        for (width, columns, text, forced) in cases {
+            let cell = VtCell { text: text.to_string(), width, ..VtCell::default() };
+            let mut target = ratatui::buffer::Cell::default();
+            apply_cell(&mut target, &cell, &resolver, None);
+            assert_eq!(target.cell_width(), columns, "Ghostty width {width:?} must remain authoritative");
+            let expected_diff_option = forced
+                .then(|| CellDiffOption::ForcedWidth(NonZeroU16::new(columns).unwrap()))
+                .unwrap_or(CellDiffOption::None);
+            assert_eq!(target.diff_option, expected_diff_option);
+        }
+    }
+
+    #[test]
+    fn selected_wide_glyph_styles_both_grid_cells() {
+        let mut terminal = Terminal::new(6, 1, 0, Callbacks::default()).unwrap();
+        terminal.vt_write("a界b".as_bytes());
+        let mut state = RenderState::new().unwrap();
+        state.update(&mut terminal).unwrap();
+        let render = SurfaceRenderFrame {
+            frame: state.build_frame().unwrap(),
+            content_generation: 1,
+            scrollback_rows: 0,
+            history_epoch: terminal.history_epoch(),
+            pointer_semantics: terminal.pointer_semantic_snapshot(),
+            palette_colors: std::array::from_fn(|idx| state.palette_color(idx as u8)),
+            palette_overridden: std::array::from_fn(|idx| state.palette_overridden(idx as u8)),
+        };
+        let mut output = RatatuiTerminal::new(TestBackend::new(4, 1)).unwrap();
+        output
+            .draw(|frame| {
+                draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 4, height: 1 }, source_x: 0 },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    |col, row| col == 1 && row == 0,
+                );
+            })
+            .unwrap();
+
+        let expected_bg = Theme::default().selection_bg;
+        assert_eq!(output.backend().buffer()[(1, 0)].bg, expected_bg);
+        assert_eq!(output.backend().buffer()[(2, 0)].bg, expected_bg);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -136,14 +136,8 @@ fn draw_render_frame_with_catalog(
     }
 
     render.frame.cursor.and_then(|cursor| {
-        cropped_cursor_position(
-            cursor,
-            render.frame.styled_rows(),
-            source_x,
-            live_cols,
-            live_rows,
-        )
-        .map(|(x, y)| (rect.x + x, rect.y + y))
+        cropped_cursor_position(cursor, render.frame.styled_rows(), source_x, live_cols, live_rows)
+            .map(|(x, y)| (rect.x + x, rect.y + y))
     })
 }
 
@@ -657,12 +651,8 @@ mod tests {
         };
         // A terminal cursor may be reported on the trailing spacer of a wide
         // grapheme. The renderer must use the lead column for its placement.
-        render.frame.cursor = Some(CursorInfo {
-            x: 2,
-            y: 0,
-            shape: CursorShape::Block,
-            blinking: false,
-        });
+        render.frame.cursor =
+            Some(CursorInfo { x: 2, y: 0, shape: CursorShape::Block, blinking: false });
 
         let mut output = RatatuiTerminal::new(TestBackend::new(3, 1)).unwrap();
         let mut cursor = None;
@@ -670,7 +660,10 @@ mod tests {
             .draw(|frame| {
                 cursor = draw_render_frame_with_catalog(
                     frame,
-                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 3, height: 1 }, source_x: 1 },
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 3, height: 1 },
+                        source_x: 1,
+                    },
                     &render,
                     &Theme::default(),
                     &ChromeTheme::dark(),
@@ -690,14 +683,17 @@ mod tests {
             .draw(|frame| {
                 cursor = draw_render_frame_with_catalog(
                     frame,
-                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 2, height: 1 }, source_x: 2 },
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 2, height: 1 },
+                        source_x: 2,
+                    },
                     &render,
                     &Theme::default(),
                     &ChromeTheme::dark(),
                     crate::localization::catalog_for_locale("en_US.UTF-8"),
                     |_, _| false,
                 );
-        })
+            })
             .unwrap();
         assert_eq!(cursor, None);
 
@@ -868,7 +864,11 @@ mod tests {
             let cell = VtCell { text: text.to_string(), width, ..VtCell::default() };
             let mut target = ratatui::buffer::Cell::default();
             apply_cell(&mut target, &cell, &resolver, None);
-            assert_eq!(target.cell_width(), columns, "Ghostty width {width:?} must remain authoritative");
+            assert_eq!(
+                target.cell_width(),
+                columns,
+                "Ghostty width {width:?} must remain authoritative"
+            );
             let expected_diff_option = forced
                 .then(|| CellDiffOption::ForcedWidth(NonZeroU16::new(columns).unwrap()))
                 .unwrap_or(CellDiffOption::None);
@@ -896,7 +896,10 @@ mod tests {
             .draw(|frame| {
                 draw_render_frame_with_catalog(
                     frame,
-                    HorizontalViewport { rect: Rect { x: 0, y: 0, width: 4, height: 1 }, source_x: 0 },
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 4, height: 1 },
+                        source_x: 0,
+                    },
                     &render,
                     &Theme::default(),
                     &ChromeTheme::dark(),

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -191,21 +191,30 @@ fn cropped_cursor_position(
     live_rows: usize,
 ) -> Option<(u16, u16)> {
     let mut x = cursor.x;
+    let row = rows.get(cursor.y as usize)?;
     if x > 0
-        && rows
-            .get(cursor.y as usize)
-            .and_then(|row| row.get(x as usize))
-            .is_some_and(|cell| cell.width == CellWidth::SpacerTail)
-        && rows
-            .get(cursor.y as usize)
-            .and_then(|row| row.get((x - 1) as usize))
-            .is_some_and(|cell| cell.width == CellWidth::Wide)
+        && row.get(x as usize).is_some_and(|cell| cell.width == CellWidth::SpacerTail)
+        && row.get((x - 1) as usize).is_some_and(|cell| cell.width == CellWidth::Wide)
     {
         x -= 1;
     }
 
-    (x >= source_x && usize::from(x - source_x) < live_cols && (cursor.y as usize) < live_rows)
-        .then_some((x - source_x, cursor.y))
+    if x < source_x || usize::from(x - source_x) >= live_cols || (cursor.y as usize) >= live_rows {
+        return None;
+    }
+
+    // A wide lead is drawable only when its trailing spacer is also inside
+    // the crop. This matches partial_wide_cell, which blanks split pairs.
+    if row.get(x as usize).is_some_and(|cell| cell.width == CellWidth::Wide)
+        && (usize::from(x - source_x).saturating_add(1) >= live_cols
+            || !row
+                .get(x.saturating_add(1) as usize)
+                .is_some_and(|cell| cell.width == CellWidth::SpacerTail))
+    {
+        return None;
+    }
+
+    Some((x - source_x, cursor.y))
 }
 
 fn partial_wide_cell(


### PR DESCRIPTION
## Summary
- normalize wide-cell cursor placement and hide cursors on cropped wide pairs
- keep Ghostty VtCell width authoritative when Ratatui symbol width differs
- style both columns of selected wide graphemes and clear width metadata on clipped blanks

## Verification
- `git diff --check`
- Local Cargo/Rust tests were not run. cmux-tui Rust tests require the Blacksmith Testbox.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11708"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790959986&installation_model_id=21920&pr_number=11708&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11708&signature=6b076d697d00ca3461104c5d6fa3385da8c504ae8990bd38945a47c453436b60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves Ghostty wide-cell render semantics in `cmux-tui`. Cursors that previously landed on a wide-cell spacer tail now move to the lead cell and disappear when the pair is cropped.

- Treats both columns of a wide grapheme as one selected unit, including spacer-tail endpoints.
- Keeps Ghostty’s cell width authoritative when rendered symbol widths differ and clears forced-width metadata from clipped blanks.
- Adds coverage for cursor cropping, width preservation, and wide-cell selection styling.

<sup>Written for commit 3c1927eff84b4a184395a13b8d50da943ada56df. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection behavior for wide characters so the entire character is treated as one selectable unit.
  * Corrected cursor placement when navigating wide characters near cropped or trailing cells.
  * Fixed terminal rendering and screen updates for wide characters, including clipped portions and differing cell widths.
  * Improved selection styling across both cells occupied by a wide character.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->