### PR TITLE
perf(cmux-tui): index panes for size leases

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4219,6 +4219,13 @@ struct PaneSizeLease {
     content_size: (u16, u16),
 }
 
+fn first_pane_by_id(panes: &[PaneView]) -> HashMap<PaneId, &PaneView> {
+    panes.iter().fold(HashMap::with_capacity(panes.len()), |mut index, pane| {
+        index.entry(pane.id).or_insert(pane);
+        index
+    })
+}
+
 impl PaneArea {
     pub(crate) fn logical_rect(&self) -> Rect {
         Rect {
@@ -14664,8 +14671,13 @@ impl App {
         // Keep inactive tabs attached for instant rendering, but give only
         // active tabs in the swept viewport a sizing lease. The settling draw
         // releases panes outside the final viewport.
+        // `ScreenView::pane` performs a linear scan. Build an index once for
+        // this active screen so one lease per pane does not turn this loop
+        // into quadratic work. `or_insert` preserves `pane`'s first-match
+        // behavior if malformed input contains duplicate pane IDs.
+        let panes_by_id = first_pane_by_id(&screen.panes);
         for lease in size_leases {
-            let Some(pane) = screen.pane(lease.pane) else { continue };
+            let Some(pane) = panes_by_id.get(&lease.pane).copied() else { continue };
             let content_size = lease.content_size;
             for tab in &pane.tabs {
                 if self.surface_only.is_some_and(|surface| surface != tab.surface) {
@@ -24690,7 +24702,7 @@ mod tests {
         canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
         client_menu_item, clip_horizontal_rect, content_size_for_rect,
         disable_host_keyboard_protocol, enable_host_keyboard_protocol, expand_status_tokens,
-        forward_host_input, forward_mux_event, forward_mux_events,
+        first_pane_by_id, forward_host_input, forward_mux_event, forward_mux_events,
         host_mouse_capture_escape_if_changed, host_startup_input_modes,
         initial_applied_outer_cursor, initial_host_mouse_capture, keyboard_protocol_accepts,
         layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,
@@ -28574,6 +28586,24 @@ mod tests {
         motion.retarget(10, false, now + VIEWPORT_ANIMATION_DURATION);
         assert_eq!(motion.offset(), 10);
         assert!(!motion.animating());
+    }
+
+    #[test]
+    fn first_pane_index_preserves_screen_pane_lookup_semantics() {
+        let pane = |name| PaneView {
+            id: 7,
+            resource_id: None,
+            short_id: name.to_string(),
+            name: Some(name.to_string()),
+            tabs: Vec::new(),
+            active_tab: 0,
+            focused_at: 0,
+        };
+        let panes = vec![pane("first"), pane("duplicate")];
+
+        let indexed = first_pane_by_id(&panes);
+
+        assert_eq!(indexed.get(&7).and_then(|pane| pane.name.as_deref()), Some("first"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- index active-screen panes once before applying size leases
- preserve ScreenView::pane first-match behavior for duplicate IDs
- add an invariant test for duplicate pane IDs

## Verification
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/app.rs
- git diff --check
- Cargo/Rust tests not run locally because cmux-tui AGENTS.md forbids local Rust builds; use hosted cmux-tui verification.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11713"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790966743&installation_model_id=21920&pr_number=11713&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11713&signature=9e6c7f61b0eb23a186e81dc59292f81040a61f2547fcd1b7709902e1e3698cca"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applying size leases previously scanned the active screen’s panes for every lease; it now builds one index, reducing lookup work from quadratic to linear as lease counts grow. Duplicate pane IDs still resolve to the first pane, matching `ScreenView::pane`.

- Adds regression coverage for that lookup invariant.

<sup>Written for commit bd766e99f5cb03b87c966846ca27768509a22f93. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved pane lease processing with faster pane lookups, helping reduce repeated searches and maintain responsiveness when multiple panes are active.

* **Bug Fixes**
  * Preserved existing behavior for duplicate pane IDs by consistently selecting the first matching pane, ensuring lease updates continue to apply to the expected pane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->