### PR TITLE
chore(cmux-tui): restore rustfmt import order

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -1,6 +1,6 @@
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use unicode_segmentation::UnicodeSegmentation;
 use ratatui::buffer::CellWidth;
+use unicode_segmentation::UnicodeSegmentation;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum InputEvent {


### PR DESCRIPTION
Summary:
- reorder the CellWidth and UnicodeSegmentation imports in ui/input.rs
- restore repository-wide cargo fmt checks without changing behavior

Verification:
- rustup run 1.95.0 rustfmt --edition 2024 --config-path cmux-tui/rustfmt.toml --check cmux-tui/crates/cmux-tui/src/ui/input.rs
- git diff --check

This is a formatter-only follow-up for the baseline failure observed in hosted run 33669563752.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11715"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790967810&installation_model_id=21920&pr_number=11715&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11715&signature=675371571c7eb4efa3b5b48b5426b3e47d651748e072409cdcbb3eae6a9a590f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorders the `CellWidth` and `UnicodeSegmentation` imports in `ui/input.rs` so repository-wide `rustfmt` checks pass again. This is a formatter-only change with no behavior impact.

<sup>Written for commit 070ea8a6301c4a2a1667ef436d08aec97435cec3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reordered import statements without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->