### PR TITLE
Fix connectivity auth provider failure mapping

### DIFF
--- a/web/services/connectivity/routeHandler.ts
+++ b/web/services/connectivity/routeHandler.ts
@@ -1,6 +1,7 @@
 import * as Effect from "effect/Effect";
 import type * as Layer from "effect/Layer";
 import { unauthorized, verifyRequest } from "../vms/auth";
+import { authProviderErrorResponse } from "../vms/authErrors";
 import { jsonResponse } from "../vms/routeHelpers";
 import { irohExpectedError } from "../iroh/errors";
 import {
@@ -40,8 +41,8 @@ async function handleConnectivitySyncMethod(
   let user: Awaited<ReturnType<typeof verifyRequest>>;
   try {
     user = await verify(request, { allowCookie: false });
-  } catch {
-    return jsonResponse({ error: "unauthorized" }, 401);
+  } catch (error) {
+    return authProviderErrorResponse(error, `connectivity.${method}.auth`);
   }
   if (!user) return unauthorized();
 

--- a/web/tests/connectivity-authority.test.ts
+++ b/web/tests/connectivity-authority.test.ts
@@ -169,6 +169,44 @@ describe("Connectivity authority", () => {
     expect(called).toBe(false);
   });
 
+  test("maps Stack Auth throttles to a retryable response", async () => {
+    let called = false;
+    const response = await handleConnectivitySync(syncRequest(null), {
+      verify: async () => {
+        throw new AggregateError([
+          new Error("Rate limited, no retry-after header received"),
+        ]);
+      },
+      authority: {
+        sync: () => {
+          called = true;
+          return Effect.die(new Error("unexpected authority work"));
+        },
+        syncScoped: () => Effect.die(new Error("unexpected scoped sync")),
+      },
+    });
+
+    expect(response.status).toBe(429);
+    expect(response.headers.get("retry-after")).toBe("60");
+    expect(await response.json()).toEqual({ error: "rate_limited" });
+    expect(called).toBe(false);
+  });
+
+  test("maps other Stack Auth provider failures to service unavailable", async () => {
+    const response = await handleScopedConnectivitySync(scopedSyncRequest(scopeWire), {
+      verify: async () => {
+        throw new Error("Stack Auth unreachable");
+      },
+      authority: {
+        sync: () => Effect.die(new Error("unexpected sync")),
+        syncScoped: () => Effect.die(new Error("unexpected scoped sync")),
+      },
+    });
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toEqual({ error: "authentication_unavailable" });
+  });
+
   test("serves an authenticated no-store sync response", async () => {
     const authority = makeConnectivityAuthority(snapshotBroker());
     const response = await handleConnectivitySync(syncRequest(null), {


### PR DESCRIPTION
## Summary
- preserve shared Stack Auth throttle and outage responses on connectivity sync routes
- add regression coverage for sync and scoped sync authentication failures

Stack Auth throttles now return 429 with Retry-After: 60, and provider outages return 503. Caller credentials are only represented as 401 when verification returns no user.

## Verification
- `bun test tests/connectivity-authority.test.ts`
- `bunx eslint services/connectivity/routeHandler.ts tests/connectivity-authority.test.ts`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connectivity sync authentication now preserves Stack Auth provider failure responses instead of converting every verification exception to `401`. Throttles return `429` with `Retry-After: 60`, provider outages return `503`, and only missing verified users remain `401`.

**Bug Fixes**

- Adds regression coverage for regular and scoped sync routes.
- Confirms authority work is skipped when authentication fails.

<sup>Written for commit 38f7f59ceb2a212fbcd0e15c5b8c04417c6209de. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved authentication error responses during connectivity synchronization.
  - Rate-limited authentication failures now return a 429 response with retry guidance.
  - Unavailable authentication providers now return a 503 response with a clear error message.
  - Prevented connectivity synchronization when authentication verification fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->