### PR TITLE
docs(tui): sync catalog counts at 125

### DIFF
--- a/cmux-tui/bindings/ERGONOMICS.md
+++ b/cmux-tui/bindings/ERGONOMICS.md
@@ -1,7 +1,7 @@
 # SDK ergonomics findings
 
 The seven public SDKs expose handwritten resource handles over the reviewed
-124-operation `cmux.protocol/2` catalog. The raw protocol inventory is a
+125-operation `cmux.protocol/2` catalog. The raw protocol inventory is a
 separate compatibility surface with 101 commands and 46 events. Deterministic
 generation is limited to those private protocol-12 models under each package's
 explicit `raw` namespace. Consumers do not run a generator or install a
@@ -64,7 +64,7 @@ implemented public behavior. None remains protocol work.
 
 ## Conformance evidence
 
-The 124 public operations are the API inventory. The public fake-server
+The 125 public operations are the API inventory. The public fake-server
 matrix is test inventory: 20 cases in each language, 140 cases total. It checks
 exact envelopes, decimal preservation, mutation replay, indeterminate effects,
 revision conflicts, duplicate-name ambiguity, bounded stream overflow,

--- a/cmux-tui/spec/README.md
+++ b/cmux-tui/spec/README.md
@@ -23,7 +23,7 @@ high-level SDKs:
 | --- | --- |
 | [`resource-api-v2.md`](resource-api-v2.md) | IDs, selectors, envelopes, mutations, streams, limits, and lifecycle rules |
 | [`resource-api-v2.json`](resource-api-v2.json) | JSON Schema for request, response, and stream envelopes |
-| [`resource-operations-v2.json`](resource-operations-v2.json) | Normative catalog of 124 transported and six local operations |
+| [`resource-operations-v2.json`](resource-operations-v2.json) | Normative catalog of 125 transported and six local operations |
 | [`resource-operations-v2.schema.json`](resource-operations-v2.schema.json) | JSON Schema for the operation catalog |
 | [`resource-operations-v2.md`](resource-operations-v2.md) | Human-readable operation inventory |
 | [`cli.md`](cli.md) | Noun-first public CLI |

--- a/cmux-tui/spec/bindings.md
+++ b/cmux-tui/spec/bindings.md
@@ -12,7 +12,7 @@ The split is deliberate:
   handwritten in each language.
 - Mechanical protocol-v12 models are generated deterministically and exposed
   only through `raw`.
-- A catalog descriptor in every package proves that all 124 transported
+- A catalog descriptor in every package proves that all 125 transported
   operations have the same class and wire name.
 - The six sidebar plugin operations are local CLI/filesystem APIs. Transported
   SDK roots expose sidebar views, not plugin resource handles.

--- a/cmux-tui/spec/resource-operations-v2.md
+++ b/cmux-tui/spec/resource-operations-v2.md
@@ -6,13 +6,13 @@ selectors, fields, results, errors, constraints, or stream types.
 
 ## Transported operations
 
-`cmux.protocol/2` transports 124 operations for exactly one local mux
+`cmux.protocol/2` transports 125 operations for exactly one local mux
 session. Cross-machine aggregation and provider lifecycle require a later
 broker protocol.
 
 | Class | Count | Semantics |
 | --- | ---: | --- |
-| `read` | 40 | Reads state and forbids an idempotency key |
+| `read` | 41 | Reads state and forbids an idempotency key |
 | `mutation` | 67 | Requires an idempotency key and returns a mutation result |
 | `stream_open` | 5 | Opens a connection-owned typed stream |
 | `connection_control` | 12 | Changes only connection-local state |


### PR DESCRIPTION
Current main catalog contains 125 transported operations (41 read, 67 mutation, 5 stream-open, 12 connection-control), but four normative documents still state 124 and the read row still states 40.\n\nThis docs-only change synchronizes those references with cmux-tui/spec/resource-operations-v2.json. It does not include the stacked agent.wait or agent.resume_plan additions from #11651.\n\nValidation:\n- git diff --check\n- static JSON count check: 125 operations, class counts 41/67/5/12\n- confirmed no stale 124 in the four updated docs\n- no Rust or Cargo commands run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the TUI catalog documentation to match `resource-operations-v2.json`: the transported operation count changes from 124 to 125, and the read count changes from 40 to 41. This docs-only change does not include the stacked `agent.wait` or `agent.resume_plan` additions from #11651.

- Synchronizes counts across the ergonomics, bindings, README, and operation inventory documents.
- Confirms the class totals are 41 reads, 67 mutations, 5 stream opens, and 12 connection-control operations.
- Verifies formatting and removes all stale `124` references from the updated documents.

<sup>Written for commit a96fad210077ac82d93d592631b4a1cc009c02fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

