### PR TITLE
fix(pipe-io): require atomic attach sizing capability

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -26,6 +26,7 @@ mod machine_provider_client;
 #[cfg(unix)]
 mod machine_provider_runtime;
 mod machine_runtime;
+mod pipe_io;
 mod plugin_manager;
 mod process_diagnostics;
 #[cfg(target_os = "linux")]
@@ -1710,6 +1711,9 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
             Err(error) => return Err(error),
         };
         if tree.resolve_terminal(terminal) != Some(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+            }
             anyhow::bail!(messages.unknown_terminal(terminal.as_str()));
         }
         Some(surface)

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -2921,6 +2921,25 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_startup_errors_distinguish_transport_loss_from_setup_failure() {
+        let transport_loss = anyhow::Error::new(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "daemon is restarting",
+        ));
+        assert_eq!(
+            pipe_io_startup_exit_reason(&transport_loss),
+            pipe_io::PipeIoExitReason::DaemonLost
+        );
+
+        let setup_failure =
+            anyhow::anyhow!("remote server does not support filtered subscriptions");
+        assert_eq!(
+            pipe_io_startup_exit_reason(&setup_failure),
+            pipe_io::PipeIoExitReason::SetupFailed
+        );
+    }
+
+    #[test]
     fn remote_normalization_preserves_leading_globals_for_direct_commands() {
         let mut json_connect = ["--json", "connect"].map(str::to_string).to_vec();
         normalize_remote_resource_args(&mut json_connect).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1626,6 +1626,26 @@ fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
     cmux_tui_core::terminal_host_runtime::serve_terminal_host_stdio(args, &mut reader, &mut writer)
 }
 
+/// Ends a `--pipe-io` relay: the machine-readable exit reason is the final
+/// stderr line (the embedder localizes what it shows) and the exit code
+/// carries the respawn decision.
+fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
+    {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{}", serde_json::json!({"exit": {"reason": reason.as_str()}}));
+        let _ = stderr.flush();
+    }
+    client_log::exit(reason.exit_code());
+}
+
+fn pipe_io_startup_exit_reason(error: &anyhow::Error) -> pipe_io::PipeIoExitReason {
+    if session::is_pipe_io_retryable_error(error) {
+        pipe_io::PipeIoExitReason::DaemonLost
+    } else {
+        pipe_io::PipeIoExitReason::SetupFailed
+    }
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
@@ -1641,20 +1661,54 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         })
         .transpose()?;
     let remote = if terminal.is_some() {
-        RemoteSession::connect_for_terminal_attach(&socket_path)?
+        match RemoteSession::connect_for_terminal_attach(&socket_path) {
+            Ok(remote) => remote,
+            // A pipe-io embedder retries daemon-lost forever (a daemon
+            // restart window looks exactly like this) but gives up on
+            // unexplained failures; a connect failure is the former.
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
+            Err(error) => return Err(error),
+        }
     } else {
         RemoteSession::connect(&socket_path)?
     };
     let surface_only = if let Some(terminal) = terminal.as_ref() {
-        let tree = remote.refresh_tree()?;
-        let surface = tree
-            .resolve_terminal(terminal)
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
+            Err(error) => return Err(error),
+        };
+        let resolved = tree.resolve_terminal(terminal);
+        // A pipe-io embedder respawns on daemon loss; a terminal that no
+        // longer exists must read as terminal-ended (do not respawn), not
+        // as a startup failure it would retry forever.
+        if args.pipe_io && resolved.is_none() {
+            exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+        }
+        let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
+            // A pipe-IO embedder needs a machine-readable terminal result for
+            // every startup path. Without the scoped subscription filter, the
+            // relay cannot safely distinguish this surface's bytes, so treat
+            // it as a retryable daemon capability loss instead of returning a
+            // plain CLI error (which would omit the final exit record).
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::SetupFailed);
+            }
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
-        remote.scope_events_to_surface(surface)?;
-        let tree = remote.refresh_tree()?;
+        if let Err(error) = remote.scope_events_to_surface(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io_startup_exit_reason(&error));
+            }
+            return Err(error);
+        }
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
+            Err(error) => return Err(error),
+        };
         if tree.resolve_terminal(terminal) != Some(surface) {
             anyhow::bail!(messages.unknown_terminal(terminal.as_str()));
         }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1,0 +1,674 @@
+//! Renderer-less byte relay for embedder-fed (manual-IO) surfaces.
+//!
+//! `cmux attach --terminal <id> --pipe-io` is the scoped attach client minus
+//! the renderer: the embedder (the macOS GUI's manual-mirror Ghostty
+//! surface) parses the byte stream itself, so this process only relays.
+//!
+//! Contract:
+//! - stdout: raw VT bytes — the daemon replay first, then live PTY output.
+//!   A replay that is not the relay's first output is prefixed with a full
+//!   reset (`ESC c` + erase-scrollback) because a daemon replay REPLACES
+//!   terminal state while a byte stream can only append.
+//! - stdin: JSON lines — `{"input":"<base64>"}` forwards raw bytes to the
+//!   daemon terminal's PTY; `{"resize":{"cols":N,"rows":N}}` drives the
+//!   daemon-side viewer size; `{"claim":{"geometry":true}}` re-asserts this
+//!   relay's geometry authority (last claim wins across attachments; the
+//!   embedder sends it when its pane receives user input). Unknown keys are
+//!   ignored (forward compat); stdin EOF means the embedder is gone and
+//!   ends the relay cleanly.
+//! - stderr: one final JSON line `{"exit":{"reason":...}}`.
+//! - exit code: 0 when the terminal ended or the embedder closed stdin (do
+//!   not respawn), 2 when the daemon connection was lost (respawning
+//!   reattaches and resyncs from a fresh replay).
+
+use std::borrow::Cow;
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use cmux_tui_core::SurfaceId;
+use cmux_tui_core::resource::TerminalPublicId;
+use crossbeam_channel::{Receiver, Sender};
+use serde::Deserialize;
+
+use crate::session::{
+    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
+    is_remote_surface_unavailable,
+};
+
+/// The terminal ended, or the embedder walked away: respawning is wrong.
+pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
+/// The daemon connection was lost: the embedder may respawn to resync.
+pub const EXIT_DAEMON_LOST: i32 = 2;
+
+/// Bounded event queue between the session reader thread and the stdout
+/// pump. A full queue means the embedder stopped reading; the session
+/// treats that as a lost transport rather than wedging its reader thread.
+const EVENT_QUEUE_CAPACITY: usize = 4096;
+const EVENT_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+const MAX_PIPE_IO_INPUT_BYTES: usize = crate::pty_input::PTY_INPUT_MAX_BYTES;
+const MAX_PIPE_IO_BASE64_BYTES: usize = MAX_PIPE_IO_INPUT_BYTES.div_ceil(3) * 4;
+const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
+
+/// Emitted before any replay that is not the relay's first output: full
+/// reset plus erase-scrollback, so the replacement replay does not stack on
+/// top of the embedder's previous terminal state.
+const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
+const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipeIoExitReason {
+    TerminalEnded,
+    DaemonLost,
+    ParentClosed,
+}
+
+impl PipeIoExitReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TerminalEnded => "terminal-ended",
+            Self::DaemonLost => "daemon-lost",
+            Self::ParentClosed => "parent-closed",
+        }
+    }
+
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
+            Self::DaemonLost => EXIT_DAEMON_LOST,
+        }
+    }
+}
+
+/// One parsed stdin line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoRequest {
+    Input(Vec<u8>),
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    /// Re-assert this relay's geometry authority over the terminal. Sent by
+    /// the embedder when its pane receives user input: authority is
+    /// last-claim-wins across attachments, so with several panes (or stale
+    /// restored panes) viewing one terminal, the pane the user actually
+    /// types in must own the PTY size.
+    ClaimGeometry,
+    /// A well-formed line carrying no verb this relay knows: ignored, so a
+    /// newer embedder can talk to an older relay.
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct PipeIoWireRequest<'a> {
+    #[serde(borrow)]
+    input: Option<Cow<'a, str>>,
+    resize: Option<PipeIoWireResize>,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    claim: bool,
+}
+
+#[derive(Deserialize)]
+struct PipeIoWireResize {
+    cols: Option<u64>,
+    rows: Option<u64>,
+}
+
+fn deserialize_present<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::de::IgnoredAny::deserialize(deserializer).map(|_| true)
+}
+
+pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
+    if line.len() > MAX_PIPE_IO_LINE_BYTES {
+        anyhow::bail!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes");
+    }
+    let request: PipeIoWireRequest<'_> = serde_json::from_str(line)?;
+    if let Some(encoded) = request.input {
+        let encoded = encoded.as_ref();
+        if encoded.len() > MAX_PIPE_IO_BASE64_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        if encoded.len() % 4 == 0 {
+            let padding = encoded.bytes().rev().take_while(|byte| *byte == b'=').count();
+            let decoded_len = encoded
+                .len()
+                .checked_div(4)
+                .and_then(|quads| quads.checked_mul(3))
+                .and_then(|bytes| bytes.checked_sub(padding))
+                .unwrap_or(usize::MAX);
+            if decoded_len > MAX_PIPE_IO_INPUT_BYTES {
+                anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+            }
+        } else if base64::decoded_len_estimate(encoded.len()) > MAX_PIPE_IO_INPUT_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        let bytes = base64::engine::general_purpose::STANDARD.decode(encoded)?;
+        if bytes.len() > MAX_PIPE_IO_INPUT_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        return Ok(PipeIoRequest::Input(bytes));
+    }
+    if let Some(resize) = request.resize {
+        let cols = resize.cols;
+        let rows = resize.rows;
+        let (Some(cols), Some(rows)) = (cols, rows) else {
+            anyhow::bail!("resize needs numeric cols and rows");
+        };
+        let (cols, rows) = (u16::try_from(cols)?, u16::try_from(rows)?);
+        return Ok(PipeIoRequest::Resize { cols: cols.max(1), rows: rows.max(1) });
+    }
+    if request.claim {
+        return Ok(PipeIoRequest::ClaimGeometry);
+    }
+    Ok(PipeIoRequest::Unknown)
+}
+
+pub fn run(
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+    surface: SurfaceId,
+    cols: u16,
+    rows: u16,
+) -> anyhow::Result<PipeIoExitReason> {
+    let (sender, receiver) = crossbeam_channel::bounded(EVENT_QUEUE_CAPACITY);
+    // Lifecycle events have their own reserved signal path. A stalled
+    // embedder can fill the byte queue, but it must never be able to hide the
+    // transport-loss event that tells the embedder to respawn.
+    let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+    let byte_budget = Arc::new(PipeIoByteBudget::new(EVENT_QUEUE_MAX_BYTES));
+    // Install before attach so the initial replay cannot be missed.
+    let tap_token = remote.install_pipe_io_tap(
+        surface,
+        sender.clone(),
+        lifecycle_sender.clone(),
+        byte_budget.clone(),
+    );
+    let tap_guard = PipeIoTapGuard { remote: remote.as_ref(), token: tap_token };
+    let handle = match remote.try_attach_pipe_io(surface, Some((cols.max(1), rows.max(1)))) {
+        Ok(PipeIoSurfaceAttach::Attached) => {
+            PipeIoSurfaceHandle { remote: remote.clone(), surface }
+        }
+        Ok(PipeIoSurfaceAttach::Retired) => {
+            return Ok(PipeIoExitReason::TerminalEnded);
+        }
+        Ok(PipeIoSurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
+        Err(error) => return Ok(attach_failure_exit_reason(&error, surface)),
+    };
+    // The daemon resizes a terminal's PTY only for its geometry-authority
+    // client (the full TUI client claims this for its active surface). The
+    // relay is the embedder's only viewer of this terminal, so claim the
+    // authority or every embedder resize is recorded but never applied.
+    if let Err(error) = remote.notify_claim_terminal_geometry(surface) {
+        eprintln!(
+            "{}",
+            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
+        );
+        // Continuing without geometry authority would make later resize
+        // requests look accepted while the daemon keeps the wrong PTY size.
+        // Classify the startup failure so the embedder can either stop for a
+        // retired terminal or reconnect after a lost daemon transport.
+        return Ok(attach_failure_exit_reason(&error, surface));
+    }
+    spawn_stdin_pump(handle, lifecycle_sender);
+    let reason = pump_events_to_stdout(
+        &receiver,
+        &lifecycle_receiver,
+        &byte_budget,
+        &mut std::io::stdout().lock(),
+    )?;
+    // Stop forwarding while the daemon probe runs. The probe has its own
+    // request path, and events for the finished relay must not fill the data
+    // queue or tear down a replacement transport.
+    drop(tap_guard);
+    if reason == PipeIoExitReason::DaemonLost {
+        return Ok(classify_daemon_loss(remote, socket_path, terminal));
+    }
+    Ok(reason)
+}
+
+/// The pipe-IO relay needs only the remote request path. Keeping this handle
+/// separate from `SurfaceHandle::Remote` prevents the normal local VT mirror
+/// from being created or mutated for a renderer-less attachment.
+#[derive(Clone)]
+struct PipeIoSurfaceHandle {
+    remote: Arc<RemoteSession>,
+    surface: SurfaceId,
+}
+
+impl PipeIoSurfaceHandle {
+    fn write_bytes(&self, bytes: &[u8]) -> anyhow::Result<()> {
+        self.remote.send_bytes(self.surface, bytes)
+    }
+
+    fn resize(&self, cols: u16, rows: u16) -> anyhow::Result<bool> {
+        self.remote.resize_pipe_io(self.surface, cols, rows)
+    }
+}
+
+struct PipeIoTapGuard<'a> {
+    remote: &'a RemoteSession,
+    token: Arc<u8>,
+}
+
+impl Drop for PipeIoTapGuard<'_> {
+    fn drop(&mut self) {
+        self.remote.clear_pipe_io_tap(&self.token);
+    }
+}
+
+fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
+    // A rejected attach naming this exact surface means the terminal ended
+    // between the tree lookup and the attach request. Every other failure is
+    // reported as retryable daemon loss so the embedder receives the normal
+    // final JSON record and exit code.
+    if is_remote_surface_unavailable(error, surface) {
+        PipeIoExitReason::TerminalEnded
+    } else {
+        PipeIoExitReason::DaemonLost
+    }
+}
+
+/// The stream ended without a terminal-exit event, but "stream lost" covers
+/// two situations the embedder must tell apart: the daemon really is
+/// unreachable (respawn until it returns), or the terminal was closed and
+/// the daemon tore the scoped stream down before the exit event reached us
+/// (never respawn). One bounded probe of the daemon resolves it: prefer the
+/// existing connection, and fall back to a fresh connect when the socket
+/// died with the stream.
+fn classify_daemon_loss(
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+) -> PipeIoExitReason {
+    let deadline = Instant::now() + DAEMON_LOSS_PROBE_TIMEOUT;
+    let terminal_still_exists = remote
+        .refresh_tree_until(deadline)
+        .ok()
+        .map(|tree| tree.resolve_terminal(terminal).is_some())
+        .or_else(|| {
+            let probe =
+                RemoteSession::connect_for_terminal_attach_until(socket_path, deadline).ok()?;
+            let tree = probe.refresh_tree_until(deadline).ok()?;
+            Some(tree.resolve_terminal(terminal).is_some())
+        });
+    match terminal_still_exists {
+        Some(false) => PipeIoExitReason::TerminalEnded,
+        Some(true) | None => PipeIoExitReason::DaemonLost,
+    }
+}
+
+fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::Result<usize> {
+    line.clear();
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(line.len());
+        }
+        let (chunk_len, has_newline) = match available.iter().position(|byte| *byte == b'\n') {
+            Some(index) => (index + 1, true),
+            None => (available.len(), false),
+        };
+        if line.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes"),
+            ));
+        }
+        let chunk = &available[..chunk_len];
+        let text = std::str::from_utf8(chunk)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        line.push_str(text);
+        reader.consume(chunk_len);
+        if has_newline {
+            return Ok(line.len());
+        }
+    }
+}
+
+/// Forwards embedder requests from stdin until EOF, then reports the closed
+/// parent through the shared event queue.
+fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+    std::thread::Builder::new()
+        .name("pipe-io-stdin".into())
+        .spawn(move || {
+            let stdin = std::io::stdin();
+            let mut reader = stdin.lock();
+            let mut line = String::new();
+            loop {
+                let Ok(bytes_read) = read_pipe_io_line(&mut reader, &mut line) else { break };
+                if bytes_read == 0 {
+                    break;
+                }
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_request(&line) {
+                    Ok(PipeIoRequest::Input(bytes)) => {
+                        if handle.write_bytes(&bytes).is_err() {
+                            // The transport owns loss reporting; input can
+                            // only stop early.
+                            break;
+                        }
+                    }
+                    Ok(PipeIoRequest::Resize { cols, rows }) => {
+                        // Diagnostics only; the exit JSON stays the final
+                        // stderr line and embedders skip lines without an
+                        // "exit" key.
+                        match handle.resize(cols, rows) {
+                            Ok(accepted) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                                })
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::ClaimGeometry) => {
+                        // Claims only establish ownership. Enqueue them on
+                        // the same ordered writer as input so a claim cannot
+                        // overtake the keystroke that follows it, and avoid a
+                        // new blocking thread for every claim.
+                        match handle.remote.notify_claim_terminal_geometry(handle.surface) {
+                            Ok(()) => eprintln!(
+                                "{}",
+                                serde_json::json!({"diag": {"claim": {"accepted": true}}})
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"claim": {"error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::Unknown) => {}
+                    // A malformed line means the embedder side is broken;
+                    // stop consuming rather than misinterpreting input.
+                    Err(_) => break,
+                }
+            }
+            // Lifecycle has its own one-slot channel, so a full byte queue
+            // cannot delay the parent-close signal.
+            let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+        })
+        .expect("spawn pipe-io stdin pump");
+}
+
+fn pump_events_to_stdout(
+    receiver: &Receiver<PipeIoEvent>,
+    lifecycle_receiver: &Receiver<PipeIoEvent>,
+    byte_budget: &PipeIoByteBudget,
+    stdout: &mut impl Write,
+) -> anyhow::Result<PipeIoExitReason> {
+    let mut emitted_output = false;
+    loop {
+        // Lifecycle signals have a separate bounded channel, so a full byte
+        // queue cannot delay or drop a transport-loss notification.
+        let event = crossbeam_channel::select_biased! {
+            recv(lifecycle_receiver) -> event => {
+                match event {
+                    Ok(PipeIoEvent::SurfaceExited) => {
+                        // Lifecycle signals use a separate channel, so a
+                        // surface-exit notification can overtake bytes that
+                        // the reader already queued. Drain those committed
+                        // bytes before preserving the terminal's final frame.
+                        // Transport loss has different semantics: queued
+                        // bytes are stale and must be discarded.
+                        while let Ok(event) = receiver.try_recv() {
+                            byte_budget.release(event.retained_bytes());
+                            match event {
+                                PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+                                    if write_pipe_io_data(
+                                        &event,
+                                        &mut emitted_output,
+                                        stdout,
+                                    )
+                                    .is_err()
+                                    {
+                                        return Ok(PipeIoExitReason::ParentClosed);
+                                    }
+                                }
+                                PipeIoEvent::SurfaceExited => {
+                                    break;
+                                }
+                                PipeIoEvent::TransportLost => {
+                                    return Ok(PipeIoExitReason::DaemonLost);
+                                }
+                                PipeIoEvent::StdinClosed => {
+                                    return Ok(PipeIoExitReason::ParentClosed);
+                                }
+                            }
+                        }
+                        return Ok(PipeIoExitReason::TerminalEnded);
+                    }
+                    Ok(PipeIoEvent::TransportLost) => {
+                        return Ok(PipeIoExitReason::DaemonLost);
+                    }
+                    Ok(PipeIoEvent::StdinClosed) => {
+                        return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                    Ok(PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_)) => {
+                        // Lifecycle senders never carry byte events. Ignore a
+                        // malformed producer rather than violating framing.
+                        continue;
+                    }
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
+            recv(receiver) -> event => {
+                match event {
+                    Ok(event) => event,
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
+        };
+        byte_budget.release(event.retained_bytes());
+        let write_result = match &event {
+            PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+                write_pipe_io_data(&event, &mut emitted_output, stdout)
+            }
+            PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
+            PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
+            PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
+        };
+        if write_result.is_err() {
+            // stdout is the embedder; a failed write means it is gone.
+            return Ok(PipeIoExitReason::ParentClosed);
+        }
+    }
+}
+
+fn write_pipe_io_data(
+    event: &PipeIoEvent,
+    emitted_output: &mut bool,
+    stdout: &mut impl Write,
+) -> std::io::Result<()> {
+    match event {
+        PipeIoEvent::Replay { bytes } => {
+            if *emitted_output {
+                stdout.write_all(REPLAY_RESET)?;
+            }
+            stdout.write_all(bytes)?;
+            stdout.flush()?;
+        }
+        PipeIoEvent::Output(bytes) => {
+            stdout.write_all(bytes)?;
+            stdout.flush()?;
+        }
+        PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost | PipeIoEvent::StdinClosed => {
+            debug_assert!(false, "lifecycle event passed to byte writer");
+        }
+    }
+    *emitted_output = true;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+    use std::sync::{Weak, mpsc};
+
+    use super::*;
+
+    fn replay(bytes: &[u8]) -> PipeIoEvent {
+        PipeIoEvent::Replay { bytes: bytes.to_vec() }
+    }
+
+    #[test]
+    fn parse_request_decodes_input_resize_and_ignores_unknown_verbs() {
+        assert_eq!(
+            parse_request(r#"{"input":"aGk="}"#).unwrap(),
+            PipeIoRequest::Input(b"hi".to_vec())
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":100,"rows":30}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 100, rows: 30 }
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":0,"rows":0}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 1, rows: 1 }
+        );
+        assert_eq!(parse_request(r#"{"future-verb":true}"#).unwrap(), PipeIoRequest::Unknown);
+        assert!(parse_request("not json").is_err());
+        assert!(parse_request(r#"{"input":"@@not-base64@@"}"#).is_err());
+        assert!(parse_request(r#"{"resize":{"cols":100}}"#).is_err());
+    }
+
+    #[test]
+    fn parse_request_rejects_oversized_lines_and_input_before_decoding() {
+        let oversized_line = " ".repeat(MAX_PIPE_IO_LINE_BYTES + 1);
+        let error = parse_request(&oversized_line).unwrap_err().to_string();
+        assert!(error.contains("request line exceeds"), "{error}");
+
+        let oversized_base64 = "A".repeat(MAX_PIPE_IO_BASE64_BYTES + 4);
+        let line = format!(r#"{{"input":"{oversized_base64}"}}"#);
+        let error = parse_request(&line).unwrap_err().to_string();
+        assert!(error.contains("input exceeds"), "{error}");
+    }
+
+    #[test]
+    fn exit_reasons_map_to_the_respawn_contract() {
+        assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
+        assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
+        assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
+        assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+    }
+
+    #[test]
+    fn stdout_pump_prefixes_only_non_initial_replays_with_a_full_reset() {
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        sender.send(replay(b"FIRST")).unwrap();
+        sender.send(PipeIoEvent::Output(b"live".to_vec())).unwrap();
+        sender.send(replay(b"SECOND")).unwrap();
+        sender.send(PipeIoEvent::SurfaceExited).unwrap();
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        let reason =
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        let mut expected = b"FIRSTlive".to_vec();
+        expected.extend_from_slice(REPLAY_RESET);
+        expected.extend_from_slice(b"SECOND");
+        assert_eq!(stdout, expected);
+    }
+
+    #[test]
+    fn stdout_pump_maps_lifecycle_events_to_exit_reasons() {
+        for (event, expected) in [
+            (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
+            (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
+        ] {
+            let (sender, receiver) = crossbeam_channel::bounded(8);
+            let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            sender.send(event).unwrap();
+            let mut stdout = Vec::new();
+            let budget = PipeIoByteBudget::new(1024);
+            assert_eq!(
+                pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout)
+                    .unwrap(),
+                expected
+            );
+            assert!(stdout.is_empty());
+        }
+        // Sender dropped without any event: the session vanished wholesale.
+        let (sender, receiver) = crossbeam_channel::bounded::<PipeIoEvent>(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        drop(sender);
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+    }
+
+    #[test]
+    fn stdout_pump_prioritizes_a_transport_loss_over_queued_bytes() {
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        sender.send(PipeIoEvent::Output(b"stale".to_vec())).unwrap();
+        lifecycle_sender.send(PipeIoEvent::TransportLost).unwrap();
+
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+        assert!(stdout.is_empty(), "stale bytes must not be emitted after transport loss");
+    }
+
+    #[test]
+    fn stdout_pump_drains_committed_bytes_before_surface_exit() {
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let budget = PipeIoByteBudget::new(1024);
+        assert!(budget.try_reserve(5));
+        sender.send(replay(b"FINAL")).unwrap();
+        lifecycle_sender.send(PipeIoEvent::SurfaceExited).unwrap();
+
+        let mut stdout = Vec::new();
+        let reason =
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        assert_eq!(stdout, b"FINAL");
+    }
+
+    #[test]
+    fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
+        let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
+        let mut input = Cursor::new(br#"{"input":"aGk="}\n"#.to_vec());
+
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
+    }
+
+    #[test]
+    fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
+        let terminal_ended =
+            crate::session::test_remote_rejected_error_with_message("unknown surface 7");
+        assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
+
+        let daemon_lost = crate::session::test_remote_transport_error();
+        assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
+
+        let unexpected = anyhow::anyhow!("attach capability negotiation failed");
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -57,29 +57,6 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Serializes diagnostics with the final exit record. The stdin pump can be
-/// blocked in a read when the relay ends, so joining it is not a safe way to
-/// establish ordering. Closing this gate makes later diagnostics no-ops while
-/// allowing an in-flight diagnostic to finish before the final record is
-/// written by the parent.
-#[derive(Default)]
-struct StderrGate(Mutex<bool>);
-
-impl StderrGate {
-    fn close(&self) {
-        *self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
-    }
-
-    fn diag(&self, value: serde_json::Value) {
-        let closed = self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        if *closed {
-            return;
-        }
-        eprintln!("{value}");
-        let _ = std::io::stderr().flush();
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -229,7 +206,7 @@ pub fn run(
     // client (the full TUI client claims this for its active surface). The
     // relay is the embedder's only viewer of this terminal, so claim the
     // authority or every embedder resize is recorded but never applied.
-    if let Err(error) = remote.notify_claim_terminal_geometry(surface) {
+    if let Err(error) = remote.claim_terminal_geometry(surface) {
         eprintln!(
             "{}",
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
@@ -248,8 +225,7 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let stderr_gate = Arc::new(StderrGate::default());
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -266,10 +242,6 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
-    // The stdin pump may still be blocked in read(2). Close the diagnostic
-    // gate before returning so the parent can write the final exit record
-    // without a late resize/claim diagnostic racing it.
-    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -386,7 +358,6 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
-    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -395,7 +366,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -405,7 +376,6 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
-    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -446,12 +416,8 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                    })),
+                    Ok(_accepted) => {}
+                    Err(_error) => {}
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -464,12 +430,8 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => {
-                        stderr_gate.diag(serde_json::json!({"diag": {"claim": {"accepted": true}}}))
-                    }
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"error": error.to_string()}}
-                    })),
+                    Ok(()) => (),
+                    Err(_error) => (),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -747,9 +709,8 @@ mod tests {
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
-        let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -761,8 +722,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            let stderr_gate = StderrGate::default();
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -327,9 +327,15 @@ fn classify_daemon_loss(
 
 fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::Result<usize> {
     line.clear();
+    let mut bytes = Vec::new();
     loop {
         let available = reader.fill_buf()?;
         if available.is_empty() {
+            if bytes.is_empty() {
+                return Ok(0);
+            }
+            *line = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
         let (chunk_len, has_newline) = match available.iter().position(|byte| *byte == b'\n') {
@@ -343,11 +349,11 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
             ));
         }
         let chunk = &available[..chunk_len];
-        let text = std::str::from_utf8(chunk)
-            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
-        line.push_str(text);
+        bytes.extend_from_slice(chunk);
         reader.consume(chunk_len);
         if has_newline {
+            *line = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -63,6 +63,7 @@ pub enum PipeIoExitReason {
     TerminalEnded,
     DaemonLost,
     ParentClosed,
+    SetupFailed,
 }
 
 impl PipeIoExitReason {
@@ -71,12 +72,13 @@ impl PipeIoExitReason {
             Self::TerminalEnded => "terminal-ended",
             Self::DaemonLost => "daemon-lost",
             Self::ParentClosed => "parent-closed",
+            Self::SetupFailed => "setup-failed",
         }
     }
 
     pub fn exit_code(self) -> i32 {
         match self {
-            Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
+            Self::TerminalEnded | Self::ParentClosed | Self::SetupFailed => EXIT_DO_NOT_RESPAWN,
             Self::DaemonLost => EXIT_DAEMON_LOST,
         }
     }
@@ -215,7 +217,17 @@ pub fn run(
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
     }
-    spawn_stdin_pump(handle, lifecycle_sender);
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+        Ok(pump) => pump,
+        Err(error) => {
+            eprintln!(
+                "{}",
+                serde_json::json!({"diag": {"stdin-pump": {"error": error.to_string()}}})
+            );
+            drop(tap_guard);
+            return Ok(PipeIoExitReason::SetupFailed);
+        }
+    };
     let reason = pump_events_to_stdout(
         &receiver,
         &lifecycle_receiver,
@@ -264,13 +276,15 @@ impl Drop for PipeIoTapGuard<'_> {
 
 fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
     // A rejected attach naming this exact surface means the terminal ended
-    // between the tree lookup and the attach request. Every other failure is
-    // reported as retryable daemon loss so the embedder receives the normal
-    // final JSON record and exit code.
+    // between the tree lookup and the attach request. Only confirmed
+    // transport failures are retryable; capability and protocol failures
+    // must stop without asking the embedder to respawn forever.
     if is_remote_surface_unavailable(error, surface) {
         PipeIoExitReason::TerminalEnded
-    } else {
+    } else if crate::session::is_pipe_io_retryable_error(error) {
         PipeIoExitReason::DaemonLost
+    } else {
+        PipeIoExitReason::SetupFailed
     }
 }
 
@@ -333,7 +347,10 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 
 /// Forwards embedder requests from stdin until EOF, then reports the closed
 /// parent through the shared event queue.
-fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+fn spawn_stdin_pump(
+    handle: PipeIoSurfaceHandle,
+    lifecycle_sender: Sender<PipeIoEvent>,
+) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
     std::thread::Builder::new()
@@ -343,7 +360,7 @@ fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIo
             let mut reader = stdin.lock();
             run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
-        .expect("spawn pipe-io stdin pump");
+        .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
 
 fn run_stdin_pump(
@@ -576,10 +593,12 @@ mod tests {
     fn exit_reasons_map_to_the_respawn_contract() {
         assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::SetupFailed.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
         assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
         assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
         assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+        assert_eq!(PipeIoExitReason::SetupFailed.as_str(), "setup-failed");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -28,14 +28,14 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
-use cmux_tui_core::resource::TerminalPublicId;
 use cmux_tui_core::SurfaceId;
+use cmux_tui_core::resource::TerminalPublicId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
 use crate::session::{
-    is_remote_surface_unavailable, PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach,
-    RemoteSession,
+    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
+    is_remote_surface_unavailable,
 };
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
@@ -239,6 +239,14 @@ pub fn run(
         // Classify the startup failure so the embedder can either stop for a
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
+    }
+    // Older daemons do not accept geometry in the attach request. Apply the
+    // requested initial size explicitly after claiming authority so the
+    // first replay uses the embedder's dimensions on that compatibility path.
+    if !remote.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY) {
+        if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
+            return Ok(attach_failure_exit_reason(&error, surface));
+        }
     }
     let stderr_gate = Arc::new(StderrGate::default());
     let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -334,76 +334,90 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 /// Forwards embedder requests from stdin until EOF, then reports the closed
 /// parent through the shared event queue.
 fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+    let remote = Arc::downgrade(&handle.remote);
+    let surface = handle.surface;
     std::thread::Builder::new()
         .name("pipe-io-stdin".into())
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            let mut line = String::new();
-            loop {
-                let Ok(bytes_read) = read_pipe_io_line(&mut reader, &mut line) else { break };
-                if bytes_read == 0 {
-                    break;
-                }
-                if line.trim().is_empty() {
-                    continue;
-                }
-                match parse_request(&line) {
-                    Ok(PipeIoRequest::Input(bytes)) => {
-                        if handle.write_bytes(&bytes).is_err() {
-                            // The transport owns loss reporting; input can
-                            // only stop early.
-                            break;
-                        }
-                    }
-                    Ok(PipeIoRequest::Resize { cols, rows }) => {
-                        // Diagnostics only; the exit JSON stays the final
-                        // stderr line and embedders skip lines without an
-                        // "exit" key.
-                        match handle.resize(cols, rows) {
-                            Ok(accepted) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                                })
-                            ),
-                            Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                                })
-                            ),
-                        }
-                    }
-                    Ok(PipeIoRequest::ClaimGeometry) => {
-                        // Claims only establish ownership. Enqueue them on
-                        // the same ordered writer as input so a claim cannot
-                        // overtake the keystroke that follows it, and avoid a
-                        // new blocking thread for every claim.
-                        match handle.remote.notify_claim_terminal_geometry(handle.surface) {
-                            Ok(()) => eprintln!(
-                                "{}",
-                                serde_json::json!({"diag": {"claim": {"accepted": true}}})
-                            ),
-                            Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"claim": {"error": error.to_string()}}
-                                })
-                            ),
-                        }
-                    }
-                    Ok(PipeIoRequest::Unknown) => {}
-                    // A malformed line means the embedder side is broken;
-                    // stop consuming rather than misinterpreting input.
-                    Err(_) => break,
-                }
-            }
-            // Lifecycle has its own one-slot channel, so a full byte queue
-            // cannot delay the parent-close signal.
-            let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .expect("spawn pipe-io stdin pump");
+}
+
+fn run_stdin_pump(
+    reader: &mut impl BufRead,
+    remote: &Weak<RemoteSession>,
+    surface: SurfaceId,
+    lifecycle_sender: &Sender<PipeIoEvent>,
+) {
+    let mut line = String::new();
+    loop {
+        let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
+        if bytes_read == 0 {
+            break;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        match parse_request(&line) {
+            Ok(PipeIoRequest::Input(bytes)) => {
+                let Some(remote) = remote.upgrade() else { break };
+                let handle = PipeIoSurfaceHandle { remote, surface };
+                if handle.write_bytes(&bytes).is_err() {
+                    // The transport owns loss reporting; input can only stop
+                    // early.
+                    break;
+                }
+            }
+            Ok(PipeIoRequest::Resize { cols, rows }) => {
+                let Some(remote) = remote.upgrade() else { break };
+                let handle = PipeIoSurfaceHandle { remote, surface };
+                // Diagnostics only; the exit JSON stays the final stderr line
+                // and embedders skip lines without an "exit" key.
+                match handle.resize(cols, rows) {
+                    Ok(accepted) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                        })
+                    ),
+                    Err(error) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                        })
+                    ),
+                }
+            }
+            Ok(PipeIoRequest::ClaimGeometry) => {
+                let Some(remote) = remote.upgrade() else { break };
+                // Claims only establish ownership. Enqueue them on the same
+                // ordered writer as input so a claim cannot overtake the
+                // keystroke that follows it, and avoid a new blocking thread
+                // for every claim.
+                match remote.notify_claim_terminal_geometry(surface) {
+                    Ok(()) => {
+                        eprintln!("{}", serde_json::json!({"diag": {"claim": {"accepted": true}}}))
+                    }
+                    Err(error) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"claim": {"error": error.to_string()}}
+                        })
+                    ),
+                }
+            }
+            Ok(PipeIoRequest::Unknown) => {}
+            // A malformed line means the embedder side is broken; stop
+            // consuming rather than misinterpreting input.
+            Err(_) => break,
+        }
+    }
+    // Lifecycle has its own one-slot channel, so a full byte queue cannot
+    // delay the parent-close signal.
+    let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
 }
 
 fn pump_events_to_stdout(
@@ -652,7 +666,7 @@ mod tests {
     #[test]
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
-        let mut input = Cursor::new(br#"{"input":"aGk="}\n"#.to_vec());
+        let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
         run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -377,6 +377,7 @@ fn run_stdin_pump(
 ) {
     let mut line = String::new();
     let mut stop_event = None;
+    let mut pending_resize = None;
     loop {
         let bytes_read = match read_pipe_io_line(reader, &mut line) {
             Ok(bytes_read) => bytes_read,
@@ -398,6 +399,16 @@ fn run_stdin_pump(
                     break;
                 };
                 let handle = PipeIoSurfaceHandle { remote, surface };
+                if let Some((cols, rows)) = pending_resize.take() {
+                    if let Err(error) = handle.resize(cols, rows) {
+                        stop_event = Some(if crate::session::is_pipe_io_retryable_error(&error) {
+                            PipeIoEvent::TransportLost
+                        } else {
+                            PipeIoEvent::StdinError
+                        });
+                        break;
+                    }
+                }
                 if handle.write_bytes(&bytes).is_err() {
                     // The transport owns loss reporting; input can only stop
                     // early.
@@ -406,19 +417,24 @@ fn run_stdin_pump(
                 }
             }
             Ok(PipeIoRequest::Resize { cols, rows }) => {
-                let Some(remote) = remote.upgrade() else {
-                    stop_event = Some(PipeIoEvent::TransportLost);
-                    break;
-                };
-                let handle = PipeIoSurfaceHandle { remote, surface };
-                // Diagnostics only; the exit JSON stays the final stderr line
-                // and embedders skip lines without an "exit" key.
-                match handle.resize(cols, rows) {
-                    Ok(_accepted) => {}
-                    Err(_error) => {}
-                }
+                pending_resize = Some((cols, rows));
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
+                if let Some((cols, rows)) = pending_resize.take() {
+                    let Some(remote) = remote.upgrade() else {
+                        stop_event = Some(PipeIoEvent::TransportLost);
+                        break;
+                    };
+                    let handle = PipeIoSurfaceHandle { remote, surface };
+                    if let Err(error) = handle.resize(cols, rows) {
+                        stop_event = Some(if crate::session::is_pipe_io_retryable_error(&error) {
+                            PipeIoEvent::TransportLost
+                        } else {
+                            PipeIoEvent::StdinError
+                        });
+                        break;
+                    }
+                }
                 let Some(remote) = remote.upgrade() else {
                     stop_event = Some(PipeIoEvent::TransportLost);
                     break;
@@ -429,7 +445,14 @@ fn run_stdin_pump(
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
                     Ok(()) => (),
-                    Err(_error) => (),
+                    Err(error) => {
+                        stop_event = Some(if crate::session::is_pipe_io_retryable_error(&error) {
+                            PipeIoEvent::TransportLost
+                        } else {
+                            PipeIoEvent::StdinError
+                        });
+                        break;
+                    }
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -220,7 +220,7 @@ pub fn run(
     // Older daemons do not accept geometry in the attach request. Apply the
     // requested initial size explicitly after claiming authority so the
     // first replay uses the embedder's dimensions on that compatibility path.
-    if !remote.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY) {
+    if !remote.supports_pipe_io_initial_size() {
         if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
             return Ok(attach_failure_exit_reason(&error, surface));
         }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,10 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Weak};
+use std::sync::{
+    Arc, Mutex, Weak,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -57,6 +60,38 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Diagnostics are best-effort. A blocked stderr pipe must never hold relay
+/// finalization, so writers use a non-blocking lock and drop the record when
+/// another diagnostic is still being written.
+struct StderrGate {
+    closed: AtomicBool,
+    writer: Mutex<()>,
+}
+
+impl Default for StderrGate {
+    fn default() -> Self {
+        Self { closed: AtomicBool::new(false), writer: Mutex::new(()) }
+    }
+}
+
+impl StderrGate {
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    fn diag(&self, value: serde_json::Value) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        let Ok(_guard) = self.writer.try_lock() else { return };
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        eprintln!("{value}");
+        let _ = std::io::stderr().flush();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -225,7 +260,8 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+    let stderr_gate = Arc::new(StderrGate::default());
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -242,6 +278,7 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
+    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -342,7 +379,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
             Some(index) => (index + 1, true),
             None => (available.len(), false),
         };
-        if line.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
+        if bytes.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes"),
@@ -364,6 +401,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -372,7 +410,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -382,6 +420,7 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -422,8 +461,12 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(_accepted) => {}
-                    Err(_error) => {}
+                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -436,8 +479,12 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => (),
-                    Err(_error) => (),
+                    Ok(()) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"accepted": true}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -716,7 +763,7 @@ mod tests {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -728,7 +775,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -33,10 +33,7 @@ use cmux_tui_core::resource::TerminalPublicId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
-use crate::session::{
-    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
-    is_remote_surface_unavailable,
-};
+use crate::session::{PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession};
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
 pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
@@ -200,7 +197,7 @@ pub fn run(
             return Ok(PipeIoExitReason::TerminalEnded);
         }
         Ok(PipeIoSurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
-        Err(error) => return Ok(attach_failure_exit_reason(&error, surface)),
+        Err(error) => return Ok(attach_failure_exit_reason(&error)),
     };
     // The daemon resizes a terminal's PTY only for its geometry-authority
     // client (the full TUI client claims this for its active surface). The
@@ -215,7 +212,7 @@ pub fn run(
         // requests look accepted while the daemon keeps the wrong PTY size.
         // Classify the startup failure so the embedder can either stop for a
         // retired terminal or reconnect after a lost daemon transport.
-        return Ok(attach_failure_exit_reason(&error, surface));
+        return Ok(attach_failure_exit_reason(&error));
     }
     // Older daemons do not accept geometry in the attach request. Apply the
     // requested initial size explicitly after claiming authority so the
@@ -282,14 +279,11 @@ impl Drop for PipeIoTapGuard<'_> {
     }
 }
 
-fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
-    // A rejected attach naming this exact surface means the terminal ended
-    // between the tree lookup and the attach request. Only confirmed
-    // transport failures are retryable; capability and protocol failures
-    // must stop without asking the embedder to respawn forever.
-    if is_remote_surface_unavailable(error, surface) {
-        PipeIoExitReason::TerminalEnded
-    } else if crate::session::is_pipe_io_retryable_error(error) {
+fn attach_failure_exit_reason(error: &anyhow::Error) -> PipeIoExitReason {
+    // Unknown rejection text is not a reliable lifecycle signal. Fail closed
+    // unless the transport itself is explicitly retryable; setup errors must
+    // not respawn forever on a stale or unauthorized surface.
+    if crate::session::is_pipe_io_retryable_error(error) {
         PipeIoExitReason::DaemonLost
     } else {
         PipeIoExitReason::SetupFailed
@@ -737,12 +731,12 @@ mod tests {
     fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
         let terminal_ended =
             crate::session::test_remote_rejected_error_with_message("unknown surface 7");
-        assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
+        assert_eq!(attach_failure_exit_reason(&terminal_ended), PipeIoExitReason::SetupFailed);
 
         let daemon_lost = crate::session::test_remote_transport_error();
-        assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(attach_failure_exit_reason(&daemon_lost), PipeIoExitReason::DaemonLost);
 
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
-        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::SetupFailed);
+        assert_eq!(attach_failure_exit_reason(&unexpected), PipeIoExitReason::SetupFailed);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -175,6 +175,12 @@ pub fn run(
     cols: u16,
     rows: u16,
 ) -> anyhow::Result<PipeIoExitReason> {
+    // The attach replay is generated before later commands can run. Without
+    // atomic initial sizing, a legacy daemon can replay bytes for its old
+    // geometry and leave the embedder with permanently mis-wrapped state.
+    if !remote.supports_pipe_io_initial_size() {
+        return Ok(PipeIoExitReason::SetupFailed);
+    }
     let (sender, receiver) = crossbeam_channel::bounded(EVENT_QUEUE_CAPACITY);
     // Lifecycle events have their own reserved signal path. A stalled
     // embedder can fill the byte queue, but it must never be able to hide the
@@ -213,14 +219,6 @@ pub fn run(
         // Classify the startup failure so the embedder can either stop for a
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error));
-    }
-    // Older daemons do not accept geometry in the attach request. Apply the
-    // requested initial size explicitly after claiming authority so the
-    // first replay uses the embedder's dimensions on that compatibility path.
-    if !remote.supports_pipe_io_initial_size() {
-        if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
-            return Ok(attach_failure_exit_reason(&error, surface));
-        }
     }
     let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -370,6 +370,7 @@ fn run_stdin_pump(
     lifecycle_sender: &Sender<PipeIoEvent>,
 ) {
     let mut line = String::new();
+    let mut stop_event = None;
     loop {
         let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
         if bytes_read == 0 {
@@ -380,16 +381,23 @@ fn run_stdin_pump(
         }
         match parse_request(&line) {
             Ok(PipeIoRequest::Input(bytes)) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 let handle = PipeIoSurfaceHandle { remote, surface };
                 if handle.write_bytes(&bytes).is_err() {
                     // The transport owns loss reporting; input can only stop
                     // early.
+                    stop_event = Some(PipeIoEvent::TransportLost);
                     break;
                 }
             }
             Ok(PipeIoRequest::Resize { cols, rows }) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 let handle = PipeIoSurfaceHandle { remote, surface };
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
@@ -409,7 +417,10 @@ fn run_stdin_pump(
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 // Claims only establish ownership. Enqueue them on the same
                 // ordered writer as input so a claim cannot overtake the
                 // keystroke that follows it, and avoid a new blocking thread
@@ -429,12 +440,16 @@ fn run_stdin_pump(
             Ok(PipeIoRequest::Unknown) => {}
             // A malformed line means the embedder side is broken; stop
             // consuming rather than misinterpreting input.
-            Err(_) => break,
+            Err(_) => {
+                stop_event = Some(PipeIoEvent::StdinError);
+                break;
+            }
         }
     }
     // Lifecycle has its own one-slot channel, so a full byte queue cannot
-    // delay the parent-close signal.
-    let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+    // delay the parent-close or failure signal. Only actual stdin EOF maps to
+    // StdinClosed; transport and protocol failures keep their own reason.
+    let _ = lifecycle_sender.send(stop_event.unwrap_or(PipeIoEvent::StdinClosed));
 }
 
 fn pump_events_to_stdout(
@@ -480,6 +495,9 @@ fn pump_events_to_stdout(
                                 PipeIoEvent::StdinClosed => {
                                     return Ok(PipeIoExitReason::ParentClosed);
                                 }
+                                PipeIoEvent::StdinError => {
+                                    return Ok(PipeIoExitReason::SetupFailed);
+                                }
                             }
                         }
                         return Ok(PipeIoExitReason::TerminalEnded);
@@ -489,6 +507,9 @@ fn pump_events_to_stdout(
                     }
                     Ok(PipeIoEvent::StdinClosed) => {
                         return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                    Ok(PipeIoEvent::StdinError) => {
+                        return Ok(PipeIoExitReason::SetupFailed);
                     }
                     Ok(PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_)) => {
                         // Lifecycle senders never carry byte events. Ignore a
@@ -513,6 +534,7 @@ fn pump_events_to_stdout(
             PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
             PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
             PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
+            PipeIoEvent::StdinError => return Ok(PipeIoExitReason::SetupFailed),
         };
         if write_result.is_err() {
             // stdout is the embedder; a failed write means it is gone.
@@ -538,7 +560,10 @@ fn write_pipe_io_data(
             stdout.write_all(bytes)?;
             stdout.flush()?;
         }
-        PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost | PipeIoEvent::StdinClosed => {
+        PipeIoEvent::SurfaceExited
+        | PipeIoEvent::TransportLost
+        | PipeIoEvent::StdinClosed
+        | PipeIoEvent::StdinError => {
             debug_assert!(false, "lifecycle event passed to byte writer");
         }
     }
@@ -549,7 +574,7 @@ fn write_pipe_io_data(
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
-    use std::sync::{Weak, mpsc};
+    use std::sync::Weak;
 
     use super::*;
 
@@ -625,6 +650,7 @@ mod tests {
         for (event, expected) in [
             (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
             (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
+            (PipeIoEvent::StdinError, PipeIoExitReason::SetupFailed),
         ] {
             let (sender, receiver) = crossbeam_channel::bounded(8);
             let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
@@ -684,12 +710,12 @@ mod tests {
 
     #[test]
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
-        let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
         run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
-        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
 
     #[test]
@@ -702,6 +728,6 @@ mod tests {
         assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
 
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
-        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::SetupFailed);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,10 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{
-    Arc, Mutex, Weak,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -60,38 +57,6 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Diagnostics are best-effort. A blocked stderr pipe must never hold relay
-/// finalization, so writers use a non-blocking lock and drop the record when
-/// another diagnostic is still being written.
-struct StderrGate {
-    closed: AtomicBool,
-    writer: Mutex<()>,
-}
-
-impl Default for StderrGate {
-    fn default() -> Self {
-        Self { closed: AtomicBool::new(false), writer: Mutex::new(()) }
-    }
-}
-
-impl StderrGate {
-    fn close(&self) {
-        self.closed.store(true, Ordering::Release);
-    }
-
-    fn diag(&self, value: serde_json::Value) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        let Ok(_guard) = self.writer.try_lock() else { return };
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        eprintln!("{value}");
-        let _ = std::io::stderr().flush();
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -260,8 +225,7 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let stderr_gate = Arc::new(StderrGate::default());
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -278,7 +242,6 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
-    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -401,7 +364,6 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
-    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -410,7 +372,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -420,7 +382,6 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
-    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -461,12 +422,8 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                    })),
+                    Ok(_accepted) => {}
+                    Err(_error) => {}
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -479,12 +436,8 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"accepted": true}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"error": error.to_string()}}
-                    })),
+                    Ok(()) => (),
+                    Err(_error) => (),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -763,7 +716,7 @@ mod tests {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -775,7 +728,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,18 +24,18 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
-use cmux_tui_core::SurfaceId;
 use cmux_tui_core::resource::TerminalPublicId;
+use cmux_tui_core::SurfaceId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
 use crate::session::{
-    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
-    is_remote_surface_unavailable,
+    is_remote_surface_unavailable, PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach,
+    RemoteSession,
 };
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
@@ -57,6 +57,29 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Serializes diagnostics with the final exit record. The stdin pump can be
+/// blocked in a read when the relay ends, so joining it is not a safe way to
+/// establish ordering. Closing this gate makes later diagnostics no-ops while
+/// allowing an in-flight diagnostic to finish before the final record is
+/// written by the parent.
+#[derive(Default)]
+struct StderrGate(Mutex<bool>);
+
+impl StderrGate {
+    fn close(&self) {
+        *self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+    }
+
+    fn diag(&self, value: serde_json::Value) {
+        let closed = self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *closed {
+            return;
+        }
+        eprintln!("{value}");
+        let _ = std::io::stderr().flush();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -217,7 +240,8 @@ pub fn run(
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
     }
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+    let stderr_gate = Arc::new(StderrGate::default());
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -234,6 +258,10 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
+    // The stdin pump may still be blocked in read(2). Close the diagnostic
+    // gate before returning so the parent can write the final exit record
+    // without a late resize/claim diagnostic racing it.
+    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -350,6 +378,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -358,7 +387,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -368,11 +397,18 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
     loop {
-        let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
+        let bytes_read = match read_pipe_io_line(reader, &mut line) {
+            Ok(bytes_read) => bytes_read,
+            Err(_) => {
+                stop_event = Some(PipeIoEvent::StdinError);
+                break;
+            }
+        };
         if bytes_read == 0 {
             break;
         }
@@ -402,18 +438,12 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                        })
-                    ),
-                    Err(error) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                        })
-                    ),
+                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -427,14 +457,11 @@ fn run_stdin_pump(
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
                     Ok(()) => {
-                        eprintln!("{}", serde_json::json!({"diag": {"claim": {"accepted": true}}}))
+                        stderr_gate.diag(serde_json::json!({"diag": {"claim": {"accepted": true}}}))
                     }
-                    Err(error) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"claim": {"error": error.to_string()}}
-                        })
-                    ),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -712,10 +739,24 @@ mod tests {
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
+        let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
+    }
+
+    #[test]
+    fn stdin_pump_reports_line_read_errors_as_stdin_errors() {
+        let inputs =
+            vec![b"{\"input\":\"aGk=\"}\n\xff".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
+        for input in inputs {
+            let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            let mut input = Cursor::new(input.to_vec());
+            let stderr_gate = StderrGate::default();
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+            assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -35,6 +35,7 @@ use ghostty_vt::{
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
+pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach, is_pipe_io_retryable_error};
 pub use remote::{
     RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface, RemoteTransport,
     RemoteTransportAbort,

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -35,7 +35,9 @@ use ghostty_vt::{
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
-pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach, is_pipe_io_retryable_error};
+pub(crate) use remote::{
+    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, is_pipe_io_retryable_error,
+};
 pub use remote::{
     RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface, RemoteTransport,
     RemoteTransportAbort,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6244,6 +6244,25 @@ mod tests {
     }
 
     #[test]
+    fn json_line_reader_preserves_utf8_across_buffer_boundaries() {
+        let input = b"{\"text\":\"\xC3\xA9\"}\n".to_vec();
+        let mut reader = BufReader::with_capacity(1, io::Cursor::new(input));
+        let mut progress = Vec::new();
+
+        let line = read_json_line_with_progress_bounded(
+            &mut reader,
+            &mut |partial| progress.push(partial.to_vec()),
+            64,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(line.as_bytes(), b"{\"text\":\"\xC3\xA9\"}");
+        assert!(progress.iter().any(|partial| partial.ends_with(&[0xC3])));
+        assert_eq!(progress.last().unwrap(), b"{\"text\":\"\xC3\xA9\"}");
+    }
+
+    #[test]
     fn remote_reader_end_reason_distinguishes_eof_from_read_failure() {
         let eof: io::Result<Option<String>> = Ok(None);
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3243,7 +3243,33 @@ impl RemoteSession {
     /// would corrupt the embedder's terminal state (bounded-backpressure
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
-        self.pipe_io_forward_owned(surface, event()).is_ok()
+        use crossbeam_channel::TrySendError;
+        let stalled_token = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return false };
+            if tap.surface != surface {
+                return false;
+            }
+            let event = event();
+            let retained_bytes = event.retained_bytes();
+            if !tap.byte_budget.try_reserve(retained_bytes) {
+                Some(tap.token.clone())
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => None,
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        tap.byte_budget.release(retained_bytes);
+                        Some(tap.token.clone())
+                    }
+                }
+            }
+        };
+        if let Some(token) = stalled_token {
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
+        }
+        true
     }
 
     /// Forwards an already-owned event without cloning its payload. If no

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,7 +7,7 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1698,6 +1698,10 @@ impl PipeIoByteBudget {
         }
     }
 
+    pub(crate) fn exceeds_limit(&self, bytes: usize) -> bool {
+        bytes > self.limit
+    }
+
     pub(crate) fn release(&self, bytes: usize) {
         if bytes == 0 {
             return;
@@ -3259,19 +3263,21 @@ impl RemoteSession {
             let event = event();
             let retained_bytes = event.retained_bytes();
             if !tap.byte_budget.try_reserve(retained_bytes) {
-                Some(tap.token.clone())
+                Some((tap.token.clone(), tap.byte_budget.exceeds_limit(retained_bytes)))
             } else {
                 match tap.sender.try_send(event) {
                     Ok(()) => None,
                     Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
                         tap.byte_budget.release(retained_bytes);
-                        Some(tap.token.clone())
+                        Some((tap.token.clone(), false))
                     }
                 }
             }
         };
-        if let Some(token) = stalled_token {
-            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+        if let Some((token, over_limit)) = stalled_token {
+            let event =
+                if over_limit { PipeIoEvent::StdinError } else { PipeIoEvent::TransportLost };
+            if self.signal_pipe_io_event(Some(surface), Some(&token), event) {
                 self.disconnect_transport();
             }
         }
@@ -3296,22 +3302,24 @@ impl RemoteSession {
             }
             let retained_bytes = event.retained_bytes();
             if !tap.byte_budget.try_reserve(retained_bytes) {
-                Some(tap.token.clone())
+                Some((tap.token.clone(), tap.byte_budget.exceeds_limit(retained_bytes)))
             } else {
                 match tap.sender.try_send(event) {
                     Ok(()) => None,
                     Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
                         tap.byte_budget.release(retained_bytes);
-                        Some(tap.token.clone())
+                        Some((tap.token.clone(), false))
                     }
                 }
             }
         };
-        if let Some(token) = stalled_token {
+        if let Some((token, over_limit)) = stalled_token {
+            let event =
+                if over_limit { PipeIoEvent::StdinError } else { PipeIoEvent::TransportLost };
             // Signal only the tap that observed the stall. A replacement tap
             // may have been installed while this reader thread released the
             // mutex; it must not be torn down by an older relay.
-            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+            if self.signal_pipe_io_event(Some(surface), Some(&token), event) {
                 self.disconnect_transport();
             }
         }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -203,8 +203,15 @@ pub(crate) enum RemoteRequestError {
     Encode(serde_json::Error),
     Transport(io::Error),
     Timeout,
-    Rejected { error: String, code: Option<String>, delivery: Option<ClearHistoryDelivery> },
+    Rejected {
+        error: String,
+        code: Option<String>,
+        delivery: Option<ClearHistoryDelivery>,
+    },
     Shutdown,
+    /// The peer closed the transport. This is retryable for pipe-IO startup,
+    /// unlike a local shutdown initiated by this process.
+    RemoteShutdown,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -240,7 +247,9 @@ impl RemoteRequestError {
 pub(crate) fn is_pipe_io_retryable_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
         if let Some(remote_error) = cause.downcast_ref::<RemoteRequestError>() {
-            return remote_error.is_transport_failure() || remote_error.is_timeout();
+            return remote_error.is_transport_failure()
+                || remote_error.is_timeout()
+                || matches!(remote_error, RemoteRequestError::RemoteShutdown);
         }
         cause.downcast_ref::<io::Error>().is_some_and(|io_error| {
             matches!(
@@ -267,6 +276,9 @@ impl std::fmt::Display for RemoteRequestError {
             Self::Timeout => write!(formatter, "remote session did not respond"),
             Self::Rejected { error, .. } => write!(formatter, "remote command rejected: {error}"),
             Self::Shutdown => write!(formatter, "remote response wait canceled for shutdown"),
+            Self::RemoteShutdown => {
+                write!(formatter, "remote response wait canceled after peer disconnect")
+            }
         }
     }
 }
@@ -2412,8 +2424,13 @@ impl RemoteSession {
                 let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data) else {
                     return;
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 self.log_frame(id, format_args!("output bytes={}", bytes.len()));
+                let bytes = match self.pipe_io_forward_owned(id, PipeIoEvent::Output(bytes)) {
+                    Ok(()) => return,
+                    Err(PipeIoEvent::Output(bytes)) => bytes,
+                    Err(_) => return,
+                };
+                let colors = value.get("colors").and_then(parse_terminal_colors);
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     surface.scan_cursor_provenance(&bytes);
                     let mut term = surface.term.lock().unwrap();
@@ -2819,6 +2836,14 @@ impl RemoteSession {
         self.request_with_deadline(cmd, RequestDeadline::Standard)
     }
 
+    fn shutdown_request_error(&self) -> RemoteRequestError {
+        if matches!(&*self.disconnect_state.lock().unwrap(), DisconnectState::Remote(_)) {
+            RemoteRequestError::RemoteShutdown
+        } else {
+            RemoteRequestError::Shutdown
+        }
+    }
+
     /// Fire-and-forget command: enqueued in order with interactive traffic,
     /// never awaited. Used for best-effort reporting such as client focus.
     pub(crate) fn notify(&self, cmd: Value) -> anyhow::Result<()> {
@@ -2864,7 +2889,7 @@ impl RemoteSession {
 
         if self.shutdown.load(Ordering::Acquire) {
             self.pending.lock().unwrap().remove(&id);
-            return Err(RemoteRequestError::Shutdown.into());
+            return Err(self.shutdown_request_error().into());
         }
 
         let response = match self.wait_for_response(rx, deadline, progress, attach_progress) {
@@ -2911,7 +2936,7 @@ impl RemoteSession {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
                 Err(RecvTimeoutError::Disconnected) if self.shutdown.load(Ordering::Acquire) => {
-                    Err(RemoteRequestError::Shutdown)
+                    Err(self.shutdown_request_error())
                 }
                 Err(RecvTimeoutError::Disconnected) => Err(RemoteRequestError::Timeout),
             };
@@ -2937,13 +2962,13 @@ impl RemoteSession {
             match rx.recv_timeout(wait) {
                 Ok(response) => return Ok(response),
                 Err(RecvTimeoutError::Disconnected) if self.shutdown.load(Ordering::Acquire) => {
-                    return Err(RemoteRequestError::Shutdown);
+                    return Err(self.shutdown_request_error());
                 }
                 Err(RecvTimeoutError::Disconnected) => return Err(RemoteRequestError::Timeout),
                 Err(RecvTimeoutError::Timeout) => {}
             }
             if self.shutdown.load(Ordering::Acquire) {
-                return Err(RemoteRequestError::Shutdown);
+                return Err(self.shutdown_request_error());
             }
         }
     }
@@ -2968,7 +2993,7 @@ impl RemoteSession {
             .map_err(RemoteRequestError::Transport)?;
         if self.shutdown.load(Ordering::Acquire) {
             self.wait_for_ordered_write(sequence).map_err(RemoteRequestError::Transport)?;
-            return Err(RemoteRequestError::Shutdown.into());
+            return Err(self.shutdown_request_error().into());
         }
         Ok(())
     }
@@ -3122,6 +3147,143 @@ impl RemoteSession {
         drop(state);
         self.begin_shutdown();
         self.interactive_writer.close();
+        self.interactive_writer.abort_transport();
+        self.interactive_writer.join_worker();
+        self.join_reader_worker();
+    }
+
+    fn join_reader_worker(&self) {
+        let current = std::thread::current().id();
+        let handle = {
+            let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
+            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                worker.take();
+                return;
+            }
+            worker.take()
+        };
+        if let Some(handle) = handle {
+            if self.reader_completion.wait(remote_write_timeout()) {
+                let _ = handle.join();
+            } else if let Err(handle) = enqueue_worker_reap(handle, self.reader_completion.clone())
+            {
+                *self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner()) =
+                    Some(handle);
+            }
+        }
+    }
+
+    /// Routes one scoped surface's raw byte stream to a `--pipe-io` relay.
+    /// Install before `attach-surface` so the initial replay is not missed.
+    pub(crate) fn install_pipe_io_tap(
+        &self,
+        surface: SurfaceId,
+        sender: EventSender<PipeIoEvent>,
+        lifecycle_sender: EventSender<PipeIoEvent>,
+        byte_budget: Arc<PipeIoByteBudget>,
+    ) -> Arc<u8> {
+        // A non-zero-sized allocation gives each tap a stable identity. A
+        // zero-sized Arc token could share the allocator's dangling pointer.
+        let token = Arc::new(0u8);
+        *self.pipe_io_tap.lock().unwrap() = Some(PipeIoTap {
+            surface,
+            sender,
+            lifecycle_sender,
+            byte_budget,
+            token: token.clone(),
+        });
+        token
+    }
+
+    pub(crate) fn clear_pipe_io_tap(&self, token: &Arc<u8>) {
+        let mut slot = self.pipe_io_tap.lock().unwrap();
+        if slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token)) {
+            slot.take();
+        }
+    }
+
+    fn signal_pipe_io_event(
+        &self,
+        surface: Option<SurfaceId>,
+        token: Option<&Arc<u8>>,
+        event: PipeIoEvent,
+    ) -> bool {
+        let tap = {
+            let mut slot = self.pipe_io_tap.lock().unwrap();
+            if (surface.is_none() || slot.as_ref().is_some_and(|tap| Some(tap.surface) == surface))
+                && token.is_none_or(|token| {
+                    slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token))
+                })
+            {
+                slot.take()
+            } else {
+                None
+            }
+        };
+        if let Some(tap) = tap {
+            // A second lifecycle event is redundant. If the one-slot signal
+            // channel is already occupied, the first event remains the
+            // authoritative reason and still wakes the relay.
+            let _ = tap.lifecycle_sender.try_send(event);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns true while this connection has a raw pipe-IO tap for
+    /// `surface`. The event reader uses this fence to avoid feeding the same
+    /// bytes into the normal local mirror parser as well as the relay.
+    fn pipe_io_owns_surface(&self, surface: SurfaceId) -> bool {
+        self.pipe_io_tap.lock().unwrap().as_ref().is_some_and(|tap| tap.surface == surface)
+    }
+
+    /// Forwards one tap event, treating a full or dropped queue as a lost
+    /// transport: the relay's reader stalled, and silently dropping bytes
+    /// would corrupt the embedder's terminal state (bounded-backpressure
+    /// policy; never wedge the session reader thread).
+    fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
+        self.pipe_io_forward_owned(surface, event()).is_ok()
+    }
+
+    /// Forwards an already-owned event without cloning its payload. If no
+    /// matching tap exists, the event is returned to the caller for normal
+    /// terminal parsing. Once a tap owns the event, queue overflow consumes it
+    /// and tears down that relay, so the caller must not parse it locally.
+    fn pipe_io_forward_owned(
+        &self,
+        surface: SurfaceId,
+        event: PipeIoEvent,
+    ) -> Result<(), PipeIoEvent> {
+        use crossbeam_channel::TrySendError;
+        let stalled_token = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return Err(event) };
+            if tap.surface != surface {
+                return Err(event);
+            }
+            let retained_bytes = event.retained_bytes();
+            if !tap.byte_budget.try_reserve(retained_bytes) {
+                Some(tap.token.clone())
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => None,
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        tap.byte_budget.release(retained_bytes);
+                        Some(tap.token.clone())
+                    }
+                }
+            }
+        };
+        if let Some(token) = stalled_token {
+            // Signal only the tap that observed the stall. A replacement tap
+            // may have been installed while this reader thread released the
+            // mutex; it must not be torn down by an older relay.
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
+        }
+        Ok(())
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -6483,6 +6645,331 @@ mod tests {
         assert!(closed.load(Ordering::Acquire));
     }
 
+    struct LifecycleReader {
+        responses: Receiver<String>,
+        remaining_responses: usize,
+        release: Arc<(Mutex<bool>, Condvar)>,
+        exited: Sender<()>,
+        entered: Option<Sender<()>>,
+        exit_delay: Duration,
+    }
+
+    impl RemoteMessageReader for LifecycleReader {
+        fn receive(&mut self) -> io::Result<Option<String>> {
+            if self.remaining_responses > 0 {
+                self.remaining_responses -= 1;
+                return self.responses.recv().map(Some).map_err(|_| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "lifecycle response channel closed")
+                });
+            }
+
+            let (released, changed) = &*self.release;
+            if let Some(entered) = self.entered.take() {
+                let _ = entered.send(());
+            }
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = changed.wait(released).unwrap();
+            }
+            if !self.exit_delay.is_zero() {
+                std::thread::sleep(self.exit_delay);
+            }
+            self.exited.send(()).unwrap();
+            Ok(None)
+        }
+    }
+
+    struct LifecycleWriter {
+        responses: Sender<String>,
+        closed: Arc<AtomicBool>,
+        exited: Sender<()>,
+    }
+
+    impl RemoteMessageWriter for LifecycleWriter {
+        fn send(&mut self, message: &str) -> io::Result<()> {
+            let request: Value = serde_json::from_str(message).map_err(io::Error::other)?;
+            let id = request
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| io::Error::other("lifecycle request omitted its id"))?;
+            let data = (request.get("cmd").and_then(Value::as_str) == Some("identify"))
+                .then(|| json!({"app": "cmux-tui", "protocol": SUPPORTED_PROTOCOL_VERSION}))
+                .unwrap_or(Value::Null);
+            self.responses
+                .send(json!({"id": id, "ok": true, "data": data}).to_string())
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "lifecycle reader exited"))
+        }
+
+        fn close(&mut self) -> io::Result<()> {
+            self.closed.store(true, Ordering::Release);
+            Ok(())
+        }
+    }
+
+    impl Drop for LifecycleWriter {
+        fn drop(&mut self) {
+            let _ = self.exited.send(());
+        }
+    }
+
+    struct LifecycleAbort {
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl RemoteTransportAbort for LifecycleAbort {
+        fn abort(&self) -> io::Result<()> {
+            let (released, changed) = &*self.release;
+            *released.lock().unwrap() = true;
+            changed.notify_all();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn transport_disconnect_cancels_and_joins_reader_and_writer_workers() {
+        let (responses, response_rx) = channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (reader_exited, reader_exited_rx) = channel();
+        let (writer_exited, writer_exited_rx) = channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let session = RemoteSession::connect_transport(RemoteTransport::new(
+            Box::new(LifecycleReader {
+                responses: response_rx,
+                remaining_responses: 3,
+                release: release.clone(),
+                exited: reader_exited,
+                entered: None,
+                exit_delay: Duration::ZERO,
+            }),
+            Box::new(LifecycleWriter { responses, closed: closed.clone(), exited: writer_exited }),
+            Arc::new(LifecycleAbort { release }),
+        ))
+        .unwrap();
+
+        session.disconnect_transport();
+
+        assert!(closed.load(Ordering::Acquire));
+        reader_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("transport shutdown must cancel the blocked reader");
+        writer_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("transport shutdown must join the writer");
+    }
+
+    #[test]
+    fn dropping_session_waits_for_blocked_reader_worker() {
+        let (responses, response_rx) = channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (reader_entered, reader_entered_rx) = channel();
+        let (reader_exited, reader_exited_rx) = channel();
+        let (writer_exited, _writer_exited_rx) = channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let session = RemoteSession::connect_transport(RemoteTransport::new(
+            Box::new(LifecycleReader {
+                responses: response_rx,
+                remaining_responses: 3,
+                release: release.clone(),
+                exited: reader_exited,
+                entered: Some(reader_entered),
+                exit_delay: Duration::from_millis(50),
+            }),
+            Box::new(LifecycleWriter { responses, closed, exited: writer_exited }),
+            Arc::new(LifecycleAbort { release }),
+        ))
+        .unwrap();
+        reader_entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("reader did not reach its blocked receive");
+
+        let started = Instant::now();
+        drop(session);
+        assert!(
+            started.elapsed() >= Duration::from_millis(40),
+            "dropping the session returned before the reader worker exited"
+        );
+        reader_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("reader worker did not exit before session drop returned");
+    }
+
+    #[test]
+    fn worker_reaper_returns_ownership_when_queue_is_saturated() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(0);
+        let completion = Arc::new(WorkerCompletion::new());
+        let handle = std::thread::spawn(|| {});
+        let returned = try_enqueue_worker_reap(&sender, handle, completion)
+            .expect_err("a zero-capacity queue must return the handle");
+        drop(receiver);
+        returned.join().expect("returned worker handle remains joinable");
+    }
+
+    #[test]
+    fn worker_reaper_returns_ownership_when_queue_is_disconnected() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        drop(receiver);
+        let completion = Arc::new(WorkerCompletion::new());
+        let handle = std::thread::spawn(|| {});
+        let returned = try_enqueue_worker_reap(&sender, handle, completion)
+            .expect_err("a disconnected queue must return the handle");
+        returned.join().expect("returned worker handle remains joinable");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn malformed_json_cancels_a_pending_request_and_preserves_decode_reason() {
+        let (client, server) = UnixStream::pair().unwrap();
+        let (release_tx, release_rx) = channel();
+        let peer = std::thread::spawn(move || {
+            let mut peer = BufReader::new(server);
+            for expected_command in ["identify", "set-client-info", "subscribe"] {
+                let mut line = String::new();
+                peer.read_line(&mut line).unwrap();
+                let request: Value = serde_json::from_str(&line).unwrap();
+                assert_eq!(request["cmd"], expected_command);
+                let data = if expected_command == "identify" {
+                    json!({
+                        "app": "cmux-tui",
+                        "protocol": SUPPORTED_PROTOCOL_VERSION,
+                        "capabilities": ["browser-pointer-frame-guard-v1"],
+                    })
+                } else {
+                    Value::Null
+                };
+                writeln!(
+                    peer.get_mut(),
+                    "{}",
+                    json!({"id": request["id"], "ok": true, "data": data})
+                )
+                .unwrap();
+            }
+
+            let mut line = String::new();
+            peer.read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(&line).unwrap();
+            assert_eq!(request["cmd"], "wait-for-malformed");
+            peer.get_mut().write_all(b"not-json\n").unwrap();
+            release_rx.recv().unwrap();
+        });
+        let session = RemoteSession::connect_stream(Box::new(client)).unwrap();
+        let request_session = session.clone();
+        let (done_tx, done_rx) = channel();
+        let request = std::thread::spawn(move || {
+            done_tx.send(request_session.request(json!({"cmd": "wait-for-malformed"}))).unwrap();
+        });
+
+        let result = match done_rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(error) => {
+                session.begin_shutdown();
+                request.join().unwrap();
+                release_tx.send(()).unwrap();
+                peer.join().unwrap();
+                panic!("malformed JSON did not cancel the request promptly: {error}");
+            }
+        };
+        request.join().unwrap();
+        release_tx.send(()).unwrap();
+        peer.join().unwrap();
+
+        let error = result.unwrap_err();
+        assert!(
+            matches!(
+                error.downcast_ref::<RemoteRequestError>(),
+                Some(RemoteRequestError::RemoteShutdown)
+            ),
+            "expected shutdown after malformed JSON canceled the request, got {error:?}"
+        );
+        assert!(
+            session
+                .transport_disconnect_reason()
+                .is_some_and(|reason| reason.starts_with("remote JSON decode failed:")),
+            "malformed JSON decode reason was not preserved: {:?}",
+            session.transport_disconnect_reason()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn full_pipe_io_queue_signals_loss_on_the_reserved_lifecycle_channel() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"first".to_vec()));
+        // The byte queue is full. The second event must force a transport
+        // loss, and that lifecycle signal must remain observable even though
+        // no byte-queue slot is available.
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"second".to_vec()));
+
+        assert_eq!(
+            lifecycle_receiver.recv_timeout(Duration::from_secs(1)).unwrap(),
+            PipeIoEvent::TransportLost
+        );
+        assert!(session.pipe_io_tap.lock().unwrap().is_none());
+        assert!(session.shutdown.load(Ordering::Acquire));
+        assert_eq!(receiver.try_recv().unwrap(), PipeIoEvent::Output(b"first".to_vec()));
+    }
+
+    #[test]
+    fn pipe_io_forward_does_not_build_payload_without_matching_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let built = Arc::new(AtomicBool::new(false));
+        let built_by_event = built.clone();
+
+        assert!(!session.pipe_io_forward(7, || {
+            built_by_event.store(true, Ordering::Release);
+            PipeIoEvent::Output(vec![0; 1024])
+        }));
+        assert!(!built.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn stale_pipe_io_tap_cleanup_cannot_remove_a_replacement() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (first_sender, _first_receiver) = crossbeam_channel::bounded(1);
+        let (first_lifecycle_sender, _first_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let first_token = session.install_pipe_io_tap(
+            7,
+            first_sender,
+            first_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        let (second_sender, second_receiver) = crossbeam_channel::bounded(1);
+        let (second_lifecycle_sender, _second_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let second_token = session.install_pipe_io_tap(
+            7,
+            second_sender,
+            second_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.clear_pipe_io_tap(&first_token);
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"replacement".to_vec()));
+
+        assert!(Arc::ptr_eq(
+            &session.pipe_io_tap.lock().unwrap().as_ref().unwrap().token,
+            &second_token
+        ));
+        assert_eq!(
+            second_receiver.try_recv().unwrap(),
+            PipeIoEvent::Output(b"replacement".to_vec())
+        );
+    }
+
     #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {
@@ -7106,7 +7593,7 @@ mod tests {
         assert!(
             matches!(
                 error.downcast_ref::<RemoteRequestError>(),
-                Some(RemoteRequestError::Shutdown)
+                Some(RemoteRequestError::RemoteShutdown)
             ),
             "expected shutdown after EOF canceled the request, got {error:?}"
         );

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use cmux_tui_core::server::{VIEWPORT_COLUMN_RESIZE_CAPABILITY, VIEWPORT_SPLITS_CAPABILITY};
 use cmux_tui_core::{
@@ -234,6 +235,28 @@ impl RemoteRequestError {
             _ => None,
         }
     }
+}
+
+pub(crate) fn is_pipe_io_retryable_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        if let Some(remote_error) = cause.downcast_ref::<RemoteRequestError>() {
+            return remote_error.is_transport_failure() || remote_error.is_timeout();
+        }
+        cause.downcast_ref::<io::Error>().is_some_and(|io_error| {
+            matches!(
+                io_error.kind(),
+                io::ErrorKind::ConnectionRefused
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::UnexpectedEof
+                    | io::ErrorKind::TimedOut
+                    | io::ErrorKind::NotConnected
+                    | io::ErrorKind::WouldBlock
+                    | io::ErrorKind::Interrupted
+                    | io::ErrorKind::NotFound
+            )
+        })
+    })
 }
 
 impl std::fmt::Display for RemoteRequestError {
@@ -1870,14 +1893,41 @@ impl RemoteSession {
     }
 
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
-        let stream = transport::connect(path).map_err(|e| {
-            anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
-        })?;
-        if subscribe {
-            Self::connect_stream(stream)
-        } else {
-            Self::connect_stream_with_subscription(stream, false)
-        }
+        let stream = transport::connect(path)
+            .with_context(|| format!("cannot connect to session socket {}", path.display()))?;
+        Self::connect_stream_with_subscription(stream, subscribe)
+    }
+
+    fn connect_path_until(
+        path: &Path,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let path_for_thread = path.to_path_buf();
+        let display = path.display().to_string();
+        let (sender, receiver) = sync_channel(1);
+        let connector =
+            std::thread::Builder::new().name("remote-probe-connect".into()).spawn(move || {
+                let _ = sender.send(transport::connect(&path_for_thread));
+            })?;
+        let stream = match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        {
+            Ok(result) => {
+                let _ = connector.join();
+                result.with_context(|| format!("cannot connect to session socket {display}"))?
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let _ = connector.join();
+                anyhow::bail!("remote probe connector stopped without a result")
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                // The pipe-io process exits after classification. Dropping the
+                // connector lets that process terminate any blocked connect.
+                drop(connector);
+                anyhow::bail!(RemoteRequestError::Timeout)
+            }
+        };
+        Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
     }
 
     /// Connect over an already-established full-duplex byte stream.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
@@ -2198,7 +2198,7 @@ impl RemoteSession {
     }
 
     /// Pipe-IO requires the daemon's attach-time geometry handshake so the
-    /// initial replay is rendered for the embedder's requested dimensions.
+    /// initial replay uses the embedder's requested dimensions.
     pub(crate) fn supports_pipe_io_initial_size(&self) -> bool {
         self.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY)
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1622,6 +1622,96 @@ pub struct RemoteSession {
     capabilities: Mutex<HashSet<String>>,
     provider_workspace_authority: Option<BearerToken>,
     provider_workspaces_guarded: AtomicBool,
+    pipe_io_tap: Mutex<Option<PipeIoTap>>,
+}
+
+/// One event on the raw byte stream a `--pipe-io` relay serves to its
+/// embedder. `Replay` REPLACES all prior terminal state (the relay must
+/// emit a full reset before any replay that is not its first output);
+/// `Output` appends live PTY bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoEvent {
+    Replay { bytes: Vec<u8> },
+    Output(Vec<u8>),
+    SurfaceExited,
+    TransportLost,
+    StdinClosed,
+    StdinError,
+}
+
+impl PipeIoEvent {
+    /// Bytes retained by the relay's bounded data queue. Lifecycle signals
+    /// have a separate one-slot channel and carry no retained payload.
+    pub(crate) fn retained_bytes(&self) -> usize {
+        match self {
+            Self::Replay { bytes } | Self::Output(bytes) => bytes.len(),
+            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed | Self::StdinError => 0,
+        }
+    }
+}
+
+/// Shared byte budget for one pipe-IO relay. A count-only bounded channel can
+/// retain megabytes per event when a replay is large; this budget makes the
+/// memory bound explicit and turns an overrun into the same transport-loss
+/// path as a full channel.
+pub(crate) struct PipeIoByteBudget {
+    retained: AtomicUsize,
+    limit: usize,
+}
+
+impl PipeIoByteBudget {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self { retained: AtomicUsize::new(0), limit: limit.max(1) }
+    }
+
+    pub(crate) fn try_reserve(&self, bytes: usize) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+        let mut current = self.retained.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(bytes) else { return false };
+            if next > self.limit {
+                return false;
+            }
+            match self.retained.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    pub(crate) fn release(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        let mut current = self.retained.load(Ordering::Acquire);
+        loop {
+            let next = current.saturating_sub(bytes);
+            match self.retained.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+struct PipeIoTap {
+    surface: SurfaceId,
+    sender: EventSender<PipeIoEvent>,
+    lifecycle_sender: EventSender<PipeIoEvent>,
+    byte_budget: Arc<PipeIoByteBudget>,
+    token: Arc<u8>,
 }
 
 pub(super) enum RemoteSurfaceAttach {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2197,6 +2197,12 @@ impl RemoteSession {
         self.capabilities.lock().unwrap().contains(capability)
     }
 
+    /// Pipe-IO requires the daemon's attach-time geometry handshake so the
+    /// initial replay is rendered for the embedder's requested dimensions.
+    pub(crate) fn supports_pipe_io_initial_size(&self) -> bool {
+        self.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY)
+    }
+
     pub fn supports_surface_subscription_filter(&self) -> bool {
         self.supports_capability(cmux_tui_core::server::SURFACE_SUBSCRIBE_FILTER_CAPABILITY)
     }
@@ -4757,6 +4763,18 @@ mod tests {
         }));
         require_capability(&with_key_fallback, CLEAR_HISTORY_KEY_CAPABILITY, "clear-history")
             .unwrap();
+    }
+
+    #[test]
+    fn pipe_io_initial_size_requires_atomic_attach_capability() {
+        let without = test_session_with_provider_context(None, HashSet::new());
+        assert!(!without.supports_pipe_io_initial_size());
+
+        let with = test_session_with_provider_context(
+            None,
+            HashSet::from([cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY.to_string()]),
+        );
+        assert!(with.supports_pipe_io_initial_size());
     }
 
     #[test]


### PR DESCRIPTION
Replacement for the pipe-IO portion of #11705, rebased onto current main 31f1ffc.

Adds a narrow RemoteSession capability contract so pipe_io does not call a private method. Pipe-IO exits setup-failed when attach-time geometry is unavailable, preventing an initial replay with stale dimensions. Includes behavior coverage for capability gating.

Static checks: rustfmt, git diff --check. Hosted cmux-tui checks remain required.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a renderer-less `--pipe-io` relay for embedded terminal attachments and now requires the daemon’s atomic attach-time sizing capability. Previously, pipe-IO could attach without it and replay stale dimensions; it now exits `setup-failed` instead, while daemon transport loss remains respawnable.

**Behavior**
- Relays replay and live VT bytes on stdout and accepts base64 input, resize, and geometry-claim JSON lines on stdin.
- Emits one final machine-readable exit record on stderr; exit code 0 means do not respawn and 2 means daemon loss may be retried.
- Distinguishes terminal, parent, setup, and transport failures, with bounded input and output buffering classifying malformed requests, non-retryable resize errors, and replay overflow as non-respawnable failures.

<sup>Written for commit eee58a9cc431a9127565d561265347ebdfca50f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11735?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pipe I/O mode for terminal attachments, enabling embedders to send input, resize surfaces, claim geometry, and receive terminal output as raw bytes.
  * Added replay and live output streaming with terminal reset handling for reconnects.
  * Added bounded buffering to help prevent unresponsive or overloaded connections.
* **Bug Fixes**
  * Improved handling of terminal, daemon, parent, and setup failures with machine-readable exit reasons and appropriate exit codes.
  * Improved transport shutdown and retry behavior for disconnected sessions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->