### PR TITLE
cmux-tui: make journal restore paging snapshot-stable

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -5812,6 +5812,27 @@ impl Mux {
             .journal_checkpoint(selector)?
             .with_context(|| format!("journal checkpoint {selector:?} does not exist"))?;
         let mut reducer = crate::journal_checkpoint::RestoreReducer::new(&checkpoint)?;
+
+        if let Some(database_path) =
+            self.workspace_registry.lock().unwrap().session_journal_database_path()
+        {
+            let reader = crate::workspace_registry::SessionJournalReader::open(&database_path)?;
+            let mut cursor = reader.restore_cursor(checkpoint.source_sequence)?;
+            let head_sequence = loop {
+                let page = cursor.next_page(1024)?;
+                let head = page.head_sequence;
+                let empty = page.records.is_empty();
+                for record in page.records {
+                    reducer.apply(&record)?;
+                }
+                if empty {
+                    break head;
+                }
+            };
+            cursor.finish()?;
+            return reducer.finish(head_sequence);
+        }
+
         let mut sequence = checkpoint.source_sequence;
         let mut target_head = None;
         let head_sequence = loop {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -5813,9 +5813,9 @@ impl Mux {
             .with_context(|| format!("journal checkpoint {selector:?} does not exist"))?;
         let mut reducer = crate::journal_checkpoint::RestoreReducer::new(&checkpoint)?;
 
-        if let Some(database_path) =
-            self.workspace_registry.lock().unwrap().session_journal_database_path()
-        {
+        let database_path =
+            self.workspace_registry.lock().unwrap().session_journal_database_path();
+        if let Some(database_path) = database_path {
             let reader = crate::workspace_registry::SessionJournalReader::open(&database_path)?;
             let mut cursor = reader.restore_cursor(checkpoint.source_sequence)?;
             let head_sequence = loop {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -85,12 +85,12 @@ pub use session_journal::{
     JournalAuthority, JournalClass, JournalProducer, JournalReplayPolicy, JournalSensitivity,
     JournalSubject, SessionJournalPage, SessionJournalRecord,
 };
+pub(crate) use session_journal::{JournalRestoreCursor, SessionJournalReader, unix_epoch_ms};
 use session_journal::{
     ResourceEffectJournalState, append_resource_effect_journal_record,
     append_resource_journal_record, create_session_journal_schema,
     migrate_resource_events_to_session_journal,
 };
-pub(crate) use session_journal::{SessionJournalReader, unix_epoch_ms};
 
 // Schema 9 shipped independently on the journal and multiview development
 // branches. Schema 10 shipped the journal extensions. Version 11 is the first

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry.rs
@@ -85,12 +85,12 @@ pub use session_journal::{
     JournalAuthority, JournalClass, JournalProducer, JournalReplayPolicy, JournalSensitivity,
     JournalSubject, SessionJournalPage, SessionJournalRecord,
 };
-pub(crate) use session_journal::{JournalRestoreCursor, SessionJournalReader, unix_epoch_ms};
 use session_journal::{
     ResourceEffectJournalState, append_resource_effect_journal_record,
     append_resource_journal_record, create_session_journal_schema,
     migrate_resource_events_to_session_journal,
 };
+pub(crate) use session_journal::{SessionJournalReader, unix_epoch_ms};
 
 // Schema 9 shipped independently on the journal and multiview development
 // branches. Schema 10 shipped the journal extensions. Version 11 is the first

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -175,6 +175,8 @@ pub(crate) struct JournalRestoreCursor {
 
 #[cfg(test)]
 static JOURNAL_SEGMENT_DECODE_COUNT: AtomicUsize = AtomicUsize::new(0);
+#[cfg(test)]
+static JOURNAL_SEGMENT_CONTENT_LOAD_COUNT: AtomicUsize = AtomicUsize::new(0);
 
 #[cfg(test)]
 fn reset_journal_segment_decode_count() {
@@ -184,6 +186,16 @@ fn reset_journal_segment_decode_count() {
 #[cfg(test)]
 fn journal_segment_decode_count() -> usize {
     JOURNAL_SEGMENT_DECODE_COUNT.load(Ordering::Relaxed)
+}
+
+#[cfg(test)]
+fn reset_journal_segment_content_load_count() {
+    JOURNAL_SEGMENT_CONTENT_LOAD_COUNT.store(0, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+fn journal_segment_content_load_count() -> usize {
+    JOURNAL_SEGMENT_CONTENT_LOAD_COUNT.load(Ordering::Relaxed)
 }
 
 impl SessionJournalReader {
@@ -1358,6 +1370,8 @@ fn query_session_journal_after_subjects(
 type JournalSegmentRow = (String, i64, i64, i64, String, Vec<u8>, i64, Vec<u8>);
 
 fn journal_segment_row(row: &Row<'_>) -> rusqlite::Result<JournalSegmentRow> {
+    #[cfg(test)]
+    JOURNAL_SEGMENT_CONTENT_LOAD_COUNT.fetch_add(1, Ordering::Relaxed);
     Ok((
         row.get(0)?,
         row.get(1)?,
@@ -2304,7 +2318,9 @@ mod tests {
         let reader =
             SessionJournalReader::open(&registry.session_journal_database_path().unwrap()).unwrap();
         reset_journal_segment_decode_count();
+        reset_journal_segment_content_load_count();
         let mut cursor = reader.restore_cursor(0).unwrap();
+        assert_eq!(journal_segment_content_load_count(), 0);
         let mut replayed = Vec::new();
         loop {
             let page = cursor.next_page(1).unwrap();
@@ -2317,6 +2333,7 @@ mod tests {
         cursor.finish().unwrap();
         assert_eq!(replayed, [1, 2, 3, 4]);
         assert_eq!(journal_segment_decode_count(), 1);
+        assert_eq!(journal_segment_content_load_count(), 1);
 
         drop(registry);
         fs::remove_dir_all(root).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -3,9 +3,11 @@ use base64::Engine;
 use flate2::read::GzDecoder;
 use rusqlite::Row;
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
 use std::io::Read;
 use std::sync::Arc;
+#[cfg(test)]
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const JOURNAL_RECORD_SCHEMA_VERSION: u32 = 1;
@@ -159,6 +161,31 @@ pub(crate) struct SessionJournalReader {
     connection: Connection,
 }
 
+pub(crate) struct JournalRestoreCursor {
+    connection: Connection,
+    source_sequence: u64,
+    target_head: u64,
+    segments: VecDeque<JournalSegmentRow>,
+    decoded_segment: Option<DecodedJournalSegment>,
+    record_offset: usize,
+    active_sequence: u64,
+    previous_segment_end: Option<u64>,
+    finished: bool,
+}
+
+#[cfg(test)]
+static JOURNAL_SEGMENT_DECODE_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+#[cfg(test)]
+fn reset_journal_segment_decode_count() {
+    JOURNAL_SEGMENT_DECODE_COUNT.store(0, Ordering::Relaxed);
+}
+
+#[cfg(test)]
+fn journal_segment_decode_count() -> usize {
+    JOURNAL_SEGMENT_DECODE_COUNT.load(Ordering::Relaxed)
+}
+
 impl SessionJournalReader {
     pub(crate) fn open(database_path: &Path) -> anyhow::Result<Self> {
         let connection = open_registry_database_with_flags(
@@ -182,6 +209,147 @@ impl SessionJournalReader {
         subjects: &[JournalSubject],
     ) -> anyhow::Result<SessionJournalSubjectPage> {
         query_session_journal_after_subjects(&self.connection, sequence, limit, subjects)
+    }
+
+    pub(crate) fn restore_cursor(
+        self,
+        source_sequence: u64,
+    ) -> anyhow::Result<JournalRestoreCursor> {
+        self.connection.execute_batch("BEGIN DEFERRED TRANSACTION")?;
+        let target_head = query_journal_head(&self.connection)?;
+        anyhow::ensure!(
+            source_sequence <= target_head,
+            "cursor.invalid: journal sequence {source_sequence} is ahead of {target_head}"
+        );
+        let mut statement = self.connection.prepare(
+            "SELECT segment_id, start_sequence, end_sequence, record_count, codec,
+                    content, uncompressed_bytes, sha256
+             FROM journal_segments
+             WHERE end_sequence > ?1
+             ORDER BY start_sequence ASC",
+        )?;
+        let segments = statement
+            .query_map([i64::try_from(source_sequence)?], journal_segment_row)?
+            .collect::<Result<VecDeque<_>, _>>()?;
+        drop(statement);
+        Ok(JournalRestoreCursor {
+            connection: self.connection,
+            source_sequence,
+            target_head,
+            segments,
+            decoded_segment: None,
+            record_offset: 0,
+            active_sequence: source_sequence,
+            previous_segment_end: None,
+            finished: false,
+        })
+    }
+}
+
+impl JournalRestoreCursor {
+    pub(crate) fn next_page(&mut self, limit: usize) -> anyhow::Result<SessionJournalPage> {
+        anyhow::ensure!(!self.finished, "journal restore cursor is finished");
+        anyhow::ensure!(limit > 0, "journal page limit must be positive");
+        anyhow::ensure!(
+            limit <= MAX_JOURNAL_PAGE_SIZE,
+            "journal page limit exceeds {MAX_JOURNAL_PAGE_SIZE}"
+        );
+        let mut records = Vec::with_capacity(limit);
+        while records.len() < limit {
+            if let Some(decoded) = self.decoded_segment.as_ref() {
+                if self.record_offset == decoded.records.len() {
+                    self.decoded_segment = None;
+                    self.record_offset = 0;
+                    continue;
+                }
+                let record = decoded.records[self.record_offset].clone();
+                self.record_offset += 1;
+                if record.sequence <= self.source_sequence {
+                    continue;
+                }
+                if record.sequence > self.target_head {
+                    break;
+                }
+                self.validate_and_advance(record, &mut records)?;
+                continue;
+            }
+
+            let Some(segment) = self.segments.pop_front() else {
+                break;
+            };
+            let decoded = decode_journal_segment(segment)?;
+            if let Some(previous_end) = self.previous_segment_end {
+                anyhow::ensure!(
+                    decoded.start_sequence == previous_end + 1,
+                    "journal segments contain a gap before sequence {}",
+                    decoded.start_sequence
+                );
+            } else {
+                anyhow::ensure!(
+                    decoded.start_sequence <= self.source_sequence.saturating_add(1),
+                    "journal segments contain a gap before sequence {}",
+                    decoded.start_sequence
+                );
+            }
+            self.previous_segment_end = Some(decoded.end_sequence);
+            self.decoded_segment = Some(decoded);
+        }
+
+        if records.len() < limit {
+            let remaining = limit - records.len();
+            let mut statement = self.connection.prepare(
+                "SELECT sequence, event_id, schema_version, kind, class, replay_policy,
+                        occurred_at_ms, committed_at_ms, producer_json, authority_json,
+                        causation_id, correlation_id, causation_depth, subjects_json,
+                        sensitivity, payload_json, content, resource_revision,
+                        previous_resource_revision
+                 FROM session_journal
+                 WHERE sequence > ?1 AND sequence <= ?2
+                 ORDER BY sequence ASC
+                 LIMIT ?3",
+            )?;
+            let active = statement
+                .query_map(
+                    params![
+                        i64::try_from(self.active_sequence)?,
+                        i64::try_from(self.target_head)?,
+                        i64::try_from(remaining)?,
+                    ],
+                    stored_record_row,
+                )?
+                .map(|row| decode_record(row?))
+                .collect::<anyhow::Result<Vec<_>>>()?;
+            for record in active {
+                self.validate_and_advance(record, &mut records)?;
+            }
+        }
+        anyhow::ensure!(
+            self.active_sequence == self.target_head || !records.is_empty(),
+            "session journal contains a gap after sequence {}",
+            self.active_sequence
+        );
+        Ok(SessionJournalPage { head_sequence: self.target_head, records })
+    }
+
+    fn validate_and_advance(
+        &mut self,
+        record: SessionJournalRecord,
+        records: &mut Vec<SessionJournalRecord>,
+    ) -> anyhow::Result<()> {
+        let expected = self.active_sequence.saturating_add(1);
+        anyhow::ensure!(
+            record.sequence == expected,
+            "session journal contains a gap before sequence {}",
+            record.sequence
+        );
+        self.active_sequence = record.sequence;
+        records.push(record);
+        Ok(())
+    }
+
+    pub(crate) fn finish(mut self) -> anyhow::Result<()> {
+        self.finished = true;
+        self.connection.execute_batch("COMMIT")
     }
 }
 
@@ -993,16 +1161,7 @@ pub(super) fn query_session_journal_after(
         limit <= MAX_JOURNAL_PAGE_SIZE,
         "journal page limit exceeds {MAX_JOURNAL_PAGE_SIZE}"
     );
-    let head_sequence = connection.query_row(
-        "SELECT MAX(
-           COALESCE((SELECT MAX(sequence) FROM session_journal), 0),
-           COALESCE((SELECT MAX(end_sequence) FROM journal_segments), 0)
-         )",
-        [],
-        |row| row.get::<_, i64>(0),
-    )?;
-    let head_sequence =
-        u64::try_from(head_sequence).context("journal head sequence is negative")?;
+    let head_sequence = query_journal_head(connection)?;
     anyhow::ensure!(
         sequence <= head_sequence,
         "cursor.invalid: journal sequence {sequence} is ahead of {head_sequence}"
@@ -1050,6 +1209,18 @@ pub(super) fn query_session_journal_after(
         "session journal contains a gap after sequence {sequence}"
     );
     Ok(SessionJournalPage { head_sequence, records })
+}
+
+fn query_journal_head(connection: &Connection) -> anyhow::Result<u64> {
+    let head_sequence = connection.query_row(
+        "SELECT MAX(
+           COALESCE((SELECT MAX(sequence) FROM session_journal), 0),
+           COALESCE((SELECT MAX(end_sequence) FROM journal_segments), 0)
+         )",
+        [],
+        |row| row.get::<_, i64>(0),
+    )?;
+    u64::try_from(head_sequence).context("journal head sequence is negative")
 }
 
 pub(super) fn query_session_journal_sequences(
@@ -1204,6 +1375,8 @@ struct DecodedJournalSegment {
 }
 
 fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJournalSegment> {
+    #[cfg(test)]
+    JOURNAL_SEGMENT_DECODE_COUNT.fetch_add(1, Ordering::Relaxed);
     let (
         segment_id,
         start_sequence,
@@ -2126,8 +2299,8 @@ mod tests {
             )
             .unwrap();
 
-        let reader = SessionJournalReader::open(&registry.session_journal_database_path().unwrap())
-            .unwrap();
+        let reader =
+            SessionJournalReader::open(&registry.session_journal_database_path().unwrap()).unwrap();
         reset_journal_segment_decode_count();
         let mut cursor = reader.restore_cursor(0).unwrap();
         let mut replayed = Vec::new();

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -319,6 +319,7 @@ impl JournalRestoreCursor {
                 )?
                 .map(|row| decode_record(row?))
                 .collect::<anyhow::Result<Vec<_>>>()?;
+            drop(statement);
             for record in active {
                 self.validate_and_advance(record, &mut records)?;
             }
@@ -349,7 +350,8 @@ impl JournalRestoreCursor {
 
     pub(crate) fn finish(mut self) -> anyhow::Result<()> {
         self.finished = true;
-        self.connection.execute_batch("COMMIT")
+        self.connection.execute_batch("COMMIT")?;
+        Ok(())
     }
 }
 

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -13,6 +13,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 const JOURNAL_RECORD_SCHEMA_VERSION: u32 = 1;
 const MAX_JOURNAL_PAGE_SIZE: usize = 1024;
 pub(super) const MAX_JOURNAL_SEGMENT_UNCOMPRESSED_BYTES: usize = 16 * 1024 * 1024;
+const MAX_JOURNAL_SEGMENT_COMPRESSED_BYTES: usize = 32 * 1024 * 1024;
 pub(super) const MAX_JOURNAL_CONTENT_BYTES: usize = 256 * 1024;
 const MIGRATION_EVENT_ID: &str = "event_session_journal_v9_migration";
 const MIGRATION_EVENT_KIND: &str = "session.journal.migrated";
@@ -165,7 +166,7 @@ pub(crate) struct JournalRestoreCursor {
     connection: Connection,
     source_sequence: u64,
     target_head: u64,
-    segments: VecDeque<JournalSegmentRow>,
+    segments: VecDeque<String>,
     decoded_segment: Option<DecodedJournalSegment>,
     record_offset: usize,
     active_sequence: u64,
@@ -234,14 +235,13 @@ impl SessionJournalReader {
             "cursor.invalid: journal sequence {source_sequence} is ahead of {target_head}"
         );
         let mut statement = self.connection.prepare(
-            "SELECT segment_id, start_sequence, end_sequence, record_count, codec,
-                    content, uncompressed_bytes, sha256
+            "SELECT segment_id
              FROM journal_segments
              WHERE end_sequence > ?1
              ORDER BY start_sequence ASC",
         )?;
         let segments = statement
-            .query_map([i64::try_from(source_sequence)?], journal_segment_row)?
+            .query_map([i64::try_from(source_sequence)?], |row| row.get(0))?
             .collect::<Result<VecDeque<_>, _>>()?;
         drop(statement);
         Ok(JournalRestoreCursor {
@@ -286,10 +286,10 @@ impl JournalRestoreCursor {
                 continue;
             }
 
-            let Some(segment) = self.segments.pop_front() else {
+            let Some(segment_id) = self.segments.pop_front() else {
                 break;
             };
-            let decoded = decode_journal_segment(segment)?;
+            let decoded = decode_journal_segment(self.load_segment(&segment_id)?)?;
             if let Some(previous_end) = self.previous_segment_end {
                 anyhow::ensure!(
                     decoded.start_sequence == previous_end + 1,
@@ -342,6 +342,22 @@ impl JournalRestoreCursor {
             self.active_sequence
         );
         Ok(SessionJournalPage { head_sequence: self.target_head, records })
+    }
+
+    fn load_segment(&self, segment_id: &str) -> anyhow::Result<JournalSegmentRow> {
+        let mut statement = self.connection.prepare(
+            "SELECT segment_id, start_sequence, end_sequence, record_count, codec,
+                    content, uncompressed_bytes, sha256
+             FROM journal_segments
+             WHERE segment_id = ?1
+               AND length(content) <= ?2",
+        )?;
+        statement
+            .query_row(
+                params![segment_id, i64::try_from(MAX_JOURNAL_SEGMENT_COMPRESSED_BYTES)?],
+                journal_segment_row,
+            )
+            .with_context(|| format!("load journal segment {segment_id}"))
     }
 
     fn validate_and_advance(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -2070,4 +2070,80 @@ mod tests {
         let error = registry.session_journal_after(0, 10).unwrap_err();
         assert!(error.to_string().contains("record count"), "{error:#}");
     }
+
+    #[test]
+    fn restore_cursor_decodes_a_multi_page_segment_once() {
+        let root = std::env::temp_dir().join(format!("cmux-journal-cursor-{}", new_uuid_v4()));
+        let mut registry = WorkspaceRegistry::open(&root, "cursor").unwrap();
+        let workspace_id = format!("ws_{}", "1".repeat(32));
+        for sequence in 1..=4 {
+            let tx = registry.connection.transaction().unwrap();
+            tx.execute(
+                "UPDATE meta SET value = ?1 WHERE key = 'resource_revision'",
+                [sequence.to_string()],
+            )
+            .unwrap();
+            append_resource_journal_record(
+                &tx,
+                sequence,
+                sequence - 1,
+                "cursor-test",
+                &format!("cursor-event-{sequence}"),
+                "workspace.focus",
+                None,
+                &serde_json::json!({"workspace_id":workspace_id}),
+                &serde_json::json!([]),
+            )
+            .unwrap();
+            tx.commit().unwrap();
+        }
+
+        let records = registry.session_journal_after(0, 10).unwrap().records;
+        let uncompressed = serde_json::to_vec(&records).unwrap();
+        let digest = Sha256::digest(&uncompressed);
+        let mut encoder =
+            flate2::GzBuilder::new().mtime(0).write(Vec::new(), flate2::Compression::fast());
+        encoder.write_all(&uncompressed).unwrap();
+        let compressed = encoder.finish().unwrap();
+        registry
+            .connection
+            .execute(
+                "INSERT INTO journal_segments(
+                   segment_id, start_sequence, end_sequence, record_count, codec, content,
+                   uncompressed_bytes, sha256, sealed_at_ms
+                 ) VALUES('cursor-segment', 1, 4, 4, 'gzip-json-v1', ?1, ?2, ?3, 1)",
+                params![compressed, i64::try_from(uncompressed.len()).unwrap(), digest.as_slice()],
+            )
+            .unwrap();
+        registry
+            .connection
+            .execute_batch(
+                "DROP TRIGGER session_journal_reject_delete;
+                 DELETE FROM session_journal;
+                 CREATE TRIGGER session_journal_reject_delete
+                   BEFORE DELETE ON session_journal
+                 BEGIN SELECT RAISE(ABORT, 'session journal is append-only'); END;",
+            )
+            .unwrap();
+
+        let reader = SessionJournalReader::open(&registry.session_journal_database_path().unwrap())
+            .unwrap();
+        reset_journal_segment_decode_count();
+        let mut cursor = reader.restore_cursor(0).unwrap();
+        let mut replayed = Vec::new();
+        loop {
+            let page = cursor.next_page(1).unwrap();
+            if page.records.is_empty() {
+                assert_eq!(page.head_sequence, 4);
+                break;
+            }
+            replayed.extend(page.records.into_iter().map(|record| record.sequence));
+        }
+        cursor.finish().unwrap();
+        assert_eq!(replayed, [1, 2, 3, 4]);
+        assert_eq!(journal_segment_decode_count(), 1);
+
+        drop(registry);
+        fs::remove_dir_all(root).unwrap();
+    }
 }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1419,6 +1419,10 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
         expected_bytes,
         expected_digest,
     ) = row;
+    anyhow::ensure!(
+        compressed.len() <= MAX_JOURNAL_SEGMENT_COMPRESSED_BYTES,
+        "journal segment {segment_id} exceeds the compressed size limit"
+    );
     let start_sequence = u64::try_from(start_sequence)?;
     let end_sequence = u64::try_from(end_sequence)?;
     let record_count = usize::try_from(record_count)?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -262,8 +262,7 @@ impl JournalRestoreCursor {
             let Some(segment_id) = self.next_segment()? else {
                 break;
             };
-            #[cfg(test)]
-            self.segment_decode_count += 1;
+            self.note_segment_decoded();
             let decoded = decode_journal_segment(self.load_segment(&segment_id)?)?;
             if let Some(previous_end) = self.previous_segment_end {
                 anyhow::ensure!(
@@ -347,9 +346,16 @@ impl JournalRestoreCursor {
         Ok(Some(segment_id))
     }
 
+    #[cfg(test)]
+    fn note_segment_decoded(&mut self) {
+        self.segment_decode_count += 1;
+    }
+
+    #[cfg(not(test))]
+    fn note_segment_decoded(&mut self) {}
+
     fn load_segment(&mut self, segment_id: &str) -> anyhow::Result<JournalSegmentRow> {
-        #[cfg(test)]
-        self.segment_content_load_count += 1;
+        self.note_segment_content_loaded();
         let mut statement = self.connection.prepare(
             "SELECT segment_id, start_sequence, end_sequence, record_count, codec,
                     content, uncompressed_bytes, sha256
@@ -364,6 +370,14 @@ impl JournalRestoreCursor {
             )
             .with_context(|| format!("load journal segment {segment_id}"))
     }
+
+    #[cfg(test)]
+    fn note_segment_content_loaded(&mut self) {
+        self.segment_content_load_count += 1;
+    }
+
+    #[cfg(not(test))]
+    fn note_segment_content_loaded(&mut self) {}
 
     fn validate_and_advance(
         &mut self,

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -2340,6 +2340,7 @@ mod tests {
         reset_journal_segment_decode_count();
         reset_journal_segment_content_load_count();
         let mut cursor = reader.restore_cursor(0).unwrap();
+        assert!(cursor.segments.is_empty());
         assert_eq!(journal_segment_content_load_count(), 0);
         let mut replayed = Vec::new();
         loop {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -3,11 +3,9 @@ use base64::Engine;
 use flate2::read::GzDecoder;
 use rusqlite::Row;
 use std::borrow::Cow;
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 use std::io::Read;
 use std::sync::Arc;
-#[cfg(test)]
-use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const JOURNAL_RECORD_SCHEMA_VERSION: u32 = 1;
@@ -166,37 +164,17 @@ pub(crate) struct JournalRestoreCursor {
     connection: Connection,
     source_sequence: u64,
     target_head: u64,
-    segments: VecDeque<String>,
+    next_segment_start: i64,
+    segments_exhausted: bool,
     decoded_segment: Option<DecodedJournalSegment>,
     record_offset: usize,
     active_sequence: u64,
     previous_segment_end: Option<u64>,
     finished: bool,
-}
-
-#[cfg(test)]
-static JOURNAL_SEGMENT_DECODE_COUNT: AtomicUsize = AtomicUsize::new(0);
-#[cfg(test)]
-static JOURNAL_SEGMENT_CONTENT_LOAD_COUNT: AtomicUsize = AtomicUsize::new(0);
-
-#[cfg(test)]
-fn reset_journal_segment_decode_count() {
-    JOURNAL_SEGMENT_DECODE_COUNT.store(0, Ordering::Relaxed);
-}
-
-#[cfg(test)]
-fn journal_segment_decode_count() -> usize {
-    JOURNAL_SEGMENT_DECODE_COUNT.load(Ordering::Relaxed)
-}
-
-#[cfg(test)]
-fn reset_journal_segment_content_load_count() {
-    JOURNAL_SEGMENT_CONTENT_LOAD_COUNT.store(0, Ordering::Relaxed);
-}
-
-#[cfg(test)]
-fn journal_segment_content_load_count() -> usize {
-    JOURNAL_SEGMENT_CONTENT_LOAD_COUNT.load(Ordering::Relaxed)
+    #[cfg(test)]
+    segment_decode_count: usize,
+    #[cfg(test)]
+    segment_content_load_count: usize,
 }
 
 impl SessionJournalReader {
@@ -234,26 +212,21 @@ impl SessionJournalReader {
             source_sequence <= target_head,
             "cursor.invalid: journal sequence {source_sequence} is ahead of {target_head}"
         );
-        let mut statement = self.connection.prepare(
-            "SELECT segment_id
-             FROM journal_segments
-             WHERE end_sequence > ?1
-             ORDER BY start_sequence ASC",
-        )?;
-        let segments = statement
-            .query_map([i64::try_from(source_sequence)?], |row| row.get(0))?
-            .collect::<Result<VecDeque<_>, _>>()?;
-        drop(statement);
         Ok(JournalRestoreCursor {
             connection: self.connection,
             source_sequence,
             target_head,
-            segments,
+            next_segment_start: -1,
+            segments_exhausted: false,
             decoded_segment: None,
             record_offset: 0,
             active_sequence: source_sequence,
             previous_segment_end: None,
             finished: false,
+            #[cfg(test)]
+            segment_decode_count: 0,
+            #[cfg(test)]
+            segment_content_load_count: 0,
         })
     }
 }
@@ -286,9 +259,11 @@ impl JournalRestoreCursor {
                 continue;
             }
 
-            let Some(segment_id) = self.segments.pop_front() else {
+            let Some(segment_id) = self.next_segment()? else {
                 break;
             };
+            #[cfg(test)]
+            self.segment_decode_count += 1;
             let decoded = decode_journal_segment(self.load_segment(&segment_id)?)?;
             if let Some(previous_end) = self.previous_segment_end {
                 anyhow::ensure!(
@@ -344,7 +319,37 @@ impl JournalRestoreCursor {
         Ok(SessionJournalPage { head_sequence: self.target_head, records })
     }
 
-    fn load_segment(&self, segment_id: &str) -> anyhow::Result<JournalSegmentRow> {
+    fn next_segment(&mut self) -> anyhow::Result<Option<String>> {
+        if self.segments_exhausted {
+            return Ok(None);
+        }
+        let mut statement = self.connection.prepare(
+            "SELECT segment_id, start_sequence
+             FROM journal_segments
+             WHERE end_sequence > ?1 AND start_sequence > ?2
+             ORDER BY start_sequence ASC
+             LIMIT 1",
+        )?;
+        let segment = statement
+            .query_row(
+                params![
+                    i64::try_from(self.source_sequence)?,
+                    self.next_segment_start,
+                ],
+                |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
+            )
+            .optional()?;
+        let Some((segment_id, start_sequence)) = segment else {
+            self.segments_exhausted = true;
+            return Ok(None);
+        };
+        self.next_segment_start = start_sequence;
+        Ok(Some(segment_id))
+    }
+
+    fn load_segment(&mut self, segment_id: &str) -> anyhow::Result<JournalSegmentRow> {
+        #[cfg(test)]
+        self.segment_content_load_count += 1;
         let mut statement = self.connection.prepare(
             "SELECT segment_id, start_sequence, end_sequence, record_count, codec,
                     content, uncompressed_bytes, sha256
@@ -1386,8 +1391,6 @@ fn query_session_journal_after_subjects(
 type JournalSegmentRow = (String, i64, i64, i64, String, Vec<u8>, i64, Vec<u8>);
 
 fn journal_segment_row(row: &Row<'_>) -> rusqlite::Result<JournalSegmentRow> {
-    #[cfg(test)]
-    JOURNAL_SEGMENT_CONTENT_LOAD_COUNT.fetch_add(1, Ordering::Relaxed);
     Ok((
         row.get(0)?,
         row.get(1)?,
@@ -1407,8 +1410,6 @@ struct DecodedJournalSegment {
 }
 
 fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJournalSegment> {
-    #[cfg(test)]
-    JOURNAL_SEGMENT_DECODE_COUNT.fetch_add(1, Ordering::Relaxed);
     let (
         segment_id,
         start_sequence,
@@ -2337,11 +2338,9 @@ mod tests {
 
         let reader =
             SessionJournalReader::open(&registry.session_journal_database_path().unwrap()).unwrap();
-        reset_journal_segment_decode_count();
-        reset_journal_segment_content_load_count();
         let mut cursor = reader.restore_cursor(0).unwrap();
-        assert!(cursor.segments.is_empty());
-        assert_eq!(journal_segment_content_load_count(), 0);
+        assert!(!cursor.segments_exhausted);
+        assert_eq!(cursor.segment_content_load_count, 0);
         let mut replayed = Vec::new();
         loop {
             let page = cursor.next_page(1).unwrap();
@@ -2351,10 +2350,10 @@ mod tests {
             }
             replayed.extend(page.records.into_iter().map(|record| record.sequence));
         }
+        assert_eq!(cursor.segment_decode_count, 1);
+        assert_eq!(cursor.segment_content_load_count, 1);
         cursor.finish().unwrap();
         assert_eq!(replayed, [1, 2, 3, 4]);
-        assert_eq!(journal_segment_decode_count(), 1);
-        assert_eq!(journal_segment_content_load_count(), 1);
 
         drop(registry);
         fs::remove_dir_all(root).unwrap();


### PR DESCRIPTION
Summary:
- add an owned SQLite snapshot cursor for restore preview
- decode each archived segment once while paging
- preserve existing page API and validation behavior

Tests:
- hosted Testbox: cargo test -p cmux-tui-core --locked restore_cursor_decodes_a_multi_page_segment_once
- hosted Testbox: cargo test -p cmux-tui-core --locked restore_preview

Regression policy: first commit adds the failing cursor regression test; second commit adds the implementation.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11711"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790964545&installation_model_id=21920&pr_number=11711&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11711&signature=7d3b2b22288cd3abe3b4b65d07ef29a5016d8403029f31861aa8d22e25551041"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Journal-backed restore preview now replays archived and live records through an owned SQLite transaction snapshot instead of paging the live journal directly. This keeps each restore pinned to one journal head and releases the workspace registry lock before restore I/O; database-free restore is unchanged.

- Loads segment IDs and content lazily, decodes each segment once, and retains only the current decoded segment.
- Validates sequence continuity, limits compressed segments to 32 MiB, commits finished cursors, and rolls back unfinished cursors.
- Adds coverage for multi-page decoding, lazy and bounded state, transaction handling, oversized segments, and gap detection.

<sup>Written for commit 1420a14960048fe95159adb4a141e54fc16c3592. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved session restoration from journal checkpoints configured with a journal database.
  * Added support for restoring histories spanning archived segments and active journal records.
  * Added validation for sequence continuity and incomplete or inconsistent journal data.
  * Added safeguards for oversized journal segments to improve reliability.
  * Improved restoration performance by processing records in pages and avoiding repeated decoding of archived content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->