### PR TITLE
docs(tui): align protocol inventory metadata with v12

### DIFF
--- a/cmux-tui/scripts/test_check_spec_inventory.py
+++ b/cmux-tui/scripts/test_check_spec_inventory.py
@@ -619,6 +619,41 @@ class InventoryContractTests(unittest.TestCase):
     def inventory(self) -> dict:
         return json.loads((CHECKER.SPEC / "inventory.json").read_text())
 
+    def test_private_protocol_domain_ids_match_inventory_version(self) -> None:
+        inventory = self.inventory()
+        private_domains = {
+            domain["id"]
+            for domain in inventory["protocol_domains"]
+            if domain["spec"] in {"commands.md", "events.md"}
+        }
+        expected = {
+            f"mux-control-v{inventory['mux_protocol']}",
+            f"mux-events-v{inventory['mux_protocol']}",
+        }
+        self.assertEqual(private_domains, expected)
+
+    def test_merged_terminal_shortcuts_head_is_not_pending(self) -> None:
+        inventory = self.inventory()
+        pending_urls = {head["url"] for head in inventory["pending_heads"]}
+        self.assertNotIn(
+            "https://github.com/manaflow-ai/cmux/pull/8698",
+            pending_urls,
+        )
+
+    def test_programmability_prose_uses_current_protocol_and_no_pending_8698(self) -> None:
+        inventory = self.inventory()
+        prose = (CHECKER.SPEC / "programmability.md").read_text()
+        self.assertIn(
+            f"The implemented v{inventory['mux_protocol']} inventory",
+            prose,
+        )
+        pending_8698_lines = [
+            line
+            for line in prose.splitlines()
+            if "8698" in line and "pending" in line
+        ]
+        self.assertEqual(pending_8698_lines, [])
+
     def test_command_profile_drift_is_rejected(self) -> None:
         inventory = copy.deepcopy(self.inventory())
         inventory["commands"]["local-admin"].remove("shutdown-daemon")

--- a/cmux-tui/scripts/test_check_spec_inventory.py
+++ b/cmux-tui/scripts/test_check_spec_inventory.py
@@ -654,6 +654,30 @@ class InventoryContractTests(unittest.TestCase):
         ]
         self.assertEqual(pending_8698_lines, [])
 
+        # The history section is the human-readable status record for the
+        # merged head. Keep the feature names and their implemented status in
+        # the contract so a version-only edit cannot silently erase them.
+        history = " ".join(prose.split("## Protocol head history", 1)[1].split())
+        self.assertIn(
+            "clear-history and structured shortcut work is now represented in "
+            "the implemented command and action inventory",
+            history,
+        )
+
+        commands = set(inventory["commands"]["control"])
+        self.assertIn("clear-history", commands)
+        actions = {action["key"]: action for action in inventory["tui_actions"]}
+        self.assertEqual(actions["clear-history"]["variant"], "ClearHistory")
+        self.assertEqual(actions["clear-history"]["classification"], "direct")
+        self.assertEqual(actions["clear-history"]["route"], "clear-history")
+        self.assertEqual(actions["show-shortcuts"]["variant"], "ShowShortcuts")
+        self.assertEqual(
+            actions["show-shortcuts"]["classification"], "presentation-only"
+        )
+        self.assertEqual(
+            actions["show-shortcuts"]["route"], "frontend shortcut overlay"
+        )
+
     def test_command_profile_drift_is_rejected(self) -> None:
         inventory = copy.deepcopy(self.inventory())
         inventory["commands"]["local-admin"].remove("shutdown-daemon")

--- a/cmux-tui/spec/inventory.json
+++ b/cmux-tui/spec/inventory.json
@@ -1376,12 +1376,12 @@
   },
   "protocol_domains": [
     {
-      "id": "mux-control-v10",
+      "id": "mux-control-v12",
       "status": "implemented",
       "spec": "commands.md"
     },
     {
-      "id": "mux-events-v10",
+      "id": "mux-events-v12",
       "status": "implemented",
       "spec": "events.md"
     },

--- a/cmux-tui/spec/programmability.md
+++ b/cmux-tui/spec/programmability.md
@@ -47,7 +47,7 @@ unknown ownership signal rejects the action instead of selecting either route.
 
 ## Required vNext primitives
 
-The implemented v10 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key remains a stable legacy alias for the terminal-host-v4 daemon message catalog. The protocol-domain row and [`terminal-host.md`](terminal-host.md) describe that daemon v4 contract; the current cross-language renderer is v3. Renderer attach to a newly launched host is not a supported route until renderer v4 support or explicit mutually supported version negotiation exists. The following primitives are required before the affected feature family can claim portable automation completeness.
+The implemented v12 inventory is complete as a description of current wire behavior. The machine-readable `secondary_protocols.terminal_host_v1` key remains a stable legacy alias for the terminal-host-v4 daemon message catalog. The protocol-domain row and [`terminal-host.md`](terminal-host.md) describe that daemon v4 contract; the current cross-language renderer is v3. Renderer attach to a newly launched host is not a supported route until renderer v4 support or explicit mutually supported version negotiation exists. The following primitives are required before the affected feature family can claim portable automation completeness.
 
 | Feature family | Current route | Required addition |
 | --- | --- | --- |


### PR DESCRIPTION
## Summary

- align private protocol-domain IDs with the inventory's mux protocol v12
- update programmability documentation to describe the implemented v12 inventory
- add focused inventory contract tests for protocol IDs, merged pending heads, and current prose

## Validation

- `python3 -m unittest scripts.test_check_spec_inventory -q`
- `git diff --check`

This is a fresh current-main replacement for the metadata portion of #10242. It does not include the old cumulative release changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the TUI spec inventory's private protocol-domain IDs with mux protocol v12 and updates the programmability docs to match, with new contract tests keeping the metadata in sync.

- Renames `mux-control-v10`/`mux-events-v10` to `mux-control-v12`/`mux-events-v12` in `inventory.json`.
- `programmability.md` now references the implemented v12 inventory and drops pending references to PR 8698.
- Tests assert the domain IDs match the inventory's `mux_protocol`, the merged shortcuts head is no longer pending, and `clear-history`/`show-shortcuts` remain in the implemented inventory.

<sup>Written for commit a1c502afc93d2dad72391d74b21085c4de0f25b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated programmability documentation to reference protocol version v12.
  * Clarified the current protocol inventory for mux control and event domains.

* **Tests**
  * Added checks to verify protocol domain versions match the inventory.
  * Added validation that merged terminal shortcut changes are no longer pending.
  * Added checks ensuring documentation does not reference outdated pending work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->