### PR TITLE
cmux-tui: tolerate dump temp removal during cleanup

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3705,7 +3705,9 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         if !is_dump_temp {
             continue;
         }
-        let metadata = fs::symlink_metadata(entry.path())?;
+        let Some(metadata) = stale_dump_entry_metadata(&entry.path())? else {
+            continue;
+        };
         if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
             continue;
         }
@@ -3730,6 +3732,15 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         }
     }
     Ok(())
+}
+
+#[cfg(unix)]
+fn stale_dump_entry_metadata(path: &Path) -> io::Result<Option<fs::Metadata>> {
+    match fs::symlink_metadata(path) {
+        Ok(metadata) => Ok(Some(metadata)),
+        Err(error) if error.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(error) => Err(error),
+    }
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4871,6 +4871,15 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_scan_ignores_missing_temp_entries() {
+        let root = tempfile::tempdir().unwrap();
+        let missing_path = root.path().join(".frames-1.log.tmp-99999999-1");
+
+        assert!(stale_dump_entry_metadata(&missing_path).unwrap().is_none());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_frame_dump_preserves_line_format() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4882,11 +4882,26 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn private_dump_scan_ignores_missing_temp_entries() {
-        let root = tempfile::tempdir().unwrap();
-        let missing_path = root.path().join(".frames-1.log.tmp-99999999-1");
+    fn private_dump_scan_ignores_missing_temp_entries_after_directory_scan() {
+        use std::cell::Cell;
 
-        assert!(stale_dump_entry_metadata(&missing_path).unwrap().is_none());
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let missing_path = dump_path.join(".frames-1.log.tmp-99999999-1");
+        fs::write(&missing_path, b"partial secret").unwrap();
+        let removed = Cell::new(false);
+
+        prune_stale_dump_temps_with(&directory, &dump_path, |path| {
+            assert_eq!(path, missing_path);
+            fs::remove_file(path).unwrap();
+            removed.set(true);
+            stale_dump_entry_metadata(path)
+        })
+        .unwrap();
+
+        assert!(removed.get());
+        assert!(!missing_path.exists());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3689,6 +3689,18 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
 
 #[cfg(unix)]
 fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
+    prune_stale_dump_temps_with(directory, path, stale_dump_entry_metadata)
+}
+
+#[cfg(unix)]
+fn prune_stale_dump_temps_with<F>(
+    directory: &fs::File,
+    path: &Path,
+    mut metadata_for_entry: F,
+) -> io::Result<()>
+where
+    F: FnMut(&Path) -> io::Result<Option<fs::Metadata>>,
+{
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
     use std::os::unix::ffi::OsStrExt;
@@ -3705,7 +3717,7 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         if !is_dump_temp {
             continue;
         }
-        let Some(metadata) = stale_dump_entry_metadata(&entry.path())? else {
+        let Some(metadata) = metadata_for_entry(&entry.path())? else {
             continue;
         };
         if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {


### PR DESCRIPTION
Stacked on https://github.com/manaflow-ai/cmux/pull/11562.

`prune_stale_dump_temps` now treats a temp file removed between directory enumeration and metadata lookup as a benign race, so one disappearing temp cannot abort `private_dump_directory` and suppress all teardown dumps.

Test-first commits:
- bcc56c0f146 adds coverage for missing temp metadata.
- 0ab41aa44e4 adds the tolerant metadata lookup.

Validation: `rustfmt --check --edition 2024`, `git diff --check`. Cargo tests were not run locally per Testbox policy; the local cargo guard also reports the 250 GiB disk floor.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in dump cleanup where a temp file removed between directory scan and metadata lookup would abort `private_dump_directory` and suppress all teardown dumps. Cleanup now treats a missing temp as benign and skips it, while still propagating other metadata errors, so the remaining dumps are written.

<sup>Written for commit ed3f8cf1e64b0274ca0a911420611c3a499da1e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

