### PR TITLE
cmux-tui: fix mux import ordering

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -29095,7 +29095,7 @@ mod tests {
 }
 #[test]
 fn initial_bootstrap_lock_serializes_concurrent_callers() {
-    use std::sync::{mpsc, Arc, Barrier};
+    use std::sync::{Arc, Barrier, mpsc};
     use std::thread;
 
     let mux = Mux::new("bootstrap-lock-test", SurfaceOptions::default());


### PR DESCRIPTION
## Summary
- Reorder the local `std::sync` imports in `cmux-tui/crates/cmux-tui-core/src/mux.rs` to match rustfmt.

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/mux.rs` on Blacksmith Testbox
- `git diff --check`
- No Rust tests run (format-only change).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders the local `std::sync` imports in `cmux-tui/crates/cmux-tui-core/src/mux.rs` to match `rustfmt` output. Format-only change with no behavior impact.

<sup>Written for commit 4464b22b4a796b77a8599221f1a981e3f1bbe16e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11710?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

