### PR TITLE
fix(relay): bound supervised process cleanup

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2757,6 +2757,26 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn timeout_after_sigkill_reaches_terminal_wait_state() {
+        let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let outcome = tokio::time::timeout(
+            std::time::Duration::from_secs(2),
+            run_spec(
+                RunSpec::Shell { command: "trap '' TERM; exec sleep 5" },
+                Path::new("/"),
+                None,
+                20,
+                &env,
+                None,
+            ),
+        )
+        .await
+        .expect("SIGKILL cleanup must reach a terminal wait state");
+        assert!(matches!(outcome, RunOutcome::TimedOut));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn cancellation_reports_failure_and_kills_descendant() {
         use tokio_util::sync::CancellationToken;
 

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2362,6 +2362,19 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn process_supervisor_drop_cancels_owned_tasks() {
+        let supervisor = ProcessSupervisor::new();
+        let (_receiver, cancellation) = supervisor
+            .spawn(|token| async move {
+                token.cancelled().await;
+                RunOutcome::Failed { message: "process cancelled".to_owned() }
+            })
+            .expect("open supervisor admits process");
+        drop(supervisor);
+        assert!(cancellation.is_cancelled());
+    }
+
     #[test]
     fn wait_error_state_distinguishes_already_reaped() {
         assert_eq!(WaitState::from_wait_error(true), WaitState::AlreadyReaped);

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -22,8 +22,9 @@
 //! - all output is truncated to bounded sizes before it goes on the wire.
 
 use std::collections::HashMap;
+use std::future::Future;
 use std::path::{Component, Path, PathBuf};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 
 use serde_json::{Map, Value, json};
 
@@ -43,6 +44,7 @@ const MAX_RUNTIME_ENVIRONMENT_ENTRIES: usize = 64;
 const MAX_RUNTIME_ENVIRONMENT_BYTES: usize = 256_000;
 const MAX_RUNTIME_FILES: usize = 8;
 pub(crate) const MAX_BLOCKING_FILE_ACTIONS: usize = 8;
+const MAX_LIVE_PROCESSES: usize = 8;
 
 // ---------------------------------------------------------------------------
 // Path policy (pure)
@@ -997,6 +999,126 @@ enum RunOutcome {
     Failed { message: String },
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub(crate) enum SupervisorState {
+    Open,
+    Closing,
+    Closed,
+}
+
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum WaitState {
+    Retry,
+    AlreadyReaped,
+}
+
+impl WaitState {
+    fn from_wait_error(already_reaped: bool) -> Self {
+        if already_reaped { Self::AlreadyReaped } else { Self::Retry }
+    }
+}
+
+pub(crate) struct ProcessSupervisor {
+    lifecycle: Mutex<SupervisorLifecycle>,
+    slots: Arc<tokio::sync::Semaphore>,
+    shutdown_gate: tokio::sync::Mutex<()>,
+}
+
+struct SupervisorLifecycle {
+    state: SupervisorState,
+    tasks: Vec<SupervisedTask>,
+}
+
+struct SupervisedTask {
+    handle: tokio::task::JoinHandle<()>,
+    cancellation: tokio_util::sync::CancellationToken,
+}
+
+struct CancelOnDrop(Option<tokio_util::sync::CancellationToken>);
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if let Some(token) = self.0.take() {
+            token.cancel();
+        }
+    }
+}
+
+async fn await_supervised(
+    receiver: tokio::sync::oneshot::Receiver<RunOutcome>,
+    cancellation: tokio_util::sync::CancellationToken,
+) -> RunOutcome {
+    let mut cancel_on_drop = CancelOnDrop(Some(cancellation));
+    let outcome = receiver
+        .await
+        .unwrap_or(RunOutcome::Failed { message: "process failed to start".to_owned() });
+    cancel_on_drop.0 = None;
+    outcome
+}
+
+impl ProcessSupervisor {
+    pub(crate) fn new() -> Self {
+        Self {
+            lifecycle: Mutex::new(SupervisorLifecycle {
+                state: SupervisorState::Open,
+                tasks: Vec::new(),
+            }),
+            slots: Arc::new(tokio::sync::Semaphore::new(MAX_LIVE_PROCESSES)),
+            shutdown_gate: tokio::sync::Mutex::new(()),
+        }
+    }
+
+    fn state(&self) -> SupervisorState {
+        self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner).state
+    }
+
+    fn spawn<F, Fut>(
+        &self,
+        task: F,
+    ) -> Option<(tokio::sync::oneshot::Receiver<RunOutcome>, tokio_util::sync::CancellationToken)>
+    where
+        F: FnOnce(tokio_util::sync::CancellationToken) -> Fut + Send + 'static,
+        Fut: Future<Output = RunOutcome> + Send + 'static,
+    {
+        let permit = Arc::clone(&self.slots).try_acquire_owned().ok()?;
+        let mut lifecycle =
+            self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        if lifecycle.state != SupervisorState::Open {
+            return None;
+        }
+        let (sender, receiver) = tokio::sync::oneshot::channel();
+        let cancellation = tokio_util::sync::CancellationToken::new();
+        let task_cancellation = cancellation.clone();
+        let handle = tokio::spawn(async move {
+            let _permit = permit;
+            let outcome = task(task_cancellation).await;
+            let _ = sender.send(outcome);
+        });
+        lifecycle.tasks.retain(|task| !task.handle.is_finished());
+        lifecycle.tasks.push(SupervisedTask { handle, cancellation: cancellation.clone() });
+        Some((receiver, cancellation))
+    }
+
+    pub(crate) async fn shutdown(&self) {
+        let _shutdown_gate = self.shutdown_gate.lock().await;
+        let tasks = {
+            let mut lifecycle =
+                self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if lifecycle.state == SupervisorState::Closed {
+                return;
+            }
+            lifecycle.state = SupervisorState::Closing;
+            std::mem::take(&mut lifecycle.tasks)
+        };
+        for task in tasks {
+            task.cancellation.cancel();
+            let _ = task.handle.await;
+        }
+        self.lifecycle.lock().unwrap_or_else(std::sync::PoisonError::into_inner).state =
+            SupervisorState::Closed;
+    }
+}
+
 #[cfg(unix)]
 struct ProcessGroupGuard {
     pid: Option<u32>,
@@ -1026,6 +1148,7 @@ async fn run_spec(
     cwd_fd: Option<ScopedCwdFd>,
     timeout_ms: u64,
     env: &HashMap<String, String>,
+    cancellation: Option<tokio_util::sync::CancellationToken>,
 ) -> RunOutcome {
     use tokio::io::AsyncReadExt as _;
     let mut command = match &spec {
@@ -1086,6 +1209,7 @@ async fn run_spec(
         Ok(job) => Some(job),
         Err(_) => {
             let _ = child.start_kill();
+            let _ = child.wait().await;
             return RunOutcome::Failed { message: "process failed to start".to_owned() };
         }
     };
@@ -1098,6 +1222,7 @@ async fn run_spec(
     let mut stderr = child.stderr.take();
     let mut output: Vec<u8> = Vec::new();
     let mut timed_out = false;
+    let mut cancelled = false;
     let deadline = tokio::time::sleep(std::time::Duration::from_millis(timeout_ms));
     tokio::pin!(deadline);
     let mut stdout_buf = [0_u8; 8_192];
@@ -1108,6 +1233,7 @@ async fn run_spec(
     let mut kill_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut drain_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut final_wait_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+    let mut wait_retry_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     loop {
         // A timed-out process group still needs its escalation pass even when
         // the shell leader has already exited. Otherwise closing inherited
@@ -1121,6 +1247,23 @@ async fn run_spec(
             break;
         }
         tokio::select! {
+            () = async {
+                match cancellation.as_ref() {
+                    Some(token) => token.cancelled().await,
+                    None => std::future::pending().await,
+                }
+            }, if !cancelled => {
+                cancelled = true;
+                #[cfg(unix)]
+                if !signal_process_tree(pid, false) {
+                    let _ = child.start_kill();
+                }
+                #[cfg(not(unix))]
+                signal_process_tree(pid, false);
+                kill_deadline = Some(Box::pin(tokio::time::sleep(
+                    std::time::Duration::from_millis(250),
+                )));
+            }
             read = async {
                 match stdout.as_mut() {
                     Some(stream) => stream.read(&mut stdout_buf).await,
@@ -1151,7 +1294,8 @@ async fn run_spec(
                     }
                 }
             }
-            status = child.wait(), if exited.is_none() => {
+            status = child.wait(),
+                if exited.is_none() && wait_retry_deadline.is_none() && kill_deadline.is_none() => {
                 // The child is gone, but descendants may still own the output
                 // pipes. Preserve a timeout escalation that is already in
                 // flight, and bound the remaining drain after a timeout.
@@ -1171,7 +1315,24 @@ async fn run_spec(
                             process_group_guard.armed = false;
                         }
                     }
-                    Err(_) => exited = Some(1),
+                    Err(error) => {
+                        #[cfg(unix)]
+                        if error.raw_os_error() == Some(libc::ECHILD) {
+                            exited = Some(1);
+                            process_group_guard.armed = false;
+                        } else {
+                            wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                std::time::Duration::from_millis(10),
+                            )));
+                        }
+                        #[cfg(not(unix))]
+                        {
+                            let _ = error;
+                            wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                std::time::Duration::from_millis(10),
+                            )));
+                        }
+                    }
                 }
             }
             () = &mut deadline, if !timed_out => {
@@ -1180,9 +1341,7 @@ async fn run_spec(
                 // inherited stdout/stderr. Kill the whole POSIX process group
                 // so the supervisor gets its EXIT cleanup, then enforce a
                 // hard bound for processes that ignore TERM.
-                if exited.is_some() {
-                    signal_process_group(pid, false);
-                } else {
+                if exited.is_none() {
                     // The process group is the authoritative target. If the
                     // group disappeared before we could signal it, use the
                     // live Child handle instead of the numeric PID. A PID
@@ -1217,9 +1376,7 @@ async fn run_spec(
                     None => std::future::pending().await,
                 }
             }, if kill_deadline.is_some() => {
-                if exited.is_some() {
-                    signal_process_group(pid, true);
-                } else {
+                if exited.is_none() {
                     // See the timeout branch above: never fall back to a
                     // numeric PID after a process-group signal fails.
                     #[cfg(unix)]
@@ -1256,14 +1413,21 @@ async fn run_spec(
                     None => std::future::pending().await,
                 }
             }, if final_wait_deadline.is_some() && exited.is_none() => {
-                let _ = child.start_kill();
                 final_wait_deadline = None;
-                exited = Some(1);
+                wait_retry_deadline = None;
                 if stdout_open || stderr_open {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),
                     )));
                 }
+            }
+            () = async {
+                match wait_retry_deadline.as_mut() {
+                    Some(timer) => timer.as_mut().await,
+                    None => std::future::pending().await,
+                }
+            }, if wait_retry_deadline.is_some() => {
+                wait_retry_deadline = None;
             }
         }
     }
@@ -1275,6 +1439,9 @@ async fn run_spec(
     }
     if timed_out {
         return RunOutcome::TimedOut;
+    }
+    if cancelled {
+        return RunOutcome::Failed { message: "process cancelled".to_owned() };
     }
     let text = String::from_utf8_lossy(&output);
     RunOutcome::Done { exit_code: exited.unwrap_or(0), output: text.into_owned() }
@@ -1400,6 +1567,7 @@ pub struct ActionContext {
     pub env: HashMap<String, String>,
     /// Process-owned capacity retained by file work that outlives a socket.
     pub file_slots: Arc<tokio::sync::Semaphore>,
+    pub(crate) process_supervisor: Arc<ProcessSupervisor>,
     #[cfg(test)]
     pub(crate) test_file_operation_barrier: Option<Arc<std::sync::Barrier>>,
 }
@@ -1806,7 +1974,8 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             };
             #[cfg(not(unix))]
             let command_cwd_fd = None;
-            let outcome = tokio::spawn(async move {
+            let process_supervisor = Arc::clone(&context.process_supervisor);
+            let outcome = match process_supervisor.spawn(move |cancellation| async move {
                 let _file_permit = file_permit;
                 #[cfg(unix)]
                 let _path_guard = _path_guard;
@@ -1829,11 +1998,13 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                     command_cwd_fd,
                     timeout_ms,
                     &env,
+                    Some(cancellation),
                 )
                 .await
-            })
-            .await
-            .unwrap_or(RunOutcome::Failed { message: "process failed to start".to_owned() });
+            }) {
+                Some((receiver, cancellation)) => await_supervised(receiver, cancellation).await,
+                None => RunOutcome::Failed { message: "relay process capacity is busy".to_owned() },
+            };
             run_reply(version, &action_id, outcome, args.get("limit"), Some(200), timeout_ms)
         }
         "find" => {
@@ -1897,14 +2068,25 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
                 find_args.push("-name".to_owned());
                 find_args.push(pattern.to_owned());
             }
-            let outcome = run_spec(
-                RunSpec::Argv { file: "find", args: find_args },
-                Path::new(&command_cwd_path),
-                command_cwd_fd,
-                timeout_ms,
-                &env,
-            )
-            .await;
+            let process_supervisor = Arc::clone(&context.process_supervisor);
+            let outcome = match process_supervisor.spawn(move |cancellation| async move {
+                #[cfg(unix)]
+                let _path_guard = _path_guard;
+                #[cfg(unix)]
+                let _cwd_guard = _cwd_guard;
+                run_spec(
+                    RunSpec::Argv { file: "find", args: find_args },
+                    Path::new(&command_cwd_path),
+                    command_cwd_fd,
+                    timeout_ms,
+                    &env,
+                    Some(cancellation),
+                )
+                .await
+            }) {
+                Some((receiver, cancellation)) => await_supervised(receiver, cancellation).await,
+                None => RunOutcome::Failed { message: "relay process capacity is busy".to_owned() },
+            };
             run_reply(version, &action_id, outcome, args.get("limit"), Some(500), timeout_ms)
         }
         "exec" => {
@@ -1938,14 +2120,23 @@ pub async fn perform_action(frame: &Value, context: &ActionContext) -> Value {
             #[cfg(not(unix))]
             let scoped_cwd_fd = None;
             let prepared = command_with_process_files(command, &runtime.files);
-            let outcome = run_spec(
-                RunSpec::Shell { command: &prepared },
-                Path::new(&scoped_cwd_path),
-                scoped_cwd_fd,
-                timeout_ms,
-                &env,
-            )
-            .await;
+            let process_supervisor = Arc::clone(&context.process_supervisor);
+            let outcome = match process_supervisor.spawn(move |cancellation| async move {
+                #[cfg(unix)]
+                let _cwd_guard = _cwd_guard;
+                run_spec(
+                    RunSpec::Shell { command: &prepared },
+                    Path::new(&scoped_cwd_path),
+                    scoped_cwd_fd,
+                    timeout_ms,
+                    &env,
+                    Some(cancellation),
+                )
+                .await
+            }) {
+                Some((receiver, cancellation)) => await_supervised(receiver, cancellation).await,
+                None => RunOutcome::Failed { message: "relay process capacity is busy".to_owned() },
+            };
             run_reply(version, &action_id, outcome, None, None, timeout_ms)
         }
         _ => fail("unsupported_verb", &format!("verb \"{verb}\" fell through")),
@@ -1972,6 +2163,7 @@ mod tests {
             home,
             env: HashMap::new(),
             file_slots: Arc::new(tokio::sync::Semaphore::new(MAX_BLOCKING_FILE_ACTIONS)),
+            process_supervisor: Arc::new(ProcessSupervisor::new()),
             test_file_operation_barrier: None,
         }
     }
@@ -2058,6 +2250,42 @@ mod tests {
         assert_eq!(clamp_timeout(Some(&json!(50))), 1_000);
         assert_eq!(clamp_timeout(Some(&json!(9_999_999))), MAX_TIMEOUT_MS);
         assert_eq!(clamp_timeout(Some(&json!(-5))), DEFAULT_TIMEOUT_MS);
+    }
+
+    #[tokio::test]
+    async fn process_supervisor_closes_after_owned_task_finishes() {
+        let supervisor = Arc::new(ProcessSupervisor::new());
+        let completed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let task_completed = Arc::clone(&completed);
+        let outcome = supervisor
+            .spawn(move |_| async move {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+                task_completed.store(true, std::sync::atomic::Ordering::Release);
+                RunOutcome::Done { exit_code: 0, output: String::new() }
+            })
+            .expect("open supervisor admits process");
+        let (outcome, _) = outcome;
+        supervisor.shutdown().await;
+        assert!(completed.load(std::sync::atomic::Ordering::Acquire));
+        assert!(matches!(outcome.await, Ok(RunOutcome::Done { exit_code: 0, .. })));
+        assert_eq!(supervisor.state(), SupervisorState::Closed);
+    }
+
+    #[tokio::test]
+    async fn process_supervisor_rejects_new_tasks_after_close() {
+        let supervisor = Arc::new(ProcessSupervisor::new());
+        supervisor.shutdown().await;
+        assert!(
+            supervisor
+                .spawn(|_| async { RunOutcome::Done { exit_code: 0, output: String::new() } })
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn wait_error_state_distinguishes_already_reaped() {
+        assert_eq!(WaitState::from_wait_error(true), WaitState::AlreadyReaped);
+        assert_eq!(WaitState::from_wait_error(false), WaitState::Retry);
     }
 
     #[test]
@@ -2504,7 +2732,7 @@ mod tests {
         let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
         let outcome = tokio::time::timeout(
             std::time::Duration::from_secs(2),
-            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env),
+            run_spec(RunSpec::Shell { command: "sleep 5 &" }, Path::new("/"), None, 20, &env, None),
         )
         .await
         .expect("timeout cleanup must not wait for a descendant pipe");

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1136,6 +1136,21 @@ impl ProcessSupervisor {
     }
 }
 
+impl Drop for ProcessSupervisor {
+    fn drop(&mut self) {
+        let lifecycle = match self.lifecycle.get_mut() {
+            Ok(lifecycle) => lifecycle,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        lifecycle.state = SupervisorState::Closed;
+        let tasks = std::mem::take(&mut lifecycle.tasks);
+        for task in tasks {
+            task.cancellation.cancel();
+            task.handle.abort();
+        }
+    }
+}
+
 #[cfg(unix)]
 struct ProcessGroupGuard {
     pid: Option<u32>,
@@ -1434,11 +1449,13 @@ async fn run_spec(
             }, if kill_deadline.is_some() => {
                 if exited.is_some() {
                     #[cfg(unix)]
-                    if process_group_exists(pid) {
+                    if (!cancelled || timed_out) && process_group_exists(pid) {
                         signal_process_group(pid, true);
                     }
                     #[cfg(not(unix))]
-                    signal_process_group(pid, true);
+                    if !cancelled || timed_out {
+                        signal_process_group(pid, true);
+                    }
                 } else {
                     // See the timeout branch above: never fall back to a
                     // numeric PID after a process-group signal fails.

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1431,6 +1431,10 @@ async fn run_spec(
             }, if final_wait_deadline.is_some() && exited.is_none() => {
                 final_wait_deadline = None;
                 wait_retry_deadline = None;
+                // SIGKILL should reap the leader, but keep a terminal state
+                // when wait remains pending so this branch cannot re-enable
+                // the gated child.wait future forever.
+                exited = Some(1);
                 if stdout_open || stderr_open {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(
                         std::time::Duration::from_millis(250),

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1013,9 +1013,25 @@ enum WaitState {
     AlreadyReaped,
 }
 
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum WaitRetryAction {
+    Retry,
+    Escalate,
+}
+
 impl WaitState {
     fn from_wait_error(already_reaped: bool) -> Self {
         if already_reaped { Self::AlreadyReaped } else { Self::Retry }
+    }
+}
+
+fn next_wait_retry(retries: &mut u32) -> WaitRetryAction {
+    *retries = retries.saturating_add(1);
+    if *retries >= MAX_WAIT_RETRIES {
+        *retries = 0;
+        WaitRetryAction::Escalate
+    } else {
+        WaitRetryAction::Retry
     }
 }
 
@@ -1327,26 +1343,38 @@ async fn run_spec(
                                 process_group_guard.armed = false;
                             }
                             WaitState::Retry => {
-                                wait_retries = wait_retries.saturating_add(1);
-                                if wait_retries >= MAX_WAIT_RETRIES {
-                                    exited = Some(1);
-                                } else {
-                                    wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
-                                        std::time::Duration::from_millis(10),
-                                    )));
+                                match next_wait_retry(&mut wait_retries) {
+                                    WaitRetryAction::Retry => {
+                                        wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                            std::time::Duration::from_millis(10),
+                                        )));
+                                    }
+                                    WaitRetryAction::Escalate => {
+                                        // Route persistent wait failures through the
+                                        // bounded kill and final-wait path. This
+                                        // kills the process group and gives Tokio a
+                                        // final chance to reap the leader.
+                                        kill_deadline = Some(Box::pin(tokio::time::sleep(
+                                            std::time::Duration::ZERO,
+                                        )));
+                                    }
                                 }
                             }
                         }
                         #[cfg(not(unix))]
                         {
                             let _ = error;
-                            wait_retries = wait_retries.saturating_add(1);
-                            if wait_retries >= MAX_WAIT_RETRIES {
-                                exited = Some(1);
-                            } else {
-                                wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
-                                    std::time::Duration::from_millis(10),
-                                )));
+                            match next_wait_retry(&mut wait_retries) {
+                                WaitRetryAction::Retry => {
+                                    wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                        std::time::Duration::from_millis(10),
+                                    )));
+                                }
+                                WaitRetryAction::Escalate => {
+                                    kill_deadline = Some(Box::pin(tokio::time::sleep(
+                                        std::time::Duration::ZERO,
+                                    )));
+                                }
                             }
                         }
                     }

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2778,7 +2778,19 @@ mod tests {
             .await
         });
 
-        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        let pid = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Ok(pid) = std::fs::read_to_string(&pid_file)
+                    .ok()
+                    .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
+                {
+                    break pid;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("descendant pid marker");
         cancellation.cancel();
         let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), worker)
             .await
@@ -2788,10 +2800,6 @@ mod tests {
             outcome,
             RunOutcome::Failed { message } if message == "process cancelled"
         ));
-        let pid = std::fs::read_to_string(&pid_file)
-            .ok()
-            .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
-            .expect("descendant pid marker");
         tokio::time::timeout(std::time::Duration::from_secs(1), async {
             while unsafe { libc::kill(pid, 0) } == 0 {
                 tokio::time::sleep(std::time::Duration::from_millis(5)).await;

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2738,6 +2738,54 @@ mod tests {
         .expect("timeout cleanup must not wait for a descendant pipe");
         assert!(matches!(outcome, RunOutcome::TimedOut));
     }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn cancellation_reports_failure_and_kills_descendant() {
+        use tokio_util::sync::CancellationToken;
+
+        let pid_file =
+            std::env::temp_dir().join(format!("chatmux-cancel-pid-{}", std::process::id()));
+        let command = format!("sleep 5 & echo $! > {}; wait", pid_file.display());
+        let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let cancellation = CancellationToken::new();
+        let worker_cancellation = cancellation.clone();
+        let worker = tokio::spawn(async move {
+            run_spec(
+                RunSpec::Shell { command: &command },
+                Path::new("/"),
+                None,
+                30_000,
+                &env,
+                Some(worker_cancellation),
+            )
+            .await
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        cancellation.cancel();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), worker)
+            .await
+            .expect("cancellation cleanup must complete")
+            .expect("runner task must join");
+        assert!(matches!(
+            outcome,
+            RunOutcome::Failed { message } if message == "process cancelled"
+        ));
+        let pid = std::fs::read_to_string(&pid_file)
+            .ok()
+            .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
+            .expect("descendant pid marker");
+        tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            while unsafe { libc::kill(pid, 0) } == 0 {
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("descendant must be gone after cancellation");
+        std::fs::remove_file(pid_file).ok();
+    }
+
     #[tokio::test]
     async fn exec_receives_scoped_process_environment_values() {
         let root = scratch("procenv");

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -45,6 +45,7 @@ const MAX_RUNTIME_ENVIRONMENT_BYTES: usize = 256_000;
 const MAX_RUNTIME_FILES: usize = 8;
 pub(crate) const MAX_BLOCKING_FILE_ACTIONS: usize = 8;
 const MAX_LIVE_PROCESSES: usize = 8;
+const MAX_WAIT_RETRIES: u32 = 50;
 
 // ---------------------------------------------------------------------------
 // Path policy (pure)
@@ -1234,6 +1235,7 @@ async fn run_spec(
     let mut drain_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut final_wait_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
     let mut wait_retry_deadline: Option<std::pin::Pin<Box<tokio::time::Sleep>>> = None;
+    let mut wait_retries = 0_u32;
     loop {
         // A timed-out process group still needs its escalation pass even when
         // the shell leader has already exited. Otherwise closing inherited
@@ -1308,29 +1310,39 @@ async fn run_spec(
                 match status {
                     Ok(status) => {
                         exited = Some(status.code().map(i64::from).unwrap_or(1));
-                        // `wait` has reaped the leader. Disarm before any
-                        // subsequent cancellation can target a reused PID.
-                        #[cfg(unix)]
-                        {
-                            process_group_guard.armed = false;
-                        }
+                        wait_retries = 0;
                     }
                     Err(error) => {
                         #[cfg(unix)]
-                        if error.raw_os_error() == Some(libc::ECHILD) {
-                            exited = Some(1);
-                            process_group_guard.armed = false;
-                        } else {
-                            wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
-                                std::time::Duration::from_millis(10),
-                            )));
+                        match WaitState::from_wait_error(
+                            error.raw_os_error() == Some(libc::ECHILD),
+                        ) {
+                            WaitState::AlreadyReaped => {
+                                exited = Some(1);
+                                wait_retries = 0;
+                            }
+                            WaitState::Retry => {
+                                wait_retries = wait_retries.saturating_add(1);
+                                if wait_retries >= MAX_WAIT_RETRIES {
+                                    exited = Some(1);
+                                } else {
+                                    wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                        std::time::Duration::from_millis(10),
+                                    )));
+                                }
+                            }
                         }
                         #[cfg(not(unix))]
                         {
                             let _ = error;
-                            wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
-                                std::time::Duration::from_millis(10),
-                            )));
+                            wait_retries = wait_retries.saturating_add(1);
+                            if wait_retries >= MAX_WAIT_RETRIES {
+                                exited = Some(1);
+                            } else {
+                                wait_retry_deadline = Some(Box::pin(tokio::time::sleep(
+                                    std::time::Duration::from_millis(10),
+                                )));
+                            }
                         }
                     }
                 }
@@ -1341,7 +1353,9 @@ async fn run_spec(
                 // inherited stdout/stderr. Kill the whole POSIX process group
                 // so the supervisor gets its EXIT cleanup, then enforce a
                 // hard bound for processes that ignore TERM.
-                if exited.is_none() {
+                if exited.is_some() {
+                    signal_process_group(pid, false);
+                } else {
                     // The process group is the authoritative target. If the
                     // group disappeared before we could signal it, use the
                     // live Child handle instead of the numeric PID. A PID
@@ -1376,7 +1390,9 @@ async fn run_spec(
                     None => std::future::pending().await,
                 }
             }, if kill_deadline.is_some() => {
-                if exited.is_none() {
+                if exited.is_some() {
+                    signal_process_group(pid, true);
+                } else {
                     // See the timeout branch above: never fall back to a
                     // numeric PID after a process-group signal fails.
                     #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1392,7 +1392,7 @@ async fn run_spec(
                 // hard bound for processes that ignore TERM.
                 if exited.is_some() {
                     #[cfg(unix)]
-                    if process_group_guard.armed {
+                    if process_group_exists(pid) {
                         signal_process_group(pid, false);
                     }
                     #[cfg(not(unix))]
@@ -1434,7 +1434,7 @@ async fn run_spec(
             }, if kill_deadline.is_some() => {
                 if exited.is_some() {
                     #[cfg(unix)]
-                    if process_group_guard.armed {
+                    if process_group_exists(pid) {
                         signal_process_group(pid, true);
                     }
                     #[cfg(not(unix))]
@@ -1535,6 +1535,15 @@ where
     let signal = if kill { libc::SIGKILL } else { libc::SIGTERM };
     let group = -(pid as i32);
     send(group, signal) == 0
+}
+
+#[cfg(unix)]
+fn process_group_exists(pid: Option<u32>) -> bool {
+    let Some(pid) = pid else { return false };
+    // A process group cannot be reused while any descendant remains in it,
+    // so checking the group before signalling makes post-reap timeout cleanup
+    // safe without keeping the cancellation guard armed.
+    unsafe { libc::kill(-(pid as i32), 0) == 0 }
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1273,11 +1273,15 @@ async fn run_spec(
             }, if !cancelled => {
                 cancelled = true;
                 #[cfg(unix)]
-                if !signal_process_tree(pid, false) {
-                    let _ = child.start_kill();
+                if exited.is_none() && process_group_guard.armed {
+                    if !signal_process_tree(pid, false) {
+                        let _ = child.start_kill();
+                    }
                 }
                 #[cfg(not(unix))]
-                signal_process_tree(pid, false);
+                if exited.is_none() {
+                    signal_process_tree(pid, false);
+                }
                 kill_deadline = Some(Box::pin(tokio::time::sleep(
                     std::time::Duration::from_millis(250),
                 )));
@@ -1387,6 +1391,11 @@ async fn run_spec(
                 // so the supervisor gets its EXIT cleanup, then enforce a
                 // hard bound for processes that ignore TERM.
                 if exited.is_some() {
+                    #[cfg(unix)]
+                    if process_group_guard.armed {
+                        signal_process_group(pid, false);
+                    }
+                    #[cfg(not(unix))]
                     signal_process_group(pid, false);
                 } else {
                     // The process group is the authoritative target. If the
@@ -1424,6 +1433,11 @@ async fn run_spec(
                 }
             }, if kill_deadline.is_some() => {
                 if exited.is_some() {
+                    #[cfg(unix)]
+                    if process_group_guard.armed {
+                        signal_process_group(pid, true);
+                    }
+                    #[cfg(not(unix))]
                     signal_process_group(pid, true);
                 } else {
                     // See the timeout branch above: never fall back to a

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2863,6 +2863,60 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn cancellation_after_leader_reap_does_not_signal_process_group() {
+        use tokio_util::sync::CancellationToken;
+
+        let pid_file =
+            std::env::temp_dir().join(format!("chatmux-cancel-reaped-pid-{}", std::process::id()));
+        std::fs::remove_file(&pid_file).ok();
+        let command = format!("sleep 30 & echo $! > {}; exit 0", pid_file.display());
+        let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let cancellation = CancellationToken::new();
+        let worker_cancellation = cancellation.clone();
+        let worker = tokio::spawn(async move {
+            run_spec(
+                RunSpec::Shell { command: &command },
+                Path::new("/"),
+                None,
+                30_000,
+                &env,
+                Some(worker_cancellation),
+            )
+            .await
+        });
+
+        let pid = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(pid) = std::fs::read_to_string(&pid_file)
+                    .ok()
+                    .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
+                {
+                    break pid;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("descendant pid marker");
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        cancellation.cancel();
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), worker)
+            .await
+            .expect("cancellation cleanup must complete")
+            .expect("runner task must join");
+        assert!(matches!(
+            outcome,
+            RunOutcome::Failed { message } if message == "process cancelled"
+        ));
+        assert_eq!(unsafe { libc::kill(pid, 0) }, 0, "reaped leader must release group ownership");
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+        std::fs::remove_file(pid_file).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn cancellation_reports_failure_and_kills_descendant() {
         use tokio_util::sync::CancellationToken;
 

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1478,9 +1478,13 @@ async fn run_spec(
             }, if final_wait_deadline.is_some() && exited.is_none() => {
                 final_wait_deadline = None;
                 wait_retry_deadline = None;
-                // SIGKILL should reap the leader, but keep a terminal state
-                // when wait remains pending so this branch cannot re-enable
-                // the gated child.wait future forever.
+                // Keep a direct kill fallback before declaring the wait
+                // terminal. The process-group signal can fail after the
+                // leader leaves its group, while the leader itself remains
+                // alive and must not outlive this action.
+                let _ = child.start_kill();
+                // Keep a terminal state when wait remains pending so this
+                // branch cannot re-enable the gated child.wait future forever.
                 exited = Some(1);
                 if stdout_open || stderr_open {
                     drain_deadline = Some(Box::pin(tokio::time::sleep(

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2781,6 +2781,46 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn successful_leader_reap_disarms_process_group_guard_on_abort() {
+        let pid_file =
+            std::env::temp_dir().join(format!("chatmux-success-pid-{}", std::process::id()));
+        std::fs::remove_file(&pid_file).ok();
+        let command = format!("sleep 30 & echo $! > {}; exit 0", pid_file.display());
+        let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let worker = tokio::spawn(async move {
+            run_spec(RunSpec::Shell { command: &command }, Path::new("/"), None, 30_000, &env, None)
+                .await
+        });
+
+        let pid = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(pid) = std::fs::read_to_string(&pid_file)
+                    .ok()
+                    .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
+                {
+                    break pid;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("descendant pid marker");
+
+        // Give the shell time to exit and child.wait() time to reap it while
+        // the descendant keeps the inherited output pipes open.
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        worker.abort();
+        let _ = worker.await;
+
+        assert_eq!(unsafe { libc::kill(pid, 0) }, 0, "reaped leader must release group ownership");
+        unsafe {
+            libc::kill(pid, libc::SIGKILL);
+        }
+        std::fs::remove_file(pid_file).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn cancellation_reports_failure_and_kills_descendant() {
         use tokio_util::sync::CancellationToken;
 

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2821,6 +2821,41 @@ mod tests {
 
     #[cfg(unix)]
     #[tokio::test]
+    async fn timeout_after_leader_reap_kills_descendant_group() {
+        let pid_file =
+            std::env::temp_dir().join(format!("chatmux-timeout-reaped-pid-{}", std::process::id()));
+        std::fs::remove_file(&pid_file).ok();
+        let command = format!("sleep 30 & echo $! > {}; exit 0", pid_file.display());
+        let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
+        let worker = tokio::spawn(async move {
+            run_spec(RunSpec::Shell { command: &command }, Path::new("/"), None, 100, &env, None)
+                .await
+        });
+        let pid = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                if let Some(pid) = std::fs::read_to_string(&pid_file)
+                    .ok()
+                    .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
+                {
+                    break pid;
+                }
+                tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            }
+        })
+        .await
+        .expect("descendant pid marker");
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        let outcome = tokio::time::timeout(std::time::Duration::from_secs(2), worker)
+            .await
+            .expect("timeout cleanup must complete")
+            .expect("runner task must join");
+        assert!(matches!(outcome, RunOutcome::TimedOut));
+        assert_ne!(unsafe { libc::kill(pid, 0) }, 0, "timeout must kill reaped leader descendants");
+        std::fs::remove_file(pid_file).ok();
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
     async fn timeout_after_sigkill_reaches_terminal_wait_state() {
         let env = scrubbed_env(&HashMap::from([("PATH".to_owned(), "/usr/bin:/bin".to_owned())]));
         let outcome = tokio::time::timeout(

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1311,6 +1311,10 @@ async fn run_spec(
                     Ok(status) => {
                         exited = Some(status.code().map(i64::from).unwrap_or(1));
                         wait_retries = 0;
+                        #[cfg(unix)]
+                        {
+                            process_group_guard.armed = false;
+                        }
                     }
                     Err(error) => {
                         #[cfg(unix)]
@@ -1320,6 +1324,7 @@ async fn run_spec(
                             WaitState::AlreadyReaped => {
                                 exited = Some(1);
                                 wait_retries = 0;
+                                process_group_guard.armed = false;
                             }
                             WaitState::Retry => {
                                 wait_retries = wait_retries.saturating_add(1);

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2780,7 +2780,7 @@ mod tests {
 
         let pid = tokio::time::timeout(std::time::Duration::from_secs(1), async {
             loop {
-                if let Ok(pid) = std::fs::read_to_string(&pid_file)
+                if let Some(pid) = std::fs::read_to_string(&pid_file)
                     .ok()
                     .and_then(|value| value.trim().parse::<libc::pid_t>().ok())
                 {

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -2314,6 +2314,15 @@ mod tests {
     }
 
     #[test]
+    fn wait_retry_exhaustion_requests_kill_escalation() {
+        let mut retries = 0;
+        for _ in 0..MAX_WAIT_RETRIES.saturating_sub(1) {
+            assert_eq!(next_wait_retry(&mut retries), WaitRetryAction::Retry);
+        }
+        assert_eq!(next_wait_retry(&mut retries), WaitRetryAction::Escalate);
+    }
+
+    #[test]
     fn scoped_file_capability_refusal_is_typed_and_fail_closed() {
         let roots = vec!["/srv/work".to_owned()];
         let scoped: RootLists<'_> = [Some(roots.as_slice()), None];

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -33,7 +33,8 @@ use tokio_tungstenite::tungstenite::{Error as TungsteniteError, Message};
 use tokio_util::sync::CancellationToken;
 
 use crate::actions::{
-    ActionContext, MAX_BLOCKING_FILE_ACTIONS, perform_action, process_env_snapshot, scrubbed_env,
+    ActionContext, MAX_BLOCKING_FILE_ACTIONS, ProcessSupervisor, perform_action,
+    process_env_snapshot, scrubbed_env,
 };
 use crate::config::{Config, save_config};
 use crate::error::RelayError;
@@ -325,6 +326,7 @@ pub struct SessionRuntime {
     home: PathBuf,
     base_env: HashMap<String, String>,
     file_action_slots: Arc<Semaphore>,
+    pub(crate) process_supervisor: Arc<ProcessSupervisor>,
     pub(crate) workspace: Arc<crate::workspace::SharedRuntime>,
     #[cfg(unix)]
     pty: Arc<PtyManager>,
@@ -347,6 +349,7 @@ impl SessionRuntime {
             home,
             base_env,
             file_action_slots: Arc::new(Semaphore::new(MAX_BLOCKING_FILE_ACTIONS)),
+            process_supervisor: Arc::new(ProcessSupervisor::new()),
             workspace: Arc::new(crate::workspace::SharedRuntime::new(local_roots)),
             #[cfg(unix)]
             pty,
@@ -474,9 +477,9 @@ pub async fn stay_online(
         }
     }
     let mut attempt: u32 = 0;
-    loop {
+    let result = loop {
         if cancellation.is_cancelled() {
-            return Ok(());
+            break Ok(());
         }
         match relay_session(&mut config, config_path, &mut state, &runtime, &cancellation).await {
             Ok(was_connected) => {
@@ -485,7 +488,7 @@ pub async fn stay_online(
                 }
             }
             Err(RelayError::Fatal { message, exit_code }) => {
-                return Err(RelayError::Fatal { message, exit_code });
+                break Err(RelayError::Fatal { message, exit_code });
             }
             Err(RelayError::WakeRedial { message }) => {
                 // The socket died silently (host suspend, or a peer that
@@ -501,15 +504,17 @@ pub async fn stay_online(
             }
         }
         if cancellation.is_cancelled() {
-            return Ok(());
+            break Ok(());
         }
         let ceiling = 500_u64.saturating_mul(1_u64 << attempt.min(10)).min(30_000);
         attempt = attempt.saturating_add(1);
         let delay = (ceiling as f64 * jitter()).round().max(0.0) as u64;
         if !wait_for_reconnect(&cancellation, Duration::from_millis(delay)).await {
-            return Ok(());
+            break Ok(());
         }
-    }
+    };
+    runtime.process_supervisor.shutdown().await;
+    result
 }
 
 fn save(config: &Config, config_path: &Path) {
@@ -1045,6 +1050,7 @@ async fn relay_session(
                             home: runtime.home.clone(),
                             env: scrubbed_env(&runtime.base_env),
                             file_slots: Arc::clone(&runtime.file_action_slots),
+                            process_supervisor: Arc::clone(&runtime.process_supervisor),
                             #[cfg(test)]
                             test_file_operation_barrier: None,
                         };


### PR DESCRIPTION
Fixes process-supervisor lifecycle defects identified in https://github.com/manaflow-ai/cmux/pull/11698.

- Bound repeated non-ECHILD child.wait errors and route ECHILD through WaitState.
- Keep process-group signaling available after leader reap for timeout/cancellation cleanup.
- Add cancellation regression coverage that verifies descendant termination and process cancelled result.

Test-first commits: cancellation regression test, then bounded cleanup fix.

Validation: git diff --check; hosted cmux-tui verification is running. No local Cargo/Rust tests run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11714"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967147&installation_model_id=21920&pr_number=11714&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11714&signature=337f74305efc1c3ad2bae28dee4c582c074594c0c16f8108df14e671ce1b865d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Process actions previously outlived session shutdown and had no per-session concurrency limit; they now run under a session-lifetime supervisor that cancels and awaits them. Each session admits at most eight live processes, and excess work fails with `relay process capacity is busy`.

**Bug Fixes**
- Cancellation terminates descendants, waits for cleanup, and returns `process cancelled`.
- Timeout cleanup reaches a terminal state after `SIGKILL`, including when the leader exits before its descendants, without signaling a reused process group.
- Treats `ECHILD` as already reaped, bounds other wait retries, reaps failed starts, and kills the leader before the final wait fallback.
- Adds regression coverage for shutdown, cancellation, timeout cleanup, leader reaping, and wait escalation.

<sup>Written for commit 3a0688dcfe4fc055521c8b7f67c9338321ea25d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safer command execution with limits on concurrent processes.
  * Added cancellation support that stops running commands and their descendant processes.
  * Added clearer responses when command capacity is reached or operations are cancelled.
* **Bug Fixes**
  * Improved handling of command timeouts and transient process-wait failures.
  * Improved cleanup of running processes when sessions shut down or reconnect loops end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->