### PR TITLE
fix(cmux-tui): unwrap terminal selection range

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -17142,7 +17142,7 @@ impl App {
                 } else {
                     point
                 };
-                Some(match mode {
+                match mode {
                     SelectionMode::Word => terminal.select_word_screen(point).ok().flatten(),
                     SelectionMode::Line => terminal
                         .select_line_screen(point)
@@ -17150,7 +17150,7 @@ impl App {
                         .flatten()
                         .or_else(|| terminal.select_line_screen_untrimmed(point).ok().flatten()),
                     SelectionMode::Cell => None,
-                })
+                }
             })
             .flatten()?;
         Some(Self::selection_from_range(surface, range))

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -27946,6 +27946,19 @@ mod tests {
     }
 
     #[test]
+    fn selection_for_click_returns_the_terminal_word_range() {
+        let (app, mux, surface, _) =
+            selection_fixture("selection-for-click-word-range-test", b"alpha beta");
+
+        let selection = app
+            .selection_for_click(surface.id, (1, 0), SelectionMode::Word)
+            .expect("a word click must return the terminal selection range");
+        assert_eq!(selection.range(), ((0, 0), (4, 0)));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn a_single_cell_press_does_not_store_a_zero_length_selection() {
         let (mut app, mux, surface, content) =
             selection_fixture("single-cell-press-selection-state-test", b"alpha beta");


### PR DESCRIPTION
Fix the E0308 compile failure in App::selection_for_click after the wrapped-wide selection merge.

The terminal callback returns one optional selection range, and SurfaceHandle::with_terminal adds the surface availability option. The callback no longer adds a redundant Some layer, so the existing single flatten produces SelectionRange before selection_from_range.

Commits:
- test(tui): cover direct word selection lookup
- fix(tui): unwrap terminal selection range once

Static checks: targeted rustfmt and git diff --check. No local Cargo or Rust builds were run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the E0308 compile failure in `cmux-tui`'s `App::selection_for_click` after the wrapped-wide selection merge. The callback now returns the selection range directly, so the existing `flatten()` yields `SelectionRange` before `selection_from_range`, and adds a regression test for word click selection.

<sup>Written for commit 23542f6f3ad88ca0a5650ad89498bb5946b76610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved click-based text selection behavior so word-mode selections correctly return the selected terminal word range.
  - Clicks that do not produce a valid selection now correctly remain unselected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->