### PR TITLE
fix(cmux-tui): normalize wrapped-wide selection heads

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27784,6 +27784,89 @@ mod tests {
         (app, mux, surface, content)
     }
 
+    fn wrapped_selection_fixture(
+        name: &str,
+        text: &[u8],
+    ) -> (App, Arc<Mux>, Arc<cmux_tui_core::Surface>, Rect) {
+        let (mux, surface) = test_mux(name, None);
+        surface.with_terminal(|terminal| {
+            terminal.resize(4, 3, 8, 16).unwrap();
+            terminal.vt_write(text);
+        });
+
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        let pane = app.tree.active_screen().unwrap().active_pane;
+        let content = Rect { x: 2, y: 3, width: 4, height: 3 };
+        app.pane_areas.push(PaneArea {
+            pane,
+            surface: surface.id,
+            rect: Rect { x: 1, y: 2, width: 7, height: 5 },
+            bar: Some(Rect { x: 1, y: 2, width: 7, height: 1 }),
+            omnibar: None,
+            content,
+            track: None,
+            viewport: None,
+        });
+        app.rendered_terminal_bounds.insert(surface.id, content);
+        (app, mux, surface, content)
+    }
+
+    #[test]
+    fn dragging_from_a_wrapped_wide_head_anchors_to_the_glyph_lead() {
+        let (mut app, mux, surface, content) =
+            wrapped_selection_fixture("wrapped-wide-cell-drag-selection-test", "ABC橋D".as_bytes());
+
+        let press = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 3,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+        app.handle_mouse(press).unwrap();
+        app.handle_mouse(MouseEvent {
+            kind: MouseEventKind::Drag(MouseButton::Left),
+            column: content.x + 2,
+            row: content.y + 1,
+            modifiers: KeyModifiers::NONE,
+        })
+        .unwrap();
+
+        let selection = app.selection.expect("dragging a wrapped glyph must create a selection");
+        assert_eq!(selection.anchor, (0, 1));
+        assert_eq!(selection.range(), ((0, 1), (2, 1)));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn double_clicking_a_wrapped_wide_head_selects_the_glyph_word() {
+        let (mut app, mux, surface, content) =
+            wrapped_selection_fixture("wrapped-wide-word-selection-test", "AB 橋".as_bytes());
+        let click = MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: content.x + 3,
+            row: content.y,
+            modifiers: KeyModifiers::NONE,
+        };
+
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+        app.handle_mouse(click).unwrap();
+        app.handle_mouse(MouseEvent { kind: MouseEventKind::Up(MouseButton::Left), ..click })
+            .unwrap();
+
+        assert_eq!(
+            app.selection.map(|selection| selection.range()),
+            Some(((0, 1), (0, 1))),
+            "double-clicking a wrapped glyph head must select its word"
+        );
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
     #[test]
     fn double_click_selects_a_complete_word() {
         let (mut app, mux, surface, content) =

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17103,6 +17103,18 @@ impl App {
         Some(SelectionPoint { column: cell.0, row: u32::try_from(cell.1).ok()? })
     }
 
+    fn canonical_selection_cell(&self, surface: SurfaceId, cell: (u16, u64)) -> (u16, u64) {
+        let Some(point) = Self::selection_point(cell) else { return cell };
+        self.session
+            .surface(surface)
+            .and_then(|handle| {
+                handle.with_terminal(|terminal| terminal.normalize_selection_point_screen(point))
+            })
+            .flatten()
+            .map(|point| (point.column, u64::from(point.row)))
+            .unwrap_or(cell)
+    }
+
     fn selection_from_range(surface: SurfaceId, range: SelectionRange) -> Selection {
         Selection {
             surface,
@@ -17118,19 +17130,27 @@ impl App {
         mode: SelectionMode,
     ) -> Option<Selection> {
         if mode == SelectionMode::Cell {
+            let cell = self.canonical_selection_cell(surface, cell);
             return Some(Selection { surface, anchor: cell, head: cell });
         }
         let point = Self::selection_point(cell)?;
         let handle = self.session.surface(surface)?;
         let range = handle
-            .with_terminal(|terminal| match mode {
-                SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
-                SelectionMode::Line => terminal
-                    .select_line_screen(point)
-                    .ok()
-                    .flatten()
-                    .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
-                SelectionMode::Cell => None,
+            .with_terminal(|terminal| {
+                let point = if mode == SelectionMode::Word {
+                    terminal.normalize_selection_point_screen(point)?
+                } else {
+                    point
+                };
+                Some(match mode {
+                    SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
+                    SelectionMode::Line => terminal
+                        .select_line_screen(point)
+                        .ok()
+                        .flatten()
+                        .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
+                    SelectionMode::Cell => None,
+                })
             })
             .flatten()?;
         Some(Self::selection_from_range(surface, range))
@@ -17311,6 +17331,23 @@ impl App {
             return;
         };
         let Some(handle) = self.session.surface(surface) else {
+            self.clear_selection_for_semantic_gesture(surface, mode);
+            self.semantic_selection_cache = None;
+            return;
+        };
+        let Some((anchor_point, current_point)) = handle
+            .with_terminal(|terminal| {
+                if mode == SelectionMode::Word {
+                    Some((
+                        terminal.normalize_selection_point_screen(anchor_point)?,
+                        terminal.normalize_selection_point_screen(current_point)?,
+                    ))
+                } else {
+                    Some((anchor_point, current_point))
+                }
+            })
+            .flatten()
+        else {
             self.clear_selection_for_semantic_gesture(surface, mode);
             self.semantic_selection_cache = None;
             return;
@@ -17521,11 +17558,16 @@ impl App {
         let moved = surface.scroll_delta(dir as isize).unwrap_or(false);
         let edge_row = if dir < 0 { 0 } else { content.height.saturating_sub(1) };
         let offset = self.surface_scroll_offset(surface_id);
-        let edge_cell = (
+        let raw_edge_cell = (
             col.min(content.width.saturating_sub(1).saturating_add(source_x)),
             offset + edge_row as u64,
         );
         self.mark_selection_dragged(surface_id);
+        let edge_cell = if self.selection_mode == SelectionMode::Line {
+            raw_edge_cell
+        } else {
+            self.canonical_selection_cell(surface_id, raw_edge_cell)
+        };
         if self.selection_mode != SelectionMode::Cell
             && self.selection_mode_surface == Some(surface_id)
         {
@@ -17533,6 +17575,7 @@ impl App {
         } else {
             let selection = self.selection.or_else(|| {
                 let anchor = self.selection_anchor_cell(surface_id)?;
+                let anchor = self.canonical_selection_cell(surface_id, anchor);
                 Some(Selection { surface: surface_id, anchor, head: edge_cell })
             });
             if let Some(mut selection) = selection {
@@ -22693,7 +22736,7 @@ impl App {
                 let offset = selection_surface
                     .map(|surface| self.surface_scroll_offset(surface))
                     .unwrap_or(0);
-                let current = (col, offset + (cy - content.y) as u64);
+                let raw_current = (col, offset + (cy - content.y) as u64);
                 if let Some(surface) = selection_surface {
                     self.mark_selection_dragged(surface);
                 }
@@ -22706,10 +22749,18 @@ impl App {
                             .map(|sequence| sequence.mode)
                     })
                     .unwrap_or(SelectionMode::Cell);
+                let current = if mode == SelectionMode::Line {
+                    raw_current
+                } else {
+                    selection_surface
+                        .map(|surface| self.canonical_selection_cell(surface, raw_current))
+                        .unwrap_or(raw_current)
+                };
                 if mode == SelectionMode::Cell {
                     let selection = self.selection.or_else(|| {
                         let surface = selection_surface?;
                         let anchor = self.selection_anchor_cell(surface)?;
+                        let anchor = self.canonical_selection_cell(surface, anchor);
                         Some(Selection { surface, anchor, head: current })
                     });
                     if let Some(mut selection) = selection {

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -144,14 +144,17 @@ fn draw_render_frame_with_catalog(
 /// Return whether a grid cell is selected, treating both columns of a wide
 /// grapheme as one selectable unit. Selection ranges are normally normalized
 /// to the lead cell, but checking the paired coordinate also keeps rendering
-/// correct for callers that still provide a raw spacer-tail endpoint.
+/// correct for callers that still provide a raw spacer-tail endpoint. A
+/// wrapped grapheme's spacer head is a non-text continuation cell, so it must
+/// never receive independent selection styling.
 fn selected_cell(
     cells: &[VtCell],
     source_col: usize,
     row: usize,
     selected: &impl Fn(u16, u16) -> bool,
 ) -> bool {
-    let selected_here = selected(source_col as u16, row as u16);
+    let selected_here =
+        cells[source_col].width != CellWidth::SpacerHead && selected(source_col as u16, row as u16);
     let paired_col = match cells[source_col].width {
         CellWidth::Wide
             if cells

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -915,6 +915,48 @@ mod tests {
     }
 
     #[test]
+    fn wrapped_wide_selection_keeps_the_spacer_head_unselected() {
+        let mut terminal = Terminal::new(4, 3, 0, Callbacks::default()).unwrap();
+        terminal.vt_write("ABC橋D".as_bytes());
+        let mut state = RenderState::new().unwrap();
+        state.update(&mut terminal).unwrap();
+        let render = SurfaceRenderFrame {
+            frame: state.build_frame().unwrap(),
+            content_generation: 1,
+            scrollback_rows: 0,
+            history_epoch: terminal.history_epoch(),
+            pointer_semantics: terminal.pointer_semantic_snapshot(),
+            palette_colors: std::array::from_fn(|idx| state.palette_color(idx as u8)),
+            palette_overridden: std::array::from_fn(|idx| state.palette_overridden(idx as u8)),
+        };
+        let mut output = RatatuiTerminal::new(TestBackend::new(4, 3)).unwrap();
+        output
+            .draw(|frame| {
+                draw_render_frame_with_catalog(
+                    frame,
+                    HorizontalViewport {
+                        rect: Rect { x: 0, y: 0, width: 4, height: 3 },
+                        source_x: 0,
+                    },
+                    &render,
+                    &Theme::default(),
+                    &ChromeTheme::dark(),
+                    crate::localization::catalog_for_locale("en_US.UTF-8"),
+                    // A row-major range can include the physical spacer head,
+                    // but only the wrapped glyph's lead row is selectable.
+                    |col, row| (col == 3 && row == 0) || (col <= 1 && row == 1),
+                );
+            })
+            .unwrap();
+
+        let buffer = output.backend().buffer();
+        let selection_bg = Theme::default().selection_bg;
+        assert_ne!(buffer[(3, 0)].bg, selection_bg);
+        assert_eq!(buffer[(0, 1)].bg, selection_bg);
+        assert_eq!(buffer[(1, 1)].bg, selection_bg);
+    }
+
+    #[test]
     fn frame_default_order_and_live_blank_cells_follow_canonical_roles() {
         let foreground = Rgb { r: 0x11, g: 0x22, b: 0x33 };
         let background = Rgb { r: 0x44, g: 0x55, b: 0x66 };

--- a/cmux-tui/crates/ghostty-vt/src/render.rs
+++ b/cmux-tui/crates/ghostty-vt/src/render.rs
@@ -742,7 +742,7 @@ fn raw_cell_bg_spec(raw: sys::GhosttyCell) -> Option<ColorSpec> {
     }
 }
 
-fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
+pub(crate) fn cell_width(raw: sys::GhosttyCell) -> CellWidth {
     let mut wide = sys::GHOSTTY_CELL_WIDE_NARROW;
     let result = unsafe {
         sys::ghostty_cell_get(raw, sys::GHOSTTY_CELL_DATA_WIDE, &mut wide as *mut _ as *mut c_void)

--- a/cmux-tui/crates/ghostty-vt/src/terminal.rs
+++ b/cmux-tui/crates/ghostty-vt/src/terminal.rs
@@ -2984,6 +2984,37 @@ impl Terminal {
         check(unsafe { sys::ghostty_tracked_grid_ref_set(tracked.raw, self.raw, point) })
     }
 
+    /// Move a screen selection point from a wide grapheme continuation cell
+    /// to the grapheme's lead cell. Ghostty represents a wide grapheme that
+    /// wraps at the right edge as a spacer head on one row and a wide lead on
+    /// the next row. The spacer head has no text of its own, so semantic
+    /// selection must address the lead cell.
+    pub fn normalize_selection_point_screen(
+        &self,
+        point: SelectionPoint,
+    ) -> Option<SelectionPoint> {
+        let width = self.cell_width_screen(point)?;
+        match width {
+            CellWidth::SpacerTail if point.column > 0 => {
+                let leading = SelectionPoint { column: point.column - 1, ..point };
+                (self.cell_width_screen(leading) == Some(CellWidth::Wide)).then_some(leading)
+            }
+            CellWidth::SpacerHead => {
+                let leading = SelectionPoint { column: 0, row: point.row.checked_add(1)? };
+                (self.cell_width_screen(leading) == Some(CellWidth::Wide)).then_some(leading)
+            }
+            _ => Some(point),
+        }
+    }
+
+    fn cell_width_screen(&self, point: SelectionPoint) -> Option<CellWidth> {
+        let grid_ref =
+            self.grid_ref(sys::GHOSTTY_POINT_TAG_SCREEN, point.column, u64::from(point.row))?;
+        let mut raw = sys::GhosttyCell::default();
+        check(unsafe { sys::ghostty_grid_ref_cell(&grid_ref, &mut raw) }).ok()?;
+        Some(crate::render::cell_width(raw))
+    }
+
     /// Select the word containing an absolute screen coordinate using
     /// Ghostty's configured word-boundary rules.
     pub fn select_word_screen(&self, point: SelectionPoint) -> Result<Option<SelectionRange>> {


### PR DESCRIPTION
## Summary

- Canonicalize Ghostty `SpacerHead` points to the next row wide lead for host cell and word selection.
- Keep line selection endpoints raw, and suppress independent styling for non-text spacer heads.
- Add behavior coverage for wrapped-wide drag, double-click, and Ratatui selection rendering.

## Verification

- `rustfmt --edition 2024 --check` on touched Rust files
- `git diff --check`
- Local Cargo build/tests not run, per cmux-tui Testbox policy.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790981485&installation_model_id=21920&pr_number=11730&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11730&signature=be5a4c79e8b9893630bfb5808c7b17cc27f8b657fcb069dc62c08fd113ad2884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes selection handling for wrapped wide glyphs in `cmux-tui` so drag and double-click select the glyph's lead cell instead of its continuation cell.

**Bug Fixes**
- Normalizes cell and word selection points to the glyph lead cell.
- Keeps line selection endpoints raw.
- Prevents spacer head cells from receiving independent selection styling.
- Adds tests for wrapped-wide drag, double-click, and rendering.

<sup>Written for commit d5110438eb1c6f0a03f0296c853e41869a4c5381. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

