### PR TITLE
fix(cmux-tui): keep active indexes valid after parse filtering

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -933,11 +933,12 @@ pub(super) fn parse_tree_with_capabilities(
             active_screen: 0,
         };
         if let Some(screens) = ws.get("screens").and_then(|v| v.as_array()) {
-            for (s, screen) in screens.iter().enumerate() {
-                if screen.get("active").and_then(|v| v.as_bool()) == Some(true) {
-                    view.active_screen = s;
-                }
+            for screen in screens {
                 if let Some(parsed) = parse_screen(screen, capabilities) {
+                    let parsed_index = view.screens.len();
+                    if screen.get("active").and_then(|v| v.as_bool()) == Some(true) {
+                        view.active_screen = parsed_index;
+                    }
                     view.screens.push(parsed);
                 }
             }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -748,6 +748,8 @@ fn parse_layout(value: &Value) -> Option<Node> {
 }
 
 fn parse_pane(value: &Value) -> Option<PaneView> {
+    let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let mut active_tab = raw_active_tab;
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
         resource_id: value
@@ -756,15 +758,16 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
             .and_then(|value| PanePublicId::parse(value.to_string()).ok()),
         short_id: value.get("short_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
         name: value.get("name").and_then(|v| v.as_str()).map(|s| s.to_string()),
-        active_tab: value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize,
         focused_at: value.get("focused_at").and_then(|v| v.as_u64()).unwrap_or(0),
         tabs: value
             .get("tabs")
             .and_then(|v| v.as_array())
             .map(|tabs| {
+                let mut compact_index = 0;
                 tabs.iter()
-                    .filter_map(|tab| {
-                        Some(TabView {
+                    .enumerate()
+                    .filter_map(|(raw_index, tab)| {
+                        let parsed = Some(TabView {
                             surface: tab.get("surface")?.as_u64()?,
                             public_id: tab
                                 .get("tab_resource_id")
@@ -816,11 +819,17 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                                 .and_then(Value::as_bool)
                                 .unwrap_or(false),
                             notification: tab.get("notification").and_then(parse_notification),
-                        })
+                        })?;
+                        if raw_index == raw_active_tab {
+                            active_tab = compact_index;
+                        }
+                        compact_index += 1;
+                        Some(parsed)
                     })
                     .collect()
             })
             .unwrap_or_default(),
+        active_tab,
     })
 }
 

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -996,6 +996,30 @@ mod tests {
         assert_eq!(pane.active_tab, 1);
     }
 
+    #[test]
+    fn parser_reindexes_active_screen_after_dropping_malformed_screens() {
+        let tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [
+                    {"active": false},
+                    {
+                        "id": 2,
+                        "active": true,
+                        "active_pane": 3,
+                        "layout": {"type": "leaf", "pane": 3},
+                        "panes": []
+                    }
+                ]
+            }]
+        }));
+
+        assert_eq!(tree.workspaces[0].screens.len(), 1);
+        assert_eq!(tree.workspaces[0].active_screen, 0);
+        assert_eq!(tree.active_screen().map(|screen| screen.id), Some(2));
+    }
+
     fn tree_with_tabs(active_tab: usize, surfaces: &[SurfaceId]) -> TreeView {
         let tabs = surfaces
             .iter()

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -753,9 +753,6 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
     let active_tab_target_exists =
         value.get("tabs").and_then(Value::as_array).is_some_and(|tabs| raw_active_tab < tabs.len());
     let mut active_tab = None;
-    let active_tab = active_tab
-        .or_else(|| active_tab_target_exists.then_some(0))
-        .unwrap_or_else(|| if active_tab_is_declared { usize::MAX } else { 0 });
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
         resource_id: value
@@ -835,7 +832,9 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                     .collect()
             })
             .unwrap_or_default(),
-        active_tab,
+        active_tab: active_tab
+            .or_else(|| active_tab_target_exists.then_some(0))
+            .unwrap_or_else(|| if active_tab_is_declared { usize::MAX } else { 0 }),
     })
 }
 

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -750,7 +750,12 @@ fn parse_layout(value: &Value) -> Option<Node> {
 fn parse_pane(value: &Value) -> Option<PaneView> {
     let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
     let active_tab_is_declared = value.get("active_tab").is_some();
+    let active_tab_target_exists =
+        value.get("tabs").and_then(Value::as_array).is_some_and(|tabs| raw_active_tab < tabs.len());
     let mut active_tab = None;
+    let active_tab = active_tab
+        .or_else(|| active_tab_target_exists.then_some(0))
+        .unwrap_or_else(|| if active_tab_is_declared { usize::MAX } else { 0 });
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
         resource_id: value
@@ -830,7 +835,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                     .collect()
             })
             .unwrap_or_default(),
-        active_tab: if active_tab_is_declared { active_tab.unwrap_or(usize::MAX) } else { 0 },
+        active_tab,
     })
 }
 
@@ -1538,8 +1543,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(pane.tabs.len(), 1);
-        assert_eq!(pane.active_tab, usize::MAX);
-        assert_eq!(pane.active_surface(), None);
+        assert_eq!(pane.active_tab, 0);
+        assert_eq!(pane.active_surface(), Some(5));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -748,7 +748,10 @@ fn parse_layout(value: &Value) -> Option<Node> {
 }
 
 fn parse_pane(value: &Value) -> Option<PaneView> {
-    let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let raw_active_tab = value
+        .get("active_tab")
+        .and_then(Value::as_u64)
+        .and_then(|value| usize::try_from(value).ok());
     let active_tab_is_declared = value.get("active_tab").is_some();
     let mut active_tab = None;
     Some(PaneView {
@@ -821,7 +824,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                                 .unwrap_or(false),
                             notification: tab.get("notification").and_then(parse_notification),
                         })?;
-                        if raw_index == raw_active_tab {
+                        if raw_active_tab == Some(raw_index) {
                             active_tab = Some(compact_index);
                         }
                         compact_index += 1;
@@ -1548,6 +1551,19 @@ mod tests {
         let pane = parse_pane(&json!({
             "id": 3,
             "active_tab": 9,
+            "tabs": [{"surface": 5, "title": "only"}]
+        }))
+        .unwrap();
+
+        assert_eq!(pane.active_tab, usize::MAX);
+        assert_eq!(pane.active_surface(), None);
+    }
+
+    #[test]
+    fn pane_parser_fails_closed_when_active_tab_value_is_malformed() {
+        let pane = parse_pane(&json!({
+            "id": 3,
+            "active_tab": "invalid",
             "tabs": [{"surface": 5, "title": "only"}]
         }))
         .unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1506,6 +1506,24 @@ mod tests {
     }
 
     #[test]
+    fn pane_parser_defaults_when_active_tab_is_malformed() {
+        let pane = parse_pane(&json!({
+            "id": 3,
+            "active_tab": 1,
+            "tabs": [
+                {"surface": 5, "title": "first"},
+                {"title": "malformed"},
+                {"surface": 6, "title": "third"}
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(pane.tabs.len(), 2);
+        assert_eq!(pane.active_tab, 0);
+        assert_eq!(pane.active_surface(), Some(5));
+    }
+
+    #[test]
     fn tree_parser_defaults_and_preserves_pane_revision() {
         assert_eq!(parse_tree(&json!({"workspaces": []})).pane_revision, None);
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -749,7 +749,7 @@ fn parse_layout(value: &Value) -> Option<Node> {
 
 fn parse_pane(value: &Value) -> Option<PaneView> {
     let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
-    let mut active_tab = raw_active_tab;
+    let mut active_tab = None;
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
         resource_id: value
@@ -821,7 +821,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                             notification: tab.get("notification").and_then(parse_notification),
                         })?;
                         if raw_index == raw_active_tab {
-                            active_tab = compact_index;
+                            active_tab = Some(compact_index);
                         }
                         compact_index += 1;
                         Some(parsed)
@@ -829,7 +829,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                     .collect()
             })
             .unwrap_or_default(),
-        active_tab,
+        active_tab: active_tab.unwrap_or(0),
     })
 }
 

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1030,6 +1030,29 @@ mod tests {
         assert_eq!(tree.active_screen().map(|screen| screen.id), Some(2));
     }
 
+    #[test]
+    fn parser_fails_closed_when_active_screen_is_malformed() {
+        let tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "active": true,
+                "screens": [
+                    {
+                        "id": 2,
+                        "active": false,
+                        "active_pane": 3,
+                        "layout": {"type": "leaf", "pane": 3},
+                        "panes": []
+                    },
+                    {"active": true}
+                ]
+            }]
+        }));
+
+        assert_eq!(tree.workspaces[0].screens.len(), 1);
+        assert!(tree.active_screen().is_none());
+    }
+
     fn tree_with_tabs(active_tab: usize, surfaces: &[SurfaceId]) -> TreeView {
         let tabs = surfaces
             .iter()
@@ -1501,8 +1524,21 @@ mod tests {
         .unwrap();
 
         assert_eq!(pane.tabs.len(), 1);
-        assert_eq!(pane.active_tab, 0);
-        assert_eq!(pane.active_surface(), Some(5));
+        assert_eq!(pane.active_tab, usize::MAX);
+        assert_eq!(pane.active_surface(), None);
+    }
+
+    #[test]
+    fn pane_parser_fails_closed_when_active_tab_is_out_of_range() {
+        let pane = parse_pane(&json!({
+            "id": 3,
+            "active_tab": 9,
+            "tabs": [{"surface": 5, "title": "only"}]
+        }))
+        .unwrap();
+
+        assert_eq!(pane.active_tab, usize::MAX);
+        assert_eq!(pane.active_surface(), None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -750,8 +750,6 @@ fn parse_layout(value: &Value) -> Option<Node> {
 fn parse_pane(value: &Value) -> Option<PaneView> {
     let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
     let active_tab_is_declared = value.get("active_tab").is_some();
-    let active_tab_target_exists =
-        value.get("tabs").and_then(Value::as_array).is_some_and(|tabs| raw_active_tab < tabs.len());
     let mut active_tab = None;
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
@@ -833,7 +831,6 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
             })
             .unwrap_or_default(),
         active_tab: active_tab
-            .or_else(|| active_tab_target_exists.then_some(0))
             .unwrap_or_else(|| if active_tab_is_declared { usize::MAX } else { 0 }),
     })
 }
@@ -1560,7 +1557,7 @@ mod tests {
     }
 
     #[test]
-    fn pane_parser_defaults_when_active_tab_is_malformed() {
+    fn pane_parser_fails_closed_when_active_tab_is_malformed() {
         let pane = parse_pane(&json!({
             "id": 3,
             "active_tab": 1,
@@ -1573,8 +1570,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(pane.tabs.len(), 2);
-        assert_eq!(pane.active_tab, 0);
-        assert_eq!(pane.active_surface(), Some(5));
+        assert_eq!(pane.active_tab, usize::MAX);
+        assert_eq!(pane.active_surface(), None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -1480,6 +1480,23 @@ mod tests {
     }
 
     #[test]
+    fn pane_parser_reindexes_active_tab_after_dropping_malformed_tabs() {
+        let pane = parse_pane(&json!({
+            "id": 3,
+            "active_tab": 1,
+            "tabs": [
+                {"title": "malformed"},
+                {"surface": 5, "title": "active"}
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(pane.tabs.len(), 1);
+        assert_eq!(pane.active_tab, 0);
+        assert_eq!(pane.active_surface(), Some(5));
+    }
+
+    #[test]
     fn tree_parser_defaults_and_preserves_pane_revision() {
         assert_eq!(parse_tree(&json!({"workspaces": []})).pane_revision, None);
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -749,6 +749,7 @@ fn parse_layout(value: &Value) -> Option<Node> {
 
 fn parse_pane(value: &Value) -> Option<PaneView> {
     let raw_active_tab = value.get("active_tab").and_then(|v| v.as_u64()).unwrap_or(0) as usize;
+    let active_tab_is_declared = value.get("active_tab").is_some();
     let mut active_tab = None;
     Some(PaneView {
         id: value.get("id")?.as_u64()?,
@@ -829,7 +830,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                     .collect()
             })
             .unwrap_or_default(),
-        active_tab: active_tab.unwrap_or(0),
+        active_tab: if active_tab_is_declared { active_tab.unwrap_or(usize::MAX) } else { 0 },
     })
 }
 
@@ -942,15 +943,28 @@ pub(super) fn parse_tree_with_capabilities(
             active_screen: 0,
         };
         if let Some(screens) = ws.get("screens").and_then(|v| v.as_array()) {
+            let mut active_screen = None;
+            let mut active_screen_is_invalid = false;
             for screen in screens {
-                if let Some(parsed) = parse_screen(screen, capabilities) {
-                    let parsed_index = view.screens.len();
-                    if screen.get("active").and_then(|v| v.as_bool()) == Some(true) {
-                        view.active_screen = parsed_index;
+                let is_active = screen.get("active").and_then(|v| v.as_bool()) == Some(true);
+                match parse_screen(screen, capabilities) {
+                    Some(parsed) => {
+                        if is_active {
+                            active_screen = Some(view.screens.len());
+                            active_screen_is_invalid = false;
+                        }
+                        view.screens.push(parsed);
                     }
-                    view.screens.push(parsed);
+                    None => {
+                        if is_active {
+                            active_screen = None;
+                            active_screen_is_invalid = true;
+                        }
+                    }
                 }
             }
+            view.active_screen = active_screen
+                .unwrap_or_else(|| if active_screen_is_invalid { usize::MAX } else { 0 });
         }
         tree.workspaces.push(view);
     }


### PR DESCRIPTION
## Summary
- reindex `active_screen` after malformed screens are dropped during tree parsing
- reindex `active_tab` after malformed tabs are dropped during pane parsing
- default to the first valid tab when the server's active tab is malformed
- add behavior tests for all filtered-index cases

The parser receives remote JSON with `filter_map` semantics. It previously copied the server's raw active indexes before filtering, so one malformed entry before the active item could select the wrong screen or tab. A malformed active tab could also leave a raw index that selected another valid tab after filtering.

Commits are test-first: each regression test precedes its fix.

## Verification
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/session/tree.rs`
- `git diff --check origin/main...HEAD`

Cargo tests were not run locally under the cmux Testbox policy.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed an issue where the active tab could change unexpectedly when invalid or incomplete tabs were present.
  - Fixed active screen selection so it remains aligned with the correctly parsed screen after malformed entries are skipped.
  - Improved session tree parsing to preserve the intended active tab and screen whenever the corresponding entries remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->