### PR TITLE
fix(ci): detect ignored-only TUI test filters reliably

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -489,7 +489,9 @@ jobs:
           ignored_listing="$RUNNER_TEMP/cmux-tui-focused-ignored-list.txt"
           cargo test --workspace --locked "$TEST_FILTER" -- --list --ignored > "$ignored_listing"
           grep -E ': test$' "$ignored_listing" | sort > "$ignored_names" || [[ "$?" -eq 1 ]]
-          if [[ -s "$normal_names" && -s "$ignored_names" ]] && cmp -s "$normal_names" "$ignored_names"; then
+          runnable_names="$RUNNER_TEMP/cmux-tui-focused-runnable.txt"
+          comm -23 "$normal_names" "$ignored_names" > "$runnable_names" || true
+          if [[ ! -s "$runnable_names" && -s "$ignored_names" ]]; then
             echo "::error::test_filter '$TEST_FILTER' matches only ignored tests" >&2
             exit 1
           fi

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import subprocess
+import tempfile
 from pathlib import Path
 
 
@@ -26,7 +27,7 @@ def test_workflow_rejects_ignored_only_filter_from_name_difference() -> None:
 
 
 def test_ignored_only_guard_returns_failure() -> None:
-    with __import__("tempfile").TemporaryDirectory() as directory:
+    with tempfile.TemporaryDirectory() as directory:
         root = Path(directory)
         normal_names = root / "normal"
         ignored_names = root / "ignored"
@@ -41,7 +42,16 @@ if [[ ! -s "$3" && -s "$2" ]]; then
 fi
 """
         result = subprocess.run(
-            ["bash", "-eu", "-c", script, "guard", str(normal_names), str(ignored_names), str(runnable_names)],
+            [
+                "bash",
+                "-eu",
+                "-c",
+                script,
+                "guard",
+                str(normal_names),
+                str(ignored_names),
+                str(runnable_names),
+            ],
             check=False,
         )
 

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WORKFLOW = ROOT / ".github" / "workflows" / "cmux-tui.yml"
+
+
+def test_ignored_only_listing_has_no_runnable_test_names() -> None:
+    listing = "test tui::slow_network_test: test\n"
+    normal_names = {line for line in listing.splitlines() if line}
+    ignored_names = {line for line in listing.splitlines() if line}
+
+    assert normal_names
+    assert ignored_names
+    assert not normal_names - ignored_names
+
+
+def test_workflow_rejects_ignored_only_filter_from_name_difference() -> None:
+    workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    assert 'comm -23 "$normal_names" "$ignored_names"' in workflow
+    assert 'if [[ ! -s "$runnable_names" && -s "$ignored_names" ]]; then' in workflow
+
+
+def test_ignored_only_guard_returns_failure() -> None:
+    with __import__("tempfile").TemporaryDirectory() as directory:
+        root = Path(directory)
+        normal_names = root / "normal"
+        ignored_names = root / "ignored"
+        runnable_names = root / "runnable"
+        normal_names.write_text("test tui::slow_network_test: test\n", encoding="utf-8")
+        ignored_names.write_text("test tui::slow_network_test: test\n", encoding="utf-8")
+        script = """
+set -euo pipefail
+comm -23 "$1" "$2" > "$3"
+if [[ ! -s "$3" && -s "$2" ]]; then
+  exit 17
+fi
+"""
+        result = subprocess.run(
+            ["bash", "-eu", "-c", script, "guard", str(normal_names), str(ignored_names), str(runnable_names)],
+            check=False,
+        )
+
+    assert result.returncode == 17


### PR DESCRIPTION
## Summary

Fix the focused `cmux-tui` workflow guard for filters that match only `#[ignore]` tests.

`libtest --list` includes ignored tests in its normal listing. The ignored-only listing is the subset of those names. The guard now computes the runnable set with `comm -23 normal ignored` and fails when that set is empty while ignored matches exist.

This supersedes [#11739](https://github.com/manaflow-ai/cmux/pull/11739) after its canonical review found that checking only file emptiness cannot distinguish ignored-only filters.

## Verification

- Test-first commits: `2fdfdeb` adds a failing ignored-only behavior test, `22e7116` adds the runnable-name difference guard.
- `python3 -m pytest -q tests/test_tui_focused_filter_guard.py` (3 passed)
- `git diff --check`
- No Rust tests or builds run locally.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the focused `cmux-tui` workflow guard by deriving runnable test names from the normal listing minus the ignored listing, rather than comparing the listings directly. Filters that match only ignored tests now fail reliably with a clear error.

- Adds regression tests for the name difference and shell guard behavior.

<sup>Written for commit e8a31394295847e336e1c7e6c14938328c13dfc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

