### PR TITLE
fix(tui): retain final replay after hosted exit

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8391,27 +8391,31 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn exited_terminal_final_replay_publishes_state_for_already_dead_host() {
+    fn exited_terminal_final_replay_does_not_reclassify_prior_host_loss() {
         let mux = Mux::new_for_test("already-dead-host-attach", SurfaceOptions::default());
         let surface =
             Surface::spawn_for_test(94, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
         let pty = surface.as_pty().unwrap();
 
-        // Another exit observer may enter after the first observer latched
-        // `dead`. It must still publish the final state for later attach.
+        // A prior host-loss path may latch `dead` before hosted exit
+        // finalization owns the terminal. It must not expose a replay that
+        // was never finalized or close streams owned by that loss path.
         pty.dead.store(true, Ordering::Release);
+        pty.host_connection_state
+            .store(TerminalHostConnectionState::Failed as u8, Ordering::Release);
         assert_eq!(
             TerminalHostConnectionState::from_u8(pty.host_connection_state.load(Ordering::Acquire)),
-            TerminalHostConnectionState::Connected
+            TerminalHostConnectionState::Failed
         );
 
         pty.finish_hosted_exit();
 
         assert_eq!(
             TerminalHostConnectionState::from_u8(pty.host_connection_state.load(Ordering::Acquire)),
-            TerminalHostConnectionState::Exited
+            TerminalHostConnectionState::Failed
         );
-        surface.attach_stream().expect("an already-dead exited host must serve final replay");
+        assert!(matches!(surface.attach_stream(), Err(ghostty_vt::Error::NoValue)));
+        assert!(matches!(surface.attach_render_stream(), Err(ghostty_vt::Error::NoValue)));
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -6508,10 +6508,9 @@ impl PtySurface {
     /// retaining the exited surface as a stable, snapshot-renderable tab.
     fn finish_hosted_exit(&self) {
         let mut term = self.term.lock().unwrap();
-        // Attach takes the same terminal lock. Publish Exited first so an
-        // attacher can observe either a live terminal or its final snapshot.
-        self.host_connection_state
-            .store(TerminalHostConnectionState::Exited as u8, Ordering::Release);
+        // Attach takes the same terminal lock. The caller that changes `dead`
+        // owns finalization; a prior host-loss owner must keep its state and
+        // reject an incomplete replay.
         if self.dead.swap(true, Ordering::AcqRel) {
             return;
         }
@@ -6519,6 +6518,11 @@ impl PtySurface {
         let _ = self.build_frame_locked(&mut term, generation, true);
         self.taps.lock().unwrap().clear();
         self.render.lock().unwrap().taps.clear();
+        // Publish Exited only after the final frame is built and both stream
+        // sets are closed. An attacher that acquires `term` next can then
+        // observe a live terminal or a complete, inert final snapshot.
+        self.host_connection_state
+            .store(TerminalHostConnectionState::Exited as u8, Ordering::Release);
     }
 
     fn mark_output_dirty(&self) {

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8420,6 +8420,10 @@ mod tests {
                 .attach_render_stream()
                 .expect("exited terminal final replay must not exhaust live render permits");
             assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Disconnected)));
+            assert!(
+                Arc::ptr_eq(&first.initial, &attach.initial),
+                "exited render attaches must share one cached final snapshot"
+            );
             attachments.push(attach);
         }
         assert!(surface.as_pty().unwrap().render.lock().unwrap().taps.is_empty());

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8351,7 +8351,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn exited_host_byte_attach_serves_final_replay() {
+    fn exited_terminal_final_replay_serves_byte_attach() {
         const MARKER: &str = "exited-byte-final-replay";
         let mux = Mux::new_for_test("exited-host-byte-attach", SurfaceOptions::default());
         let surface = exited_host_surface("byte-attach", 92, &mux);
@@ -8368,7 +8368,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn exited_host_render_attach_serves_final_frame() {
+    fn exited_terminal_final_replay_serves_render_attach() {
         const MARKER: &str = "exited-render-final-frame";
         let mux = Mux::new_for_test("exited-host-render-attach", SurfaceOptions::default());
         let surface = exited_host_surface("render-attach", 93, &mux);
@@ -8391,7 +8391,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn already_dead_host_publishes_exited_state_before_attach() {
+    fn exited_terminal_final_replay_publishes_state_for_already_dead_host() {
         let mux = Mux::new_for_test("already-dead-host-attach", SurfaceOptions::default());
         let surface =
             Surface::spawn_for_test(94, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
@@ -8416,7 +8416,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn hosted_exit_and_attach_never_expose_a_dead_connected_gap() {
+    fn exited_terminal_final_replay_closes_the_exit_attach_race() {
         for iteration in 0..64 {
             let mux = Mux::new_for_test(
                 format!("hosted-exit-attach-race-{iteration}"),
@@ -8449,7 +8449,7 @@ mod tests {
     }
 
     #[test]
-    fn rejected_dead_render_attach_releases_the_global_permit() {
+    fn exited_terminal_final_replay_releases_rejected_render_permit() {
         let mux = Mux::new_for_test("dead-render-attach-permit", SurfaceOptions::default());
         let dead =
             Surface::spawn_for_test(200, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1045,7 +1045,7 @@ impl Drop for RenderAttachFrameReceiver {
 pub struct RenderAttachStream {
     pub initial: Arc<SurfaceRenderFrame>,
     pub stream: RenderAttachFrameReceiver,
-    _permit: crate::mux::RenderAttachmentPermit,
+    _permit: Option<crate::mux::RenderAttachmentPermit>,
 }
 
 struct RenderHub {
@@ -5550,12 +5550,13 @@ impl Surface {
             return Err(ghostty_vt::Error::InvalidValue);
         };
         let mut term = pty.term.lock().unwrap();
+        let dead = pty.dead.load(Ordering::Acquire);
+        let exited = dead
+            && pty.host_connection_state.load(Ordering::Acquire)
+                == TerminalHostConnectionState::Exited as u8;
         // An exited terminal has no live tap, but its final replay remains
         // useful. Other dead states can represent an incomplete host loss.
-        if pty.dead.load(Ordering::Acquire)
-            && pty.host_connection_state.load(Ordering::Acquire)
-                != TerminalHostConnectionState::Exited as u8
-        {
+        if dead && !exited {
             return Err(ghostty_vt::Error::NoValue);
         }
         let (tap, stream) =
@@ -5568,7 +5569,9 @@ impl Surface {
         let (cols, rows) = (term.cols(), term.rows());
         let defaults = pty.mux.upgrade().map(|mux| mux.default_colors()).unwrap_or_default();
         let colors = pty.terminal_colors_locked(&term, defaults);
-        if !pty.dead.load(Ordering::Acquire) {
+        if exited || pty.dead.load(Ordering::Acquire) {
+            drop(tap);
+        } else {
             let mut taps = pty.taps.lock().unwrap();
             if taps.is_empty() {
                 *pty.last_attach_colors.lock().unwrap() =
@@ -5594,22 +5597,28 @@ impl Surface {
         let Some(pty) = self.as_pty() else {
             return Err(ghostty_vt::Error::InvalidValue);
         };
-        let permit = pty
-            .mux
-            .upgrade()
-            .and_then(|mux| mux.claim_render_attachment())
-            .ok_or(ghostty_vt::Error::OutOfSpace)?;
         let mut term = pty.term.lock().unwrap();
-        if pty.dead.load(Ordering::Acquire)
+        let dead = pty.dead.load(Ordering::Acquire);
+        let exited = dead
             && pty.host_connection_state.load(Ordering::Acquire)
-                != TerminalHostConnectionState::Exited as u8
-        {
+                == TerminalHostConnectionState::Exited as u8;
+        if dead && !exited {
             return Err(ghostty_vt::Error::NoValue);
         }
+        let permit = if exited {
+            None
+        } else {
+            Some(
+                pty.mux
+                    .upgrade()
+                    .and_then(|mux| mux.claim_render_attachment())
+                    .ok_or(ghostty_vt::Error::OutOfSpace)?,
+            )
+        };
         let generation = pty.render_generation.load(Ordering::Acquire);
         let _ = pty.build_frame_locked(&mut term, generation, false)?;
         let (tap, stream) = RenderTap::pair(&pty.render);
-        let initial = {
+        let (initial, registered) = {
             let mut render = pty.render.lock().unwrap();
             let shared = render.latest.clone().ok_or(ghostty_vt::Error::NoValue)?;
             let initial_graphics = match render.initial_graphics.as_ref() {
@@ -5627,10 +5636,20 @@ impl Surface {
             };
             let mut initial = (*shared).clone();
             initial.frame.kitty_graphics = initial_graphics;
-            if !pty.dead.load(Ordering::Acquire) {
+            let registered = if exited || pty.dead.load(Ordering::Acquire) {
+                drop(tap);
+                false
+            } else {
                 render.taps.push(tap);
-            }
-            Arc::new(initial)
+                true
+            };
+            (Arc::new(initial), registered)
+        };
+        let permit = if registered {
+            permit
+        } else {
+            drop(permit);
+            None
         };
         Ok(RenderAttachStream { initial, stream, _permit: permit })
     }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8454,7 +8454,7 @@ mod tests {
                 .expect("exited terminal final replay must not exhaust live render permits");
             assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Disconnected)));
             assert!(
-                Arc::ptr_eq(&first.initial, &attach.initial),
+                Arc::ptr_eq(&attachments[0].initial, &attach.initial),
                 "exited render attaches must share one cached final snapshot"
             );
             attachments.push(attach);

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8322,6 +8322,140 @@ mod tests {
         surface.write_paste(b"must not reach a dead host").unwrap();
     }
 
+    #[cfg(unix)]
+    fn exited_host_surface(name: &str, id: SurfaceId, mux: &Arc<Mux>) -> Arc<Surface> {
+        let identity = crate::terminal_host_runtime::TerminalHostIdentity {
+            terminal_id: crate::terminal_host::TerminalId::random().unwrap().to_hex(),
+            incarnation: crate::terminal_host::HostIncarnation::random().unwrap().to_hex(),
+        };
+        Surface::exited_terminal_placeholder(
+            id,
+            SurfaceOptions { command: Some(vec![name.into()]), ..SurfaceOptions::default() },
+            Arc::downgrade(mux),
+            identity,
+        )
+        .unwrap()
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_host_byte_attach_serves_final_replay() {
+        const MARKER: &str = "exited-byte-final-replay";
+        let mux = Mux::new_for_test("exited-host-byte-attach", SurfaceOptions::default());
+        let surface = exited_host_surface("byte-attach", 92, &mux);
+        surface.with_terminal(|term| term.vt_write(MARKER.as_bytes()));
+
+        let attach = surface.attach_stream().expect("exited terminal must serve byte replay");
+        let mut mirror =
+            Terminal::new(attach.cols, attach.rows, 10_000, Callbacks::default()).unwrap();
+        mirror.vt_write(&attach.replay);
+
+        assert!(mirror.plain_text().unwrap().contains(MARKER));
+        assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Disconnected)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn exited_host_render_attach_serves_final_frame() {
+        const MARKER: &str = "exited-render-final-frame";
+        let mux = Mux::new_for_test("exited-host-render-attach", SurfaceOptions::default());
+        let surface = exited_host_surface("render-attach", 93, &mux);
+        surface.with_terminal(|term| term.vt_write(MARKER.as_bytes()));
+
+        let attach =
+            surface.attach_render_stream().expect("exited terminal must serve final render frame");
+        let rendered = attach
+            .initial
+            .frame
+            .styled_rows()
+            .iter()
+            .flat_map(|row| row.iter())
+            .map(|cell| cell.text.as_str())
+            .collect::<String>();
+
+        assert!(rendered.contains(MARKER), "final render frame omitted {MARKER}: {rendered:?}");
+        assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Disconnected)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn already_dead_host_publishes_exited_state_before_attach() {
+        let mux = Mux::new_for_test("already-dead-host-attach", SurfaceOptions::default());
+        let surface =
+            Surface::spawn_for_test(94, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
+        let pty = surface.as_pty().unwrap();
+
+        // Another exit observer may enter after the first observer latched
+        // `dead`. It must still publish the final state for later attach.
+        pty.dead.store(true, Ordering::Release);
+        assert_eq!(
+            TerminalHostConnectionState::from_u8(pty.host_connection_state.load(Ordering::Acquire)),
+            TerminalHostConnectionState::Connected
+        );
+
+        pty.finish_hosted_exit();
+
+        assert_eq!(
+            TerminalHostConnectionState::from_u8(pty.host_connection_state.load(Ordering::Acquire)),
+            TerminalHostConnectionState::Exited
+        );
+        surface.attach_stream().expect("an already-dead exited host must serve final replay");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn hosted_exit_and_attach_never_expose_a_dead_connected_gap() {
+        for iteration in 0..64 {
+            let mux = Mux::new_for_test(
+                format!("hosted-exit-attach-race-{iteration}"),
+                SurfaceOptions::default(),
+            );
+            let surface = Surface::spawn_for_test(
+                iteration + 100,
+                SurfaceOptions::default(),
+                Arc::downgrade(&mux),
+            )
+            .unwrap();
+            let start = Arc::new(std::sync::Barrier::new(2));
+
+            std::thread::scope(|scope| {
+                let exit_surface = surface.clone();
+                let exit_start = start.clone();
+                let exit = scope.spawn(move || {
+                    exit_start.wait();
+                    exit_surface.as_pty().unwrap().finish_hosted_exit();
+                });
+
+                start.wait();
+                let during_exit = surface.attach_stream();
+                exit.join().unwrap();
+
+                during_exit.expect("attach racing hosted exit must serve live or final replay");
+                surface.attach_stream().expect("attach after hosted exit must serve final replay");
+            });
+        }
+    }
+
+    #[test]
+    fn rejected_dead_render_attach_releases_the_global_permit() {
+        let mux = Mux::new_for_test("dead-render-attach-permit", SurfaceOptions::default());
+        let dead =
+            Surface::spawn_for_test(200, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
+        dead.as_pty().unwrap().dead.store(true, Ordering::Release);
+
+        for _ in 0..crate::mux::RENDER_ATTACHMENT_LIMIT * 2 {
+            assert!(matches!(dead.attach_render_stream(), Err(ghostty_vt::Error::NoValue)));
+        }
+
+        let live =
+            Surface::spawn_for_test(201, SurfaceOptions::default(), Arc::downgrade(&mux)).unwrap();
+        let mut attachments = Vec::new();
+        for _ in 0..crate::mux::RENDER_ATTACHMENT_LIMIT {
+            attachments.push(live.attach_render_stream().expect("rejected attach leaked a permit"));
+        }
+        assert!(matches!(live.attach_render_stream(), Err(ghostty_vt::Error::OutOfSpace)));
+    }
+
     #[test]
     fn terminal_reconnect_failure_state_never_decodes_as_connected() {
         assert_ne!(TerminalHostConnectionState::from_u8(3), TerminalHostConnectionState::Connected);

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -5550,7 +5550,12 @@ impl Surface {
             return Err(ghostty_vt::Error::InvalidValue);
         };
         let mut term = pty.term.lock().unwrap();
-        if pty.dead.load(Ordering::Acquire) {
+        // An exited terminal has no live tap, but its final replay remains
+        // useful. Other dead states can represent an incomplete host loss.
+        if pty.dead.load(Ordering::Acquire)
+            && pty.host_connection_state.load(Ordering::Acquire)
+                != TerminalHostConnectionState::Exited as u8
+        {
             return Err(ghostty_vt::Error::NoValue);
         }
         let (tap, stream) =
@@ -5595,7 +5600,10 @@ impl Surface {
             .and_then(|mux| mux.claim_render_attachment())
             .ok_or(ghostty_vt::Error::OutOfSpace)?;
         let mut term = pty.term.lock().unwrap();
-        if pty.dead.load(Ordering::Acquire) {
+        if pty.dead.load(Ordering::Acquire)
+            && pty.host_connection_state.load(Ordering::Acquire)
+                != TerminalHostConnectionState::Exited as u8
+        {
             return Err(ghostty_vt::Error::NoValue);
         }
         let generation = pty.render_generation.load(Ordering::Acquire);
@@ -6500,6 +6508,10 @@ impl PtySurface {
     /// retaining the exited surface as a stable, snapshot-renderable tab.
     fn finish_hosted_exit(&self) {
         let mut term = self.term.lock().unwrap();
+        // Attach takes the same terminal lock. Publish Exited first so an
+        // attacher can observe either a live terminal or its final snapshot.
+        self.host_connection_state
+            .store(TerminalHostConnectionState::Exited as u8, Ordering::Release);
         if self.dead.swap(true, Ordering::AcqRel) {
             return;
         }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -1053,7 +1053,45 @@ struct RenderHub {
     built_generation: u64,
     latest: Option<Arc<SurfaceRenderFrame>>,
     initial_graphics: Option<InitialGraphicsSnapshot>,
+    final_initial: Option<Arc<SurfaceRenderFrame>>,
     taps: Vec<RenderTap>,
+}
+
+impl RenderHub {
+    fn build_attach_initial(
+        &mut self,
+        term: &Terminal,
+    ) -> ghostty_vt::Result<Arc<SurfaceRenderFrame>> {
+        let shared = self.latest.clone().ok_or(ghostty_vt::Error::NoValue)?;
+        let initial_graphics = match self.initial_graphics.as_ref() {
+            Some(cached) if Arc::ptr_eq(&cached.source, &shared.frame.kitty_graphics) => {
+                cached.snapshot.clone()
+            }
+            _ => {
+                let snapshot = self.state.snapshot_kitty_graphics(term, true)?;
+                self.initial_graphics = Some(InitialGraphicsSnapshot {
+                    source: shared.frame.kitty_graphics.clone(),
+                    snapshot: snapshot.clone(),
+                });
+                snapshot
+            }
+        };
+        let mut initial = (*shared).clone();
+        initial.frame.kitty_graphics = initial_graphics;
+        Ok(Arc::new(initial))
+    }
+
+    fn final_attach_initial(
+        &mut self,
+        term: &Terminal,
+    ) -> ghostty_vt::Result<Arc<SurfaceRenderFrame>> {
+        if let Some(initial) = self.final_initial.as_ref() {
+            return Ok(initial.clone());
+        }
+        let initial = self.build_attach_initial(term)?;
+        self.final_initial = Some(initial.clone());
+        Ok(initial)
+    }
 }
 
 struct InitialGraphicsSnapshot {
@@ -2461,6 +2499,7 @@ impl Surface {
                     built_generation: 0,
                     latest: None,
                     initial_graphics: None,
+                    final_initial: None,
                     taps: Vec::new(),
                 })),
                 render_generation: AtomicU64::new(1),
@@ -2956,6 +2995,7 @@ impl Surface {
                     built_generation: 0,
                     latest: None,
                     initial_graphics: None,
+                    final_initial: None,
                     taps: Vec::new(),
                 })),
                 render_generation: AtomicU64::new(1),
@@ -3999,6 +4039,7 @@ impl Surface {
                     built_generation: 0,
                     latest: None,
                     initial_graphics: None,
+                    final_initial: None,
                     taps: Vec::new(),
                 })),
                 render_generation: AtomicU64::new(1),
@@ -4226,6 +4267,7 @@ impl Surface {
                     built_generation: 0,
                     latest: None,
                     initial_graphics: None,
+                    final_initial: None,
                     taps: Vec::new(),
                 })),
                 render_generation: AtomicU64::new(1),
@@ -4521,6 +4563,7 @@ impl Surface {
                 render.state.clear_kitty_graphics_cache();
                 render.latest = None;
                 render.initial_graphics = None;
+                render.final_initial = None;
             }
             graphics_changed
         };
@@ -5620,22 +5663,11 @@ impl Surface {
         let (tap, stream) = RenderTap::pair(&pty.render);
         let (initial, registered) = {
             let mut render = pty.render.lock().unwrap();
-            let shared = render.latest.clone().ok_or(ghostty_vt::Error::NoValue)?;
-            let initial_graphics = match render.initial_graphics.as_ref() {
-                Some(cached) if Arc::ptr_eq(&cached.source, &shared.frame.kitty_graphics) => {
-                    cached.snapshot.clone()
-                }
-                _ => {
-                    let snapshot = render.state.snapshot_kitty_graphics(&term, true)?;
-                    render.initial_graphics = Some(InitialGraphicsSnapshot {
-                        source: shared.frame.kitty_graphics.clone(),
-                        snapshot: snapshot.clone(),
-                    });
-                    snapshot
-                }
+            let initial = if exited {
+                render.final_attach_initial(&term)?
+            } else {
+                render.build_attach_initial(&term)?
             };
-            let mut initial = (*shared).clone();
-            initial.frame.kitty_graphics = initial_graphics;
             let registered = if exited || pty.dead.load(Ordering::Acquire) {
                 drop(tap);
                 false
@@ -5643,7 +5675,7 @@ impl Surface {
                 render.taps.push(tap);
                 true
             };
-            (Arc::new(initial), registered)
+            (initial, registered)
         };
         let permit = if registered {
             permit
@@ -6588,6 +6620,7 @@ impl PtySurface {
                 }
                 render.built_generation = generation;
                 render.latest = Some(frame.clone());
+                render.final_initial = None;
                 render.taps.retain(|tap| tap.send(RenderAttachFrame::Frame(frame.clone())));
                 true
             }

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -8368,6 +8368,7 @@ mod tests {
 
         assert!(mirror.plain_text().unwrap().contains(MARKER));
         assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Disconnected)));
+        assert!(surface.as_pty().unwrap().taps.lock().unwrap().is_empty());
     }
 
     #[cfg(unix)]
@@ -8378,9 +8379,9 @@ mod tests {
         let surface = exited_host_surface("render-attach", 93, &mux);
         surface.with_terminal(|term| term.vt_write(MARKER.as_bytes()));
 
-        let attach =
+        let first =
             surface.attach_render_stream().expect("exited terminal must serve final render frame");
-        let rendered = attach
+        let rendered = first
             .initial
             .frame
             .styled_rows()
@@ -8390,7 +8391,19 @@ mod tests {
             .collect::<String>();
 
         assert!(rendered.contains(MARKER), "final render frame omitted {MARKER}: {rendered:?}");
-        assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Disconnected)));
+        assert!(matches!(first.stream.try_recv(), Err(TryRecvError::Disconnected)));
+
+        // Final snapshots are inert and must not consume the live attachment
+        // budget even when their callers retain them.
+        let mut attachments = vec![first];
+        for _ in 1..crate::mux::RENDER_ATTACHMENT_LIMIT * 2 {
+            let attach = surface
+                .attach_render_stream()
+                .expect("exited terminal final replay must not exhaust live render permits");
+            assert!(matches!(attach.stream.try_recv(), Err(TryRecvError::Disconnected)));
+            attachments.push(attach);
+        }
+        assert!(surface.as_pty().unwrap().render.lock().unwrap().taps.is_empty());
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Summary

- let the caller that first changes `dead` own hosted-exit finalization
- build the final frame and close byte/render streams before publishing `Exited`
- preserve prior host-loss state and reject replay that was not finalized
- return exited byte and render replay with disconnected streams and no registered taps
- retain render permits only for registered live render attachments
- cache one final render attachment frame and reuse its `Arc` for every exited attach
- keep the independent change limited to `surface.rs`

## Test history

Commit `a4022614ffc` adds the prior-host-loss regression test before commit `a49f83a5953` fixes finalization ownership.

Commit `2222add6504` extends exited replay coverage before commit `2c3a72ce1d9` makes final attachments inert. It retains 128 exited render snapshots, requires every stream to be disconnected, and verifies that no byte or render taps remain registered. The existing live attachment test still requires the live render limit to be enforced.

Commit `bc9e937c871` adds pointer-identity coverage before commit `d1ecfedfe8a` caches one final attachment frame. Commit `cbb4a8fa120` keeps the first attachment reachable through the retained vector so the identity assertion compiles after moving `first`.

The exact head is `cbb4a8fa120b49f9becc5194015dbbad267e26a3` on main `188190a43843423aee9ae19c747b57072edddca8`.

## Verification

Static checks passed:

- `git diff --check`
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/surface.rs`

No Rust build, test, hosted workflow, or canonical review ran on this head.