### PR TITLE
Fix cmux-cli compile error on main: hookEventName argument order

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -35213,9 +35213,9 @@ export default CMUXSessionRestore;
                         pid: pid,
                         launchCommand: resumeLaunchCommand,
                         agentLifecycle: .unknown,
+                        hookEventName: persistedHookEventName,
                         runtimeStatus: suppressVisibleMutations ? nil : .running,
                         updateRuntimeStatus: !suppressVisibleMutations,
-                        hookEventName: persistedHookEventName,
                         supersedesSameProcessSession: def.name == "omp"
                     )) ?? []
                     acceptedSessionStart = true


### PR DESCRIPTION
PR https://github.com/manaflow-ai/cmux/pull/11529 added an `store.upsert(...)` call site in `CLI/cmux.swift` that passes `hookEventName:` after `updateRuntimeStatus:`, but the signature declares `hookEventName` before `runtimeStatus`. Swift requires call-site order to match declaration order, so the `cmux-cli` target fails to compile on main:

```
CLI/cmux.swift:35218:25: error: argument 'hookEventName' must precede argument 'runtimeStatus'
```

The PR lane has no macOS compile gate, so this landed red. This reorders the one misordered call site; the other seven `hookEventName:` call sites already use the correct order. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the `cmux-cli` compile error on main by reordering `hookEventName:` before `runtimeStatus:` in the `store.upsert(...)` call.

- The previous argument order didn't match the function signature, so the target failed to build.
- The other seven `hookEventName:` call sites already use the correct order.
- No behavior change.

<sup>Written for commit a8dbaf4f4ffbb724ce3f4f186b52255501d7cac2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered session initialization arguments without changing their values or runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->