### PR TITLE
ci: report ignored-only focused filters

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -489,7 +489,7 @@ jobs:
           ignored_listing="$RUNNER_TEMP/cmux-tui-focused-ignored-list.txt"
           cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored > "$ignored_listing"
           grep -E ': test$' "$ignored_listing" | sort > "$ignored_names" || [[ "$?" -eq 1 ]]
-          if [[ -s "$normal_names" && -s "$ignored_names" ]] && cmp -s "$normal_names" "$ignored_names"; then
+          if [[ ! -s "$normal_names" && -s "$ignored_names" ]]; then
             echo "::error::test_filter '$TEST_FILTER' matches only ignored tests" >&2
             exit 1
           fi

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "cmux-tui.yml"
+
+
+def test_focused_filter_rejects_ignored_only_matches() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'if [[ ! -s "$normal_names" && -s "$ignored_names" ]]; then' in workflow
+    assert 'if [[ -s "$normal_names" && -s "$ignored_names" ]] && cmp -s' not in workflow


### PR DESCRIPTION
## Summary

- fail focused cmux-tui verification when the selector matches ignored tests but no normal tests
- add a regression guard for the workflow condition

## Validation

- `python3 -m pytest -q tests/test_tui_focused_filter_guard.py`
- `git diff --check`

This is a fresh current-main replacement for #11655. It keeps the original scope and has two commits so the regression test is visible before the fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fails focused cmux-tui CI verification when the test filter matches ignored tests but no normal tests. Previously the workflow errored only when the matched normal and ignored test lists were identical; now it also errors when the filter matches only ignored tests. Adds a regression test that reads the workflow file and pins the new condition in place.

<sup>Written for commit f0d91b8f7541d1c7fb3bc44b77587608c12ca093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11739?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

