### PR TITLE
style(cmux-tui-core): apply cargo fmt fixes

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -5813,8 +5813,7 @@ impl Mux {
             .with_context(|| format!("journal checkpoint {selector:?} does not exist"))?;
         let mut reducer = crate::journal_checkpoint::RestoreReducer::new(&checkpoint)?;
 
-        let database_path =
-            self.workspace_registry.lock().unwrap().session_journal_database_path();
+        let database_path = self.workspace_registry.lock().unwrap().session_journal_database_path();
         if let Some(database_path) = database_path {
             let reader = crate::workspace_registry::SessionJournalReader::open(&database_path)?;
             let mut cursor = reader.restore_cursor(checkpoint.source_sequence)?;

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -331,10 +331,7 @@ impl JournalRestoreCursor {
         )?;
         let segment = statement
             .query_row(
-                params![
-                    i64::try_from(self.source_sequence)?,
-                    self.next_segment_start,
-                ],
+                params![i64::try_from(self.source_sequence)?, self.next_segment_start,],
                 |row| Ok((row.get::<_, String>(0)?, row.get::<_, i64>(1)?)),
             )
             .optional()?;


### PR DESCRIPTION
Apply the two existing cargo fmt formatting fixes in cmux-tui-core.

Changed only:
- cmux-tui/crates/cmux-tui-core/src/mux.rs
- cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs

No behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the existing `cargo fmt` fixes in `cmux-tui-core` so both Rust files match the formatter output. No behavior changes.

<sup>Written for commit 81f6eca91d43012ff8ea9ebaf69173427d1de008. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted internal code for improved consistency and readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->