### PR TITLE
refactor(cmux-tui): simplify first pane index construction

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -4220,10 +4220,11 @@ struct PaneSizeLease {
 }
 
 fn first_pane_by_id(panes: &[PaneView]) -> HashMap<PaneId, &PaneView> {
-    panes.iter().fold(HashMap::with_capacity(panes.len()), |mut index, pane| {
+    let mut index = HashMap::with_capacity(panes.len());
+    for pane in panes {
         index.entry(pane.id).or_insert(pane);
-        index
-    })
+    }
+    index
 }
 
 impl PaneArea {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -28754,6 +28754,11 @@ mod tests {
     }
 
     #[test]
+    fn first_pane_index_is_empty_for_empty_input() {
+        assert!(first_pane_by_id(&[]).is_empty());
+    }
+
+    #[test]
     fn viewport_animation_leases_every_column_in_its_swept_range() {
         let pane = |id, surface| PaneView {
             id,


### PR DESCRIPTION
## Summary
- Build the pane index with an explicit loop and `HashMap::Entry::or_insert`.
- Preserve the existing first-wins behavior for duplicate pane IDs and the existing capacity hint.
- Add empty-input behavior coverage.

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/app.rs`
- `git diff --check origin/main...HEAD`
- No local Rust build or test run, per task constraints.

Two commits keep the behavior test before the implementation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refactors `first_pane_by_id` to build the pane index with an explicit loop instead of a fold, preserving first-wins behavior for duplicate pane IDs and the existing capacity hint.

- Adds a test confirming empty input produces an empty index.

<sup>Written for commit 4883732a9b7f4cc478670882659db178246f3b91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved pane handling so the first pane remains consistently selected when duplicate identifiers are encountered.
  - Ensured pane handling behaves correctly when no panes are available, returning an empty result without errors.
- **Tests**
  - Added coverage for duplicate pane identifiers and empty pane collections to help maintain consistent behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->