### PR TITLE
fix(remote): guarantee worker ownership during shutdown

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1431,6 +1431,10 @@ struct ReaperState {
     fail_next_spawn: bool,
 }
 
+// A wake token only prompts the reaper to inspect its pending list. Keep a
+// finite reserve for bursts while never allowing teardown to block on notify.
+const REMOTE_REAPER_WAKE_CAPACITY: usize = 1024;
+
 struct WorkerRuntime {
     admission: Arc<WorkerAdmission>,
     reaper: Arc<Mutex<ReaperState>>,
@@ -1509,7 +1513,8 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     if current.sender.is_some() {
         return;
     }
-    let (sender, receiver) = std::sync::mpsc::sync_channel::<()>(1);
+    let (sender, receiver) =
+        std::sync::mpsc::sync_channel::<()>(REMOTE_REAPER_WAKE_CAPACITY);
     let worker_state = state.clone();
     #[cfg(test)]
     if current.fail_next_spawn {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,9 +7,7 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::mpsc::{
-    Receiver, RecvError, RecvTimeoutError, Sender, TrySendError, channel, sync_channel,
-};
+use std::sync::mpsc::{Receiver, RecvError, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -1511,7 +1509,7 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     if current.sender.is_some() {
         return;
     }
-    let (sender, receiver) = sync_channel::<()>(1);
+    let (sender, receiver) = std::sync::mpsc::sync_channel::<()>(1);
     let worker_state = state.clone();
     #[cfg(test)]
     if current.fail_next_spawn {
@@ -1609,8 +1607,8 @@ fn enqueue_worker_reap_in_state(
         current.pending.push((handle, completion));
         if let Some(sender) = current.sender.as_ref() {
             match sender.try_send(()) {
-                Ok(()) | Err(TrySendError::Full(())) => {}
-                Err(TrySendError::Disconnected(())) => current.sender = None,
+                Ok(()) | Err(std::sync::mpsc::TrySendError::Full(())) => {}
+                Err(std::sync::mpsc::TrySendError::Disconnected(())) => current.sender = None,
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1471,6 +1471,20 @@ impl WorkerRuntime {
     }
 
     fn reserve_slot(&self) -> Option<WorkerSlot> {
+        if let Some(slot) = self.admission.try_reserve() {
+            return Some(slot);
+        }
+        // A failed reaper startup leaves completed handles owned by the
+        // runtime. Drain finished handles before rejecting new work, then
+        // give the reaper another chance for handles that are still running.
+        reap_completed_workers(&self.reaper);
+        let has_pending_without_reaper = {
+            let state = self.reaper.lock().unwrap_or_else(|poison| poison.into_inner());
+            state.sender.is_none() && !state.pending.is_empty()
+        };
+        if has_pending_without_reaper {
+            try_start_reaper(&self.reaper);
+        }
         self.admission.try_reserve()
     }
 
@@ -1583,8 +1597,8 @@ fn reap_completed_workers(state: &Arc<Mutex<ReaperState>>) {
     while index > 0 {
         index -= 1;
         if pending[index].0.thread().id() == current {
-            let (handle, completion) = pending.swap_remove(index);
-            completion.install_handle(handle);
+            // A worker cannot join its own handle. Keep it in the runtime's
+            // pending queue so a later admission or reaper wake retries it.
             continue;
         }
         if pending[index].1.is_done() {
@@ -1604,8 +1618,6 @@ fn enqueue_worker_reap_in_state(
     handle: std::thread::JoinHandle<()>,
     completion: Arc<WorkerCompletion>,
 ) {
-    let self_thread = handle.thread().id() == std::thread::current().id();
-    let completion_for_fallback = completion.clone();
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));
@@ -1621,21 +1633,6 @@ fn enqueue_worker_reap_in_state(
         try_start_reaper(state);
         if state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none() {
             reap_completed_workers(state);
-            if self_thread {
-                let retained = {
-                    let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
-                    current
-                        .pending
-                        .iter()
-                        .position(|(pending, _)| {
-                            pending.thread().id() == std::thread::current().id()
-                        })
-                        .map(|index| current.pending.swap_remove(index).0)
-                };
-                if let Some(handle) = retained {
-                    completion_for_fallback.install_handle(handle);
-                }
-            }
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1305,57 +1305,78 @@ impl WorkerCompletion {
     fn was_joined(&self) -> bool {
         self.joined.load(Ordering::Acquire)
     }
+
+    fn mark_joined(&self) {
+        #[cfg(test)]
+        self.joined.store(true, Ordering::Release);
+    }
+}
+
+type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
+
+static REAPER: OnceLock<Sender<ReapRequest>> = OnceLock::new();
+static REAPER_FALLBACK: OnceLock<Arc<Mutex<Vec<ReapRequest>>>> = OnceLock::new();
+
+fn reaper_fallback() -> &'static Arc<Mutex<Vec<ReapRequest>>> {
+    REAPER_FALLBACK.get_or_init(|| Arc::new(Mutex::new(Vec::new())))
 }
 
 fn enqueue_worker_reap(
     handle: std::thread::JoinHandle<()>,
     completion: Arc<WorkerCompletion>,
 ) -> Result<(), std::thread::JoinHandle<()>> {
-    type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
-    static REAPER: OnceLock<std::sync::mpsc::SyncSender<ReapRequest>> = OnceLock::new();
+    let fallback = reaper_fallback().clone();
     let sender = REAPER.get_or_init(|| {
-        let (sender, receiver) = std::sync::mpsc::sync_channel::<ReapRequest>(64);
-        let Ok(_) =
-            std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
-                let mut pending = Vec::new();
-                loop {
-                    while let Ok(request) = receiver.try_recv() {
-                        pending.push(request);
+        let (sender, receiver) = channel::<ReapRequest>();
+        let reaper_fallback = fallback.clone();
+        let _ = std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
+            let mut pending = Vec::new();
+            loop {
+                pending.extend(
+                    reaper_fallback.lock().unwrap_or_else(|poison| poison.into_inner()).drain(..),
+                );
+                while let Ok(request) = receiver.try_recv() {
+                    pending.push(request);
+                }
+                let mut index = pending.len();
+                while index > 0 {
+                    index -= 1;
+                    if pending[index].1.is_done() {
+                        let (handle, completion) = pending.swap_remove(index);
+                        completion.mark_joined();
+                        let _ = handle.join();
                     }
-                    let mut index = pending.len();
-                    while index > 0 {
-                        index -= 1;
-                        if pending[index].1.is_done() {
-                            let (handle, _) = pending.swap_remove(index);
-                            let _ = handle.join();
-                        }
+                }
+                if pending.is_empty() {
+                    match receiver.recv() {
+                        Ok(request) => pending.push(request),
+                        Err(_) => break,
                     }
-                    if pending.is_empty() {
-                        match receiver.recv() {
-                            Ok(request) => pending.push(request),
-                            Err(_) => break,
-                        }
-                    } else {
-                        match receiver.recv_timeout(Duration::from_millis(50)) {
-                            Ok(request) => pending.push(request),
-                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                                for (handle, completion) in pending.drain(..) {
-                                    completion.wait_forever();
-                                    let _ = handle.join();
-                                }
-                                break;
+                } else {
+                    match receiver.recv_timeout(Duration::from_millis(50)) {
+                        Ok(request) => pending.push(request),
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                            for (handle, completion) in pending.drain(..) {
+                                completion.wait_forever();
+                                completion.mark_joined();
+                                let _ = handle.join();
                             }
+                            break;
                         }
                     }
                 }
-            })
-        else {
-            return sender;
-        };
+            }
+        });
         sender
     });
-    try_enqueue_worker_reap(sender, handle, completion)
+    match sender.send((handle, completion)) {
+        Ok(()) => Ok(()),
+        Err(std::sync::mpsc::SendError(request)) => {
+            fallback.lock().unwrap_or_else(|poison| poison.into_inner()).push(request);
+            Ok(())
+        }
+    }
 }
 
 fn try_enqueue_worker_reap(
@@ -1569,10 +1590,8 @@ impl InteractiveWriter {
                 .wait(deadline.saturating_duration_since(Instant::now()))
             {
                 let _ = handle.join();
-            } else if let Err(handle) =
-                enqueue_worker_reap(handle, self.shared.worker_completion.clone())
-            {
-                *self.worker.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(handle);
+            } else {
+                let _ = enqueue_worker_reap(handle, self.shared.worker_completion.clone());
             }
         }
     }
@@ -1588,11 +1607,7 @@ impl InteractiveWriter {
                 return;
             };
             if !self.shared.worker_completion.is_done() {
-                if let Err(handle) =
-                    enqueue_worker_reap(handle, self.shared.worker_completion.clone())
-                {
-                    *worker = Some(handle);
-                }
+                let _ = enqueue_worker_reap(handle, self.shared.worker_completion.clone());
                 return;
             }
             Some(handle)
@@ -3220,7 +3235,11 @@ impl RemoteSession {
         let handle = {
             let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
             if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
-                worker.take();
+                let handle = worker.take();
+                drop(worker);
+                if let Some(handle) = handle {
+                    let _ = enqueue_worker_reap(handle, self.reader_completion.clone());
+                }
                 return;
             }
             worker.take()
@@ -3228,10 +3247,8 @@ impl RemoteSession {
         if let Some(handle) = handle {
             if self.reader_completion.wait(deadline.saturating_duration_since(Instant::now())) {
                 let _ = handle.join();
-            } else if let Err(handle) = enqueue_worker_reap(handle, self.reader_completion.clone())
-            {
-                *self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner()) =
-                    Some(handle);
+            } else {
+                let _ = enqueue_worker_reap(handle, self.reader_completion.clone());
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1265,6 +1265,13 @@ impl WorkerCompletion {
         Self::with_runtime(test_worker_runtime(), None, false)
     }
 
+    #[cfg(test)]
+    fn completed() -> Self {
+        let completion = Self::new();
+        *completion.done.lock().unwrap() = true;
+        completion
+    }
+
     fn with_runtime(
         runtime: Arc<WorkerRuntime>,
         slot: Option<WorkerSlot>,
@@ -4451,7 +4458,7 @@ fn test_session_with_writer(
             worker_runtime,
         )
         .unwrap(),
-        reader_completion: Arc::new(WorkerCompletion::new()),
+        reader_completion: Arc::new(WorkerCompletion::completed()),
         disconnect_state: Mutex::new(DisconnectState::default()),
         pending: Mutex::new(PendingRemoteRequests::default()),
         next_id: AtomicU64::new(1),
@@ -5701,7 +5708,7 @@ mod tests {
         let worker_runtime = test_worker_runtime();
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort, worker_runtime).unwrap(),
-            reader_completion: Arc::new(WorkerCompletion::new()),
+            reader_completion: Arc::new(WorkerCompletion::completed()),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1566,6 +1566,8 @@ fn enqueue_worker_reap_in_state(
     handle: std::thread::JoinHandle<()>,
     completion: Arc<WorkerCompletion>,
 ) {
+    let self_thread = handle.thread().id() == std::thread::current().id();
+    let completion_for_fallback = completion.clone();
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));
@@ -1581,6 +1583,21 @@ fn enqueue_worker_reap_in_state(
         try_start_reaper(state);
         if state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none() {
             reap_completed_workers(state);
+            if self_thread {
+                let retained = {
+                    let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
+                    current
+                        .pending
+                        .iter()
+                        .position(|(pending, _)| {
+                            pending.thread().id() == std::thread::current().id()
+                        })
+                        .map(|index| current.pending.swap_remove(index).0)
+                };
+                if let Some(handle) = retained {
+                    completion_for_fallback.install_handle(handle);
+                }
+            }
         }
     }
 }
@@ -2034,7 +2051,6 @@ enum DisconnectState {
 
 pub struct RemoteSession {
     interactive_writer: InteractiveWriter,
-    reader_worker: Mutex<Option<std::thread::JoinHandle<()>>>,
     reader_completion: Arc<WorkerCompletion>,
     /// The first terminal state wins. Local shutdown is kept separate from a
     /// reader failure so closing our own transport does not report a fake
@@ -2403,7 +2419,6 @@ impl RemoteSession {
             Arc::new(WorkerCompletion::with_slot(worker_runtime, Some(reader_slot)));
         let session = Arc::new(RemoteSession {
             interactive_writer,
-            reader_worker: Mutex::new(None),
             reader_completion: reader_completion.clone(),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
@@ -2479,7 +2494,7 @@ impl RemoteSession {
             .inspect_err(|_| {
                 reader_completion.release_slot();
             })?;
-        *session.reader_worker.lock().unwrap() = Some(reader_worker);
+        reader_completion.install_handle(reader_worker);
 
         if let Err(error) = session.initialize(subscribe) {
             session.disconnect_transport();
@@ -3497,25 +3512,19 @@ impl RemoteSession {
 
     fn join_reader_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
-        let handle = {
-            let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
-            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
-                let handle = worker.take();
-                drop(worker);
-                if let Some(handle) = handle {
-                    self.reader_completion.runtime.enqueue(handle, self.reader_completion.clone());
-                }
-                return;
-            }
-            worker.take()
+        let Some(handle) = self.reader_completion.take_handle() else {
+            let _ = self.reader_completion.wait(deadline.saturating_duration_since(Instant::now()));
+            return;
         };
-        if let Some(handle) = handle {
-            if self.reader_completion.wait(deadline.saturating_duration_since(Instant::now())) {
-                let _ = handle.join();
-                self.reader_completion.release_slot();
-            } else {
-                self.reader_completion.runtime.enqueue(handle, self.reader_completion.clone());
-            }
+        if handle.thread().id() == current {
+            self.reader_completion.install_handle(handle);
+            return;
+        }
+        if self.reader_completion.wait(deadline.saturating_duration_since(Instant::now())) {
+            let _ = handle.join();
+            self.reader_completion.release_slot();
+        } else {
+            self.reader_completion.runtime.enqueue(handle, self.reader_completion.clone());
         }
     }
 
@@ -4442,7 +4451,6 @@ fn test_session_with_writer(
             worker_runtime,
         )
         .unwrap(),
-        reader_worker: Mutex::new(None),
         reader_completion: Arc::new(WorkerCompletion::new()),
         disconnect_state: Mutex::new(DisconnectState::default()),
         pending: Mutex::new(PendingRemoteRequests::default()),
@@ -5693,7 +5701,6 @@ mod tests {
         let worker_runtime = test_worker_runtime();
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort, worker_runtime).unwrap(),
-            reader_worker: Mutex::new(None),
             reader_completion: Arc::new(WorkerCompletion::new()),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1253,6 +1253,7 @@ struct WorkerCompletion {
     changed: Condvar,
     admission: Mutex<Option<WorkerSlot>>,
     handle: Mutex<Option<std::thread::JoinHandle<()>>>,
+    thread_id: Mutex<Option<std::thread::ThreadId>>,
     runtime: Arc<WorkerRuntime>,
     wake_reaper: bool,
     #[cfg(test)]
@@ -1282,6 +1283,7 @@ impl WorkerCompletion {
             changed: Condvar::new(),
             admission: Mutex::new(slot),
             handle: Mutex::new(None),
+            thread_id: Mutex::new(None),
             runtime,
             wake_reaper,
             #[cfg(test)]
@@ -1312,6 +1314,18 @@ impl WorkerCompletion {
 
     fn take_handle(&self) -> Option<std::thread::JoinHandle<()>> {
         self.handle.lock().unwrap_or_else(|poison| poison.into_inner()).take()
+    }
+
+    fn set_thread_id(&self) {
+        *self.thread_id.lock().unwrap_or_else(|poison| poison.into_inner()) =
+            Some(std::thread::current().id());
+    }
+
+    fn is_current_thread(&self) -> bool {
+        self.thread_id
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner())
+            .is_some_and(|id| id == std::thread::current().id())
     }
 
     fn reap_owned_handle(self: &Arc<Self>) {
@@ -1852,6 +1866,9 @@ impl InteractiveWriter {
     fn join_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
         let Some(handle) = self.shared.worker_completion.take_handle() else {
+            if self.shared.worker_completion.is_current_thread() {
+                return;
+            }
             let _ = self
                 .shared
                 .worker_completion
@@ -1941,6 +1958,7 @@ fn interactive_writer_worker(
     mut writer: Box<dyn RemoteMessageWriter>,
     worker_completion: Arc<WorkerCompletion>,
 ) {
+    worker_completion.set_thread_id();
     let _completion = WorkerCompletionGuard(worker_completion);
     loop {
         let write = {
@@ -2457,6 +2475,7 @@ impl RemoteSession {
         let reader_worker = std::thread::Builder::new()
             .name("remote-reader".into())
             .spawn(move || {
+                reader_completion_for_worker.set_thread_id();
                 let _completion = WorkerCompletionGuard(reader_completion_for_worker);
                 let mut report_progress = |partial: &[u8]| {
                     if let Some(session) = reader_session.upgrade() {
@@ -3514,6 +3533,9 @@ impl RemoteSession {
     fn join_reader_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
         let Some(handle) = self.reader_completion.take_handle() else {
+            if self.reader_completion.is_current_thread() {
+                return;
+            }
             let _ = self.reader_completion.wait(deadline.saturating_duration_since(Instant::now()));
             return;
         };

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8,7 +8,7 @@ use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
-use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -1282,6 +1282,51 @@ impl WorkerCompletion {
         }
         *done
     }
+
+    fn is_done(&self) -> bool {
+        *self.done.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn wait_forever(&self) {
+        let mut done = self.done.lock().unwrap_or_else(|poison| poison.into_inner());
+        while !*done {
+            done = self.changed.wait(done).unwrap_or_else(|poison| poison.into_inner());
+        }
+    }
+}
+
+fn enqueue_worker_reap(
+    handle: std::thread::JoinHandle<()>,
+    completion: Arc<WorkerCompletion>,
+) -> Result<(), std::thread::JoinHandle<()>> {
+    type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
+    static REAPER: OnceLock<std::sync::mpsc::SyncSender<ReapRequest>> = OnceLock::new();
+    let sender = REAPER.get_or_init(|| {
+        let (sender, receiver) = std::sync::mpsc::sync_channel::<ReapRequest>(64);
+        let Ok(_) =
+            std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
+                while let Ok((handle, completion)) = receiver.recv() {
+                    completion.wait_forever();
+                    let _ = handle.join();
+                }
+            })
+        else {
+            return sender;
+        };
+        sender
+    });
+    try_enqueue_worker_reap(sender, handle, completion)
+}
+
+fn try_enqueue_worker_reap(
+    sender: &std::sync::mpsc::SyncSender<(std::thread::JoinHandle<()>, Arc<WorkerCompletion>)>,
+    handle: std::thread::JoinHandle<()>,
+    completion: Arc<WorkerCompletion>,
+) -> Result<(), std::thread::JoinHandle<()>> {
+    sender.try_send((handle, completion)).map_err(|error| match error {
+        std::sync::mpsc::TrySendError::Full((handle, _))
+        | std::sync::mpsc::TrySendError::Disconnected((handle, _)) => handle,
+    })
 }
 
 struct WorkerCompletionGuard(Arc<WorkerCompletion>);
@@ -1476,9 +1521,36 @@ impl InteractiveWriter {
         if let Some(handle) = handle {
             if self.shared.worker_completion.wait(remote_write_timeout()) {
                 let _ = handle.join();
-            } else {
+            } else if let Err(handle) =
+                enqueue_worker_reap(handle, self.shared.worker_completion.clone())
+            {
                 *self.worker.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(handle);
             }
+        }
+    }
+
+    fn join_worker_if_done(&self) {
+        let current = std::thread::current().id();
+        let handle = {
+            let mut worker = self.worker.lock().unwrap_or_else(|poison| poison.into_inner());
+            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                return;
+            }
+            let Some(handle) = worker.take() else {
+                return;
+            };
+            if !self.shared.worker_completion.is_done() {
+                if let Err(handle) =
+                    enqueue_worker_reap(handle, self.shared.worker_completion.clone())
+                {
+                    *worker = Some(handle);
+                }
+                return;
+            }
+            Some(handle)
+        };
+        if let Some(handle) = handle {
+            let _ = handle.join();
         }
     }
 
@@ -1509,7 +1581,6 @@ impl InteractiveWriter {
                 "remote writer did not close before its deadline",
             ));
         }
-        self.join_worker();
     }
 }
 
@@ -1524,7 +1595,7 @@ impl Drop for InteractiveWriter {
                 "remote writer owner was dropped",
             ));
         }
-        self.join_worker();
+        self.join_worker_if_done();
     }
 }
 
@@ -3073,6 +3144,7 @@ impl RemoteSession {
         self.begin_shutdown();
         self.interactive_writer.close();
         self.interactive_writer.abort_transport();
+        self.interactive_writer.join_worker();
         self.join_reader_worker();
     }
 
@@ -3081,6 +3153,7 @@ impl RemoteSession {
         let handle = {
             let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
             if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                worker.take();
                 return;
             }
             worker.take()
@@ -3088,7 +3161,8 @@ impl RemoteSession {
         if let Some(handle) = handle {
             if self.reader_completion.wait(remote_write_timeout()) {
                 let _ = handle.join();
-            } else {
+            } else if let Err(handle) = enqueue_worker_reap(handle, self.reader_completion.clone())
+            {
                 *self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner()) =
                     Some(handle);
             }
@@ -3700,7 +3774,9 @@ fn local_hostname() -> Option<String> {
 
 impl Drop for RemoteSession {
     fn drop(&mut self) {
-        self.disconnect_transport();
+        self.interactive_writer.request_close();
+        self.interactive_writer.abort_transport();
+        self.interactive_writer.join_worker_if_done();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;
         };
@@ -6540,6 +6616,28 @@ mod tests {
         writer_exited_rx
             .recv_timeout(Duration::from_millis(100))
             .expect("transport shutdown must join the writer");
+    }
+
+    #[test]
+    fn worker_reaper_returns_ownership_when_queue_is_saturated() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(0);
+        let completion = Arc::new(WorkerCompletion::new());
+        let handle = std::thread::spawn(|| {});
+        let returned = try_enqueue_worker_reap(&sender, handle, completion)
+            .expect_err("a zero-capacity queue must return the handle");
+        drop(receiver);
+        returned.join().expect("returned worker handle remains joinable");
+    }
+
+    #[test]
+    fn worker_reaper_returns_ownership_when_queue_is_disconnected() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        drop(receiver);
+        let completion = Arc::new(WorkerCompletion::new());
+        let handle = std::thread::spawn(|| {});
+        let returned = try_enqueue_worker_reap(&sender, handle, completion)
+            .expect_err("a disconnected queue must return the handle");
+        returned.join().expect("returned worker handle remains joinable");
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1251,11 +1251,18 @@ struct InteractiveWriterShared {
 struct WorkerCompletion {
     done: Mutex<bool>,
     changed: Condvar,
+    #[cfg(test)]
+    joined: AtomicBool,
 }
 
 impl WorkerCompletion {
     fn new() -> Self {
-        Self { done: Mutex::new(false), changed: Condvar::new() }
+        Self {
+            done: Mutex::new(false),
+            changed: Condvar::new(),
+            #[cfg(test)]
+            joined: AtomicBool::new(false),
+        }
     }
 
     fn mark_done(&self) {
@@ -1292,6 +1299,11 @@ impl WorkerCompletion {
         while !*done {
             done = self.changed.wait(done).unwrap_or_else(|poison| poison.into_inner());
         }
+    }
+
+    #[cfg(test)]
+    fn was_joined(&self) -> bool {
+        self.joined.load(Ordering::Acquire)
     }
 }
 
@@ -6720,6 +6732,77 @@ mod tests {
             .expect("reader worker did not exit before session drop returned");
     }
 
+    fn wait_for_worker_join(completion: &WorkerCompletion) {
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while !completion.was_joined() {
+            assert!(Instant::now() < deadline, "worker reaper did not join the worker");
+            std::thread::yield_now();
+        }
+    }
+
+    #[test]
+    fn reader_self_disconnect_keeps_its_join_handle_owned() {
+        let (responses, response_rx) = channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (reader_exited, reader_exited_rx) = channel();
+        let (writer_exited, _writer_exited_rx) = channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let session = RemoteSession::connect_transport(RemoteTransport::new(
+            Box::new(LifecycleReader {
+                responses: response_rx,
+                remaining_responses: 3,
+                release: release.clone(),
+                exited: reader_exited,
+                entered: None,
+                exit_delay: Duration::ZERO,
+            }),
+            Box::new(LifecycleWriter { responses, closed, exited: writer_exited }),
+            Arc::new(LifecycleAbort { release: release.clone() }),
+        ))
+        .unwrap();
+
+        let completion = session.reader_completion.clone();
+        let (released, changed) = &*release;
+        *released.lock().unwrap() = true;
+        changed.notify_all();
+        reader_exited_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("reader did not self-disconnect");
+        wait_for_worker_join(&completion);
+        assert!(completion.was_joined());
+    }
+
+    #[test]
+    fn reaper_does_not_block_completed_workers_behind_a_stalled_worker() {
+        let first_release = Arc::new((Mutex::new(false), Condvar::new()));
+        let first_completion = Arc::new(WorkerCompletion::new());
+        let second_completion = Arc::new(WorkerCompletion::new());
+        let first_release_thread = first_release.clone();
+        let first_completion_thread = first_completion.clone();
+        let first = std::thread::spawn(move || {
+            let (released, changed) = &*first_release_thread;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = changed.wait(released).unwrap();
+            }
+            first_completion_thread.mark_done();
+        });
+        let second_completion_thread = second_completion.clone();
+        let second = std::thread::spawn(move || {
+            second_completion_thread.mark_done();
+        });
+        enqueue_worker_reap(first, first_completion.clone()).unwrap();
+        enqueue_worker_reap(second, second_completion.clone()).unwrap();
+
+        wait_for_worker_join(&second_completion);
+        assert!(!first_completion.was_joined());
+
+        let (released, changed) = &*first_release;
+        *released.lock().unwrap() = true;
+        changed.notify_all();
+        wait_for_worker_join(&first_completion);
+    }
+
     #[test]
     fn worker_reaper_returns_ownership_when_queue_is_saturated() {
         let (sender, receiver) = std::sync::mpsc::sync_channel(0);
@@ -7627,6 +7710,25 @@ mod tests {
             state.failure,
             Some(ref failure) if failure.kind == io::ErrorKind::TimedOut
         ));
+    }
+
+    #[test]
+    fn disconnect_uses_one_total_shutdown_deadline() {
+        let (writer, control) = BlockingWriteStream::new();
+        let session = test_session_with_provider_context(Box::new(writer), HashSet::new(), None);
+        session.send_bytes(7, b"blocked").unwrap();
+        control.wait_until_entered();
+
+        let started = Instant::now();
+        session.disconnect_transport();
+        assert!(
+            started.elapsed() < remote_write_timeout() * 2,
+            "shutdown exceeded its total deadline: {:?}",
+            started.elapsed()
+        );
+
+        control.release();
+        drop(session);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,8 +6,6 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
-#[cfg(test)]
-use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Condvar, Mutex, Weak};
@@ -1402,12 +1400,20 @@ struct WorkerRuntime {
     reaper: Arc<Mutex<ReaperState>>,
 }
 
+static PROCESS_WORKER_ADMISSION: OnceLock<Arc<WorkerAdmission>> = OnceLock::new();
+
+fn process_worker_admission() -> Arc<WorkerAdmission> {
+    PROCESS_WORKER_ADMISSION
+        .get_or_init(|| {
+            Arc::new(WorkerAdmission { available: AtomicUsize::new(REMOTE_WORKER_SLOT_LIMIT) })
+        })
+        .clone()
+}
+
 impl WorkerRuntime {
     fn new() -> Arc<Self> {
         Arc::new(Self {
-            admission: Arc::new(WorkerAdmission {
-                available: AtomicUsize::new(REMOTE_WORKER_SLOT_LIMIT),
-            }),
+            admission: process_worker_admission(),
             reaper: Arc::new(Mutex::new(ReaperState {
                 sender: None,
                 worker: None,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1513,8 +1513,7 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     if current.sender.is_some() {
         return;
     }
-    let (sender, receiver) =
-        std::sync::mpsc::sync_channel::<()>(REMOTE_REAPER_WAKE_CAPACITY);
+    let (sender, receiver) = std::sync::mpsc::sync_channel::<()>(REMOTE_REAPER_WAKE_CAPACITY);
     let worker_state = state.clone();
     #[cfg(test)]
     if current.fail_next_spawn {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7247,7 +7247,7 @@ mod tests {
 
         let completion = Arc::new(WorkerCompletion::with_runtime(runtime, None, true));
         let (finished_tx, finished_rx) = channel();
-        let worker_completion = completion.clone();
+        let worker_completion = completion;
         let worker = std::thread::spawn(move || {
             worker_completion.mark_done();
             finished_tx.send(()).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
@@ -1251,15 +1251,21 @@ struct InteractiveWriterShared {
 struct WorkerCompletion {
     done: Mutex<bool>,
     changed: Condvar,
+    admission: Mutex<Option<WorkerSlot>>,
     #[cfg(test)]
     joined: AtomicBool,
 }
 
 impl WorkerCompletion {
     fn new() -> Self {
+        Self::with_slot(None)
+    }
+
+    fn with_slot(slot: Option<WorkerSlot>) -> Self {
         Self {
             done: Mutex::new(false),
             changed: Condvar::new(),
+            admission: Mutex::new(slot),
             #[cfg(test)]
             joined: AtomicBool::new(false),
         }
@@ -1300,8 +1306,58 @@ impl WorkerCompletion {
     }
 
     fn mark_joined(&self) {
+        self.release_slot();
         #[cfg(test)]
         self.joined.store(true, Ordering::Release);
+    }
+
+    fn release_slot(&self) {
+        let _ = self.admission.lock().unwrap_or_else(|poison| poison.into_inner()).take();
+    }
+}
+
+const REMOTE_WORKER_SLOT_LIMIT: usize = 256;
+
+struct WorkerAdmission {
+    available: AtomicUsize,
+}
+
+struct WorkerSlot(Arc<WorkerAdmission>);
+
+static WORKER_ADMISSION: OnceLock<Arc<WorkerAdmission>> = OnceLock::new();
+
+impl WorkerAdmission {
+    fn try_reserve(self: &Arc<Self>) -> Option<WorkerSlot> {
+        let mut available = self.available.load(Ordering::Acquire);
+        loop {
+            if available == 0 {
+                return None;
+            }
+            match self.available.compare_exchange_weak(
+                available,
+                available - 1,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return Some(WorkerSlot(self.clone())),
+                Err(next) => available = next,
+            }
+        }
+    }
+}
+
+fn reserve_worker_slot() -> Option<WorkerSlot> {
+    let admission = WORKER_ADMISSION
+        .get_or_init(|| {
+            Arc::new(WorkerAdmission { available: AtomicUsize::new(REMOTE_WORKER_SLOT_LIMIT) })
+        })
+        .clone();
+    admission.try_reserve()
+}
+
+impl Drop for WorkerSlot {
+    fn drop(&mut self) {
+        self.0.available.fetch_add(1, Ordering::Release);
     }
 }
 
@@ -1338,8 +1394,8 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
                     index -= 1;
                     if pending[index].1.is_done() {
                         let (handle, completion) = pending.swap_remove(index);
-                        completion.mark_joined();
                         let _ = handle.join();
+                        completion.mark_joined();
                     }
                 }
                 {
@@ -1429,19 +1485,26 @@ impl InteractiveWriter {
         writer: Box<dyn RemoteMessageWriter>,
         abort: Arc<dyn RemoteTransportAbort>,
     ) -> io::Result<Self> {
+        let slot = reserve_worker_slot().ok_or_else(|| {
+            io::Error::new(io::ErrorKind::WouldBlock, "remote worker slots exhausted")
+        })?;
+        let worker_completion = Arc::new(WorkerCompletion::with_slot(Some(slot)));
         let shared = Arc::new(InteractiveWriterShared {
             state: Mutex::new(InteractiveWriteQueueState::default()),
             changed: Condvar::new(),
             metrics: InteractiveWriteMetrics::default(),
-            worker_completion: Arc::new(WorkerCompletion::new()),
+            worker_completion: worker_completion.clone(),
             #[cfg(test)]
             wait_until_written_gate: Mutex::new(None),
         });
         let worker_shared = shared.clone();
-        let worker_completion = shared.worker_completion.clone();
         let worker = std::thread::Builder::new()
             .name("remote-input-writer".into())
-            .spawn(move || interactive_writer_worker(worker_shared, writer, worker_completion))?;
+            .spawn(move || interactive_writer_worker(worker_shared, writer, worker_completion))
+            .map_err(|error| {
+                shared.worker_completion.release_slot();
+                error
+            })?;
         Ok(Self { shared, abort, worker: Mutex::new(Some(worker)) })
     }
 
@@ -1610,6 +1673,7 @@ impl InteractiveWriter {
                 .wait(deadline.saturating_duration_since(Instant::now()))
             {
                 let _ = handle.join();
+                self.shared.worker_completion.release_slot();
             } else {
                 enqueue_worker_reap(handle, self.shared.worker_completion.clone());
             }
@@ -1634,6 +1698,7 @@ impl InteractiveWriter {
         };
         if let Some(handle) = handle {
             let _ = handle.join();
+            self.shared.worker_completion.release_slot();
         }
     }
 
@@ -2162,10 +2227,13 @@ impl RemoteSession {
         let RemoteTransport { mut reader, writer, abort } = transport;
         let interactive_writer = InteractiveWriter::spawn(writer, abort)
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
+        let reader_slot = reserve_worker_slot()
+            .ok_or_else(|| anyhow::anyhow!("remote worker slots exhausted"))?;
+        let reader_completion = Arc::new(WorkerCompletion::with_slot(Some(reader_slot)));
         let session = Arc::new(RemoteSession {
             interactive_writer,
             reader_worker: Mutex::new(None),
-            reader_completion: Arc::new(WorkerCompletion::new()),
+            reader_completion: reader_completion.clone(),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
@@ -2198,10 +2266,11 @@ impl RemoteSession {
         });
 
         let reader_session = Arc::downgrade(&session);
-        let reader_completion = session.reader_completion.clone();
-        let reader_worker =
-            std::thread::Builder::new().name("remote-reader".into()).spawn(move || {
-                let _completion = WorkerCompletionGuard(reader_completion);
+        let reader_completion_for_worker = reader_completion.clone();
+        let reader_worker = std::thread::Builder::new()
+            .name("remote-reader".into())
+            .spawn(move || {
+                let _completion = WorkerCompletionGuard(reader_completion_for_worker);
                 let mut report_progress = |partial: &[u8]| {
                     if let Some(session) = reader_session.upgrade() {
                         session.report_read_progress(partial);
@@ -2235,6 +2304,10 @@ impl RemoteSession {
                     session.disconnect_transport_with_reason(reason);
                     session.emit(MuxEvent::Empty);
                 }
+            })
+            .map_err(|error| {
+                reader_completion.release_slot();
+                error
             })?;
         *session.reader_worker.lock().unwrap() = Some(reader_worker);
 
@@ -3269,6 +3342,7 @@ impl RemoteSession {
         if let Some(handle) = handle {
             if self.reader_completion.wait(deadline.saturating_duration_since(Instant::now())) {
                 let _ = handle.join();
+                self.reader_completion.release_slot();
             } else {
                 enqueue_worker_reap(handle, self.reader_completion.clone());
             }
@@ -6854,6 +6928,15 @@ mod tests {
         assert!(state.lock().unwrap().worker.is_some());
         wait_for_worker_join(&completion);
         assert!(completion.was_joined());
+    }
+
+    #[test]
+    fn worker_admission_rejects_saturation_and_recovers_after_release() {
+        let admission = Arc::new(WorkerAdmission { available: AtomicUsize::new(1) });
+        let slot = admission.try_reserve().expect("first worker slot should be available");
+        assert!(admission.try_reserve().is_none());
+        drop(slot);
+        assert!(admission.try_reserve().is_some());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1374,7 +1374,20 @@ impl WorkerCompletion {
     }
 }
 
-const REMOTE_WORKER_SLOT_LIMIT: usize = 256;
+const REMOTE_WORKER_SLOT_FLOOR: usize = 256;
+
+fn remote_worker_slot_limit_for_warm_connections(warm_connections: usize) -> usize {
+    warm_connections.saturating_mul(2).max(REMOTE_WORKER_SLOT_FLOOR)
+}
+
+fn remote_worker_slot_limit() -> usize {
+    let warm_connections = std::env::var("CMUX_TUI_WARM_MACHINES")
+        .ok()
+        .and_then(|value| value.trim().parse::<usize>().ok())
+        .filter(|limit| *limit >= 2)
+        .unwrap_or(5);
+    remote_worker_slot_limit_for_warm_connections(warm_connections)
+}
 
 struct WorkerAdmission {
     available: AtomicUsize,
@@ -1443,7 +1456,7 @@ fn process_reaper_state() -> Arc<Mutex<ReaperState>> {
 fn process_worker_admission() -> Arc<WorkerAdmission> {
     PROCESS_WORKER_ADMISSION
         .get_or_init(|| {
-            Arc::new(WorkerAdmission { available: AtomicUsize::new(REMOTE_WORKER_SLOT_LIMIT) })
+            Arc::new(WorkerAdmission { available: AtomicUsize::new(remote_worker_slot_limit()) })
         })
         .clone()
 }
@@ -1592,8 +1605,7 @@ fn enqueue_worker_reap_in_state(
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));
-        if current.sender.is_some()
-            && let Some(sender) = current.sender.as_ref()
+        if let Some(sender) = current.sender.as_ref()
             && sender.send(()).is_err()
         {
             current.sender = None;
@@ -7180,12 +7192,15 @@ mod tests {
     #[test]
     fn completed_worker_retries_reaper_after_spawn_failure() {
         let _reaper_guard = reaper_test_guard();
-        let state = reaper_state();
+        let runtime = Arc::new(WorkerRuntime {
+            admission: process_worker_admission(),
+            reaper: new_reaper_state(),
+        });
+        let state = runtime.reaper.clone();
         state.lock().unwrap().sender = None;
 
         let release = Arc::new((Mutex::new(false), Condvar::new()));
-        let completion =
-            Arc::new(WorkerCompletion::with_runtime(test_worker_runtime(), None, true));
+        let completion = Arc::new(WorkerCompletion::with_runtime(runtime.clone(), None, true));
         let worker_release = release.clone();
         let worker_completion = completion.clone();
         let handle = std::thread::spawn(move || {
@@ -7198,7 +7213,7 @@ mod tests {
         });
 
         state.lock().unwrap().fail_next_spawn = true;
-        enqueue_worker_reap(handle, completion.clone());
+        enqueue_worker_reap_in_state(&state, handle, completion.clone());
         assert!(!completion.was_joined(), "failed reaper spawn must retain the handle");
 
         let (released, changed) = &*release;
@@ -7248,6 +7263,12 @@ mod tests {
         assert!(admission.try_reserve().is_none());
         drop(slot);
         assert!(admission.try_reserve().is_some());
+    }
+
+    #[test]
+    fn worker_admission_scales_with_warm_connection_limit() {
+        assert_eq!(remote_worker_slot_limit_for_warm_connections(5), REMOTE_WORKER_SLOT_FLOOR);
+        assert_eq!(remote_worker_slot_limit_for_warm_connections(200), 400);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3776,6 +3776,7 @@ impl Drop for RemoteSession {
     fn drop(&mut self) {
         self.interactive_writer.request_close();
         self.interactive_writer.abort_transport();
+        self.join_reader_worker();
         self.interactive_writer.join_worker_if_done();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1298,8 +1298,9 @@ impl WorkerCompletion {
     }
 
     fn install_handle(self: &Arc<Self>, handle: std::thread::JoinHandle<()>) {
+        let current = handle.thread().id() == std::thread::current().id();
         *self.handle.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(handle);
-        if self.is_done() {
+        if self.is_done() && !current {
             self.reap_owned_handle();
         }
     }
@@ -1525,8 +1526,12 @@ fn reap_completed_workers(state: &Arc<Mutex<ReaperState>>) {
         std::mem::take(&mut current.pending)
     };
     let mut index = pending.len();
+    let current = std::thread::current().id();
     while index > 0 {
         index -= 1;
+        if pending[index].0.thread().id() == current {
+            continue;
+        }
         if pending[index].1.is_done() {
             let (handle, completion) = pending.swap_remove(index);
             let _ = handle.join();
@@ -1544,6 +1549,10 @@ fn enqueue_worker_reap_in_state(
     handle: std::thread::JoinHandle<()>,
     completion: Arc<WorkerCompletion>,
 ) {
+    if handle.thread().id() == std::thread::current().id() {
+        completion.install_handle(handle);
+        return;
+    }
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1426,6 +1426,8 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
             }
         })
     else {
+        drop(current);
+        reap_completed_workers(state);
         return;
     };
     let old_worker = current.worker.take();
@@ -1434,6 +1436,26 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     drop(current);
     if let Some(old_worker) = old_worker {
         let _ = old_worker.join();
+    }
+}
+
+fn reap_completed_workers(state: &Arc<Mutex<ReaperState>>) {
+    let mut pending = {
+        let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
+        std::mem::take(&mut current.pending)
+    };
+    let mut index = pending.len();
+    while index > 0 {
+        index -= 1;
+        if pending[index].1.is_done() {
+            let (handle, completion) = pending.swap_remove(index);
+            let _ = handle.join();
+            completion.mark_joined();
+        }
+    }
+    if !pending.is_empty() {
+        let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
+        current.pending.append(&mut pending);
     }
 }
 
@@ -1452,6 +1474,9 @@ fn enqueue_worker_reap(handle: std::thread::JoinHandle<()>, completion: Arc<Work
     let needs_start = state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none();
     if needs_start {
         try_start_reaper(&state);
+        if state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none() {
+            reap_completed_workers(&state);
+        }
     }
 }
 
@@ -1484,6 +1509,7 @@ struct InteractiveWaitUntilWrittenGate {
 struct InteractiveWriter {
     shared: Arc<InteractiveWriterShared>,
     abort: Arc<dyn RemoteTransportAbort>,
+    transport_aborted: AtomicBool,
     worker: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
@@ -1513,7 +1539,12 @@ impl InteractiveWriter {
             .inspect_err(|_| {
                 shared.worker_completion.release_slot();
             })?;
-        Ok(Self { shared, abort, worker: Mutex::new(Some(worker)) })
+        Ok(Self {
+            shared,
+            abort,
+            transport_aborted: AtomicBool::new(false),
+            worker: Mutex::new(Some(worker)),
+        })
     }
 
     fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
@@ -1646,13 +1677,20 @@ impl InteractiveWriter {
             state.queued_bytes = 0;
         }
         self.shared.changed.notify_all();
-        if let Err(abort_error) = self.abort.abort() {
+        if let Err(abort_error) = self.abort_transport() {
             self.record_abort_failure(&abort_error);
         }
     }
 
     fn abort_transport(&self) -> io::Result<()> {
-        self.abort.abort()
+        if self.transport_aborted.load(Ordering::Acquire) {
+            return Ok(());
+        }
+        let result = self.abort.abort();
+        if result.is_ok() {
+            self.transport_aborted.store(true, Ordering::Release);
+        }
+        result
     }
 
     fn record_abort_failure(&self, error: &io::Error) {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7200,7 +7200,7 @@ mod tests {
         state.lock().unwrap().sender = None;
 
         let release = Arc::new((Mutex::new(false), Condvar::new()));
-        let completion = Arc::new(WorkerCompletion::with_runtime(runtime.clone(), None, true));
+        let completion = Arc::new(WorkerCompletion::with_runtime(runtime, None, true));
         let worker_release = release.clone();
         let worker_completion = completion.clone();
         let handle = std::thread::spawn(move || {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8,7 +8,7 @@ use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
-use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -1401,6 +1401,15 @@ struct WorkerRuntime {
 }
 
 static PROCESS_WORKER_ADMISSION: OnceLock<Arc<WorkerAdmission>> = OnceLock::new();
+static PROCESS_REAPER: OnceLock<Arc<Mutex<ReaperState>>> = OnceLock::new();
+
+fn new_reaper_state() -> Arc<Mutex<ReaperState>> {
+    Arc::new(Mutex::new(ReaperState { sender: None, worker: None, pending: Vec::new() }))
+}
+
+fn process_reaper_state() -> Arc<Mutex<ReaperState>> {
+    PROCESS_REAPER.get_or_init(new_reaper_state).clone()
+}
 
 fn process_worker_admission() -> Arc<WorkerAdmission> {
     PROCESS_WORKER_ADMISSION
@@ -1412,14 +1421,7 @@ fn process_worker_admission() -> Arc<WorkerAdmission> {
 
 impl WorkerRuntime {
     fn new() -> Arc<Self> {
-        Arc::new(Self {
-            admission: process_worker_admission(),
-            reaper: Arc::new(Mutex::new(ReaperState {
-                sender: None,
-                worker: None,
-                pending: Vec::new(),
-            })),
-        })
+        Arc::new(Self { admission: process_worker_admission(), reaper: process_reaper_state() })
     }
 
     fn reserve_slot(&self) -> Option<WorkerSlot> {
@@ -1445,7 +1447,14 @@ static FAIL_NEXT_REAPER_SPAWN: AtomicBool = AtomicBool::new(false);
 #[cfg(test)]
 fn test_worker_runtime() -> Arc<WorkerRuntime> {
     static RUNTIME: OnceLock<Arc<WorkerRuntime>> = OnceLock::new();
-    RUNTIME.get_or_init(WorkerRuntime::new).clone()
+    RUNTIME
+        .get_or_init(|| {
+            Arc::new(WorkerRuntime {
+                admission: process_worker_admission(),
+                reaper: new_reaper_state(),
+            })
+        })
+        .clone()
 }
 
 #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1305,9 +1305,37 @@ fn enqueue_worker_reap(
         let (sender, receiver) = std::sync::mpsc::sync_channel::<ReapRequest>(64);
         let Ok(_) =
             std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
-                while let Ok((handle, completion)) = receiver.recv() {
-                    completion.wait_forever();
-                    let _ = handle.join();
+                let mut pending = Vec::new();
+                loop {
+                    while let Ok(request) = receiver.try_recv() {
+                        pending.push(request);
+                    }
+                    let mut index = pending.len();
+                    while index > 0 {
+                        index -= 1;
+                        if pending[index].1.is_done() {
+                            let (handle, _) = pending.swap_remove(index);
+                            let _ = handle.join();
+                        }
+                    }
+                    if pending.is_empty() {
+                        match receiver.recv() {
+                            Ok(request) => pending.push(request),
+                            Err(_) => break,
+                        }
+                    } else {
+                        match receiver.recv_timeout(Duration::from_millis(50)) {
+                            Ok(request) => pending.push(request),
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                                for (handle, completion) in pending.drain(..) {
+                                    completion.wait_forever();
+                                    let _ = handle.join();
+                                }
+                                break;
+                            }
+                        }
+                    }
                 }
             })
         else {
@@ -1510,6 +1538,10 @@ impl InteractiveWriter {
     }
 
     fn join_worker(&self) {
+        self.join_worker_until(Instant::now() + remote_write_timeout());
+    }
+
+    fn join_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
         let handle = {
             let mut worker = self.worker.lock().unwrap_or_else(|poison| poison.into_inner());
@@ -1519,7 +1551,11 @@ impl InteractiveWriter {
             worker.take()
         };
         if let Some(handle) = handle {
-            if self.shared.worker_completion.wait(remote_write_timeout()) {
+            if self
+                .shared
+                .worker_completion
+                .wait(deadline.saturating_duration_since(Instant::now()))
+            {
                 let _ = handle.join();
             } else if let Err(handle) =
                 enqueue_worker_reap(handle, self.shared.worker_completion.clone())
@@ -1555,8 +1591,11 @@ impl InteractiveWriter {
     }
 
     fn close(&self) {
+        self.close_until(Instant::now() + remote_write_timeout());
+    }
+
+    fn close_until(&self, deadline: Instant) {
         self.request_close();
-        let deadline = Instant::now() + remote_write_timeout();
         let mut state = self.shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
         while !state.writer_closed {
             let remaining = deadline.saturating_duration_since(Instant::now());
@@ -3105,6 +3144,10 @@ impl RemoteSession {
     }
 
     pub fn begin_shutdown(&self) {
+        self.begin_shutdown_until(Instant::now() + remote_write_timeout());
+    }
+
+    fn begin_shutdown_until(&self, deadline: Instant) {
         self.shutdown.store(true, Ordering::Release);
         self.provider_workspaces_guarded.store(false, Ordering::Release);
         let pending = std::mem::take(&mut *self.pending.lock().unwrap());
@@ -3112,12 +3155,19 @@ impl RemoteSession {
             let _ = request.response.send(json!({"shutdown": true}));
         }
         if let Ok(Some(sequence)) = self.interactive_writer.last_enqueued_sequence() {
-            let _ = self.wait_for_ordered_write(sequence);
+            let _ = self.wait_for_ordered_write_until(sequence, deadline);
         }
     }
 
     fn wait_for_ordered_write(&self, sequence: u64) -> io::Result<()> {
-        match self.interactive_writer.wait_until_written(sequence, remote_write_timeout()) {
+        self.wait_for_ordered_write_until(sequence, Instant::now() + remote_write_timeout())
+    }
+
+    fn wait_for_ordered_write_until(&self, sequence: u64, deadline: Instant) -> io::Result<()> {
+        match self
+            .interactive_writer
+            .wait_until_written(sequence, deadline.saturating_duration_since(Instant::now()))
+        {
             Ok(()) => Ok(()),
             Err(error) => {
                 if error.kind() == io::ErrorKind::TimedOut {
@@ -3133,6 +3183,7 @@ impl RemoteSession {
     }
 
     pub(super) fn disconnect_transport_with_reason(&self, reason: Option<String>) {
+        let deadline = Instant::now() + remote_write_timeout();
         let mut state = self.disconnect_state.lock().unwrap();
         if matches!(&*state, DisconnectState::Active) {
             *state = match reason {
@@ -3141,14 +3192,18 @@ impl RemoteSession {
             };
         }
         drop(state);
-        self.begin_shutdown();
-        self.interactive_writer.close();
+        self.begin_shutdown_until(deadline);
+        self.interactive_writer.close_until(deadline);
         self.interactive_writer.abort_transport();
-        self.interactive_writer.join_worker();
-        self.join_reader_worker();
+        self.interactive_writer.join_worker_until(deadline);
+        self.join_reader_worker_until(deadline);
     }
 
     fn join_reader_worker(&self) {
+        self.join_reader_worker_until(Instant::now() + remote_write_timeout());
+    }
+
+    fn join_reader_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
         let handle = {
             let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
@@ -3159,7 +3214,7 @@ impl RemoteSession {
             worker.take()
         };
         if let Some(handle) = handle {
-            if self.reader_completion.wait(remote_write_timeout()) {
+            if self.reader_completion.wait(deadline.saturating_duration_since(Instant::now())) {
                 let _ = handle.join();
             } else if let Err(handle) = enqueue_worker_reap(handle, self.reader_completion.clone())
             {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,9 +6,11 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::sync::OnceLock;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::mpsc::{Receiver, RecvError, RecvTimeoutError, Sender, channel};
-use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -1809,25 +1811,25 @@ impl InteractiveWriter {
 
     fn join_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
-        let handle = self.shared.worker_completion.take_handle();
-        if let Some(handle) = handle {
-            if handle.thread().id() == current {
-                self.shared.worker_completion.install_handle(handle);
-                return;
-            }
-            if self
+        let Some(handle) = self.shared.worker_completion.take_handle() else {
+            let _ = self
                 .shared
                 .worker_completion
-                .wait(deadline.saturating_duration_since(Instant::now()))
-            {
-                let _ = handle.join();
-                self.shared.worker_completion.release_slot();
-            } else {
-                self.shared
-                    .worker_completion
-                    .runtime
-                    .enqueue(handle, self.shared.worker_completion.clone());
-            }
+                .wait(deadline.saturating_duration_since(Instant::now()));
+            return;
+        };
+        if handle.thread().id() == current {
+            self.shared.worker_completion.install_handle(handle);
+            return;
+        }
+        if self.shared.worker_completion.wait(deadline.saturating_duration_since(Instant::now())) {
+            let _ = handle.join();
+            self.shared.worker_completion.release_slot();
+        } else {
+            self.shared
+                .worker_completion
+                .runtime
+                .enqueue(handle, self.shared.worker_completion.clone());
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1556,9 +1556,9 @@ fn enqueue_worker_reap_in_state(
     }
     let needs_start = state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none();
     if needs_start {
-        try_start_reaper(&state);
+        try_start_reaper(state);
         if state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none() {
-            reap_completed_workers(&state);
+            reap_completed_workers(state);
         }
     }
 }
@@ -1581,7 +1581,7 @@ fn wake_reaper_after_completion(state: &Arc<Mutex<ReaperState>>) {
         }
     };
     if needs_start {
-        try_start_reaper(&state);
+        try_start_reaper(state);
     }
 }
 
@@ -2378,7 +2378,7 @@ impl RemoteSession {
             .reserve_slot()
             .ok_or_else(|| anyhow::anyhow!("remote worker slots exhausted"))?;
         let reader_completion =
-            Arc::new(WorkerCompletion::with_slot(worker_runtime.clone(), Some(reader_slot)));
+            Arc::new(WorkerCompletion::with_slot(worker_runtime, Some(reader_slot)));
         let session = Arc::new(RemoteSession {
             interactive_writer,
             reader_worker: Mutex::new(None),
@@ -7088,7 +7088,7 @@ mod tests {
     #[test]
     fn reaper_restarts_after_sender_disconnect_and_drains_pending_workers() {
         let _reaper_guard = reaper_test_guard();
-        let state = reaper_state().clone();
+        let state = reaper_state();
         state.lock().unwrap().sender = None;
         let completion = Arc::new(WorkerCompletion::new());
         let worker_completion = completion.clone();
@@ -7102,7 +7102,7 @@ mod tests {
     #[test]
     fn completed_worker_retries_reaper_after_spawn_failure() {
         let _reaper_guard = reaper_test_guard();
-        let state = reaper_state().clone();
+        let state = reaper_state();
         state.lock().unwrap().sender = None;
 
         let release = Arc::new((Mutex::new(false), Condvar::new()));
@@ -7133,7 +7133,7 @@ mod tests {
     #[test]
     fn concurrent_reaper_enqueue_starts_one_owned_worker() {
         let _reaper_guard = reaper_test_guard();
-        let state = reaper_state().clone();
+        let state = reaper_state();
         state.lock().unwrap().sender = None;
 
         let worker_count = 16;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1309,49 +1309,65 @@ type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
 
 struct ReaperState {
     sender: Option<Sender<()>>,
+    worker: Option<std::thread::JoinHandle<()>>,
     pending: Vec<ReapRequest>,
 }
 
 static REAPER: OnceLock<Arc<Mutex<ReaperState>>> = OnceLock::new();
 
 fn reaper_state() -> &'static Arc<Mutex<ReaperState>> {
-    REAPER.get_or_init(|| Arc::new(Mutex::new(ReaperState { sender: None, pending: Vec::new() })))
+    REAPER.get_or_init(|| {
+        Arc::new(Mutex::new(ReaperState { sender: None, worker: None, pending: Vec::new() }))
+    })
 }
 
 fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     let (sender, receiver) = channel::<()>();
     let worker_state = state.clone();
-    let Ok(()) = std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
-        let mut pending = Vec::new();
-        loop {
-            {
-                let mut state = worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
-                pending.append(&mut state.pending);
-            }
-            let mut index = pending.len();
-            while index > 0 {
-                index -= 1;
-                if pending[index].1.is_done() {
-                    let (handle, completion) = pending.swap_remove(index);
-                    completion.mark_joined();
-                    let _ = handle.join();
+    let Ok(reaper_worker) =
+        std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
+            let mut pending = Vec::new();
+            loop {
+                {
+                    let mut state =
+                        worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
+                    pending.append(&mut state.pending);
+                }
+                let mut index = pending.len();
+                while index > 0 {
+                    index -= 1;
+                    if pending[index].1.is_done() {
+                        let (handle, completion) = pending.swap_remove(index);
+                        completion.mark_joined();
+                        let _ = handle.join();
+                    }
+                }
+                {
+                    let mut state =
+                        worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
+                    state.pending.append(&mut pending);
+                }
+                match receiver.recv_timeout(Duration::from_millis(50)) {
+                    Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
                 }
             }
-            {
-                let mut state = worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
-                state.pending.append(&mut pending);
-            }
-            match receiver.recv_timeout(Duration::from_millis(50)) {
-                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
-            }
-        }
-    }) else {
+        })
+    else {
         return;
     };
     let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
     if current.sender.is_none() {
+        let old_worker = current.worker.take();
         current.sender = Some(sender);
+        current.worker = Some(reaper_worker);
+        drop(current);
+        if let Some(old_worker) = old_worker {
+            let _ = old_worker.join();
+        }
+    } else {
+        drop(current);
+        let _ = reaper_worker.join();
     }
 }
 
@@ -1559,11 +1575,19 @@ impl InteractiveWriter {
             state.queued_bytes = 0;
         }
         self.shared.changed.notify_all();
-        let _ = self.abort.abort();
+        if let Err(abort_error) = self.abort.abort() {
+            self.record_abort_failure(&abort_error);
+        }
     }
 
-    fn abort_transport(&self) {
-        let _ = self.abort.abort();
+    fn abort_transport(&self) -> io::Result<()> {
+        self.abort.abort()
+    }
+
+    fn record_abort_failure(&self, error: &io::Error) {
+        let mut state = self.shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        state.failure.get_or_insert_with(|| InteractiveWriteFailure::from_error(error));
+        self.shared.changed.notify_all();
     }
 
     fn join_worker(&self) {
@@ -3217,7 +3241,9 @@ impl RemoteSession {
         drop(state);
         self.begin_shutdown_until(deadline);
         self.interactive_writer.close_until(deadline);
-        self.interactive_writer.abort_transport();
+        if let Err(error) = self.interactive_writer.abort_transport() {
+            self.interactive_writer.record_abort_failure(&error);
+        }
         self.interactive_writer.join_worker_until(deadline);
         self.join_reader_worker_until(deadline);
     }
@@ -3855,7 +3881,9 @@ fn local_hostname() -> Option<String> {
 impl Drop for RemoteSession {
     fn drop(&mut self) {
         self.interactive_writer.request_close();
-        self.interactive_writer.abort_transport();
+        if let Err(error) = self.interactive_writer.abort_transport() {
+            self.interactive_writer.record_abort_failure(&error);
+        }
         self.join_reader_worker();
         self.interactive_writer.join_worker_if_done();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
@@ -6823,6 +6851,7 @@ mod tests {
         let completion = Arc::new(WorkerCompletion::new());
         let handle = std::thread::spawn(|| {});
         enqueue_worker_reap(handle, completion.clone());
+        assert!(state.lock().unwrap().worker.is_some());
         wait_for_worker_join(&completion);
         assert!(completion.was_joined());
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1256,6 +1256,7 @@ struct InteractiveWaitUntilWrittenGate {
 struct InteractiveWriter {
     shared: Arc<InteractiveWriterShared>,
     abort: Arc<dyn RemoteTransportAbort>,
+    worker: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
 impl InteractiveWriter {
@@ -1273,10 +1274,10 @@ impl InteractiveWriter {
             wait_until_written_gate: Mutex::new(None),
         });
         let worker_shared = shared.clone();
-        std::thread::Builder::new()
+        let worker = std::thread::Builder::new()
             .name("remote-input-writer".into())
             .spawn(move || interactive_writer_worker(worker_shared, writer))?;
-        Ok(Self { shared, abort })
+        Ok(Self { shared, abort, worker: Mutex::new(Some(worker)) })
     }
 
     fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
@@ -1412,6 +1413,24 @@ impl InteractiveWriter {
         let _ = self.abort.abort();
     }
 
+    fn abort_transport(&self) {
+        let _ = self.abort.abort();
+    }
+
+    fn join_worker(&self) {
+        let current = std::thread::current().id();
+        let handle = {
+            let mut worker = self.worker.lock().unwrap_or_else(|poison| poison.into_inner());
+            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                return;
+            }
+            worker.take()
+        };
+        if let Some(handle) = handle {
+            let _ = handle.join();
+        }
+    }
+
     fn close(&self) {
         self.request_close();
         let deadline = Instant::now() + remote_write_timeout();
@@ -1439,6 +1458,7 @@ impl InteractiveWriter {
                 "remote writer did not close before its deadline",
             ));
         }
+        self.join_worker();
     }
 }
 
@@ -1453,6 +1473,7 @@ impl Drop for InteractiveWriter {
                 "remote writer owner was dropped",
             ));
         }
+        self.join_worker();
     }
 }
 
@@ -1570,6 +1591,7 @@ enum DisconnectState {
 
 pub struct RemoteSession {
     interactive_writer: InteractiveWriter,
+    reader_worker: Mutex<Option<std::thread::JoinHandle<()>>>,
     /// The first terminal state wins. Local shutdown is kept separate from a
     /// reader failure so closing our own transport does not report a fake
     /// remote diagnostic.
@@ -1931,6 +1953,7 @@ impl RemoteSession {
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
         let session = Arc::new(RemoteSession {
             interactive_writer,
+            reader_worker: Mutex::new(None),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
@@ -1963,39 +1986,43 @@ impl RemoteSession {
         });
 
         let reader_session = Arc::downgrade(&session);
-        std::thread::Builder::new().name("remote-reader".into()).spawn(move || {
-            let mut report_progress = |partial: &[u8]| {
-                if let Some(session) = reader_session.upgrade() {
-                    session.report_read_progress(partial);
-                }
-            };
-            let reason = loop {
-                let received = reader.receive_with_progress(&mut report_progress);
-                if let Some(reason) = remote_reader_end_reason(&received) {
-                    break Some(reason);
-                }
-                let Ok(Some(mut message)) = received else { unreachable!("end reason handled") };
-                if message.len() > REMOTE_SESSION_MESSAGE_MAX_BYTES {
-                    break Some(remote_reader_message_too_large(&mut message));
-                }
-                let value = match serde_json::from_str::<Value>(&message) {
-                    Ok(value) => value,
-                    Err(error) => {
-                        let reason = format!("remote JSON decode failed: {error}");
-                        zeroize_string(&mut message);
-                        break Some(reason);
+        let reader_worker =
+            std::thread::Builder::new().name("remote-reader".into()).spawn(move || {
+                let mut report_progress = |partial: &[u8]| {
+                    if let Some(session) = reader_session.upgrade() {
+                        session.report_read_progress(partial);
                     }
                 };
-                zeroize_string(&mut message);
-                let Some(session) = reader_session.upgrade() else { break None };
-                session.handle_line(value);
-            };
-            // Connection lost: retain the reason before telling the app to quit.
-            if let Some(session) = reader_session.upgrade() {
-                session.disconnect_transport_with_reason(reason);
-                session.emit(MuxEvent::Empty);
-            }
-        })?;
+                let reason = loop {
+                    let received = reader.receive_with_progress(&mut report_progress);
+                    if let Some(reason) = remote_reader_end_reason(&received) {
+                        break Some(reason);
+                    }
+                    let Ok(Some(mut message)) = received else {
+                        unreachable!("end reason handled")
+                    };
+                    if message.len() > REMOTE_SESSION_MESSAGE_MAX_BYTES {
+                        break Some(remote_reader_message_too_large(&mut message));
+                    }
+                    let value = match serde_json::from_str::<Value>(&message) {
+                        Ok(value) => value,
+                        Err(error) => {
+                            let reason = format!("remote JSON decode failed: {error}");
+                            zeroize_string(&mut message);
+                            break Some(reason);
+                        }
+                    };
+                    zeroize_string(&mut message);
+                    let Some(session) = reader_session.upgrade() else { break None };
+                    session.handle_line(value);
+                };
+                // Connection lost: retain the reason before telling the app to quit.
+                if let Some(session) = reader_session.upgrade() {
+                    session.disconnect_transport_with_reason(reason);
+                    session.emit(MuxEvent::Empty);
+                }
+            })?;
+        *session.reader_worker.lock().unwrap() = Some(reader_worker);
 
         if let Err(error) = session.initialize(subscribe) {
             session.disconnect_transport();
@@ -2988,6 +3015,22 @@ impl RemoteSession {
         drop(state);
         self.begin_shutdown();
         self.interactive_writer.close();
+        self.interactive_writer.abort_transport();
+        self.join_reader_worker();
+    }
+
+    fn join_reader_worker(&self) {
+        let current = std::thread::current().id();
+        let handle = {
+            let mut worker = self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner());
+            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+                return;
+            }
+            worker.take()
+        };
+        if let Some(handle) = handle {
+            let _ = handle.join();
+        }
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -3595,6 +3638,7 @@ fn local_hostname() -> Option<String> {
 
 impl Drop for RemoteSession {
     fn drop(&mut self) {
+        self.disconnect_transport();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;
         };
@@ -3901,6 +3945,7 @@ fn test_session_with_writer(
 ) -> Arc<RemoteSession> {
     Arc::new(RemoteSession {
         interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
+        reader_worker: Mutex::new(None),
         disconnect_state: Mutex::new(DisconnectState::default()),
         pending: Mutex::new(PendingRemoteRequests::default()),
         next_id: AtomicU64::new(1),
@@ -5143,6 +5188,7 @@ mod tests {
     ) -> Arc<RemoteSession> {
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
+            reader_worker: Mutex::new(None),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
@@ -6432,6 +6478,81 @@ mod tests {
             .expect("transport shutdown must join the writer");
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn malformed_json_cancels_a_pending_request_and_preserves_decode_reason() {
+        let (client, server) = UnixStream::pair().unwrap();
+        let (release_tx, release_rx) = channel();
+        let peer = std::thread::spawn(move || {
+            let mut peer = BufReader::new(server);
+            for expected_command in ["identify", "set-client-info", "subscribe"] {
+                let mut line = String::new();
+                peer.read_line(&mut line).unwrap();
+                let request: Value = serde_json::from_str(&line).unwrap();
+                assert_eq!(request["cmd"], expected_command);
+                let data = if expected_command == "identify" {
+                    json!({
+                        "app": "cmux-tui",
+                        "protocol": SUPPORTED_PROTOCOL_VERSION,
+                        "capabilities": ["browser-pointer-frame-guard-v1"],
+                    })
+                } else {
+                    Value::Null
+                };
+                writeln!(
+                    peer.get_mut(),
+                    "{}",
+                    json!({"id": request["id"], "ok": true, "data": data})
+                )
+                .unwrap();
+            }
+
+            let mut line = String::new();
+            peer.read_line(&mut line).unwrap();
+            let request: Value = serde_json::from_str(&line).unwrap();
+            assert_eq!(request["cmd"], "wait-for-malformed");
+            peer.get_mut().write_all(b"not-json\n").unwrap();
+            release_rx.recv().unwrap();
+        });
+        let session = RemoteSession::connect_stream(Box::new(client)).unwrap();
+        let request_session = session.clone();
+        let (done_tx, done_rx) = channel();
+        let request = std::thread::spawn(move || {
+            done_tx.send(request_session.request(json!({"cmd": "wait-for-malformed"}))).unwrap();
+        });
+
+        let result = match done_rx.recv_timeout(Duration::from_secs(2)) {
+            Ok(result) => result,
+            Err(error) => {
+                session.begin_shutdown();
+                request.join().unwrap();
+                release_tx.send(()).unwrap();
+                peer.join().unwrap();
+                panic!("malformed JSON did not cancel the request promptly: {error}");
+            }
+        };
+        request.join().unwrap();
+        release_tx.send(()).unwrap();
+        peer.join().unwrap();
+
+        let error = result.unwrap_err();
+        assert!(
+            matches!(
+                error.downcast_ref::<RemoteRequestError>(),
+                Some(RemoteRequestError::Shutdown)
+            ),
+            "expected shutdown after malformed JSON canceled the request, got {error:?}"
+        );
+        assert!(
+            session
+                .transport_disconnect_reason()
+                .is_some_and(|reason| reason.starts_with("remote JSON decode failed:")),
+            "malformed JSON decode reason was not preserved: {:?}",
+            session.transport_disconnect_reason()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
     #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {
@@ -7061,81 +7182,6 @@ mod tests {
         );
         assert!(started.elapsed() < Duration::from_secs(2));
         assert!(session.shutdown.load(Ordering::Acquire));
-        assert!(session.pending.lock().unwrap().is_empty());
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn malformed_json_cancels_a_pending_request_and_preserves_decode_reason() {
-        let (client, server) = UnixStream::pair().unwrap();
-        let (release_tx, release_rx) = channel();
-        let peer = std::thread::spawn(move || {
-            let mut peer = BufReader::new(server);
-            for expected_command in ["identify", "set-client-info", "subscribe"] {
-                let mut line = String::new();
-                peer.read_line(&mut line).unwrap();
-                let request: Value = serde_json::from_str(&line).unwrap();
-                assert_eq!(request["cmd"], expected_command);
-                let data = if expected_command == "identify" {
-                    json!({
-                        "app": "cmux-tui",
-                        "protocol": SUPPORTED_PROTOCOL_VERSION,
-                        "capabilities": ["browser-pointer-frame-guard-v1"],
-                    })
-                } else {
-                    Value::Null
-                };
-                writeln!(
-                    peer.get_mut(),
-                    "{}",
-                    json!({"id": request["id"], "ok": true, "data": data})
-                )
-                .unwrap();
-            }
-
-            let mut line = String::new();
-            peer.read_line(&mut line).unwrap();
-            let request: Value = serde_json::from_str(&line).unwrap();
-            assert_eq!(request["cmd"], "wait-for-malformed");
-            peer.get_mut().write_all(b"not-json\n").unwrap();
-            release_rx.recv().unwrap();
-        });
-        let session = RemoteSession::connect_stream(Box::new(client)).unwrap();
-        let request_session = session.clone();
-        let (done_tx, done_rx) = channel();
-        let request = std::thread::spawn(move || {
-            done_tx.send(request_session.request(json!({"cmd": "wait-for-malformed"}))).unwrap();
-        });
-
-        let result = match done_rx.recv_timeout(Duration::from_secs(2)) {
-            Ok(result) => result,
-            Err(error) => {
-                session.begin_shutdown();
-                request.join().unwrap();
-                release_tx.send(()).unwrap();
-                peer.join().unwrap();
-                panic!("malformed JSON did not cancel the request promptly: {error}");
-            }
-        };
-        request.join().unwrap();
-        release_tx.send(()).unwrap();
-        peer.join().unwrap();
-
-        let error = result.unwrap_err();
-        assert!(
-            matches!(
-                error.downcast_ref::<RemoteRequestError>(),
-                Some(RemoteRequestError::Shutdown)
-            ),
-            "expected shutdown after malformed JSON canceled the request, got {error:?}"
-        );
-        assert!(
-            session
-                .transport_disconnect_reason()
-                .is_some_and(|reason| reason.starts_with("remote JSON decode failed:")),
-            "malformed JSON decode reason was not preserved: {:?}",
-            session.transport_disconnect_reason()
-        );
         assert!(session.pending.lock().unwrap().is_empty());
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1374,20 +1374,7 @@ impl WorkerCompletion {
     }
 }
 
-const REMOTE_WORKER_SLOT_FLOOR: usize = 256;
-
-fn remote_worker_slot_limit_for_warm_connections(warm_connections: usize) -> usize {
-    warm_connections.saturating_mul(2).max(REMOTE_WORKER_SLOT_FLOOR)
-}
-
-fn remote_worker_slot_limit() -> usize {
-    let warm_connections = std::env::var("CMUX_TUI_WARM_MACHINES")
-        .ok()
-        .and_then(|value| value.trim().parse::<usize>().ok())
-        .filter(|limit| *limit >= 2)
-        .unwrap_or(5);
-    remote_worker_slot_limit_for_warm_connections(warm_connections)
-}
+const REMOTE_WORKER_SLOT_LIMIT: usize = 256;
 
 struct WorkerAdmission {
     available: AtomicUsize,
@@ -1456,7 +1443,7 @@ fn process_reaper_state() -> Arc<Mutex<ReaperState>> {
 fn process_worker_admission() -> Arc<WorkerAdmission> {
     PROCESS_WORKER_ADMISSION
         .get_or_init(|| {
-            Arc::new(WorkerAdmission { available: AtomicUsize::new(remote_worker_slot_limit()) })
+            Arc::new(WorkerAdmission { available: AtomicUsize::new(REMOTE_WORKER_SLOT_LIMIT) })
         })
         .clone()
 }
@@ -1605,7 +1592,8 @@ fn enqueue_worker_reap_in_state(
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));
-        if let Some(sender) = current.sender.as_ref()
+        if current.sender.is_some()
+            && let Some(sender) = current.sender.as_ref()
             && sender.send(()).is_err()
         {
             current.sender = None;
@@ -7192,15 +7180,12 @@ mod tests {
     #[test]
     fn completed_worker_retries_reaper_after_spawn_failure() {
         let _reaper_guard = reaper_test_guard();
-        let runtime = Arc::new(WorkerRuntime {
-            admission: process_worker_admission(),
-            reaper: new_reaper_state(),
-        });
-        let state = runtime.reaper.clone();
+        let state = reaper_state();
         state.lock().unwrap().sender = None;
 
         let release = Arc::new((Mutex::new(false), Condvar::new()));
-        let completion = Arc::new(WorkerCompletion::with_runtime(runtime.clone(), None, true));
+        let completion =
+            Arc::new(WorkerCompletion::with_runtime(test_worker_runtime(), None, true));
         let worker_release = release.clone();
         let worker_completion = completion.clone();
         let handle = std::thread::spawn(move || {
@@ -7213,7 +7198,7 @@ mod tests {
         });
 
         state.lock().unwrap().fail_next_spawn = true;
-        enqueue_worker_reap_in_state(&state, handle, completion.clone());
+        enqueue_worker_reap(handle, completion.clone());
         assert!(!completion.was_joined(), "failed reaper spawn must retain the handle");
 
         let (released, changed) = &*release;
@@ -7263,12 +7248,6 @@ mod tests {
         assert!(admission.try_reserve().is_none());
         drop(slot);
         assert!(admission.try_reserve().is_some());
-    }
-
-    #[test]
-    fn worker_admission_scales_with_warm_connection_limit() {
-        assert_eq!(remote_worker_slot_limit_for_warm_connections(5), REMOTE_WORKER_SLOT_FLOOR);
-        assert_eq!(remote_worker_slot_limit_for_warm_connections(200), 400);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1294,13 +1294,6 @@ impl WorkerCompletion {
         *self.done.lock().unwrap_or_else(|poison| poison.into_inner())
     }
 
-    fn wait_forever(&self) {
-        let mut done = self.done.lock().unwrap_or_else(|poison| poison.into_inner());
-        while !*done {
-            done = self.changed.wait(done).unwrap_or_else(|poison| poison.into_inner());
-        }
-    }
-
     #[cfg(test)]
     fn was_joined(&self) -> bool {
         self.joined.load(Ordering::Acquire)
@@ -1314,74 +1307,70 @@ impl WorkerCompletion {
 
 type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
 
-static REAPER: OnceLock<Option<Sender<ReapRequest>>> = OnceLock::new();
-static UNREAPED_WORKERS: OnceLock<Mutex<Vec<ReapRequest>>> = OnceLock::new();
-
-fn retain_unreaped_worker(handle: std::thread::JoinHandle<()>, completion: Arc<WorkerCompletion>) {
-    UNREAPED_WORKERS
-        .get_or_init(|| Mutex::new(Vec::new()))
-        .lock()
-        .unwrap_or_else(|poison| poison.into_inner())
-        .push((handle, completion));
+struct ReaperState {
+    sender: Option<Sender<()>>,
+    pending: Vec<ReapRequest>,
 }
 
-fn join_worker_after_reap_failure(
-    handle: std::thread::JoinHandle<()>,
-    completion: Arc<WorkerCompletion>,
-) {
-    completion.wait_forever();
-    let _ = handle.join();
+static REAPER: OnceLock<Arc<Mutex<ReaperState>>> = OnceLock::new();
+
+fn reaper_state() -> &'static Arc<Mutex<ReaperState>> {
+    REAPER.get_or_init(|| Arc::new(Mutex::new(ReaperState { sender: None, pending: Vec::new() })))
 }
 
-fn enqueue_worker_reap(
-    handle: std::thread::JoinHandle<()>,
-    completion: Arc<WorkerCompletion>,
-) -> Result<(), std::thread::JoinHandle<()>> {
-    let sender = REAPER.get_or_init(|| {
-        let (sender, receiver) = channel::<ReapRequest>();
-        let spawned =
-            std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
-                let mut pending = Vec::new();
-                loop {
-                    while let Ok(request) = receiver.try_recv() {
-                        pending.push(request);
-                    }
-                    let mut index = pending.len();
-                    while index > 0 {
-                        index -= 1;
-                        if pending[index].1.is_done() {
-                            let (handle, completion) = pending.swap_remove(index);
-                            completion.mark_joined();
-                            let _ = handle.join();
-                        }
-                    }
-                    if pending.is_empty() {
-                        match receiver.recv() {
-                            Ok(request) => pending.push(request),
-                            Err(_) => break,
-                        }
-                    } else {
-                        match receiver.recv_timeout(Duration::from_millis(50)) {
-                            Ok(request) => pending.push(request),
-                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                                for (handle, completion) in pending.drain(..) {
-                                    join_worker_after_reap_failure(handle, completion);
-                                }
-                                break;
-                            }
-                        }
-                    }
+fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
+    let (sender, receiver) = channel::<()>();
+    let worker_state = state.clone();
+    let Ok(()) = std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
+        let mut pending = Vec::new();
+        loop {
+            {
+                let mut state = worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
+                pending.append(&mut state.pending);
+            }
+            let mut index = pending.len();
+            while index > 0 {
+                index -= 1;
+                if pending[index].1.is_done() {
+                    let (handle, completion) = pending.swap_remove(index);
+                    completion.mark_joined();
+                    let _ = handle.join();
                 }
-            });
-        spawned.ok().map(|_| sender)
-    });
-    let Some(sender) = sender else {
-        return Err(handle);
+            }
+            {
+                let mut state = worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
+                state.pending.append(&mut pending);
+            }
+            match receiver.recv_timeout(Duration::from_millis(50)) {
+                Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        }
+    }) else {
+        return;
     };
-    match sender.send((handle, completion)) {
-        Ok(()) => Ok(()),
-        Err(std::sync::mpsc::SendError((handle, completion))) => Err(handle),
+    let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
+    if current.sender.is_none() {
+        current.sender = Some(sender);
+    }
+}
+
+fn enqueue_worker_reap(handle: std::thread::JoinHandle<()>, completion: Arc<WorkerCompletion>) {
+    let state = reaper_state().clone();
+    {
+        let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
+        current.pending.push((handle, completion));
+        if current.sender.is_some() {
+            if let Some(sender) = current.sender.as_ref() {
+                if sender.send(()).is_err() {
+                    current.sender = None;
+                }
+            }
+        }
+    }
+    let needs_start = state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none();
+    if needs_start {
+        try_start_reaper(&state);
     }
 }
 
@@ -1598,10 +1587,7 @@ impl InteractiveWriter {
             {
                 let _ = handle.join();
             } else {
-                let completion = self.shared.worker_completion.clone();
-                if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
-                    join_worker_after_reap_failure(handle, completion);
-                }
+                enqueue_worker_reap(handle, self.shared.worker_completion.clone());
             }
         }
     }
@@ -1617,10 +1603,7 @@ impl InteractiveWriter {
                 return;
             };
             if !self.shared.worker_completion.is_done() {
-                let completion = self.shared.worker_completion.clone();
-                if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
-                    join_worker_after_reap_failure(handle, completion);
-                }
+                enqueue_worker_reap(handle, self.shared.worker_completion.clone());
                 return;
             }
             Some(handle)
@@ -3251,10 +3234,7 @@ impl RemoteSession {
                 let handle = worker.take();
                 drop(worker);
                 if let Some(handle) = handle {
-                    let completion = self.reader_completion.clone();
-                    if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
-                        retain_unreaped_worker(handle, completion);
-                    }
+                    enqueue_worker_reap(handle, self.reader_completion.clone());
                 }
                 return;
             }
@@ -3264,10 +3244,7 @@ impl RemoteSession {
             if self.reader_completion.wait(deadline.saturating_duration_since(Instant::now())) {
                 let _ = handle.join();
             } else {
-                let completion = self.reader_completion.clone();
-                if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
-                    join_worker_after_reap_failure(handle, completion);
-                }
+                enqueue_worker_reap(handle, self.reader_completion.clone());
             }
         }
     }
@@ -6827,8 +6804,8 @@ mod tests {
         let second = std::thread::spawn(move || {
             second_completion_thread.mark_done();
         });
-        enqueue_worker_reap(first, first_completion.clone()).unwrap();
-        enqueue_worker_reap(second, second_completion.clone()).unwrap();
+        enqueue_worker_reap(first, first_completion.clone());
+        enqueue_worker_reap(second, second_completion.clone());
 
         wait_for_worker_join(&second_completion);
         assert!(!first_completion.was_joined());

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3530,10 +3530,6 @@ impl RemoteSession {
         self.join_reader_worker_until(deadline);
     }
 
-    fn join_reader_worker(&self) {
-        self.join_reader_worker_until(Instant::now() + remote_write_timeout());
-    }
-
     fn reap_reader_worker(&self) {
         let current = std::thread::current().id();
         let Some(handle) = self.reader_completion.take_handle() else {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,7 +7,7 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvError, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -1405,14 +1405,22 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
                         completion.mark_joined();
                     }
                 }
+                let has_pending = !pending.is_empty();
                 {
                     let mut state =
                         worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
                     state.pending.append(&mut pending);
                 }
-                match receiver.recv_timeout(Duration::from_millis(50)) {
-                    Ok(()) | Err(RecvTimeoutError::Timeout) => {}
-                    Err(RecvTimeoutError::Disconnected) => break,
+                if has_pending {
+                    match receiver.recv_timeout(Duration::from_millis(50)) {
+                        Ok(()) | Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => break,
+                    }
+                } else {
+                    match receiver.recv() {
+                        Ok(()) => {}
+                        Err(RecvError) => break,
+                    }
                 }
             }
         })
@@ -4718,6 +4726,12 @@ mod tests {
 
     use super::*;
 
+    static REAPER_TEST_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+    fn reaper_test_guard() -> std::sync::MutexGuard<'static, ()> {
+        REAPER_TEST_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
     fn attached_surface(outcome: RemoteSurfaceAttach) -> Arc<RemoteSurface> {
         let RemoteSurfaceAttach::Attached(surface) = outcome else {
             panic!("surface attach did not produce a mirror");
@@ -6773,6 +6787,7 @@ mod tests {
 
     #[test]
     fn transport_disconnect_cancels_and_joins_reader_and_writer_workers() {
+        let _reaper_guard = reaper_test_guard();
         let (responses, response_rx) = channel();
         let release = Arc::new((Mutex::new(false), Condvar::new()));
         let (reader_exited, reader_exited_rx) = channel();
@@ -6805,6 +6820,7 @@ mod tests {
 
     #[test]
     fn dropping_session_waits_for_blocked_reader_worker() {
+        let _reaper_guard = reaper_test_guard();
         let (responses, response_rx) = channel();
         let release = Arc::new((Mutex::new(false), Condvar::new()));
         let (reader_entered, reader_entered_rx) = channel();
@@ -6849,6 +6865,7 @@ mod tests {
 
     #[test]
     fn reader_self_disconnect_keeps_its_join_handle_owned() {
+        let _reaper_guard = reaper_test_guard();
         let (responses, response_rx) = channel();
         let release = Arc::new((Mutex::new(false), Condvar::new()));
         let (reader_exited, reader_exited_rx) = channel();
@@ -6881,6 +6898,7 @@ mod tests {
 
     #[test]
     fn reaper_does_not_block_completed_workers_behind_a_stalled_worker() {
+        let _reaper_guard = reaper_test_guard();
         let first_release = Arc::new((Mutex::new(false), Condvar::new()));
         let first_completion = Arc::new(WorkerCompletion::new());
         let second_completion = Arc::new(WorkerCompletion::new());
@@ -6912,6 +6930,7 @@ mod tests {
 
     #[test]
     fn reaper_restarts_after_sender_disconnect_and_drains_pending_workers() {
+        let _reaper_guard = reaper_test_guard();
         let state = reaper_state().clone();
         state.lock().unwrap().sender = None;
         let completion = Arc::new(WorkerCompletion::new());
@@ -6924,6 +6943,7 @@ mod tests {
 
     #[test]
     fn concurrent_reaper_enqueue_starts_one_owned_worker() {
+        let _reaper_guard = reaper_test_guard();
         let state = reaper_state().clone();
         state.lock().unwrap().sender = None;
 
@@ -7792,6 +7812,7 @@ mod tests {
 
     #[test]
     fn write_timeout_aborts_the_blocked_writer_and_discards_queued_mutations() {
+        let _reaper_guard = reaper_test_guard();
         let (stream, control) = BlockingWriteStream::new();
         let output = stream.output.clone();
         let session = blocking_test_session(stream);
@@ -7827,6 +7848,7 @@ mod tests {
 
     #[test]
     fn dropping_a_session_aborts_a_blocked_writer() {
+        let _reaper_guard = reaper_test_guard();
         let (stream, control) = BlockingWriteStream::new();
         let session = blocking_test_session(stream);
         session.send_bytes(7, b"blocked").unwrap();
@@ -7848,6 +7870,7 @@ mod tests {
 
     #[test]
     fn closing_a_session_aborts_a_writer_that_cannot_drain() {
+        let _reaper_guard = reaper_test_guard();
         let (stream, control) = BlockingWriteStream::new();
         let session = blocking_test_session(stream);
         session.send_bytes(7, b"blocked").unwrap();
@@ -7870,6 +7893,7 @@ mod tests {
 
     #[test]
     fn disconnect_uses_one_total_shutdown_deadline() {
+        let _reaper_guard = reaper_test_guard();
         let (writer, control) = BlockingWriteStream::new();
         let session = test_session_with_provider_context(Box::new(writer), HashSet::new(), None);
         session.send_bytes(7, b"blocked").unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7229,6 +7229,32 @@ mod tests {
     }
 
     #[test]
+    fn completed_worker_does_not_block_when_reaper_wake_queue_is_full() {
+        let runtime = Arc::new(WorkerRuntime {
+            admission: process_worker_admission(),
+            reaper: new_reaper_state(),
+        });
+        let state = runtime.reaper.clone();
+        let (sender, receiver) = std::sync::mpsc::sync_channel(1);
+        sender.try_send(()).expect("the wake queue should be full");
+        state.lock().unwrap().sender = Some(sender);
+
+        let completion = Arc::new(WorkerCompletion::with_runtime(runtime, None, true));
+        let (finished_tx, finished_rx) = channel();
+        let worker_completion = completion.clone();
+        let worker = std::thread::spawn(move || {
+            worker_completion.mark_done();
+            finished_tx.send(()).unwrap();
+        });
+
+        finished_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("worker completion must not block on a full wake queue");
+        worker.join().unwrap();
+        drop(receiver);
+    }
+
+    #[test]
     fn concurrent_reaper_enqueue_starts_one_owned_worker() {
         let _reaper_guard = reaper_test_guard();
         let state = reaper_state();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6330,6 +6330,108 @@ mod tests {
         assert!(closed.load(Ordering::Acquire));
     }
 
+    struct LifecycleReader {
+        responses: Receiver<String>,
+        remaining_responses: usize,
+        release: Arc<(Mutex<bool>, Condvar)>,
+        exited: Sender<()>,
+    }
+
+    impl RemoteMessageReader for LifecycleReader {
+        fn receive(&mut self) -> io::Result<Option<String>> {
+            if self.remaining_responses > 0 {
+                self.remaining_responses -= 1;
+                return self.responses.recv().map(Some).map_err(|_| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "lifecycle response channel closed")
+                });
+            }
+
+            let (released, changed) = &*self.release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = changed.wait(released).unwrap();
+            }
+            self.exited.send(()).unwrap();
+            Ok(None)
+        }
+    }
+
+    struct LifecycleWriter {
+        responses: Sender<String>,
+        closed: Arc<AtomicBool>,
+        exited: Sender<()>,
+    }
+
+    impl RemoteMessageWriter for LifecycleWriter {
+        fn send(&mut self, message: &str) -> io::Result<()> {
+            let request: Value = serde_json::from_str(message).map_err(io::Error::other)?;
+            let id = request
+                .get("id")
+                .and_then(Value::as_u64)
+                .ok_or_else(|| io::Error::other("lifecycle request omitted its id"))?;
+            let data = (request.get("cmd").and_then(Value::as_str) == Some("identify"))
+                .then(|| json!({"app": "cmux-tui", "protocol": SUPPORTED_PROTOCOL_VERSION}))
+                .unwrap_or(Value::Null);
+            self.responses
+                .send(json!({"id": id, "ok": true, "data": data}).to_string())
+                .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "lifecycle reader exited"))
+        }
+
+        fn close(&mut self) -> io::Result<()> {
+            self.closed.store(true, Ordering::Release);
+            Ok(())
+        }
+    }
+
+    impl Drop for LifecycleWriter {
+        fn drop(&mut self) {
+            let _ = self.exited.send(());
+        }
+    }
+
+    struct LifecycleAbort {
+        release: Arc<(Mutex<bool>, Condvar)>,
+    }
+
+    impl RemoteTransportAbort for LifecycleAbort {
+        fn abort(&self) -> io::Result<()> {
+            let (released, changed) = &*self.release;
+            *released.lock().unwrap() = true;
+            changed.notify_all();
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn transport_disconnect_cancels_and_joins_reader_and_writer_workers() {
+        let (responses, response_rx) = channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (reader_exited, reader_exited_rx) = channel();
+        let (writer_exited, writer_exited_rx) = channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let session = RemoteSession::connect_transport(RemoteTransport::new(
+            Box::new(LifecycleReader {
+                responses: response_rx,
+                remaining_responses: 3,
+                release: release.clone(),
+                exited: reader_exited,
+            }),
+            Box::new(LifecycleWriter { responses, closed: closed.clone(), exited: writer_exited }),
+            Arc::new(LifecycleAbort { release }),
+        ))
+        .unwrap();
+
+        session.disconnect_transport();
+
+        assert!(closed.load(Ordering::Acquire));
+        reader_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("transport shutdown must cancel the blocked reader");
+        writer_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("transport shutdown must join the writer");
+    }
+
     #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1252,6 +1252,8 @@ struct WorkerCompletion {
     done: Mutex<bool>,
     changed: Condvar,
     admission: Mutex<Option<WorkerSlot>>,
+    handle: Mutex<Option<std::thread::JoinHandle<()>>>,
+    runtime: Arc<WorkerRuntime>,
     wake_reaper: bool,
     #[cfg(test)]
     joined: AtomicBool,
@@ -1260,29 +1262,53 @@ struct WorkerCompletion {
 impl WorkerCompletion {
     #[cfg(test)]
     fn new() -> Self {
-        Self::with_slot_and_reaper(None, false)
+        Self::with_runtime(test_worker_runtime(), None, false)
     }
 
-    fn with_slot(slot: Option<WorkerSlot>) -> Self {
-        Self::with_slot_and_reaper(slot, true)
-    }
-
-    fn with_slot_and_reaper(slot: Option<WorkerSlot>, wake_reaper: bool) -> Self {
+    fn with_runtime(
+        runtime: Arc<WorkerRuntime>,
+        slot: Option<WorkerSlot>,
+        wake_reaper: bool,
+    ) -> Self {
         Self {
             done: Mutex::new(false),
             changed: Condvar::new(),
             admission: Mutex::new(slot),
+            handle: Mutex::new(None),
+            runtime,
             wake_reaper,
             #[cfg(test)]
             joined: AtomicBool::new(false),
         }
     }
 
-    fn mark_done(&self) {
+    fn with_slot(runtime: Arc<WorkerRuntime>, slot: Option<WorkerSlot>) -> Self {
+        Self::with_runtime(runtime, slot, true)
+    }
+
+    fn mark_done(self: &Arc<Self>) {
         *self.done.lock().unwrap_or_else(|poison| poison.into_inner()) = true;
         self.changed.notify_all();
         if self.wake_reaper {
-            wake_reaper_after_completion();
+            self.runtime.wake_reaper();
+        }
+        self.reap_owned_handle();
+    }
+
+    fn install_handle(self: &Arc<Self>, handle: std::thread::JoinHandle<()>) {
+        *self.handle.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(handle);
+        if self.is_done() {
+            self.reap_owned_handle();
+        }
+    }
+
+    fn take_handle(&self) -> Option<std::thread::JoinHandle<()>> {
+        self.handle.lock().unwrap_or_else(|poison| poison.into_inner()).take()
+    }
+
+    fn reap_owned_handle(self: &Arc<Self>) {
+        if let Some(handle) = self.take_handle() {
+            self.runtime.enqueue(handle, self.clone());
         }
     }
 
@@ -1334,8 +1360,6 @@ struct WorkerAdmission {
 
 struct WorkerSlot(Arc<WorkerAdmission>);
 
-static WORKER_ADMISSION: OnceLock<Arc<WorkerAdmission>> = OnceLock::new();
-
 impl WorkerAdmission {
     fn try_reserve(self: &Arc<Self>) -> Option<WorkerSlot> {
         let mut available = self.available.load(Ordering::Acquire);
@@ -1356,15 +1380,6 @@ impl WorkerAdmission {
     }
 }
 
-fn reserve_worker_slot() -> Option<WorkerSlot> {
-    let admission = WORKER_ADMISSION
-        .get_or_init(|| {
-            Arc::new(WorkerAdmission { available: AtomicUsize::new(REMOTE_WORKER_SLOT_LIMIT) })
-        })
-        .clone();
-    admission.try_reserve()
-}
-
 impl Drop for WorkerSlot {
     fn drop(&mut self) {
         self.0.available.fetch_add(1, Ordering::Release);
@@ -1379,15 +1394,54 @@ struct ReaperState {
     pending: Vec<ReapRequest>,
 }
 
-static REAPER: OnceLock<Arc<Mutex<ReaperState>>> = OnceLock::new();
+struct WorkerRuntime {
+    admission: Arc<WorkerAdmission>,
+    reaper: Arc<Mutex<ReaperState>>,
+}
+
+impl WorkerRuntime {
+    fn new() -> Arc<Self> {
+        Arc::new(Self {
+            admission: Arc::new(WorkerAdmission {
+                available: AtomicUsize::new(REMOTE_WORKER_SLOT_LIMIT),
+            }),
+            reaper: Arc::new(Mutex::new(ReaperState {
+                sender: None,
+                worker: None,
+                pending: Vec::new(),
+            })),
+        })
+    }
+
+    fn reserve_slot(&self) -> Option<WorkerSlot> {
+        self.admission.try_reserve()
+    }
+
+    fn enqueue(
+        self: &Arc<Self>,
+        handle: std::thread::JoinHandle<()>,
+        completion: Arc<WorkerCompletion>,
+    ) {
+        enqueue_worker_reap_in_state(&self.reaper, handle, completion);
+    }
+
+    fn wake_reaper(&self) {
+        wake_reaper_after_completion(&self.reaper);
+    }
+}
 
 #[cfg(test)]
 static FAIL_NEXT_REAPER_SPAWN: AtomicBool = AtomicBool::new(false);
 
-fn reaper_state() -> &'static Arc<Mutex<ReaperState>> {
-    REAPER.get_or_init(|| {
-        Arc::new(Mutex::new(ReaperState { sender: None, worker: None, pending: Vec::new() }))
-    })
+#[cfg(test)]
+fn test_worker_runtime() -> Arc<WorkerRuntime> {
+    static RUNTIME: OnceLock<Arc<WorkerRuntime>> = OnceLock::new();
+    RUNTIME.get_or_init(WorkerRuntime::new).clone()
+}
+
+#[cfg(test)]
+fn reaper_state() -> Arc<Mutex<ReaperState>> {
+    test_worker_runtime().reaper.clone()
 }
 
 fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
@@ -1430,15 +1484,21 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
                         worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
                     state.pending.append(&mut pending);
                 }
-                if has_pending {
-                    match receiver.recv_timeout(Duration::from_millis(50)) {
-                        Ok(()) | Err(RecvTimeoutError::Timeout) => {}
-                        Err(RecvTimeoutError::Disconnected) => break,
+                match receiver.recv_timeout(Duration::from_millis(50)) {
+                    Ok(()) => {}
+                    Err(RecvTimeoutError::Timeout) if !has_pending => {
+                        let mut state =
+                            worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
+                        if state.pending.is_empty() {
+                            state.sender = None;
+                            break;
+                        }
                     }
-                } else {
-                    match receiver.recv() {
-                        Ok(()) => {}
-                        Err(RecvError) => break,
+                    Err(RecvTimeoutError::Timeout) => {}
+                    Err(RecvTimeoutError::Disconnected) => {
+                        worker_state.lock().unwrap_or_else(|poison| poison.into_inner()).sender =
+                            None;
+                        break;
                     }
                 }
             }
@@ -1477,8 +1537,11 @@ fn reap_completed_workers(state: &Arc<Mutex<ReaperState>>) {
     }
 }
 
-fn enqueue_worker_reap(handle: std::thread::JoinHandle<()>, completion: Arc<WorkerCompletion>) {
-    let state = reaper_state().clone();
+fn enqueue_worker_reap_in_state(
+    state: &Arc<Mutex<ReaperState>>,
+    handle: std::thread::JoinHandle<()>,
+    completion: Arc<WorkerCompletion>,
+) {
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));
@@ -1498,10 +1561,12 @@ fn enqueue_worker_reap(handle: std::thread::JoinHandle<()>, completion: Arc<Work
     }
 }
 
-fn wake_reaper_after_completion() {
-    let Some(state) = REAPER.get().cloned() else {
-        return;
-    };
+#[cfg(test)]
+fn enqueue_worker_reap(handle: std::thread::JoinHandle<()>, completion: Arc<WorkerCompletion>) {
+    test_worker_runtime().enqueue(handle, completion);
+}
+
+fn wake_reaper_after_completion(state: &Arc<Mutex<ReaperState>>) {
     let needs_start = {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         match current.sender.as_ref() {
@@ -1549,7 +1614,6 @@ struct InteractiveWriter {
     abort: Arc<dyn RemoteTransportAbort>,
     transport_abort_lock: Mutex<()>,
     transport_aborted: AtomicBool,
-    worker: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
 
 impl InteractiveWriter {
@@ -1558,11 +1622,12 @@ impl InteractiveWriter {
     fn spawn(
         writer: Box<dyn RemoteMessageWriter>,
         abort: Arc<dyn RemoteTransportAbort>,
+        runtime: Arc<WorkerRuntime>,
     ) -> io::Result<Self> {
-        let slot = reserve_worker_slot().ok_or_else(|| {
+        let slot = runtime.reserve_slot().ok_or_else(|| {
             io::Error::new(io::ErrorKind::WouldBlock, "remote worker slots exhausted")
         })?;
-        let worker_completion = Arc::new(WorkerCompletion::with_slot(Some(slot)));
+        let worker_completion = Arc::new(WorkerCompletion::with_slot(runtime, Some(slot)));
         let shared = Arc::new(InteractiveWriterShared {
             state: Mutex::new(InteractiveWriteQueueState::default()),
             changed: Condvar::new(),
@@ -1578,12 +1643,12 @@ impl InteractiveWriter {
             .inspect_err(|_| {
                 shared.worker_completion.release_slot();
             })?;
+        shared.worker_completion.install_handle(worker);
         Ok(Self {
             shared,
             abort,
             transport_abort_lock: Mutex::new(()),
             transport_aborted: AtomicBool::new(false),
-            worker: Mutex::new(Some(worker)),
         })
     }
 
@@ -1744,14 +1809,12 @@ impl InteractiveWriter {
 
     fn join_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
-        let handle = {
-            let mut worker = self.worker.lock().unwrap_or_else(|poison| poison.into_inner());
-            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
+        let handle = self.shared.worker_completion.take_handle();
+        if let Some(handle) = handle {
+            if handle.thread().id() == current {
+                self.shared.worker_completion.install_handle(handle);
                 return;
             }
-            worker.take()
-        };
-        if let Some(handle) = handle {
             if self
                 .shared
                 .worker_completion
@@ -1760,31 +1823,31 @@ impl InteractiveWriter {
                 let _ = handle.join();
                 self.shared.worker_completion.release_slot();
             } else {
-                enqueue_worker_reap(handle, self.shared.worker_completion.clone());
+                self.shared
+                    .worker_completion
+                    .runtime
+                    .enqueue(handle, self.shared.worker_completion.clone());
             }
         }
     }
 
     fn join_worker_if_done(&self) {
-        let current = std::thread::current().id();
-        let handle = {
-            let mut worker = self.worker.lock().unwrap_or_else(|poison| poison.into_inner());
-            if worker.as_ref().is_some_and(|handle| handle.thread().id() == current) {
-                return;
-            }
-            let Some(handle) = worker.take() else {
-                return;
-            };
-            if !self.shared.worker_completion.is_done() {
-                enqueue_worker_reap(handle, self.shared.worker_completion.clone());
-                return;
-            }
-            Some(handle)
+        let Some(handle) = self.shared.worker_completion.take_handle() else {
+            return;
         };
-        if let Some(handle) = handle {
-            let _ = handle.join();
-            self.shared.worker_completion.release_slot();
+        if handle.thread().id() == std::thread::current().id() {
+            self.shared.worker_completion.install_handle(handle);
+            return;
         }
+        if !self.shared.worker_completion.is_done() {
+            self.shared
+                .worker_completion
+                .runtime
+                .enqueue(handle, self.shared.worker_completion.clone());
+            return;
+        }
+        let _ = handle.join();
+        self.shared.worker_completion.release_slot();
     }
 
     fn close_until(&self, deadline: Instant) {
@@ -2306,11 +2369,14 @@ impl RemoteSession {
         subscribe: bool,
     ) -> anyhow::Result<Arc<Self>> {
         let RemoteTransport { mut reader, writer, abort } = transport;
-        let interactive_writer = InteractiveWriter::spawn(writer, abort)
+        let worker_runtime = WorkerRuntime::new();
+        let interactive_writer = InteractiveWriter::spawn(writer, abort, worker_runtime.clone())
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
-        let reader_slot = reserve_worker_slot()
+        let reader_slot = worker_runtime
+            .reserve_slot()
             .ok_or_else(|| anyhow::anyhow!("remote worker slots exhausted"))?;
-        let reader_completion = Arc::new(WorkerCompletion::with_slot(Some(reader_slot)));
+        let reader_completion =
+            Arc::new(WorkerCompletion::with_slot(worker_runtime.clone(), Some(reader_slot)));
         let session = Arc::new(RemoteSession {
             interactive_writer,
             reader_worker: Mutex::new(None),
@@ -3413,7 +3479,7 @@ impl RemoteSession {
                 let handle = worker.take();
                 drop(worker);
                 if let Some(handle) = handle {
-                    enqueue_worker_reap(handle, self.reader_completion.clone());
+                    self.reader_completion.runtime.enqueue(handle, self.reader_completion.clone());
                 }
                 return;
             }
@@ -3424,7 +3490,7 @@ impl RemoteSession {
                 let _ = handle.join();
                 self.reader_completion.release_slot();
             } else {
-                enqueue_worker_reap(handle, self.reader_completion.clone());
+                self.reader_completion.runtime.enqueue(handle, self.reader_completion.clone());
             }
         }
     }
@@ -4344,8 +4410,14 @@ fn test_session_with_writer(
     provider_workspace_authority: Option<BearerToken>,
     capabilities: HashSet<String>,
 ) -> Arc<RemoteSession> {
+    let worker_runtime = test_worker_runtime();
     Arc::new(RemoteSession {
-        interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
+        interactive_writer: InteractiveWriter::spawn(
+            writer,
+            Arc::new(NoopTransportAbort),
+            worker_runtime,
+        )
+        .unwrap(),
         reader_worker: Mutex::new(None),
         reader_completion: Arc::new(WorkerCompletion::new()),
         disconnect_state: Mutex::new(DisconnectState::default()),
@@ -5594,8 +5666,9 @@ mod tests {
         capabilities: HashSet<String>,
         provider_workspace_authority: Option<BearerToken>,
     ) -> Arc<RemoteSession> {
+        let worker_runtime = test_worker_runtime();
         Arc::new(RemoteSession {
-            interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
+            interactive_writer: InteractiveWriter::spawn(writer, abort, worker_runtime).unwrap(),
             reader_worker: Mutex::new(None),
             reader_completion: Arc::new(WorkerCompletion::new()),
             disconnect_state: Mutex::new(DisconnectState::default()),
@@ -7030,7 +7103,8 @@ mod tests {
         state.lock().unwrap().sender = None;
 
         let release = Arc::new((Mutex::new(false), Condvar::new()));
-        let completion = Arc::new(WorkerCompletion::with_slot_and_reaper(None, true));
+        let completion =
+            Arc::new(WorkerCompletion::with_runtime(test_worker_runtime(), None, true));
         let worker_release = release.clone();
         let worker_completion = completion.clone();
         let handle = std::thread::spawn(move || {
@@ -8025,6 +8099,7 @@ mod tests {
 
     #[test]
     fn send_failure_wakes_every_waiter_and_discards_the_queue() {
+        let _reaper_guard = reaper_test_guard();
         let (stream, control) = BlockingWriteStream::new();
         let output = stream.output.clone();
         let session = blocking_test_session(stream);
@@ -8065,6 +8140,7 @@ mod tests {
         drop(state);
         assert!(output.lock().unwrap().is_empty());
         assert_eq!(session.interactive_write_metrics().write_failures, 1);
+        wait_for_worker_join(&session.interactive_writer.shared.worker_completion);
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1547,6 +1547,7 @@ struct InteractiveWaitUntilWrittenGate {
 struct InteractiveWriter {
     shared: Arc<InteractiveWriterShared>,
     abort: Arc<dyn RemoteTransportAbort>,
+    transport_abort_lock: Mutex<()>,
     transport_aborted: AtomicBool,
     worker: Mutex<Option<std::thread::JoinHandle<()>>>,
 }
@@ -1580,6 +1581,7 @@ impl InteractiveWriter {
         Ok(Self {
             shared,
             abort,
+            transport_abort_lock: Mutex::new(()),
             transport_aborted: AtomicBool::new(false),
             worker: Mutex::new(Some(worker)),
         })
@@ -1722,6 +1724,8 @@ impl InteractiveWriter {
     }
 
     fn abort_transport(&self) -> io::Result<()> {
+        let _abort_guard =
+            self.transport_abort_lock.lock().unwrap_or_else(|poison| poison.into_inner());
         if self.transport_aborted.load(Ordering::Acquire) {
             return Ok(());
         }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1243,8 +1243,53 @@ struct InteractiveWriterShared {
     state: Mutex<InteractiveWriteQueueState>,
     changed: Condvar,
     metrics: InteractiveWriteMetrics,
+    worker_completion: Arc<WorkerCompletion>,
     #[cfg(test)]
     wait_until_written_gate: Mutex<Option<InteractiveWaitUntilWrittenGate>>,
+}
+
+struct WorkerCompletion {
+    done: Mutex<bool>,
+    changed: Condvar,
+}
+
+impl WorkerCompletion {
+    fn new() -> Self {
+        Self { done: Mutex::new(false), changed: Condvar::new() }
+    }
+
+    fn mark_done(&self) {
+        *self.done.lock().unwrap_or_else(|poison| poison.into_inner()) = true;
+        self.changed.notify_all();
+    }
+
+    fn wait(&self, timeout: Duration) -> bool {
+        let deadline = Instant::now() + timeout;
+        let mut done = self.done.lock().unwrap_or_else(|poison| poison.into_inner());
+        while !*done {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            let (next, timeout) = self
+                .changed
+                .wait_timeout(done, remaining)
+                .unwrap_or_else(|poison| poison.into_inner());
+            done = next;
+            if timeout.timed_out() {
+                break;
+            }
+        }
+        *done
+    }
+}
+
+struct WorkerCompletionGuard(Arc<WorkerCompletion>);
+
+impl Drop for WorkerCompletionGuard {
+    fn drop(&mut self) {
+        self.0.mark_done();
+    }
 }
 
 #[cfg(test)]
@@ -1270,13 +1315,15 @@ impl InteractiveWriter {
             state: Mutex::new(InteractiveWriteQueueState::default()),
             changed: Condvar::new(),
             metrics: InteractiveWriteMetrics::default(),
+            worker_completion: Arc::new(WorkerCompletion::new()),
             #[cfg(test)]
             wait_until_written_gate: Mutex::new(None),
         });
         let worker_shared = shared.clone();
+        let worker_completion = shared.worker_completion.clone();
         let worker = std::thread::Builder::new()
             .name("remote-input-writer".into())
-            .spawn(move || interactive_writer_worker(worker_shared, writer))?;
+            .spawn(move || interactive_writer_worker(worker_shared, writer, worker_completion))?;
         Ok(Self { shared, abort, worker: Mutex::new(Some(worker)) })
     }
 
@@ -1427,7 +1474,11 @@ impl InteractiveWriter {
             worker.take()
         };
         if let Some(handle) = handle {
-            let _ = handle.join();
+            if self.shared.worker_completion.wait(remote_write_timeout()) {
+                let _ = handle.join();
+            } else {
+                *self.worker.lock().unwrap_or_else(|poison| poison.into_inner()) = Some(handle);
+            }
         }
     }
 
@@ -1480,7 +1531,9 @@ impl Drop for InteractiveWriter {
 fn interactive_writer_worker(
     shared: Arc<InteractiveWriterShared>,
     mut writer: Box<dyn RemoteMessageWriter>,
+    worker_completion: Arc<WorkerCompletion>,
 ) {
+    let _completion = WorkerCompletionGuard(worker_completion);
     loop {
         let write = {
             let mut state = shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
@@ -1592,6 +1645,7 @@ enum DisconnectState {
 pub struct RemoteSession {
     interactive_writer: InteractiveWriter,
     reader_worker: Mutex<Option<std::thread::JoinHandle<()>>>,
+    reader_completion: Arc<WorkerCompletion>,
     /// The first terminal state wins. Local shutdown is kept separate from a
     /// reader failure so closing our own transport does not report a fake
     /// remote diagnostic.
@@ -1954,6 +2008,7 @@ impl RemoteSession {
         let session = Arc::new(RemoteSession {
             interactive_writer,
             reader_worker: Mutex::new(None),
+            reader_completion: Arc::new(WorkerCompletion::new()),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),
@@ -1986,8 +2041,10 @@ impl RemoteSession {
         });
 
         let reader_session = Arc::downgrade(&session);
+        let reader_completion = session.reader_completion.clone();
         let reader_worker =
             std::thread::Builder::new().name("remote-reader".into()).spawn(move || {
+                let _completion = WorkerCompletionGuard(reader_completion);
                 let mut report_progress = |partial: &[u8]| {
                     if let Some(session) = reader_session.upgrade() {
                         session.report_read_progress(partial);
@@ -3029,7 +3086,12 @@ impl RemoteSession {
             worker.take()
         };
         if let Some(handle) = handle {
-            let _ = handle.join();
+            if self.reader_completion.wait(remote_write_timeout()) {
+                let _ = handle.join();
+            } else {
+                *self.reader_worker.lock().unwrap_or_else(|poison| poison.into_inner()) =
+                    Some(handle);
+            }
         }
     }
 
@@ -3946,6 +4008,7 @@ fn test_session_with_writer(
     Arc::new(RemoteSession {
         interactive_writer: InteractiveWriter::spawn(writer, Arc::new(NoopTransportAbort)).unwrap(),
         reader_worker: Mutex::new(None),
+        reader_completion: Arc::new(WorkerCompletion::new()),
         disconnect_state: Mutex::new(DisconnectState::default()),
         pending: Mutex::new(PendingRemoteRequests::default()),
         next_id: AtomicU64::new(1),
@@ -5189,6 +5252,7 @@ mod tests {
         Arc::new(RemoteSession {
             interactive_writer: InteractiveWriter::spawn(writer, abort).unwrap(),
             reader_worker: Mutex::new(None),
+            reader_completion: Arc::new(WorkerCompletion::new()),
             disconnect_state: Mutex::new(DisconnectState::default()),
             pending: Mutex::new(PendingRemoteRequests::default()),
             next_id: AtomicU64::new(1),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1378,6 +1378,13 @@ fn reaper_state() -> &'static Arc<Mutex<ReaperState>> {
 }
 
 fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
+    // Serialize startup while holding the state lock. Two callers must not
+    // spawn competing workers, because the loser cannot safely join a worker
+    // whose receiver still has an owning sender on its stack.
+    let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
+    if current.sender.is_some() {
+        return;
+    }
     let (sender, receiver) = channel::<()>();
     let worker_state = state.clone();
     let Ok(reaper_worker) =
@@ -1412,18 +1419,12 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     else {
         return;
     };
-    let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
-    if current.sender.is_none() {
-        let old_worker = current.worker.take();
-        current.sender = Some(sender);
-        current.worker = Some(reaper_worker);
-        drop(current);
-        if let Some(old_worker) = old_worker {
-            let _ = old_worker.join();
-        }
-    } else {
-        drop(current);
-        let _ = reaper_worker.join();
+    let old_worker = current.worker.take();
+    current.sender = Some(sender);
+    current.worker = Some(reaper_worker);
+    drop(current);
+    if let Some(old_worker) = old_worker {
+        let _ = old_worker.join();
     }
 }
 
@@ -6928,6 +6929,34 @@ mod tests {
         assert!(state.lock().unwrap().worker.is_some());
         wait_for_worker_join(&completion);
         assert!(completion.was_joined());
+    }
+
+    #[test]
+    fn concurrent_reaper_enqueue_starts_one_owned_worker() {
+        let state = reaper_state().clone();
+        state.lock().unwrap().sender = None;
+
+        let worker_count = 16;
+        let barrier = Arc::new(std::sync::Barrier::new(worker_count));
+        let completions =
+            (0..worker_count).map(|_| Arc::new(WorkerCompletion::new())).collect::<Vec<_>>();
+        let mut callers = Vec::with_capacity(worker_count);
+        for completion in &completions {
+            let barrier = barrier.clone();
+            let completion = completion.clone();
+            callers.push(std::thread::spawn(move || {
+                barrier.wait();
+                enqueue_worker_reap(std::thread::spawn(|| {}), completion);
+            }));
+        }
+        for caller in callers {
+            caller.join().expect("reaper enqueue caller should finish");
+        }
+
+        for completion in &completions {
+            wait_for_worker_join(completion);
+        }
+        assert!(state.lock().unwrap().worker.is_some());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1428,7 +1428,7 @@ struct ReaperState {
     worker: Option<std::thread::JoinHandle<()>>,
     pending: Vec<ReapRequest>,
     #[cfg(test)]
-    fail_next_spawn: bool,
+    fail_spawns_remaining: usize,
 }
 
 // A wake token only prompts the reaper to inspect its pending list. Keep a
@@ -1449,7 +1449,7 @@ fn new_reaper_state() -> Arc<Mutex<ReaperState>> {
         worker: None,
         pending: Vec::new(),
         #[cfg(test)]
-        fail_next_spawn: false,
+        fail_spawns_remaining: 0,
     }))
 }
 
@@ -1516,8 +1516,8 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     let (sender, receiver) = std::sync::mpsc::sync_channel::<()>(REMOTE_REAPER_WAKE_CAPACITY);
     let worker_state = state.clone();
     #[cfg(test)]
-    if current.fail_next_spawn {
-        current.fail_next_spawn = false;
+    if current.fail_spawns_remaining > 0 {
+        current.fail_spawns_remaining -= 1;
         drop(current);
         reap_completed_workers(state);
         return;
@@ -7223,7 +7223,7 @@ mod tests {
             worker_completion.mark_done();
         });
 
-        state.lock().unwrap().fail_next_spawn = true;
+        state.lock().unwrap().fail_spawns_remaining = 1;
         enqueue_worker_reap_in_state(&state, handle, completion.clone());
         assert!(!completion.was_joined(), "failed reaper spawn must retain the handle");
 
@@ -7258,6 +7258,57 @@ mod tests {
             .expect("worker completion must not block on a full wake queue");
         worker.join().unwrap();
         drop(receiver);
+    }
+
+    #[test]
+    fn repeated_reaper_spawn_failure_retains_handle_and_recovers_worker_slot() {
+        let _reaper_guard = reaper_test_guard();
+        let runtime = Arc::new(WorkerRuntime {
+            admission: Arc::new(WorkerAdmission { available: AtomicUsize::new(1) }),
+            reaper: new_reaper_state(),
+        });
+        let state = runtime.reaper.clone();
+        let slot = runtime.reserve_slot().expect("the worker slot should be available");
+        let completion = Arc::new(WorkerCompletion::with_slot(runtime.clone(), Some(slot)));
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let worker_release = release.clone();
+        let worker_completion = completion.clone();
+        let (finished_tx, finished_rx) = channel();
+        let handle = std::thread::spawn(move || {
+            let (released, changed) = &*worker_release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = changed.wait(released).unwrap();
+            }
+            drop(released);
+            worker_completion.mark_done();
+            finished_tx.send(()).unwrap();
+        });
+        completion.install_handle(handle);
+        state.lock().unwrap().fail_spawns_remaining = 2;
+
+        let (released, changed) = &*release;
+        *released.lock().unwrap() = true;
+        changed.notify_all();
+        finished_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("worker completion should return after reaper spawn failure");
+
+        assert_eq!(
+            state.lock().unwrap().pending.len(),
+            1,
+            "failed reaper startup must retain the handle in the retry queue"
+        );
+        let deadline = Instant::now() + Duration::from_secs(1);
+        let recovered_slot = loop {
+            if let Some(slot) = runtime.reserve_slot() {
+                break slot;
+            }
+            assert!(Instant::now() < deadline, "worker slot did not recover after retry");
+            std::thread::yield_now();
+        };
+        wait_for_worker_join(&completion);
+        drop(recovered_slot);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7145,7 +7145,11 @@ mod tests {
             let completion = completion.clone();
             callers.push(std::thread::spawn(move || {
                 barrier.wait();
-                enqueue_worker_reap(std::thread::spawn(|| {}), completion);
+                let worker_completion = completion.clone();
+                enqueue_worker_reap(
+                    std::thread::spawn(move || worker_completion.mark_done()),
+                    completion,
+                );
             }));
         }
         for caller in callers {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1530,6 +1530,8 @@ fn reap_completed_workers(state: &Arc<Mutex<ReaperState>>) {
     while index > 0 {
         index -= 1;
         if pending[index].0.thread().id() == current {
+            let (handle, completion) = pending.swap_remove(index);
+            completion.install_handle(handle);
             continue;
         }
         if pending[index].1.is_done() {
@@ -1549,10 +1551,6 @@ fn enqueue_worker_reap_in_state(
     handle: std::thread::JoinHandle<()>,
     completion: Arc<WorkerCompletion>,
 ) {
-    if handle.thread().id() == std::thread::current().id() {
-        completion.install_handle(handle);
-        return;
-    }
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1252,6 +1252,7 @@ struct WorkerCompletion {
     done: Mutex<bool>,
     changed: Condvar,
     admission: Mutex<Option<WorkerSlot>>,
+    wake_reaper: bool,
     #[cfg(test)]
     joined: AtomicBool,
 }
@@ -1259,14 +1260,19 @@ struct WorkerCompletion {
 impl WorkerCompletion {
     #[cfg(test)]
     fn new() -> Self {
-        Self::with_slot(None)
+        Self::with_slot_and_reaper(None, false)
     }
 
     fn with_slot(slot: Option<WorkerSlot>) -> Self {
+        Self::with_slot_and_reaper(slot, true)
+    }
+
+    fn with_slot_and_reaper(slot: Option<WorkerSlot>, wake_reaper: bool) -> Self {
         Self {
             done: Mutex::new(false),
             changed: Condvar::new(),
             admission: Mutex::new(slot),
+            wake_reaper,
             #[cfg(test)]
             joined: AtomicBool::new(false),
         }
@@ -1275,6 +1281,9 @@ impl WorkerCompletion {
     fn mark_done(&self) {
         *self.done.lock().unwrap_or_else(|poison| poison.into_inner()) = true;
         self.changed.notify_all();
+        if self.wake_reaper {
+            wake_reaper_after_completion();
+        }
     }
 
     fn wait(&self, timeout: Duration) -> bool {
@@ -1372,6 +1381,9 @@ struct ReaperState {
 
 static REAPER: OnceLock<Arc<Mutex<ReaperState>>> = OnceLock::new();
 
+#[cfg(test)]
+static FAIL_NEXT_REAPER_SPAWN: AtomicBool = AtomicBool::new(false);
+
 fn reaper_state() -> &'static Arc<Mutex<ReaperState>> {
     REAPER.get_or_init(|| {
         Arc::new(Mutex::new(ReaperState { sender: None, worker: None, pending: Vec::new() }))
@@ -1388,6 +1400,12 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     }
     let (sender, receiver) = channel::<()>();
     let worker_state = state.clone();
+    #[cfg(test)]
+    if FAIL_NEXT_REAPER_SPAWN.swap(false, Ordering::AcqRel) {
+        drop(current);
+        reap_completed_workers(state);
+        return;
+    }
     let Ok(reaper_worker) =
         std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
             let mut pending = Vec::new();
@@ -1477,6 +1495,26 @@ fn enqueue_worker_reap(handle: std::thread::JoinHandle<()>, completion: Arc<Work
         if state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none() {
             reap_completed_workers(&state);
         }
+    }
+}
+
+fn wake_reaper_after_completion() {
+    let Some(state) = REAPER.get().cloned() else {
+        return;
+    };
+    let needs_start = {
+        let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
+        match current.sender.as_ref() {
+            Some(sender) if sender.send(()).is_ok() => false,
+            Some(_) => {
+                current.sender = None;
+                true
+            }
+            None => true,
+        }
+    };
+    if needs_start {
+        try_start_reaper(&state);
     }
 }
 
@@ -6977,6 +7015,36 @@ mod tests {
         let handle = std::thread::spawn(|| {});
         enqueue_worker_reap(handle, completion.clone());
         assert!(state.lock().unwrap().worker.is_some());
+        wait_for_worker_join(&completion);
+        assert!(completion.was_joined());
+    }
+
+    #[test]
+    fn completed_worker_retries_reaper_after_spawn_failure() {
+        let _reaper_guard = reaper_test_guard();
+        let state = reaper_state().clone();
+        state.lock().unwrap().sender = None;
+
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let completion = Arc::new(WorkerCompletion::with_slot_and_reaper(None, true));
+        let worker_release = release.clone();
+        let worker_completion = completion.clone();
+        let handle = std::thread::spawn(move || {
+            let (released, changed) = &*worker_release;
+            let mut released = released.lock().unwrap();
+            while !*released {
+                released = changed.wait(released).unwrap();
+            }
+            worker_completion.mark_done();
+        });
+
+        FAIL_NEXT_REAPER_SPAWN.store(true, Ordering::Release);
+        enqueue_worker_reap(handle, completion.clone());
+        assert!(!completion.was_joined(), "failed reaper spawn must retain the handle");
+
+        let (released, changed) = &*release;
+        *released.lock().unwrap() = true;
+        changed.notify_all();
         wait_for_worker_join(&completion);
         assert!(completion.was_joined());
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,7 +7,9 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::mpsc::{Receiver, RecvError, RecvTimeoutError, Sender, channel};
+use std::sync::mpsc::{
+    Receiver, RecvError, RecvTimeoutError, Sender, TrySendError, channel, sync_channel,
+};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -1424,7 +1426,7 @@ impl Drop for WorkerSlot {
 type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
 
 struct ReaperState {
-    sender: Option<Sender<()>>,
+    sender: Option<std::sync::mpsc::SyncSender<()>>,
     worker: Option<std::thread::JoinHandle<()>>,
     pending: Vec<ReapRequest>,
     #[cfg(test)]
@@ -1509,7 +1511,7 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     if current.sender.is_some() {
         return;
     }
-    let (sender, receiver) = channel::<()>();
+    let (sender, receiver) = sync_channel::<()>(1);
     let worker_state = state.clone();
     #[cfg(test)]
     if current.fail_next_spawn {
@@ -1605,10 +1607,11 @@ fn enqueue_worker_reap_in_state(
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));
-        if let Some(sender) = current.sender.as_ref()
-            && sender.send(()).is_err()
-        {
-            current.sender = None;
+        if let Some(sender) = current.sender.as_ref() {
+            match sender.try_send(()) {
+                Ok(()) | Err(TrySendError::Full(())) => {}
+                Err(TrySendError::Disconnected(())) => current.sender = None,
+            }
         }
     }
     let needs_start = state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1649,11 +1649,17 @@ fn wake_reaper_after_completion(state: &Arc<Mutex<ReaperState>>) {
     let needs_start = {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         match current.sender.as_ref() {
-            Some(sender) if sender.send(()).is_ok() => false,
-            Some(_) => {
-                current.sender = None;
-                true
-            }
+            // A wake token is only a hint. If the finite queue is full, the
+            // reaper will observe this completed worker on its next scan. Do
+            // not block the worker while it is publishing completion, since
+            // the reaper may be joining that same worker before receiving.
+            Some(sender) => match sender.try_send(()) {
+                Ok(()) | Err(std::sync::mpsc::TrySendError::Full(())) => false,
+                Err(std::sync::mpsc::TrySendError::Disconnected(())) => {
+                    current.sender = None;
+                    true
+                }
+            },
             None => true,
         }
     };

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7032,7 +7032,7 @@ mod tests {
     }
 
     #[test]
-    fn dropping_session_waits_for_blocked_reader_worker() {
+    fn dropping_session_reaps_blocked_reader_worker_without_waiting() {
         let _reaper_guard = reaper_test_guard();
         let (responses, response_rx) = channel();
         let release = Arc::new((Mutex::new(false), Condvar::new()));
@@ -7060,12 +7060,12 @@ mod tests {
         let started = Instant::now();
         drop(session);
         assert!(
-            started.elapsed() >= Duration::from_millis(40),
-            "dropping the session returned before the reader worker exited"
+            started.elapsed() < Duration::from_millis(40),
+            "dropping the session waited for the reader worker"
         );
         reader_exited_rx
             .recv_timeout(Duration::from_millis(100))
-            .expect("reader worker did not exit before session drop returned");
+            .expect("reader worker did not exit after session drop returned");
     }
 
     fn wait_for_worker_join(completion: &WorkerCompletion) {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1677,7 +1677,8 @@ impl InteractiveWriter {
             state.queued_bytes = 0;
         }
         self.shared.changed.notify_all();
-        if let Err(abort_error) = self.abort_transport() {
+        let abort_result = self.abort_transport();
+        if let Err(abort_error) = abort_result {
             self.record_abort_failure(&abort_error);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6817,6 +6817,17 @@ mod tests {
     }
 
     #[test]
+    fn reaper_restarts_after_sender_disconnect_and_drains_pending_workers() {
+        let state = reaper_state().clone();
+        state.lock().unwrap().sender = None;
+        let completion = Arc::new(WorkerCompletion::new());
+        let handle = std::thread::spawn(|| {});
+        enqueue_worker_reap(handle, completion.clone());
+        wait_for_worker_join(&completion);
+        assert!(completion.was_joined());
+    }
+
+    #[test]
     fn worker_reaper_returns_ownership_when_queue_is_saturated() {
         let (sender, receiver) = std::sync::mpsc::sync_channel(0);
         let completion = Arc::new(WorkerCompletion::new());

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,7 +7,7 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
+use std::sync::mpsc::{Receiver, RecvError, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
@@ -1509,21 +1509,15 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
                         worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
                     state.pending.append(&mut pending);
                 }
-                match receiver.recv_timeout(Duration::from_millis(50)) {
-                    Ok(()) => {}
-                    Err(RecvTimeoutError::Timeout) if !has_pending => {
-                        let mut state =
-                            worker_state.lock().unwrap_or_else(|poison| poison.into_inner());
-                        if state.pending.is_empty() {
-                            state.sender = None;
-                            break;
-                        }
+                if has_pending {
+                    match receiver.recv_timeout(Duration::from_millis(50)) {
+                        Ok(()) | Err(RecvTimeoutError::Timeout) => {}
+                        Err(RecvTimeoutError::Disconnected) => break,
                     }
-                    Err(RecvTimeoutError::Timeout) => {}
-                    Err(RecvTimeoutError::Disconnected) => {
-                        worker_state.lock().unwrap_or_else(|poison| poison.into_inner()).sender =
-                            None;
-                        break;
+                } else {
+                    match receiver.recv() {
+                        Ok(()) => {}
+                        Err(RecvError) => break,
                     }
                 }
             }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -81,7 +81,7 @@ fn remote_write_timeout() -> Duration {
 
 #[cfg(test)]
 fn remote_write_timeout() -> Duration {
-    static TIMEOUT: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+    static TIMEOUT: OnceLock<Duration> = OnceLock::new();
     *TIMEOUT.get_or_init(|| {
         let scale = std::env::var("CMUX_TEST_TIMEOUT_SCALE")
             .ok()
@@ -1411,8 +1411,8 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
                     state.pending.append(&mut pending);
                 }
                 match receiver.recv_timeout(Duration::from_millis(50)) {
-                    Ok(()) | Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    Ok(()) | Err(RecvTimeoutError::Timeout) => {}
+                    Err(RecvTimeoutError::Disconnected) => break,
                 }
             }
         })
@@ -1433,12 +1433,11 @@ fn enqueue_worker_reap(handle: std::thread::JoinHandle<()>, completion: Arc<Work
     {
         let mut current = state.lock().unwrap_or_else(|poison| poison.into_inner());
         current.pending.push((handle, completion));
-        if current.sender.is_some() {
-            if let Some(sender) = current.sender.as_ref() {
-                if sender.send(()).is_err() {
-                    current.sender = None;
-                }
-            }
+        if current.sender.is_some()
+            && let Some(sender) = current.sender.as_ref()
+            && sender.send(()).is_err()
+        {
+            current.sender = None;
         }
     }
     let needs_start = state.lock().unwrap_or_else(|poison| poison.into_inner()).sender.is_none();
@@ -1502,9 +1501,8 @@ impl InteractiveWriter {
         let worker = std::thread::Builder::new()
             .name("remote-input-writer".into())
             .spawn(move || interactive_writer_worker(worker_shared, writer, worker_completion))
-            .map_err(|error| {
+            .inspect_err(|_| {
                 shared.worker_completion.release_slot();
-                error
             })?;
         Ok(Self { shared, abort, worker: Mutex::new(Some(worker)) })
     }
@@ -1654,10 +1652,6 @@ impl InteractiveWriter {
         self.shared.changed.notify_all();
     }
 
-    fn join_worker(&self) {
-        self.join_worker_until(Instant::now() + remote_write_timeout());
-    }
-
     fn join_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
         let handle = {
@@ -1701,10 +1695,6 @@ impl InteractiveWriter {
             let _ = handle.join();
             self.shared.worker_completion.release_slot();
         }
-    }
-
-    fn close(&self) {
-        self.close_until(Instant::now() + remote_write_timeout());
     }
 
     fn close_until(&self, deadline: Instant) {
@@ -2306,9 +2296,8 @@ impl RemoteSession {
                     session.emit(MuxEvent::Empty);
                 }
             })
-            .map_err(|error| {
+            .inspect_err(|_| {
                 reader_completion.release_slot();
-                error
             })?;
         *session.reader_worker.lock().unwrap() = Some(reader_worker);
 
@@ -6747,9 +6736,11 @@ mod tests {
                 .get("id")
                 .and_then(Value::as_u64)
                 .ok_or_else(|| io::Error::other("lifecycle request omitted its id"))?;
-            let data = (request.get("cmd").and_then(Value::as_str) == Some("identify"))
-                .then(|| json!({"app": "cmux-tui", "protocol": SUPPORTED_PROTOCOL_VERSION}))
-                .unwrap_or(Value::Null);
+            let data = if request.get("cmd").and_then(Value::as_str) == Some("identify") {
+                json!({"app": "cmux-tui", "protocol": SUPPORTED_PROTOCOL_VERSION})
+            } else {
+                Value::Null
+            };
             self.responses
                 .send(json!({"id": id, "ok": true, "data": data}).to_string())
                 .map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "lifecycle reader exited"))

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1314,71 +1314,78 @@ impl WorkerCompletion {
 
 type ReapRequest = (std::thread::JoinHandle<()>, Arc<WorkerCompletion>);
 
-static REAPER: OnceLock<Sender<ReapRequest>> = OnceLock::new();
-static REAPER_FALLBACK: OnceLock<Arc<Mutex<Vec<ReapRequest>>>> = OnceLock::new();
+static REAPER: OnceLock<Option<Sender<ReapRequest>>> = OnceLock::new();
+static UNREAPED_WORKERS: OnceLock<Mutex<Vec<ReapRequest>>> = OnceLock::new();
 
-fn reaper_fallback() -> &'static Arc<Mutex<Vec<ReapRequest>>> {
-    REAPER_FALLBACK.get_or_init(|| Arc::new(Mutex::new(Vec::new())))
+fn retain_unreaped_worker(handle: std::thread::JoinHandle<()>, completion: Arc<WorkerCompletion>) {
+    UNREAPED_WORKERS
+        .get_or_init(|| Mutex::new(Vec::new()))
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner())
+        .push((handle, completion));
+}
+
+fn join_worker_after_reap_failure(
+    handle: std::thread::JoinHandle<()>,
+    completion: Arc<WorkerCompletion>,
+) {
+    completion.wait_forever();
+    let _ = handle.join();
 }
 
 fn enqueue_worker_reap(
     handle: std::thread::JoinHandle<()>,
     completion: Arc<WorkerCompletion>,
 ) -> Result<(), std::thread::JoinHandle<()>> {
-    let fallback = reaper_fallback().clone();
     let sender = REAPER.get_or_init(|| {
         let (sender, receiver) = channel::<ReapRequest>();
-        let reaper_fallback = fallback.clone();
-        let _ = std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
-            let mut pending = Vec::new();
-            loop {
-                pending.extend(
-                    reaper_fallback.lock().unwrap_or_else(|poison| poison.into_inner()).drain(..),
-                );
-                while let Ok(request) = receiver.try_recv() {
-                    pending.push(request);
-                }
-                let mut index = pending.len();
-                while index > 0 {
-                    index -= 1;
-                    if pending[index].1.is_done() {
-                        let (handle, completion) = pending.swap_remove(index);
-                        completion.mark_joined();
-                        let _ = handle.join();
+        let spawned =
+            std::thread::Builder::new().name("remote-worker-reaper".into()).spawn(move || {
+                let mut pending = Vec::new();
+                loop {
+                    while let Ok(request) = receiver.try_recv() {
+                        pending.push(request);
                     }
-                }
-                if pending.is_empty() {
-                    match receiver.recv() {
-                        Ok(request) => pending.push(request),
-                        Err(_) => break,
+                    let mut index = pending.len();
+                    while index > 0 {
+                        index -= 1;
+                        if pending[index].1.is_done() {
+                            let (handle, completion) = pending.swap_remove(index);
+                            completion.mark_joined();
+                            let _ = handle.join();
+                        }
                     }
-                } else {
-                    match receiver.recv_timeout(Duration::from_millis(50)) {
-                        Ok(request) => pending.push(request),
-                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
-                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
-                            for (handle, completion) in pending.drain(..) {
-                                completion.wait_forever();
-                                completion.mark_joined();
-                                let _ = handle.join();
+                    if pending.is_empty() {
+                        match receiver.recv() {
+                            Ok(request) => pending.push(request),
+                            Err(_) => break,
+                        }
+                    } else {
+                        match receiver.recv_timeout(Duration::from_millis(50)) {
+                            Ok(request) => pending.push(request),
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {}
+                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => {
+                                for (handle, completion) in pending.drain(..) {
+                                    join_worker_after_reap_failure(handle, completion);
+                                }
+                                break;
                             }
-                            break;
                         }
                     }
                 }
-            }
-        });
-        sender
+            });
+        spawned.ok().map(|_| sender)
     });
+    let Some(sender) = sender else {
+        return Err(handle);
+    };
     match sender.send((handle, completion)) {
         Ok(()) => Ok(()),
-        Err(std::sync::mpsc::SendError(request)) => {
-            fallback.lock().unwrap_or_else(|poison| poison.into_inner()).push(request);
-            Ok(())
-        }
+        Err(std::sync::mpsc::SendError((handle, completion))) => Err(handle),
     }
 }
 
+#[cfg(test)]
 fn try_enqueue_worker_reap(
     sender: &std::sync::mpsc::SyncSender<(std::thread::JoinHandle<()>, Arc<WorkerCompletion>)>,
     handle: std::thread::JoinHandle<()>,
@@ -1591,7 +1598,10 @@ impl InteractiveWriter {
             {
                 let _ = handle.join();
             } else {
-                let _ = enqueue_worker_reap(handle, self.shared.worker_completion.clone());
+                let completion = self.shared.worker_completion.clone();
+                if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
+                    join_worker_after_reap_failure(handle, completion);
+                }
             }
         }
     }
@@ -1607,7 +1617,10 @@ impl InteractiveWriter {
                 return;
             };
             if !self.shared.worker_completion.is_done() {
-                let _ = enqueue_worker_reap(handle, self.shared.worker_completion.clone());
+                let completion = self.shared.worker_completion.clone();
+                if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
+                    join_worker_after_reap_failure(handle, completion);
+                }
                 return;
             }
             Some(handle)
@@ -3238,7 +3251,10 @@ impl RemoteSession {
                 let handle = worker.take();
                 drop(worker);
                 if let Some(handle) = handle {
-                    let _ = enqueue_worker_reap(handle, self.reader_completion.clone());
+                    let completion = self.reader_completion.clone();
+                    if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
+                        retain_unreaped_worker(handle, completion);
+                    }
                 }
                 return;
             }
@@ -3248,7 +3264,10 @@ impl RemoteSession {
             if self.reader_completion.wait(deadline.saturating_duration_since(Instant::now())) {
                 let _ = handle.join();
             } else {
-                let _ = enqueue_worker_reap(handle, self.reader_completion.clone());
+                let completion = self.reader_completion.clone();
+                if let Err(handle) = enqueue_worker_reap(handle, completion.clone()) {
+                    join_worker_after_reap_failure(handle, completion);
+                }
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1257,6 +1257,7 @@ struct WorkerCompletion {
 }
 
 impl WorkerCompletion {
+    #[cfg(test)]
     fn new() -> Self {
         Self::with_slot(None)
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7091,7 +7091,8 @@ mod tests {
         let state = reaper_state().clone();
         state.lock().unwrap().sender = None;
         let completion = Arc::new(WorkerCompletion::new());
-        let handle = std::thread::spawn(|| {});
+        let worker_completion = completion.clone();
+        let handle = std::thread::spawn(move || worker_completion.mark_done());
         enqueue_worker_reap(handle, completion.clone());
         assert!(state.lock().unwrap().worker.is_some());
         wait_for_worker_join(&completion);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6521,6 +6521,8 @@ mod tests {
         remaining_responses: usize,
         release: Arc<(Mutex<bool>, Condvar)>,
         exited: Sender<()>,
+        entered: Option<Sender<()>>,
+        exit_delay: Duration,
     }
 
     impl RemoteMessageReader for LifecycleReader {
@@ -6533,9 +6535,15 @@ mod tests {
             }
 
             let (released, changed) = &*self.release;
+            if let Some(entered) = self.entered.take() {
+                let _ = entered.send(());
+            }
             let mut released = released.lock().unwrap();
             while !*released {
                 released = changed.wait(released).unwrap();
+            }
+            if !self.exit_delay.is_zero() {
+                std::thread::sleep(self.exit_delay);
             }
             self.exited.send(()).unwrap();
             Ok(None)
@@ -6601,6 +6609,8 @@ mod tests {
                 remaining_responses: 3,
                 release: release.clone(),
                 exited: reader_exited,
+                entered: None,
+                exit_delay: Duration::ZERO,
             }),
             Box::new(LifecycleWriter { responses, closed: closed.clone(), exited: writer_exited }),
             Arc::new(LifecycleAbort { release }),
@@ -6616,6 +6626,42 @@ mod tests {
         writer_exited_rx
             .recv_timeout(Duration::from_millis(100))
             .expect("transport shutdown must join the writer");
+    }
+
+    #[test]
+    fn dropping_session_waits_for_blocked_reader_worker() {
+        let (responses, response_rx) = channel();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (reader_entered, reader_entered_rx) = channel();
+        let (reader_exited, reader_exited_rx) = channel();
+        let (writer_exited, _writer_exited_rx) = channel();
+        let closed = Arc::new(AtomicBool::new(false));
+        let session = RemoteSession::connect_transport(RemoteTransport::new(
+            Box::new(LifecycleReader {
+                responses: response_rx,
+                remaining_responses: 3,
+                release: release.clone(),
+                exited: reader_exited,
+                entered: Some(reader_entered),
+                exit_delay: Duration::from_millis(50),
+            }),
+            Box::new(LifecycleWriter { responses, closed, exited: writer_exited }),
+            Arc::new(LifecycleAbort { release }),
+        ))
+        .unwrap();
+        reader_entered_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("reader did not reach its blocked receive");
+
+        let started = Instant::now();
+        drop(session);
+        assert!(
+            started.elapsed() >= Duration::from_millis(40),
+            "dropping the session returned before the reader worker exited"
+        );
+        reader_exited_rx
+            .recv_timeout(Duration::from_millis(100))
+            .expect("reader worker did not exit before session drop returned");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3534,6 +3534,26 @@ impl RemoteSession {
         self.join_reader_worker_until(Instant::now() + remote_write_timeout());
     }
 
+    fn reap_reader_worker(&self) {
+        let current = std::thread::current().id();
+        let Some(handle) = self.reader_completion.take_handle() else {
+            // The reader may still be in startup. Its startup path installs
+            // the handle into the completion, which then enqueues it when
+            // teardown has already marked it done.
+            return;
+        };
+        if handle.thread().id() == current {
+            self.reader_completion.install_handle(handle);
+            return;
+        }
+        if self.reader_completion.is_done() {
+            let _ = handle.join();
+            self.reader_completion.release_slot();
+        } else {
+            self.reader_completion.runtime.enqueue(handle, self.reader_completion.clone());
+        }
+    }
+
     fn join_reader_worker_until(&self, deadline: Instant) {
         let current = std::thread::current().id();
         let Some(handle) = self.reader_completion.take_handle() else {
@@ -4164,7 +4184,7 @@ impl Drop for RemoteSession {
         if let Err(error) = self.interactive_writer.abort_transport() {
             self.interactive_writer.record_abort_failure(&error);
         }
-        self.join_reader_worker();
+        self.reap_reader_worker();
         self.interactive_writer.join_worker_if_done();
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1836,6 +1836,10 @@ impl InteractiveWriter {
             state.failure.get_or_insert_with(|| InteractiveWriteFailure::from_error(error));
             state.writes.clear();
             state.queued_bytes = 0;
+            // Aborting closes the logical writer immediately. The worker may
+            // still be unwinding in the background and remains owned by its
+            // completion/reaper until it joins.
+            state.writer_closed = true;
         }
         self.shared.changed.notify_all();
         let abort_result = self.abort_transport();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1414,6 +1414,8 @@ struct ReaperState {
     sender: Option<Sender<()>>,
     worker: Option<std::thread::JoinHandle<()>>,
     pending: Vec<ReapRequest>,
+    #[cfg(test)]
+    fail_next_spawn: bool,
 }
 
 struct WorkerRuntime {
@@ -1425,7 +1427,13 @@ static PROCESS_WORKER_ADMISSION: OnceLock<Arc<WorkerAdmission>> = OnceLock::new(
 static PROCESS_REAPER: OnceLock<Arc<Mutex<ReaperState>>> = OnceLock::new();
 
 fn new_reaper_state() -> Arc<Mutex<ReaperState>> {
-    Arc::new(Mutex::new(ReaperState { sender: None, worker: None, pending: Vec::new() }))
+    Arc::new(Mutex::new(ReaperState {
+        sender: None,
+        worker: None,
+        pending: Vec::new(),
+        #[cfg(test)]
+        fail_next_spawn: false,
+    }))
 }
 
 fn process_reaper_state() -> Arc<Mutex<ReaperState>> {
@@ -1463,9 +1471,6 @@ impl WorkerRuntime {
 }
 
 #[cfg(test)]
-static FAIL_NEXT_REAPER_SPAWN: AtomicBool = AtomicBool::new(false);
-
-#[cfg(test)]
 fn test_worker_runtime() -> Arc<WorkerRuntime> {
     static RUNTIME: OnceLock<Arc<WorkerRuntime>> = OnceLock::new();
     RUNTIME
@@ -1494,7 +1499,8 @@ fn try_start_reaper(state: &Arc<Mutex<ReaperState>>) {
     let (sender, receiver) = channel::<()>();
     let worker_state = state.clone();
     #[cfg(test)]
-    if FAIL_NEXT_REAPER_SPAWN.swap(false, Ordering::AcqRel) {
+    if current.fail_next_spawn {
+        current.fail_next_spawn = false;
         drop(current);
         reap_completed_workers(state);
         return;
@@ -7191,7 +7197,7 @@ mod tests {
             worker_completion.mark_done();
         });
 
-        FAIL_NEXT_REAPER_SPAWN.store(true, Ordering::Release);
+        state.lock().unwrap().fail_next_spawn = true;
         enqueue_worker_reap(handle, completion.clone());
         assert!(!completion.was_joined(), "failed reaper spawn must retain the handle");
 


### PR DESCRIPTION
Replaces the lifecycle cleanup portion of #11675 and supersedes #11732.

This branch is based on eb1b9d38c34. It keeps one total shutdown deadline, lets the reaper progress past stalled workers, and retains every deferred JoinHandle, including reader self-disconnect and reaper startup failure.

Behavior tests cover self-disconnect reaping, non-head-of-line reaping, and the shared shutdown deadline.

Static checks: rustfmt --check, git diff --check. No local builds run.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11742"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790986172&installation_model_id=21920&pr_number=11742&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11742&signature=5983840f6de89f2b2e471f3666551809c0c507ff04e1f9023f607001474fd851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remote session shutdown no longer waits on blocked reader and writer workers: it aborts the transport before any worker wait, uses one total deadline, and hands unfinished workers to a shared process-wide reaper so teardown cannot hang behind a stalled worker. Dropping a session returns immediately, and new sessions fail when the process-wide worker slot limit is exhausted (minimum 256 slots).

**Bug Fixes**

- Serializes transport aborts, records abort failures, and marks aborted writers closed.
- Retains handles across reaper startup failures and reader self-disconnects.
- Coalesces completion wakeups on an explicit bounded reaper channel and releases worker slots only after handles join.

**Tests**

- Covers cancellation, drop cleanup, shutdown deadlines, worker saturation, reaper recovery and races, queue ownership, and malformed reader input.

<sup>Written for commit bdb25dd2ee7c16960966aeed1e96f3fb86875ef9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11742?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when remote sessions disconnect or are destroyed.
  * Ensured pending requests and remote connections are cleaned up within shutdown time limits.
  * Improved handling of shutdown timeouts, malformed messages, and incomplete session termination.
  * Reduced the risk of sessions becoming stuck during shutdown or reconnection.
  * Improved cleanup when remote session components finish independently or cannot stop immediately.

* **Tests**
  * Expanded coverage for remote session lifecycle, shutdown, timeout, malformed data, and cleanup scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->