### PR TITLE
fix(tui): reconcile every PyPI wheel after upload

### DIFF
--- a/.github/workflows/cmux-tui-nightly.yml
+++ b/.github/workflows/cmux-tui-nightly.yml
@@ -219,3 +219,8 @@ jobs:
         with:
           packages-dir: dist
           attestations: true
+
+      - name: Verify every nightly PyPI wheel after upload
+        env:
+          VERSION: ${{ needs.version.outputs.pypi_version }}
+        run: bash cmux-tui/scripts/verify-pypi-tui-upload.sh dist "$VERSION"

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "cmux-tui/**"
+      - "cmux-tui/scripts/verify-pypi-tui-upload.sh"
       - ".github/actions/setup-cmux-tui-rust/**"
       - ".github/workflows/cmux-tui-artifacts.yml"
       - ".github/workflows/cmux-tui-build-package.yml"
@@ -36,6 +37,7 @@ on:
   pull_request:
     paths:
       - "cmux-tui/**"
+      - "cmux-tui/scripts/verify-pypi-tui-upload.sh"
       - ".github/actions/setup-cmux-tui-rust/**"
       - ".github/workflows/cmux-tui-artifacts.yml"
       - ".github/workflows/cmux-tui-build-package.yml"

--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -29,6 +29,7 @@ on:
       - ".github/workflows/tui-publish-pypi.yml"
       - "tests/test_tui_installers.py"
       - "tests/test_tui_publish_workflow_security.py"
+      - "tests/test_tui_pypi_postpublish_reconcile.sh"
       - "tests/test_tui_npm_package_artifact.py"
       - "tests/test_tui_package_contract.py"
       - "web/public/tui/install-static.ps1"
@@ -58,6 +59,7 @@ on:
       - ".github/workflows/tui-publish-pypi.yml"
       - "tests/test_tui_installers.py"
       - "tests/test_tui_publish_workflow_security.py"
+      - "tests/test_tui_pypi_postpublish_reconcile.sh"
       - "tests/test_tui_npm_package_artifact.py"
       - "tests/test_tui_package_contract.py"
       - "web/public/tui/install-static.ps1"
@@ -129,6 +131,9 @@ jobs:
 
       - name: Test SDK publishing workflow guards
         run: python3 tests/test_tui_publish_workflow_security.py -v
+
+      - name: Test PyPI post-upload reconciliation helper
+        run: bash tests/test_tui_pypi_postpublish_reconcile.sh
 
       - name: Test TUI package artifact contract
         run: python3 tests/test_tui_package_contract.py

--- a/.github/workflows/tui-publish-pypi.yml
+++ b/.github/workflows/tui-publish-pypi.yml
@@ -171,3 +171,8 @@ jobs:
         with:
           packages-dir: dist
           attestations: true
+
+      - name: Verify every PyPI wheel after upload
+        env:
+          VERSION: ${{ inputs.version }}
+        run: bash cmux-tui/scripts/verify-pypi-tui-upload.sh dist "$VERSION"

--- a/cmux-tui/scripts/verify-pypi-tui-upload.sh
+++ b/cmux-tui/scripts/verify-pypi-tui-upload.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <wheel-directory> <version>" >&2
+}
+
+if [[ $# -ne 2 ]]; then
+  usage
+  exit 2
+fi
+
+wheel_directory="$1"
+version="$2"
+if [[ ! -d "$wheel_directory" ]]; then
+  echo "PyPI wheel directory does not exist: $wheel_directory" >&2
+  exit 1
+fi
+if [[ -z "$version" ]]; then
+  echo "PyPI version must not be empty" >&2
+  exit 1
+fi
+
+script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+reconciler="$script_directory/../bindings/reconcile_registry_artifact.py"
+if [[ ! -f "$reconciler" ]]; then
+  echo "PyPI reconciler does not exist: $reconciler" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+wheels=("$wheel_directory"/*.whl)
+if [[ "${#wheels[@]}" -ne 6 ]]; then
+  echo "expected six immutable PyPI wheels, found ${#wheels[@]}" >&2
+  exit 1
+fi
+
+allowed_arguments=()
+for wheel in "${wheels[@]}"; do
+  allowed_arguments+=(--allowed-artifact "$wheel")
+done
+
+for wheel in "${wheels[@]}"; do
+  python3 "$reconciler" check \
+    --registry pypi \
+    --package cmux \
+    --version "$version" \
+    --artifact "$wheel" \
+    "${allowed_arguments[@]}" \
+    --wait-seconds 120 \
+    --require-match
+done

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1436,6 +1436,61 @@ def test_stable_pypi_publish_is_not_triggered_directly_by_a_tag() -> None:
     assert "push:\n    tags:" not in text
 
 
+def test_tui_pypi_publishers_reconcile_every_wheel_after_upload() -> None:
+    cases = (
+        (
+            "tui-publish-pypi.yml",
+            "publish",
+            "Publish package distributions to PyPI",
+            "Verify every PyPI wheel after upload",
+            "${{ inputs.version }}",
+        ),
+        (
+            "cmux-tui-nightly.yml",
+            "publish-pypi",
+            "Publish nightly package distributions to PyPI",
+            "Verify every nightly PyPI wheel after upload",
+            "${{ needs.version.outputs.pypi_version }}",
+        ),
+    )
+
+    for name, job_name, publish_name, verify_name, version in cases:
+        document = yaml.load(workflow(name), Loader=yaml.BaseLoader)
+        assert isinstance(document, dict)
+        jobs = document.get("jobs")
+        assert isinstance(jobs, dict)
+        job = jobs.get(job_name)
+        assert isinstance(job, dict)
+        steps = job.get("steps")
+        assert isinstance(steps, list)
+        names = [step.get("name", "") for step in steps]
+        publish_index = names.index(publish_name)
+        verify_index = names.index(verify_name)
+        assert publish_index < verify_index
+        assert verify_index == len(steps) - 1
+
+        verify_step = steps[verify_index]
+        assert isinstance(verify_step, dict)
+        assert verify_step.get("env", {}).get("VERSION") == version
+        run = verify_step.get("run", "")
+        assert "bash cmux-tui/scripts/verify-pypi-tui-upload.sh dist \"$VERSION\"" in run
+        assert "secrets." not in run
+        assert "gh-action-pypi-publish" not in run
+        assert "twine " not in run
+
+
+def test_tui_pypi_reconciliation_behavior_test_is_in_tui_ci() -> None:
+    text = workflow("cmux-tui-sdks.yml")
+    triggers = workflow_triggers(text)
+    for event in ("push", "pull_request"):
+        event_config = triggers[event]
+        assert isinstance(event_config, dict)
+        paths = event_config["paths"]
+        assert isinstance(paths, list)
+        assert "tests/test_tui_pypi_postpublish_reconcile.sh" in paths
+    assert "run: bash tests/test_tui_pypi_postpublish_reconcile.sh" in text
+
+
 def test_npm_publishers_pin_the_oidc_capable_npm_version() -> None:
     for name in (
         "tui-publish-npm.yml",

--- a/tests/test_tui_pypi_postpublish_reconcile.sh
+++ b/tests/test_tui_pypi_postpublish_reconcile.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+HELPER="$ROOT_DIR/cmux-tui/scripts/verify-pypi-tui-upload.sh"
+[[ -x "$HELPER" ]] || {
+  echo "missing executable PyPI reconciliation helper: $HELPER" >&2
+  exit 1
+}
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/cmux-tui-pypi-reconcile.XXXXXX")"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+wheel_directory="$tmp_dir/dist"
+stub_directory="$tmp_dir/bin"
+calls="$tmp_dir/calls"
+artifacts="$tmp_dir/artifacts"
+counter="$tmp_dir/counter"
+expected_wheels=()
+mkdir -p "$wheel_directory" "$stub_directory"
+
+for wheel in \
+  cmux-1.2.3-py3-none-macosx_11_0_arm64.whl \
+  cmux-1.2.3-py3-none-macosx_10_12_x86_64.whl \
+  cmux-1.2.3-py3-none-manylinux_2_17_x86_64.whl \
+  cmux-1.2.3-py3-none-musllinux_1_2_x86_64.whl \
+  cmux-1.2.3-py3-none-manylinux_2_17_aarch64.whl \
+  cmux-1.2.3-py3-none-musllinux_1_2_aarch64.whl; do
+  : >"$wheel_directory/$wheel"
+  expected_wheels+=("$wheel_directory/$wheel")
+done
+
+cat >"$stub_directory/python3" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${CALL_LOG:?}"
+: "${ARTIFACT_LOG:?}"
+printf '%s\n' "$*" >>"$CALL_LOG"
+
+previous=""
+artifact=""
+for argument in "$@"; do
+  if [[ "$previous" == "--artifact" ]]; then
+    artifact="$argument"
+  fi
+  if [[ "$argument" == "publish" ]]; then
+    echo "the check helper must never invoke publish mode" >&2
+    exit 9
+  fi
+  previous="$argument"
+done
+printf '%s\n' "$artifact" >>"$ARTIFACT_LOG"
+
+if [[ -n "${FAIL_AT:-}" ]]; then
+  : "${CALL_COUNT:?}"
+  count=0
+  if [[ -f "$CALL_COUNT" ]]; then
+    count="$(<"$CALL_COUNT")"
+  fi
+  count=$((count + 1))
+  printf '%s\n' "$count" >"$CALL_COUNT"
+  if [[ "$count" -eq "$FAIL_AT" ]]; then
+    exit 7
+  fi
+fi
+EOF
+chmod +x "$stub_directory/python3"
+
+CALL_LOG="$calls" \
+ARTIFACT_LOG="$artifacts" \
+PATH="$stub_directory:$PATH" \
+  "$HELPER" "$wheel_directory" 1.2.3
+
+[[ "$(wc -l <"$calls" | tr -d '[:space:]')" == 6 ]] || {
+  echo "expected one reconciliation call per wheel" >&2
+  exit 1
+}
+while IFS= read -r invocation; do
+  for wheel in "${expected_wheels[@]}"; do
+    [[ "$invocation" == *"$(basename "$wheel")"* ]] || {
+      echo "reconciliation omitted wheel $(basename "$wheel")" >&2
+      exit 1
+    }
+  done
+  [[ "$invocation" == *"--registry pypi"* ]] || exit 1
+  [[ "$invocation" == *"--package cmux"* ]] || exit 1
+  [[ "$invocation" == *"--version 1.2.3"* ]] || exit 1
+  [[ "$invocation" == *"--wait-seconds 120"* ]] || exit 1
+  [[ "$invocation" == *"--require-match"* ]] || exit 1
+  [[ "$(grep -o -- '--allowed-artifact' <<<"$invocation" | wc -l | tr -d '[:space:]')" == 6 ]] || exit 1
+done <"$calls"
+for wheel in "$wheel_directory"/*.whl; do
+  grep -Fxq "$wheel" "$artifacts" || {
+    echo "wheel was not reconciled: $wheel" >&2
+    exit 1
+  }
+done
+
+missing_wheel="$wheel_directory/cmux-1.2.3-py3-none-musllinux_1_2_aarch64.whl"
+rm "$missing_wheel"
+: >"$calls"
+: >"$artifacts"
+if CALL_LOG="$calls" \
+  ARTIFACT_LOG="$artifacts" \
+  PATH="$stub_directory:$PATH" \
+  "$HELPER" "$wheel_directory" 1.2.3 \
+  >"$tmp_dir/missing.stdout" 2>"$tmp_dir/missing.stderr"; then
+  echo "helper accepted a release with fewer than six wheels" >&2
+  exit 1
+fi
+[[ ! -s "$calls" ]] || {
+  echo "helper invoked the reconciler before rejecting the wheel count" >&2
+  exit 1
+}
+grep -Fq "expected six immutable PyPI wheels" "$tmp_dir/missing.stderr"
+
+: >"$missing_wheel"
+: >"$calls"
+: >"$artifacts"
+: >"$counter"
+if CALL_LOG="$calls" \
+  ARTIFACT_LOG="$artifacts" \
+  CALL_COUNT="$counter" \
+  FAIL_AT=3 \
+  PATH="$stub_directory:$PATH" \
+  "$HELPER" "$wheel_directory" 1.2.3 \
+  >"$tmp_dir/failure.stdout" 2>"$tmp_dir/failure.stderr"; then
+  echo "helper ignored a failed reconciliation" >&2
+  exit 1
+fi
+[[ "$(wc -l <"$artifacts" | tr -d '[:space:]')" == 3 ]] || {
+  echo "helper did not stop after a failed reconciliation" >&2
+  exit 1
+}
+
+echo "PASS: PyPI post-upload helper reconciles every wheel and fails closed"


### PR DESCRIPTION
## Summary

Add a shared post-upload check to the stable and nightly cmux-tui PyPI publishers. The helper requires exactly six local wheels, passes the complete wheel set to the existing PyPI registry reconciler, waits up to 120 seconds per wheel for propagation, and requires `MATCH`. The check uses PyPI's public JSON metadata and never republishes.

The behavior test runs the helper with a fake Python reconciler and proves one check call per wheel, the complete allowed set, check-only mode, fail-closed wheel counts, and fail-fast errors.

## Regression sequence

- `cdc323c17ec` adds the failing behavior and workflow contract tests.
- `3cdefa40903` adds the helper and publisher steps.

## Verification

- `bash tests/test_tui_pypi_postpublish_reconcile.sh`
- `shellcheck cmux-tui/scripts/verify-pypi-tui-upload.sh tests/test_tui_pypi_postpublish_reconcile.sh`
- `actionlint .github/workflows/tui-publish-pypi.yml .github/workflows/cmux-tui-nightly.yml .github/workflows/cmux-tui-sdks.yml`
- `python3 -m pytest -q tests/test_tui_publish_workflow_security.py tests/test_tui_package_contract.py tests/test_tui_npm_package_artifact.py` (71 passed)
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stable and nightly `cmux` PyPI publishers now reconcile all six uploaded wheels with PyPI after upload instead of trusting upload success, and fail if any wheel doesn't match. The check waits up to 120 seconds for propagation, runs in check-only mode, and never republishes artifacts.

**Checks**

- The helper fails closed on an incomplete wheel set and stops at the first failed check.
- TUI CI runs the behavior and workflow contract tests.
- The SDK workflow triggers when the verifier or its test changes.

<sup>Written for commit b1348126941eaad0f921b383676a79d5be03d72a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Reliability**
  * PyPI releases now verify that all expected wheels are uploaded and match the published version.
  * Releases fail safely when wheels are missing or post-upload verification cannot be completed.

* **Tests**
  * Added automated checks for stable and nightly publishing workflows.
  * Added end-to-end coverage for successful verification, incomplete uploads, and reconciliation failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->