### PR TITLE
fix(pipe-io): expose scoped attach sizing capability

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -776,7 +776,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "socket2",
+ "socket2 0.5.10",
  "smallvec",
  "tempfile",
  "terminput",

--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -776,6 +776,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "socket2",
  "smallvec",
  "tempfile",
  "terminput",

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -96,7 +96,7 @@ png = "0.17"
 libc = "0.2"
 tungstenite = { version = "0.29", default-features = false, features = ["handshake"] }
 uds_windows = "1.2"
-windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
+windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_IO", "Win32_System_JobObjects", "Win32_System_Threading"] }
 regex = "1"
 # reqwest and time are already in the dependency graph via iroh; declaring
 # them here adds no new transitive code. chatmux-relay uses reqwest for the

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -44,6 +44,7 @@ terminput.workspace = true
 terminput-crossterm.workspace = true
 parking_lot.workspace = true
 sha2.workspace = true
+socket2.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
 fs4.workspace = true

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1717,6 +1717,14 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
+            // A pipe-IO embedder needs a machine-readable terminal result for
+            // every startup path. Without the scoped subscription filter, the
+            // relay cannot safely distinguish this surface's bytes, so treat
+            // it as a retryable daemon capability loss instead of returning a
+            // plain CLI error (which would omit the final exit record).
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+            }
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1668,7 +1668,7 @@ fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
 /// carries the respawn decision.
 fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
     {
-        let mut stderr = std::io::stderr().lock();
+        let mut stderr = io::stderr().lock();
         let _ = writeln!(stderr, "{}", serde_json::json!({"exit": {"reason": reason.as_str()}}));
         let _ = stderr.flush();
     }
@@ -1768,7 +1768,7 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
             args.pipe_io_rows.unwrap_or(24),
         )
         .unwrap_or_else(|error| {
-            crate::client_log::error("pipe-io", &format!("relay failed: {error}"));
+            client_log::error("pipe-io", &format!("relay failed: {error}"));
             pipe_io_startup_exit_reason(&error)
         });
         exit_pipe_io(reason);

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1681,20 +1681,33 @@ fn pipe_io_startup_exit_reason(error: &anyhow::Error) -> pipe_io::PipeIoExitReas
     }
 }
 
+fn pipe_io_startup_result<T>(pipe_io: bool, result: anyhow::Result<T>) -> anyhow::Result<T> {
+    match result {
+        Ok(value) => Ok(value),
+        Err(error) if pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
+        Err(error) => Err(error),
+    }
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
-    let socket_path = match args.socket {
-        Some(path) => path,
-        None => cmux_tui_core::server::try_default_socket_path(&args.session)?,
-    };
+    let socket_path = pipe_io_startup_result(
+        args.pipe_io,
+        match args.socket {
+            Some(path) => Ok(path),
+            None => cmux_tui_core::server::try_default_socket_path(&args.session),
+        },
+    )?;
     let messages = &localization::catalog().attach;
-    let terminal = args
-        .terminal
-        .as_deref()
-        .map(|reference| {
-            TerminalPublicId::parse(reference.to_string())
-                .map_err(|_| anyhow::anyhow!(messages.unknown_terminal(reference)))
-        })
-        .transpose()?;
+    let terminal = pipe_io_startup_result(
+        args.pipe_io,
+        args.terminal
+            .as_deref()
+            .map(|reference| {
+                TerminalPublicId::parse(reference.to_string())
+                    .map_err(|_| anyhow::anyhow!(messages.unknown_terminal(reference)))
+            })
+            .transpose(),
+    )?;
     let remote = if terminal.is_some() {
         match RemoteSession::connect_for_terminal_attach(&socket_path) {
             Ok(remote) => remote,

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1727,9 +1727,9 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         if !remote.supports_surface_subscription_filter() {
             // A pipe-IO embedder needs a machine-readable terminal result for
             // every startup path. Without the scoped subscription filter, the
-            // relay cannot safely distinguish this surface's bytes, so treat
-            // it as a retryable daemon capability loss instead of returning a
-            // plain CLI error (which would omit the final exit record).
+            // relay cannot safely distinguish this surface's bytes, so report
+            // a non-respawnable setup failure instead of returning a plain CLI
+            // error (which would omit the final exit record).
             if args.pipe_io {
                 exit_pipe_io(pipe_io::PipeIoExitReason::SetupFailed);
             }
@@ -1766,7 +1766,11 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
             surface,
             args.pipe_io_cols.unwrap_or(80),
             args.pipe_io_rows.unwrap_or(24),
-        )?;
+        )
+        .unwrap_or_else(|error| {
+            crate::client_log::error("pipe-io", &format!("relay failed: {error}"));
+            pipe_io_startup_exit_reason(&error)
+        });
         exit_pipe_io(reason);
     }
     run_connected_session_client(

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -3028,6 +3028,25 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_startup_errors_distinguish_transport_loss_from_setup_failure() {
+        let transport_loss = anyhow::Error::new(io::Error::new(
+            io::ErrorKind::ConnectionRefused,
+            "daemon is restarting",
+        ));
+        assert_eq!(
+            pipe_io_startup_exit_reason(&transport_loss),
+            pipe_io::PipeIoExitReason::DaemonLost
+        );
+
+        let setup_failure =
+            anyhow::anyhow!("remote server does not support filtered subscriptions");
+        assert_eq!(
+            pipe_io_startup_exit_reason(&setup_failure),
+            pipe_io::PipeIoExitReason::SetupFailed
+        );
+    }
+
+    #[test]
     fn remote_normalization_preserves_leading_globals_for_direct_commands() {
         let mut json_connect = ["--json", "connect"].map(str::to_string).to_vec();
         normalize_remote_resource_args(&mut json_connect).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -28,6 +28,7 @@ mod machine_provider_client;
 #[cfg(unix)]
 mod machine_provider_runtime;
 mod machine_runtime;
+mod pipe_io;
 mod plugin_manager;
 mod process_diagnostics;
 #[cfg(target_os = "linux")]
@@ -430,6 +431,13 @@ START OPTIONS
   --session <name>   Session name (default: main). Determines the socket path.
   --socket <path>    Explicit control socket path.
   --terminal <id>    With attach, show only this terminal (use `cmux terminal list`).
+  --pipe-io          With attach --terminal, relay raw bytes over stdio for an
+                     embedder that parses them itself instead of rendering
+                     (stdout = replay then live output, stdin = JSON
+                     input/resize lines, exit 0 = terminal ended, exit 2 =
+                     daemon connection lost).
+  --cols <n>         Initial viewer columns for --pipe-io (default 80).
+  --rows <n>         Initial viewer rows for --pipe-io (default 24).
   --state <path>     Durable session-state root (default: platform state dir).
   --ephemeral        Keep workspace state in memory for this run only.
   --machine-provider <path>
@@ -493,6 +501,9 @@ struct Args {
     session: String,
     socket: Option<PathBuf>,
     terminal: Option<String>,
+    pipe_io: bool,
+    pipe_io_cols: Option<u16>,
+    pipe_io_rows: Option<u16>,
     state: Option<PathBuf>,
     ephemeral: bool,
     machine_provider: Option<PathBuf>,
@@ -567,6 +578,9 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
         session: "main".to_string(),
         socket: None,
         terminal: None,
+        pipe_io: false,
+        pipe_io_cols: None,
+        pipe_io_rows: None,
         state: None,
         ephemeral: false,
         machine_provider: None,
@@ -619,6 +633,19 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
             "--terminal" => {
                 out.terminal =
                     Some(args.next().ok_or_else(|| "--terminal needs a value".to_string())?);
+            }
+            "--pipe-io" => {
+                out.pipe_io = true;
+            }
+            "--cols" => {
+                let value = args.next().ok_or_else(|| "--cols needs a value".to_string())?;
+                out.pipe_io_cols =
+                    Some(value.parse().map_err(|_| "--cols needs a number".to_string())?);
+            }
+            "--rows" => {
+                let value = args.next().ok_or_else(|| "--rows needs a value".to_string())?;
+                out.pipe_io_rows =
+                    Some(value.parse().map_err(|_| "--rows needs a number".to_string())?);
             }
             "--machine-provider" => {
                 if out.machine_provider.is_some() {
@@ -813,6 +840,12 @@ fn parse_args_result(args: impl IntoIterator<Item = String>) -> Result<Args, Str
     }
     if out.terminal.is_some() && !out.attach {
         return Err("--terminal requires `cmux attach`".to_string());
+    }
+    if out.pipe_io && out.terminal.is_none() {
+        return Err("--pipe-io requires `cmux attach --terminal`".to_string());
+    }
+    if (out.pipe_io_cols.is_some() || out.pipe_io_rows.is_some()) && !out.pipe_io {
+        return Err("--cols/--rows require --pipe-io".to_string());
     }
     #[cfg(not(unix))]
     if out.agent_browser_provider {
@@ -1254,6 +1287,8 @@ const STARTUP_VALUE_OPTIONS: &[&str] = &[
     "--session",
     "--machine",
     "--terminal",
+    "--cols",
+    "--rows",
     "--state",
     "--machine-provider",
     "--cloud-host",
@@ -1628,6 +1663,18 @@ fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
     cmux_tui_core::terminal_host_runtime::serve_terminal_host_stdio(args, &mut reader, &mut writer)
 }
 
+/// Ends a `--pipe-io` relay: the machine-readable exit reason is the final
+/// stderr line (the embedder localizes what it shows) and the exit code
+/// carries the respawn decision.
+fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
+    {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{}", serde_json::json!({"exit": {"reason": reason.as_str()}}));
+        let _ = stderr.flush();
+    }
+    client_log::exit(reason.exit_code());
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
@@ -1643,27 +1690,69 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
         })
         .transpose()?;
     let remote = if terminal.is_some() {
-        RemoteSession::connect_for_terminal_attach(&socket_path)?
+        match RemoteSession::connect_for_terminal_attach(&socket_path) {
+            Ok(remote) => remote,
+            // A pipe-io embedder retries daemon-lost forever (a daemon
+            // restart window looks exactly like this) but gives up on
+            // unexplained failures; a connect failure is the former.
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        }
     } else {
         RemoteSession::connect(&socket_path)?
     };
     let surface_only = if let Some(terminal) = terminal.as_ref() {
-        let tree = remote.refresh_tree()?;
-        let surface = tree
-            .resolve_terminal(terminal)
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        };
+        let resolved = tree.resolve_terminal(terminal);
+        // A pipe-io embedder respawns on daemon loss; a terminal that no
+        // longer exists must read as terminal-ended (do not respawn), not
+        // as a startup failure it would retry forever.
+        if args.pipe_io && resolved.is_none() {
+            exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+        }
+        let surface = resolved
             .ok_or_else(|| anyhow::anyhow!(messages.unknown_terminal(terminal.as_str())))?;
         if !remote.supports_surface_subscription_filter() {
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
-        remote.scope_events_to_surface(surface)?;
-        let tree = remote.refresh_tree()?;
+        if let Err(error) = remote.scope_events_to_surface(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+            }
+            return Err(error);
+        }
+        let tree = match remote.refresh_tree() {
+            Ok(tree) => tree,
+            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) => return Err(error),
+        };
         if tree.resolve_terminal(terminal) != Some(surface) {
+            if args.pipe_io {
+                exit_pipe_io(pipe_io::PipeIoExitReason::TerminalEnded);
+            }
             anyhow::bail!(messages.unknown_terminal(terminal.as_str()));
         }
         Some(surface)
     } else {
         None
     };
+    if args.pipe_io {
+        let surface = surface_only.expect("--pipe-io is validated to carry --terminal");
+        let terminal = terminal.as_ref().expect("--pipe-io is validated to carry --terminal");
+        let reason = pipe_io::run(
+            &remote,
+            &socket_path,
+            terminal,
+            surface,
+            args.pipe_io_cols.unwrap_or(80),
+            args.pipe_io_rows.unwrap_or(24),
+        )?;
+        exit_pipe_io(reason);
+    }
     run_connected_session_client(
         socket_path,
         args.session,

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1667,11 +1667,9 @@ fn run_terminal_host_process(args: &[String]) -> anyhow::Result<()> {
 /// stderr line (the embedder localizes what it shows) and the exit code
 /// carries the respawn decision.
 fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
-    {
-        let mut stderr = io::stderr().lock();
-        let _ = writeln!(stderr, "{}", serde_json::json!({"exit": {"reason": reason.as_str()}}));
-        let _ = stderr.flush();
-    }
+    pipe_io::write_stderr_line_bounded(
+        &serde_json::json!({"exit": {"reason": reason.as_str()}}).to_string(),
+    );
     client_log::exit(reason.exit_code());
 }
 

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -1675,6 +1675,14 @@ fn exit_pipe_io(reason: pipe_io::PipeIoExitReason) -> ! {
     client_log::exit(reason.exit_code());
 }
 
+fn pipe_io_startup_exit_reason(error: &anyhow::Error) -> pipe_io::PipeIoExitReason {
+    if session::is_pipe_io_retryable_error(error) {
+        pipe_io::PipeIoExitReason::DaemonLost
+    } else {
+        pipe_io::PipeIoExitReason::SetupFailed
+    }
+}
+
 fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Result<()> {
     let socket_path = match args.socket {
         Some(path) => path,
@@ -1695,7 +1703,7 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
             // A pipe-io embedder retries daemon-lost forever (a daemon
             // restart window looks exactly like this) but gives up on
             // unexplained failures; a connect failure is the former.
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
             Err(error) => return Err(error),
         }
     } else {
@@ -1704,7 +1712,7 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
     let surface_only = if let Some(terminal) = terminal.as_ref() {
         let tree = match remote.refresh_tree() {
             Ok(tree) => tree,
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
             Err(error) => return Err(error),
         };
         let resolved = tree.resolve_terminal(terminal);
@@ -1723,19 +1731,19 @@ fn run_attach(args: Args, config: config::StartupConfigSnapshot) -> anyhow::Resu
             // it as a retryable daemon capability loss instead of returning a
             // plain CLI error (which would omit the final exit record).
             if args.pipe_io {
-                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+                exit_pipe_io(pipe_io::PipeIoExitReason::SetupFailed);
             }
             anyhow::bail!(messages.filtered_subscription_unavailable);
         }
         if let Err(error) = remote.scope_events_to_surface(surface) {
             if args.pipe_io {
-                exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost);
+                exit_pipe_io(pipe_io_startup_exit_reason(&error));
             }
             return Err(error);
         }
         let tree = match remote.refresh_tree() {
             Ok(tree) => tree,
-            Err(_) if args.pipe_io => exit_pipe_io(pipe_io::PipeIoExitReason::DaemonLost),
+            Err(error) if args.pipe_io => exit_pipe_io(pipe_io_startup_exit_reason(&error)),
             Err(error) => return Err(error),
         };
         if tree.resolve_terminal(terminal) != Some(surface) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1,0 +1,656 @@
+//! Renderer-less byte relay for embedder-fed (manual-IO) surfaces.
+//!
+//! `cmux attach --terminal <id> --pipe-io` is the scoped attach client minus
+//! the renderer: the embedder (the macOS GUI's manual-mirror Ghostty
+//! surface) parses the byte stream itself, so this process only relays.
+//!
+//! Contract:
+//! - stdout: raw VT bytes — the daemon replay first, then live PTY output.
+//!   A replay that is not the relay's first output is prefixed with a full
+//!   reset (`ESC c` + erase-scrollback) because a daemon replay REPLACES
+//!   terminal state while a byte stream can only append.
+//! - stdin: JSON lines — `{"input":"<base64>"}` forwards raw bytes to the
+//!   daemon terminal's PTY; `{"resize":{"cols":N,"rows":N}}` drives the
+//!   daemon-side viewer size; `{"claim":{"geometry":true}}` re-asserts this
+//!   relay's geometry authority (last claim wins across attachments; the
+//!   embedder sends it when its pane receives user input). Unknown keys are
+//!   ignored (forward compat); stdin EOF means the embedder is gone and
+//!   ends the relay cleanly.
+//! - stderr: one final JSON line `{"exit":{"reason":...}}`.
+//! - exit code: 0 when the terminal ended or the embedder closed stdin (do
+//!   not respawn), 2 when the daemon connection was lost (respawning
+//!   reattaches and resyncs from a fresh replay).
+
+use std::borrow::Cow;
+use std::io::{BufRead, Write};
+use std::path::Path;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use base64::Engine as _;
+use cmux_tui_core::SurfaceId;
+use cmux_tui_core::resource::TerminalPublicId;
+use crossbeam_channel::{Receiver, Sender};
+use serde::Deserialize;
+
+use crate::session::{
+    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
+    is_remote_surface_unavailable,
+};
+
+/// The terminal ended, or the embedder walked away: respawning is wrong.
+pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
+/// The daemon connection was lost: the embedder may respawn to resync.
+pub const EXIT_DAEMON_LOST: i32 = 2;
+
+/// Bounded event queue between the session reader thread and the stdout
+/// pump. A full queue means the embedder stopped reading; the session
+/// treats that as a lost transport rather than wedging its reader thread.
+const EVENT_QUEUE_CAPACITY: usize = 4096;
+const EVENT_QUEUE_MAX_BYTES: usize = 8 * 1024 * 1024;
+const MAX_PIPE_IO_INPUT_BYTES: usize = crate::pty_input::PTY_INPUT_MAX_BYTES;
+const MAX_PIPE_IO_BASE64_BYTES: usize = MAX_PIPE_IO_INPUT_BYTES.div_ceil(3) * 4;
+const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
+
+/// Emitted before any replay that is not the relay's first output: full
+/// reset plus erase-scrollback, so the replacement replay does not stack on
+/// top of the embedder's previous terminal state.
+const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
+const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PipeIoExitReason {
+    TerminalEnded,
+    DaemonLost,
+    ParentClosed,
+}
+
+impl PipeIoExitReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TerminalEnded => "terminal-ended",
+            Self::DaemonLost => "daemon-lost",
+            Self::ParentClosed => "parent-closed",
+        }
+    }
+
+    pub fn exit_code(self) -> i32 {
+        match self {
+            Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
+            Self::DaemonLost => EXIT_DAEMON_LOST,
+        }
+    }
+}
+
+/// One parsed stdin line.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoRequest {
+    Input(Vec<u8>),
+    Resize {
+        cols: u16,
+        rows: u16,
+    },
+    /// Re-assert this relay's geometry authority over the terminal. Sent by
+    /// the embedder when its pane receives user input: authority is
+    /// last-claim-wins across attachments, so with several panes (or stale
+    /// restored panes) viewing one terminal, the pane the user actually
+    /// types in must own the PTY size.
+    ClaimGeometry,
+    /// A well-formed line carrying no verb this relay knows: ignored, so a
+    /// newer embedder can talk to an older relay.
+    Unknown,
+}
+
+#[derive(Deserialize)]
+struct PipeIoWireRequest<'a> {
+    #[serde(borrow)]
+    input: Option<Cow<'a, str>>,
+    resize: Option<PipeIoWireResize>,
+    #[serde(default, deserialize_with = "deserialize_present")]
+    claim: bool,
+}
+
+#[derive(Deserialize)]
+struct PipeIoWireResize {
+    cols: Option<u64>,
+    rows: Option<u64>,
+}
+
+fn deserialize_present<'de, D>(deserializer: D) -> Result<bool, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    serde::de::IgnoredAny::deserialize(deserializer).map(|_| true)
+}
+
+pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
+    if line.len() > MAX_PIPE_IO_LINE_BYTES {
+        anyhow::bail!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes");
+    }
+    let request: PipeIoWireRequest<'_> = serde_json::from_str(line)?;
+    if let Some(encoded) = request.input {
+        let encoded = encoded.as_ref();
+        if encoded.len() > MAX_PIPE_IO_BASE64_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        if encoded.len() % 4 == 0 {
+            let padding = encoded.bytes().rev().take_while(|byte| *byte == b'=').count();
+            let decoded_len = encoded
+                .len()
+                .checked_div(4)
+                .and_then(|quads| quads.checked_mul(3))
+                .and_then(|bytes| bytes.checked_sub(padding))
+                .unwrap_or(usize::MAX);
+            if decoded_len > MAX_PIPE_IO_INPUT_BYTES {
+                anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+            }
+        } else if base64::decoded_len_estimate(encoded.len()) > MAX_PIPE_IO_INPUT_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        let bytes = base64::engine::general_purpose::STANDARD.decode(encoded)?;
+        if bytes.len() > MAX_PIPE_IO_INPUT_BYTES {
+            anyhow::bail!("pipe-io input exceeds {MAX_PIPE_IO_INPUT_BYTES} decoded bytes");
+        }
+        return Ok(PipeIoRequest::Input(bytes));
+    }
+    if let Some(resize) = request.resize {
+        let cols = resize.cols;
+        let rows = resize.rows;
+        let (Some(cols), Some(rows)) = (cols, rows) else {
+            anyhow::bail!("resize needs numeric cols and rows");
+        };
+        let (cols, rows) = (u16::try_from(cols)?, u16::try_from(rows)?);
+        return Ok(PipeIoRequest::Resize { cols: cols.max(1), rows: rows.max(1) });
+    }
+    if request.claim {
+        return Ok(PipeIoRequest::ClaimGeometry);
+    }
+    Ok(PipeIoRequest::Unknown)
+}
+
+pub fn run(
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+    surface: SurfaceId,
+    cols: u16,
+    rows: u16,
+) -> anyhow::Result<PipeIoExitReason> {
+    let (sender, receiver) = crossbeam_channel::bounded(EVENT_QUEUE_CAPACITY);
+    // Lifecycle events have their own reserved signal path. A stalled
+    // embedder can fill the byte queue, but it must never be able to hide the
+    // transport-loss event that tells the embedder to respawn.
+    let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+    let byte_budget = Arc::new(PipeIoByteBudget::new(EVENT_QUEUE_MAX_BYTES));
+    // Install before attach so the initial replay cannot be missed.
+    let tap_token = remote.install_pipe_io_tap(
+        surface,
+        sender.clone(),
+        lifecycle_sender.clone(),
+        byte_budget.clone(),
+    );
+    let tap_guard = PipeIoTapGuard { remote: remote.as_ref(), token: tap_token };
+    let handle = match remote.try_attach_pipe_io(surface, Some((cols.max(1), rows.max(1)))) {
+        Ok(PipeIoSurfaceAttach::Attached) => {
+            PipeIoSurfaceHandle { remote: remote.clone(), surface }
+        }
+        Ok(PipeIoSurfaceAttach::Retired) => {
+            return Ok(PipeIoExitReason::TerminalEnded);
+        }
+        Ok(PipeIoSurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
+        Err(error) => return Ok(attach_failure_exit_reason(&error, surface)),
+    };
+    // The daemon resizes a terminal's PTY only for its geometry-authority
+    // client (the full TUI client claims this for its active surface). The
+    // relay is the embedder's only viewer of this terminal, so claim the
+    // authority or every embedder resize is recorded but never applied.
+    if let Err(error) = remote.notify_claim_terminal_geometry(surface) {
+        eprintln!(
+            "{}",
+            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
+        );
+    }
+    spawn_stdin_pump(handle, lifecycle_sender);
+    let reason = pump_events_to_stdout(
+        &receiver,
+        &lifecycle_receiver,
+        &byte_budget,
+        &mut std::io::stdout().lock(),
+    )?;
+    // Stop forwarding while the daemon probe runs. The probe has its own
+    // request path, and events for the finished relay must not fill the data
+    // queue or tear down a replacement transport.
+    drop(tap_guard);
+    if reason == PipeIoExitReason::DaemonLost {
+        return Ok(classify_daemon_loss(remote, socket_path, terminal));
+    }
+    Ok(reason)
+}
+
+/// The pipe-IO relay needs only the remote request path. Keeping this handle
+/// separate from `SurfaceHandle::Remote` prevents the normal local VT mirror
+/// from being created or mutated for a renderer-less attachment.
+#[derive(Clone)]
+struct PipeIoSurfaceHandle {
+    remote: Arc<RemoteSession>,
+    surface: SurfaceId,
+}
+
+impl PipeIoSurfaceHandle {
+    fn write_bytes(&self, bytes: &[u8]) -> anyhow::Result<()> {
+        self.remote.send_bytes(self.surface, bytes)
+    }
+
+    fn resize(&self, cols: u16, rows: u16) -> anyhow::Result<bool> {
+        self.remote.resize_pipe_io(self.surface, cols, rows)
+    }
+}
+
+struct PipeIoTapGuard<'a> {
+    remote: &'a RemoteSession,
+    token: Arc<u8>,
+}
+
+impl Drop for PipeIoTapGuard<'_> {
+    fn drop(&mut self) {
+        self.remote.clear_pipe_io_tap(&self.token);
+    }
+}
+
+fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
+    // A rejected attach naming this exact surface means the terminal ended
+    // between the tree lookup and the attach request. Every other failure is
+    // reported as retryable daemon loss so the embedder receives the normal
+    // final JSON record and exit code.
+    if is_remote_surface_unavailable(error, surface) {
+        PipeIoExitReason::TerminalEnded
+    } else {
+        PipeIoExitReason::DaemonLost
+    }
+}
+
+/// The stream ended without a terminal-exit event, but "stream lost" covers
+/// two situations the embedder must tell apart: the daemon really is
+/// unreachable (respawn until it returns), or the terminal was closed and
+/// the daemon tore the scoped stream down before the exit event reached us
+/// (never respawn). One bounded probe of the daemon resolves it: prefer the
+/// existing connection, and fall back to a fresh connect when the socket
+/// died with the stream.
+fn classify_daemon_loss(
+    remote: &Arc<RemoteSession>,
+    socket_path: &Path,
+    terminal: &TerminalPublicId,
+) -> PipeIoExitReason {
+    let deadline = Instant::now() + DAEMON_LOSS_PROBE_TIMEOUT;
+    let terminal_still_exists = remote
+        .refresh_tree_until(deadline)
+        .ok()
+        .map(|tree| tree.resolve_terminal(terminal).is_some())
+        .or_else(|| {
+            let probe =
+                RemoteSession::connect_for_terminal_attach_until(socket_path, deadline).ok()?;
+            let tree = probe.refresh_tree_until(deadline).ok()?;
+            Some(tree.resolve_terminal(terminal).is_some())
+        });
+    match terminal_still_exists {
+        Some(false) => PipeIoExitReason::TerminalEnded,
+        Some(true) | None => PipeIoExitReason::DaemonLost,
+    }
+}
+
+fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::Result<usize> {
+    line.clear();
+    loop {
+        let available = reader.fill_buf()?;
+        if available.is_empty() {
+            return Ok(line.len());
+        }
+        let (chunk_len, has_newline) = match available.iter().position(|byte| *byte == b'\n') {
+            Some(index) => (index + 1, true),
+            None => (available.len(), false),
+        };
+        if line.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes"),
+            ));
+        }
+        let chunk = &available[..chunk_len];
+        let text = std::str::from_utf8(chunk)
+            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+        line.push_str(text);
+        reader.consume(chunk_len);
+        if has_newline {
+            return Ok(line.len());
+        }
+    }
+}
+
+/// Forwards embedder requests from stdin until EOF, then reports the closed
+/// parent through the shared event queue.
+fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+    std::thread::Builder::new()
+        .name("pipe-io-stdin".into())
+        .spawn(move || {
+            let stdin = std::io::stdin();
+            let mut reader = stdin.lock();
+            let mut line = String::new();
+            loop {
+                let Ok(bytes_read) = read_pipe_io_line(&mut reader, &mut line) else { break };
+                if bytes_read == 0 {
+                    break;
+                }
+                if line.trim().is_empty() {
+                    continue;
+                }
+                match parse_request(&line) {
+                    Ok(PipeIoRequest::Input(bytes)) => {
+                        if handle.write_bytes(&bytes).is_err() {
+                            // The transport owns loss reporting; input can
+                            // only stop early.
+                            break;
+                        }
+                    }
+                    Ok(PipeIoRequest::Resize { cols, rows }) => {
+                        // Diagnostics only; the exit JSON stays the final
+                        // stderr line and embedders skip lines without an
+                        // "exit" key.
+                        match handle.resize(cols, rows) {
+                            Ok(accepted) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                                })
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::ClaimGeometry) => {
+                        // Claims only establish ownership. Enqueue them on
+                        // the same ordered writer as input so a claim cannot
+                        // overtake the keystroke that follows it, and avoid a
+                        // new blocking thread for every claim.
+                        match handle.remote.notify_claim_terminal_geometry(handle.surface) {
+                            Ok(()) => eprintln!(
+                                "{}",
+                                serde_json::json!({"diag": {"claim": {"accepted": true}}})
+                            ),
+                            Err(error) => eprintln!(
+                                "{}",
+                                serde_json::json!({
+                                    "diag": {"claim": {"error": error.to_string()}}
+                                })
+                            ),
+                        }
+                    }
+                    Ok(PipeIoRequest::Unknown) => {}
+                    // A malformed line means the embedder side is broken;
+                    // stop consuming rather than misinterpreting input.
+                    Err(_) => break,
+                }
+            }
+            // Lifecycle has its own one-slot channel, so a full byte queue
+            // cannot delay the parent-close signal.
+            let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+        })
+        .expect("spawn pipe-io stdin pump");
+}
+
+fn pump_events_to_stdout(
+    receiver: &Receiver<PipeIoEvent>,
+    lifecycle_receiver: &Receiver<PipeIoEvent>,
+    byte_budget: &PipeIoByteBudget,
+    stdout: &mut impl Write,
+) -> anyhow::Result<PipeIoExitReason> {
+    let mut emitted_output = false;
+    loop {
+        // Lifecycle signals have a separate bounded channel, so a full byte
+        // queue cannot delay or drop a transport-loss notification.
+        let event = crossbeam_channel::select_biased! {
+            recv(lifecycle_receiver) -> event => {
+                match event {
+                    Ok(PipeIoEvent::SurfaceExited) => {
+                        // Lifecycle signals use a separate channel, so a
+                        // surface-exit notification can overtake bytes that
+                        // the reader already queued. Drain those committed
+                        // bytes before preserving the terminal's final frame.
+                        // Transport loss has different semantics: queued
+                        // bytes are stale and must be discarded.
+                        while let Ok(event) = receiver.try_recv() {
+                            byte_budget.release(event.retained_bytes());
+                            match event {
+                                PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+                                    if write_pipe_io_data(
+                                        &event,
+                                        &mut emitted_output,
+                                        stdout,
+                                    )
+                                    .is_err()
+                                    {
+                                        return Ok(PipeIoExitReason::ParentClosed);
+                                    }
+                                }
+                                PipeIoEvent::SurfaceExited => {
+                                    break;
+                                }
+                                PipeIoEvent::TransportLost => {
+                                    return Ok(PipeIoExitReason::DaemonLost);
+                                }
+                                PipeIoEvent::StdinClosed => {
+                                    return Ok(PipeIoExitReason::ParentClosed);
+                                }
+                            }
+                        }
+                        return Ok(PipeIoExitReason::TerminalEnded);
+                    }
+                    Ok(PipeIoEvent::TransportLost) => {
+                        return Ok(PipeIoExitReason::DaemonLost);
+                    }
+                    Ok(PipeIoEvent::StdinClosed) => {
+                        return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                    Ok(PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_)) => {
+                        // Lifecycle senders never carry byte events. Ignore a
+                        // malformed producer rather than violating framing.
+                        continue;
+                    }
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
+            recv(receiver) -> event => {
+                match event {
+                    Ok(event) => event,
+                    Err(_) => return Ok(PipeIoExitReason::DaemonLost),
+                }
+            }
+        };
+        byte_budget.release(event.retained_bytes());
+        let write_result = match &event {
+            PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+                write_pipe_io_data(&event, &mut emitted_output, stdout)
+            }
+            PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
+            PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
+            PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
+        };
+        if write_result.is_err() {
+            // stdout is the embedder; a failed write means it is gone.
+            return Ok(PipeIoExitReason::ParentClosed);
+        }
+    }
+}
+
+fn write_pipe_io_data(
+    event: &PipeIoEvent,
+    emitted_output: &mut bool,
+    stdout: &mut impl Write,
+) -> std::io::Result<()> {
+    match event {
+        PipeIoEvent::Replay { bytes } => {
+            if *emitted_output {
+                stdout.write_all(REPLAY_RESET)?;
+            }
+            stdout.write_all(bytes)?;
+            stdout.flush()?;
+        }
+        PipeIoEvent::Output(bytes) => {
+            stdout.write_all(bytes)?;
+            stdout.flush()?;
+        }
+        PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost | PipeIoEvent::StdinClosed => {
+            debug_assert!(false, "lifecycle event passed to byte writer");
+        }
+    }
+    *emitted_output = true;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn replay(bytes: &[u8]) -> PipeIoEvent {
+        PipeIoEvent::Replay { bytes: bytes.to_vec() }
+    }
+
+    #[test]
+    fn parse_request_decodes_input_resize_and_ignores_unknown_verbs() {
+        assert_eq!(
+            parse_request(r#"{"input":"aGk="}"#).unwrap(),
+            PipeIoRequest::Input(b"hi".to_vec())
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":100,"rows":30}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 100, rows: 30 }
+        );
+        assert_eq!(
+            parse_request(r#"{"resize":{"cols":0,"rows":0}}"#).unwrap(),
+            PipeIoRequest::Resize { cols: 1, rows: 1 }
+        );
+        assert_eq!(parse_request(r#"{"future-verb":true}"#).unwrap(), PipeIoRequest::Unknown);
+        assert!(parse_request("not json").is_err());
+        assert!(parse_request(r#"{"input":"@@not-base64@@"}"#).is_err());
+        assert!(parse_request(r#"{"resize":{"cols":100}}"#).is_err());
+    }
+
+    #[test]
+    fn parse_request_rejects_oversized_lines_and_input_before_decoding() {
+        let oversized_line = " ".repeat(MAX_PIPE_IO_LINE_BYTES + 1);
+        let error = parse_request(&oversized_line).unwrap_err().to_string();
+        assert!(error.contains("request line exceeds"), "{error}");
+
+        let oversized_base64 = "A".repeat(MAX_PIPE_IO_BASE64_BYTES + 4);
+        let line = format!(r#"{{"input":"{oversized_base64}"}}"#);
+        let error = parse_request(&line).unwrap_err().to_string();
+        assert!(error.contains("input exceeds"), "{error}");
+    }
+
+    #[test]
+    fn exit_reasons_map_to_the_respawn_contract() {
+        assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
+        assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
+        assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
+        assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+    }
+
+    #[test]
+    fn stdout_pump_prefixes_only_non_initial_replays_with_a_full_reset() {
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        sender.send(replay(b"FIRST")).unwrap();
+        sender.send(PipeIoEvent::Output(b"live".to_vec())).unwrap();
+        sender.send(replay(b"SECOND")).unwrap();
+        sender.send(PipeIoEvent::SurfaceExited).unwrap();
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        let reason =
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        let mut expected = b"FIRSTlive".to_vec();
+        expected.extend_from_slice(REPLAY_RESET);
+        expected.extend_from_slice(b"SECOND");
+        assert_eq!(stdout, expected);
+    }
+
+    #[test]
+    fn stdout_pump_maps_lifecycle_events_to_exit_reasons() {
+        for (event, expected) in [
+            (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
+            (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
+        ] {
+            let (sender, receiver) = crossbeam_channel::bounded(8);
+            let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            sender.send(event).unwrap();
+            let mut stdout = Vec::new();
+            let budget = PipeIoByteBudget::new(1024);
+            assert_eq!(
+                pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout)
+                    .unwrap(),
+                expected
+            );
+            assert!(stdout.is_empty());
+        }
+        // Sender dropped without any event: the session vanished wholesale.
+        let (sender, receiver) = crossbeam_channel::bounded::<PipeIoEvent>(8);
+        let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        drop(sender);
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+    }
+
+    #[test]
+    fn stdout_pump_prioritizes_a_transport_loss_over_queued_bytes() {
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        sender.send(PipeIoEvent::Output(b"stale".to_vec())).unwrap();
+        lifecycle_sender.send(PipeIoEvent::TransportLost).unwrap();
+
+        let mut stdout = Vec::new();
+        let budget = PipeIoByteBudget::new(1024);
+        assert_eq!(
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap(),
+            PipeIoExitReason::DaemonLost
+        );
+        assert!(stdout.is_empty(), "stale bytes must not be emitted after transport loss");
+    }
+
+    #[test]
+    fn stdout_pump_drains_committed_bytes_before_surface_exit() {
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let budget = PipeIoByteBudget::new(1024);
+        assert!(budget.try_reserve(5));
+        sender.send(replay(b"FINAL")).unwrap();
+        lifecycle_sender.send(PipeIoEvent::SurfaceExited).unwrap();
+
+        let mut stdout = Vec::new();
+        let reason =
+            pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        assert_eq!(stdout, b"FINAL");
+    }
+
+    #[test]
+    fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
+        let terminal_ended =
+            crate::session::test_remote_rejected_error_with_message("unknown surface 7");
+        assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
+
+        let daemon_lost = crate::session::test_remote_transport_error();
+        assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
+
+        let unexpected = anyhow::anyhow!("attach capability negotiation failed");
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -209,6 +209,11 @@ pub fn run(
             "{}",
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
         );
+        // Continuing without geometry authority would make later resize
+        // requests look accepted while the daemon keeps the wrong PTY size.
+        // Classify the startup failure so the embedder can either stop for a
+        // retired terminal or reconnect after a lost daemon transport.
+        return Ok(attach_failure_exit_reason(&error, surface));
     }
     spawn_stdin_pump(handle, lifecycle_sender);
     let reason = pump_events_to_stdout(

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -57,29 +57,6 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Serializes diagnostics with the final exit record. The stdin pump can be
-/// blocked in a read when the relay ends, so joining it is not a safe way to
-/// establish ordering. Closing this gate makes later diagnostics no-ops while
-/// allowing an in-flight diagnostic to finish before the final record is
-/// written by the parent.
-#[derive(Default)]
-struct StderrGate(Mutex<bool>);
-
-impl StderrGate {
-    fn close(&self) {
-        *self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
-    }
-
-    fn diag(&self, value: serde_json::Value) {
-        let closed = self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-        if *closed {
-            return;
-        }
-        eprintln!("{value}");
-        let _ = std::io::stderr().flush();
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -229,7 +206,7 @@ pub fn run(
     // client (the full TUI client claims this for its active surface). The
     // relay is the embedder's only viewer of this terminal, so claim the
     // authority or every embedder resize is recorded but never applied.
-    if let Err(error) = remote.notify_claim_terminal_geometry(surface) {
+    if let Err(error) = remote.claim_terminal_geometry(surface) {
         eprintln!(
             "{}",
             serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
@@ -248,8 +225,7 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let stderr_gate = Arc::new(StderrGate::default());
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -266,10 +242,6 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
-    // The stdin pump may still be blocked in read(2). Close the diagnostic
-    // gate before returning so the parent can write the final exit record
-    // without a late resize/claim diagnostic racing it.
-    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -386,7 +358,6 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
-    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -395,7 +366,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -405,7 +376,6 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
-    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -446,12 +416,8 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                    })),
+                    Ok(_accepted) => {}
+                    Err(_error) => {}
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -464,12 +430,8 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => {
-                        stderr_gate.diag(serde_json::json!({"diag": {"claim": {"accepted": true}}}))
-                    }
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"error": error.to_string()}}
-                    })),
+                    Ok(()) => (),
+                    Err(_error) => (),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -747,9 +709,8 @@ mod tests {
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
-        let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -761,8 +722,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            let stderr_gate = StderrGate::default();
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -327,9 +327,15 @@ fn classify_daemon_loss(
 
 fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::Result<usize> {
     line.clear();
+    let mut bytes = Vec::new();
     loop {
         let available = reader.fill_buf()?;
         if available.is_empty() {
+            if bytes.is_empty() {
+                return Ok(0);
+            }
+            *line = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
         let (chunk_len, has_newline) = match available.iter().position(|byte| *byte == b'\n') {
@@ -343,11 +349,11 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
             ));
         }
         let chunk = &available[..chunk_len];
-        let text = std::str::from_utf8(chunk)
-            .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
-        line.push_str(text);
+        bytes.extend_from_slice(chunk);
         reader.consume(chunk_len);
         if has_newline {
+            *line = String::from_utf8(bytes)
+                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -63,6 +63,7 @@ pub enum PipeIoExitReason {
     TerminalEnded,
     DaemonLost,
     ParentClosed,
+    SetupFailed,
 }
 
 impl PipeIoExitReason {
@@ -71,12 +72,13 @@ impl PipeIoExitReason {
             Self::TerminalEnded => "terminal-ended",
             Self::DaemonLost => "daemon-lost",
             Self::ParentClosed => "parent-closed",
+            Self::SetupFailed => "setup-failed",
         }
     }
 
     pub fn exit_code(self) -> i32 {
         match self {
-            Self::TerminalEnded | Self::ParentClosed => EXIT_DO_NOT_RESPAWN,
+            Self::TerminalEnded | Self::ParentClosed | Self::SetupFailed => EXIT_DO_NOT_RESPAWN,
             Self::DaemonLost => EXIT_DAEMON_LOST,
         }
     }
@@ -215,7 +217,17 @@ pub fn run(
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
     }
-    spawn_stdin_pump(handle, lifecycle_sender);
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+        Ok(pump) => pump,
+        Err(error) => {
+            eprintln!(
+                "{}",
+                serde_json::json!({"diag": {"stdin-pump": {"error": error.to_string()}}})
+            );
+            drop(tap_guard);
+            return Ok(PipeIoExitReason::SetupFailed);
+        }
+    };
     let reason = pump_events_to_stdout(
         &receiver,
         &lifecycle_receiver,
@@ -264,13 +276,15 @@ impl Drop for PipeIoTapGuard<'_> {
 
 fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
     // A rejected attach naming this exact surface means the terminal ended
-    // between the tree lookup and the attach request. Every other failure is
-    // reported as retryable daemon loss so the embedder receives the normal
-    // final JSON record and exit code.
+    // between the tree lookup and the attach request. Only confirmed
+    // transport failures are retryable; capability and protocol failures
+    // must stop without asking the embedder to respawn forever.
     if is_remote_surface_unavailable(error, surface) {
         PipeIoExitReason::TerminalEnded
-    } else {
+    } else if crate::session::is_pipe_io_retryable_error(error) {
         PipeIoExitReason::DaemonLost
+    } else {
+        PipeIoExitReason::SetupFailed
     }
 }
 
@@ -333,7 +347,10 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 
 /// Forwards embedder requests from stdin until EOF, then reports the closed
 /// parent through the shared event queue.
-fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+fn spawn_stdin_pump(
+    handle: PipeIoSurfaceHandle,
+    lifecycle_sender: Sender<PipeIoEvent>,
+) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
     std::thread::Builder::new()
@@ -343,7 +360,7 @@ fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIo
             let mut reader = stdin.lock();
             run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
-        .expect("spawn pipe-io stdin pump");
+        .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
 
 fn run_stdin_pump(
@@ -576,10 +593,12 @@ mod tests {
     fn exit_reasons_map_to_the_respawn_contract() {
         assert_eq!(PipeIoExitReason::TerminalEnded.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::ParentClosed.exit_code(), EXIT_DO_NOT_RESPAWN);
+        assert_eq!(PipeIoExitReason::SetupFailed.exit_code(), EXIT_DO_NOT_RESPAWN);
         assert_eq!(PipeIoExitReason::DaemonLost.exit_code(), EXIT_DAEMON_LOST);
         assert_eq!(PipeIoExitReason::TerminalEnded.as_str(), "terminal-ended");
         assert_eq!(PipeIoExitReason::DaemonLost.as_str(), "daemon-lost");
         assert_eq!(PipeIoExitReason::ParentClosed.as_str(), "parent-closed");
+        assert_eq!(PipeIoExitReason::SetupFailed.as_str(), "setup-failed");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -28,14 +28,14 @@ use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
-use cmux_tui_core::resource::TerminalPublicId;
 use cmux_tui_core::SurfaceId;
+use cmux_tui_core::resource::TerminalPublicId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
 use crate::session::{
-    is_remote_surface_unavailable, PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach,
-    RemoteSession,
+    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
+    is_remote_surface_unavailable,
 };
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
@@ -239,6 +239,14 @@ pub fn run(
         // Classify the startup failure so the embedder can either stop for a
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
+    }
+    // Older daemons do not accept geometry in the attach request. Apply the
+    // requested initial size explicitly after claiming authority so the
+    // first replay uses the embedder's dimensions on that compatibility path.
+    if !remote.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY) {
+        if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
+            return Ok(attach_failure_exit_reason(&error, surface));
+        }
     }
     let stderr_gate = Arc::new(StderrGate::default());
     let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -517,6 +517,9 @@ fn write_pipe_io_data(
 
 #[cfg(test)]
 mod tests {
+    use std::io::Cursor;
+    use std::sync::{Weak, mpsc};
+
     use super::*;
 
     fn replay(bytes: &[u8]) -> PipeIoEvent {
@@ -644,6 +647,16 @@ mod tests {
             pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
         assert_eq!(reason, PipeIoExitReason::TerminalEnded);
         assert_eq!(stdout, b"FINAL");
+    }
+
+    #[test]
+    fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
+        let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
+        let mut input = Cursor::new(br#"{"input":"aGk="}\n"#.to_vec());
+
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::Arc;
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -334,76 +334,90 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 /// Forwards embedder requests from stdin until EOF, then reports the closed
 /// parent through the shared event queue.
 fn spawn_stdin_pump(handle: PipeIoSurfaceHandle, lifecycle_sender: Sender<PipeIoEvent>) {
+    let remote = Arc::downgrade(&handle.remote);
+    let surface = handle.surface;
     std::thread::Builder::new()
         .name("pipe-io-stdin".into())
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            let mut line = String::new();
-            loop {
-                let Ok(bytes_read) = read_pipe_io_line(&mut reader, &mut line) else { break };
-                if bytes_read == 0 {
-                    break;
-                }
-                if line.trim().is_empty() {
-                    continue;
-                }
-                match parse_request(&line) {
-                    Ok(PipeIoRequest::Input(bytes)) => {
-                        if handle.write_bytes(&bytes).is_err() {
-                            // The transport owns loss reporting; input can
-                            // only stop early.
-                            break;
-                        }
-                    }
-                    Ok(PipeIoRequest::Resize { cols, rows }) => {
-                        // Diagnostics only; the exit JSON stays the final
-                        // stderr line and embedders skip lines without an
-                        // "exit" key.
-                        match handle.resize(cols, rows) {
-                            Ok(accepted) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                                })
-                            ),
-                            Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                                })
-                            ),
-                        }
-                    }
-                    Ok(PipeIoRequest::ClaimGeometry) => {
-                        // Claims only establish ownership. Enqueue them on
-                        // the same ordered writer as input so a claim cannot
-                        // overtake the keystroke that follows it, and avoid a
-                        // new blocking thread for every claim.
-                        match handle.remote.notify_claim_terminal_geometry(handle.surface) {
-                            Ok(()) => eprintln!(
-                                "{}",
-                                serde_json::json!({"diag": {"claim": {"accepted": true}}})
-                            ),
-                            Err(error) => eprintln!(
-                                "{}",
-                                serde_json::json!({
-                                    "diag": {"claim": {"error": error.to_string()}}
-                                })
-                            ),
-                        }
-                    }
-                    Ok(PipeIoRequest::Unknown) => {}
-                    // A malformed line means the embedder side is broken;
-                    // stop consuming rather than misinterpreting input.
-                    Err(_) => break,
-                }
-            }
-            // Lifecycle has its own one-slot channel, so a full byte queue
-            // cannot delay the parent-close signal.
-            let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .expect("spawn pipe-io stdin pump");
+}
+
+fn run_stdin_pump(
+    reader: &mut impl BufRead,
+    remote: &Weak<RemoteSession>,
+    surface: SurfaceId,
+    lifecycle_sender: &Sender<PipeIoEvent>,
+) {
+    let mut line = String::new();
+    loop {
+        let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
+        if bytes_read == 0 {
+            break;
+        }
+        if line.trim().is_empty() {
+            continue;
+        }
+        match parse_request(&line) {
+            Ok(PipeIoRequest::Input(bytes)) => {
+                let Some(remote) = remote.upgrade() else { break };
+                let handle = PipeIoSurfaceHandle { remote, surface };
+                if handle.write_bytes(&bytes).is_err() {
+                    // The transport owns loss reporting; input can only stop
+                    // early.
+                    break;
+                }
+            }
+            Ok(PipeIoRequest::Resize { cols, rows }) => {
+                let Some(remote) = remote.upgrade() else { break };
+                let handle = PipeIoSurfaceHandle { remote, surface };
+                // Diagnostics only; the exit JSON stays the final stderr line
+                // and embedders skip lines without an "exit" key.
+                match handle.resize(cols, rows) {
+                    Ok(accepted) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                        })
+                    ),
+                    Err(error) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                        })
+                    ),
+                }
+            }
+            Ok(PipeIoRequest::ClaimGeometry) => {
+                let Some(remote) = remote.upgrade() else { break };
+                // Claims only establish ownership. Enqueue them on the same
+                // ordered writer as input so a claim cannot overtake the
+                // keystroke that follows it, and avoid a new blocking thread
+                // for every claim.
+                match remote.notify_claim_terminal_geometry(surface) {
+                    Ok(()) => {
+                        eprintln!("{}", serde_json::json!({"diag": {"claim": {"accepted": true}}}))
+                    }
+                    Err(error) => eprintln!(
+                        "{}",
+                        serde_json::json!({
+                            "diag": {"claim": {"error": error.to_string()}}
+                        })
+                    ),
+                }
+            }
+            Ok(PipeIoRequest::Unknown) => {}
+            // A malformed line means the embedder side is broken; stop
+            // consuming rather than misinterpreting input.
+            Err(_) => break,
+        }
+    }
+    // Lifecycle has its own one-slot channel, so a full byte queue cannot
+    // delay the parent-close signal.
+    let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
 }
 
 fn pump_events_to_stdout(
@@ -652,7 +666,7 @@ mod tests {
     #[test]
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
-        let mut input = Cursor::new(br#"{"input":"aGk="}\n"#.to_vec());
+        let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
         run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -220,7 +220,7 @@ pub fn run(
     // Older daemons do not accept geometry in the attach request. Apply the
     // requested initial size explicitly after claiming authority so the
     // first replay uses the embedder's dimensions on that compatibility path.
-    if !remote.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY) {
+    if !remote.supports_pipe_io_initial_size() {
         if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
             return Ok(attach_failure_exit_reason(&error, surface));
         }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,10 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Weak};
+use std::sync::{
+    Arc, Mutex, Weak,
+    atomic::{AtomicBool, Ordering},
+};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -57,6 +60,38 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Diagnostics are best-effort. A blocked stderr pipe must never hold relay
+/// finalization, so writers use a non-blocking lock and drop the record when
+/// another diagnostic is still being written.
+struct StderrGate {
+    closed: AtomicBool,
+    writer: Mutex<()>,
+}
+
+impl Default for StderrGate {
+    fn default() -> Self {
+        Self { closed: AtomicBool::new(false), writer: Mutex::new(()) }
+    }
+}
+
+impl StderrGate {
+    fn close(&self) {
+        self.closed.store(true, Ordering::Release);
+    }
+
+    fn diag(&self, value: serde_json::Value) {
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        let Ok(_guard) = self.writer.try_lock() else { return };
+        if self.closed.load(Ordering::Acquire) {
+            return;
+        }
+        eprintln!("{value}");
+        let _ = std::io::stderr().flush();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -225,7 +260,8 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+    let stderr_gate = Arc::new(StderrGate::default());
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -242,6 +278,7 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
+    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -342,7 +379,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
             Some(index) => (index + 1, true),
             None => (available.len(), false),
         };
-        if line.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
+        if bytes.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::InvalidData,
                 format!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes"),
@@ -364,6 +401,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -372,7 +410,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -382,6 +420,7 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -422,8 +461,12 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(_accepted) => {}
-                    Err(_error) => {}
+                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -436,8 +479,12 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => (),
-                    Err(_error) => (),
+                    Ok(()) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"accepted": true}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -716,7 +763,7 @@ mod tests {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -728,7 +775,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -33,10 +33,7 @@ use cmux_tui_core::resource::TerminalPublicId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
-use crate::session::{
-    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
-    is_remote_surface_unavailable,
-};
+use crate::session::{PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession};
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
 pub const EXIT_DO_NOT_RESPAWN: i32 = 0;
@@ -200,7 +197,7 @@ pub fn run(
             return Ok(PipeIoExitReason::TerminalEnded);
         }
         Ok(PipeIoSurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
-        Err(error) => return Ok(attach_failure_exit_reason(&error, surface)),
+        Err(error) => return Ok(attach_failure_exit_reason(&error)),
     };
     // The daemon resizes a terminal's PTY only for its geometry-authority
     // client (the full TUI client claims this for its active surface). The
@@ -215,7 +212,7 @@ pub fn run(
         // requests look accepted while the daemon keeps the wrong PTY size.
         // Classify the startup failure so the embedder can either stop for a
         // retired terminal or reconnect after a lost daemon transport.
-        return Ok(attach_failure_exit_reason(&error, surface));
+        return Ok(attach_failure_exit_reason(&error));
     }
     // Older daemons do not accept geometry in the attach request. Apply the
     // requested initial size explicitly after claiming authority so the
@@ -282,14 +279,11 @@ impl Drop for PipeIoTapGuard<'_> {
     }
 }
 
-fn attach_failure_exit_reason(error: &anyhow::Error, surface: SurfaceId) -> PipeIoExitReason {
-    // A rejected attach naming this exact surface means the terminal ended
-    // between the tree lookup and the attach request. Only confirmed
-    // transport failures are retryable; capability and protocol failures
-    // must stop without asking the embedder to respawn forever.
-    if is_remote_surface_unavailable(error, surface) {
-        PipeIoExitReason::TerminalEnded
-    } else if crate::session::is_pipe_io_retryable_error(error) {
+fn attach_failure_exit_reason(error: &anyhow::Error) -> PipeIoExitReason {
+    // Unknown rejection text is not a reliable lifecycle signal. Fail closed
+    // unless the transport itself is explicitly retryable; setup errors must
+    // not respawn forever on a stale or unauthorized surface.
+    if crate::session::is_pipe_io_retryable_error(error) {
         PipeIoExitReason::DaemonLost
     } else {
         PipeIoExitReason::SetupFailed
@@ -737,12 +731,12 @@ mod tests {
     fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
         let terminal_ended =
             crate::session::test_remote_rejected_error_with_message("unknown surface 7");
-        assert_eq!(attach_failure_exit_reason(&terminal_ended, 7), PipeIoExitReason::TerminalEnded);
+        assert_eq!(attach_failure_exit_reason(&terminal_ended), PipeIoExitReason::SetupFailed);
 
         let daemon_lost = crate::session::test_remote_transport_error();
-        assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(attach_failure_exit_reason(&daemon_lost), PipeIoExitReason::DaemonLost);
 
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
-        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::SetupFailed);
+        assert_eq!(attach_failure_exit_reason(&unexpected), PipeIoExitReason::SetupFailed);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -370,6 +370,7 @@ fn run_stdin_pump(
     lifecycle_sender: &Sender<PipeIoEvent>,
 ) {
     let mut line = String::new();
+    let mut stop_event = None;
     loop {
         let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
         if bytes_read == 0 {
@@ -380,16 +381,23 @@ fn run_stdin_pump(
         }
         match parse_request(&line) {
             Ok(PipeIoRequest::Input(bytes)) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 let handle = PipeIoSurfaceHandle { remote, surface };
                 if handle.write_bytes(&bytes).is_err() {
                     // The transport owns loss reporting; input can only stop
                     // early.
+                    stop_event = Some(PipeIoEvent::TransportLost);
                     break;
                 }
             }
             Ok(PipeIoRequest::Resize { cols, rows }) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 let handle = PipeIoSurfaceHandle { remote, surface };
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
@@ -409,7 +417,10 @@ fn run_stdin_pump(
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
-                let Some(remote) = remote.upgrade() else { break };
+                let Some(remote) = remote.upgrade() else {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
+                };
                 // Claims only establish ownership. Enqueue them on the same
                 // ordered writer as input so a claim cannot overtake the
                 // keystroke that follows it, and avoid a new blocking thread
@@ -429,12 +440,16 @@ fn run_stdin_pump(
             Ok(PipeIoRequest::Unknown) => {}
             // A malformed line means the embedder side is broken; stop
             // consuming rather than misinterpreting input.
-            Err(_) => break,
+            Err(_) => {
+                stop_event = Some(PipeIoEvent::StdinError);
+                break;
+            }
         }
     }
     // Lifecycle has its own one-slot channel, so a full byte queue cannot
-    // delay the parent-close signal.
-    let _ = lifecycle_sender.send(PipeIoEvent::StdinClosed);
+    // delay the parent-close or failure signal. Only actual stdin EOF maps to
+    // StdinClosed; transport and protocol failures keep their own reason.
+    let _ = lifecycle_sender.send(stop_event.unwrap_or(PipeIoEvent::StdinClosed));
 }
 
 fn pump_events_to_stdout(
@@ -480,6 +495,9 @@ fn pump_events_to_stdout(
                                 PipeIoEvent::StdinClosed => {
                                     return Ok(PipeIoExitReason::ParentClosed);
                                 }
+                                PipeIoEvent::StdinError => {
+                                    return Ok(PipeIoExitReason::SetupFailed);
+                                }
                             }
                         }
                         return Ok(PipeIoExitReason::TerminalEnded);
@@ -489,6 +507,9 @@ fn pump_events_to_stdout(
                     }
                     Ok(PipeIoEvent::StdinClosed) => {
                         return Ok(PipeIoExitReason::ParentClosed);
+                    }
+                    Ok(PipeIoEvent::StdinError) => {
+                        return Ok(PipeIoExitReason::SetupFailed);
                     }
                     Ok(PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_)) => {
                         // Lifecycle senders never carry byte events. Ignore a
@@ -513,6 +534,7 @@ fn pump_events_to_stdout(
             PipeIoEvent::SurfaceExited => return Ok(PipeIoExitReason::TerminalEnded),
             PipeIoEvent::TransportLost => return Ok(PipeIoExitReason::DaemonLost),
             PipeIoEvent::StdinClosed => return Ok(PipeIoExitReason::ParentClosed),
+            PipeIoEvent::StdinError => return Ok(PipeIoExitReason::SetupFailed),
         };
         if write_result.is_err() {
             // stdout is the embedder; a failed write means it is gone.
@@ -538,7 +560,10 @@ fn write_pipe_io_data(
             stdout.write_all(bytes)?;
             stdout.flush()?;
         }
-        PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost | PipeIoEvent::StdinClosed => {
+        PipeIoEvent::SurfaceExited
+        | PipeIoEvent::TransportLost
+        | PipeIoEvent::StdinClosed
+        | PipeIoEvent::StdinError => {
             debug_assert!(false, "lifecycle event passed to byte writer");
         }
     }
@@ -549,7 +574,7 @@ fn write_pipe_io_data(
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
-    use std::sync::{Weak, mpsc};
+    use std::sync::Weak;
 
     use super::*;
 
@@ -625,6 +650,7 @@ mod tests {
         for (event, expected) in [
             (PipeIoEvent::TransportLost, PipeIoExitReason::DaemonLost),
             (PipeIoEvent::StdinClosed, PipeIoExitReason::ParentClosed),
+            (PipeIoEvent::StdinError, PipeIoExitReason::SetupFailed),
         ] {
             let (sender, receiver) = crossbeam_channel::bounded(8);
             let (_lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
@@ -684,12 +710,12 @@ mod tests {
 
     #[test]
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
-        let (lifecycle_sender, lifecycle_receiver) = mpsc::channel();
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
         run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
-        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
 
     #[test]
@@ -702,6 +728,6 @@ mod tests {
         assert_eq!(attach_failure_exit_reason(&daemon_lost, 7), PipeIoExitReason::DaemonLost);
 
         let unexpected = anyhow::anyhow!("attach capability negotiation failed");
-        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::DaemonLost);
+        assert_eq!(attach_failure_exit_reason(&unexpected, 7), PipeIoExitReason::SetupFailed);
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,10 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{
-    Arc, Mutex, Weak,
-    atomic::{AtomicBool, Ordering},
-};
+use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -60,38 +57,6 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
-
-/// Diagnostics are best-effort. A blocked stderr pipe must never hold relay
-/// finalization, so writers use a non-blocking lock and drop the record when
-/// another diagnostic is still being written.
-struct StderrGate {
-    closed: AtomicBool,
-    writer: Mutex<()>,
-}
-
-impl Default for StderrGate {
-    fn default() -> Self {
-        Self { closed: AtomicBool::new(false), writer: Mutex::new(()) }
-    }
-}
-
-impl StderrGate {
-    fn close(&self) {
-        self.closed.store(true, Ordering::Release);
-    }
-
-    fn diag(&self, value: serde_json::Value) {
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        let Ok(_guard) = self.writer.try_lock() else { return };
-        if self.closed.load(Ordering::Acquire) {
-            return;
-        }
-        eprintln!("{value}");
-        let _ = std::io::stderr().flush();
-    }
-}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -260,8 +225,7 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error, surface));
         }
     }
-    let stderr_gate = Arc::new(StderrGate::default());
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -278,7 +242,6 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
-    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -401,7 +364,6 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
-    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -410,7 +372,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -420,7 +382,6 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
-    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -461,12 +422,8 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                    })),
+                    Ok(_accepted) => {}
+                    Err(_error) => {}
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -479,12 +436,8 @@ fn run_stdin_pump(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"accepted": true}}
-                    })),
-                    Err(error) => stderr_gate.diag(serde_json::json!({
-                        "diag": {"claim": {"error": error.to_string()}}
-                    })),
+                    Ok(()) => (),
+                    Err(_error) => (),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -763,7 +716,7 @@ mod tests {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -775,7 +728,7 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &StderrGate::default());
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,18 +24,18 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
-use cmux_tui_core::SurfaceId;
 use cmux_tui_core::resource::TerminalPublicId;
+use cmux_tui_core::SurfaceId;
 use crossbeam_channel::{Receiver, Sender};
 use serde::Deserialize;
 
 use crate::session::{
-    PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach, RemoteSession,
-    is_remote_surface_unavailable,
+    is_remote_surface_unavailable, PipeIoByteBudget, PipeIoEvent, PipeIoSurfaceAttach,
+    RemoteSession,
 };
 
 /// The terminal ended, or the embedder walked away: respawning is wrong.
@@ -57,6 +57,29 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Serializes diagnostics with the final exit record. The stdin pump can be
+/// blocked in a read when the relay ends, so joining it is not a safe way to
+/// establish ordering. Closing this gate makes later diagnostics no-ops while
+/// allowing an in-flight diagnostic to finish before the final record is
+/// written by the parent.
+#[derive(Default)]
+struct StderrGate(Mutex<bool>);
+
+impl StderrGate {
+    fn close(&self) {
+        *self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = true;
+    }
+
+    fn diag(&self, value: serde_json::Value) {
+        let closed = self.0.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
+        if *closed {
+            return;
+        }
+        eprintln!("{value}");
+        let _ = std::io::stderr().flush();
+    }
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -217,7 +240,8 @@ pub fn run(
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(attach_failure_exit_reason(&error, surface));
     }
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+    let stderr_gate = Arc::new(StderrGate::default());
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
             eprintln!(
@@ -234,6 +258,10 @@ pub fn run(
         &byte_budget,
         &mut std::io::stdout().lock(),
     )?;
+    // The stdin pump may still be blocked in read(2). Close the diagnostic
+    // gate before returning so the parent can write the final exit record
+    // without a late resize/claim diagnostic racing it.
+    stderr_gate.close();
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -350,6 +378,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -358,7 +387,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -368,11 +397,18 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+    stderr_gate: &StderrGate,
 ) {
     let mut line = String::new();
     let mut stop_event = None;
     loop {
-        let Ok(bytes_read) = read_pipe_io_line(reader, &mut line) else { break };
+        let bytes_read = match read_pipe_io_line(reader, &mut line) {
+            Ok(bytes_read) => bytes_read,
+            Err(_) => {
+                stop_event = Some(PipeIoEvent::StdinError);
+                break;
+            }
+        };
         if bytes_read == 0 {
             break;
         }
@@ -402,18 +438,12 @@ fn run_stdin_pump(
                 // Diagnostics only; the exit JSON stays the final stderr line
                 // and embedders skip lines without an "exit" key.
                 match handle.resize(cols, rows) {
-                    Ok(accepted) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
-                        })
-                    ),
-                    Err(error) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
-                        })
-                    ),
+                    Ok(accepted) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "accepted": accepted}}
+                    })),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"resize": {"cols": cols, "rows": rows, "error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
@@ -427,14 +457,11 @@ fn run_stdin_pump(
                 // for every claim.
                 match remote.notify_claim_terminal_geometry(surface) {
                     Ok(()) => {
-                        eprintln!("{}", serde_json::json!({"diag": {"claim": {"accepted": true}}}))
+                        stderr_gate.diag(serde_json::json!({"diag": {"claim": {"accepted": true}}}))
                     }
-                    Err(error) => eprintln!(
-                        "{}",
-                        serde_json::json!({
-                            "diag": {"claim": {"error": error.to_string()}}
-                        })
-                    ),
+                    Err(error) => stderr_gate.diag(serde_json::json!({
+                        "diag": {"claim": {"error": error.to_string()}}
+                    })),
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -712,10 +739,24 @@ mod tests {
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
+        let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
+    }
+
+    #[test]
+    fn stdin_pump_reports_line_read_errors_as_stdin_errors() {
+        let inputs =
+            vec![b"{\"input\":\"aGk=\"}\n\xff".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
+        for input in inputs {
+            let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            let mut input = Cursor::new(input.to_vec());
+            let stderr_gate = StderrGate::default();
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+            assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -953,6 +953,14 @@ enum PipeIoControlResult<T> {
     Failed(anyhow::Error),
 }
 
+fn control_result_requires_transport_loss<T>(result: &PipeIoControlResult<T>) -> bool {
+    match result {
+        PipeIoControlResult::Gone => true,
+        PipeIoControlResult::Failed(error) => crate::session::is_pipe_io_retryable_error(error),
+        PipeIoControlResult::Completed(_) => false,
+    }
+}
+
 fn run_stdin_pump(
     reader: &mut impl BufRead,
     remote: &Weak<RemoteSession>,
@@ -1053,7 +1061,12 @@ fn run_stdin_pump_with_handlers(
             Ok(PipeIoRequest::Resize { cols, rows }) => {
                 let result = resize(cols, rows);
                 emit_diag(resize_diag_line(cols, rows, &result));
-                if matches!(result, PipeIoControlResult::Gone) {
+                if control_result_requires_transport_loss(&result) {
+                    // A retryable request failure means this session's
+                    // transport cannot make progress. End the pump so the
+                    // parent can classify it as daemon loss; explicit
+                    // protocol/setup rejections remain diagnostics and the
+                    // embedder may continue issuing requests.
                     stop_event = Some(PipeIoEvent::TransportLost);
                     break;
                 }
@@ -1065,7 +1078,7 @@ fn run_stdin_pump_with_handlers(
                 // for every claim.
                 let result = claim();
                 emit_diag(claim_diag_line(&result));
-                if matches!(result, PipeIoControlResult::Gone) {
+                if control_result_requires_transport_loss(&result) {
                     stop_event = Some(PipeIoEvent::TransportLost);
                     break;
                 }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1270,6 +1270,102 @@ mod tests {
         drop(reader);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn stdout_writer_drains_committed_bytes_after_surface_exit() {
+        use std::io::Read;
+        use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+
+        let mut fds = [0 as RawFd; 2];
+        // SAFETY: `fds` points to two writable integers owned by this test;
+        // `pipe` initializes both descriptors on success.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let reader = unsafe { File::from_raw_fd(fds[0]) };
+        let writer_file = unsafe { File::from_raw_fd(fds[1]) };
+        set_nonblocking(writer_file.as_raw_fd()).unwrap();
+
+        let fill = [0_u8; 4096];
+        loop {
+            // SAFETY: `writer_file` owns the descriptor and `fill` remains
+            // alive and readable for the duration of each call.
+            let written =
+                unsafe { libc::write(writer_file.as_raw_fd(), fill.as_ptr().cast(), fill.len()) };
+            if written >= 0 {
+                continue;
+            }
+            let error = io::Error::last_os_error();
+            assert!(
+                error.raw_os_error() == Some(libc::EAGAIN)
+                    || error.raw_os_error() == Some(libc::EWOULDBLOCK),
+                "unexpected pipe fill error: {error}"
+            );
+            break;
+        }
+
+        let cancellation = PipeIoOutputCancellation::new().unwrap();
+        cancellation.request(PipeIoExitReason::TerminalEnded);
+        let mut stdout = PipeIoStdout { file: writer_file, cancellation };
+        let (started_sender, started_receiver) = sync_channel(0);
+        let (finished_sender, finished_receiver) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            started_sender.send(()).unwrap();
+            finished_sender.send(stdout.write_bytes(b"final")).unwrap();
+        });
+        started_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        // A terminal-exit drain is bounded, but it must not reject committed
+        // bytes while the embedder is still able to resume reading.
+        assert!(finished_receiver.recv_timeout(Duration::from_millis(50)).is_err());
+
+        let reader = std::thread::spawn(move || {
+            let mut bytes = Vec::new();
+            reader.read_to_end(&mut bytes).unwrap();
+            bytes
+        });
+        let result = finished_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(result.is_ok(), "terminal-exit drain failed: {result:?}");
+        let bytes = reader.join().unwrap();
+        assert!(bytes.ends_with(b"final"), "final bytes were not drained");
+        writer.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stderr_writer_bounds_a_stalled_pipe() {
+        use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+
+        let mut fds = [0 as RawFd; 2];
+        // SAFETY: `fds` points to two writable integers owned by this test;
+        // `pipe` initializes both descriptors on success.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        let reader = unsafe { File::from_raw_fd(fds[0]) };
+        let writer = unsafe { File::from_raw_fd(fds[1]) };
+        set_nonblocking(writer.as_raw_fd()).unwrap();
+
+        let fill = [0_u8; 4096];
+        loop {
+            // SAFETY: `writer` owns the descriptor and `fill` remains alive
+            // and readable for the duration of each call.
+            let written =
+                unsafe { libc::write(writer.as_raw_fd(), fill.as_ptr().cast(), fill.len()) };
+            if written >= 0 {
+                continue;
+            }
+            let error = io::Error::last_os_error();
+            assert!(
+                error.raw_os_error() == Some(libc::EAGAIN)
+                    || error.raw_os_error() == Some(libc::EWOULDBLOCK),
+                "unexpected pipe fill error: {error}"
+            );
+            break;
+        }
+
+        let started = Instant::now();
+        assert!(!write_fd_line_bounded(writer.as_raw_fd(), "blocked"));
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(reader);
+        drop(writer);
+    }
+
     #[test]
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -93,7 +93,7 @@ impl StderrGate {
 
     fn diag(&self, line: String) {
         self.emit_with(line, |line| {
-            let mut stderr = std::io::stderr().lock();
+            let mut stderr = io::stderr().lock();
             let _ = writeln!(stderr, "{line}");
             let _ = stderr.flush();
         });
@@ -194,7 +194,7 @@ struct PipeIoStdout {
 
 #[cfg(unix)]
 fn pipe_io_stdout(cancellation: PipeIoOutputCancellation) -> io::Result<PipeIoStdout> {
-    let stdout = std::io::stdout();
+    let stdout = io::stdout();
     let stdout_fd = stdout.as_fd().try_clone_to_owned()?;
     let file = File::from(stdout_fd);
     set_nonblocking(file.as_raw_fd())?;
@@ -724,7 +724,7 @@ fn classify_daemon_loss(
     }
 }
 
-fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::Result<usize> {
+fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> io::Result<usize> {
     line.clear();
     let mut bytes = Vec::new();
     loop {
@@ -734,7 +734,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
                 return Ok(0);
             }
             *line = String::from_utf8(bytes)
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
         let (chunk_len, has_newline) = match available.iter().position(|byte| *byte == b'\n') {
@@ -742,8 +742,8 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
             None => (available.len(), false),
         };
         if bytes.len().saturating_add(chunk_len) > MAX_PIPE_IO_LINE_BYTES {
-            return Err(std::io::Error::new(
-                std::io::ErrorKind::InvalidData,
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
                 format!("pipe-io request line exceeds {MAX_PIPE_IO_LINE_BYTES} bytes"),
             ));
         }
@@ -752,7 +752,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
         reader.consume(chunk_len);
         if has_newline {
             *line = String::from_utf8(bytes)
-                .map_err(|error| std::io::Error::new(std::io::ErrorKind::InvalidData, error))?;
+                .map_err(|error| io::Error::new(io::ErrorKind::InvalidData, error))?;
             return Ok(line.len());
         }
     }
@@ -764,17 +764,17 @@ fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
     stderr_gate: Arc<StderrGate>,
-) -> std::io::Result<std::thread::JoinHandle<()>> {
+) -> io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
     std::thread::Builder::new()
         .name("pipe-io-stdin".into())
         .spawn(move || {
-            let stdin = std::io::stdin();
+            let stdin = io::stdin();
             let mut reader = stdin.lock();
             run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
-        .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
+        .map_err(|error| io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
 
 enum PipeIoControlResult<T> {
@@ -1027,7 +1027,7 @@ fn write_pipe_io_data(
     event: &PipeIoEvent,
     emitted_output: &mut bool,
     stdout: &mut impl PipeIoOutput,
-) -> std::io::Result<()> {
+) -> io::Result<()> {
     match event {
         PipeIoEvent::Replay { bytes, .. } => {
             if *emitted_output {
@@ -1218,8 +1218,8 @@ mod tests {
         assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
         // Keep the read side open but never consume it. This models an
         // embedder that stopped reading while its process remains alive.
-        let reader = unsafe { std::fs::File::from_raw_fd(fds[0]) };
-        let writer_file = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+        let reader = unsafe { File::from_raw_fd(fds[0]) };
+        let writer_file = unsafe { File::from_raw_fd(fds[1]) };
         set_nonblocking(writer_file.as_raw_fd()).unwrap();
 
         // Fill the kernel pipe so the first relay write must wait for

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1876,6 +1876,7 @@ mod tests {
             || Ok(()),
         )
         .unwrap();
+        worker.flush_output().unwrap();
         let (finished_sender, finished_receiver) = std::sync::mpsc::channel();
         let writer = std::thread::spawn(move || {
             finished_sender.send(worker.write_bytes(b"blocked")).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1656,7 +1656,7 @@ mod tests {
                 |_bytes| PipeIoControlResult::Completed(()),
                 move |_cols, _rows| {
                     if resize_case {
-                        PipeIoControlResult::Failed(crate::session::test_remote_transport_error())
+                        PipeIoControlResult::Failed(crate::session::test_remote_timeout_error())
                     } else {
                         PipeIoControlResult::Completed(true)
                     }
@@ -1665,13 +1665,17 @@ mod tests {
                     if resize_case {
                         PipeIoControlResult::Completed(())
                     } else {
-                        PipeIoControlResult::Failed(crate::session::test_remote_transport_error())
+                        PipeIoControlResult::Failed(anyhow::Error::new(io::Error::new(
+                            io::ErrorKind::ConnectionReset,
+                            "socket reset",
+                        )))
                     }
                 },
                 |line| diagnostics.push(line),
             );
 
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
+            assert!(lifecycle_receiver.try_recv().is_err());
             assert_eq!(diagnostics.len(), 1);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -26,7 +26,7 @@ use std::io::{self, BufRead, Write};
 use std::path::Path;
 #[cfg(test)]
 use std::sync::mpsc::sync_channel;
-use std::sync::{Arc, Mutex, Weak};
+use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 #[cfg(unix)]
@@ -63,6 +63,8 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+const STDERR_WRITE_TIMEOUT: Duration = Duration::from_millis(100);
+const PIPE_IO_FINAL_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
 const CLAIM_GEOMETRY_ERROR_CODE: &str = "claim-terminal-geometry-failed";
 const STDIN_PUMP_ERROR_CODE: &str = "stdin-pump-failed";
 const RESIZE_ERROR_CODE: &str = "resize-failed";
@@ -76,28 +78,131 @@ fn log_pipe_io_error(operation: &str, error: &anyhow::Error) {
 /// The stdin pump may remain blocked in a read when the relay ends, so closing
 /// the gate stops later diagnostics without detaching an in-flight write.
 #[derive(Default)]
-struct StderrGate(Mutex<bool>);
+struct StderrGate {
+    state: Mutex<StderrGateState>,
+    idle: Condvar,
+}
+
+#[derive(Default)]
+struct StderrGateState {
+    closed: bool,
+    in_flight: usize,
+}
+
+struct StderrFlight<'a> {
+    gate: &'a StderrGate,
+}
+
+impl Drop for StderrFlight<'_> {
+    fn drop(&mut self) {
+        let mut state = self.gate.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        state.in_flight = state.in_flight.saturating_sub(1);
+        if state.in_flight == 0 {
+            self.gate.idle.notify_all();
+        }
+    }
+}
 
 impl StderrGate {
     fn close(&self) {
-        *self.0.lock().unwrap_or_else(|poison| poison.into_inner()) = true;
+        let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        state.closed = true;
+        while state.in_flight != 0 {
+            state = self.idle.wait(state).unwrap_or_else(|poison| poison.into_inner());
+        }
     }
 
     fn emit_with(&self, line: String, writer: impl FnOnce(&str)) {
-        let closed = self.0.lock().unwrap_or_else(|poison| poison.into_inner());
-        if *closed {
+        let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        if state.closed {
             return;
         }
+        state.in_flight += 1;
+        drop(state);
+        let _flight = StderrFlight { gate: self };
         writer(&line);
     }
 
     fn diag(&self, line: String) {
-        self.emit_with(line, |line| {
-            let mut stderr = io::stderr().lock();
-            let _ = writeln!(stderr, "{line}");
-            let _ = stderr.flush();
-        });
+        self.emit_with(line, |line| write_stderr_line_bounded(line));
     }
+}
+
+/// Writes one stderr line without allowing a stopped embedder to strand the
+/// relay. Unix uses a temporary nonblocking descriptor and a short deadline;
+/// other platforms retain the standard stream writer as their fallback.
+#[cfg(unix)]
+pub(crate) fn write_stderr_line_bounded(line: &str) {
+    let stderr = io::stderr();
+    let Ok(fd) = stderr.as_fd().try_clone_to_owned() else { return };
+    let _ = write_fd_line_bounded(fd.as_raw_fd(), line);
+}
+
+#[cfg(not(unix))]
+pub(crate) fn write_stderr_line_bounded(line: &str) {
+    let mut stderr = io::stderr().lock();
+    let _ = writeln!(stderr, "{line}");
+    let _ = stderr.flush();
+}
+
+#[cfg(unix)]
+fn write_fd_line_bounded(fd: RawFd, line: &str) -> bool {
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return false;
+    }
+    if unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) } < 0 {
+        return false;
+    }
+
+    let mut bytes = Vec::with_capacity(line.len() + 1);
+    bytes.extend_from_slice(line.as_bytes());
+    bytes.push(b'\n');
+    let deadline = Instant::now() + STDERR_WRITE_TIMEOUT;
+    let mut offset = 0;
+    let complete = loop {
+        if offset == bytes.len() {
+            break true;
+        }
+        let written =
+            unsafe { libc::write(fd, bytes[offset..].as_ptr().cast(), bytes.len() - offset) };
+        if written > 0 {
+            offset += written as usize;
+            continue;
+        }
+        if written == 0 {
+            break false;
+        }
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        if !matches!(
+            error.raw_os_error(),
+            Some(code) if code == libc::EAGAIN || code == libc::EWOULDBLOCK
+        ) {
+            break false;
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            break false;
+        }
+        let timeout_ms = remaining.as_millis().clamp(1, i32::MAX as u128) as i32;
+        let mut poll_fd = libc::pollfd { fd, events: libc::POLLOUT, revents: 0 };
+        let ready = unsafe { libc::poll(&mut poll_fd, 1, timeout_ms) };
+        if ready > 0 {
+            continue;
+        }
+        if ready < 0 && io::Error::last_os_error().raw_os_error() == Some(libc::EINTR) {
+            continue;
+        }
+        break false;
+    };
+    // The duplicate shares the stream's open-file description, so restore the
+    // caller's flags before dropping it. The bounded write itself is complete
+    // or explicitly abandoned at the deadline.
+    let _ = unsafe { libc::fcntl(fd, libc::F_SETFL, flags) };
+    complete
 }
 
 /// Cancellation shared by the lifecycle monitor and the stdout writer.
@@ -107,11 +212,17 @@ impl StderrGate {
 /// event, with no polling timeout and no detached writer thread.
 #[derive(Clone)]
 struct PipeIoOutputCancellation {
-    reason: Arc<Mutex<Option<PipeIoExitReason>>>,
+    state: Arc<Mutex<PipeIoCancellationState>>,
     #[cfg(unix)]
     wake_reader: Arc<UnixStream>,
     #[cfg(unix)]
     wake_writer: Arc<Mutex<UnixStream>>,
+}
+
+#[derive(Clone, Copy, Default)]
+struct PipeIoCancellationState {
+    reason: Option<PipeIoExitReason>,
+    drain_deadline: Option<Instant>,
 }
 
 impl PipeIoOutputCancellation {
@@ -125,21 +236,24 @@ impl PipeIoOutputCancellation {
             wake_reader.set_nonblocking(true)?;
             wake_writer.set_nonblocking(true)?;
             Ok(Self {
-                reason: Arc::new(Mutex::new(None)),
+                state: Arc::new(Mutex::new(PipeIoCancellationState::default())),
                 wake_reader: Arc::new(wake_reader),
                 wake_writer: Arc::new(Mutex::new(wake_writer)),
             })
         }
 
         #[cfg(not(unix))]
-        Ok(Self { reason: Arc::new(Mutex::new(None)) })
+        Ok(Self { state: Arc::new(Mutex::new(PipeIoCancellationState::default())) })
     }
 
     fn request(&self, reason: PipeIoExitReason) {
         let first_reason = {
-            let mut state = self.reason.lock().unwrap_or_else(|poison| poison.into_inner());
-            if state.is_none() {
-                *state = Some(reason);
+            let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            if state.reason.is_none() {
+                state.reason = Some(reason);
+                if reason == PipeIoExitReason::TerminalEnded {
+                    state.drain_deadline = Some(Instant::now() + PIPE_IO_FINAL_DRAIN_TIMEOUT);
+                }
                 true
             } else {
                 false
@@ -156,7 +270,22 @@ impl PipeIoOutputCancellation {
     }
 
     fn reason(&self) -> Option<PipeIoExitReason> {
-        *self.reason.lock().unwrap_or_else(|poison| poison.into_inner())
+        self.state.lock().unwrap_or_else(|poison| poison.into_inner()).reason
+    }
+
+    fn cancellation_state(&self) -> PipeIoCancellationState {
+        *self.state.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    fn writes_cancelled(&self) -> bool {
+        let state = self.cancellation_state();
+        match state.reason {
+            None => false,
+            Some(PipeIoExitReason::TerminalEnded) => {
+                state.drain_deadline.is_none_or(|deadline| Instant::now() >= deadline)
+            }
+            Some(_) => true,
+        }
     }
 
     #[cfg(unix)]
@@ -220,17 +349,44 @@ fn set_nonblocking(fd: RawFd) -> io::Result<()> {
 impl PipeIoStdout {
     fn wait_until_writable(&self) -> io::Result<()> {
         loop {
+            let cancellation = self.cancellation.cancellation_state();
+            let terminal_drain = cancellation.reason == Some(PipeIoExitReason::TerminalEnded)
+                && cancellation.drain_deadline.is_some_and(|deadline| Instant::now() < deadline);
+            if cancellation.reason.is_some() && !terminal_drain {
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "pipe-io stdout canceled"));
+            }
+            let timeout_ms = if terminal_drain {
+                let remaining = cancellation
+                    .drain_deadline
+                    .expect("terminal drain has a deadline")
+                    .saturating_duration_since(Instant::now());
+                remaining.as_millis().clamp(1, i32::MAX as u128) as i32
+            } else {
+                -1
+            };
             let mut poll_fds = [
                 libc::pollfd { fd: self.file.as_raw_fd(), events: libc::POLLOUT, revents: 0 },
-                libc::pollfd { fd: self.cancellation.wake_fd(), events: libc::POLLIN, revents: 0 },
+                libc::pollfd {
+                    fd: self.cancellation.wake_fd(),
+                    // Once terminal-exit draining begins, ignore the already
+                    // readable wake descriptor and wait for stdout or the
+                    // explicit drain deadline. Otherwise poll would spin on
+                    // the same cancellation byte.
+                    events: if terminal_drain { 0 } else { libc::POLLIN },
+                    revents: 0,
+                },
             ];
-            let ready = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, -1) };
+            let ready =
+                unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, timeout_ms) };
             if ready < 0 {
                 let error = io::Error::last_os_error();
                 if error.raw_os_error() == Some(libc::EINTR) {
                     continue;
                 }
                 return Err(error);
+            }
+            if ready == 0 {
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "pipe-io stdout canceled"));
             }
 
             let output_events = poll_fds[0].revents;
@@ -240,13 +396,6 @@ impl PipeIoStdout {
                 != 0;
             let output_writable = output_events & libc::POLLOUT != 0;
 
-            // If stdout is writable at the same instant as lifecycle
-            // cancellation, allow one more write. This preserves committed
-            // bytes for a normal surface-exit drain. If it is not writable,
-            // return immediately instead of waiting for a reader that stopped.
-            if cancellation_requested && !output_writable {
-                return Err(io::Error::new(io::ErrorKind::Interrupted, "pipe-io stdout canceled"));
-            }
             if output_events & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
                 if let Some(reason) = self.cancellation.reason() {
                     return Err(io::Error::new(
@@ -257,7 +406,16 @@ impl PipeIoStdout {
                 return Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout closed"));
             }
             if output_writable {
+                if self.cancellation.writes_cancelled() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "pipe-io stdout canceled",
+                    ));
+                }
                 return Ok(());
+            }
+            if cancellation_requested && !terminal_drain {
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "pipe-io stdout canceled"));
             }
         }
     }
@@ -267,6 +425,9 @@ impl PipeIoStdout {
 impl PipeIoOutput for PipeIoStdout {
     fn write_bytes(&mut self, mut bytes: &[u8]) -> io::Result<()> {
         while !bytes.is_empty() {
+            if self.cancellation.writes_cancelled() {
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "pipe-io stdout canceled"));
+            }
             // The descriptor is nonblocking, so a full pipe returns EAGAIN
             // and the poll below can also watch the cancellation wakeup.
             let written =
@@ -551,9 +712,11 @@ pub fn run(
     // authority or every embedder resize is recorded but never applied.
     if let Err(error) = remote.claim_terminal_geometry(surface) {
         log_pipe_io_error("claim terminal geometry", &error);
-        eprintln!(
-            "{}",
-            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": CLAIM_GEOMETRY_ERROR_CODE}}})
+        write_stderr_line_bounded(
+            &serde_json::json!({
+                "diag": {"claim-terminal-geometry": {"error": CLAIM_GEOMETRY_ERROR_CODE}}
+            })
+            .to_string(),
         );
         // Continuing without geometry authority would make later resize
         // requests look accepted while the daemon keeps the wrong PTY size.
@@ -608,9 +771,9 @@ pub fn run(
         Err(error) => {
             let error = anyhow::Error::new(error);
             log_pipe_io_error("spawn stdin pump", &error);
-            eprintln!(
-                "{}",
-                serde_json::json!({"diag": {"stdin-pump": {"error": STDIN_PUMP_ERROR_CODE}}})
+            write_stderr_line_bounded(
+                &serde_json::json!({"diag": {"stdin-pump": {"error": STDIN_PUMP_ERROR_CODE}}})
+                    .to_string(),
             );
             lifecycle_monitor.stop();
             drop(tap_guard);
@@ -1280,7 +1443,7 @@ mod tests {
         // SAFETY: `fds` points to two writable integers owned by this test;
         // `pipe` initializes both descriptors on success.
         assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
-        let reader = unsafe { File::from_raw_fd(fds[0]) };
+        let mut reader = unsafe { File::from_raw_fd(fds[0]) };
         let writer_file = unsafe { File::from_raw_fd(fds[1]) };
         set_nonblocking(writer_file.as_raw_fd()).unwrap();
 

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1329,13 +1329,17 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, stderr_gate);
         })
         .map_err(|error| io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
 
 enum PipeIoControlResult<T> {
     Completed(T),
+    /// The command was admitted in FIFO order and its acknowledgement is
+    /// being handled by the single claim owner. No acceptance diagnostic is
+    /// emitted until that owner observes the daemon response.
+    Pending,
     Gone,
     Failed(anyhow::Error),
 }
@@ -1344,7 +1348,176 @@ fn control_result_requires_transport_loss<T>(result: &PipeIoControlResult<T>) ->
     match result {
         PipeIoControlResult::Gone => true,
         PipeIoControlResult::Failed(error) => crate::session::is_pipe_io_retryable_error(error),
-        PipeIoControlResult::Completed(_) => false,
+        PipeIoControlResult::Completed(_) | PipeIoControlResult::Pending => false,
+    }
+}
+
+struct PipeIoClaimOwnerState {
+    closed: bool,
+    active: bool,
+    terminal_reason: Option<PipeIoExitReason>,
+    worker: Option<std::thread::JoinHandle<()>>,
+}
+
+/// Owns at most one in-flight geometry claim. The stdin reader only performs
+/// the immediate FIFO enqueue; a dedicated, joined worker waits for the
+/// daemon response and emits the final diagnostic.
+struct PipeIoClaimOwner {
+    remote: Weak<RemoteSession>,
+    surface: SurfaceId,
+    lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
+    state: Arc<Mutex<PipeIoClaimOwnerState>>,
+}
+
+impl PipeIoClaimOwner {
+    fn new(
+        remote: Weak<RemoteSession>,
+        surface: SurfaceId,
+        lifecycle_sender: Sender<PipeIoEvent>,
+        stderr_gate: Arc<StderrGate>,
+    ) -> Self {
+        Self {
+            remote,
+            surface,
+            lifecycle_sender,
+            stderr_gate,
+            state: Arc::new(Mutex::new(PipeIoClaimOwnerState {
+                closed: false,
+                active: false,
+                terminal_reason: None,
+                worker: None,
+            })),
+        }
+    }
+
+    fn reap_finished(&self) {
+        let join = {
+            let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            let finished = state.worker.as_ref().is_some_and(std::thread::JoinHandle::is_finished);
+            finished.then(|| state.worker.take()).flatten()
+        };
+        if let Some(join) = join {
+            let _ = join.join();
+            let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            state.active = false;
+        }
+    }
+
+    fn submit(&self) -> PipeIoControlResult<()> {
+        self.reap_finished();
+        {
+            let state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            if state.closed || state.terminal_reason.is_some() {
+                return PipeIoControlResult::Gone;
+            }
+            if state.active {
+                // Coalesce repeated claims while the previous ordered command
+                // is still awaiting its acknowledgement.
+                return PipeIoControlResult::Pending;
+            }
+        }
+        let Some(remote) = self.remote.upgrade() else {
+            return PipeIoControlResult::Gone;
+        };
+        let ticket = match remote.enqueue_claim_terminal_geometry(self.surface) {
+            Ok(ticket) => ticket,
+            Err(error) => return PipeIoControlResult::Failed(error),
+        };
+
+        {
+            let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            if state.closed || state.terminal_reason.is_some() {
+                drop(state);
+                drop(ticket);
+                return PipeIoControlResult::Gone;
+            }
+            // The enqueue happened before this flag is published. Any later
+            // stdin line therefore observes the claim's FIFO position.
+            state.active = true;
+        }
+
+        let owner_state = self.state.clone();
+        let lifecycle_sender = self.lifecycle_sender.clone();
+        let stderr_gate = self.stderr_gate.clone();
+        let surface = self.surface;
+        let worker_remote = remote.clone();
+        let worker =
+            match std::thread::Builder::new().name("pipe-io-claim".into()).spawn(move || {
+                let result = worker_remote.await_claim_terminal_geometry(ticket);
+                let control = match result {
+                    Ok(()) => PipeIoControlResult::Completed(()),
+                    Err(error) => PipeIoControlResult::Failed(error),
+                };
+                let retryable = control_result_requires_transport_loss(&control);
+                let retired = worker_remote.surface_is_retired(surface);
+                let local_shutdown = matches!(
+                    &control,
+                    PipeIoControlResult::Failed(error)
+                        if error
+                            .downcast_ref::<crate::session::RemoteRequestError>()
+                            .is_some_and(|error| {
+                                matches!(error, crate::session::RemoteRequestError::Shutdown)
+                            })
+                );
+                if !local_shutdown {
+                    stderr_gate.diag(claim_diag_line(&control));
+                }
+                if retryable || retired {
+                    let reason = if retired {
+                        PipeIoExitReason::TerminalEnded
+                    } else {
+                        PipeIoExitReason::DaemonLost
+                    };
+                    let mut state = owner_state.lock().unwrap_or_else(|poison| poison.into_inner());
+                    state.terminal_reason.get_or_insert(reason);
+                    state.closed = true;
+                    drop(state);
+                    let event = pipe_io_exit_event(reason);
+                    let _ = lifecycle_sender.try_send(event);
+                }
+            }) {
+                Ok(worker) => worker,
+                Err(error) => {
+                    let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+                    state.active = false;
+                    drop(state);
+                    return PipeIoControlResult::Failed(
+                        io::Error::other(format!("spawn pipe-io claim worker: {error}")).into(),
+                    );
+                }
+            };
+        let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        state.worker = Some(worker);
+        PipeIoControlResult::Pending
+    }
+
+    fn finish(&self) -> Option<PipeIoExitReason> {
+        let (join, had_active) = {
+            let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            state.closed = true;
+            (state.worker.take(), state.active)
+        };
+        if had_active {
+            if let Some(remote) = self.remote.upgrade() {
+                // Wake a response waiter before joining. `begin_shutdown` also
+                // preserves the writer's FIFO barrier for commands accepted before
+                // stdin reached EOF.
+                remote.begin_shutdown();
+            }
+        }
+        if let Some(join) = join {
+            let _ = join.join();
+        }
+        let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        state.active = false;
+        state.terminal_reason
+    }
+}
+
+impl Drop for PipeIoClaimOwner {
+    fn drop(&mut self) {
+        let _ = self.finish();
     }
 }
 
@@ -1353,15 +1526,21 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
-    stderr_gate: &StderrGate,
+    stderr_gate: Arc<StderrGate>,
 ) {
     let input_remote = remote.clone();
     let resize_remote = remote.clone();
-    let claim_remote = remote.clone();
+    let claim_owner = PipeIoClaimOwner::new(
+        remote.clone(),
+        surface,
+        lifecycle_sender.clone(),
+        stderr_gate.clone(),
+    );
+    let (pump_lifecycle_sender, pump_lifecycle_receiver) = crossbeam_channel::bounded(1);
     let mut emit_diag = |line: String| stderr_gate.diag(line);
     run_stdin_pump_with_handlers(
         reader,
-        lifecycle_sender,
+        &pump_lifecycle_sender,
         move |bytes| {
             let Some(remote) = input_remote.upgrade() else {
                 return PipeIoControlResult::Gone;
@@ -1382,17 +1561,22 @@ fn run_stdin_pump(
                 Err(error) => PipeIoControlResult::Failed(error),
             }
         },
-        move || {
-            let Some(remote) = claim_remote.upgrade() else {
-                return PipeIoControlResult::Gone;
-            };
-            match remote.claim_terminal_geometry(surface) {
-                Ok(()) => PipeIoControlResult::Completed(()),
-                Err(error) => PipeIoControlResult::Failed(error),
-            }
-        },
+        || claim_owner.submit(),
         &mut emit_diag,
     );
+    let fallback = pump_lifecycle_receiver.recv().unwrap_or(PipeIoEvent::StdinError);
+    let owner_reason = claim_owner.finish();
+    let final_event = owner_reason.map(pipe_io_exit_event).unwrap_or(fallback);
+    let _ = lifecycle_sender.try_send(final_event);
+}
+
+fn pipe_io_exit_event(reason: PipeIoExitReason) -> PipeIoEvent {
+    match reason {
+        PipeIoExitReason::TerminalEnded => PipeIoEvent::SurfaceExited,
+        PipeIoExitReason::DaemonLost => PipeIoEvent::TransportLost,
+        PipeIoExitReason::ParentClosed => PipeIoEvent::StdinClosed,
+        PipeIoExitReason::SetupFailed => PipeIoEvent::StdinError,
+    }
 }
 
 fn run_stdin_pump_with_handlers(
@@ -1423,6 +1607,11 @@ fn run_stdin_pump_with_handlers(
             Ok(PipeIoRequest::Input(bytes)) => {
                 match write_input(&bytes) {
                     PipeIoControlResult::Completed(()) => {}
+                    PipeIoControlResult::Pending => {
+                        // Input writes are fire-and-forget. Keep this arm for
+                        // the shared result type, although the production
+                        // input handler never returns Pending.
+                    }
                     PipeIoControlResult::Gone => {
                         // A dropped remote session cannot accept more input;
                         // reconnecting is the only way to recover it.
@@ -1464,7 +1653,9 @@ fn run_stdin_pump_with_handlers(
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
                 let result = claim();
-                emit_diag(claim_diag_line(&result));
+                if !matches!(&result, PipeIoControlResult::Pending) {
+                    emit_diag(claim_diag_line(&result));
+                }
                 if control_result_requires_transport_loss(&result) {
                     stop_event = Some(PipeIoEvent::TransportLost);
                     break;
@@ -1490,6 +1681,11 @@ fn resize_diag_line(cols: u16, rows: u16, result: &PipeIoControlResult<bool>) ->
         PipeIoControlResult::Completed(accepted) => {
             serde_json::json!({"cols": cols, "rows": rows, "accepted": accepted})
         }
+        PipeIoControlResult::Pending => serde_json::json!({
+            "cols": cols,
+            "rows": rows,
+            "accepted": false,
+        }),
         PipeIoControlResult::Gone => serde_json::json!({
             "cols": cols,
             "rows": rows,
@@ -1506,6 +1702,7 @@ fn resize_diag_line(cols: u16, rows: u16, result: &PipeIoControlResult<bool>) ->
 fn claim_diag_line(result: &PipeIoControlResult<()>) -> String {
     let details = match result {
         PipeIoControlResult::Completed(()) => serde_json::json!({"accepted": true}),
+        PipeIoControlResult::Pending => serde_json::json!({"accepted": false}),
         PipeIoControlResult::Gone => serde_json::json!({"error": CLAIM_ERROR_CODE}),
         PipeIoControlResult::Failed(error) => {
             log_pipe_io_error("claim geometry", error);
@@ -2068,7 +2265,7 @@ mod tests {
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
         let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, Arc::new(stderr_gate));
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -2130,44 +2327,77 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
     #[test]
     fn stdin_pump_does_not_wait_for_a_blocked_claim_before_forwarding_input() {
-        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
-        let mut input = Cursor::new(
-            b"{\"claim\":{\"geometry\":true}}\n{\"input\":\"aGk=\"}\n".to_vec(),
-        );
-        let (claim_started_sender, claim_started_receiver) = sync_channel(0);
-        let (release_sender, release_receiver) = std::sync::mpsc::channel();
-        let (input_seen_sender, input_seen_receiver) = sync_channel(0);
+        let (client, server) = UnixStream::pair().unwrap();
+        let (input_before_ack_sender, input_before_ack_receiver) = sync_channel(0);
+        let (server_done_sender, server_done_receiver) = std::sync::mpsc::channel();
+        let peer = std::thread::spawn(move || {
+            let mut peer = io::BufReader::new(server);
+            for expected_command in ["identify", "set-client-info", "subscribe"] {
+                let mut line = String::new();
+                peer.read_line(&mut line).unwrap();
+                let request: serde_json::Value = serde_json::from_str(&line).unwrap();
+                assert_eq!(request["cmd"], expected_command);
+                let data = if expected_command == "identify" {
+                    serde_json::json!({"app": "cmux-tui", "protocol": 12})
+                } else {
+                    serde_json::Value::Null
+                };
+                writeln!(
+                    peer.get_mut(),
+                    "{}",
+                    serde_json::json!({
+                        "id": request["id"],
+                        "ok": true,
+                        "data": data,
+                    })
+                )
+                .unwrap();
+            }
 
-        let pump = std::thread::spawn(move || {
-            run_stdin_pump_with_handlers(
-                &mut input,
-                &lifecycle_sender,
-                move |_bytes| {
-                    input_seen_sender.send(()).unwrap();
-                    PipeIoControlResult::Completed(())
-                },
-                |_cols, _rows| PipeIoControlResult::Completed(true),
-                move || {
-                    claim_started_sender.send(()).unwrap();
-                    release_receiver.recv().unwrap();
-                    PipeIoControlResult::Completed(())
-                },
-                |_line| {},
-            );
+            let mut claim_line = String::new();
+            peer.read_line(&mut claim_line).unwrap();
+            let claim: serde_json::Value = serde_json::from_str(&claim_line).unwrap();
+            assert_eq!(claim["cmd"], "set-client-sizing");
+            peer.get_mut().set_read_timeout(Some(Duration::from_millis(100))).unwrap();
+            let mut input_line = String::new();
+            let input_before_ack = peer.read_line(&mut input_line).is_ok();
+            input_before_ack_sender.send(input_before_ack).unwrap();
+            writeln!(
+                peer.get_mut(),
+                "{}",
+                serde_json::json!({
+                    "id": claim["id"],
+                    "ok": true,
+                    "data": null,
+                })
+            )
+            .unwrap();
+            let _ = server_done_receiver.recv();
         });
 
-        claim_started_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
-        let input_forwarded_before_claim_release =
-            input_seen_receiver.recv_timeout(Duration::from_millis(100)).is_ok();
-        release_sender.send(()).unwrap();
+        let remote = RemoteSession::connect_stream(Box::new(client)).unwrap();
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let stderr_gate = Arc::new(StderrGate::default());
+        let input = b"{\"claim\":{\"geometry\":true}}\n{\"input\":\"aGk=\"}\n".to_vec();
+        let pump_remote = Arc::downgrade(&remote);
+        let pump_stderr = stderr_gate.clone();
+        let pump = std::thread::spawn(move || {
+            let mut input = Cursor::new(input);
+            run_stdin_pump(&mut input, &pump_remote, 9, &lifecycle_sender, pump_stderr);
+        });
+
+        assert!(
+            input_before_ack_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .expect("server did not inspect the input command")
+        );
         pump.join().unwrap();
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
-        assert!(
-            input_forwarded_before_claim_release,
-            "stdin input waited for the geometry claim response"
-        );
+        server_done_sender.send(()).unwrap();
+        peer.join().unwrap();
     }
 
     #[test]
@@ -2177,7 +2407,7 @@ mod tests {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
             let stderr_gate = StderrGate::default();
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, Arc::new(stderr_gate));
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -65,6 +65,8 @@ const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 const STDERR_WRITE_TIMEOUT: Duration = Duration::from_millis(100);
 const PIPE_IO_FINAL_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
+const PIPE_IO_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
+const PIPE_IO_OUTPUT_QUEUE_CAPACITY: usize = 1;
 const CLAIM_GEOMETRY_ERROR_CODE: &str = "claim-terminal-geometry-failed";
 const STDIN_PUMP_ERROR_CODE: &str = "stdin-pump-failed";
 const RESIZE_ERROR_CODE: &str = "resize-failed";
@@ -213,6 +215,11 @@ fn write_fd_line_bounded(fd: RawFd, line: &str) -> bool {
 #[derive(Clone)]
 struct PipeIoOutputCancellation {
     state: Arc<Mutex<PipeIoCancellationState>>,
+    /// A bounded, one-shot wake path for portable output workers. The Unix
+    /// descriptor below remains necessary for `poll(2)`, while this channel
+    /// lets a non-Unix worker wait without a timeout loop.
+    cancel_sender: Sender<()>,
+    cancel_receiver: Receiver<()>,
     #[cfg(unix)]
     wake_reader: Arc<UnixStream>,
     #[cfg(unix)]
@@ -227,6 +234,7 @@ struct PipeIoCancellationState {
 
 impl PipeIoOutputCancellation {
     fn new() -> io::Result<Self> {
+        let (cancel_sender, cancel_receiver) = crossbeam_channel::bounded(1);
         #[cfg(unix)]
         {
             let (wake_reader, wake_writer) = UnixStream::pair()?;
@@ -237,13 +245,19 @@ impl PipeIoOutputCancellation {
             wake_writer.set_nonblocking(true)?;
             Ok(Self {
                 state: Arc::new(Mutex::new(PipeIoCancellationState::default())),
+                cancel_sender,
+                cancel_receiver,
                 wake_reader: Arc::new(wake_reader),
                 wake_writer: Arc::new(Mutex::new(wake_writer)),
             })
         }
 
         #[cfg(not(unix))]
-        Ok(Self { state: Arc::new(Mutex::new(PipeIoCancellationState::default())) })
+        Ok(Self {
+            state: Arc::new(Mutex::new(PipeIoCancellationState::default())),
+            cancel_sender,
+            cancel_receiver,
+        })
     }
 
     fn request(&self, reason: PipeIoExitReason) {
@@ -262,6 +276,11 @@ impl PipeIoOutputCancellation {
         if !first_reason {
             return;
         }
+
+        // The receiver is owned by the sole stdout pump. A full channel means
+        // the wake is already pending, so publishing lifecycle state never
+        // blocks the monitor.
+        let _ = self.cancel_sender.try_send(());
 
         #[cfg(unix)]
         if let Ok(mut wake_writer) = self.wake_writer.lock() {
@@ -312,6 +331,158 @@ impl<W: Write> PipeIoOutput for W {
 
     fn flush_output(&mut self) -> io::Result<()> {
         self.flush()
+    }
+}
+
+/// A bounded, single-owner output handoff used on platforms where stdio
+/// writes cannot be made nonblocking directly. The worker owns the sink and
+/// all commands are acknowledged in FIFO order. Cancellation is handled by
+/// the owner through `abort`, then the worker is always joined by `Drop`.
+trait PipeIoOutputSink: Send {
+    fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()>;
+    fn flush_output(&mut self) -> io::Result<()>;
+}
+
+impl<W: Write + Send> PipeIoOutputSink for W {
+    fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.write_all(bytes)
+    }
+
+    fn flush_output(&mut self) -> io::Result<()> {
+        self.flush()
+    }
+}
+
+enum PipeIoOutputCommand {
+    Write { bytes: Vec<u8>, completion: Sender<io::Result<()>> },
+    Flush { completion: Sender<io::Result<()>> },
+}
+
+struct PipeIoOutputWorker {
+    command_sender: Sender<PipeIoOutputCommand>,
+    stop_sender: Sender<()>,
+    join: Option<std::thread::JoinHandle<()>>,
+    cancellation: PipeIoOutputCancellation,
+    abort: Arc<dyn Fn() + Send + Sync>,
+}
+
+impl PipeIoOutputWorker {
+    fn spawn<S, F>(
+        sink: S,
+        cancellation: PipeIoOutputCancellation,
+        abort: Arc<dyn Fn() + Send + Sync>,
+        on_started: F,
+    ) -> io::Result<Self>
+    where
+        S: PipeIoOutputSink + 'static,
+        F: FnOnce() -> io::Result<()> + Send + 'static,
+    {
+        let (command_sender, command_receiver) =
+            crossbeam_channel::bounded(PIPE_IO_OUTPUT_QUEUE_CAPACITY);
+        let (stop_sender, stop_receiver) = crossbeam_channel::bounded(1);
+        let (ready_sender, ready_receiver) = crossbeam_channel::bounded(1);
+        let worker_cancellation = cancellation.clone();
+        let join = std::thread::Builder::new()
+            .name("pipe-io-stdout".into())
+            .spawn(move || {
+                let startup = on_started();
+                let startup_failed = startup.is_err();
+                let _ = ready_sender.send(startup);
+                if startup_failed {
+                    return;
+                }
+
+                let mut sink = sink;
+                loop {
+                    crossbeam_channel::select_biased! {
+                        recv(stop_receiver) -> _ => break,
+                        recv(command_receiver) -> command => {
+                            let Ok(command) = command else { break };
+                            match command {
+                                PipeIoOutputCommand::Write { bytes, completion } => {
+                                    let result = if worker_cancellation.writes_cancelled() {
+                                        Err(io::Error::new(
+                                            io::ErrorKind::Interrupted,
+                                            "pipe-io stdout canceled",
+                                        ))
+                                    } else {
+                                        sink.write_bytes(&bytes)
+                                    };
+                                    let _ = completion.send(result);
+                                }
+                                PipeIoOutputCommand::Flush { completion } => {
+                                    let result = if worker_cancellation.writes_cancelled() {
+                                        Err(io::Error::new(
+                                            io::ErrorKind::Interrupted,
+                                            "pipe-io stdout canceled",
+                                        ))
+                                    } else {
+                                        sink.flush_output()
+                                    };
+                                    let _ = completion.send(result);
+                                }
+                            }
+                        }
+                    }
+                }
+            })
+            .map_err(|error| io::Error::other(format!("spawn pipe-io stdout worker: {error}")))?;
+
+        match ready_receiver.recv() {
+            Ok(Ok(())) => {
+                Ok(Self { command_sender, stop_sender, join: Some(join), cancellation, abort })
+            }
+            Ok(Err(error)) => {
+                let _ = stop_sender.send(());
+                let _ = join.join();
+                Err(error)
+            }
+            Err(_) => {
+                let _ = stop_sender.send(());
+                let _ = join.join();
+                Err(io::Error::other("pipe-io stdout worker exited during startup"))
+            }
+        }
+    }
+
+    fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
+        for chunk in bytes.chunks(PIPE_IO_OUTPUT_CHUNK_BYTES) {
+            let (completion, result_receiver) = crossbeam_channel::bounded(1);
+            self.command_sender
+                .send(PipeIoOutputCommand::Write { bytes: chunk.to_vec(), completion })
+                .map_err(|_| {
+                    io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
+                })?;
+            result_receiver.recv().map_err(|_| {
+                io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
+            })??;
+        }
+        Ok(())
+    }
+
+    fn flush_output(&mut self) -> io::Result<()> {
+        let (completion, result_receiver) = crossbeam_channel::bounded(1);
+        self.command_sender.send(PipeIoOutputCommand::Flush { completion }).map_err(|_| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
+        })?;
+        result_receiver.recv().map_err(|_| {
+            io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
+        })??;
+        Ok(())
+    }
+}
+
+impl Drop for PipeIoOutputWorker {
+    fn drop(&mut self) {
+        // The pump has stopped issuing commands by the time this owner drops.
+        // Publish a reason so a sink blocked between acknowledgements can be
+        // interrupted, then stop and join the worker explicitly.
+        self.cancellation.request(PipeIoExitReason::ParentClosed);
+        (self.abort)();
+        let _ = self.stop_sender.try_send(());
+        if let Some(join) = self.join.take() {
+            let _ = join.join();
+        }
     }
 }
 
@@ -1447,6 +1618,68 @@ mod tests {
         .unwrap();
         assert_eq!(reason, PipeIoExitReason::TerminalEnded);
         assert_eq!(stdout, b"last");
+    }
+
+    #[test]
+    fn output_worker_interrupts_a_blocked_write_when_reader_closes() {
+        struct BlockingSink {
+            started: std::sync::mpsc::SyncSender<()>,
+            release: Arc<(Mutex<bool>, Condvar)>,
+        }
+
+        impl PipeIoOutputSink for BlockingSink {
+            fn write_bytes(&mut self, _bytes: &[u8]) -> io::Result<()> {
+                self.started.send(()).unwrap();
+                let (released, wake) = &*self.release;
+                let mut released = released.lock().unwrap();
+                while !*released {
+                    released = wake.wait(released).unwrap();
+                }
+                Ok(())
+            }
+
+            fn flush_output(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let cancellation = PipeIoOutputCancellation::new().unwrap();
+        let release = Arc::new((Mutex::new(false), Condvar::new()));
+        let (started_sender, started_receiver) = sync_channel(0);
+        let abort_release = release.clone();
+        let abort: Arc<dyn Fn() + Send + Sync> = Arc::new(move || {
+            let (released, wake) = &*abort_release;
+            *released.lock().unwrap() = true;
+            wake.notify_all();
+        });
+        let cleanup_abort = abort.clone();
+        let mut worker = PipeIoOutputWorker::spawn(
+            BlockingSink { started: started_sender, release },
+            cancellation.clone(),
+            abort,
+            || Ok(()),
+        )
+        .unwrap();
+        let (finished_sender, finished_receiver) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            finished_sender.send(worker.write_bytes(b"blocked")).unwrap();
+        });
+        started_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        cancellation.request(PipeIoExitReason::DaemonLost);
+        let mut observed = finished_receiver.recv_timeout(Duration::from_millis(100)).ok();
+        let completed_before_cleanup = observed.is_some();
+        if observed.is_none() {
+            // Keep the red test bounded even before the worker learns about
+            // cancellation. The assertion below still records that it was
+            // not prompt; this release only prevents a wedged test process.
+            cleanup_abort();
+            observed = Some(finished_receiver.recv_timeout(Duration::from_secs(1)).unwrap());
+        }
+        assert!(completed_before_cleanup, "blocked output did not observe cancellation");
+        let result = observed.unwrap().unwrap_err();
+        assert_eq!(result.kind(), io::ErrorKind::Interrupted);
+        writer.join().unwrap();
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -867,6 +867,41 @@ mod tests {
     }
 
     #[test]
+    fn stderr_gate_waits_for_in_flight_diagnostic_before_closing() {
+        let gate = Arc::new(StderrGate::default());
+        let (entered_sender, entered_receiver) = std::sync::mpsc::sync_channel(0);
+        let (release_sender, release_receiver) = std::sync::mpsc::channel();
+        let lines = Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        let writer_gate = gate.clone();
+        let writer_lines = lines.clone();
+        let writer = std::thread::spawn(move || {
+            writer_gate.emit_with("in-flight".to_string(), |line| {
+                entered_sender.send(()).unwrap();
+                release_receiver.recv().unwrap();
+                writer_lines.lock().unwrap().push(line.to_string());
+            });
+        });
+        entered_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let (closed_sender, closed_receiver) = std::sync::mpsc::channel();
+        let close_gate = gate.clone();
+        let closer = std::thread::spawn(move || {
+            close_gate.close();
+            closed_sender.send(()).unwrap();
+        });
+        assert!(closed_receiver.recv_timeout(Duration::from_millis(50)).is_err());
+
+        release_sender.send(()).unwrap();
+        writer.join().unwrap();
+        closer.join().unwrap();
+        closed_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        gate.emit_with("late".to_string(), |line| lines.lock().unwrap().push(line.to_string()));
+        assert_eq!(lines.lock().unwrap().as_slice(), ["in-flight"]);
+    }
+
+    #[test]
     fn stdin_pump_emits_structured_resize_and_claim_diagnostics() {
         let mut input = Cursor::new(
             b"{\"resize\":{\"cols\":100,\"rows\":30}}\n\

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -17,9 +17,9 @@
 //!   ignored (forward compat); stdin EOF means the embedder is gone and
 //!   ends the relay cleanly.
 //! - stderr: one final JSON line `{"exit":{"reason":...}}`.
-//! - exit code: 0 when the terminal ended or the embedder closed stdin (do
-//!   not respawn), 2 when the daemon connection was lost (respawning
-//!   reattaches and resyncs from a fresh replay).
+//! - exit code: 0 when the terminal ended, the embedder closed stdin, or
+//!   setup failed (do not respawn); 2 when the daemon connection was lost
+//!   (respawning reattaches and resyncs from a fresh replay).
 
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
@@ -54,6 +54,28 @@ const MAX_PIPE_IO_LINE_BYTES: usize = MAX_PIPE_IO_BASE64_BYTES + 128;
 /// top of the embedder's previous terminal state.
 const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+const CLAIM_GEOMETRY_ERROR_CODE: &str = "claim-terminal-geometry-failed";
+const STDIN_PUMP_ERROR_CODE: &str = "stdin-pump-failed";
+const RESIZE_ERROR_CODE: &str = "resize-failed";
+const CLAIM_ERROR_CODE: &str = "claim-failed";
+
+fn log_pipe_io_error(operation: &str, error: &anyhow::Error) {
+    crate::client_log::error("pipe-io", &format!("{operation}: {error}"));
+}
+
+#[cfg(unix)]
+fn pipe_io_stdout() -> std::io::Result<std::io::BufWriter<std::fs::File>> {
+    use std::os::fd::AsFd;
+
+    let stdout = std::io::stdout();
+    let stdout_fd = stdout.as_fd().try_clone_to_owned()?;
+    Ok(std::io::BufWriter::new(std::fs::File::from(stdout_fd)))
+}
+
+#[cfg(not(unix))]
+fn pipe_io_stdout() -> std::io::Result<std::io::BufWriter<std::io::Stdout>> {
+    Ok(std::io::BufWriter::new(std::io::stdout()))
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum PipeIoExitReason {
@@ -105,8 +127,8 @@ struct PipeIoWireRequest<'a> {
     #[serde(borrow)]
     input: Option<Cow<'a, str>>,
     resize: Option<PipeIoWireResize>,
-    #[serde(default, deserialize_with = "deserialize_present")]
-    claim: bool,
+    #[serde(default)]
+    claim: PipeIoClaimField,
 }
 
 #[derive(Deserialize)]
@@ -115,11 +137,31 @@ struct PipeIoWireResize {
     rows: Option<u64>,
 }
 
-fn deserialize_present<'de, D>(deserializer: D) -> Result<bool, D::Error>
-where
-    D: serde::Deserializer<'de>,
-{
-    serde::de::IgnoredAny::deserialize(deserializer).map(|_| true)
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PipeIoWireClaim {
+    geometry: bool,
+}
+
+#[derive(Default)]
+enum PipeIoClaimField {
+    #[default]
+    Absent,
+    Enabled,
+}
+
+impl<'de> Deserialize<'de> for PipeIoClaimField {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let claim = PipeIoWireClaim::deserialize(deserializer)?;
+        if claim.geometry {
+            Ok(Self::Enabled)
+        } else {
+            Err(serde::de::Error::custom("claim geometry must be true"))
+        }
+    }
 }
 
 pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
@@ -161,7 +203,7 @@ pub fn parse_request(line: &str) -> anyhow::Result<PipeIoRequest> {
         let (cols, rows) = (u16::try_from(cols)?, u16::try_from(rows)?);
         return Ok(PipeIoRequest::Resize { cols: cols.max(1), rows: rows.max(1) });
     }
-    if request.claim {
+    if matches!(request.claim, PipeIoClaimField::Enabled) {
         return Ok(PipeIoRequest::ClaimGeometry);
     }
     Ok(PipeIoRequest::Unknown)
@@ -204,9 +246,10 @@ pub fn run(
     // relay is the embedder's only viewer of this terminal, so claim the
     // authority or every embedder resize is recorded but never applied.
     if let Err(error) = remote.claim_terminal_geometry(surface) {
+        log_pipe_io_error("claim terminal geometry", &error);
         eprintln!(
             "{}",
-            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": error.to_string()}}})
+            serde_json::json!({"diag": {"claim-terminal-geometry": {"error": CLAIM_GEOMETRY_ERROR_CODE}}})
         );
         // Continuing without geometry authority would make later resize
         // requests look accepted while the daemon keeps the wrong PTY size.
@@ -225,20 +268,20 @@ pub fn run(
     let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
         Ok(pump) => pump,
         Err(error) => {
+            let error = anyhow::Error::new(error);
+            log_pipe_io_error("spawn stdin pump", &error);
             eprintln!(
                 "{}",
-                serde_json::json!({"diag": {"stdin-pump": {"error": error.to_string()}}})
+                serde_json::json!({"diag": {"stdin-pump": {"error": STDIN_PUMP_ERROR_CODE}}})
             );
             drop(tap_guard);
             return Ok(PipeIoExitReason::SetupFailed);
         }
     };
-    let reason = pump_events_to_stdout(
-        &receiver,
-        &lifecycle_receiver,
-        &byte_budget,
-        &mut std::io::stdout().lock(),
-    )?;
+    // On Unix, duplicate the raw stdout descriptor so VT bytes bypass the
+    // standard library's line writer. The protocol flushes each event.
+    let mut stdout = pipe_io_stdout()?;
+    let reason = pump_events_to_stdout(&receiver, &lifecycle_receiver, &byte_budget, &mut stdout)?;
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -506,7 +549,8 @@ fn resize_diag_line(cols: u16, rows: u16, result: &PipeIoControlResult<bool>) ->
             "error": "remote session unavailable"
         }),
         PipeIoControlResult::Failed(error) => {
-            serde_json::json!({"cols": cols, "rows": rows, "error": error.to_string()})
+            log_pipe_io_error("resize", error);
+            serde_json::json!({"cols": cols, "rows": rows, "error": RESIZE_ERROR_CODE})
         }
     };
     serde_json::json!({"diag": {"resize": details}}).to_string()
@@ -518,7 +562,10 @@ fn claim_diag_line(result: &PipeIoControlResult<()>) -> String {
         PipeIoControlResult::Gone => {
             serde_json::json!({"error": "remote session unavailable"})
         }
-        PipeIoControlResult::Failed(error) => serde_json::json!({"error": error.to_string()}),
+        PipeIoControlResult::Failed(error) => {
+            log_pipe_io_error("claim geometry", error);
+            serde_json::json!({"error": CLAIM_ERROR_CODE})
+        }
     };
     serde_json::json!({"diag": {"claim": details}}).to_string()
 }
@@ -620,7 +667,7 @@ fn write_pipe_io_data(
     stdout: &mut impl Write,
 ) -> std::io::Result<()> {
     match event {
-        PipeIoEvent::Replay { bytes } => {
+        PipeIoEvent::Replay { bytes, .. } => {
             if *emitted_output {
                 stdout.write_all(REPLAY_RESET)?;
             }
@@ -650,7 +697,7 @@ mod tests {
     use super::*;
 
     fn replay(bytes: &[u8]) -> PipeIoEvent {
-        PipeIoEvent::Replay { bytes: bytes.to_vec() }
+        PipeIoEvent::replay(bytes.to_vec())
     }
 
     #[test]
@@ -685,6 +732,7 @@ mod tests {
             r#"{"claim":null}"#,
             r#"{"claim":{"geometry":false}}"#,
             r#"{"claim":{"other":true}}"#,
+            r#"{"claim":{"geometry":true,"other":true}}"#,
             r#"{"claim":"true"}"#,
         ] {
             assert!(parse_request(line).is_err(), "accepted invalid claim {line}");
@@ -809,8 +857,7 @@ mod tests {
 
     #[test]
     fn stdin_pump_reports_line_read_errors_as_stdin_errors() {
-        let inputs =
-            vec![b"{\"input\":\"aGk=\"}\n\xff".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
+        let inputs = vec![b"\xff\n".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
@@ -865,9 +912,9 @@ mod tests {
             vec![
                 serde_json::json!({"diag": {"resize": {"cols": 100, "rows": 30, "accepted": true}}}),
                 serde_json::json!({"diag": {"resize": {"cols": 80, "rows": 24, "accepted": false}}}),
-                serde_json::json!({"diag": {"resize": {"cols": 120, "rows": 40, "error": "resize rejected"}}}),
+                serde_json::json!({"diag": {"resize": {"cols": 120, "rows": 40, "error": RESIZE_ERROR_CODE}}}),
                 serde_json::json!({"diag": {"claim": {"accepted": true}}}),
-                serde_json::json!({"diag": {"claim": {"error": "claim enqueue failed"}}}),
+                serde_json::json!({"diag": {"claim": {"error": CLAIM_ERROR_CODE}}}),
             ]
         );
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -283,7 +283,7 @@ pub fn run(
         // requests look accepted while the daemon keeps the wrong PTY size.
         // Classify the startup failure so the embedder can either stop for a
         // retired terminal or reconnect after a lost daemon transport.
-        return Ok(attach_failure_exit_reason(&error));
+        return Ok(classify_claim_failure(remote, surface, &error));
     }
     // Older daemons do not accept geometry in the attach request. Apply the
     // requested initial size explicitly after claiming authority so the
@@ -370,6 +370,21 @@ fn attach_failure_exit_reason(error: &anyhow::Error) -> PipeIoExitReason {
         PipeIoExitReason::DaemonLost
     } else {
         PipeIoExitReason::SetupFailed
+    }
+}
+
+/// A claim can be rejected after the terminal-exit event retires its surface.
+/// Preserve the terminal-ended contract for that known race; unrelated claim
+/// failures retain their setup or daemon-loss classification.
+pub(crate) fn classify_claim_failure(
+    remote: &RemoteSession,
+    surface: SurfaceId,
+    error: &anyhow::Error,
+) -> PipeIoExitReason {
+    if remote.surface_is_retired(surface) {
+        PipeIoExitReason::TerminalEnded
+    } else {
+        attach_failure_exit_reason(error)
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1441,7 +1441,7 @@ impl PipeIoClaimOwner {
         let lifecycle_sender = self.lifecycle_sender.clone();
         let stderr_gate = self.stderr_gate.clone();
         let surface = self.surface;
-        let worker_remote = remote.clone();
+        let worker_remote = remote;
         let worker =
             match std::thread::Builder::new().name("pipe-io-claim".into()).spawn(move || {
                 let result = worker_remote.await_claim_terminal_geometry(ticket);
@@ -1498,13 +1498,11 @@ impl PipeIoClaimOwner {
             state.closed = true;
             (state.worker.take(), state.active)
         };
-        if had_active {
-            if let Some(remote) = self.remote.upgrade() {
-                // Wake a response waiter before joining. `begin_shutdown` also
-                // preserves the writer's FIFO barrier for commands accepted before
-                // stdin reached EOF.
-                remote.begin_shutdown();
-            }
+        if had_active && let Some(remote) = self.remote.upgrade() {
+            // Wake a response waiter before joining. `begin_shutdown` also
+            // preserves the writer's FIFO barrier for commands accepted before
+            // stdin reached EOF.
+            remote.begin_shutdown();
         }
         if let Some(join) = join {
             let _ = join.join();
@@ -2383,7 +2381,7 @@ mod tests {
         let stderr_gate = Arc::new(StderrGate::default());
         let input = b"{\"claim\":{\"geometry\":true}}\n{\"claim\":{\"geometry\":true}}\n{\"input\":\"aGk=\"}\n".to_vec();
         let pump_remote = Arc::downgrade(&remote);
-        let pump_stderr = stderr_gate.clone();
+        let pump_stderr = stderr_gate;
         let pump = std::thread::spawn(move || {
             let mut input = Cursor::new(input);
             run_stdin_pump(&mut input, &pump_remote, 9, &lifecycle_sender, pump_stderr);

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -124,11 +124,11 @@ impl PipeIoOutputCancellation {
             // socket already means a wake is pending.
             wake_reader.set_nonblocking(true)?;
             wake_writer.set_nonblocking(true)?;
-            return Ok(Self {
+            Ok(Self {
                 reason: Arc::new(Mutex::new(None)),
                 wake_reader: Arc::new(wake_reader),
                 wake_writer: Arc::new(Mutex::new(wake_writer)),
-            });
+            })
         }
 
         #[cfg(not(unix))]
@@ -532,12 +532,8 @@ pub fn run(
     let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
     let byte_budget = Arc::new(PipeIoByteBudget::new(EVENT_QUEUE_MAX_BYTES));
     // Install before attach so the initial replay cannot be missed.
-    let tap_token = remote.install_pipe_io_tap(
-        surface,
-        sender.clone(),
-        lifecycle_sender.clone(),
-        byte_budget.clone(),
-    );
+    let tap_token =
+        remote.install_pipe_io_tap(surface, sender, lifecycle_sender.clone(), byte_budget.clone());
     let tap_guard = PipeIoTapGuard { remote: remote.as_ref(), token: tap_token };
     let handle = match remote.try_attach_pipe_io(surface, Some((cols.max(1), rows.max(1)))) {
         Ok(PipeIoSurfaceAttach::Attached) => {
@@ -569,10 +565,10 @@ pub fn run(
     // `try_attach_pipe_io`. Re-apply it after claiming authority because a
     // newer terminal-authority daemon may report the pre-attach sample as
     // passive. An unchanged size does not produce a second replay.
-    if !remote.supports_pipe_io_initial_size() {
-        if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
-            return Ok(attach_failure_exit_reason(&error));
-        }
+    if !remote.supports_pipe_io_initial_size()
+        && let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1))
+    {
+        return Ok(attach_failure_exit_reason(&error));
     }
     let stderr_gate = Arc::new(StderrGate::default());
     let cancellation = match PipeIoOutputCancellation::new() {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -499,7 +499,7 @@ fn run_stdin_pump(
             let Some(remote) = claim_remote.upgrade() else {
                 return PipeIoControlResult::Gone;
             };
-            match remote.notify_claim_terminal_geometry(surface) {
+            match remote.claim_terminal_geometry(surface) {
                 Ok(()) => PipeIoControlResult::Completed(()),
                 Err(error) => PipeIoControlResult::Failed(error),
             }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -679,8 +679,8 @@ mod tests {
             parse_request(r#"{"claim":{"geometry":true}}"#).unwrap(),
             PipeIoRequest::ClaimGeometry
         );
-        assert_eq!(parse_request(r#"{"claim":true}"#).unwrap(), PipeIoRequest::ClaimGeometry);
         for line in [
+            r#"{"claim":true}"#,
             r#"{"claim":false}"#,
             r#"{"claim":null}"#,
             r#"{"claim":{"geometry":false}}"#,

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -674,6 +674,24 @@ mod tests {
     }
 
     #[test]
+    fn parse_request_requires_a_valid_geometry_claim() {
+        assert_eq!(
+            parse_request(r#"{"claim":{"geometry":true}}"#).unwrap(),
+            PipeIoRequest::ClaimGeometry
+        );
+        assert_eq!(parse_request(r#"{"claim":true}"#).unwrap(), PipeIoRequest::ClaimGeometry);
+        for line in [
+            r#"{"claim":false}"#,
+            r#"{"claim":null}"#,
+            r#"{"claim":{"geometry":false}}"#,
+            r#"{"claim":{"other":true}}"#,
+            r#"{"claim":"true"}"#,
+        ] {
+            assert!(parse_request(line).is_err(), "accepted invalid claim {line}");
+        }
+    }
+
+    #[test]
     fn parse_request_rejects_oversized_lines_and_input_before_decoding() {
         let oversized_line = " ".repeat(MAX_PIPE_IO_LINE_BYTES + 1);
         let error = parse_request(&oversized_line).unwrap_err().to_string();

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -22,12 +22,19 @@
 //!   (respawning reattaches and resyncs from a fresh replay).
 
 use std::borrow::Cow;
-use std::io::{BufRead, Write};
+use std::io::{self, BufRead, Write};
 use std::path::Path;
 #[cfg(test)]
 use std::sync::mpsc::sync_channel;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
+
+#[cfg(unix)]
+use std::fs::File;
+#[cfg(unix)]
+use std::os::fd::{AsFd, AsRawFd, RawFd};
+#[cfg(unix)]
+use std::os::unix::net::UnixStream;
 
 use base64::Engine as _;
 use cmux_tui_core::SurfaceId;
@@ -93,18 +100,235 @@ impl StderrGate {
     }
 }
 
-#[cfg(unix)]
-fn pipe_io_stdout() -> std::io::Result<std::io::BufWriter<std::fs::File>> {
-    use std::os::fd::AsFd;
+/// Cancellation shared by the lifecycle monitor and the stdout writer.
+///
+/// Unix uses a wake-up stream in addition to the reason state. This lets a
+/// blocked nonblocking write wait for either writable stdout or a lifecycle
+/// event, with no polling timeout and no detached writer thread.
+#[derive(Clone)]
+struct PipeIoOutputCancellation {
+    reason: Arc<Mutex<Option<PipeIoExitReason>>>,
+    #[cfg(unix)]
+    wake_reader: Arc<UnixStream>,
+    #[cfg(unix)]
+    wake_writer: Arc<Mutex<UnixStream>>,
+}
 
+impl PipeIoOutputCancellation {
+    fn new() -> io::Result<Self> {
+        #[cfg(unix)]
+        {
+            let (wake_reader, wake_writer) = UnixStream::pair()?;
+            // The monitor must never block while publishing a lifecycle
+            // reason. One byte is enough to wake the writer, and a full
+            // socket already means a wake is pending.
+            wake_reader.set_nonblocking(true)?;
+            wake_writer.set_nonblocking(true)?;
+            return Ok(Self {
+                reason: Arc::new(Mutex::new(None)),
+                wake_reader: Arc::new(wake_reader),
+                wake_writer: Arc::new(Mutex::new(wake_writer)),
+            });
+        }
+
+        #[cfg(not(unix))]
+        Ok(Self { reason: Arc::new(Mutex::new(None)) })
+    }
+
+    fn request(&self, reason: PipeIoExitReason) {
+        let first_reason = {
+            let mut state = self.reason.lock().unwrap_or_else(|poison| poison.into_inner());
+            if state.is_none() {
+                *state = Some(reason);
+                true
+            } else {
+                false
+            }
+        };
+        if !first_reason {
+            return;
+        }
+
+        #[cfg(unix)]
+        if let Ok(mut wake_writer) = self.wake_writer.lock() {
+            let _ = wake_writer.write(&[1]);
+        }
+    }
+
+    fn reason(&self) -> Option<PipeIoExitReason> {
+        *self.reason.lock().unwrap_or_else(|poison| poison.into_inner())
+    }
+
+    #[cfg(unix)]
+    fn wake_fd(&self) -> RawFd {
+        self.wake_reader.as_raw_fd()
+    }
+}
+
+/// Output abstraction used by the event pump. The normal test writers use the
+/// standard `Write` implementation, while the process stdout writer uses a
+/// nonblocking descriptor that can observe lifecycle cancellation.
+trait PipeIoOutput {
+    fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()>;
+    fn flush_output(&mut self) -> io::Result<()>;
+    fn cancellation_reason(&self) -> Option<PipeIoExitReason> {
+        None
+    }
+}
+
+impl<W: Write> PipeIoOutput for W {
+    fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.write_all(bytes)
+    }
+
+    fn flush_output(&mut self) -> io::Result<()> {
+        self.flush()
+    }
+}
+
+#[cfg(unix)]
+struct PipeIoStdout {
+    file: File,
+    cancellation: PipeIoOutputCancellation,
+}
+
+#[cfg(unix)]
+fn pipe_io_stdout(cancellation: PipeIoOutputCancellation) -> io::Result<PipeIoStdout> {
     let stdout = std::io::stdout();
     let stdout_fd = stdout.as_fd().try_clone_to_owned()?;
-    Ok(std::io::BufWriter::new(std::fs::File::from(stdout_fd)))
+    let file = File::from(stdout_fd);
+    set_nonblocking(file.as_raw_fd())?;
+    Ok(PipeIoStdout { file, cancellation })
+}
+
+#[cfg(unix)]
+fn set_nonblocking(fd: RawFd) -> io::Result<()> {
+    // `fd` is borrowed from the live `File`; both fcntl calls only inspect or
+    // update descriptor flags and do not take ownership of it.
+    let flags = unsafe { libc::fcntl(fd, libc::F_GETFL) };
+    if flags < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if flags & libc::O_NONBLOCK != 0 {
+        return Ok(());
+    }
+    let result = unsafe { libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) };
+    if result < 0 { Err(io::Error::last_os_error()) } else { Ok(()) }
+}
+
+#[cfg(unix)]
+impl PipeIoStdout {
+    fn wait_until_writable(&self) -> io::Result<()> {
+        loop {
+            let mut poll_fds = [
+                libc::pollfd { fd: self.file.as_raw_fd(), events: libc::POLLOUT, revents: 0 },
+                libc::pollfd { fd: self.cancellation.wake_fd(), events: libc::POLLIN, revents: 0 },
+            ];
+            let ready = unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, -1) };
+            if ready < 0 {
+                let error = io::Error::last_os_error();
+                if error.raw_os_error() == Some(libc::EINTR) {
+                    continue;
+                }
+                return Err(error);
+            }
+
+            let output_events = poll_fds[0].revents;
+            let cancel_events = poll_fds[1].revents;
+            let cancellation_requested = cancel_events
+                & (libc::POLLIN | libc::POLLHUP | libc::POLLERR | libc::POLLNVAL)
+                != 0;
+            let output_writable = output_events & libc::POLLOUT != 0;
+
+            // If stdout is writable at the same instant as lifecycle
+            // cancellation, allow one more write. This preserves committed
+            // bytes for a normal surface-exit drain. If it is not writable,
+            // return immediately instead of waiting for a reader that stopped.
+            if cancellation_requested && !output_writable {
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "pipe-io stdout canceled"));
+            }
+            if output_events & (libc::POLLERR | libc::POLLHUP | libc::POLLNVAL) != 0 {
+                if let Some(reason) = self.cancellation.reason() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        format!("pipe-io stdout canceled ({})", reason.as_str()),
+                    ));
+                }
+                return Err(io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout closed"));
+            }
+            if output_writable {
+                return Ok(());
+            }
+        }
+    }
+}
+
+#[cfg(unix)]
+impl PipeIoOutput for PipeIoStdout {
+    fn write_bytes(&mut self, mut bytes: &[u8]) -> io::Result<()> {
+        while !bytes.is_empty() {
+            // The descriptor is nonblocking, so a full pipe returns EAGAIN
+            // and the poll below can also watch the cancellation wakeup.
+            let written =
+                unsafe { libc::write(self.file.as_raw_fd(), bytes.as_ptr().cast(), bytes.len()) };
+            if written > 0 {
+                bytes = &bytes[written as usize..];
+                continue;
+            }
+            if written == 0 {
+                return Err(io::Error::new(io::ErrorKind::WriteZero, "pipe-io stdout write zero"));
+            }
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::EINTR) {
+                continue;
+            }
+            if matches!(
+                error.raw_os_error(),
+                Some(code) if code == libc::EAGAIN || code == libc::EWOULDBLOCK
+            ) {
+                self.wait_until_writable()?;
+                continue;
+            }
+            return Err(error);
+        }
+        Ok(())
+    }
+
+    fn flush_output(&mut self) -> io::Result<()> {
+        // Each event is written directly to the descriptor. There is no
+        // userspace buffer whose flush could block independently.
+        Ok(())
+    }
+
+    fn cancellation_reason(&self) -> Option<PipeIoExitReason> {
+        self.cancellation.reason()
+    }
 }
 
 #[cfg(not(unix))]
-fn pipe_io_stdout() -> std::io::Result<std::io::BufWriter<std::io::Stdout>> {
-    Ok(std::io::BufWriter::new(std::io::stdout()))
+struct PipeIoStdout {
+    inner: std::io::BufWriter<std::io::Stdout>,
+    cancellation: PipeIoOutputCancellation,
+}
+
+#[cfg(not(unix))]
+fn pipe_io_stdout(cancellation: PipeIoOutputCancellation) -> io::Result<PipeIoStdout> {
+    Ok(PipeIoStdout { inner: std::io::BufWriter::new(std::io::stdout()), cancellation })
+}
+
+#[cfg(not(unix))]
+impl PipeIoOutput for PipeIoStdout {
+    fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
+        self.inner.write_all(bytes)
+    }
+
+    fn flush_output(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+
+    fn cancellation_reason(&self) -> Option<PipeIoExitReason> {
+        self.cancellation.reason()
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -130,6 +354,60 @@ impl PipeIoExitReason {
             Self::TerminalEnded | Self::ParentClosed | Self::SetupFailed => EXIT_DO_NOT_RESPAWN,
             Self::DaemonLost => EXIT_DAEMON_LOST,
         }
+    }
+}
+
+fn lifecycle_exit_reason(event: &PipeIoEvent) -> PipeIoExitReason {
+    match event {
+        PipeIoEvent::SurfaceExited => PipeIoExitReason::TerminalEnded,
+        PipeIoEvent::TransportLost => PipeIoExitReason::DaemonLost,
+        PipeIoEvent::StdinClosed => PipeIoExitReason::ParentClosed,
+        PipeIoEvent::StdinError => PipeIoExitReason::SetupFailed,
+        PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
+            // Lifecycle senders never carry byte events. Treat a malformed
+            // event as a daemon loss, which is the only retryable safe
+            // classification when framing is corrupted.
+            PipeIoExitReason::DaemonLost
+        }
+    }
+}
+
+/// Relays lifecycle events to the byte pump and wakes a blocked stdout write.
+/// The source channel is separate from the bounded byte queue, so this thread
+/// remains able to publish daemon loss while the embedder has stopped reading.
+struct PipeIoLifecycleMonitor {
+    stop: Sender<()>,
+    join: std::thread::JoinHandle<()>,
+}
+
+impl PipeIoLifecycleMonitor {
+    fn spawn(
+        lifecycle_receiver: Receiver<PipeIoEvent>,
+        pump_sender: Sender<PipeIoEvent>,
+        cancellation: PipeIoOutputCancellation,
+    ) -> io::Result<Self> {
+        let (stop, stop_receiver) = crossbeam_channel::bounded(1);
+        let join = std::thread::Builder::new()
+            .name("pipe-io-lifecycle".into())
+            .spawn(move || {
+                crossbeam_channel::select_biased! {
+                    recv(stop_receiver) -> _ => {}
+                    recv(lifecycle_receiver) -> event => {
+                        let event = event.unwrap_or(PipeIoEvent::TransportLost);
+                        cancellation.request(lifecycle_exit_reason(&event));
+                        let _ = pump_sender.try_send(event);
+                    }
+                }
+            })
+            .map_err(|error| {
+                io::Error::other(format!("spawn pipe-io lifecycle monitor: {error}"))
+            })?;
+        Ok(Self { stop, join })
+    }
+
+    fn stop(self) {
+        let _ = self.stop.send(());
+        let _ = self.join.join();
     }
 }
 
@@ -297,6 +575,38 @@ pub fn run(
         }
     }
     let stderr_gate = Arc::new(StderrGate::default());
+    let cancellation = match PipeIoOutputCancellation::new() {
+        Ok(cancellation) => cancellation,
+        Err(error) => {
+            stderr_gate.close();
+            drop(tap_guard);
+            return Err(error.into());
+        }
+    };
+    // On Unix, duplicate stdout and make the descriptor nonblocking. Each
+    // write then waits on stdout readiness and the lifecycle wakeup together,
+    // so a stopped reader cannot strand this relay in write_all or flush.
+    let mut stdout = match pipe_io_stdout(cancellation.clone()) {
+        Ok(stdout) => stdout,
+        Err(error) => {
+            stderr_gate.close();
+            drop(tap_guard);
+            return Err(error.into());
+        }
+    };
+    let (pump_lifecycle_sender, pump_lifecycle_receiver) = crossbeam_channel::bounded(1);
+    let lifecycle_monitor = match PipeIoLifecycleMonitor::spawn(
+        lifecycle_receiver,
+        pump_lifecycle_sender,
+        cancellation,
+    ) {
+        Ok(monitor) => monitor,
+        Err(error) => {
+            stderr_gate.close();
+            drop(tap_guard);
+            return Err(error.into());
+        }
+    };
     let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
@@ -306,21 +616,15 @@ pub fn run(
                 "{}",
                 serde_json::json!({"diag": {"stdin-pump": {"error": STDIN_PUMP_ERROR_CODE}}})
             );
+            lifecycle_monitor.stop();
             drop(tap_guard);
+            stderr_gate.close();
             return Ok(PipeIoExitReason::SetupFailed);
         }
     };
-    // On Unix, duplicate the raw stdout descriptor so VT bytes bypass the
-    // standard library's line writer. The protocol flushes each event.
-    let mut stdout = match pipe_io_stdout() {
-        Ok(stdout) => stdout,
-        Err(error) => {
-            stderr_gate.close();
-            return Err(error.into());
-        }
-    };
     let pump_result =
-        pump_events_to_stdout(&receiver, &lifecycle_receiver, &byte_budget, &mut stdout);
+        pump_events_to_stdout(&receiver, &pump_lifecycle_receiver, &byte_budget, &mut stdout);
+    lifecycle_monitor.stop();
     // The stdin pump can still be blocked in read(2). Close the gate before
     // returning so no late resize/claim diagnostic can follow the exit record.
     stderr_gate.close();
@@ -628,7 +932,7 @@ fn pump_events_to_stdout(
     receiver: &Receiver<PipeIoEvent>,
     lifecycle_receiver: &Receiver<PipeIoEvent>,
     byte_budget: &PipeIoByteBudget,
-    stdout: &mut impl Write,
+    stdout: &mut impl PipeIoOutput,
 ) -> anyhow::Result<PipeIoExitReason> {
     let mut emitted_output = false;
     loop {
@@ -655,7 +959,11 @@ fn pump_events_to_stdout(
                                     )
                                     .is_err()
                                     {
-                                        return Ok(PipeIoExitReason::ParentClosed);
+                                        return Ok(
+                                            stdout
+                                                .cancellation_reason()
+                                                .unwrap_or(PipeIoExitReason::ParentClosed),
+                                        );
                                     }
                                 }
                                 PipeIoEvent::SurfaceExited => {
@@ -710,7 +1018,7 @@ fn pump_events_to_stdout(
         };
         if write_result.is_err() {
             // stdout is the embedder; a failed write means it is gone.
-            return Ok(PipeIoExitReason::ParentClosed);
+            return Ok(stdout.cancellation_reason().unwrap_or(PipeIoExitReason::ParentClosed));
         }
     }
 }
@@ -718,19 +1026,19 @@ fn pump_events_to_stdout(
 fn write_pipe_io_data(
     event: &PipeIoEvent,
     emitted_output: &mut bool,
-    stdout: &mut impl Write,
+    stdout: &mut impl PipeIoOutput,
 ) -> std::io::Result<()> {
     match event {
         PipeIoEvent::Replay { bytes, .. } => {
             if *emitted_output {
-                stdout.write_all(REPLAY_RESET)?;
+                stdout.write_bytes(REPLAY_RESET)?;
             }
-            stdout.write_all(bytes)?;
-            stdout.flush()?;
+            stdout.write_bytes(bytes)?;
+            stdout.flush_output()?;
         }
         PipeIoEvent::Output(bytes) => {
-            stdout.write_all(bytes)?;
-            stdout.flush()?;
+            stdout.write_bytes(bytes)?;
+            stdout.flush_output()?;
         }
         PipeIoEvent::SurfaceExited
         | PipeIoEvent::TransportLost
@@ -897,6 +1205,73 @@ mod tests {
             pump_events_to_stdout(&receiver, &lifecycle_receiver, &budget, &mut stdout).unwrap();
         assert_eq!(reason, PipeIoExitReason::TerminalEnded);
         assert_eq!(stdout, b"FINAL");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn stdout_writer_stops_when_lifecycle_arrives_with_reader_open() {
+        use std::os::fd::{AsRawFd, FromRawFd, RawFd};
+
+        let mut fds = [0 as RawFd; 2];
+        // SAFETY: `fds` points to two writable integers owned by this test;
+        // `pipe` initializes both descriptors on success.
+        assert_eq!(unsafe { libc::pipe(fds.as_mut_ptr()) }, 0);
+        // Keep the read side open but never consume it. This models an
+        // embedder that stopped reading while its process remains alive.
+        let reader = unsafe { std::fs::File::from_raw_fd(fds[0]) };
+        let writer_file = unsafe { std::fs::File::from_raw_fd(fds[1]) };
+        set_nonblocking(writer_file.as_raw_fd()).unwrap();
+
+        // Fill the kernel pipe so the first relay write must wait for
+        // POLLOUT. No unbounded userspace buffer is involved.
+        let fill = [0_u8; 4096];
+        loop {
+            // SAFETY: `writer_file` owns the descriptor and `fill` remains
+            // alive and readable for the duration of each call.
+            let written =
+                unsafe { libc::write(writer_file.as_raw_fd(), fill.as_ptr().cast(), fill.len()) };
+            if written >= 0 {
+                continue;
+            }
+            let error = io::Error::last_os_error();
+            assert!(
+                error.raw_os_error() == Some(libc::EAGAIN)
+                    || error.raw_os_error() == Some(libc::EWOULDBLOCK),
+                "unexpected pipe fill error: {error}"
+            );
+            break;
+        }
+
+        let cancellation = PipeIoOutputCancellation::new().unwrap();
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let (pump_sender, pump_receiver) = crossbeam_channel::bounded(1);
+        let monitor =
+            PipeIoLifecycleMonitor::spawn(lifecycle_receiver, pump_sender, cancellation.clone())
+                .unwrap();
+        let mut stdout = PipeIoStdout { file: writer_file, cancellation: cancellation.clone() };
+        let (finished_sender, finished_receiver) = std::sync::mpsc::channel();
+        let writer = std::thread::spawn(move || {
+            finished_sender.send(stdout.write_bytes(b"blocked")).unwrap();
+        });
+
+        lifecycle_sender.send(PipeIoEvent::TransportLost).unwrap();
+        let result = match finished_receiver.recv_timeout(Duration::from_secs(1)) {
+            Ok(result) => result,
+            Err(_) => {
+                // Ensure the writer can be joined if the assertion below
+                // fails, while retaining the primary timeout signal.
+                drop(reader);
+                let _ = finished_receiver.recv_timeout(Duration::from_secs(1));
+                let _ = writer.join();
+                panic!("stdout writer did not observe lifecycle cancellation");
+            }
+        };
+        assert_eq!(result.unwrap_err().kind(), io::ErrorKind::Interrupted);
+        assert_eq!(cancellation.reason(), Some(PipeIoExitReason::DaemonLost));
+        assert_eq!(pump_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
+        writer.join().unwrap();
+        monitor.stop();
+        drop(reader);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -287,9 +287,10 @@ pub fn run(
         // retired terminal or reconnect after a lost daemon transport.
         return Ok(classify_claim_failure(remote, surface, &error));
     }
-    // Older daemons do not accept geometry in the attach request. Apply the
-    // requested initial size explicitly after claiming authority so the
-    // first replay uses the embedder's dimensions on that compatibility path.
+    // Older daemons receive a best-effort pre-attach size in
+    // `try_attach_pipe_io`. Re-apply it after claiming authority because a
+    // newer terminal-authority daemon may report the pre-attach sample as
+    // passive. An unchanged size does not produce a second replay.
     if !remote.supports_pipe_io_initial_size() {
         if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
             return Ok(attach_failure_exit_reason(&error));

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1383,6 +1383,23 @@ mod tests {
         assert_eq!(stdout, b"FINAL");
     }
 
+    #[test]
+    fn retired_attach_drain_forwards_committed_bytes_before_exit() {
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let budget = PipeIoByteBudget::new(1024);
+        let mut event = PipeIoEvent::Output(b"last".to_vec());
+        assert!(budget.try_reserve_event(&mut event));
+        sender.send(event).unwrap();
+        lifecycle_sender.send(PipeIoEvent::SurfaceExited).unwrap();
+
+        let mut stdout = Vec::new();
+        let reason =
+            drain_retired_pipe_io(&receiver, lifecycle_receiver, &budget, &mut stdout).unwrap();
+        assert_eq!(reason, PipeIoExitReason::TerminalEnded);
+        assert_eq!(stdout, b"last");
+    }
+
     #[cfg(unix)]
     #[test]
     fn stdout_writer_stops_when_lifecycle_arrives_with_reader_open() {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -703,6 +703,17 @@ pub fn run(
         Ok(PipeIoSurfaceAttach::Retired) => {
             return Ok(PipeIoExitReason::TerminalEnded);
         }
+        Ok(PipeIoSurfaceAttach::RetiredAfterAttach) => {
+            let cancellation = PipeIoOutputCancellation::new()?;
+            let mut stdout = pipe_io_stdout(cancellation.clone())?;
+            return drain_retired_pipe_io(
+                &receiver,
+                lifecycle_receiver,
+                &byte_budget,
+                &mut stdout,
+                cancellation,
+            );
+        }
         Ok(PipeIoSurfaceAttach::Deferred) => return Ok(PipeIoExitReason::DaemonLost),
         Err(error) => return Ok(attach_failure_exit_reason(&error)),
     };
@@ -1227,6 +1238,24 @@ fn write_pipe_io_data(
     Ok(())
 }
 
+/// Completes a renderer-less attach that retired after the server opened its
+/// byte stream. The lifecycle monitor wakes a blocked writer and the normal
+/// pump drains every event committed before the retirement fence.
+fn drain_retired_pipe_io(
+    receiver: &Receiver<PipeIoEvent>,
+    lifecycle_receiver: Receiver<PipeIoEvent>,
+    byte_budget: &PipeIoByteBudget,
+    stdout: &mut impl PipeIoOutput,
+    cancellation: PipeIoOutputCancellation,
+) -> anyhow::Result<PipeIoExitReason> {
+    let (pump_lifecycle_sender, pump_lifecycle_receiver) = crossbeam_channel::bounded(1);
+    let lifecycle_monitor =
+        PipeIoLifecycleMonitor::spawn(lifecycle_receiver, pump_lifecycle_sender, cancellation)?;
+    let result = pump_events_to_stdout(receiver, &pump_lifecycle_receiver, byte_budget, stdout);
+    lifecycle_monitor.stop();
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use std::io::Cursor;
@@ -1394,8 +1423,15 @@ mod tests {
         lifecycle_sender.send(PipeIoEvent::SurfaceExited).unwrap();
 
         let mut stdout = Vec::new();
-        let reason =
-            drain_retired_pipe_io(&receiver, lifecycle_receiver, &budget, &mut stdout).unwrap();
+        let cancellation = PipeIoOutputCancellation::new().unwrap();
+        let reason = drain_retired_pipe_io(
+            &receiver,
+            lifecycle_receiver,
+            &budget,
+            &mut stdout,
+            cancellation,
+        )
+        .unwrap();
         assert_eq!(reason, PipeIoExitReason::TerminalEnded);
         assert_eq!(stdout, b"last");
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -219,7 +219,7 @@ pub fn run(
     // first replay uses the embedder's dimensions on that compatibility path.
     if !remote.supports_pipe_io_initial_size() {
         if let Err(error) = remote.resize_pipe_io(surface, cols.max(1), rows.max(1)) {
-            return Ok(attach_failure_exit_reason(&error, surface));
+            return Ok(attach_failure_exit_reason(&error));
         }
     }
     let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -371,11 +371,69 @@ fn spawn_stdin_pump(
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
 
+enum PipeIoControlResult<T> {
+    Completed(T),
+    Gone,
+    Failed(anyhow::Error),
+}
+
 fn run_stdin_pump(
     reader: &mut impl BufRead,
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+) {
+    let input_remote = remote.clone();
+    let resize_remote = remote.clone();
+    let claim_remote = remote.clone();
+    let mut emit_diag = |line: String| {
+        let mut stderr = std::io::stderr().lock();
+        let _ = writeln!(stderr, "{line}");
+        let _ = stderr.flush();
+    };
+    run_stdin_pump_with_handlers(
+        reader,
+        lifecycle_sender,
+        move |bytes| {
+            let Some(remote) = input_remote.upgrade() else {
+                return PipeIoControlResult::Gone;
+            };
+            let handle = PipeIoSurfaceHandle { remote, surface };
+            match handle.write_bytes(bytes) {
+                Ok(()) => PipeIoControlResult::Completed(()),
+                Err(error) => PipeIoControlResult::Failed(error),
+            }
+        },
+        move |cols, rows| {
+            let Some(remote) = resize_remote.upgrade() else {
+                return PipeIoControlResult::Gone;
+            };
+            let handle = PipeIoSurfaceHandle { remote, surface };
+            match handle.resize(cols, rows) {
+                Ok(accepted) => PipeIoControlResult::Completed(accepted),
+                Err(error) => PipeIoControlResult::Failed(error),
+            }
+        },
+        move || {
+            let Some(remote) = claim_remote.upgrade() else {
+                return PipeIoControlResult::Gone;
+            };
+            match remote.notify_claim_terminal_geometry(surface) {
+                Ok(()) => PipeIoControlResult::Completed(()),
+                Err(error) => PipeIoControlResult::Failed(error),
+            }
+        },
+        &mut emit_diag,
+    );
+}
+
+fn run_stdin_pump_with_handlers(
+    reader: &mut impl BufRead,
+    lifecycle_sender: &Sender<PipeIoEvent>,
+    mut write_input: impl FnMut(&[u8]) -> PipeIoControlResult<()>,
+    mut resize: impl FnMut(u16, u16) -> PipeIoControlResult<bool>,
+    mut claim: impl FnMut() -> PipeIoControlResult<()>,
+    mut emit_diag: impl FnMut(String),
 ) {
     let mut line = String::new();
     let mut stop_event = None;
@@ -395,12 +453,7 @@ fn run_stdin_pump(
         }
         match parse_request(&line) {
             Ok(PipeIoRequest::Input(bytes)) => {
-                let Some(remote) = remote.upgrade() else {
-                    stop_event = Some(PipeIoEvent::TransportLost);
-                    break;
-                };
-                let handle = PipeIoSurfaceHandle { remote, surface };
-                if handle.write_bytes(&bytes).is_err() {
+                if !matches!(write_input(&bytes), PipeIoControlResult::Completed(())) {
                     // The transport owns loss reporting; input can only stop
                     // early.
                     stop_event = Some(PipeIoEvent::TransportLost);
@@ -408,30 +461,23 @@ fn run_stdin_pump(
                 }
             }
             Ok(PipeIoRequest::Resize { cols, rows }) => {
-                let Some(remote) = remote.upgrade() else {
+                let result = resize(cols, rows);
+                emit_diag(resize_diag_line(cols, rows, &result));
+                if matches!(result, PipeIoControlResult::Gone) {
                     stop_event = Some(PipeIoEvent::TransportLost);
                     break;
-                };
-                let handle = PipeIoSurfaceHandle { remote, surface };
-                // Diagnostics only; the exit JSON stays the final stderr line
-                // and embedders skip lines without an "exit" key.
-                match handle.resize(cols, rows) {
-                    Ok(_accepted) => {}
-                    Err(_error) => {}
                 }
             }
             Ok(PipeIoRequest::ClaimGeometry) => {
-                let Some(remote) = remote.upgrade() else {
-                    stop_event = Some(PipeIoEvent::TransportLost);
-                    break;
-                };
                 // Claims only establish ownership. Enqueue them on the same
                 // ordered writer as input so a claim cannot overtake the
                 // keystroke that follows it, and avoid a new blocking thread
                 // for every claim.
-                match remote.notify_claim_terminal_geometry(surface) {
-                    Ok(()) => (),
-                    Err(_error) => (),
+                let result = claim();
+                emit_diag(claim_diag_line(&result));
+                if matches!(result, PipeIoControlResult::Gone) {
+                    stop_event = Some(PipeIoEvent::TransportLost);
+                    break;
                 }
             }
             Ok(PipeIoRequest::Unknown) => {}
@@ -447,6 +493,34 @@ fn run_stdin_pump(
     // delay the parent-close or failure signal. Only actual stdin EOF maps to
     // StdinClosed; transport and protocol failures keep their own reason.
     let _ = lifecycle_sender.send(stop_event.unwrap_or(PipeIoEvent::StdinClosed));
+}
+
+fn resize_diag_line(cols: u16, rows: u16, result: &PipeIoControlResult<bool>) -> String {
+    let details = match result {
+        PipeIoControlResult::Completed(accepted) => {
+            serde_json::json!({"cols": cols, "rows": rows, "accepted": accepted})
+        }
+        PipeIoControlResult::Gone => serde_json::json!({
+            "cols": cols,
+            "rows": rows,
+            "error": "remote session unavailable"
+        }),
+        PipeIoControlResult::Failed(error) => {
+            serde_json::json!({"cols": cols, "rows": rows, "error": error.to_string()})
+        }
+    };
+    serde_json::json!({"diag": {"resize": details}}).to_string()
+}
+
+fn claim_diag_line(result: &PipeIoControlResult<()>) -> String {
+    let details = match result {
+        PipeIoControlResult::Completed(()) => serde_json::json!({"accepted": true}),
+        PipeIoControlResult::Gone => {
+            serde_json::json!({"error": "remote session unavailable"})
+        }
+        PipeIoControlResult::Failed(error) => serde_json::json!({"error": error.to_string()}),
+    };
+    serde_json::json!({"diag": {"claim": details}}).to_string()
 }
 
 fn pump_events_to_stdout(
@@ -470,7 +544,7 @@ fn pump_events_to_stdout(
                         // Transport loss has different semantics: queued
                         // bytes are stale and must be discarded.
                         while let Ok(event) = receiver.try_recv() {
-                            byte_budget.release(event.retained_bytes());
+                            byte_budget.release_event(&event);
                             match event {
                                 PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
                                     if write_pipe_io_data(
@@ -523,7 +597,7 @@ fn pump_events_to_stdout(
                 }
             }
         };
-        byte_budget.release(event.retained_bytes());
+        byte_budget.release_event(&event);
         let write_result = match &event {
             PipeIoEvent::Replay { .. } | PipeIoEvent::Output(_) => {
                 write_pipe_io_data(&event, &mut emitted_output, stdout)
@@ -732,12 +806,14 @@ mod tests {
         let mut input = Cursor::new(
             b"{\"resize\":{\"cols\":100,\"rows\":30}}\n\
               {\"resize\":{\"cols\":80,\"rows\":24}}\n\
+              {\"resize\":{\"cols\":120,\"rows\":40}}\n\
               {\"claim\":{\"geometry\":true}}\n\
               {\"claim\":{\"geometry\":true}}\n"
                 .to_vec(),
         );
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut resize_results = vec![
+            PipeIoControlResult::Completed(true),
             PipeIoControlResult::Completed(false),
             PipeIoControlResult::Failed(anyhow::anyhow!("resize rejected")),
         ]
@@ -754,7 +830,7 @@ mod tests {
             &lifecycle_sender,
             |_bytes| PipeIoControlResult::Completed(()),
             |cols, rows| {
-                assert!(matches!((cols, rows), (100, 30) | (80, 24)));
+                assert!(matches!((cols, rows), (100, 30) | (80, 24) | (120, 40)));
                 resize_results.next().unwrap()
             },
             || claim_results.next().unwrap(),
@@ -769,8 +845,9 @@ mod tests {
         assert_eq!(
             diagnostics,
             vec![
-                serde_json::json!({"diag": {"resize": {"cols": 100, "rows": 30, "accepted": false}}}),
-                serde_json::json!({"diag": {"resize": {"cols": 80, "rows": 24, "error": "resize rejected"}}}),
+                serde_json::json!({"diag": {"resize": {"cols": 100, "rows": 30, "accepted": true}}}),
+                serde_json::json!({"diag": {"resize": {"cols": 80, "rows": 24, "accepted": false}}}),
+                serde_json::json!({"diag": {"resize": {"cols": 120, "rows": 40, "error": "resize rejected"}}}),
                 serde_json::json!({"diag": {"claim": {"accepted": true}}}),
                 serde_json::json!({"diag": {"claim": {"error": "claim enqueue failed"}}}),
             ]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -928,7 +928,7 @@ mod tests {
         let gate = Arc::new(StderrGate::default());
         let (entered_sender, entered_receiver) = sync_channel(0);
         let (release_sender, release_receiver) = std::sync::mpsc::channel();
-        let lines = Arc::new(std::sync::Mutex::new(Vec::new()));
+        let lines = Arc::new(Mutex::new(Vec::new()));
 
         let writer_gate = gate.clone();
         let writer_lines = lines.clone();

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1012,6 +1012,48 @@ mod tests {
     }
 
     #[test]
+    fn stdin_pump_uses_contract_tokens_when_remote_session_is_gone() {
+        for (line, expected) in [
+            (
+                r#"{"resize":{"cols":80,"rows":24}}"#,
+                serde_json::json!({
+                    "diag": {
+                        "resize": {
+                            "cols": 80,
+                            "rows": 24,
+                            "error": RESIZE_ERROR_CODE,
+                        }
+                    }
+                }),
+            ),
+            (
+                r#"{"claim":{"geometry":true}}"#,
+                serde_json::json!({"diag": {"claim": {"error": CLAIM_ERROR_CODE}}}),
+            ),
+        ] {
+            let mut input = Cursor::new(format!("{line}\n").into_bytes());
+            let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            let mut diagnostics = Vec::new();
+
+            run_stdin_pump_with_handlers(
+                &mut input,
+                &lifecycle_sender,
+                |_bytes| PipeIoControlResult::Completed(()),
+                |_cols, _rows| PipeIoControlResult::Gone,
+                || PipeIoControlResult::Gone,
+                |line| diagnostics.push(line),
+            );
+
+            assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&diagnostics[0]).unwrap(),
+                expected
+            );
+        }
+    }
+
+    #[test]
     fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
         let terminal_ended =
             crate::session::test_remote_rejected_error_with_message("unknown surface 7");

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1628,6 +1628,42 @@ mod tests {
     }
 
     #[test]
+    fn stdin_pump_stops_on_retryable_resize_or_claim_failure() {
+        for (line, resize_case) in [
+            (r#"{"resize":{"cols":80,"rows":24}}"#, true),
+            (r#"{"claim":{"geometry":true}}"#, false),
+        ] {
+            let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+            let mut input = Cursor::new(format!("{line}\n{{\"input\":\"aGk=\"}}\n").into_bytes());
+            let mut diagnostics = Vec::new();
+
+            run_stdin_pump_with_handlers(
+                &mut input,
+                &lifecycle_sender,
+                |_bytes| PipeIoControlResult::Completed(()),
+                move |_cols, _rows| {
+                    if resize_case {
+                        PipeIoControlResult::Failed(crate::session::test_remote_transport_error())
+                    } else {
+                        PipeIoControlResult::Completed(true)
+                    }
+                },
+                move || {
+                    if resize_case {
+                        PipeIoControlResult::Completed(())
+                    } else {
+                        PipeIoControlResult::Failed(crate::session::test_remote_transport_error())
+                    }
+                },
+                |line| diagnostics.push(line),
+            );
+
+            assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
+            assert_eq!(diagnostics.len(), 1);
+        }
+    }
+
+    #[test]
     fn stdin_pump_reports_line_read_errors_as_stdin_errors() {
         let inputs = vec![b"\xff\n".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
         for input in inputs {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -728,6 +728,56 @@ mod tests {
     }
 
     #[test]
+    fn stdin_pump_emits_structured_resize_and_claim_diagnostics() {
+        let mut input = Cursor::new(
+            b"{\"resize\":{\"cols\":100,\"rows\":30}}\n\
+              {\"resize\":{\"cols\":80,\"rows\":24}}\n\
+              {\"claim\":{\"geometry\":true}}\n\
+              {\"claim\":{\"geometry\":true}}\n"
+                .to_vec(),
+        );
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let mut resize_results = vec![
+            PipeIoControlResult::Completed(false),
+            PipeIoControlResult::Failed(anyhow::anyhow!("resize rejected")),
+        ]
+        .into_iter();
+        let mut claim_results = vec![
+            PipeIoControlResult::Completed(()),
+            PipeIoControlResult::Failed(anyhow::anyhow!("claim enqueue failed")),
+        ]
+        .into_iter();
+        let mut diagnostics = Vec::new();
+
+        run_stdin_pump_with_handlers(
+            &mut input,
+            &lifecycle_sender,
+            |_bytes| PipeIoControlResult::Completed(()),
+            |cols, rows| {
+                assert!(matches!((cols, rows), (100, 30) | (80, 24)));
+                resize_results.next().unwrap()
+            },
+            || claim_results.next().unwrap(),
+            |line| diagnostics.push(line),
+        );
+
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
+        let diagnostics = diagnostics
+            .iter()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .collect::<Vec<_>>();
+        assert_eq!(
+            diagnostics,
+            vec![
+                serde_json::json!({"diag": {"resize": {"cols": 100, "rows": 30, "accepted": false}}}),
+                serde_json::json!({"diag": {"resize": {"cols": 80, "rows": 24, "error": "resize rejected"}}}),
+                serde_json::json!({"diag": {"claim": {"accepted": true}}}),
+                serde_json::json!({"diag": {"claim": {"error": "claim enqueue failed"}}}),
+            ]
+        );
+    }
+
+    #[test]
     fn attach_failures_preserve_terminal_and_daemon_exit_contracts() {
         let terminal_ended =
             crate::session::test_remote_rejected_error_with_message("unknown surface 7");

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,7 +24,7 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
-use std::sync::{Arc, Weak};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine as _;
@@ -61,6 +61,34 @@ const CLAIM_ERROR_CODE: &str = "claim-failed";
 
 fn log_pipe_io_error(operation: &str, error: &anyhow::Error) {
     crate::client_log::error("pipe-io", &format!("{operation}: {error}"));
+}
+
+/// Serializes stdin diagnostics with the final machine-readable exit record.
+/// The stdin pump may remain blocked in a read when the relay ends, so closing
+/// the gate stops later diagnostics without detaching an in-flight write.
+#[derive(Default)]
+struct StderrGate(Mutex<bool>);
+
+impl StderrGate {
+    fn close(&self) {
+        *self.0.lock().unwrap_or_else(|poison| poison.into_inner()) = true;
+    }
+
+    fn emit_with(&self, line: String, writer: impl FnOnce(&str)) {
+        let closed = self.0.lock().unwrap_or_else(|poison| poison.into_inner());
+        if *closed {
+            return;
+        }
+        writer(&line);
+    }
+
+    fn diag(&self, line: String) {
+        self.emit_with(line, |line| {
+            let mut stderr = std::io::stderr().lock();
+            let _ = writeln!(stderr, "{line}");
+            let _ = stderr.flush();
+        });
+    }
 }
 
 #[cfg(unix)]
@@ -265,7 +293,8 @@ pub fn run(
             return Ok(attach_failure_exit_reason(&error));
         }
     }
-    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender) {
+    let stderr_gate = Arc::new(StderrGate::default());
+    let _stdin_pump = match spawn_stdin_pump(handle, lifecycle_sender, stderr_gate.clone()) {
         Ok(pump) => pump,
         Err(error) => {
             let error = anyhow::Error::new(error);
@@ -280,8 +309,19 @@ pub fn run(
     };
     // On Unix, duplicate the raw stdout descriptor so VT bytes bypass the
     // standard library's line writer. The protocol flushes each event.
-    let mut stdout = pipe_io_stdout()?;
-    let reason = pump_events_to_stdout(&receiver, &lifecycle_receiver, &byte_budget, &mut stdout)?;
+    let mut stdout = match pipe_io_stdout() {
+        Ok(stdout) => stdout,
+        Err(error) => {
+            stderr_gate.close();
+            return Err(error.into());
+        }
+    };
+    let pump_result =
+        pump_events_to_stdout(&receiver, &lifecycle_receiver, &byte_budget, &mut stdout);
+    // The stdin pump can still be blocked in read(2). Close the gate before
+    // returning so no late resize/claim diagnostic can follow the exit record.
+    stderr_gate.close();
+    let reason = pump_result?;
     // Stop forwarding while the daemon probe runs. The probe has its own
     // request path, and events for the finished relay must not fill the data
     // queue or tear down a replacement transport.
@@ -401,6 +441,7 @@ fn read_pipe_io_line(reader: &mut impl BufRead, line: &mut String) -> std::io::R
 fn spawn_stdin_pump(
     handle: PipeIoSurfaceHandle,
     lifecycle_sender: Sender<PipeIoEvent>,
+    stderr_gate: Arc<StderrGate>,
 ) -> std::io::Result<std::thread::JoinHandle<()>> {
     let remote = Arc::downgrade(&handle.remote);
     let surface = handle.surface;
@@ -409,7 +450,7 @@ fn spawn_stdin_pump(
         .spawn(move || {
             let stdin = std::io::stdin();
             let mut reader = stdin.lock();
-            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender);
+            run_stdin_pump(&mut reader, &remote, surface, &lifecycle_sender, &stderr_gate);
         })
         .map_err(|error| std::io::Error::other(format!("spawn pipe-io stdin pump: {error}")))
 }
@@ -425,15 +466,12 @@ fn run_stdin_pump(
     remote: &Weak<RemoteSession>,
     surface: SurfaceId,
     lifecycle_sender: &Sender<PipeIoEvent>,
+    stderr_gate: &StderrGate,
 ) {
     let input_remote = remote.clone();
     let resize_remote = remote.clone();
     let claim_remote = remote.clone();
-    let mut emit_diag = |line: String| {
-        let mut stderr = std::io::stderr().lock();
-        let _ = writeln!(stderr, "{line}");
-        let _ = stderr.flush();
-    };
+    let mut emit_diag = |line: String| stderr_gate.diag(line);
     run_stdin_pump_with_handlers(
         reader,
         lifecycle_sender,
@@ -849,8 +887,9 @@ mod tests {
     fn stdin_pump_stops_without_retaining_a_gone_remote_session() {
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
+        let stderr_gate = StderrGate::default();
 
-        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+        run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
 
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::TransportLost);
     }
@@ -861,7 +900,8 @@ mod tests {
         for input in inputs {
             let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
             let mut input = Cursor::new(input.to_vec());
-            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender);
+            let stderr_gate = StderrGate::default();
+            run_stdin_pump(&mut input, &Weak::new(), 7, &lifecycle_sender, &stderr_gate);
             assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -2131,6 +2131,46 @@ mod tests {
     }
 
     #[test]
+    fn stdin_pump_does_not_wait_for_a_blocked_claim_before_forwarding_input() {
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let mut input = Cursor::new(
+            b"{\"claim\":{\"geometry\":true}}\n{\"input\":\"aGk=\"}\n".to_vec(),
+        );
+        let (claim_started_sender, claim_started_receiver) = sync_channel(0);
+        let (release_sender, release_receiver) = std::sync::mpsc::channel();
+        let (input_seen_sender, input_seen_receiver) = sync_channel(0);
+
+        let pump = std::thread::spawn(move || {
+            run_stdin_pump_with_handlers(
+                &mut input,
+                &lifecycle_sender,
+                move |_bytes| {
+                    input_seen_sender.send(()).unwrap();
+                    PipeIoControlResult::Completed(())
+                },
+                |_cols, _rows| PipeIoControlResult::Completed(true),
+                move || {
+                    claim_started_sender.send(()).unwrap();
+                    release_receiver.recv().unwrap();
+                    PipeIoControlResult::Completed(())
+                },
+                |_line| {},
+            );
+        });
+
+        claim_started_receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let input_forwarded_before_claim_release =
+            input_seen_receiver.recv_timeout(Duration::from_millis(100)).is_ok();
+        release_sender.send(()).unwrap();
+        pump.join().unwrap();
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
+        assert!(
+            input_forwarded_before_claim_release,
+            "stdin input waited for the geometry claim response"
+        );
+    }
+
+    #[test]
     fn stdin_pump_reports_line_read_errors_as_stdin_errors() {
         let inputs = vec![b"\xff\n".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
         for input in inputs {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -65,7 +65,9 @@ const REPLAY_RESET: &[u8] = b"\x1bc\x1b[3J";
 const DAEMON_LOSS_PROBE_TIMEOUT: Duration = Duration::from_millis(500);
 const STDERR_WRITE_TIMEOUT: Duration = Duration::from_millis(100);
 const PIPE_IO_FINAL_DRAIN_TIMEOUT: Duration = Duration::from_millis(500);
+#[cfg(any(test, not(unix)))]
 const PIPE_IO_OUTPUT_CHUNK_BYTES: usize = 64 * 1024;
+#[cfg(any(test, not(unix)))]
 const PIPE_IO_OUTPUT_QUEUE_CAPACITY: usize = 1;
 const CLAIM_GEOMETRY_ERROR_CODE: &str = "claim-terminal-geometry-failed";
 const STDIN_PUMP_ERROR_CODE: &str = "stdin-pump-failed";
@@ -218,7 +220,9 @@ struct PipeIoOutputCancellation {
     /// A bounded, one-shot wake path for portable output workers. The Unix
     /// descriptor below remains necessary for `poll(2)`, while this channel
     /// lets a non-Unix worker wait without a timeout loop.
+    #[cfg(any(test, not(unix)))]
     cancel_sender: Sender<()>,
+    #[cfg(any(test, not(unix)))]
     cancel_receiver: Receiver<()>,
     #[cfg(unix)]
     wake_reader: Arc<UnixStream>,
@@ -234,6 +238,7 @@ struct PipeIoCancellationState {
 
 impl PipeIoOutputCancellation {
     fn new() -> io::Result<Self> {
+        #[cfg(any(test, not(unix)))]
         let (cancel_sender, cancel_receiver) = crossbeam_channel::bounded(1);
         #[cfg(unix)]
         {
@@ -245,7 +250,9 @@ impl PipeIoOutputCancellation {
             wake_writer.set_nonblocking(true)?;
             Ok(Self {
                 state: Arc::new(Mutex::new(PipeIoCancellationState::default())),
+                #[cfg(any(test, not(unix)))]
                 cancel_sender,
+                #[cfg(any(test, not(unix)))]
                 cancel_receiver,
                 wake_reader: Arc::new(wake_reader),
                 wake_writer: Arc::new(Mutex::new(wake_writer)),
@@ -255,7 +262,9 @@ impl PipeIoOutputCancellation {
         #[cfg(not(unix))]
         Ok(Self {
             state: Arc::new(Mutex::new(PipeIoCancellationState::default())),
+            #[cfg(any(test, not(unix)))]
             cancel_sender,
+            #[cfg(any(test, not(unix)))]
             cancel_receiver,
         })
     }
@@ -277,9 +286,10 @@ impl PipeIoOutputCancellation {
             return;
         }
 
-        // The receiver is owned by the sole stdout pump. A full channel means
-        // the wake is already pending, so publishing lifecycle state never
-        // blocks the monitor.
+        // The receiver is owned by the sole portable stdout pump. A full
+        // channel means the wake is already pending, so publishing lifecycle
+        // state never blocks the monitor.
+        #[cfg(any(test, not(unix)))]
         let _ = self.cancel_sender.try_send(());
 
         #[cfg(unix)]
@@ -338,11 +348,13 @@ impl<W: Write> PipeIoOutput for W {
 /// writes cannot be made nonblocking directly. The worker owns the sink and
 /// all commands are acknowledged in FIFO order. Cancellation is handled by
 /// the owner through `abort`, then the worker is always joined by `Drop`.
+#[cfg(any(test, not(unix)))]
 trait PipeIoOutputSink: Send {
     fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()>;
     fn flush_output(&mut self) -> io::Result<()>;
 }
 
+#[cfg(any(test, not(unix)))]
 impl<W: Write + Send> PipeIoOutputSink for W {
     fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
         self.write_all(bytes)
@@ -353,11 +365,13 @@ impl<W: Write + Send> PipeIoOutputSink for W {
     }
 }
 
+#[cfg(any(test, not(unix)))]
 enum PipeIoOutputCommand {
     Write { bytes: Vec<u8>, completion: Sender<io::Result<()>> },
     Flush { completion: Sender<io::Result<()>> },
 }
 
+#[cfg(any(test, not(unix)))]
 struct PipeIoOutputWorker {
     command_sender: Sender<PipeIoOutputCommand>,
     stop_sender: Sender<()>,
@@ -366,6 +380,7 @@ struct PipeIoOutputWorker {
     abort: Arc<dyn Fn() + Send + Sync>,
 }
 
+#[cfg(any(test, not(unix)))]
 impl PipeIoOutputWorker {
     fn spawn<S, F>(
         sink: S,
@@ -453,9 +468,7 @@ impl PipeIoOutputWorker {
                 .map_err(|_| {
                     io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
                 })?;
-            result_receiver.recv().map_err(|_| {
-                io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
-            })??;
+            self.wait_for_completion(result_receiver)?;
         }
         Ok(())
     }
@@ -465,13 +478,62 @@ impl PipeIoOutputWorker {
         self.command_sender.send(PipeIoOutputCommand::Flush { completion }).map_err(|_| {
             io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
         })?;
-        result_receiver.recv().map_err(|_| {
-            io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed")
-        })??;
+        self.wait_for_completion(result_receiver)?;
         Ok(())
+    }
+
+    fn wait_for_completion(&self, completion: Receiver<io::Result<()>>) -> io::Result<()> {
+        loop {
+            if self.cancellation.writes_cancelled() {
+                (self.abort)();
+                return Err(io::Error::new(io::ErrorKind::Interrupted, "pipe-io stdout canceled"));
+            }
+
+            let cancellation = self.cancellation.cancellation_state();
+            let terminal_deadline = (cancellation.reason == Some(PipeIoExitReason::TerminalEnded))
+                .then_some(cancellation.drain_deadline)
+                .flatten();
+            if let Some(deadline) = terminal_deadline {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    (self.abort)();
+                    return Err(io::Error::new(
+                        io::ErrorKind::Interrupted,
+                        "pipe-io stdout drain deadline expired",
+                    ));
+                }
+                let timeout = crossbeam_channel::after(remaining);
+                let cancel_receiver = self.cancellation.cancel_receiver.clone();
+                crossbeam_channel::select_biased! {
+                    recv(completion) -> result => return completion_result(result),
+                    recv(cancel_receiver) -> _ => continue,
+                    recv(timeout) -> _ => {
+                        (self.abort)();
+                        return Err(io::Error::new(
+                            io::ErrorKind::Interrupted,
+                            "pipe-io stdout drain deadline expired",
+                        ));
+                    }
+                }
+            } else {
+                let cancel_receiver = self.cancellation.cancel_receiver.clone();
+                crossbeam_channel::select_biased! {
+                    recv(completion) -> result => return completion_result(result),
+                    recv(cancel_receiver) -> _ => continue,
+                }
+            }
+        }
     }
 }
 
+#[cfg(any(test, not(unix)))]
+fn completion_result(
+    result: Result<io::Result<()>, crossbeam_channel::RecvError>,
+) -> io::Result<()> {
+    result.map_err(|_| io::Error::new(io::ErrorKind::BrokenPipe, "pipe-io stdout worker closed"))?
+}
+
+#[cfg(any(test, not(unix)))]
 impl Drop for PipeIoOutputWorker {
     fn drop(&mut self) {
         // The pump has stopped issuing commands by the time this owner drops.
@@ -637,29 +699,183 @@ impl PipeIoOutput for PipeIoStdout {
     }
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
+use std::os::windows::io::AsRawHandle;
+
+#[cfg(windows)]
+use windows_sys::Win32::Foundation::{CloseHandle, DUPLICATE_SAME_ACCESS, DuplicateHandle, HANDLE};
+#[cfg(windows)]
+use windows_sys::Win32::Storage::FileSystem::WriteFile;
+#[cfg(windows)]
+use windows_sys::Win32::System::IO::CancelSynchronousIo;
+#[cfg(windows)]
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, GetCurrentThread};
+
+#[cfg(windows)]
+struct WindowsPipeIoAbort {
+    // Store the native handle as an integer so the cancellation closure keeps
+    // the ordinary `Send + Sync` guarantees of its shared state. It is cast
+    // back to `HANDLE` only at the Win32 call boundary.
+    worker_thread: Mutex<Option<usize>>,
+}
+
+#[cfg(windows)]
+impl WindowsPipeIoAbort {
+    fn install_current_thread(&self) -> io::Result<()> {
+        let mut handle = std::ptr::null_mut();
+        // SAFETY: the pseudo handles refer to this worker and process. The
+        // duplicated handle is owned by `WindowsPipeIoAbort` until join.
+        let copied = unsafe {
+            DuplicateHandle(
+                GetCurrentProcess(),
+                GetCurrentThread(),
+                GetCurrentProcess(),
+                &mut handle,
+                0,
+                0,
+                DUPLICATE_SAME_ACCESS,
+            )
+        };
+        if copied == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        *self.worker_thread.lock().unwrap_or_else(|poison| poison.into_inner()) =
+            Some(handle as usize);
+        Ok(())
+    }
+
+    fn cancel(&self) {
+        let handle = *self.worker_thread.lock().unwrap_or_else(|poison| poison.into_inner());
+        if let Some(handle) = handle {
+            // SAFETY: `handle` is a live duplicate of the output worker's
+            // thread handle. Windows permits another thread to cancel pending
+            // synchronous I/O issued by that worker.
+            unsafe {
+                let _ = CancelSynchronousIo(handle as HANDLE);
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+impl Default for WindowsPipeIoAbort {
+    fn default() -> Self {
+        Self { worker_thread: Mutex::new(None) }
+    }
+}
+
+#[cfg(windows)]
+impl Drop for WindowsPipeIoAbort {
+    fn drop(&mut self) {
+        let handle = self.worker_thread.lock().unwrap_or_else(|poison| poison.into_inner()).take();
+        if let Some(handle) = handle {
+            // SAFETY: the duplicated handle is owned by this value and the
+            // worker has already been joined by `PipeIoOutputWorker::Drop`.
+            unsafe {
+                let _ = CloseHandle(handle as HANDLE);
+            }
+        }
+    }
+}
+
+#[cfg(windows)]
+struct WindowsStdoutSink {
+    stdout: std::io::Stdout,
+}
+
+#[cfg(windows)]
+impl Write for WindowsStdoutSink {
+    fn write(&mut self, bytes: &[u8]) -> io::Result<usize> {
+        if bytes.is_empty() {
+            return Ok(0);
+        }
+        let length = bytes.len().min(u32::MAX as usize) as u32;
+        let mut written = 0_u32;
+        // SAFETY: `stdout` owns a valid process output handle for the life of
+        // this worker. `bytes` remains borrowed until `WriteFile` returns.
+        let ok = unsafe {
+            WriteFile(
+                self.stdout.as_raw_handle() as HANDLE,
+                bytes.as_ptr(),
+                length,
+                &mut written,
+                std::ptr::null_mut(),
+            )
+        };
+        if ok == 0 {
+            return Err(io::Error::last_os_error());
+        }
+        Ok(written as usize)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        // Writes are issued directly to the handle, so there is no userspace
+        // buffer whose flush could block independently.
+        Ok(())
+    }
+}
+
+#[cfg(windows)]
 struct PipeIoStdout {
-    inner: std::io::BufWriter<std::io::Stdout>,
+    worker: PipeIoOutputWorker,
     cancellation: PipeIoOutputCancellation,
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 fn pipe_io_stdout(cancellation: PipeIoOutputCancellation) -> io::Result<PipeIoStdout> {
-    Ok(PipeIoStdout { inner: std::io::BufWriter::new(std::io::stdout()), cancellation })
+    let abort_state = Arc::new(WindowsPipeIoAbort::default());
+    let startup_state = abort_state.clone();
+    let abort_for_worker = abort_state.clone();
+    let abort: Arc<dyn Fn() + Send + Sync> = Arc::new(move || abort_for_worker.cancel());
+    let worker = PipeIoOutputWorker::spawn(
+        WindowsStdoutSink { stdout: std::io::stdout() },
+        cancellation.clone(),
+        abort,
+        move || startup_state.install_current_thread(),
+    )?;
+    Ok(PipeIoStdout { worker, cancellation })
 }
 
-#[cfg(not(unix))]
+#[cfg(windows)]
 impl PipeIoOutput for PipeIoStdout {
     fn write_bytes(&mut self, bytes: &[u8]) -> io::Result<()> {
-        self.inner.write_all(bytes)
+        self.worker.write_bytes(bytes)
     }
 
     fn flush_output(&mut self) -> io::Result<()> {
-        self.inner.flush()
+        self.worker.flush_output()
     }
 
     fn cancellation_reason(&self) -> Option<PipeIoExitReason> {
         self.cancellation.reason()
+    }
+}
+
+/// cmux-tui currently supports Unix hosts and Windows ConPTY work is planned
+/// separately. Unknown non-Unix targets fail setup instead of exposing a
+/// blocking stdio writer that cannot honor relay cancellation.
+#[cfg(all(not(unix), not(windows)))]
+struct PipeIoStdout;
+
+#[cfg(all(not(unix), not(windows)))]
+fn pipe_io_stdout(_cancellation: PipeIoOutputCancellation) -> io::Result<PipeIoStdout> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        "pipe-io stdout cancellation is unavailable on this platform",
+    ))
+}
+
+#[cfg(all(not(unix), not(windows)))]
+impl PipeIoOutput for PipeIoStdout {
+    fn write_bytes(&mut self, _bytes: &[u8]) -> io::Result<()> {
+        Err(io::Error::new(
+            io::ErrorKind::Unsupported,
+            "pipe-io stdout cancellation is unavailable on this platform",
+        ))
+    }
+
+    fn flush_output(&mut self) -> io::Result<()> {
+        Ok(())
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -24,6 +24,8 @@
 use std::borrow::Cow;
 use std::io::{BufRead, Write};
 use std::path::Path;
+#[cfg(test)]
+use std::sync::mpsc::sync_channel;
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
@@ -924,7 +926,7 @@ mod tests {
     #[test]
     fn stderr_gate_waits_for_in_flight_diagnostic_before_closing() {
         let gate = Arc::new(StderrGate::default());
-        let (entered_sender, entered_receiver) = std::sync::mpsc::sync_channel(0);
+        let (entered_sender, entered_receiver) = sync_channel(0);
         let (release_sender, release_receiver) = std::sync::mpsc::channel();
         let lines = Arc::new(std::sync::Mutex::new(Vec::new()));
 

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -601,7 +601,7 @@ fn resize_diag_line(cols: u16, rows: u16, result: &PipeIoControlResult<bool>) ->
         PipeIoControlResult::Gone => serde_json::json!({
             "cols": cols,
             "rows": rows,
-            "error": "remote session unavailable"
+            "error": RESIZE_ERROR_CODE
         }),
         PipeIoControlResult::Failed(error) => {
             log_pipe_io_error("resize", error);
@@ -614,9 +614,7 @@ fn resize_diag_line(cols: u16, rows: u16, result: &PipeIoControlResult<bool>) ->
 fn claim_diag_line(result: &PipeIoControlResult<()>) -> String {
     let details = match result {
         PipeIoControlResult::Completed(()) => serde_json::json!({"accepted": true}),
-        PipeIoControlResult::Gone => {
-            serde_json::json!({"error": "remote session unavailable"})
-        }
+        PipeIoControlResult::Gone => serde_json::json!({"error": CLAIM_ERROR_CODE}),
         PipeIoControlResult::Failed(error) => {
             log_pipe_io_error("claim geometry", error);
             serde_json::json!({"error": CLAIM_ERROR_CODE})

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1015,11 +1015,28 @@ fn run_stdin_pump_with_handlers(
         }
         match parse_request(&line) {
             Ok(PipeIoRequest::Input(bytes)) => {
-                if !matches!(write_input(&bytes), PipeIoControlResult::Completed(())) {
-                    // The transport owns loss reporting; input can only stop
-                    // early.
-                    stop_event = Some(PipeIoEvent::TransportLost);
-                    break;
+                match write_input(&bytes) {
+                    PipeIoControlResult::Completed(()) => {}
+                    PipeIoControlResult::Gone => {
+                        // A dropped remote session cannot accept more input;
+                        // reconnecting is the only way to recover it.
+                        stop_event = Some(PipeIoEvent::TransportLost);
+                        break;
+                    }
+                    PipeIoControlResult::Failed(error) => {
+                        // Keep protocol or setup rejections non-retryable.
+                        // The full cause belongs in the internal client log;
+                        // the machine-readable exit record carries only the
+                        // stable setup-failed token.
+                        let retryable = crate::session::is_pipe_io_retryable_error(&error);
+                        log_pipe_io_error("input", &error);
+                        stop_event = Some(if retryable {
+                            PipeIoEvent::TransportLost
+                        } else {
+                            PipeIoEvent::StdinError
+                        });
+                        break;
+                    }
                 }
             }
             Ok(PipeIoRequest::Resize { cols, rows }) => {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -2381,7 +2381,7 @@ mod tests {
         let remote = RemoteSession::connect_stream(Box::new(client)).unwrap();
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let stderr_gate = Arc::new(StderrGate::default());
-        let input = b"{\"claim\":{\"geometry\":true}}\n{\"input\":\"aGk=\"}\n".to_vec();
+        let input = b"{\"claim\":{\"geometry\":true}}\n{\"claim\":{\"geometry\":true}}\n{\"input\":\"aGk=\"}\n".to_vec();
         let pump_remote = Arc::downgrade(&remote);
         let pump_stderr = stderr_gate.clone();
         let pump = std::thread::spawn(move || {
@@ -2389,15 +2389,14 @@ mod tests {
             run_stdin_pump(&mut input, &pump_remote, 9, &lifecycle_sender, pump_stderr);
         });
 
-        assert!(
-            input_before_ack_receiver
-                .recv_timeout(Duration::from_secs(1))
-                .expect("server did not inspect the input command")
-        );
+        let input_before_ack = input_before_ack_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .expect("server did not inspect the input command");
         pump.join().unwrap();
         assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinClosed);
         server_done_sender.send(()).unwrap();
         peer.join().unwrap();
+        assert!(input_before_ack, "stdin input waited for the geometry claim response");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -1541,6 +1541,23 @@ mod tests {
     }
 
     #[test]
+    fn stdin_pump_does_not_retry_non_transport_input_failures() {
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let mut input = Cursor::new(b"{\"input\":\"aGk=\"}\n".to_vec());
+
+        run_stdin_pump_with_handlers(
+            &mut input,
+            &lifecycle_sender,
+            |_bytes| PipeIoControlResult::Failed(anyhow::anyhow!("healthy daemon rejected input")),
+            |_cols, _rows| PipeIoControlResult::Completed(true),
+            || PipeIoControlResult::Completed(()),
+            |_line| {},
+        );
+
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::StdinError);
+    }
+
+    #[test]
     fn stdin_pump_reports_line_read_errors_as_stdin_errors() {
         let inputs = vec![b"\xff\n".to_vec(), vec![b'a'; MAX_PIPE_IO_LINE_BYTES + 1]];
         for input in inputs {

--- a/cmux-tui/crates/cmux-tui/src/pipe_io.rs
+++ b/cmux-tui/crates/cmux-tui/src/pipe_io.rs
@@ -124,7 +124,7 @@ impl StderrGate {
     }
 
     fn diag(&self, line: String) {
-        self.emit_with(line, |line| write_stderr_line_bounded(line));
+        self.emit_with(line, write_stderr_line_bounded);
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/pty_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/pty_input.rs
@@ -19,7 +19,8 @@ use crate::session::{SurfaceHandle, is_remote_timeout, is_remote_transport_failu
 
 pub(crate) const PTY_OPERATION_QUEUE_CAPACITY: usize = 512;
 pub(crate) const TERMINAL_EXITED_LABEL: &str = "terminal exited";
-const MAX_QUEUED_BYTES: usize = 4 * 1024 * 1024;
+pub(crate) const PTY_INPUT_MAX_BYTES: usize = 4 * 1024 * 1024;
+const MAX_QUEUED_BYTES: usize = PTY_INPUT_MAX_BYTES;
 const MAX_CONCURRENT_SURFACE_OPERATIONS: usize = 32;
 const RESERVED_RELEASE_BYTES: usize = 64;
 const REMOTE_RELEASE_MAX_ATTEMPTS: u8 = 3;

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -35,9 +35,10 @@ use ghostty_vt::{
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
+pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach};
 pub use remote::{
-    RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface, RemoteTransport,
-    RemoteTransportAbort,
+    PipeIoEvent, RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface,
+    RemoteTransport, RemoteTransportAbort,
 };
 pub use tree::{TabNotificationView, TreeView, WorkspaceView};
 

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -35,7 +35,7 @@ use ghostty_vt::{
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
-pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach};
+pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach, is_pipe_io_retryable_error};
 pub use remote::{
     PipeIoEvent, RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface,
     RemoteTransport, RemoteTransportAbort,

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -169,15 +169,11 @@ fn request_receipted_creation(
 }
 
 pub(crate) fn is_remote_transport_failure(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<RemoteRequestError>()
-        .is_some_and(RemoteRequestError::is_transport_failure)
+    error.downcast_ref::<RemoteRequestError>().is_some_and(RemoteRequestError::is_transport_failure)
 }
 
 pub(crate) fn is_remote_timeout(error: &anyhow::Error) -> bool {
-    error
-        .downcast_ref::<RemoteRequestError>()
-        .is_some_and(RemoteRequestError::is_timeout)
+    error.downcast_ref::<RemoteRequestError>().is_some_and(RemoteRequestError::is_timeout)
 }
 
 pub(crate) fn is_remote_surface_unavailable(error: &anyhow::Error, surface: SurfaceId) -> bool {
@@ -295,8 +291,7 @@ pub(crate) fn test_remote_rejected_error() -> anyhow::Error {
 
 #[cfg(test)]
 pub(crate) fn test_remote_rejected_error_with_message(message: &str) -> anyhow::Error {
-    RemoteRequestError::Rejected { error: message.to_string(), code: None, delivery: None }
-        .into()
+    RemoteRequestError::Rejected { error: message.to_string(), code: None, delivery: None }.into()
 }
 
 #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -621,14 +621,7 @@ impl Session {
                 .claim_terminal_geometry(surface, 0)
                 .map(|_| ())
                 .ok_or_else(|| anyhow::anyhow!("unknown terminal {surface}")),
-            Session::Remote(remote) => remote
-                .request(json!({
-                    "cmd": "set-client-sizing",
-                    "surface": surface,
-                    "enabled": true,
-                    "exclusive": true,
-                }))
-                .map(|_| ()),
+            Session::Remote(remote) => remote.claim_terminal_geometry(surface),
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -170,25 +170,25 @@ fn request_receipted_creation(
 
 pub(crate) fn is_remote_transport_failure(error: &anyhow::Error) -> bool {
     error
-        .downcast_ref::<remote::RemoteRequestError>()
-        .is_some_and(remote::RemoteRequestError::is_transport_failure)
+        .downcast_ref::<RemoteRequestError>()
+        .is_some_and(RemoteRequestError::is_transport_failure)
 }
 
 pub(crate) fn is_remote_timeout(error: &anyhow::Error) -> bool {
     error
-        .downcast_ref::<remote::RemoteRequestError>()
-        .is_some_and(remote::RemoteRequestError::is_timeout)
+        .downcast_ref::<RemoteRequestError>()
+        .is_some_and(RemoteRequestError::is_timeout)
 }
 
 pub(crate) fn is_remote_surface_unavailable(error: &anyhow::Error, surface: SurfaceId) -> bool {
     let expected = format!("unknown surface {surface}");
     error
-        .downcast_ref::<remote::RemoteRequestError>()
+        .downcast_ref::<RemoteRequestError>()
         .is_some_and(|error| error.rejection_message() == Some(expected.as_str()))
 }
 
 fn normalize_remote_layout_undo_error(error: anyhow::Error) -> anyhow::Error {
-    let Some(remote) = error.downcast_ref::<remote::RemoteRequestError>() else {
+    let Some(remote) = error.downcast_ref::<RemoteRequestError>() else {
         return error;
     };
     match remote.rejection_code() {
@@ -221,7 +221,7 @@ fn normalize_remote_split_ratio_error(
     split: SplitId,
     ratio: f32,
 ) -> anyhow::Error {
-    let Some(remote) = error.downcast_ref::<remote::RemoteRequestError>() else {
+    let Some(remote) = error.downcast_ref::<RemoteRequestError>() else {
         return error;
     };
     let messages = &crate::localization::catalog().layout;
@@ -259,7 +259,7 @@ fn localized_viewport_width_error(error: ViewportWidthError) -> anyhow::Error {
 }
 
 fn normalize_remote_viewport_width_error(error: anyhow::Error, pane: PaneId) -> anyhow::Error {
-    let Some(remote) = error.downcast_ref::<remote::RemoteRequestError>() else {
+    let Some(remote) = error.downcast_ref::<RemoteRequestError>() else {
         return error;
     };
     let messages = &crate::localization::catalog().layout;
@@ -276,12 +276,12 @@ fn normalize_remote_viewport_width_error(error: anyhow::Error, pane: PaneId) -> 
 
 #[cfg(test)]
 pub(crate) fn test_remote_timeout_error() -> anyhow::Error {
-    remote::RemoteRequestError::Timeout.into()
+    RemoteRequestError::Timeout.into()
 }
 
 #[cfg(test)]
 pub(crate) fn test_remote_transport_error() -> anyhow::Error {
-    remote::RemoteRequestError::Transport(std::io::Error::new(
+    RemoteRequestError::Transport(std::io::Error::new(
         std::io::ErrorKind::BrokenPipe,
         "socket closed",
     ))
@@ -295,13 +295,13 @@ pub(crate) fn test_remote_rejected_error() -> anyhow::Error {
 
 #[cfg(test)]
 pub(crate) fn test_remote_rejected_error_with_message(message: &str) -> anyhow::Error {
-    remote::RemoteRequestError::Rejected { error: message.to_string(), code: None, delivery: None }
+    RemoteRequestError::Rejected { error: message.to_string(), code: None, delivery: None }
         .into()
 }
 
 #[cfg(test)]
 fn test_remote_rejected_error_with_code(message: &str, code: &str) -> anyhow::Error {
-    remote::RemoteRequestError::Rejected {
+    RemoteRequestError::Rejected {
         error: message.to_string(),
         code: Some(code.to_string()),
         delivery: None,

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -35,7 +35,9 @@ use ghostty_vt::{
 use serde::Deserialize;
 use serde_json::{Map, Value, json};
 
-pub(crate) use remote::{PipeIoByteBudget, PipeIoSurfaceAttach, is_pipe_io_retryable_error};
+pub(crate) use remote::{
+    PipeIoByteBudget, PipeIoSurfaceAttach, RemoteRequestError, is_pipe_io_retryable_error,
+};
 pub use remote::{
     PipeIoEvent, RemoteMessageReader, RemoteMessageWriter, RemoteSession, RemoteSurface,
     RemoteTransport, RemoteTransportAbort,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -9501,6 +9501,57 @@ mod tests {
     }
 
     #[test]
+    fn fixed_request_deadline_caps_queue_write_and_response_wait() {
+        let (stream, control) = BlockingWriteStream::new();
+        let session = blocking_test_session(stream);
+        session.send_bytes(7, b"blocked").unwrap();
+        control.wait_until_entered();
+
+        // Hold admission long enough to consume part of the request budget,
+        // then hold the ordered writer for another phase. The writer never
+        // sends a response, so a request that recreates a relative timeout
+        // for each phase runs well past its fixed budget.
+        let queue_guard = session.interactive_writer.shared.state.lock();
+        let timeout = Duration::from_millis(180);
+        let request_session = session.clone();
+        let (started_tx, started_rx) = channel();
+        let (finished_tx, finished_rx) = channel();
+        let request = std::thread::spawn(move || {
+            let started = Instant::now();
+            started_tx.send(started).unwrap();
+            let result = request_session.request_with_deadline(
+                json!({"cmd": "fixed-deadline-probe"}),
+                RequestDeadline::Fixed(timeout),
+            );
+            finished_tx.send((started.elapsed(), result)).unwrap();
+        });
+
+        let started = started_rx.recv().unwrap();
+        let pending_deadline = Instant::now() + Duration::from_secs(1);
+        while session.pending.lock().unwrap().is_empty() {
+            assert!(Instant::now() < pending_deadline, "request did not reach pending state");
+            std::thread::yield_now();
+        }
+        std::thread::sleep(Duration::from_millis(60));
+        drop(queue_guard);
+        std::thread::sleep(Duration::from_millis(60));
+        control.release();
+
+        let (elapsed, result) = finished_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("fixed-deadline request did not finish");
+        request.join().unwrap();
+        assert!(matches!(
+            result.as_ref().err().and_then(|error| error.downcast_ref::<RemoteRequestError>()),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            elapsed < timeout + Duration::from_millis(70),
+            "fixed request deadline was reset between phases: started at {started:?}, elapsed {elapsed:?}"
+        );
+    }
+
+    #[test]
     fn bounded_admission_rejects_an_expired_deadline_after_lock_acquisition() {
         let session = test_session(Box::new(SilentWriter));
         let deadline = Instant::now() - Duration::from_millis(1);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1182,6 +1182,7 @@ struct AttachResponseDeadline {
 }
 
 impl AttachResponseDeadline {
+    #[cfg(test)]
     fn new(
         started: Instant,
         request_progress: u64,
@@ -1598,6 +1599,7 @@ impl InteractiveWriter {
         Ok((state.last_enqueued_sequence != 0).then_some(state.last_enqueued_sequence))
     }
 
+    #[cfg(test)]
     fn wait_until_written(&self, sequence: u64, timeout: Duration) -> io::Result<()> {
         self.wait_until_written_until(sequence, Instant::now() + timeout)
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5674,7 +5674,7 @@ mod tests {
     #[cfg(unix)]
     use std::io::{BufRead, Read, Write};
     #[cfg(unix)]
-    use std::os::unix::net::UnixStream;
+    use std::os::unix::net::{UnixListener, UnixStream};
     use std::sync::atomic::{AtomicBool, AtomicU64};
     use std::sync::mpsc::{Receiver, Sender};
     use std::sync::{Condvar, Mutex, Weak};
@@ -9639,6 +9639,39 @@ mod tests {
             .expect("deadline-bounded ordered wait blocked on the state mutex")
             .expect_err("an unwritten sequence unexpectedly completed");
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn expired_probe_does_not_start_a_socket_connector() {
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("probe.sock");
+        let listener = UnixListener::bind(&path).unwrap();
+        listener.set_nonblocking(true).unwrap();
+
+        let error = RemoteSession::connect_for_terminal_attach_until(
+            &path,
+            Instant::now() - Duration::from_millis(1),
+        )
+        .expect_err("an expired probe unexpectedly connected");
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+
+        let settle_deadline = Instant::now() + Duration::from_millis(100);
+        loop {
+            match listener.accept() {
+                Ok(_) => panic!("expired probe started a connector after returning"),
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    if Instant::now() >= settle_deadline {
+                        break;
+                    }
+                    std::thread::yield_now();
+                }
+                Err(error) => panic!("probe listener failed: {error}"),
+            }
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2148,6 +2148,7 @@ impl RemoteSession {
     /// establishment outside `RemoteSession` lets clients use a local socket,
     /// an SSH relay, or another authenticated tunnel without teaching the
     /// session and rendering layers about those transports.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn connect_stream(stream: Box<dyn transport::Stream>) -> anyhow::Result<Arc<Self>> {
         Self::connect_stream_with_subscription(stream, true)
     }
@@ -4117,6 +4118,7 @@ impl RemoteSession {
 
     /// Refresh the workspace tree with a bounded request deadline. Used by
     /// reconnect classification, where a stale daemon must not hold the relay.
+    #[cfg_attr(not(test), allow(dead_code))]
     pub fn refresh_tree_with_timeout(&self, timeout: Duration) -> anyhow::Result<TreeView> {
         self.refresh_tree_until(Instant::now() + timeout)
     }
@@ -8282,7 +8284,7 @@ mod tests {
         assert_eq!(command["enabled"], true);
         assert_eq!(command["exclusive"], true);
         assert!(command.get("no_reply").is_none());
-        assert!(finished_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        assert!(finished_rx.try_recv().is_err());
 
         session.handle_line(json!({"id": command["id"], "ok": true, "data": null}));
         assert!(finished_rx.recv_timeout(Duration::from_secs(1)).unwrap().is_ok());

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7533,6 +7533,67 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_sparse_colors_changed_preserves_omitted_defaults_and_clears_old_palette() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.handle_line(json!({
+            "event": "colors-changed",
+            "surface": 7,
+            "fg": "#abcdef",
+            "bg": "#102030",
+            "cursor": "#fedcba",
+            "cursor_style": "bar",
+            "cursor_blink": true,
+            "palette": {"2": "#0a0b0c"},
+        }));
+        let first = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+        let PipeIoEvent::Output(first_bytes) = first else {
+            panic!("initial colors-changed did not forward output");
+        };
+
+        session.handle_line(json!({
+            "event": "colors-changed",
+            "surface": 7,
+            "fg": "#abcdef",
+            "bg": "#102030",
+            "palette": {},
+        }));
+        let PipeIoEvent::Output(second_bytes) =
+            receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("sparse colors-changed did not forward output");
+        };
+
+        let mut terminal = Terminal::new(80, 24, 100, Callbacks::default()).unwrap();
+        terminal.vt_write(&first_bytes);
+        assert_eq!(terminal.effective_cursor_visual().unwrap(), (CursorShape::Bar, true));
+        terminal.vt_write(&second_bytes);
+        assert_eq!(
+            terminal.effective_colors(),
+            (
+                Some(Rgb { r: 0xab, g: 0xcd, b: 0xef }),
+                Some(Rgb { r: 0x10, g: 0x20, b: 0x30 }),
+                Some(Rgb { r: 0xfe, g: 0xdc, b: 0xba }),
+            )
+        );
+        assert_eq!(terminal.color_overrides().palette[2], None);
+        assert!(
+            !second_bytes.windows(b"\x1b[0 q".len()).any(|window| window == b"\x1b[0 q"),
+            "palette-only update must preserve the current cursor visual"
+        );
+    }
+
+    #[test]
     fn pipe_io_resized_replay_restores_the_coupled_color_state() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1336,15 +1336,28 @@ impl InteractiveWriter {
         Ok(Self { shared, abort })
     }
 
-    fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
+    /// Queue admission is fail-fast. It never waits for the queue mutex or
+    /// for capacity, so a caller's request deadline remains authoritative even
+    /// when the remote writer is stalled.
+    fn try_enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
         let mut write =
             InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
         let message_bytes = write.message.len();
-        let mut state = self
-            .shared
-            .state
-            .lock()
-            .map_err(|_| io::Error::other("interactive writer queue is poisoned"))?;
+        let mut state = match self.shared.state.try_lock() {
+            Ok(state) => state,
+            Err(std::sync::TryLockError::Poisoned(_)) => {
+                return Err(io::Error::other("interactive writer queue is poisoned"));
+            }
+            Err(std::sync::TryLockError::WouldBlock) => {
+                if measure_latency {
+                    self.shared.metrics.backpressure_rejections.fetch_add(1, Ordering::Relaxed);
+                }
+                return Err(io::Error::new(
+                    io::ErrorKind::WouldBlock,
+                    "interactive writer queue mutex is contended",
+                ));
+            }
+        };
         if let Some(failure) = &state.failure {
             return Err(failure.to_error());
         }
@@ -1373,6 +1386,11 @@ impl InteractiveWriter {
         drop(state);
         self.shared.changed.notify_one();
         Ok(sequence)
+    }
+
+    #[cfg(test)]
+    fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
+        self.try_enqueue(message, measure_latency)
     }
 
     fn last_enqueued_sequence(&self) -> io::Result<Option<u64>> {
@@ -3095,12 +3113,19 @@ impl RemoteSession {
             zeroize_string(authority);
         }
 
+        // Serialization and request construction can consume a shared probe
+        // deadline. Do not add a pending request or queue work after it has
+        // expired.
+        if let Err(error) = deadline.remaining() {
+            return Err(error.into());
+        }
+
         let (tx, rx) = channel();
         self.pending.lock().unwrap().insert(
             id,
             PendingRemoteRequest { response: tx, progress: progress.clone(), attach_surface },
         );
-        let sequence = match self.interactive_writer.enqueue(message, false) {
+        let sequence = match self.interactive_writer.try_enqueue(message, false) {
             Ok(sequence) => sequence,
             Err(error) => {
                 self.pending.lock().unwrap().remove(&id);
@@ -3219,7 +3244,7 @@ impl RemoteSession {
             .map_err(anyhow::Error::new)?;
         let sequence = self
             .interactive_writer
-            .enqueue(message, true)
+            .try_enqueue(message, true)
             .map_err(RemoteRequestError::Transport)?;
         if self.shutdown.load(Ordering::Acquire) {
             self.wait_for_ordered_write(sequence).map_err(RemoteRequestError::Transport)?;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5292,6 +5292,32 @@ mod tests {
         assert!(with.supports_pipe_io_initial_size());
     }
 
+    #[test]
+    fn pipe_io_attach_reports_retirement_after_stream_open() {
+        let (session, attach_started_rx, release_attach_tx) =
+            super::test_session_with_deferred_attach();
+        let (sender, receiver) = crossbeam_channel::bounded(8);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+        let attaching = session.clone();
+        let worker = std::thread::spawn(move || attaching.try_attach_pipe_io(7, Some((80, 24))));
+        attach_started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        session.pipe_io_forward_owned(7, PipeIoEvent::Output(b"last".to_vec())).unwrap();
+        session.handle_line(json!({"event": "surface-exited", "surface": 7}));
+        release_attach_tx.send(()).unwrap();
+
+        let result = worker.join().unwrap().unwrap();
+        assert!(matches!(result, PipeIoSurfaceAttach::RetiredAfterAttach));
+        assert_eq!(receiver.try_recv().unwrap(), PipeIoEvent::Output(b"last".to_vec()));
+        assert_eq!(lifecycle_receiver.try_recv().unwrap(), PipeIoEvent::SurfaceExited);
+    }
+
     #[cfg(unix)]
     #[test]
     fn legacy_pipe_io_sizes_before_attach() {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -533,7 +533,6 @@ struct PipeIoCachedPaletteSet {
     bytes: Vec<u8>,
 }
 
-#[derive(Default)]
 struct PipeIoColorCache {
     fg: PipeIoCachedColor,
     bg: PipeIoCachedColor,
@@ -543,6 +542,21 @@ struct PipeIoColorCache {
     palette_known: bool,
     palette_set_bytes: [Option<PipeIoCachedPaletteSet>; 256],
     palette_reset_bytes: [Option<Vec<u8>>; 256],
+}
+
+impl Default for PipeIoColorCache {
+    fn default() -> Self {
+        Self {
+            fg: PipeIoCachedColor::default(),
+            bg: PipeIoCachedColor::default(),
+            cursor: PipeIoCachedColor::default(),
+            cursor_visual: PipeIoCachedCursorVisual::default(),
+            palette: [None; 256],
+            palette_known: false,
+            palette_set_bytes: std::array::from_fn(|_| None),
+            palette_reset_bytes: std::array::from_fn(|_| None),
+        }
+    }
 }
 
 impl PipeIoColorCache {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1336,28 +1336,49 @@ impl InteractiveWriter {
         Ok(Self { shared, abort })
     }
 
-    /// Queue admission is fail-fast. It never waits for the queue mutex or
-    /// for capacity, so a caller's request deadline remains authoritative even
-    /// when the remote writer is stalled.
+    fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
+        self.enqueue_inner(message, measure_latency, false)
+    }
+
+    /// Bounded-probe admission is fail-fast. It never waits for the queue
+    /// mutex or for capacity, so a shared reconnect deadline remains
+    /// authoritative when the remote writer is stalled.
     fn try_enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
+        self.enqueue_inner(message, measure_latency, true)
+    }
+
+    fn enqueue_inner(
+        &self,
+        message: String,
+        measure_latency: bool,
+        nonblocking: bool,
+    ) -> io::Result<u64> {
         let mut write =
             InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
         let message_bytes = write.message.len();
-        let mut state = match self.shared.state.try_lock() {
-            Ok(state) => state,
-            Err(std::sync::TryLockError::Poisoned(_)) => {
-                return Err(io::Error::other("interactive writer queue is poisoned"));
-            }
-            Err(std::sync::TryLockError::WouldBlock) => {
-                if measure_latency {
-                    self.shared.metrics.backpressure_rejections.fetch_add(1, Ordering::Relaxed);
+        let state = if nonblocking {
+            match self.shared.state.try_lock() {
+                Ok(state) => Ok(state),
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    Err(io::Error::other("interactive writer queue is poisoned"))
                 }
-                return Err(io::Error::new(
-                    io::ErrorKind::WouldBlock,
-                    "interactive writer queue mutex is contended",
-                ));
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    if measure_latency {
+                        self.shared.metrics.backpressure_rejections.fetch_add(1, Ordering::Relaxed);
+                    }
+                    Err(io::Error::new(
+                        io::ErrorKind::WouldBlock,
+                        "interactive writer queue mutex is contended",
+                    ))
+                }
             }
+        } else {
+            self.shared
+                .state
+                .lock()
+                .map_err(|_| io::Error::other("interactive writer queue is poisoned"))
         };
+        let mut state = state?;
         if let Some(failure) = &state.failure {
             return Err(failure.to_error());
         }
@@ -1386,11 +1407,6 @@ impl InteractiveWriter {
         drop(state);
         self.shared.changed.notify_one();
         Ok(sequence)
-    }
-
-    #[cfg(test)]
-    fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
-        self.try_enqueue(message, measure_latency)
     }
 
     fn last_enqueued_sequence(&self) -> io::Result<Option<u64>> {
@@ -3125,7 +3141,14 @@ impl RemoteSession {
             id,
             PendingRemoteRequest { response: tx, progress: progress.clone(), attach_surface },
         );
-        let sequence = match self.interactive_writer.try_enqueue(message, false) {
+        // Reconnect probes share one absolute deadline. They must not wait on
+        // a queue mutex held by a stalled writer; normal control requests keep
+        // their existing short mutex critical section and preserve input FIFO.
+        let enqueue_result = match deadline {
+            RequestDeadline::Until(_) => self.interactive_writer.try_enqueue(message, false),
+            _ => self.interactive_writer.enqueue(message, false),
+        };
+        let sequence = match enqueue_result {
             Ok(sequence) => sequence,
             Err(error) => {
                 self.pending.lock().unwrap().remove(&id);
@@ -3244,7 +3267,7 @@ impl RemoteSession {
             .map_err(anyhow::Error::new)?;
         let sequence = self
             .interactive_writer
-            .try_enqueue(message, true)
+            .enqueue(message, true)
             .map_err(RemoteRequestError::Transport)?;
         if self.shutdown.load(Ordering::Acquire) {
             self.wait_for_ordered_write(sequence).map_err(RemoteRequestError::Transport)?;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7092,6 +7092,35 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_replay_forward_returns_the_owned_payload_without_a_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let replay = vec![b'R'; 64];
+
+        assert_eq!(session.pipe_io_forward_replay(7, replay.clone()), Some(replay));
+    }
+
+    #[test]
+    fn pipe_io_replay_forward_consumes_the_owned_payload_for_a_matching_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+        let replay = vec![b'R'; 64];
+
+        assert_eq!(session.pipe_io_forward_replay(7, replay.clone()), None);
+        assert_eq!(receiver.try_recv().unwrap(), PipeIoEvent::replay(replay));
+    }
+
+    #[test]
     fn pipe_io_budget_keeps_same_length_oversized_replay_reserved() {
         let budget = PipeIoByteBudget::new(16);
         let mut first = PipeIoEvent::replay(vec![b'A'; 16]);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,9 +6,9 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
-use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
+use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
 use base64::Engine;
@@ -27,11 +27,13 @@ use cmux_tui_core::{
     },
 };
 use cmux_tui_machine_protocol::BearerToken;
+use crossbeam_channel::Sender as EventSender;
 use ghostty_vt::{
     Callbacks, CursorShape, KeyInput, KittyGraphicsLimits, KittyImageIdCursors, KittyReplayState,
     MouseEncoders, MouseInput, RenderState, Terminal, TerminalColorOverrides,
     TerminalPointerSemanticSnapshot, parse_color,
 };
+use parking_lot::Mutex as ParkingMutex;
 use serde_json::{Value, json};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -981,6 +983,25 @@ enum RequestDeadline {
     Standard,
     Attach,
     Fixed(Duration),
+    /// A deadline shared by a sequence of requests, such as reconnect
+    /// classification. Each phase consumes only the time that remains.
+    Until(Instant),
+}
+
+impl RequestDeadline {
+    fn remaining(self) -> Result<Duration, RemoteRequestError> {
+        match self {
+            Self::Standard => Ok(REMOTE_REQUEST_TIMEOUT),
+            Self::Fixed(timeout) => Ok(timeout),
+            Self::Until(deadline) => {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() { Err(RemoteRequestError::Timeout) } else { Ok(remaining) }
+            }
+            // Attach has its own progress-aware response deadline, but its
+            // enqueue/write phase still needs the normal bounded write wait.
+            Self::Attach => Ok(remote_write_timeout()),
+        }
+    }
 }
 
 struct AttachResponseDeadline {
@@ -1586,7 +1607,7 @@ pub struct RemoteSession {
     retire_surface_test_marker: Mutex<Option<Sender<SurfaceId>>>,
     tree: Mutex<RemoteTreeCache>,
     browser_sources: Mutex<HashMap<SurfaceId, BrowserSource>>,
-    tree_refresh: Mutex<()>,
+    tree_refresh: ParkingMutex<()>,
     tree_stale: AtomicBool,
     subscription_started: AtomicBool,
     event_surface_filter: AtomicU64,
@@ -1602,10 +1623,108 @@ pub struct RemoteSession {
     capabilities: Mutex<HashSet<String>>,
     provider_workspace_authority: Option<BearerToken>,
     provider_workspaces_guarded: AtomicBool,
+    pipe_io_tap: Mutex<Option<PipeIoTap>>,
+}
+
+/// One event on the raw byte stream a `--pipe-io` relay serves to its
+/// embedder. `Replay` REPLACES all prior terminal state (the relay must
+/// emit a full reset before any replay that is not its first output);
+/// `Output` appends live PTY bytes.
+#[derive(Debug, PartialEq, Eq)]
+pub enum PipeIoEvent {
+    Replay { bytes: Vec<u8> },
+    Output(Vec<u8>),
+    SurfaceExited,
+    TransportLost,
+    StdinClosed,
+}
+
+impl PipeIoEvent {
+    /// Bytes retained by the relay's bounded data queue. Lifecycle signals
+    /// have a separate one-slot channel and carry no retained payload.
+    pub(crate) fn retained_bytes(&self) -> usize {
+        match self {
+            Self::Replay { bytes } | Self::Output(bytes) => bytes.len(),
+            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed => 0,
+        }
+    }
+}
+
+/// Shared byte budget for one pipe-IO relay. A count-only bounded channel can
+/// retain megabytes per event when a replay is large; this budget makes the
+/// memory bound explicit and turns an overrun into the same transport-loss
+/// path as a full channel.
+pub(crate) struct PipeIoByteBudget {
+    retained: AtomicUsize,
+    limit: usize,
+}
+
+impl PipeIoByteBudget {
+    pub(crate) fn new(limit: usize) -> Self {
+        Self { retained: AtomicUsize::new(0), limit: limit.max(1) }
+    }
+
+    pub(crate) fn try_reserve(&self, bytes: usize) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+        let mut current = self.retained.load(Ordering::Acquire);
+        loop {
+            let Some(next) = current.checked_add(bytes) else { return false };
+            if next > self.limit {
+                return false;
+            }
+            match self.retained.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return true,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+
+    pub(crate) fn release(&self, bytes: usize) {
+        if bytes == 0 {
+            return;
+        }
+        let mut current = self.retained.load(Ordering::Acquire);
+        loop {
+            let next = current.saturating_sub(bytes);
+            match self.retained.compare_exchange_weak(
+                current,
+                next,
+                Ordering::AcqRel,
+                Ordering::Acquire,
+            ) {
+                Ok(_) => return,
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+struct PipeIoTap {
+    surface: SurfaceId,
+    sender: EventSender<PipeIoEvent>,
+    lifecycle_sender: EventSender<PipeIoEvent>,
+    byte_budget: Arc<PipeIoByteBudget>,
+    token: Arc<u8>,
 }
 
 pub(super) enum RemoteSurfaceAttach {
     Attached(Arc<RemoteSurface>),
+    Retired,
+    Deferred,
+}
+
+/// Result of registering a renderer-less pipe-IO attachment. Unlike
+/// `RemoteSurfaceAttach`, this path deliberately does not allocate a local VT
+/// parser. The relay receives the server's raw byte stream and owns parsing.
+pub(crate) enum PipeIoSurfaceAttach {
+    Attached,
     Retired,
     Deferred,
 }
@@ -1684,6 +1803,19 @@ impl RemoteTransport {
 
     pub fn json_lines(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         stream.set_write_timeout(Some(remote_write_timeout()))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_with_timeout(
+        stream: Box<dyn transport::Stream>,
+        timeout: Duration,
+    ) -> io::Result<Self> {
+        stream.set_read_timeout(Some(timeout))?;
+        stream.set_write_timeout(Some(timeout))?;
+        Self::json_lines_parts(stream)
+    }
+
+    fn json_lines_parts(stream: Box<dyn transport::Stream>) -> io::Result<Self> {
         let read_half = stream.try_clone_box()?;
         let abort_stream = stream.try_clone_box()?;
         Ok(Self {
@@ -1872,15 +2004,52 @@ impl RemoteSession {
         Self::connect_path(path, false)
     }
 
+    pub(crate) fn connect_for_terminal_attach_until(
+        path: &Path,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_path_until(path, false, deadline)
+    }
+
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
         let stream = transport::connect(path).map_err(|e| {
             anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
         })?;
-        if subscribe {
-            Self::connect_stream(stream)
-        } else {
-            Self::connect_stream_with_subscription(stream, false)
-        }
+        Self::connect_stream_with_subscription(stream, subscribe)
+    }
+
+    fn connect_path_until(
+        path: &Path,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let path_for_thread = path.to_path_buf();
+        let display = path.display().to_string();
+        let (sender, receiver) = sync_channel(1);
+        let connector =
+            std::thread::Builder::new().name("remote-probe-connect".into()).spawn(move || {
+                let _ = sender.send(transport::connect(&path_for_thread));
+            })?;
+        let stream = match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        {
+            Ok(result) => {
+                let _ = connector.join();
+                result.map_err(|error| {
+                    anyhow::anyhow!("cannot connect to session socket {display}: {error}")
+                })?
+            }
+            Err(RecvTimeoutError::Disconnected) => {
+                let _ = connector.join();
+                anyhow::bail!("remote probe connector stopped without a result")
+            }
+            Err(RecvTimeoutError::Timeout) => {
+                // The pipe-io process exits after classification. Dropping the
+                // connector lets that process terminate any blocked connect.
+                drop(connector);
+                anyhow::bail!(RemoteRequestError::Timeout)
+            }
+        };
+        Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
     }
 
     /// Connect over an already-established full-duplex byte stream.
@@ -1901,6 +2070,27 @@ impl RemoteSession {
             anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
         })?;
         Self::connect_transport_with_initial_subscription(transport, subscribe)
+    }
+
+    fn connect_stream_with_subscription_until(
+        stream: Box<dyn transport::Stream>,
+        subscribe: bool,
+        deadline: Instant,
+    ) -> anyhow::Result<Arc<Self>> {
+        let timeout = deadline.saturating_duration_since(Instant::now());
+        if timeout.is_zero() {
+            anyhow::bail!(RemoteRequestError::Timeout);
+        }
+        let transport =
+            RemoteTransport::json_lines_with_timeout(stream, timeout).map_err(|error| {
+                anyhow::anyhow!("cannot configure JSON-lines session transport: {error}")
+            })?;
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            None,
+            subscribe,
+            Some(deadline),
+        )
     }
 
     pub fn connect_transport(transport: RemoteTransport) -> anyhow::Result<Arc<Self>> {
@@ -1926,6 +2116,20 @@ impl RemoteSession {
         provider_workspace_authority: Option<BearerToken>,
         subscribe: bool,
     ) -> anyhow::Result<Arc<Self>> {
+        Self::connect_transport_with_provider_authority_until(
+            transport,
+            provider_workspace_authority,
+            subscribe,
+            None,
+        )
+    }
+
+    fn connect_transport_with_provider_authority_until(
+        transport: RemoteTransport,
+        provider_workspace_authority: Option<BearerToken>,
+        subscribe: bool,
+        deadline: Option<Instant>,
+    ) -> anyhow::Result<Arc<Self>> {
         let RemoteTransport { mut reader, writer, abort } = transport;
         let interactive_writer = InteractiveWriter::spawn(writer, abort)
             .map_err(|error| anyhow::anyhow!("cannot start remote interactive writer: {error}"))?;
@@ -1944,7 +2148,7 @@ impl RemoteSession {
             retire_surface_test_marker: Mutex::new(None),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -1960,6 +2164,7 @@ impl RemoteSession {
             capabilities: Mutex::new(HashSet::new()),
             provider_workspace_authority,
             provider_workspaces_guarded: AtomicBool::new(false),
+            pipe_io_tap: Mutex::new(None),
         });
 
         let reader_session = Arc::downgrade(&session);
@@ -1997,7 +2202,11 @@ impl RemoteSession {
             }
         })?;
 
-        if let Err(error) = session.initialize(subscribe) {
+        let initialization = deadline.map_or_else(
+            || session.initialize(subscribe),
+            |deadline| session.initialize_until(subscribe, deadline),
+        );
+        if let Err(error) = initialization {
             session.disconnect_transport();
             return Err(error);
         }
@@ -2005,8 +2214,20 @@ impl RemoteSession {
     }
 
     fn initialize(&self, subscribe: bool) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Standard)
+    }
+
+    fn initialize_until(&self, subscribe: bool, deadline: Instant) -> anyhow::Result<()> {
+        self.initialize_with_deadline(subscribe, RequestDeadline::Until(deadline))
+    }
+
+    fn initialize_with_deadline(
+        &self,
+        subscribe: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<()> {
         // Identify the endpoint and register this connection before any optional subscription.
-        let ident = self.request(json!({"cmd": "identify"}))?;
+        let ident = self.request_with_deadline(json!({"cmd": "identify"}), deadline)?;
         validate_remote_identity(&ident)?;
         *self.capabilities.lock().unwrap() = identity_capabilities(&ident);
         let mut client_info = json!({"cmd": "set-client-info", "kind": "tui"});
@@ -2032,10 +2253,10 @@ impl RemoteSession {
         if !negotiated.is_empty() {
             client_info["capabilities"] = json!(negotiated);
         }
-        self.request(client_info)?;
+        self.request_with_deadline(client_info, deadline)?;
         if subscribe {
             self.prime_local_subscription();
-            if let Err(error) = self.request(self.subscription_request()) {
+            if let Err(error) = self.request_with_deadline(self.subscription_request(), deadline) {
                 self.primed_subscription.lock().unwrap().take();
                 return Err(error);
             }
@@ -2188,6 +2409,12 @@ impl RemoteSession {
     }
 
     fn handle_line(self: &Arc<Self>, value: Value) {
+        // The reader can have one buffered JSON line after the transport has
+        // been closed. Do not let that late event mutate a replacement relay
+        // or resurrect a mirror during local shutdown.
+        if self.shutdown.load(Ordering::Acquire) {
+            return;
+        }
         let surface_id = || value.get("surface").and_then(|v| v.as_u64());
         let event = value.get("event").and_then(Value::as_str);
         if event.is_some_and(|event| !self.accepts_event_in_surface_scope(event, &value)) {
@@ -2208,11 +2435,20 @@ impl RemoteSession {
                 let Ok(replay) = base64::engine::general_purpose::STANDARD.decode(data) else {
                     return;
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 self.log_frame(
                     id,
                     format_args!("vt-state cols={cols} rows={rows} bytes={}", replay.len()),
                 );
+                let pipe_io_owned =
+                    self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() });
+                // A pipe-IO relay consumes the authoritative VT byte stream
+                // itself. Do not also parse the same replay into a local
+                // `RemoteSurface`: that duplicate parser can fail or mutate
+                // state even though the embedder never reads it.
+                if pipe_io_owned {
+                    return;
+                }
+                let colors = value.get("colors").and_then(parse_terminal_colors);
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
                     return;
@@ -2275,8 +2511,12 @@ impl RemoteSession {
                 let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(data) else {
                     return;
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 self.log_frame(id, format_args!("output bytes={}", bytes.len()));
+                let pipe_io_owned = self.pipe_io_forward(id, || PipeIoEvent::Output(bytes.clone()));
+                if pipe_io_owned {
+                    return;
+                }
+                let colors = value.get("colors").and_then(parse_terminal_colors);
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     surface.scan_cursor_provenance(&bytes);
                     let mut term = surface.term.lock().unwrap();
@@ -2310,6 +2550,21 @@ impl RemoteSession {
                     }
                     None => None,
                 };
+                self.log_frame(
+                    id,
+                    format_args!(
+                        "resized cols={cols} rows={rows} bytes={}",
+                        replay.as_ref().map(|bytes| bytes.len()).unwrap_or(0)
+                    ),
+                );
+                let pipe_io_owned = if let Some(replay) = replay.as_ref() {
+                    self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() })
+                } else {
+                    self.pipe_io_owns_surface(id)
+                };
+                if pipe_io_owned {
+                    return;
+                }
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
                     return;
@@ -2319,13 +2574,6 @@ impl RemoteSession {
                     return;
                 };
                 let colors = value.get("colors").and_then(parse_terminal_colors);
-                self.log_frame(
-                    id,
-                    format_args!(
-                        "resized cols={cols} rows={rows} bytes={}",
-                        replay.as_ref().map(|bytes| bytes.len()).unwrap_or(0)
-                    ),
-                );
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     if surface
                         .apply_stream_resize_with_colors(
@@ -2353,6 +2601,9 @@ impl RemoteSession {
             }
             Some("colors-changed") => {
                 let Some(id) = surface_id() else { return };
+                if self.pipe_io_owns_surface(id) {
+                    return;
+                }
                 let Some(colors) = parse_terminal_colors(&value) else { return };
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     let mut term = surface.term.lock().unwrap();
@@ -2395,6 +2646,11 @@ impl RemoteSession {
             }
             Some("detached") => {
                 if let Some(id) = surface_id() {
+                    // A server-side stream detach (e.g. backpressure
+                    // overflow) ends the byte feed without ending the
+                    // terminal. The relay reports a lost connection so its
+                    // embedder respawns and resyncs from a fresh replay.
+                    self.pipe_io_forward(id, || PipeIoEvent::TransportLost);
                     self.surfaces.lock().unwrap().remove(&id);
                     self.emit(MuxEvent::SurfaceOutput(id));
                 }
@@ -2444,6 +2700,7 @@ impl RemoteSession {
             }
             Some("surface-exited") => {
                 if let Some(id) = surface_id() {
+                    self.pipe_io_forward(id, || PipeIoEvent::SurfaceExited);
                     // Retire the mirror immediately. The authoritative tree
                     // refresh may lag this event, but input and reattach must
                     // already fail closed for a known-exited surface.
@@ -2696,6 +2953,12 @@ impl RemoteSession {
         mut cmd: Value,
         deadline: RequestDeadline,
     ) -> anyhow::Result<Value> {
+        // A shared deadline must cover enqueueing, the ordered write, and the
+        // response wait. Check it before creating a pending request so an
+        // expired reconnect probe cannot add work to the relay.
+        if let Err(error) = deadline.remaining() {
+            return Err(error.into());
+        }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let progress = Arc::new(AtomicU64::new(0));
         let attach_progress = matches!(deadline, RequestDeadline::Attach)
@@ -2723,7 +2986,14 @@ impl RemoteSession {
                 return Err(RemoteRequestError::Transport(error).into());
             }
         };
-        if let Err(error) = self.wait_for_ordered_write(sequence) {
+        let write_timeout = match deadline.remaining() {
+            Ok(timeout) => timeout,
+            Err(error) => {
+                self.pending.lock().unwrap().remove(&id);
+                return Err(error.into());
+            }
+        };
+        if let Err(error) = self.wait_for_ordered_write_with_timeout(sequence, write_timeout) {
             self.pending.lock().unwrap().remove(&id);
             return Err(RemoteRequestError::Transport(error).into());
         }
@@ -2767,12 +3037,10 @@ impl RemoteSession {
         progress: Arc<AtomicU64>,
         attach_progress: Option<u64>,
     ) -> Result<Value, RemoteRequestError> {
-        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) = deadline {
-            let timeout = match deadline {
-                RequestDeadline::Standard => REMOTE_REQUEST_TIMEOUT,
-                RequestDeadline::Fixed(timeout) => timeout,
-                RequestDeadline::Attach => unreachable!(),
-            };
+        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) | RequestDeadline::Until(_) =
+            deadline
+        {
+            let timeout = deadline.remaining().map_err(|_| RemoteRequestError::Timeout)?;
             return match rx.recv_timeout(timeout) {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
@@ -2864,6 +3132,32 @@ impl RemoteSession {
     pub fn send_bytes(&self, surface: SurfaceId, bytes: &[u8]) -> anyhow::Result<()> {
         let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
         self.request_no_wait(json!({"cmd": "send", "surface": surface, "bytes": encoded}))
+    }
+
+    /// Claims exclusive terminal geometry for a renderer-less pipe-IO
+    /// attachment. This mirrors `Session::claim_terminal_geometry` without
+    /// requiring a local `RemoteSurface` mirror.
+    pub(crate) fn claim_terminal_geometry(&self, surface: SurfaceId) -> anyhow::Result<()> {
+        self.request(json!({
+            "cmd": "set-client-sizing",
+            "surface": surface,
+            "enabled": true,
+            "exclusive": true,
+        }))
+        .map(|_| ())
+    }
+
+    /// Enqueues a geometry claim without waiting for its acknowledgement.
+    /// Claims only establish ownership; input and resize requests already use
+    /// the same ordered writer, so a fire-and-forget claim cannot overtake the
+    /// keystroke that follows it.
+    pub(crate) fn notify_claim_terminal_geometry(&self, surface: SurfaceId) -> anyhow::Result<()> {
+        self.notify(json!({
+            "cmd": "set-client-sizing",
+            "surface": surface,
+            "enabled": true,
+            "exclusive": true,
+        }))
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -2962,7 +3256,15 @@ impl RemoteSession {
     }
 
     fn wait_for_ordered_write(&self, sequence: u64) -> io::Result<()> {
-        match self.interactive_writer.wait_until_written(sequence, remote_write_timeout()) {
+        self.wait_for_ordered_write_with_timeout(sequence, remote_write_timeout())
+    }
+
+    fn wait_for_ordered_write_with_timeout(
+        &self,
+        sequence: u64,
+        timeout: Duration,
+    ) -> io::Result<()> {
+        match self.interactive_writer.wait_until_written(sequence, timeout) {
             Ok(()) => Ok(()),
             Err(error) => {
                 if error.kind() == io::ErrorKind::TimedOut {
@@ -2986,8 +3288,121 @@ impl RemoteSession {
             };
         }
         drop(state);
+        // Signal the pipe-io relay before shutdown waits on any in-flight
+        // writer. The lifecycle channel is separate from the bounded byte
+        // queue, so this wake cannot be dropped behind queued output.
+        self.signal_pipe_io_event(None, None, PipeIoEvent::TransportLost);
         self.begin_shutdown();
         self.interactive_writer.close();
+    }
+
+    /// Routes one scoped surface's raw byte stream to a `--pipe-io` relay.
+    /// Install before `attach-surface` so the initial replay is not missed.
+    pub(crate) fn install_pipe_io_tap(
+        &self,
+        surface: SurfaceId,
+        sender: EventSender<PipeIoEvent>,
+        lifecycle_sender: EventSender<PipeIoEvent>,
+        byte_budget: Arc<PipeIoByteBudget>,
+    ) -> Arc<u8> {
+        // A non-zero-sized allocation gives each tap a stable identity. A
+        // zero-sized Arc token could share the allocator's dangling pointer.
+        let token = Arc::new(0u8);
+        *self.pipe_io_tap.lock().unwrap() = Some(PipeIoTap {
+            surface,
+            sender,
+            lifecycle_sender,
+            byte_budget,
+            token: token.clone(),
+        });
+        token
+    }
+
+    pub(crate) fn clear_pipe_io_tap(&self, token: &Arc<u8>) {
+        let mut slot = self.pipe_io_tap.lock().unwrap();
+        if slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token)) {
+            slot.take();
+        }
+    }
+
+    fn signal_pipe_io_event(
+        &self,
+        surface: Option<SurfaceId>,
+        token: Option<&Arc<u8>>,
+        event: PipeIoEvent,
+    ) -> bool {
+        let tap = {
+            let mut slot = self.pipe_io_tap.lock().unwrap();
+            if (surface.is_none() || slot.as_ref().is_some_and(|tap| Some(tap.surface) == surface))
+                && token.is_none_or(|token| {
+                    slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token))
+                })
+            {
+                slot.take()
+            } else {
+                None
+            }
+        };
+        if let Some(tap) = tap {
+            // A second lifecycle event is redundant. If the one-slot signal
+            // channel is already occupied, the first event remains the
+            // authoritative reason and still wakes the relay.
+            let _ = tap.lifecycle_sender.try_send(event);
+            true
+        } else {
+            false
+        }
+    }
+
+    /// Returns true while this connection has a raw pipe-IO tap for
+    /// `surface`. The event reader uses this fence to avoid feeding the same
+    /// bytes into the normal local mirror parser as well as the relay.
+    fn pipe_io_owns_surface(&self, surface: SurfaceId) -> bool {
+        self.pipe_io_tap.lock().unwrap().as_ref().is_some_and(|tap| tap.surface == surface)
+    }
+
+    /// Forwards one tap event, treating a full or dropped queue as a lost
+    /// transport: the relay's reader stalled, and silently dropping bytes
+    /// would corrupt the embedder's terminal state (bounded-backpressure
+    /// policy; never wedge the session reader thread).
+    fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
+        use crossbeam_channel::TrySendError;
+        let event = event();
+        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
+            return self.signal_pipe_io_event(Some(surface), None, event);
+        }
+        let (stalled_token, pipe_io_owned) = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return false };
+            if tap.surface != surface {
+                return false;
+            }
+            let retained_bytes = event.retained_bytes();
+            if !tap.byte_budget.try_reserve(retained_bytes) {
+                (Some(tap.token.clone()), true)
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => (None, true),
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        tap.byte_budget.release(retained_bytes);
+                        (Some(tap.token.clone()), true)
+                    }
+                }
+            }
+        };
+        if let Some(token) = stalled_token {
+            // Signal only the tap that observed the stall. A replacement tap
+            // may have been installed while this reader thread released the
+            // mutex; it must not be torn down by an older relay.
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
+        }
+        // Capture ownership while holding the tap lock. A concurrent relay
+        // teardown can remove the tap before the caller reaches its parser
+        // fence; returning this snapshot prevents one raw event from being
+        // parsed twice during that handoff.
+        pipe_io_owned
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -3223,6 +3638,114 @@ impl RemoteSession {
         })
     }
 
+    /// Registers one renderer-less attachment for a pipe-IO relay. The
+    /// normal `try_ensure_surface` path creates a local `RemoteSurface` and
+    /// parses every VT event. A raw relay must only register the server stream
+    /// and preserve those bytes for the embedder's parser.
+    pub(crate) fn try_attach_pipe_io(
+        &self,
+        id: SurfaceId,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<PipeIoSurfaceAttach> {
+        if self.retired_surfaces.lock().unwrap().contains(&id) {
+            return Ok(PipeIoSurfaceAttach::Retired);
+        }
+        if !self.can_attach_after_overflow(id) {
+            return Ok(PipeIoSurfaceAttach::Deferred);
+        }
+        let initial_size = size.map(|(cols, rows)| (cols.max(1), rows.max(1))).filter(|_| {
+            self.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY)
+        });
+        let mut request = json!({"cmd": "attach-surface", "surface": id, "mode": "bytes"});
+        if let Some((cols, rows)) = initial_size {
+            request["cols"] = json!(cols);
+            request["rows"] = json!(rows);
+        }
+        let response = match self.request_with_deadline(request, RequestDeadline::Attach) {
+            Ok(response) => response,
+            Err(error) => {
+                if error
+                    .downcast_ref::<RemoteRequestError>()
+                    .is_some_and(RemoteRequestError::is_timeout)
+                {
+                    // The server registers the stream before it queues the
+                    // attach response. Closing the connection is the only
+                    // protocol cancellation that guarantees cleanup.
+                    self.disconnect_transport();
+                }
+                return Err(error);
+            }
+        };
+        let attachment_lease = if self.supports_capability(VIEW_ATTACHMENT_LEASE_CAPABILITY) {
+            let Some(lease) = response.get("lease").and_then(Value::as_str) else {
+                self.disconnect_transport();
+                anyhow::bail!(
+                    "server advertised {VIEW_ATTACHMENT_LEASE_CAPABILITY} but pipe-IO attach returned no lease"
+                );
+            };
+            Some(lease.to_string())
+        } else {
+            None
+        };
+        // Retirement can race the attach response. Do not start a relay for
+        // a terminal that already emitted `surface-exited`; closing this
+        // connection releases the server-side pending stream.
+        if self.retired_surfaces.lock().unwrap().contains(&id) {
+            self.disconnect_transport();
+            return Ok(PipeIoSurfaceAttach::Retired);
+        }
+        if let Some(lease) = attachment_lease {
+            self.surface_leases.lock().unwrap().insert(id, lease);
+        }
+        // Mark a successful raw attachment as stable for the same overflow
+        // recovery budget used by the normal mirror path. Without this
+        // commit, every reconnect would remain in the pre-stability window
+        // and consume another backoff slot forever.
+        if let Some(recovery) = self.surface_overflow_recovery.lock().unwrap().get_mut(&id) {
+            recovery.attached_at = Some(Instant::now());
+            recovery.retry_after = None;
+        }
+        Ok(PipeIoSurfaceAttach::Attached)
+    }
+
+    /// Sends a resize for a renderer-less attachment. There is no local
+    /// `RemoteSurface` to hold a reported size, so every accepted sample is
+    /// sent; the Swift pump already coalesces samples and bounds traffic.
+    pub(crate) fn resize_pipe_io(
+        &self,
+        surface: SurfaceId,
+        cols: u16,
+        rows: u16,
+    ) -> anyhow::Result<bool> {
+        let desired = (cols.max(1), rows.max(1));
+        let mut request = json!({
+            "cmd": "resize-surface",
+            "surface": surface,
+            "cols": desired.0,
+            "rows": desired.1,
+        });
+        if self.supports_capability(VIEW_ATTACHMENT_LEASE_CAPABILITY) {
+            let Some(lease) = self.attachment_lease(surface) else {
+                anyhow::bail!("pipe-IO attachment lease is no longer active");
+            };
+            request = json!({
+                "cmd": "resize-attached-view",
+                "surface": surface,
+                "lease": lease,
+                "cols": desired.0,
+                "rows": desired.1,
+            });
+        }
+        let response = self.request(request)?;
+        match response.get("outcome").and_then(Value::as_str) {
+            Some("superseded") | Some("passive") => Ok(false),
+            Some("applied") | None => {
+                Ok(response.get("accepted").and_then(Value::as_bool).unwrap_or(true))
+            }
+            Some(other) => anyhow::bail!("unknown pipe-IO resize outcome {other}"),
+        }
+    }
+
     /// Mirror for a surface, attaching on first use. Servers advertising
     /// initial attach sizing receive the first viewer claim atomically with
     /// the attach, so the initial replay already has its final geometry.
@@ -3449,12 +3972,37 @@ impl RemoteSession {
         self.refresh_tree_inner(true)
     }
 
+    /// Refresh the workspace tree with a bounded request deadline. Used by
+    /// reconnect classification, where a stale daemon must not hold the relay.
+    pub fn refresh_tree_with_timeout(&self, timeout: Duration) -> anyhow::Result<TreeView> {
+        self.refresh_tree_until(Instant::now() + timeout)
+    }
+
+    pub(crate) fn refresh_tree_until(&self, deadline: Instant) -> anyhow::Result<TreeView> {
+        self.refresh_tree_inner_with_deadline(true, RequestDeadline::Until(deadline))
+    }
+
     pub fn refresh_tree_background(&self) -> anyhow::Result<TreeView> {
         self.refresh_tree_inner(false)
     }
 
     fn refresh_tree_inner(&self, identity_refresh: bool) -> anyhow::Result<TreeView> {
-        let _refresh = self.tree_refresh.lock().unwrap();
+        self.refresh_tree_inner_with_deadline(identity_refresh, RequestDeadline::Standard)
+    }
+
+    fn refresh_tree_inner_with_deadline(
+        &self,
+        identity_refresh: bool,
+        deadline: RequestDeadline,
+    ) -> anyhow::Result<TreeView> {
+        let refresh_timeout = match deadline {
+            RequestDeadline::Standard => REMOTE_REQUEST_TIMEOUT,
+            RequestDeadline::Attach => remote_write_timeout(),
+            RequestDeadline::Fixed(timeout) => timeout,
+            RequestDeadline::Until(deadline) => deadline.saturating_duration_since(Instant::now()),
+        };
+        let _refresh =
+            self.tree_refresh.try_lock_for(refresh_timeout).ok_or(RemoteRequestError::Timeout)?;
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
         }
@@ -3462,7 +4010,7 @@ impl RemoteSession {
             let cache = self.tree.lock().unwrap();
             (cache.title_generation(), cache.agent_generation())
         };
-        let data = match self.request(json!({"cmd": "list-workspaces"})) {
+        let data = match self.request_with_deadline(json!({"cmd": "list-workspaces"}), deadline) {
             Ok(data) => data,
             Err(e) => {
                 if identity_refresh {
@@ -3473,7 +4021,7 @@ impl RemoteSession {
             }
         };
         let agents = self
-            .request(json!({"cmd": "list-agents"}))
+            .request_with_deadline(json!({"cmd": "list-agents"}), deadline)
             .ok()
             .and_then(|data| {
                 data.get("agents")
@@ -3913,7 +4461,7 @@ fn test_session_with_writer(
         retire_surface_test_marker: Mutex::new(None),
         tree: Mutex::new(RemoteTreeCache::default()),
         browser_sources: Mutex::new(HashMap::new()),
-        tree_refresh: Mutex::new(()),
+        tree_refresh: ParkingMutex::new(()),
         tree_stale: AtomicBool::new(true),
         subscription_started: AtomicBool::new(false),
         event_surface_filter: AtomicU64::new(0),
@@ -3929,6 +4477,7 @@ fn test_session_with_writer(
         capabilities: Mutex::new(capabilities),
         provider_workspace_authority,
         provider_workspaces_guarded: AtomicBool::new(false),
+        pipe_io_tap: Mutex::new(None),
     })
 }
 
@@ -5155,7 +5704,7 @@ mod tests {
             retire_surface_test_marker: Mutex::new(None),
             tree: Mutex::new(RemoteTreeCache::default()),
             browser_sources: Mutex::new(HashMap::new()),
-            tree_refresh: Mutex::new(()),
+            tree_refresh: ParkingMutex::new(()),
             tree_stale: AtomicBool::new(true),
             subscription_started: AtomicBool::new(false),
             event_surface_filter: AtomicU64::new(0),
@@ -5171,6 +5720,7 @@ mod tests {
             capabilities: Mutex::new(capabilities),
             provider_workspace_authority,
             provider_workspaces_guarded: AtomicBool::new(false),
+            pipe_io_tap: Mutex::new(None),
         })
     }
 
@@ -6331,6 +6881,71 @@ mod tests {
     }
 
     #[test]
+    fn full_pipe_io_queue_signals_loss_on_the_reserved_lifecycle_channel() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"first".to_vec()));
+        // The byte queue is full. The second event must force a transport
+        // loss, and that lifecycle signal must remain observable even though
+        // no byte-queue slot is available.
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"second".to_vec()));
+
+        assert_eq!(
+            lifecycle_receiver.recv_timeout(Duration::from_secs(1)).unwrap(),
+            PipeIoEvent::TransportLost
+        );
+        assert!(session.pipe_io_tap.lock().unwrap().is_none());
+        assert!(session.shutdown.load(Ordering::Acquire));
+        assert_eq!(receiver.try_recv().unwrap(), PipeIoEvent::Output(b"first".to_vec()));
+    }
+
+    #[test]
+    fn stale_pipe_io_tap_cleanup_cannot_remove_a_replacement() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (first_sender, _first_receiver) = crossbeam_channel::bounded(1);
+        let (first_lifecycle_sender, _first_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let first_token = session.install_pipe_io_tap(
+            7,
+            first_sender,
+            first_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        let (second_sender, second_receiver) = crossbeam_channel::bounded(1);
+        let (second_lifecycle_sender, _second_lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let second_token = session.install_pipe_io_tap(
+            7,
+            second_sender,
+            second_lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.clear_pipe_io_tap(&first_token);
+        session.pipe_io_forward(7, || PipeIoEvent::Output(b"replacement".to_vec()));
+
+        assert!(Arc::ptr_eq(
+            &session.pipe_io_tap.lock().unwrap().as_ref().unwrap().token,
+            &second_token
+        ));
+        assert_eq!(
+            second_receiver.try_recv().unwrap(),
+            PipeIoEvent::Output(b"replacement".to_vec())
+        );
+    }
+
+    #[test]
     fn transport_disconnect_reason_is_first_writer_wins() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),
@@ -6894,6 +7509,103 @@ mod tests {
         assert!(session.pending.lock().unwrap().is_empty());
         assert!(session.shutdown.load(Ordering::Acquire));
         assert!(closed.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn bounded_tree_refresh_times_out_and_clears_pending_probe() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let started = Instant::now();
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a silent probe unexpectedly completed"),
+        };
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms probe deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_does_not_wait_for_another_refresh_lock() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let _refresh = session.tree_refresh.lock();
+        let started = Instant::now();
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a contended refresh lock unexpectedly completed"),
+        };
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms lock deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn standard_tree_refresh_does_not_wait_indefinitely_for_another_refresh_lock() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let _refresh = session.tree_refresh.lock();
+        let started = Instant::now();
+        let error = match session.refresh_tree() {
+            Err(error) => error,
+            Ok(_) => panic!("a contended refresh lock unexpectedly completed"),
+        };
+
+        assert!(matches!(
+            error.downcast_ref::<RemoteRequestError>(),
+            Some(RemoteRequestError::Timeout)
+        ));
+        assert!(
+            started.elapsed() < REMOTE_REQUEST_TIMEOUT + Duration::from_millis(100),
+            "refresh lock deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
+    fn bounded_tree_refresh_aborts_a_blocked_ordered_write() {
+        let (stream, control) = BlockingWriteStream::new();
+        let session = blocking_test_session(stream);
+        session.send_bytes(7, b"blocked").unwrap();
+        control.wait_until_entered();
+
+        let started = Instant::now();
+        let error = match session.refresh_tree_with_timeout(Duration::from_millis(5)) {
+            Err(error) => error,
+            Ok(_) => panic!("a blocked probe write unexpectedly completed"),
+        };
+
+        assert!(error.downcast_ref::<RemoteRequestError>().is_some_and(|error| {
+            matches!(error, RemoteRequestError::Transport(io_error)
+                if io_error.kind() == io::ErrorKind::TimedOut)
+        }));
+        assert!(
+            started.elapsed() < Duration::from_millis(100),
+            "5ms write deadline was exceeded by {:?}",
+            started.elapsed()
+        );
+        assert!(control.state.0.lock().unwrap().aborted);
+        assert!(session.pending.lock().unwrap().is_empty());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -9598,6 +9598,33 @@ mod tests {
     }
 
     #[test]
+    fn bounded_ordered_wait_does_not_block_on_contended_state_mutex() {
+        let session = test_session(Box::new(SilentWriter));
+        let queue_guard = session.interactive_writer.shared.state.lock();
+        let (wait_started_rx, resume_wait_tx) =
+            session.interactive_writer.gate_next_wait_until_written();
+        let waiting_session = session.clone();
+        let (finished_tx, finished_rx) = channel();
+        let deadline = Instant::now() + Duration::from_millis(50);
+        let waiter = std::thread::spawn(move || {
+            finished_tx
+                .send(waiting_session.interactive_writer.wait_until_written_until(1, deadline))
+                .unwrap();
+        });
+
+        wait_started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        resume_wait_tx.send(()).unwrap();
+        let result = finished_rx.recv_timeout(Duration::from_millis(200));
+        drop(queue_guard);
+        waiter.join().unwrap();
+
+        let error = result
+            .expect("deadline-bounded ordered wait blocked on the state mutex")
+            .expect_err("an unwritten sequence unexpectedly completed");
+        assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    }
+
+    #[test]
     fn fixed_request_deadline_caps_queue_write_and_response_wait() {
         let (stream, control) = BlockingWriteStream::new();
         let session = blocking_test_session(stream);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8550,6 +8550,36 @@ mod tests {
     }
 
     #[test]
+    fn bounded_request_rejects_a_contended_writer_queue_without_waiting() {
+        let session = test_session(Box::new(SilentWriter));
+        let queue_guard = session.interactive_writer.shared.state.lock().unwrap();
+        let request_session = session.clone();
+        let (finished_tx, finished_rx) = channel();
+        let deadline = Instant::now() + Duration::from_millis(20);
+        let request = std::thread::spawn(move || {
+            finished_tx
+                .send(request_session.request_with_deadline(
+                    json!({"cmd": "bounded-probe"}),
+                    RequestDeadline::Until(deadline),
+                ))
+                .unwrap();
+        });
+
+        let result_while_contended = finished_rx.recv_timeout(Duration::from_millis(50));
+        drop(queue_guard);
+        request.join().unwrap();
+        let result = result_while_contended
+            .expect("deadline-bounded request waited for the interactive queue mutex");
+        assert!(result.is_err(), "contended request unexpectedly received a response");
+        let error = result.unwrap_err();
+        assert!(error.downcast_ref::<RemoteRequestError>().is_some_and(|error| {
+            matches!(error, RemoteRequestError::Transport(io_error)
+                if io_error.kind() == io::ErrorKind::WouldBlock)
+        }));
+        assert!(session.pending.lock().unwrap().is_empty());
+    }
+
+    #[test]
     fn latency_histogram_reports_fixed_bucket_percentiles() {
         let metrics = InteractiveWriteMetrics::default();
         for latency in [

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2650,7 +2650,7 @@ impl RemoteSession {
                     // overflow) ends the byte feed without ending the
                     // terminal. The relay reports a lost connection so its
                     // embedder respawns and resyncs from a fresh replay.
-                    self.pipe_io_forward(id, || PipeIoEvent::TransportLost);
+                    self.signal_pipe_io_event(Some(id), None, PipeIoEvent::TransportLost);
                     self.surfaces.lock().unwrap().remove(&id);
                     self.emit(MuxEvent::SurfaceOutput(id));
                 }
@@ -2700,7 +2700,7 @@ impl RemoteSession {
             }
             Some("surface-exited") => {
                 if let Some(id) = surface_id() {
-                    self.pipe_io_forward(id, || PipeIoEvent::SurfaceExited);
+                    self.signal_pipe_io_event(Some(id), None, PipeIoEvent::SurfaceExited);
                     // Retire the mirror immediately. The authoritative tree
                     // refresh may lag this event, but input and reattach must
                     // already fail closed for a known-exited surface.
@@ -3367,16 +3367,16 @@ impl RemoteSession {
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
         use crossbeam_channel::TrySendError;
-        let event = event();
-        if matches!(&event, PipeIoEvent::SurfaceExited | PipeIoEvent::TransportLost) {
-            return self.signal_pipe_io_event(Some(surface), None, event);
-        }
         let (stalled_token, pipe_io_owned) = {
             let tap = self.pipe_io_tap.lock().unwrap();
             let Some(tap) = tap.as_ref() else { return false };
             if tap.surface != surface {
                 return false;
             }
+            // Resolve ownership before invoking the closure. Output and
+            // replay call sites capture a payload clone in the closure, and
+            // sessions without a matching tap must not pay that allocation.
+            let event = event();
             let retained_bytes = event.retained_bytes();
             if !tap.byte_budget.try_reserve(retained_bytes) {
                 (Some(tap.token.clone()), true)

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1454,11 +1454,19 @@ struct InteractiveWriterShared {
     metrics: InteractiveWriteMetrics,
     #[cfg(test)]
     wait_until_written_gate: Mutex<Option<InteractiveWaitUntilWrittenGate>>,
+    #[cfg(test)]
+    enqueue_until_gate: Mutex<Option<InteractiveEnqueueUntilGate>>,
 }
 
 #[cfg(test)]
 struct InteractiveWaitUntilWrittenGate {
     entered: Sender<u64>,
+    resume: Receiver<()>,
+}
+
+#[cfg(test)]
+struct InteractiveEnqueueUntilGate {
+    entered: Sender<()>,
     resume: Receiver<()>,
 }
 
@@ -1480,6 +1488,8 @@ impl InteractiveWriter {
             metrics: InteractiveWriteMetrics::default(),
             #[cfg(test)]
             wait_until_written_gate: Mutex::new(None),
+            #[cfg(test)]
+            enqueue_until_gate: Mutex::new(None),
         });
         let worker_shared = shared.clone();
         std::thread::Builder::new()
@@ -1580,6 +1590,8 @@ impl InteractiveWriter {
             state.queued_bytes += message_bytes;
             write.sequence = sequence;
             state.writes.push_back(write);
+            #[cfg(test)]
+            self.await_enqueue_until_gate();
             drop(state);
             self.shared.changed.notify_one();
             return Ok(sequence);
@@ -1670,6 +1682,29 @@ impl InteractiveWriter {
         let gate = self.shared.wait_until_written_gate.lock().unwrap().take();
         if let Some(gate) = gate {
             gate.entered.send(sequence).unwrap();
+            gate.resume.recv().unwrap();
+        }
+    }
+
+    #[cfg(test)]
+    fn gate_next_enqueue_until(&self) -> (Receiver<()>, Sender<()>) {
+        let (entered_tx, entered_rx) = channel();
+        let (resume_tx, resume_rx) = channel();
+        let previous = self
+            .shared
+            .enqueue_until_gate
+            .lock()
+            .unwrap()
+            .replace(InteractiveEnqueueUntilGate { entered: entered_tx, resume: resume_rx });
+        assert!(previous.is_none(), "interactive enqueue gate was already installed");
+        (entered_rx, resume_tx)
+    }
+
+    #[cfg(test)]
+    fn await_enqueue_until_gate(&self) {
+        let gate = self.shared.enqueue_until_gate.lock().unwrap().take();
+        if let Some(gate) = gate {
+            gate.entered.send(()).unwrap();
             gate.resume.recv().unwrap();
         }
     }
@@ -6654,6 +6689,8 @@ mod tests {
         entered: bool,
         aborted: bool,
         fail_on_release: bool,
+        completed_writes: usize,
+        reblock_after_send: bool,
     }
 
     #[derive(Clone)]
@@ -6675,10 +6712,40 @@ mod tests {
             }
         }
 
+        fn wait_until_completed(&self, count: usize) {
+            let deadline = Instant::now() + Duration::from_secs(1);
+            let (state, changed) = &*self.state;
+            let mut state = state.lock().unwrap();
+            while state.completed_writes < count {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                assert!(
+                    !remaining.is_zero(),
+                    "interactive writer did not complete the test stream write"
+                );
+                let (next, timeout) = changed.wait_timeout(state, remaining).unwrap();
+                state = next;
+                assert!(!timeout.timed_out() || state.completed_writes >= count);
+            }
+        }
+
+        fn completed_writes(&self) -> usize {
+            self.state.0.lock().unwrap().completed_writes
+        }
+
+        fn release_one(&self) {
+            let (state, changed) = &*self.state;
+            let mut state = state.lock().unwrap();
+            state.blocked = false;
+            state.reblock_after_send = true;
+            drop(state);
+            changed.notify_all();
+        }
+
         fn release(&self) {
             let (state, changed) = &*self.state;
             let mut state = state.lock().unwrap();
             state.blocked = false;
+            state.reblock_after_send = false;
             drop(state);
             changed.notify_all();
         }
@@ -6708,6 +6775,8 @@ mod tests {
                         entered: false,
                         aborted: false,
                         fail_on_release: false,
+                        completed_writes: 0,
+                        reblock_after_send: false,
                     }),
                     Condvar::new(),
                 )),
@@ -6731,10 +6800,19 @@ mod tests {
             if state.fail_on_release {
                 return Err(io::Error::new(io::ErrorKind::BrokenPipe, "scripted write failure"));
             }
+            if state.reblock_after_send {
+                state.blocked = true;
+                state.reblock_after_send = false;
+            }
             drop(state);
             let mut output = self.output.lock().unwrap();
             output.extend_from_slice(message.as_bytes());
             output.push(b'\n');
+            let (state, changed) = &*self.control.state;
+            let mut state = state.lock().unwrap();
+            state.completed_writes += 1;
+            drop(state);
+            changed.notify_all();
             Ok(())
         }
 
@@ -9647,6 +9725,62 @@ mod tests {
             .expect("deadline-bounded ordered wait blocked on the state mutex")
             .expect_err("an unwritten sequence unexpectedly completed");
         assert_eq!(error.kind(), io::ErrorKind::TimedOut);
+    }
+
+    #[test]
+    fn timed_out_control_request_is_not_sent_after_queue_release() {
+        let (stream, control) = BlockingWriteStream::new();
+        let output = stream.output.clone();
+        let session = blocking_test_session(stream);
+        session.send_bytes(7, b"first").unwrap();
+        control.wait_until_entered();
+
+        // Pause immediately after enqueue so the request's write deadline
+        // expires while its sequence is still queued behind the blocked input.
+        let (enqueue_started_rx, resume_enqueue_tx) =
+            session.interactive_writer.gate_next_enqueue_until();
+        let request_session = session.clone();
+        let (finished_tx, finished_rx) = channel();
+        let timeout = Duration::from_millis(50);
+        let request = std::thread::spawn(move || {
+            finished_tx
+                .send(request_session.request_with_deadline(
+                    json!({"cmd": "stale-control"}),
+                    RequestDeadline::Fixed(timeout),
+                ))
+                .unwrap();
+        });
+
+        enqueue_started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        std::thread::sleep(timeout + Duration::from_millis(20));
+        resume_enqueue_tx.send(()).unwrap();
+
+        let result = finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(matches!(
+            result.as_ref().err().and_then(|error| error.downcast_ref::<RemoteRequestError>()),
+            Some(RemoteRequestError::Timeout)
+        ));
+        request.join().unwrap();
+
+        // Release only the already accepted input. The test writer re-blocks
+        // before a second send, which makes a stale queued control observable
+        // without racing the first write's completion.
+        control.release_one();
+        control.wait_until_completed(1);
+        control.release();
+        let settle_deadline = Instant::now() + Duration::from_millis(200);
+        while control.completed_writes() < 2 && Instant::now() < settle_deadline {
+            std::thread::yield_now();
+        }
+        assert_eq!(
+            control.completed_writes(),
+            1,
+            "timed-out control request was sent after the queue was released"
+        );
+        let output = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        assert!(output.contains("\"bytes\":\"Zmlyc3Q=\""));
+        assert!(!output.contains("stale-control"));
+        drop(session);
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8,7 +8,7 @@ use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
-use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
+use std::sync::{Arc, Condvar, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
@@ -3462,6 +3462,7 @@ impl RemoteSession {
     /// transport: the relay's reader stalled, and silently dropping bytes
     /// would corrupt the embedder's terminal state (bounded-backpressure
     /// policy; never wedge the session reader thread).
+    #[cfg(test)]
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
         use crossbeam_channel::TrySendError;
         let stalled_token = {
@@ -4784,7 +4785,7 @@ fn test_session_with_deferred_attach_control(
     capabilities: HashSet<String>,
 ) -> (Arc<RemoteSession>, Receiver<()>, Sender<()>) {
     let session_slot = Arc::new(Mutex::new(None));
-    let (attach_started_tx, attach_started_rx) = std::sync::mpsc::sync_channel(1);
+    let (attach_started_tx, attach_started_rx) = sync_channel(1);
     let (release_attach_tx, release_attach_rx) = channel();
     let session = test_session_with_writer(
         Box::new(DeferredAttachTestWriter {
@@ -4809,7 +4810,7 @@ fn test_session_with_deferred_attach_control(
 fn test_session_with_deferred_leased_attach()
 -> (Arc<RemoteSession>, Receiver<()>, Sender<()>, Receiver<Value>) {
     let session_slot = Arc::new(Mutex::new(None));
-    let (attach_started_tx, attach_started_rx) = std::sync::mpsc::sync_channel(1);
+    let (attach_started_tx, attach_started_rx) = sync_channel(1);
     let (release_attach_tx, release_attach_rx) = channel();
     let (request_tx, request_rx) = channel();
     let session = test_session_with_writer(
@@ -4844,7 +4845,7 @@ pub(super) struct DeferredAttachResizeFailureFixture {
 #[cfg(test)]
 pub(super) fn test_session_with_deferred_attach_and_first_resize_failure()
 -> DeferredAttachResizeFailureFixture {
-    let (resize_started_tx, resize_started_rx) = std::sync::mpsc::sync_channel(1);
+    let (resize_started_tx, resize_started_rx) = sync_channel(1);
     let (release_resize_tx, release_resize_rx) = channel();
     let (session, attach_started, release_attach) = test_session_with_deferred_attach_control(
         Some((resize_started_tx, release_resize_rx)),
@@ -5130,10 +5131,10 @@ mod tests {
 
     #[test]
     fn pipe_io_initial_size_requires_atomic_attach_capability() {
-        let without = test_session_with_provider_context(None, HashSet::new());
+        let without = super::test_session_with_provider_context(None, HashSet::new());
         assert!(!without.supports_pipe_io_initial_size());
 
-        let with = test_session_with_provider_context(
+        let with = super::test_session_with_provider_context(
             None,
             HashSet::from([cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY.to_string()]),
         );

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2302,6 +2302,12 @@ impl RemoteSession {
         self.capabilities.lock().unwrap().contains(capability)
     }
 
+    /// Pipe-IO requires the daemon's attach-time geometry handshake so the
+    /// initial replay is rendered for the embedder's requested dimensions.
+    pub(crate) fn supports_pipe_io_initial_size(&self) -> bool {
+        self.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY)
+    }
+
     pub fn supports_surface_subscription_filter(&self) -> bool {
         self.supports_capability(cmux_tui_core::server::SURFACE_SUBSCRIBE_FILTER_CAPABILITY)
     }
@@ -5056,6 +5062,18 @@ mod tests {
         }));
         require_capability(&with_key_fallback, CLEAR_HISTORY_KEY_CAPABILITY, "clear-history")
             .unwrap();
+    }
+
+    #[test]
+    fn pipe_io_initial_size_requires_atomic_attach_capability() {
+        let without = test_session_with_provider_context(None, HashSet::new());
+        assert!(!without.supports_pipe_io_initial_size());
+
+        let with = test_session_with_provider_context(
+            None,
+            HashSet::from([cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY.to_string()]),
+        );
+        assert!(with.supports_pipe_io_initial_size());
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2372,11 +2372,7 @@ impl RemoteSession {
             let socket = socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::STREAM, None)?;
             socket.connect_timeout(&address, timeout)?;
             let stream: std::os::unix::net::UnixStream = socket.into();
-            return Self::connect_stream_with_subscription_until(
-                Box::new(stream),
-                subscribe,
-                deadline,
-            );
+            Self::connect_stream_with_subscription_until(Box::new(stream), subscribe, deadline)
         }
 
         #[cfg(windows)]
@@ -2387,7 +2383,7 @@ impl RemoteSession {
             let stream = transport::connect(path).map_err(|error| {
                 anyhow::anyhow!("cannot connect to session socket {}: {error}", path.display())
             })?;
-            return Self::connect_stream_with_subscription_until(stream, subscribe, deadline);
+            Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
         }
 
         #[cfg(not(any(unix, windows)))]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7072,6 +7072,22 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_budget_keeps_same_length_oversized_replay_reserved() {
+        let budget = PipeIoByteBudget::new(16);
+        let first = PipeIoEvent::Replay { bytes: vec![b'A'; 16] };
+        let second = PipeIoEvent::Replay { bytes: vec![b'B'; 16] };
+        let third = PipeIoEvent::Replay { bytes: vec![b'C'; 16] };
+
+        assert!(budget.try_reserve_event(&first));
+        assert!(budget.try_reserve_event(&second));
+        budget.release_event(&first);
+        assert!(!budget.try_reserve_event(&third));
+        budget.release_event(&second);
+        assert!(budget.try_reserve_event(&third));
+        budget.release_event(&third);
+    }
+
+    #[test]
     fn pipe_io_forward_does_not_build_payload_without_matching_tap() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1914,6 +1914,10 @@ pub(super) enum RemoteSurfaceAttach {
 pub(crate) enum PipeIoSurfaceAttach {
     Attached,
     Retired,
+    /// The server accepted the stream, but a surface-exit event retired it
+    /// before the attach response completed. The tap may contain committed
+    /// replay or output that the relay must drain before exiting.
+    RetiredAfterAttach,
     Deferred,
 }
 
@@ -3967,8 +3971,13 @@ impl RemoteSession {
         // a terminal that already emitted `surface-exited`; closing this
         // connection releases the server-side pending stream.
         if self.retired_surfaces.lock().unwrap().contains(&id) {
+            // A direct retirement can race this response without the normal
+            // event reader having signalled the tap yet. Publish the terminal
+            // lifecycle event before closing the transport so the relay's
+            // startup drain has a bounded completion signal.
+            self.signal_pipe_io_event(Some(id), None, PipeIoEvent::SurfaceExited);
             self.disconnect_transport();
-            return Ok(PipeIoSurfaceAttach::Retired);
+            return Ok(PipeIoSurfaceAttach::RetiredAfterAttach);
         }
         if let Some(lease) = attachment_lease {
             self.surface_leases.lock().unwrap().insert(id, lease);
@@ -5294,8 +5303,7 @@ mod tests {
 
     #[test]
     fn pipe_io_attach_reports_retirement_after_stream_open() {
-        let (session, attach_started_rx, release_attach_tx) =
-            super::test_session_with_deferred_attach();
+        let (session, attach_started_rx, release_attach_tx) = test_session_with_deferred_attach();
         let (sender, receiver) = crossbeam_channel::bounded(8);
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let _token = session.install_pipe_io_tap(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1802,6 +1802,7 @@ impl PipeIoEvent {
 /// because it is larger than the normal live-output budget.
 struct PipeIoBudgetState {
     retained: usize,
+    live_retained: usize,
     oversized_replay: Option<u64>,
     next_oversized_replay_id: u64,
 }
@@ -1816,6 +1817,7 @@ impl PipeIoByteBudget {
         Self {
             state: Mutex::new(PipeIoBudgetState {
                 retained: 0,
+                live_retained: 0,
                 oversized_replay: None,
                 next_oversized_replay_id: 1,
             }),
@@ -1828,11 +1830,14 @@ impl PipeIoByteBudget {
             return true;
         }
         let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
-        let Some(next) = state.retained.checked_add(bytes) else { return false };
-        if next > self.limit {
+        let Some(next_total) = state.retained.checked_add(bytes) else { return false };
+        let Some(next_live) = state.live_retained.checked_add(bytes) else { return false };
+        let max_total = self.limit.saturating_add(PIPE_IO_REPLAY_SINGLE_FRAME_MAX_BYTES);
+        if next_live > self.limit || next_total > max_total {
             return false;
         }
-        state.retained = next;
+        state.retained = next_total;
+        state.live_retained = next_live;
         true
     }
 
@@ -1878,6 +1883,9 @@ impl PipeIoByteBudget {
         }
         let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
         state.retained = state.retained.saturating_sub(bytes);
+        if matches!(event, PipeIoEvent::Output(_)) {
+            state.live_retained = state.live_retained.saturating_sub(bytes);
+        }
         if let PipeIoEvent::Replay { reservation_id: Some(id), .. } = event
             && state.oversized_replay == Some(*id)
         {
@@ -3554,27 +3562,25 @@ impl RemoteSession {
         token: Option<&Arc<u8>>,
         event: PipeIoEvent,
     ) -> bool {
-        let tap = {
-            let mut slot = self.pipe_io_tap.lock().unwrap();
-            if (surface.is_none() || slot.as_ref().is_some_and(|tap| Some(tap.surface) == surface))
-                && token.is_none_or(|token| {
-                    slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token))
-                })
-            {
-                slot.take()
-            } else {
-                None
-            }
-        };
-        if let Some(tap) = tap {
-            // A second lifecycle event is redundant. If the one-slot signal
-            // channel is already occupied, the first event remains the
-            // authoritative reason and still wakes the relay.
-            let _ = tap.lifecycle_sender.try_send(event);
-            true
-        } else {
-            false
+        let mut slot = self.pipe_io_tap.lock().unwrap();
+        let matches = (surface.is_none()
+            || slot.as_ref().is_some_and(|tap| Some(tap.surface) == surface))
+            && token.is_none_or(|token| {
+                slot.as_ref().is_some_and(|tap| Arc::ptr_eq(&tap.token, token))
+            });
+        let Some(tap) = slot.as_ref() else { return false };
+        if !matches {
+            return false;
         }
+
+        // Publish the lifecycle reason while the tap still owns the byte
+        // sender. The receiver can then observe the structured event before
+        // the byte channel closes when this slot is released.
+        let _ = tap.lifecycle_sender.try_send(event);
+        // A second lifecycle event is redundant. If the one-slot signal
+        // channel is already occupied, the first event remains authoritative.
+        slot.take();
+        true
     }
 
     /// Returns true while this connection has a raw pipe-IO tap for

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8770,6 +8770,19 @@ mod tests {
     }
 
     #[test]
+    fn bounded_admission_rejects_an_expired_deadline_after_lock_acquisition() {
+        let session = test_session(Box::new(SilentWriter));
+        let deadline = Instant::now() - Duration::from_millis(1);
+        let error = session
+            .interactive_writer
+            .enqueue_until(json!({"cmd": "expired-probe"}).to_string(), false, deadline)
+            .expect_err("expired admission unexpectedly entered the writer queue");
+
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
+        assert_eq!(session.interactive_writer.last_enqueued_sequence().unwrap(), None);
+    }
+
+    #[test]
     fn normal_input_waits_through_brief_writer_queue_contention() {
         let session = test_session(Box::new(SilentWriter));
         let queue_guard = session.interactive_writer.shared.state.lock().unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5143,6 +5143,112 @@ mod tests {
         assert!(with.supports_pipe_io_initial_size());
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn legacy_pipe_io_sizes_before_attach() {
+        struct OrderedPipeIoAttachWriter {
+            session: Arc<Mutex<Option<Weak<RemoteSession>>>>,
+            requests: Sender<Value>,
+            release_attach: Option<Receiver<()>>,
+        }
+
+        impl RemoteMessageWriter for OrderedPipeIoAttachWriter {
+            fn send(&mut self, message: &str) -> io::Result<()> {
+                let request: Value = serde_json::from_str(message).map_err(io::Error::other)?;
+                let id = request
+                    .get("id")
+                    .and_then(Value::as_u64)
+                    .ok_or_else(|| io::Error::other("remote request omitted its id"))?;
+                self.requests.send(request.clone()).map_err(io::Error::other)?;
+                let session = self
+                    .session
+                    .lock()
+                    .unwrap()
+                    .as_ref()
+                    .cloned()
+                    .ok_or_else(|| io::Error::other("test remote session was dropped"))?;
+                if request.get("cmd").and_then(Value::as_str) == Some("attach-surface") {
+                    let release = self
+                        .release_attach
+                        .take()
+                        .ok_or_else(|| io::Error::other("attach release already consumed"))?;
+                    std::thread::spawn(move || {
+                        let _ = release.recv();
+                        let Some(session) = session.upgrade() else { return };
+                        let Some(response) = session.pending.lock().unwrap().remove(&id) else {
+                            return;
+                        };
+                        let _ = response.response.send(json!({
+                            "id": id,
+                            "ok": true,
+                            "data": null,
+                        }));
+                    });
+                    return Ok(());
+                }
+                let session = session
+                    .upgrade()
+                    .ok_or_else(|| io::Error::other("test remote session was dropped"))?;
+                let response = session
+                    .pending
+                    .lock()
+                    .unwrap()
+                    .remove(&id)
+                    .ok_or_else(|| io::Error::other("remote request was not pending"))?;
+                response
+                    .response
+                    .send(json!({"id": id, "ok": true, "data": null}))
+                    .map_err(|_| io::Error::other("remote response receiver was dropped"))
+            }
+
+            fn close(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let session_slot = Arc::new(Mutex::new(None));
+        let (requests_tx, requests_rx) = channel();
+        let (release_attach_tx, release_attach_rx) = channel();
+        let session = test_session_with_writer(
+            Box::new(OrderedPipeIoAttachWriter {
+                session: session_slot.clone(),
+                requests: requests_tx,
+                release_attach: Some(release_attach_rx),
+            }),
+            None,
+            HashSet::new(),
+        );
+        *session_slot.lock().unwrap() = Some(Arc::downgrade(&session));
+
+        let attaching = session.clone();
+        let worker = std::thread::spawn(move || attaching.try_attach_pipe_io(7, Some((100, 30))));
+        let first = requests_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("pipe-IO attach did not issue its first request");
+        let second = if first["cmd"] == "attach-surface" {
+            // The pre-fix ordering sends attach first and waits for its
+            // response. Release it now so the test can report the ordering
+            // failure instead of hitting the attach deadline.
+            let _ = release_attach_tx.send(());
+            requests_rx.recv_timeout(Duration::from_secs(1))
+        } else {
+            let second = requests_rx.recv_timeout(Duration::from_secs(1));
+            let _ = release_attach_tx.send(());
+            second
+        };
+        let result = worker.join().unwrap().expect("pipe-IO attach failed");
+
+        assert_eq!(first["cmd"], "resize-surface");
+        assert_eq!(first["surface"], 7);
+        assert_eq!(first["cols"], 100);
+        assert_eq!(first["rows"], 30);
+        let second = second.expect("legacy attach request was not sent");
+        assert_eq!(second["cmd"], "attach-surface");
+        assert!(second.get("cols").is_none());
+        assert!(second.get("rows").is_none());
+        assert!(matches!(result, PipeIoSurfaceAttach::Attached));
+    }
+
     #[test]
     fn protocol_12_identity_is_accepted() {
         validate_remote_identity(&json!({"app": "cmux-tui", "protocol": 12})).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1666,9 +1666,9 @@ pub struct RemoteSession {
 /// embedder. `Replay` REPLACES all prior terminal state (the relay must
 /// emit a full reset before any replay that is not its first output);
 /// `Output` appends live PTY bytes.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug)]
 pub enum PipeIoEvent {
-    Replay { bytes: Vec<u8> },
+    Replay { bytes: Vec<u8>, reservation_id: Option<u64> },
     Output(Vec<u8>),
     SurfaceExited,
     TransportLost,
@@ -1676,12 +1676,32 @@ pub enum PipeIoEvent {
     StdinError,
 }
 
+impl PartialEq for PipeIoEvent {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Replay { bytes: left, .. }, Self::Replay { bytes: right, .. }) => left == right,
+            (Self::Output(left), Self::Output(right)) => left == right,
+            (Self::SurfaceExited, Self::SurfaceExited)
+            | (Self::TransportLost, Self::TransportLost)
+            | (Self::StdinClosed, Self::StdinClosed)
+            | (Self::StdinError, Self::StdinError) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for PipeIoEvent {}
+
 impl PipeIoEvent {
+    pub(crate) fn replay(bytes: Vec<u8>) -> Self {
+        Self::Replay { bytes, reservation_id: None }
+    }
+
     /// Bytes retained by the relay's bounded data queue. Lifecycle signals
     /// have a separate one-slot channel and carry no retained payload.
     pub(crate) fn retained_bytes(&self) -> usize {
         match self {
-            Self::Replay { bytes } | Self::Output(bytes) => bytes.len(),
+            Self::Replay { bytes, .. } | Self::Output(bytes) => bytes.len(),
             Self::SurfaceExited | Self::TransportLost | Self::StdinClosed | Self::StdinError => 0,
         }
     }
@@ -1695,7 +1715,8 @@ impl PipeIoEvent {
 /// because it is larger than the normal live-output budget.
 struct PipeIoBudgetState {
     retained: usize,
-    oversized_replay: Option<usize>,
+    oversized_replay: Option<u64>,
+    next_oversized_replay_id: u64,
 }
 
 pub(crate) struct PipeIoByteBudget {
@@ -1706,7 +1727,11 @@ pub(crate) struct PipeIoByteBudget {
 impl PipeIoByteBudget {
     pub(crate) fn new(limit: usize) -> Self {
         Self {
-            state: Mutex::new(PipeIoBudgetState { retained: 0, oversized_replay: None }),
+            state: Mutex::new(PipeIoBudgetState {
+                retained: 0,
+                oversized_replay: None,
+                next_oversized_replay_id: 1,
+            }),
             limit: limit.max(1),
         }
     }
@@ -1724,7 +1749,7 @@ impl PipeIoByteBudget {
         true
     }
 
-    fn try_reserve_replay(&self, bytes: usize) -> bool {
+    fn try_reserve_replay(&self, bytes: usize, reservation_id: &mut Option<u64>) -> bool {
         if bytes == 0 {
             return true;
         }
@@ -1742,13 +1767,19 @@ impl PipeIoByteBudget {
             return false;
         }
         state.retained = next;
-        state.oversized_replay = Some(bytes);
+        let id = state.next_oversized_replay_id;
+        state.next_oversized_replay_id = state.next_oversized_replay_id.checked_add(1).unwrap_or(1);
+        state.oversized_replay = Some(id);
+        *reservation_id = Some(id);
         true
     }
 
-    pub(crate) fn try_reserve_event(&self, event: &PipeIoEvent) -> bool {
+    pub(crate) fn try_reserve_event(&self, event: &mut PipeIoEvent) -> bool {
         match event {
-            PipeIoEvent::Replay { bytes } => self.try_reserve_replay(bytes.len()),
+            PipeIoEvent::Replay { bytes, reservation_id } => {
+                *reservation_id = None;
+                self.try_reserve_replay(bytes.len(), reservation_id)
+            }
             _ => self.try_reserve(event.retained_bytes()),
         }
     }
@@ -1760,8 +1791,10 @@ impl PipeIoByteBudget {
         }
         let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
         state.retained = state.retained.saturating_sub(bytes);
-        if matches!(event, PipeIoEvent::Replay { .. }) && state.oversized_replay == Some(bytes) {
-            state.oversized_replay = None;
+        if let PipeIoEvent::Replay { reservation_id: Some(id), .. } = event {
+            if state.oversized_replay == Some(*id) {
+                state.oversized_replay = None;
+            }
         }
     }
 }
@@ -2503,7 +2536,7 @@ impl RemoteSession {
                     format_args!("vt-state cols={cols} rows={rows} bytes={}", replay.len()),
                 );
                 let pipe_io_owned =
-                    self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() });
+                    self.pipe_io_forward(id, || PipeIoEvent::replay(replay.clone()));
                 // A pipe-IO relay consumes the authoritative VT byte stream
                 // itself. Do not also parse the same replay into a local
                 // `RemoteSurface`: that duplicate parser can fail or mutate
@@ -2622,7 +2655,7 @@ impl RemoteSession {
                     ),
                 );
                 let pipe_io_owned = if let Some(replay) = replay.as_ref() {
-                    self.pipe_io_forward(id, || PipeIoEvent::Replay { bytes: replay.clone() })
+                    self.pipe_io_forward(id, || PipeIoEvent::replay(replay.clone()))
                 } else {
                     self.pipe_io_owns_surface(id)
                 };
@@ -3445,8 +3478,8 @@ impl RemoteSession {
             if tap.surface != surface {
                 return false;
             }
-            let event = event();
-            if !tap.byte_budget.try_reserve_event(&event) {
+            let mut event = event();
+            if !tap.byte_budget.try_reserve_event(&mut event) {
                 Some(tap.token.clone())
             } else {
                 match tap.sender.try_send(event) {
@@ -3473,7 +3506,7 @@ impl RemoteSession {
     fn pipe_io_forward_owned(
         &self,
         surface: SurfaceId,
-        event: PipeIoEvent,
+        mut event: PipeIoEvent,
     ) -> Result<(), PipeIoEvent> {
         use crossbeam_channel::TrySendError;
         let stalled_token = {
@@ -3482,7 +3515,7 @@ impl RemoteSession {
             if tap.surface != surface {
                 return Err(event);
             }
-            if !tap.byte_budget.try_reserve_event(&event) {
+            if !tap.byte_budget.try_reserve_event(&mut event) {
                 Some(tap.token.clone())
             } else {
                 match tap.sender.try_send(event) {
@@ -7051,39 +7084,39 @@ mod tests {
         let _token =
             session.install_pipe_io_tap(7, sender.clone(), lifecycle_sender, budget.clone());
 
-        let queued = PipeIoEvent::Output(vec![0; 7]);
-        assert!(budget.try_reserve_event(&queued));
+        let mut queued = PipeIoEvent::Output(vec![0; 7]);
+        assert!(budget.try_reserve_event(&mut queued));
         sender.send(queued).unwrap();
 
         let replay_bytes = vec![b'R'; 16];
-        assert!(session.pipe_io_forward(7, || PipeIoEvent::Replay { bytes: replay_bytes.clone() }));
+        assert!(session.pipe_io_forward(7, || PipeIoEvent::replay(replay_bytes.clone())));
         assert!(lifecycle_receiver.try_recv().is_err());
 
         let queued = receiver.try_recv().unwrap();
         let replay = receiver.try_recv().unwrap();
         assert_eq!(queued, PipeIoEvent::Output(vec![0; 7]));
-        assert_eq!(replay, PipeIoEvent::Replay { bytes: replay_bytes });
-        let second_replay = PipeIoEvent::Replay { bytes: vec![b'S'; 16] };
-        assert!(!budget.try_reserve_event(&second_replay));
+        assert_eq!(replay, PipeIoEvent::replay(replay_bytes));
+        let mut second_replay = PipeIoEvent::replay(vec![b'S'; 16]);
+        assert!(!budget.try_reserve_event(&mut second_replay));
         budget.release_event(&queued);
         budget.release_event(&replay);
-        assert!(budget.try_reserve_event(&second_replay));
+        assert!(budget.try_reserve_event(&mut second_replay));
         budget.release_event(&second_replay);
     }
 
     #[test]
     fn pipe_io_budget_keeps_same_length_oversized_replay_reserved() {
         let budget = PipeIoByteBudget::new(16);
-        let first = PipeIoEvent::Replay { bytes: vec![b'A'; 16] };
-        let second = PipeIoEvent::Replay { bytes: vec![b'B'; 16] };
-        let third = PipeIoEvent::Replay { bytes: vec![b'C'; 16] };
+        let mut first = PipeIoEvent::replay(vec![b'A'; 16]);
+        let mut second = PipeIoEvent::replay(vec![b'B'; 16]);
+        let mut third = PipeIoEvent::replay(vec![b'C'; 16]);
 
-        assert!(budget.try_reserve_event(&first));
-        assert!(budget.try_reserve_event(&second));
+        assert!(budget.try_reserve_event(&mut first));
+        assert!(budget.try_reserve_event(&mut second));
         budget.release_event(&first);
-        assert!(!budget.try_reserve_event(&third));
+        assert!(!budget.try_reserve_event(&mut third));
         budget.release_event(&second);
-        assert!(budget.try_reserve_event(&third));
+        assert!(budget.try_reserve_event(&mut third));
         budget.release_event(&third);
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -205,8 +205,15 @@ pub(crate) enum RemoteRequestError {
     Encode(serde_json::Error),
     Transport(io::Error),
     Timeout,
-    Rejected { error: String, code: Option<String>, delivery: Option<ClearHistoryDelivery> },
+    Rejected {
+        error: String,
+        code: Option<String>,
+        delivery: Option<ClearHistoryDelivery>,
+    },
     Shutdown,
+    /// The peer closed the transport. This is retryable for pipe-IO startup,
+    /// unlike a local shutdown initiated by this process.
+    RemoteShutdown,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -242,7 +249,9 @@ impl RemoteRequestError {
 pub(crate) fn is_pipe_io_retryable_error(error: &anyhow::Error) -> bool {
     error.chain().any(|cause| {
         if let Some(remote_error) = cause.downcast_ref::<RemoteRequestError>() {
-            return remote_error.is_transport_failure() || remote_error.is_timeout();
+            return remote_error.is_transport_failure()
+                || remote_error.is_timeout()
+                || matches!(remote_error, RemoteRequestError::RemoteShutdown);
         }
         cause.downcast_ref::<io::Error>().is_some_and(|io_error| {
             matches!(
@@ -269,6 +278,9 @@ impl std::fmt::Display for RemoteRequestError {
             Self::Timeout => write!(formatter, "remote session did not respond"),
             Self::Rejected { error, .. } => write!(formatter, "remote command rejected: {error}"),
             Self::Shutdown => write!(formatter, "remote response wait canceled for shutdown"),
+            Self::RemoteShutdown => {
+                write!(formatter, "remote response wait canceled after peer disconnect")
+            }
         }
     }
 }
@@ -2533,10 +2545,11 @@ impl RemoteSession {
                     return;
                 };
                 self.log_frame(id, format_args!("output bytes={}", bytes.len()));
-                let pipe_io_owned = self.pipe_io_forward(id, || PipeIoEvent::Output(bytes.clone()));
-                if pipe_io_owned {
-                    return;
-                }
+                let bytes = match self.pipe_io_forward_owned(id, PipeIoEvent::Output(bytes)) {
+                    Ok(()) => return,
+                    Err(PipeIoEvent::Output(bytes)) => bytes,
+                    Err(_) => return,
+                };
                 let colors = value.get("colors").and_then(parse_terminal_colors);
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     surface.scan_cursor_provenance(&bytes);
@@ -2963,6 +2976,14 @@ impl RemoteSession {
         self.request_with_deadline(cmd, RequestDeadline::Standard)
     }
 
+    fn shutdown_request_error(&self) -> RemoteRequestError {
+        if matches!(&*self.disconnect_state.lock().unwrap(), DisconnectState::Remote(_)) {
+            RemoteRequestError::RemoteShutdown
+        } else {
+            RemoteRequestError::Shutdown
+        }
+    }
+
     /// Fire-and-forget command: enqueued in order with interactive traffic,
     /// never awaited. Used for best-effort reporting such as client focus.
     pub(crate) fn notify(&self, cmd: Value) -> anyhow::Result<()> {
@@ -3021,7 +3042,7 @@ impl RemoteSession {
 
         if self.shutdown.load(Ordering::Acquire) {
             self.pending.lock().unwrap().remove(&id);
-            return Err(RemoteRequestError::Shutdown.into());
+            return Err(self.shutdown_request_error().into());
         }
 
         let response = match self.wait_for_response(rx, deadline, progress, attach_progress) {
@@ -3066,7 +3087,7 @@ impl RemoteSession {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
                 Err(RecvTimeoutError::Disconnected) if self.shutdown.load(Ordering::Acquire) => {
-                    Err(RemoteRequestError::Shutdown)
+                    Err(self.shutdown_request_error())
                 }
                 Err(RecvTimeoutError::Disconnected) => Err(RemoteRequestError::Timeout),
             };
@@ -3092,13 +3113,13 @@ impl RemoteSession {
             match rx.recv_timeout(wait) {
                 Ok(response) => return Ok(response),
                 Err(RecvTimeoutError::Disconnected) if self.shutdown.load(Ordering::Acquire) => {
-                    return Err(RemoteRequestError::Shutdown);
+                    return Err(self.shutdown_request_error());
                 }
                 Err(RecvTimeoutError::Disconnected) => return Err(RemoteRequestError::Timeout),
                 Err(RecvTimeoutError::Timeout) => {}
             }
             if self.shutdown.load(Ordering::Acquire) {
-                return Err(RemoteRequestError::Shutdown);
+                return Err(self.shutdown_request_error());
             }
         }
     }
@@ -3123,7 +3144,7 @@ impl RemoteSession {
             .map_err(RemoteRequestError::Transport)?;
         if self.shutdown.load(Ordering::Acquire) {
             self.wait_for_ordered_write(sequence).map_err(RemoteRequestError::Transport)?;
-            return Err(RemoteRequestError::Shutdown.into());
+            return Err(self.shutdown_request_error().into());
         }
         Ok(())
     }
@@ -3387,26 +3408,34 @@ impl RemoteSession {
     /// would corrupt the embedder's terminal state (bounded-backpressure
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
+        self.pipe_io_forward_owned(surface, event()).is_ok()
+    }
+
+    /// Forwards an already-owned event without cloning its payload. If no
+    /// matching tap exists, the event is returned to the caller for normal
+    /// terminal parsing. Once a tap owns the event, queue overflow consumes it
+    /// and tears down that relay, so the caller must not parse it locally.
+    fn pipe_io_forward_owned(
+        &self,
+        surface: SurfaceId,
+        event: PipeIoEvent,
+    ) -> Result<(), PipeIoEvent> {
         use crossbeam_channel::TrySendError;
-        let (stalled_token, pipe_io_owned) = {
+        let stalled_token = {
             let tap = self.pipe_io_tap.lock().unwrap();
-            let Some(tap) = tap.as_ref() else { return false };
+            let Some(tap) = tap.as_ref() else { return Err(event) };
             if tap.surface != surface {
-                return false;
+                return Err(event);
             }
-            // Resolve ownership before invoking the closure. Output and
-            // replay call sites capture a payload clone in the closure, and
-            // sessions without a matching tap must not pay that allocation.
-            let event = event();
             let retained_bytes = event.retained_bytes();
             if !tap.byte_budget.try_reserve(retained_bytes) {
-                (Some(tap.token.clone()), true)
+                Some(tap.token.clone())
             } else {
                 match tap.sender.try_send(event) {
-                    Ok(()) => (None, true),
+                    Ok(()) => None,
                     Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
                         tap.byte_budget.release(retained_bytes);
-                        (Some(tap.token.clone()), true)
+                        Some(tap.token.clone())
                     }
                 }
             }
@@ -3419,11 +3448,7 @@ impl RemoteSession {
                 self.disconnect_transport();
             }
         }
-        // Capture ownership while holding the tap lock. A concurrent relay
-        // teardown can remove the tap before the caller reaches its parser
-        // fence; returning this snapshot prevents one raw event from being
-        // parsed twice during that handoff.
-        pipe_io_owned
+        Ok(())
     }
 
     /// Returns the first reason recorded when the remote reader stopped.
@@ -7720,7 +7745,7 @@ mod tests {
         assert!(
             matches!(
                 error.downcast_ref::<RemoteRequestError>(),
-                Some(RemoteRequestError::Shutdown)
+                Some(RemoteRequestError::RemoteShutdown)
             ),
             "expected shutdown after EOF canceled the request, got {error:?}"
         );
@@ -7790,7 +7815,7 @@ mod tests {
         assert!(
             matches!(
                 error.downcast_ref::<RemoteRequestError>(),
-                Some(RemoteRequestError::Shutdown)
+                Some(RemoteRequestError::RemoteShutdown)
             ),
             "expected shutdown after malformed JSON canceled the request, got {error:?}"
         );

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1605,9 +1605,26 @@ impl InteractiveWriter {
     }
 
     fn wait_until_written_until(&self, sequence: u64, deadline: Instant) -> io::Result<()> {
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "ordered remote write did not complete before its deadline",
+            ));
+        }
         #[cfg(test)]
         self.await_wait_until_written_gate(sequence);
-        let mut state = self.shared.state.lock();
+        let Some(mut state) = self.shared.state.try_lock_until(deadline) else {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "ordered remote write did not complete before its deadline",
+            ));
+        };
+        if Instant::now() >= deadline {
+            return Err(io::Error::new(
+                io::ErrorKind::TimedOut,
+                "ordered remote write did not complete before its deadline",
+            ));
+        }
         loop {
             if state.last_written_sequence >= sequence {
                 return Ok(());

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4807,7 +4807,7 @@ fn append_pipe_io_colors(
                     )
                     .as_bytes(),
                 ),
-                None if previous.is_some_and(Option::is_some) => {
+                None if previous.is_some_and(|color| color.is_some()) => {
                     bytes.extend_from_slice(format!("\x1b]104;{index}\x1b\\").as_bytes());
                 }
                 None => {}

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1096,19 +1096,81 @@ enum RequestDeadline {
 }
 
 impl RequestDeadline {
-    fn remaining(self) -> Result<Duration, RemoteRequestError> {
+    fn resolve(self) -> Result<ResolvedRequestDeadline, RemoteRequestError> {
+        self.resolve_at(Instant::now())
+    }
+
+    fn resolve_at(self, started: Instant) -> Result<ResolvedRequestDeadline, RemoteRequestError> {
         match self {
-            Self::Standard => Ok(REMOTE_REQUEST_TIMEOUT),
-            Self::Fixed(timeout) => Ok(timeout),
-            Self::Until(deadline) => {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                if remaining.is_zero() { Err(RemoteRequestError::Timeout) } else { Ok(remaining) }
+            Self::Standard => Ok(ResolvedRequestDeadline::Absolute {
+                deadline: checked_request_deadline(started, REMOTE_REQUEST_TIMEOUT)?,
+            }),
+            Self::Attach => Ok(ResolvedRequestDeadline::Attach {
+                write_deadline: checked_request_deadline(started, remote_write_timeout())?,
+                response_deadline: checked_request_deadline(started, REMOTE_ATTACH_MAX_TIMEOUT)?,
+            }),
+            Self::Fixed(timeout) => Ok(ResolvedRequestDeadline::Absolute {
+                deadline: checked_request_deadline(started, timeout)?,
+            }),
+            Self::Until(deadline) if deadline > started => {
+                Ok(ResolvedRequestDeadline::Absolute { deadline })
             }
-            // Attach has its own progress-aware response deadline, but its
-            // enqueue/write phase still needs the normal bounded write wait.
-            Self::Attach => Ok(remote_write_timeout()),
+            Self::Until(_) => Err(RemoteRequestError::Timeout),
         }
     }
+}
+
+fn checked_request_deadline(
+    started: Instant,
+    timeout: Duration,
+) -> Result<Instant, RemoteRequestError> {
+    started
+        .checked_add(timeout)
+        .filter(|deadline| *deadline > started)
+        .ok_or(RemoteRequestError::Timeout)
+}
+
+#[derive(Clone, Copy)]
+enum ResolvedRequestDeadline {
+    /// Standard, fixed, and shared probe requests use one absolute deadline
+    /// for queue admission, ordered writing, and response delivery.
+    Absolute { deadline: Instant },
+    /// Attach keeps a short write budget and a longer progress-aware response
+    /// budget, both anchored at the request start. The response idle window
+    /// begins only after the ordered attach write completes.
+    Attach { write_deadline: Instant, response_deadline: Instant },
+}
+
+impl ResolvedRequestDeadline {
+    fn is_attach(self) -> bool {
+        matches!(self, Self::Attach { .. })
+    }
+
+    fn write_deadline(self) -> Instant {
+        match self {
+            Self::Absolute { deadline } | Self::Attach { write_deadline: deadline, .. } => deadline,
+        }
+    }
+
+    fn response_deadline(self) -> Instant {
+        match self {
+            Self::Absolute { deadline } => deadline,
+            Self::Attach { response_deadline, .. } => response_deadline,
+        }
+    }
+
+    fn write_remaining(self) -> Result<Duration, RemoteRequestError> {
+        remaining_until(self.write_deadline())
+    }
+
+    fn response_remaining(self) -> Result<Duration, RemoteRequestError> {
+        remaining_until(self.response_deadline())
+    }
+}
+
+fn remaining_until(deadline: Instant) -> Result<Duration, RemoteRequestError> {
+    let remaining = deadline.saturating_duration_since(Instant::now());
+    if remaining.is_zero() { Err(RemoteRequestError::Timeout) } else { Ok(remaining) }
 }
 
 struct AttachResponseDeadline {
@@ -1127,10 +1189,26 @@ impl AttachResponseDeadline {
         idle_timeout: Duration,
         maximum_timeout: Duration,
     ) -> Self {
+        Self::new_with_maximum_deadline(
+            started,
+            request_progress,
+            attach_progress,
+            idle_timeout,
+            started + maximum_timeout,
+        )
+    }
+
+    fn new_with_maximum_deadline(
+        started: Instant,
+        request_progress: u64,
+        attach_progress: u64,
+        idle_timeout: Duration,
+        maximum_deadline: Instant,
+    ) -> Self {
         Self {
             idle_timeout,
             idle_deadline: started + idle_timeout,
-            maximum_deadline: started + maximum_timeout,
+            maximum_deadline,
             observed_request_progress: request_progress,
             observed_attach_progress: attach_progress,
         }
@@ -1521,9 +1599,12 @@ impl InteractiveWriter {
     }
 
     fn wait_until_written(&self, sequence: u64, timeout: Duration) -> io::Result<()> {
+        self.wait_until_written_until(sequence, Instant::now() + timeout)
+    }
+
+    fn wait_until_written_until(&self, sequence: u64, deadline: Instant) -> io::Result<()> {
         #[cfg(test)]
         self.await_wait_until_written_gate(sequence);
-        let deadline = Instant::now() + timeout;
         let mut state = self.shared.state.lock();
         loop {
             if state.last_written_sequence >= sequence {
@@ -3246,19 +3327,21 @@ impl RemoteSession {
         mut cmd: Value,
         deadline: RequestDeadline,
     ) -> anyhow::Result<Value> {
-        // A shared deadline must cover enqueueing, the ordered write, and the
-        // response wait. Check it before creating a pending request so an
-        // expired reconnect probe cannot add work to the relay.
-        if let Err(error) = deadline.remaining() {
+        let deadline = deadline.resolve()?;
+        // Resolve the request budget before enqueueing. Standard, fixed, and
+        // shared-probe requests use one absolute deadline for every phase;
+        // attach requests use two absolute caps anchored at this same start.
+        // Check the write cap before creating a pending request so an expired
+        // probe cannot add work to the relay.
+        if let Err(error) = deadline.write_remaining() {
             return Err(error.into());
         }
         let id = self.next_id.fetch_add(1, Ordering::Relaxed);
         let progress = Arc::new(AtomicU64::new(0));
-        let attach_progress = matches!(deadline, RequestDeadline::Attach)
-            .then(|| self.attach_progress.load(Ordering::Acquire));
-        let attach_surface = matches!(deadline, RequestDeadline::Attach)
-            .then(|| cmd.get("surface").and_then(Value::as_u64))
-            .flatten();
+        let attach_progress =
+            deadline.is_attach().then(|| self.attach_progress.load(Ordering::Acquire));
+        let attach_surface =
+            deadline.is_attach().then(|| cmd.get("surface").and_then(Value::as_u64)).flatten();
         cmd["id"] = json!(id);
         let message = serde_json::to_string(&cmd)
             .map_err(RemoteRequestError::Encode)
@@ -3270,7 +3353,7 @@ impl RemoteSession {
         // Serialization and request construction can consume a shared probe
         // deadline. Do not add a pending request or queue work after it has
         // expired.
-        if let Err(error) = deadline.remaining() {
+        if let Err(error) = deadline.write_remaining() {
             return Err(error.into());
         }
 
@@ -3282,24 +3365,8 @@ impl RemoteSession {
         // Control requests have a bounded admission budget for both the queue
         // mutex and queue capacity. Normal PTY input uses `request_no_wait`
         // and keeps its blocking FIFO behavior during brief contention.
-        let enqueue_result = match deadline {
-            RequestDeadline::Standard => self.interactive_writer.enqueue_until(
-                message,
-                false,
-                Instant::now() + REMOTE_REQUEST_TIMEOUT,
-            ),
-            RequestDeadline::Attach => self.interactive_writer.enqueue_until(
-                message,
-                false,
-                Instant::now() + remote_write_timeout(),
-            ),
-            RequestDeadline::Fixed(timeout) => {
-                self.interactive_writer.enqueue_until(message, false, Instant::now() + timeout)
-            }
-            RequestDeadline::Until(probe_deadline) => {
-                self.interactive_writer.enqueue_until(message, false, probe_deadline)
-            }
-        };
+        let enqueue_result =
+            self.interactive_writer.enqueue_until(message, false, deadline.write_deadline());
         let sequence = match enqueue_result {
             Ok(sequence) => sequence,
             Err(error) => {
@@ -3307,14 +3374,11 @@ impl RemoteSession {
                 return Err(RemoteRequestError::Transport(error).into());
             }
         };
-        let write_timeout = match deadline.remaining() {
-            Ok(timeout) => timeout,
-            Err(error) => {
-                self.pending.lock().unwrap().remove(&id);
-                return Err(error.into());
-            }
-        };
-        if let Err(error) = self.wait_for_ordered_write_with_timeout(sequence, write_timeout) {
+        if let Err(error) = deadline.write_remaining() {
+            self.pending.lock().unwrap().remove(&id);
+            return Err(error.into());
+        }
+        if let Err(error) = self.wait_for_ordered_write_until(sequence, deadline.write_deadline()) {
             self.pending.lock().unwrap().remove(&id);
             return Err(RemoteRequestError::Transport(error).into());
         }
@@ -3354,14 +3418,12 @@ impl RemoteSession {
     fn wait_for_response(
         &self,
         rx: Receiver<Value>,
-        deadline: RequestDeadline,
+        deadline: ResolvedRequestDeadline,
         progress: Arc<AtomicU64>,
         attach_progress: Option<u64>,
     ) -> Result<Value, RemoteRequestError> {
-        if let RequestDeadline::Standard | RequestDeadline::Fixed(_) | RequestDeadline::Until(_) =
-            deadline
-        {
-            let timeout = deadline.remaining().map_err(|_| RemoteRequestError::Timeout)?;
+        if !deadline.is_attach() {
+            let timeout = deadline.response_remaining()?;
             return match rx.recv_timeout(timeout) {
                 Ok(response) => Ok(response),
                 Err(RecvTimeoutError::Timeout) => Err(RemoteRequestError::Timeout),
@@ -3372,13 +3434,16 @@ impl RemoteSession {
             };
         }
 
-        let started = Instant::now();
-        let mut deadline = AttachResponseDeadline::new(
-            started,
+        let response_deadline = match deadline {
+            ResolvedRequestDeadline::Attach { response_deadline, .. } => response_deadline,
+            ResolvedRequestDeadline::Absolute { .. } => unreachable!("non-attach deadline branch"),
+        };
+        let mut deadline = AttachResponseDeadline::new_with_maximum_deadline(
+            Instant::now(),
             progress.load(Ordering::Acquire),
             attach_progress.expect("attach response wait requires an attach progress epoch"),
             REMOTE_ATTACH_IDLE_TIMEOUT,
-            REMOTE_ATTACH_MAX_TIMEOUT,
+            response_deadline,
         );
         loop {
             let request_progress = progress.load(Ordering::Acquire);
@@ -3572,7 +3637,11 @@ impl RemoteSession {
         sequence: u64,
         timeout: Duration,
     ) -> io::Result<()> {
-        match self.interactive_writer.wait_until_written(sequence, timeout) {
+        self.wait_for_ordered_write_until(sequence, Instant::now() + timeout)
+    }
+
+    fn wait_for_ordered_write_until(&self, sequence: u64, deadline: Instant) -> io::Result<()> {
+        match self.interactive_writer.wait_until_written_until(sequence, deadline) {
             Ok(()) => Ok(()),
             Err(error) => {
                 if error.kind() == io::ErrorKind::TimedOut {
@@ -8516,6 +8585,32 @@ mod tests {
     }
 
     #[test]
+    fn request_deadline_modes_anchor_all_phase_budgets_at_request_start() {
+        let started = Instant::now();
+        let standard = RequestDeadline::Standard.resolve_at(started).unwrap();
+        assert_eq!(
+            standard.write_deadline(),
+            started + REMOTE_REQUEST_TIMEOUT,
+            "standard admission and write budget moved after request construction"
+        );
+        assert_eq!(standard.response_deadline(), started + REMOTE_REQUEST_TIMEOUT);
+
+        let fixed_timeout = Duration::from_millis(123);
+        let fixed = RequestDeadline::Fixed(fixed_timeout).resolve_at(started).unwrap();
+        assert_eq!(fixed.write_deadline(), started + fixed_timeout);
+        assert_eq!(fixed.response_deadline(), started + fixed_timeout);
+
+        let attach = RequestDeadline::Attach.resolve_at(started).unwrap();
+        assert_eq!(attach.write_deadline(), started + remote_write_timeout());
+        assert_eq!(attach.response_deadline(), started + REMOTE_ATTACH_MAX_TIMEOUT);
+
+        let shared_deadline = started + Duration::from_secs(1);
+        let shared = RequestDeadline::Until(shared_deadline).resolve_at(started).unwrap();
+        assert_eq!(shared.write_deadline(), shared_deadline);
+        assert_eq!(shared.response_deadline(), shared_deadline);
+    }
+
+    #[test]
     fn attach_progress_reverse_index_tracks_only_live_matching_requests() {
         let mut pending = PendingRemoteRequests::default();
         let unrelated_progress = Arc::new(AtomicU64::new(0));
@@ -9549,6 +9644,76 @@ mod tests {
             elapsed < timeout + Duration::from_millis(70),
             "fixed request deadline was reset between phases: started at {started:?}, elapsed {elapsed:?}"
         );
+    }
+
+    fn blocked_request_write_timeout(
+        deadline: RequestDeadline,
+        command: Value,
+        contention: Duration,
+    ) -> (Duration, anyhow::Result<Value>) {
+        let (stream, control) = BlockingWriteStream::new();
+        let session = blocking_test_session(stream);
+        session.send_bytes(7, b"blocked").unwrap();
+        control.wait_until_entered();
+
+        let queue_guard = session.interactive_writer.shared.state.lock();
+        let request_session = session.clone();
+        let (started_tx, started_rx) = channel();
+        let (finished_tx, finished_rx) = channel();
+        let request = std::thread::spawn(move || {
+            let started = Instant::now();
+            started_tx.send(started).unwrap();
+            let result = request_session.request_with_deadline(command, deadline);
+            finished_tx.send((started.elapsed(), result)).unwrap();
+        });
+
+        let started = started_rx.recv().unwrap();
+        let pending_deadline = Instant::now() + Duration::from_secs(1);
+        while session.pending.lock().unwrap().is_empty() {
+            assert!(Instant::now() < pending_deadline, "request did not reach pending state");
+            std::thread::yield_now();
+        }
+        std::thread::sleep(contention);
+        drop(queue_guard);
+
+        let result = finished_rx
+            .recv_timeout(Duration::from_secs(2))
+            .expect("blocked request did not finish");
+        request.join().unwrap();
+        // The timeout path aborts the writer, releasing the test stream even
+        // though this helper deliberately never releases it itself.
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "blocked request helper exceeded its cleanup bound"
+        );
+        result
+    }
+
+    #[test]
+    fn request_deadline_modes_cap_ordered_write_after_queue_contention() {
+        let contention = Duration::from_millis(70);
+        let timeout = remote_write_timeout();
+        let cases = [
+            ("standard", RequestDeadline::Standard, json!({"cmd": "standard-deadline"})),
+            ("attach", RequestDeadline::Attach, json!({"cmd": "attach-surface", "surface": 7})),
+            ("fixed", RequestDeadline::Fixed(timeout), json!({"cmd": "fixed-deadline"})),
+        ];
+
+        for (name, deadline, command) in cases {
+            let (elapsed, result) = blocked_request_write_timeout(deadline, command, contention);
+            assert!(matches!(
+                result
+                    .as_ref()
+                    .err()
+                    .and_then(|error| error.downcast_ref::<RemoteRequestError>()),
+                Some(RemoteRequestError::Transport(error))
+                    if error.kind() == io::ErrorKind::TimedOut
+            ));
+            assert!(
+                elapsed < timeout + Duration::from_millis(45),
+                "{name} request reset its ordered-write deadline after queue contention: {elapsed:?}"
+            );
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3252,19 +3252,6 @@ impl RemoteSession {
         .map(|_| ())
     }
 
-    /// Enqueues a geometry claim without waiting for its acknowledgement.
-    /// Claims only establish ownership; input and resize requests already use
-    /// the same ordered writer, so a fire-and-forget claim cannot overtake the
-    /// keystroke that follows it.
-    pub(crate) fn notify_claim_terminal_geometry(&self, surface: SurfaceId) -> anyhow::Result<()> {
-        self.notify(json!({
-            "cmd": "set-client-sizing",
-            "surface": surface,
-            "enabled": true,
-            "exclusive": true,
-        }))
-    }
-
     #[cfg_attr(not(test), allow(dead_code))]
     pub(crate) fn interactive_write_metrics(&self) -> InteractiveWriteMetricsSnapshot {
         self.interactive_writer.metrics()
@@ -8231,7 +8218,7 @@ mod tests {
         let (finished_tx, finished_rx) = channel();
         let sender_session = session.clone();
         let sender = std::thread::spawn(move || {
-            finished_tx.send(sender_session.notify_claim_terminal_geometry(9)).unwrap();
+            finished_tx.send(sender_session.claim_terminal_geometry(9)).unwrap();
         });
 
         let mut peer = BufReader::new(server);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4826,9 +4826,8 @@ fn append_pipe_io_colors(
         replay_reset,
     );
 
-    let cursor_visual = presence
-        .cursor_visual
-        .then(|| colors.cursor_style.zip(colors.cursor_blink).map(|(style, blink)| (style, blink)));
+    let cursor_visual =
+        presence.cursor_visual.then(|| colors.cursor_style.zip(colors.cursor_blink));
     append_cached_pipe_io_cursor_visual(
         bytes,
         &mut cache.cursor_visual,
@@ -7926,20 +7925,22 @@ mod tests {
             lifecycle_sender,
             Arc::new(PipeIoByteBudget::new(1024)),
         );
-        let colors = json!({
-            "fg": "#102030",
-            "bg": "#405060",
-            "cursor": "#708090",
-            "cursor_style": "underline",
-            "cursor_blink": true,
-            "palette": {"196": "#010203"},
-        });
+        let colors = || {
+            json!({
+                "fg": "#102030",
+                "bg": "#405060",
+                "cursor": "#708090",
+                "cursor_style": "underline",
+                "cursor_blink": true,
+                "palette": {"196": "#010203"},
+            })
+        };
 
         session.handle_line(json!({
             "event": "output",
             "surface": 7,
             "data": base64::engine::general_purpose::STANDARD.encode(b"first"),
-            "colors": colors.clone(),
+            "colors": colors(),
         }));
         let PipeIoEvent::Output(first) = receiver.recv_timeout(Duration::from_secs(1)).unwrap()
         else {
@@ -7951,7 +7952,7 @@ mod tests {
             "event": "output",
             "surface": 7,
             "data": base64::engine::general_purpose::STANDARD.encode(b"second"),
-            "colors": colors,
+            "colors": colors(),
         }));
         let PipeIoEvent::Output(second) = receiver.recv_timeout(Duration::from_secs(1)).unwrap()
         else {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1337,48 +1337,18 @@ impl InteractiveWriter {
     }
 
     fn enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
-        self.enqueue_inner(message, measure_latency, false)
+        self.enqueue_inner(message, measure_latency)
     }
 
-    /// Bounded-probe admission is fail-fast. It never waits for the queue
-    /// mutex or for capacity, so a shared reconnect deadline remains
-    /// authoritative when the remote writer is stalled.
-    fn try_enqueue(&self, message: String, measure_latency: bool) -> io::Result<u64> {
-        self.enqueue_inner(message, measure_latency, true)
-    }
-
-    fn enqueue_inner(
-        &self,
-        message: String,
-        measure_latency: bool,
-        nonblocking: bool,
-    ) -> io::Result<u64> {
+    fn enqueue_inner(&self, message: String, measure_latency: bool) -> io::Result<u64> {
         let mut write =
             InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
         let message_bytes = write.message.len();
-        let state = if nonblocking {
-            match self.shared.state.try_lock() {
-                Ok(state) => Ok(state),
-                Err(std::sync::TryLockError::Poisoned(_)) => {
-                    Err(io::Error::other("interactive writer queue is poisoned"))
-                }
-                Err(std::sync::TryLockError::WouldBlock) => {
-                    if measure_latency {
-                        self.shared.metrics.backpressure_rejections.fetch_add(1, Ordering::Relaxed);
-                    }
-                    Err(io::Error::new(
-                        io::ErrorKind::WouldBlock,
-                        "interactive writer queue mutex is contended",
-                    ))
-                }
-            }
-        } else {
-            self.shared
-                .state
-                .lock()
-                .map_err(|_| io::Error::other("interactive writer queue is poisoned"))
-        };
-        let mut state = state?;
+        let mut state = self
+            .shared
+            .state
+            .lock()
+            .map_err(|_| io::Error::other("interactive writer queue is poisoned"))?;
         if let Some(failure) = &state.failure {
             return Err(failure.to_error());
         }
@@ -1407,6 +1377,89 @@ impl InteractiveWriter {
         drop(state);
         self.shared.changed.notify_one();
         Ok(sequence)
+    }
+
+    /// Admit a deadline-bound control request without allowing either the
+    /// queue mutex or a full queue to consume time beyond its request budget.
+    /// Normal PTY input continues to use `enqueue`, which preserves its
+    /// blocking FIFO behavior during brief mutex contention.
+    fn enqueue_until(
+        &self,
+        message: String,
+        measure_latency: bool,
+        deadline: Instant,
+    ) -> io::Result<u64> {
+        let mut write =
+            InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
+        let message_bytes = write.message.len();
+        loop {
+            let mut state = match self.shared.state.try_lock() {
+                Ok(state) => state,
+                Err(std::sync::TryLockError::Poisoned(_)) => {
+                    return Err(io::Error::other("interactive writer queue is poisoned"));
+                }
+                Err(std::sync::TryLockError::WouldBlock) => {
+                    let remaining = deadline.saturating_duration_since(Instant::now());
+                    if remaining.is_zero() {
+                        return self.queue_admission_timeout(measure_latency);
+                    }
+                    // std::sync::Mutex has no timed lock. Yield in short
+                    // bounded intervals so a transient holder is not
+                    // rejected, while the absolute request deadline remains
+                    // authoritative.
+                    std::thread::sleep(remaining.min(Duration::from_millis(1)));
+                    continue;
+                }
+            };
+
+            if let Some(failure) = &state.failure {
+                return Err(failure.to_error());
+            }
+            if state.closed {
+                return Err(io::Error::new(
+                    io::ErrorKind::BrokenPipe,
+                    "interactive writer is closed",
+                ));
+            }
+            let queue_full = state.writes.len() >= INTERACTIVE_WRITE_QUEUE_CAPACITY
+                || message_bytes > INTERACTIVE_WRITE_QUEUE_BYTES.saturating_sub(state.queued_bytes);
+            if queue_full {
+                let remaining = deadline.saturating_duration_since(Instant::now());
+                if remaining.is_zero() {
+                    return self.queue_admission_timeout(measure_latency);
+                }
+                let (_next, timeout) = self
+                    .shared
+                    .changed
+                    .wait_timeout(state, remaining)
+                    .unwrap_or_else(|poison| poison.into_inner());
+                if timeout.timed_out() {
+                    return self.queue_admission_timeout(measure_latency);
+                }
+                continue;
+            }
+
+            let sequence = state.last_enqueued_sequence.checked_add(1).ok_or_else(|| {
+                io::Error::other("interactive writer sequence space is exhausted")
+            })?;
+            state.last_enqueued_sequence = sequence;
+            state.queued_bytes += message_bytes;
+            write.sequence = sequence;
+            state.writes.push_back(write);
+            drop(state);
+            self.shared.changed.notify_one();
+            return Ok(sequence);
+        }
+    }
+
+    fn queue_admission_timeout(&self, measure_latency: bool) -> io::Result<u64> {
+        if measure_latency {
+            self.shared.metrics.backpressure_rejections.fetch_add(1, Ordering::Relaxed);
+        }
+        Err(io::Error::new(
+            io::ErrorKind::WouldBlock,
+            "interactive writer queue admission deadline expired",
+        ))
     }
 
     fn last_enqueued_sequence(&self) -> io::Result<Option<u64>> {
@@ -3141,12 +3194,26 @@ impl RemoteSession {
             id,
             PendingRemoteRequest { response: tx, progress: progress.clone(), attach_surface },
         );
-        // Reconnect probes share one absolute deadline. They must not wait on
-        // a queue mutex held by a stalled writer; normal control requests keep
-        // their existing short mutex critical section and preserve input FIFO.
+        // Control requests have a bounded admission budget for both the queue
+        // mutex and queue capacity. Normal PTY input uses `request_no_wait`
+        // and keeps its blocking FIFO behavior during brief contention.
         let enqueue_result = match deadline {
-            RequestDeadline::Until(_) => self.interactive_writer.try_enqueue(message, false),
-            _ => self.interactive_writer.enqueue(message, false),
+            RequestDeadline::Standard => self.interactive_writer.enqueue_until(
+                message,
+                false,
+                Instant::now() + REMOTE_REQUEST_TIMEOUT,
+            ),
+            RequestDeadline::Attach => self.interactive_writer.enqueue_until(
+                message,
+                false,
+                Instant::now() + remote_write_timeout(),
+            ),
+            RequestDeadline::Fixed(timeout) => {
+                self.interactive_writer.enqueue_until(message, false, Instant::now() + timeout)
+            }
+            RequestDeadline::Until(probe_deadline) => {
+                self.interactive_writer.enqueue_until(message, false, probe_deadline)
+            }
         };
         let sequence = match enqueue_result {
             Ok(sequence) => sequence,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -9927,6 +9927,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn sent_request_timeout_reconciles_transport_before_returning() {
+        struct RecordingAbort(AtomicBool);
+
+        impl RemoteTransportAbort for RecordingAbort {
+            fn abort(&self) -> io::Result<()> {
+                self.0.store(true, Ordering::Release);
+                Ok(())
+            }
+        }
+
+        let abort = Arc::new(RecordingAbort(AtomicBool::new(false)));
+        let session = test_session_with_abort_and_context(
+            Box::new(SilentWriter),
+            abort.clone(),
+            HashSet::new(),
+            None,
+        );
+        let result = session.request_with_deadline(
+            json!({"cmd": "sent-timeout"}),
+            RequestDeadline::Fixed(Duration::from_millis(20)),
+        );
+
+        assert!(result.is_err(), "a request without a response unexpectedly succeeded");
+        assert!(
+            abort.0.load(Ordering::Acquire),
+            "a request that was already written did not reconcile the transport"
+        );
+    }
+
     fn blocked_request_write_timeout(
         deadline: RequestDeadline,
         command: Value,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1878,10 +1878,10 @@ impl PipeIoByteBudget {
         }
         let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
         state.retained = state.retained.saturating_sub(bytes);
-        if let PipeIoEvent::Replay { reservation_id: Some(id), .. } = event {
-            if state.oversized_replay == Some(*id) {
-                state.oversized_replay = None;
-            }
+        if let PipeIoEvent::Replay { reservation_id: Some(id), .. } = event
+            && state.oversized_replay == Some(*id)
+        {
+            state.oversized_replay = None;
         }
     }
 }
@@ -3610,10 +3610,10 @@ impl RemoteSession {
                 }
             }
         };
-        if let Some(token) = stalled_token {
-            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
-                self.disconnect_transport();
-            }
+        if let Some(token) = stalled_token
+            && self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost)
+        {
+            self.disconnect_transport();
         }
         true
     }
@@ -5363,8 +5363,7 @@ mod tests {
         );
         *session_slot.lock().unwrap() = Some(Arc::downgrade(&session));
 
-        let attaching = session.clone();
-        let worker = std::thread::spawn(move || attaching.try_attach_pipe_io(7, Some((100, 30))));
+        let worker = std::thread::spawn(move || session.try_attach_pipe_io(7, Some((100, 30))));
         let first = requests_rx
             .recv_timeout(Duration::from_secs(1))
             .expect("pipe-IO attach did not issue its first request");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7019,6 +7019,39 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_forward_accepts_replay_when_queued_budget_remainder_is_small() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let budget = Arc::new(PipeIoByteBudget::new(8));
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender.clone(),
+            lifecycle_sender,
+            budget.clone(),
+        );
+
+        let queued = PipeIoEvent::Output(vec![0; 7]);
+        assert!(budget.try_reserve_event(&queued));
+        sender.send(queued).unwrap();
+
+        let replay_bytes = vec![b'R'; 16];
+        assert!(session.pipe_io_forward(7, || PipeIoEvent::Replay {
+            bytes: replay_bytes.clone(),
+        }));
+        assert!(lifecycle_receiver.try_recv().is_err());
+
+        let queued = receiver.try_recv().unwrap();
+        let replay = receiver.try_recv().unwrap();
+        assert_eq!(queued, PipeIoEvent::Output(vec![0; 7]));
+        assert_eq!(replay, PipeIoEvent::Replay { bytes: replay_bytes });
+        budget.release_event(&queued);
+        budget.release_event(&replay);
+    }
+
+    #[test]
     fn pipe_io_forward_does_not_build_payload_without_matching_tap() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6910,6 +6910,21 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_forward_does_not_build_payload_without_matching_tap() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let built = Arc::new(AtomicBool::new(false));
+        let built_by_event = built.clone();
+
+        assert!(!session.pipe_io_forward(7, || {
+            built_by_event.store(true, Ordering::Release);
+            PipeIoEvent::Output(vec![0; 1024])
+        }));
+        assert!(!built.load(Ordering::Acquire));
+    }
+
+    #[test]
     fn stale_pipe_io_tap_cleanup_cannot_remove_a_replacement() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1660,6 +1660,7 @@ pub enum PipeIoEvent {
     SurfaceExited,
     TransportLost,
     StdinClosed,
+    StdinError,
 }
 
 impl PipeIoEvent {
@@ -1668,7 +1669,7 @@ impl PipeIoEvent {
     pub(crate) fn retained_bytes(&self) -> usize {
         match self {
             Self::Replay { bytes } | Self::Output(bytes) => bytes.len(),
-            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed => 0,
+            Self::SurfaceExited | Self::TransportLost | Self::StdinClosed | Self::StdinError => 0,
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7395,6 +7395,192 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_replay_forwards_the_coupled_color_state() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.handle_line(json!({
+            "event": "vt-state",
+            "surface": 7,
+            "cols": 80,
+            "rows": 24,
+            "data": base64::engine::general_purpose::STANDARD.encode(b"prompt"),
+            "colors": {
+                "fg": "#112233",
+                "bg": "#445566",
+                "cursor": "#778899",
+                "cursor_style": "bar",
+                "cursor_blink": false,
+                "palette": {"1": "#aabbcc"},
+            },
+        }));
+
+        let PipeIoEvent::Replay { bytes, .. } =
+            receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("vt-state did not forward a replay event");
+        };
+        let mut terminal = Terminal::new(80, 24, 100, Callbacks::default()).unwrap();
+        terminal.vt_write(&bytes);
+        assert_eq!(
+            terminal.effective_colors(),
+            (
+                Some(Rgb { r: 0x11, g: 0x22, b: 0x33 }),
+                Some(Rgb { r: 0x44, g: 0x55, b: 0x66 }),
+                Some(Rgb { r: 0x77, g: 0x88, b: 0x99 }),
+            )
+        );
+        assert_eq!(terminal.color_overrides().palette[1], Some(Rgb { r: 0xaa, g: 0xbb, b: 0xcc }));
+        assert_eq!(terminal.effective_cursor_visual().unwrap(), (CursorShape::Bar, false));
+    }
+
+    #[test]
+    fn pipe_io_output_keeps_color_state_after_live_bytes() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.handle_line(json!({
+            "event": "output",
+            "surface": 7,
+            "data": base64::engine::general_purpose::STANDARD.encode(b"live"),
+            "colors": {
+                "fg": "#102030",
+                "bg": "#405060",
+                "cursor": "#708090",
+                "cursor_style": "underline",
+                "cursor_blink": true,
+                "palette": {"196": "#010203"},
+            },
+        }));
+
+        let PipeIoEvent::Output(bytes) = receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("output did not forward an output event");
+        };
+        assert!(bytes.starts_with(b"live"), "color restoration must follow live bytes");
+        let mut terminal = Terminal::new(80, 24, 100, Callbacks::default()).unwrap();
+        terminal.vt_write(&bytes);
+        assert_eq!(
+            terminal.effective_colors(),
+            (
+                Some(Rgb { r: 0x10, g: 0x20, b: 0x30 }),
+                Some(Rgb { r: 0x40, g: 0x50, b: 0x60 }),
+                Some(Rgb { r: 0x70, g: 0x80, b: 0x90 }),
+            )
+        );
+        assert_eq!(terminal.color_overrides().palette[196], Some(Rgb { r: 1, g: 2, b: 3 }));
+        assert_eq!(terminal.effective_cursor_visual().unwrap(), (CursorShape::Underline, true));
+    }
+
+    #[test]
+    fn pipe_io_colors_changed_is_forwarded_to_an_owned_surface() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.handle_line(json!({
+            "event": "colors-changed",
+            "surface": 7,
+            "fg": "#abcdef",
+            "bg": "#102030",
+            "cursor": "#fedcba",
+            "cursor_style": "block",
+            "cursor_blink": true,
+            "palette": {"2": "#0a0b0c"},
+        }));
+
+        let PipeIoEvent::Output(bytes) = receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("colors-changed did not forward an output event");
+        };
+        let mut terminal = Terminal::new(80, 24, 100, Callbacks::default()).unwrap();
+        terminal.vt_write(&bytes);
+        assert_eq!(
+            terminal.effective_colors(),
+            (
+                Some(Rgb { r: 0xab, g: 0xcd, b: 0xef }),
+                Some(Rgb { r: 0x10, g: 0x20, b: 0x30 }),
+                Some(Rgb { r: 0xfe, g: 0xdc, b: 0xba }),
+            )
+        );
+        assert_eq!(terminal.color_overrides().palette[2], Some(Rgb { r: 0x0a, g: 0x0b, b: 0x0c }));
+    }
+
+    #[test]
+    fn pipe_io_resized_replay_restores_the_coupled_color_state() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.handle_line(json!({
+            "event": "resized",
+            "surface": 7,
+            "cols": 100,
+            "rows": 30,
+            "replay": base64::engine::general_purpose::STANDARD.encode(b"resized"),
+            "colors": {
+                "fg": "#203040",
+                "bg": "#506070",
+                "cursor": "#8090a0",
+                "cursor_style": "block",
+                "cursor_blink": false,
+                "palette": {"3": "#0d0e0f"},
+            },
+        }));
+
+        let PipeIoEvent::Replay { bytes, .. } =
+            receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("resized did not forward a replay event");
+        };
+        let mut terminal = Terminal::new(100, 30, 100, Callbacks::default()).unwrap();
+        terminal.vt_write(&bytes);
+        assert_eq!(
+            terminal.effective_colors(),
+            (
+                Some(Rgb { r: 0x20, g: 0x30, b: 0x40 }),
+                Some(Rgb { r: 0x50, g: 0x60, b: 0x70 }),
+                Some(Rgb { r: 0x80, g: 0x90, b: 0xa0 }),
+            )
+        );
+        assert_eq!(terminal.color_overrides().palette[3], Some(Rgb { r: 0x0d, g: 0x0e, b: 0x0f }));
+    }
+
+    #[test]
     fn pipe_io_budget_keeps_same_length_oversized_replay_reserved() {
         let budget = PipeIoByteBudget::new(16);
         let mut first = PipeIoEvent::replay(vec![b'A'; 16]);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7716,6 +7716,53 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_repeated_output_color_state_emits_only_changed_sidecar() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+        let colors = json!({
+            "fg": "#102030",
+            "bg": "#405060",
+            "cursor": "#708090",
+            "cursor_style": "underline",
+            "cursor_blink": true,
+            "palette": {"196": "#010203"},
+        });
+
+        session.handle_line(json!({
+            "event": "output",
+            "surface": 7,
+            "data": base64::engine::general_purpose::STANDARD.encode(b"first"),
+            "colors": colors.clone(),
+        }));
+        let PipeIoEvent::Output(first) = receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("first output did not forward");
+        };
+        assert!(first.starts_with(b"first"));
+
+        session.handle_line(json!({
+            "event": "output",
+            "surface": 7,
+            "data": base64::engine::general_purpose::STANDARD.encode(b"second"),
+            "colors": colors,
+        }));
+        let PipeIoEvent::Output(second) = receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("second output did not forward");
+        };
+        assert_eq!(second, b"second");
+    }
+
+    #[test]
     fn pipe_io_colors_changed_is_forwarded_to_an_owned_surface() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8605,6 +8605,31 @@ mod tests {
     }
 
     #[test]
+    fn normal_input_waits_through_brief_writer_queue_contention() {
+        let session = test_session(Box::new(SilentWriter));
+        let queue_guard = session.interactive_writer.shared.state.lock().unwrap();
+        let input_session = session.clone();
+        let (finished_tx, finished_rx) = channel();
+        let input = std::thread::spawn(move || {
+            finished_tx.send(input_session.send_bytes(7, b"input")).unwrap();
+        });
+
+        let early_result = finished_rx.recv_timeout(Duration::from_millis(50));
+        let stayed_blocked = early_result.is_err();
+        drop(queue_guard);
+        let result = match early_result {
+            Ok(result) => result,
+            Err(_) => finished_rx
+                .recv_timeout(Duration::from_secs(1))
+                .expect("normal input did not resume after queue contention"),
+        };
+        input.join().unwrap();
+
+        assert!(stayed_blocked, "normal input was rejected during brief queue contention");
+        assert!(result.is_ok(), "normal input failed after queue contention: {result:?}");
+    }
+
+    #[test]
     fn latency_histogram_reports_fixed_bucket_percentiles() {
         let metrics = InteractiveWriteMetrics::default();
         for latency in [

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2360,31 +2360,41 @@ impl RemoteSession {
         subscribe: bool,
         deadline: Instant,
     ) -> anyhow::Result<Arc<Self>> {
-        let path_for_thread = path.to_path_buf();
-        let display = path.display().to_string();
-        let (sender, receiver) = sync_channel(1);
-        let connector =
-            std::thread::Builder::new().name("remote-probe-connect".into()).spawn(move || {
-                let _ = sender.send(transport::connect(&path_for_thread));
-            })?;
-        let stream = match receiver.recv_timeout(deadline.saturating_duration_since(Instant::now()))
+        #[cfg(unix)]
         {
-            Ok(result) => {
-                let _ = connector.join();
-                result.with_context(|| format!("cannot connect to session socket {display}"))?
+            let timeout = deadline.saturating_duration_since(Instant::now());
+            if timeout.is_zero() {
+                anyhow::bail!(RemoteRequestError::Timeout);
             }
-            Err(RecvTimeoutError::Disconnected) => {
-                let _ = connector.join();
-                anyhow::bail!("remote probe connector stopped without a result")
-            }
-            Err(RecvTimeoutError::Timeout) => {
-                // The pipe-io process exits after classification. Dropping the
-                // connector lets that process terminate any blocked connect.
-                drop(connector);
-                anyhow::bail!(RemoteRequestError::Timeout)
-            }
-        };
-        Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
+            let address = socket2::SockAddr::unix(path)?;
+            let socket = socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::STREAM, None)?;
+            socket.connect_timeout(&address, timeout)?;
+            let stream: std::os::unix::net::UnixStream = socket.into();
+            return Self::connect_stream_with_subscription_until(
+                Box::new(stream),
+                subscribe,
+                deadline,
+            );
+        }
+
+        #[cfg(windows)]
+        {
+            // The Windows UDS adapter does not expose a cancellable connect
+            // primitive. Its local probe failures return promptly, while the
+            // Unix implementation above has an OS-level deadline.
+            let stream = transport::connect(path).map_err(|error| {
+                anyhow::anyhow!("cannot connect to session socket {}: {error}", path.display())
+            })?;
+            return Self::connect_stream_with_subscription_until(stream, subscribe, deadline);
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let stream = transport::connect(path).map_err(|error| {
+                anyhow::anyhow!("cannot connect to session socket {}: {error}", path.display())
+            })?;
+            Self::connect_stream_with_subscription_until(stream, subscribe, deadline)
+        }
     }
 
     /// Connect over an already-established full-duplex byte stream.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4092,6 +4092,12 @@ impl RemoteSession {
         self.exited_surfaces.lock().unwrap().ids.contains(&id)
     }
 
+    /// Reports explicit retirement captured at the surface-exit boundary.
+    /// Pipe-IO uses this fence when a claim response races terminal exit.
+    pub(crate) fn surface_is_retired(&self, id: SurfaceId) -> bool {
+        self.retired_surfaces.lock().unwrap().contains(&id)
+    }
+
     pub fn surface_kind(&self, id: SurfaceId) -> SurfaceKind {
         self.tree.lock().unwrap().view.surface_kind(id)
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8,7 +8,7 @@ use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
-use std::sync::{Arc, Condvar, Mutex, Weak};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
 use anyhow::Context;
@@ -34,7 +34,7 @@ use ghostty_vt::{
     MouseEncoders, MouseInput, RenderState, Terminal, TerminalColorOverrides,
     TerminalPointerSemanticSnapshot, parse_color,
 };
-use parking_lot::Mutex as ParkingMutex;
+use parking_lot::{Condvar as ParkingCondvar, Mutex as ParkingMutex};
 use serde_json::{Value, json};
 use zeroize::{Zeroize, Zeroizing};
 
@@ -1297,8 +1297,8 @@ fn latency_percentile(
 }
 
 struct InteractiveWriterShared {
-    state: Mutex<InteractiveWriteQueueState>,
-    changed: Condvar,
+    state: ParkingMutex<InteractiveWriteQueueState>,
+    changed: ParkingCondvar,
     metrics: InteractiveWriteMetrics,
     #[cfg(test)]
     wait_until_written_gate: Mutex<Option<InteractiveWaitUntilWrittenGate>>,
@@ -1323,8 +1323,8 @@ impl InteractiveWriter {
         abort: Arc<dyn RemoteTransportAbort>,
     ) -> io::Result<Self> {
         let shared = Arc::new(InteractiveWriterShared {
-            state: Mutex::new(InteractiveWriteQueueState::default()),
-            changed: Condvar::new(),
+            state: ParkingMutex::new(InteractiveWriteQueueState::default()),
+            changed: ParkingCondvar::new(),
             metrics: InteractiveWriteMetrics::default(),
             #[cfg(test)]
             wait_until_written_gate: Mutex::new(None),
@@ -1344,11 +1344,7 @@ impl InteractiveWriter {
         let mut write =
             InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
         let message_bytes = write.message.len();
-        let mut state = self
-            .shared
-            .state
-            .lock()
-            .map_err(|_| io::Error::other("interactive writer queue is poisoned"))?;
+        let mut state = self.shared.state.lock();
         if let Some(failure) = &state.failure {
             return Err(failure.to_error());
         }
@@ -1393,24 +1389,16 @@ impl InteractiveWriter {
             InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
         let message_bytes = write.message.len();
         loop {
-            let mut state = match self.shared.state.try_lock() {
-                Ok(state) => state,
-                Err(std::sync::TryLockError::Poisoned(_)) => {
-                    return Err(io::Error::other("interactive writer queue is poisoned"));
-                }
-                Err(std::sync::TryLockError::WouldBlock) => {
-                    let remaining = deadline.saturating_duration_since(Instant::now());
-                    if remaining.is_zero() {
-                        return self.queue_admission_timeout(measure_latency);
-                    }
-                    // std::sync::Mutex has no timed lock. Yield in short
-                    // bounded intervals so a transient holder is not
-                    // rejected, while the absolute request deadline remains
-                    // authoritative.
-                    std::thread::sleep(remaining.min(Duration::from_millis(1)));
-                    continue;
-                }
+            let Some(mut state) = self.shared.state.try_lock_until(deadline) else {
+                return self.queue_admission_timeout(measure_latency);
             };
+
+            // `try_lock_until` may acquire an uncontended mutex even when the
+            // deadline has just elapsed. Keep the deadline authoritative for
+            // queue admission, including this final lock/check boundary.
+            if Instant::now() >= deadline {
+                return self.queue_admission_timeout(measure_latency);
+            }
 
             if let Some(failure) = &state.failure {
                 return Err(failure.to_error());
@@ -1424,21 +1412,15 @@ impl InteractiveWriter {
             let queue_full = state.writes.len() >= INTERACTIVE_WRITE_QUEUE_CAPACITY
                 || message_bytes > INTERACTIVE_WRITE_QUEUE_BYTES.saturating_sub(state.queued_bytes);
             if queue_full {
-                let remaining = deadline.saturating_duration_since(Instant::now());
-                if remaining.is_zero() {
-                    return self.queue_admission_timeout(measure_latency);
-                }
-                let (_next, timeout) = self
-                    .shared
-                    .changed
-                    .wait_timeout(state, remaining)
-                    .unwrap_or_else(|poison| poison.into_inner());
-                if timeout.timed_out() {
+                if self.shared.changed.wait_until(&mut state, deadline).timed_out() {
                     return self.queue_admission_timeout(measure_latency);
                 }
                 continue;
             }
 
+            if Instant::now() >= deadline {
+                return self.queue_admission_timeout(measure_latency);
+            }
             let sequence = state.last_enqueued_sequence.checked_add(1).ok_or_else(|| {
                 io::Error::other("interactive writer sequence space is exhausted")
             })?;
@@ -1463,11 +1445,7 @@ impl InteractiveWriter {
     }
 
     fn last_enqueued_sequence(&self) -> io::Result<Option<u64>> {
-        let state = self
-            .shared
-            .state
-            .lock()
-            .map_err(|_| io::Error::other("interactive writer queue is poisoned"))?;
+        let state = self.shared.state.lock();
         Ok((state.last_enqueued_sequence != 0).then_some(state.last_enqueued_sequence))
     }
 
@@ -1475,11 +1453,7 @@ impl InteractiveWriter {
         #[cfg(test)]
         self.await_wait_until_written_gate(sequence);
         let deadline = Instant::now() + timeout;
-        let mut state = self
-            .shared
-            .state
-            .lock()
-            .map_err(|_| io::Error::other("interactive writer queue is poisoned"))?;
+        let mut state = self.shared.state.lock();
         loop {
             if state.last_written_sequence >= sequence {
                 return Ok(());
@@ -1494,13 +1468,7 @@ impl InteractiveWriter {
                     "ordered remote write did not complete before its deadline",
                 ));
             }
-            let (next, timeout) = self
-                .shared
-                .changed
-                .wait_timeout(state, remaining)
-                .unwrap_or_else(|poison| poison.into_inner());
-            state = next;
-            if timeout.timed_out()
+            if self.shared.changed.wait_until(&mut state, deadline).timed_out()
                 && state.last_written_sequence < sequence
                 && state.failure.is_none()
             {
@@ -1538,7 +1506,7 @@ impl InteractiveWriter {
     }
 
     fn request_close(&self) {
-        let mut state = self.shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        let mut state = self.shared.state.lock();
         state.closed = true;
         drop(state);
         self.shared.changed.notify_one();
@@ -1546,7 +1514,7 @@ impl InteractiveWriter {
 
     fn abort(&self, error: &io::Error) {
         {
-            let mut state = self.shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            let mut state = self.shared.state.lock();
             state.closed = true;
             state.failure.get_or_insert_with(|| InteractiveWriteFailure::from_error(error));
             state.writes.clear();
@@ -1559,19 +1527,13 @@ impl InteractiveWriter {
     fn close(&self) {
         self.request_close();
         let deadline = Instant::now() + remote_write_timeout();
-        let mut state = self.shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        let mut state = self.shared.state.lock();
         while !state.writer_closed {
             let remaining = deadline.saturating_duration_since(Instant::now());
             if remaining.is_zero() {
                 break;
             }
-            let (next, timeout) = self
-                .shared
-                .changed
-                .wait_timeout(state, remaining)
-                .unwrap_or_else(|poison| poison.into_inner());
-            state = next;
-            if timeout.timed_out() {
+            if self.shared.changed.wait_until(&mut state, deadline).timed_out() {
                 break;
             }
         }
@@ -1589,8 +1551,7 @@ impl InteractiveWriter {
 impl Drop for InteractiveWriter {
     fn drop(&mut self) {
         self.request_close();
-        let writer_closed =
-            self.shared.state.lock().unwrap_or_else(|poison| poison.into_inner()).writer_closed;
+        let writer_closed = self.shared.state.lock().writer_closed;
         if !writer_closed {
             self.abort(&io::Error::new(
                 io::ErrorKind::BrokenPipe,
@@ -1606,14 +1567,14 @@ fn interactive_writer_worker(
 ) {
     loop {
         let write = {
-            let mut state = shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+            let mut state = shared.state.lock();
             while state.writes.is_empty() && !state.closed && state.failure.is_none() {
-                state = shared.changed.wait(state).unwrap_or_else(|poison| poison.into_inner());
+                shared.changed.wait(&mut state);
             }
             let Some(write) = state.writes.pop_front() else {
                 drop(state);
                 let _ = writer.close();
-                let mut state = shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+                let mut state = shared.state.lock();
                 state.writer_closed = true;
                 drop(state);
                 shared.changed.notify_all();
@@ -1629,7 +1590,7 @@ fn interactive_writer_worker(
                 if write.measure_latency {
                     shared.metrics.record_latency(write.enqueued_at.elapsed());
                 }
-                let mut state = shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+                let mut state = shared.state.lock();
                 state.last_written_sequence = write.sequence;
                 drop(state);
                 shared.changed.notify_all();
@@ -1639,7 +1600,7 @@ fn interactive_writer_worker(
                     shared.metrics.write_failures.fetch_add(1, Ordering::Relaxed);
                 }
                 let _ = writer.close();
-                let mut state = shared.state.lock().unwrap_or_else(|poison| poison.into_inner());
+                let mut state = shared.state.lock();
                 state.failure.get_or_insert_with(|| InteractiveWriteFailure::from_error(&error));
                 state.writes.clear();
                 state.queued_bytes = 0;
@@ -8402,7 +8363,7 @@ mod tests {
             "expected shutdown after the ordered write completed, got {error:?}"
         );
         release.join().unwrap();
-        let writer_state = session.interactive_writer.shared.state.lock().unwrap();
+        let writer_state = session.interactive_writer.shared.state.lock();
         assert!(writer_state.last_written_sequence >= sequence);
         drop(writer_state);
         assert!(!output.lock().unwrap().is_empty());
@@ -8436,7 +8397,7 @@ mod tests {
         resume_wait_tx.send(()).unwrap();
         finished_rx.recv_timeout(remote_write_timeout() * 2).unwrap();
         shutdown.join().unwrap();
-        let writer_state = session.interactive_writer.shared.state.lock().unwrap();
+        let writer_state = session.interactive_writer.shared.state.lock();
         assert!(writer_state.last_written_sequence >= sequence);
         drop(writer_state);
         assert!(!output.lock().unwrap().is_empty());
@@ -8458,7 +8419,7 @@ mod tests {
         assert!(started.elapsed() < remote_write_timeout() * 5);
         let deadline = Instant::now() + remote_write_timeout();
         loop {
-            let state = session.interactive_writer.shared.state.lock().unwrap();
+            let state = session.interactive_writer.shared.state.lock();
             if state.writer_closed {
                 assert!(state.writes.is_empty());
                 assert_eq!(state.queued_bytes, 0);
@@ -8512,7 +8473,7 @@ mod tests {
         let state = control.state.0.lock().unwrap();
         assert!(state.aborted);
         drop(state);
-        let state = session.interactive_writer.shared.state.lock().unwrap();
+        let state = session.interactive_writer.shared.state.lock();
         assert!(state.writer_closed);
         assert!(matches!(
             state.failure,
@@ -8555,7 +8516,7 @@ mod tests {
         for waiter in waiters {
             waiter.join().unwrap();
         }
-        let state = session.interactive_writer.shared.state.lock().unwrap();
+        let state = session.interactive_writer.shared.state.lock();
         assert!(state.writes.is_empty());
         assert_eq!(state.queued_bytes, 0);
         assert!(state.writer_closed);
@@ -8742,7 +8703,7 @@ mod tests {
     #[test]
     fn bounded_request_rejects_a_contended_writer_queue_without_waiting() {
         let session = test_session(Box::new(SilentWriter));
-        let queue_guard = session.interactive_writer.shared.state.lock().unwrap();
+        let queue_guard = session.interactive_writer.shared.state.lock();
         let request_session = session.clone();
         let (finished_tx, finished_rx) = channel();
         let deadline = Instant::now() + Duration::from_millis(20);
@@ -8785,7 +8746,7 @@ mod tests {
     #[test]
     fn normal_input_waits_through_brief_writer_queue_contention() {
         let session = test_session(Box::new(SilentWriter));
-        let queue_guard = session.interactive_writer.shared.state.lock().unwrap();
+        let queue_guard = session.interactive_writer.shared.state.lock();
         let input_session = session.clone();
         let (finished_tx, finished_rx) = channel();
         let input = std::thread::spawn(move || {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -11,6 +11,7 @@ use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel}
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
 
+use anyhow::Context;
 use base64::Engine;
 use cmux_tui_core::server::{VIEWPORT_COLUMN_RESIZE_CAPABILITY, VIEWPORT_SPLITS_CAPABILITY};
 use cmux_tui_core::{
@@ -236,6 +237,28 @@ impl RemoteRequestError {
             _ => None,
         }
     }
+}
+
+pub(crate) fn is_pipe_io_retryable_error(error: &anyhow::Error) -> bool {
+    error.chain().any(|cause| {
+        if let Some(remote_error) = cause.downcast_ref::<RemoteRequestError>() {
+            return remote_error.is_transport_failure() || remote_error.is_timeout();
+        }
+        cause.downcast_ref::<io::Error>().is_some_and(|io_error| {
+            matches!(
+                io_error.kind(),
+                io::ErrorKind::ConnectionRefused
+                    | io::ErrorKind::ConnectionReset
+                    | io::ErrorKind::BrokenPipe
+                    | io::ErrorKind::UnexpectedEof
+                    | io::ErrorKind::TimedOut
+                    | io::ErrorKind::NotConnected
+                    | io::ErrorKind::WouldBlock
+                    | io::ErrorKind::Interrupted
+                    | io::ErrorKind::NotFound
+            )
+        })
+    })
 }
 
 impl std::fmt::Display for RemoteRequestError {
@@ -2012,9 +2035,8 @@ impl RemoteSession {
     }
 
     fn connect_path(path: &Path, subscribe: bool) -> anyhow::Result<Arc<Self>> {
-        let stream = transport::connect(path).map_err(|e| {
-            anyhow::anyhow!("cannot connect to session socket {}: {e}", path.display())
-        })?;
+        let stream = transport::connect(path)
+            .with_context(|| format!("cannot connect to session socket {}", path.display()))?;
         Self::connect_stream_with_subscription(stream, subscribe)
     }
 
@@ -2034,9 +2056,7 @@ impl RemoteSession {
         {
             Ok(result) => {
                 let _ = connector.join();
-                result.map_err(|error| {
-                    anyhow::anyhow!("cannot connect to session socket {display}: {error}")
-                })?
+                result.with_context(|| format!("cannot connect to session socket {display}"))?
             }
             Err(RecvTimeoutError::Disconnected) => {
                 let _ = connector.join();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8225,6 +8225,33 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn geometry_claim_waits_for_daemon_acknowledgement() {
+        let (client, server) = UnixStream::pair().unwrap();
+        let session = socket_test_session(client);
+        let (finished_tx, finished_rx) = channel();
+        let sender_session = session.clone();
+        let sender = std::thread::spawn(move || {
+            finished_tx.send(sender_session.notify_claim_terminal_geometry(9)).unwrap();
+        });
+
+        let mut peer = BufReader::new(server);
+        let mut line = String::new();
+        peer.read_line(&mut line).unwrap();
+        let command: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(command["cmd"], "set-client-sizing");
+        assert_eq!(command["surface"], 9);
+        assert_eq!(command["enabled"], true);
+        assert_eq!(command["exclusive"], true);
+        assert!(command.get("no_reply").is_none());
+        assert!(finished_rx.recv_timeout(Duration::from_millis(100)).is_err());
+
+        session.handle_line(json!({"id": command["id"], "ok": true, "data": null}));
+        assert!(finished_rx.recv_timeout(Duration::from_secs(1)).unwrap().is_ok());
+        sender.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn accepted_interactive_writes_remain_fifo() {
         let (client, server) = UnixStream::pair().unwrap();
         let session = socket_test_session(client);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1822,6 +1822,16 @@ pub(crate) enum PipeIoSurfaceAttach {
     Deferred,
 }
 
+fn parse_pipe_io_resize_response(response: &Value) -> anyhow::Result<bool> {
+    match response.get("outcome").and_then(Value::as_str) {
+        Some("superseded") | Some("passive") => Ok(false),
+        Some("applied") | None => {
+            Ok(response.get("accepted").and_then(Value::as_bool).unwrap_or(true))
+        }
+        Some(other) => anyhow::bail!("unknown pipe-IO resize outcome {other}"),
+    }
+}
+
 /// Receive complete JSON protocol messages from one transport.
 ///
 /// Message framing belongs to the transport adapter: Unix sockets and SSH
@@ -3791,9 +3801,16 @@ impl RemoteSession {
         if !self.can_attach_after_overflow(id) {
             return Ok(PipeIoSurfaceAttach::Deferred);
         }
-        let initial_size = size.map(|(cols, rows)| (cols.max(1), rows.max(1))).filter(|_| {
-            self.supports_capability(cmux_tui_core::server::ATTACH_INITIAL_SIZE_CAPABILITY)
-        });
+        let requested_size = size.map(|(cols, rows)| (cols.max(1), rows.max(1)));
+        let initial_size = requested_size.filter(|_| self.supports_pipe_io_initial_size());
+        if initial_size.is_none()
+            && let Some((cols, rows)) = requested_size
+        {
+            // Older daemons cannot size the PTY as part of attach. A generic
+            // resize is valid before the stream is opened and establishes the
+            // requested geometry before the daemon publishes its first replay.
+            self.resize_pipe_io_before_attach(id, cols, rows)?;
+        }
         let mut request = json!({"cmd": "attach-surface", "surface": id, "mode": "bytes"});
         if let Some((cols, rows)) = initial_size {
             request["cols"] = json!(cols);
@@ -3874,14 +3891,25 @@ impl RemoteSession {
                 "rows": desired.1,
             });
         }
-        let response = self.request(request)?;
-        match response.get("outcome").and_then(Value::as_str) {
-            Some("superseded") | Some("passive") => Ok(false),
-            Some("applied") | None => {
-                Ok(response.get("accepted").and_then(Value::as_bool).unwrap_or(true))
-            }
-            Some(other) => anyhow::bail!("unknown pipe-IO resize outcome {other}"),
-        }
+        parse_pipe_io_resize_response(&self.request(request)?)
+    }
+
+    /// Size a legacy attachment before opening its byte stream. This must use
+    /// the unleased command because the attachment lease does not exist yet.
+    pub(crate) fn resize_pipe_io_before_attach(
+        &self,
+        surface: SurfaceId,
+        cols: u16,
+        rows: u16,
+    ) -> anyhow::Result<bool> {
+        let desired = (cols.max(1), rows.max(1));
+        let response = self.request(json!({
+            "cmd": "resize-surface",
+            "surface": surface,
+            "cols": desired.0,
+            "rows": desired.1,
+        }))?;
+        parse_pipe_io_resize_response(&response)
     }
 
     /// Mirror for a surface, attaching on first use. Servers advertising

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7594,6 +7594,54 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_palette_replacement_resets_only_removed_entries() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(4);
+        let (lifecycle_sender, _lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let _token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        session.handle_line(json!({
+            "event": "colors-changed",
+            "surface": 7,
+            "fg": "#abcdef",
+            "bg": "#102030",
+            "cursor": null,
+            "palette": {"2": "#0a0b0c"},
+        }));
+        let _ = receiver.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        session.handle_line(json!({
+            "event": "colors-changed",
+            "surface": 7,
+            "fg": "#abcdef",
+            "bg": "#102030",
+            "cursor": null,
+            "palette": {"3": "#0d0e0f"},
+        }));
+        let PipeIoEvent::Output(bytes) = receiver.recv_timeout(Duration::from_secs(1)).unwrap()
+        else {
+            panic!("palette replacement did not forward output");
+        };
+
+        assert!(bytes.windows(b"\x1b]104;2\x1b\\".len()).any(|window| {
+            window == b"\x1b]104;2\x1b\\"
+        }));
+        assert!(!bytes.windows(b"\x1b]104\x1b\\".len()).any(|window| {
+            window == b"\x1b]104\x1b\\"
+        }));
+        assert!(bytes.windows(b"\x1b]4;3;rgb:0d/0e/0f\x1b\\".len()).any(|window| {
+            window == b"\x1b]4;3;rgb:0d/0e/0f\x1b\\"
+        }));
+    }
+
+    #[test]
     fn pipe_io_resized_replay_restores_the_coupled_color_state() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3408,7 +3408,33 @@ impl RemoteSession {
     /// would corrupt the embedder's terminal state (bounded-backpressure
     /// policy; never wedge the session reader thread).
     fn pipe_io_forward(&self, surface: SurfaceId, event: impl FnOnce() -> PipeIoEvent) -> bool {
-        self.pipe_io_forward_owned(surface, event()).is_ok()
+        use crossbeam_channel::TrySendError;
+        let stalled_token = {
+            let tap = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap.as_ref() else { return false };
+            if tap.surface != surface {
+                return false;
+            }
+            let event = event();
+            let retained_bytes = event.retained_bytes();
+            if !tap.byte_budget.try_reserve(retained_bytes) {
+                Some(tap.token.clone())
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => None,
+                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
+                        tap.byte_budget.release(retained_bytes);
+                        Some(tap.token.clone())
+                    }
+                }
+            }
+        };
+        if let Some(token) = stalled_token {
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
+        }
+        true
     }
 
     /// Forwards an already-owned event without cloning its payload. If no

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6,7 +6,7 @@ use std::fs;
 use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
 use std::sync::{Arc, Condvar, Mutex, OnceLock, Weak};
 use std::time::{Duration, Instant};
@@ -53,6 +53,7 @@ const MAX_SURFACE_OVERFLOW_RECOVERIES: usize = 256;
 const INTERACTIVE_WRITE_QUEUE_CAPACITY: usize = 512;
 const INTERACTIVE_WRITE_QUEUE_BYTES: usize = 8 * 1024 * 1024;
 pub(crate) const REMOTE_CONTROL_MESSAGE_MAX_BYTES: usize = REMOTE_SESSION_MESSAGE_MAX_BYTES;
+const PIPE_IO_REPLAY_SINGLE_FRAME_MAX_BYTES: usize = REMOTE_CONTROL_MESSAGE_MAX_BYTES;
 const REMOTE_FRAME_LOG_MAX_ENTRIES: usize = 16 * 1024;
 const REMOTE_FRAME_LOG_MAX_BYTES: usize = 2 * 1024 * 1024;
 const REMOTE_TERMINAL_DIMENSION_MAX: u64 = 10_000;
@@ -1689,55 +1690,78 @@ impl PipeIoEvent {
 /// Shared byte budget for one pipe-IO relay. A count-only bounded channel can
 /// retain megabytes per event when a replay is large; this budget makes the
 /// memory bound explicit and turns an overrun into the same transport-loss
-/// path as a full channel.
+/// path as a full channel. One replay may use a single additional allowance
+/// bounded by the remote message limit, so a valid replay is not rejected only
+/// because it is larger than the normal live-output budget.
+struct PipeIoBudgetState {
+    retained: usize,
+    oversized_replay: Option<usize>,
+}
+
 pub(crate) struct PipeIoByteBudget {
-    retained: AtomicUsize,
+    state: Mutex<PipeIoBudgetState>,
     limit: usize,
 }
 
 impl PipeIoByteBudget {
     pub(crate) fn new(limit: usize) -> Self {
-        Self { retained: AtomicUsize::new(0), limit: limit.max(1) }
+        Self {
+            state: Mutex::new(PipeIoBudgetState { retained: 0, oversized_replay: None }),
+            limit: limit.max(1),
+        }
     }
 
     pub(crate) fn try_reserve(&self, bytes: usize) -> bool {
         if bytes == 0 {
             return true;
         }
-        let mut current = self.retained.load(Ordering::Acquire);
-        loop {
-            let Some(next) = current.checked_add(bytes) else { return false };
-            if next > self.limit {
-                return false;
-            }
-            match self.retained.compare_exchange_weak(
-                current,
-                next,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => return true,
-                Err(observed) => current = observed,
-            }
+        let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        let Some(next) = state.retained.checked_add(bytes) else { return false };
+        if next > self.limit {
+            return false;
+        }
+        state.retained = next;
+        true
+    }
+
+    fn try_reserve_replay(&self, bytes: usize) -> bool {
+        if bytes == 0 {
+            return true;
+        }
+        let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        let Some(next) = state.retained.checked_add(bytes) else { return false };
+        if next <= self.limit {
+            state.retained = next;
+            return true;
+        }
+        let max_total = self.limit.saturating_add(PIPE_IO_REPLAY_SINGLE_FRAME_MAX_BYTES);
+        if bytes > PIPE_IO_REPLAY_SINGLE_FRAME_MAX_BYTES
+            || state.oversized_replay.is_some()
+            || next > max_total
+        {
+            return false;
+        }
+        state.retained = next;
+        state.oversized_replay = Some(bytes);
+        true
+    }
+
+    pub(crate) fn try_reserve_event(&self, event: &PipeIoEvent) -> bool {
+        match event {
+            PipeIoEvent::Replay { bytes } => self.try_reserve_replay(bytes.len()),
+            _ => self.try_reserve(event.retained_bytes()),
         }
     }
 
-    pub(crate) fn release(&self, bytes: usize) {
+    pub(crate) fn release_event(&self, event: &PipeIoEvent) {
+        let bytes = event.retained_bytes();
         if bytes == 0 {
             return;
         }
-        let mut current = self.retained.load(Ordering::Acquire);
-        loop {
-            let next = current.saturating_sub(bytes);
-            match self.retained.compare_exchange_weak(
-                current,
-                next,
-                Ordering::AcqRel,
-                Ordering::Acquire,
-            ) {
-                Ok(_) => return,
-                Err(observed) => current = observed,
-            }
+        let mut state = self.state.lock().unwrap_or_else(|poison| poison.into_inner());
+        state.retained = state.retained.saturating_sub(bytes);
+        if matches!(event, PipeIoEvent::Replay { .. }) && state.oversized_replay == Some(bytes) {
+            state.oversized_replay = None;
         }
     }
 }
@@ -3422,14 +3446,13 @@ impl RemoteSession {
                 return false;
             }
             let event = event();
-            let retained_bytes = event.retained_bytes();
-            if !tap.byte_budget.try_reserve(retained_bytes) {
+            if !tap.byte_budget.try_reserve_event(&event) {
                 Some(tap.token.clone())
             } else {
                 match tap.sender.try_send(event) {
                     Ok(()) => None,
-                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
-                        tap.byte_budget.release(retained_bytes);
+                    Err(TrySendError::Full(event) | TrySendError::Disconnected(event)) => {
+                        tap.byte_budget.release_event(&event);
                         Some(tap.token.clone())
                     }
                 }
@@ -3459,14 +3482,13 @@ impl RemoteSession {
             if tap.surface != surface {
                 return Err(event);
             }
-            let retained_bytes = event.retained_bytes();
-            if !tap.byte_budget.try_reserve(retained_bytes) {
+            if !tap.byte_budget.try_reserve_event(&event) {
                 Some(tap.token.clone())
             } else {
                 match tap.sender.try_send(event) {
                     Ok(()) => None,
-                    Err(TrySendError::Full(_) | TrySendError::Disconnected(_)) => {
-                        tap.byte_budget.release(retained_bytes);
+                    Err(TrySendError::Full(event) | TrySendError::Disconnected(event)) => {
+                        tap.byte_budget.release_event(&event);
                         Some(tap.token.clone())
                     }
                 }
@@ -7026,29 +7048,27 @@ mod tests {
         let (sender, receiver) = crossbeam_channel::bounded(4);
         let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
         let budget = Arc::new(PipeIoByteBudget::new(8));
-        let _token = session.install_pipe_io_tap(
-            7,
-            sender.clone(),
-            lifecycle_sender,
-            budget.clone(),
-        );
+        let _token =
+            session.install_pipe_io_tap(7, sender.clone(), lifecycle_sender, budget.clone());
 
         let queued = PipeIoEvent::Output(vec![0; 7]);
         assert!(budget.try_reserve_event(&queued));
         sender.send(queued).unwrap();
 
         let replay_bytes = vec![b'R'; 16];
-        assert!(session.pipe_io_forward(7, || PipeIoEvent::Replay {
-            bytes: replay_bytes.clone(),
-        }));
+        assert!(session.pipe_io_forward(7, || PipeIoEvent::Replay { bytes: replay_bytes.clone() }));
         assert!(lifecycle_receiver.try_recv().is_err());
 
         let queued = receiver.try_recv().unwrap();
         let replay = receiver.try_recv().unwrap();
         assert_eq!(queued, PipeIoEvent::Output(vec![0; 7]));
         assert_eq!(replay, PipeIoEvent::Replay { bytes: replay_bytes });
+        let second_replay = PipeIoEvent::Replay { bytes: vec![b'S'; 16] };
+        assert!(!budget.try_reserve_event(&second_replay));
         budget.release_event(&queued);
         budget.release_event(&replay);
+        assert!(budget.try_reserve_event(&second_replay));
+        budget.release_event(&second_replay);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -514,6 +514,48 @@ struct PipeIoColorState {
     presence: PipeIoColorPresence,
 }
 
+#[derive(Default)]
+struct PipeIoCachedColor {
+    known: bool,
+    value: Option<Rgb>,
+    bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+struct PipeIoCachedCursorVisual {
+    known: bool,
+    value: Option<(CursorShape, bool)>,
+}
+
+#[derive(Default)]
+struct PipeIoCachedPaletteSet {
+    color: Rgb,
+    bytes: Vec<u8>,
+}
+
+#[derive(Default)]
+struct PipeIoColorCache {
+    fg: PipeIoCachedColor,
+    bg: PipeIoCachedColor,
+    cursor: PipeIoCachedColor,
+    cursor_visual: PipeIoCachedCursorVisual,
+    palette: [Option<Rgb>; 256],
+    palette_known: bool,
+    palette_set_bytes: [Option<PipeIoCachedPaletteSet>; 256],
+    palette_reset_bytes: [Option<Vec<u8>>; 256],
+}
+
+impl PipeIoColorCache {
+    fn reset_for_replay(&mut self) {
+        self.fg.known = false;
+        self.bg.known = false;
+        self.cursor.known = false;
+        self.cursor_visual.known = false;
+        self.palette = [None; 256];
+        self.palette_known = false;
+    }
+}
+
 impl RemoteSurface {
     #[cfg(test)]
     fn run_geometry_test_hook(&self, step: RemoteGeometryTestStep) {
@@ -1876,11 +1918,10 @@ struct PipeIoTap {
     lifecycle_sender: EventSender<PipeIoEvent>,
     byte_budget: Arc<PipeIoByteBudget>,
     token: Arc<u8>,
-    // A pipe receives color state as VT sidecars. Keep the last sparse
-    // authored palette so a live replacement can reset only entries that
-    // disappeared, while omitted entries retain the embedder's theme.
-    palette: [Option<Rgb>; 256],
-    palette_known: bool,
+    // A pipe receives color state as VT sidecars. Cache the encoded fields and
+    // last sparse authored palette so unchanged live events do not allocate or
+    // append duplicate escape sequences.
+    color_cache: PipeIoColorCache,
 }
 
 pub(super) enum RemoteSurfaceAttach {
@@ -3567,8 +3608,7 @@ impl RemoteSession {
             lifecycle_sender,
             byte_budget,
             token: token.clone(),
-            palette: [None; 256],
-            palette_known: false,
+            color_cache: PipeIoColorCache::default(),
         });
         token
     }
@@ -3712,28 +3752,18 @@ impl RemoteSession {
                         // after the first one. The reset clears authored
                         // palette state, so replay the complete sparse set
                         // rather than diffing against the prior live state.
-                        append_pipe_io_colors(bytes, colors, None, true);
+                        append_pipe_io_colors(bytes, colors, &mut tap.color_cache, true);
                     }
                     PipeIoEvent::Output(bytes) => {
-                        let previous = tap.palette_known.then_some(&tap.palette);
-                        append_pipe_io_colors(bytes, colors, previous, false);
+                        append_pipe_io_colors(bytes, colors, &mut tap.color_cache, false);
                     }
                     _ => {}
                 }
-            }
-            if matches!(&event, PipeIoEvent::Replay { .. }) {
-                // A replay replaces the terminal. Without a palette field the
-                // server gave us no authoritative authored set, so do not
-                // compare a later sparse update with stale state.
-                tap.palette_known = colors.is_some_and(|colors| colors.presence.palette);
-                if let Some(colors) = colors.filter(|colors| colors.presence.palette) {
-                    tap.palette = colors.colors.palette;
-                } else {
-                    tap.palette = [None; 256];
-                }
-            } else if let Some(colors) = colors.filter(|colors| colors.presence.palette) {
-                tap.palette = colors.colors.palette;
-                tap.palette_known = true;
+            } else if matches!(&event, PipeIoEvent::Replay { .. }) {
+                // A replay replaces the terminal. Without a colors field the
+                // server gave us no authoritative state, so do not compare a
+                // later sparse update with stale values.
+                tap.color_cache.reset_for_replay();
             }
             if !tap.byte_budget.try_reserve_event(&mut event) {
                 Some(tap.token.clone())
@@ -4736,84 +4766,238 @@ fn parse_pipe_io_colors(value: &Value) -> Option<PipeIoColorState> {
 
 /// Append the VT sidecar needed by a raw pipe to adopt one protocol color
 /// transition. The JSON attach stream carries this state beside replay/output
-/// bytes, but a pipe embedder only receives bytes. Dynamic colors are emitted
-/// only when their field is present, allowing legacy live palette events to
-/// preserve omitted defaults and cursor metadata. A present sparse palette is
-/// a complete authored-override snapshot. On a live transition, reset only
+/// bytes, but a pipe embedder only receives bytes. Dynamic fields are cached
+/// per tap and emitted only when present and changed. A present sparse palette
+/// is a complete authored-override snapshot. On a live transition, reset only
 /// entries removed from the previous snapshot so omitted entries retain the
 /// embedder's theme. A replay has already reset the terminal, so it emits all
 /// current authored entries without a broad palette reset.
 fn append_pipe_io_colors(
     bytes: &mut Vec<u8>,
     state: &PipeIoColorState,
-    previous_palette: Option<&[Option<Rgb>; 256]>,
+    cache: &mut PipeIoColorCache,
     replay_reset: bool,
 ) {
-    fn dynamic_color(
-        bytes: &mut Vec<u8>,
-        present: bool,
-        set_code: u16,
-        reset_code: u16,
-        color: Option<Rgb>,
-    ) {
-        if !present {
-            return;
-        }
-        match color {
-            Some(color) => bytes.extend_from_slice(
-                format!(
-                    "\x1b]{set_code};rgb:{:02x}/{:02x}/{:02x}\x1b\\",
-                    color.r, color.g, color.b
-                )
-                .as_bytes(),
-            ),
-            None => bytes.extend_from_slice(format!("\x1b]{reset_code}\x1b\\").as_bytes()),
-        }
+    if replay_reset {
+        cache.reset_for_replay();
     }
 
     let colors = &state.colors;
     let presence = state.presence;
-    dynamic_color(bytes, presence.fg, 10, 110, colors.fg);
-    dynamic_color(bytes, presence.bg, 11, 111, colors.bg);
-    dynamic_color(bytes, presence.cursor, 12, 112, colors.cursor);
+    append_cached_pipe_io_color(
+        bytes,
+        &mut cache.fg,
+        presence.fg,
+        10,
+        110,
+        colors.fg,
+        replay_reset,
+    );
+    append_cached_pipe_io_color(
+        bytes,
+        &mut cache.bg,
+        presence.bg,
+        11,
+        111,
+        colors.bg,
+        replay_reset,
+    );
+    append_cached_pipe_io_color(
+        bytes,
+        &mut cache.cursor,
+        presence.cursor,
+        12,
+        112,
+        colors.cursor,
+        replay_reset,
+    );
 
-    if presence.cursor_visual
-        && let (Some(style), Some(blink)) = (colors.cursor_style, colors.cursor_blink)
-    {
-        let value = match (style, blink) {
-            (CursorShape::Block | CursorShape::BlockHollow, true) => 1,
-            (CursorShape::Block | CursorShape::BlockHollow, false) => 2,
-            (CursorShape::Underline, true) => 3,
-            (CursorShape::Underline, false) => 4,
-            (CursorShape::Bar, true) => 5,
-            (CursorShape::Bar, false) => 6,
-        };
-        // Reset any application-authored DECSCUSR before applying the
-        // resolved pair, matching apply_terminal_colors on local mirrors.
-        bytes.extend_from_slice(format!("\x1b[0 q\x1b[{value} q").as_bytes());
-    }
+    let cursor_visual = presence
+        .cursor_visual
+        .then(|| colors.cursor_style.zip(colors.cursor_blink).map(|(style, blink)| (style, blink)));
+    append_cached_pipe_io_cursor_visual(
+        bytes,
+        &mut cache.cursor_visual,
+        cursor_visual.flatten(),
+        replay_reset,
+    );
 
     if presence.palette {
-        for (index, color) in colors.palette.iter().enumerate() {
-            let previous = previous_palette.map(|palette| palette[index]);
-            if !replay_reset && previous == Some(*color) {
+        let previous_known = cache.palette_known;
+        for index in 0..256 {
+            let current = colors.palette[index];
+            let previous = previous_known.then_some(cache.palette[index]);
+            if !replay_reset && previous == Some(current) {
                 continue;
             }
-            match color {
-                Some(color) => bytes.extend_from_slice(
-                    format!(
-                        "\x1b]4;{index};rgb:{:02x}/{:02x}/{:02x}\x1b\\",
-                        color.r, color.g, color.b
-                    )
-                    .as_bytes(),
-                ),
+            match current {
+                Some(color) => {
+                    append_cached_pipe_io_palette_set(
+                        bytes,
+                        &mut cache.palette_set_bytes[index],
+                        index,
+                        color,
+                    );
+                }
                 None if previous.is_some_and(|color| color.is_some()) => {
-                    bytes.extend_from_slice(format!("\x1b]104;{index}\x1b\\").as_bytes());
+                    append_cached_pipe_io_palette_reset(
+                        bytes,
+                        &mut cache.palette_reset_bytes[index],
+                        index,
+                    );
                 }
                 None => {}
             }
         }
+        cache.palette = colors.palette;
+        cache.palette_known = true;
     }
+}
+
+fn append_cached_pipe_io_color(
+    bytes: &mut Vec<u8>,
+    cache: &mut PipeIoCachedColor,
+    present: bool,
+    set_code: u16,
+    reset_code: u16,
+    value: Option<Rgb>,
+    replay_reset: bool,
+) {
+    if replay_reset {
+        cache.known = false;
+    }
+    if !present {
+        return;
+    }
+    if !replay_reset && cache.known && cache.value == value {
+        return;
+    }
+    if cache.value != value || cache.bytes.is_empty() {
+        cache.value = value;
+        cache.bytes = pipe_io_dynamic_color_bytes(set_code, reset_code, value);
+    }
+    bytes.extend_from_slice(&cache.bytes);
+    cache.known = true;
+}
+
+fn append_cached_pipe_io_cursor_visual(
+    bytes: &mut Vec<u8>,
+    cache: &mut PipeIoCachedCursorVisual,
+    value: Option<(CursorShape, bool)>,
+    replay_reset: bool,
+) {
+    if replay_reset {
+        cache.known = false;
+    }
+    let Some(value) = value else { return };
+    if !replay_reset && cache.known && cache.value == Some(value) {
+        return;
+    }
+    // Reset any application-authored DECSCUSR before applying the resolved
+    // pair, matching apply_terminal_colors on local mirrors.
+    bytes.extend_from_slice(pipe_io_cursor_visual_bytes(value));
+    cache.value = Some(value);
+    cache.known = true;
+}
+
+fn append_cached_pipe_io_palette_set(
+    bytes: &mut Vec<u8>,
+    cache: &mut Option<PipeIoCachedPaletteSet>,
+    index: usize,
+    color: Rgb,
+) {
+    let needs_build = !cache.as_ref().is_some_and(|cached| cached.color == color);
+    if needs_build {
+        *cache =
+            Some(PipeIoCachedPaletteSet { color, bytes: pipe_io_palette_set_bytes(index, color) });
+    }
+    if let Some(cached) = cache.as_ref() {
+        bytes.extend_from_slice(&cached.bytes);
+    }
+}
+
+fn append_cached_pipe_io_palette_reset(
+    bytes: &mut Vec<u8>,
+    cache: &mut Option<Vec<u8>>,
+    index: usize,
+) {
+    if cache.is_none() {
+        *cache = Some(pipe_io_palette_reset_bytes(index));
+    }
+    if let Some(cached) = cache.as_ref() {
+        bytes.extend_from_slice(cached);
+    }
+}
+
+fn pipe_io_dynamic_color_bytes(set_code: u16, reset_code: u16, color: Option<Rgb>) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(24);
+    bytes.extend_from_slice(b"\x1b]");
+    if let Some(color) = color {
+        push_pipe_io_decimal(&mut bytes, set_code as usize);
+        bytes.extend_from_slice(b";rgb:");
+        push_pipe_io_hex_byte(&mut bytes, color.r);
+        bytes.push(b'/');
+        push_pipe_io_hex_byte(&mut bytes, color.g);
+        bytes.push(b'/');
+        push_pipe_io_hex_byte(&mut bytes, color.b);
+    } else {
+        push_pipe_io_decimal(&mut bytes, reset_code as usize);
+    }
+    bytes.extend_from_slice(b"\x1b\\");
+    bytes
+}
+
+fn pipe_io_palette_set_bytes(index: usize, color: Rgb) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(30);
+    bytes.extend_from_slice(b"\x1b]4;");
+    push_pipe_io_decimal(&mut bytes, index);
+    bytes.extend_from_slice(b";rgb:");
+    push_pipe_io_hex_byte(&mut bytes, color.r);
+    bytes.push(b'/');
+    push_pipe_io_hex_byte(&mut bytes, color.g);
+    bytes.push(b'/');
+    push_pipe_io_hex_byte(&mut bytes, color.b);
+    bytes.extend_from_slice(b"\x1b\\");
+    bytes
+}
+
+fn pipe_io_palette_reset_bytes(index: usize) -> Vec<u8> {
+    let mut bytes = Vec::with_capacity(12);
+    bytes.extend_from_slice(b"\x1b]104;");
+    push_pipe_io_decimal(&mut bytes, index);
+    bytes.extend_from_slice(b"\x1b\\");
+    bytes
+}
+
+fn pipe_io_cursor_visual_bytes(value: (CursorShape, bool)) -> &'static [u8] {
+    match value {
+        (CursorShape::Block | CursorShape::BlockHollow, true) => b"\x1b[0 q\x1b[1 q",
+        (CursorShape::Block | CursorShape::BlockHollow, false) => b"\x1b[0 q\x1b[2 q",
+        (CursorShape::Underline, true) => b"\x1b[0 q\x1b[3 q",
+        (CursorShape::Underline, false) => b"\x1b[0 q\x1b[4 q",
+        (CursorShape::Bar, true) => b"\x1b[0 q\x1b[5 q",
+        (CursorShape::Bar, false) => b"\x1b[0 q\x1b[6 q",
+    }
+}
+
+fn push_pipe_io_hex_byte(bytes: &mut Vec<u8>, value: u8) {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    bytes.push(HEX[(value >> 4) as usize]);
+    bytes.push(HEX[(value & 0x0f) as usize]);
+}
+
+fn push_pipe_io_decimal(bytes: &mut Vec<u8>, mut value: usize) {
+    let mut digits = [0u8; 5];
+    let mut cursor = digits.len();
+    loop {
+        cursor -= 1;
+        digits[cursor] = b'0' + (value % 10) as u8;
+        value /= 10;
+        if value == 0 {
+            break;
+        }
+    }
+    bytes.extend_from_slice(&digits[cursor..]);
 }
 
 fn apply_terminal_colors(terminal: &mut Terminal, colors: &RemoteTerminalColors) {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -208,6 +208,10 @@ pub(crate) enum RemoteRequestError {
     Encode(serde_json::Error),
     Transport(io::Error),
     Timeout,
+    /// The request may have reached the peer, but its acknowledgement was
+    /// not observed. Retrying on the same session could execute a mutation
+    /// twice, so callers must reconnect or otherwise reconcile first.
+    Ambiguous,
     Rejected {
         error: String,
         code: Option<String>,
@@ -231,7 +235,7 @@ impl RemoteRequestError {
     }
 
     pub(crate) fn is_timeout(&self) -> bool {
-        matches!(self, Self::Timeout)
+        matches!(self, Self::Timeout | Self::Ambiguous)
     }
 
     pub(crate) fn rejection_code(&self) -> Option<&str> {
@@ -279,6 +283,9 @@ impl std::fmt::Display for RemoteRequestError {
             Self::Encode(error) => write!(formatter, "could not encode remote request: {error}"),
             Self::Transport(error) => write!(formatter, "remote transport write failed: {error}"),
             Self::Timeout => write!(formatter, "remote session did not respond"),
+            Self::Ambiguous => {
+                write!(formatter, "remote request delivery is ambiguous; reconnect before retrying")
+            }
             Self::Rejected { error, .. } => write!(formatter, "remote command rejected: {error}"),
             Self::Shutdown => write!(formatter, "remote response wait canceled for shutdown"),
             Self::RemoteShutdown => {
@@ -1251,6 +1258,42 @@ struct PendingRemoteRequest {
     attach_surface: Option<SurfaceId>,
 }
 
+/// A request whose command has been admitted to the ordered writer but whose
+/// response can be awaited by another owner. Pipe-IO uses this split to keep
+/// its stdin reader nonblocking while retaining one deadline and one FIFO
+/// sequence for the claim command.
+pub(crate) struct RemoteRequestTicket {
+    id: u64,
+    sequence: u64,
+    response: Receiver<Value>,
+    deadline: ResolvedRequestDeadline,
+    progress: Arc<AtomicU64>,
+    attach_progress: Option<u64>,
+    remote: Weak<RemoteSession>,
+    cleanup_on_drop: bool,
+}
+
+impl RemoteRequestTicket {
+    fn disarm_cleanup(&mut self) {
+        self.cleanup_on_drop = false;
+    }
+}
+
+impl Drop for RemoteRequestTicket {
+    fn drop(&mut self) {
+        if !self.cleanup_on_drop {
+            return;
+        }
+        let Some(remote) = self.remote.upgrade() else { return };
+        remote.pending.lock().unwrap().remove(&self.id);
+        match remote.interactive_writer.cancel_sequence(self.sequence) {
+            InteractiveWriteCancellation::Canceled => {}
+            InteractiveWriteCancellation::AlreadyWritten
+            | InteractiveWriteCancellation::InFlight => remote.reconcile_ambiguous_request(),
+        }
+    }
+}
+
 #[derive(Default)]
 struct PendingRemoteRequests {
     requests: HashMap<u64, PendingRemoteRequest>,
@@ -1333,6 +1376,18 @@ struct InteractiveWrite {
     sequence: u64,
     measure_latency: bool,
     canceled: bool,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum InteractiveWriteCancellation {
+    /// The worker has not taken the command. Its FIFO tombstone guarantees
+    /// that it will never reach the transport.
+    Canceled,
+    /// The worker recorded a completed transport write for this sequence.
+    AlreadyWritten,
+    /// The worker took the command, or state contention prevented us from
+    /// proving that it remains queued. Delivery is therefore uncertain.
+    InFlight,
 }
 
 impl Drop for InteractiveWrite {
@@ -1503,6 +1558,46 @@ impl InteractiveWriter {
         self.enqueue_inner(message, measure_latency)
     }
 
+    /// Admit a command only when the queue mutex and capacity are immediately
+    /// available. This is used by the pipe-IO claim owner, which must preserve
+    /// FIFO ordering without waiting for a daemon acknowledgement (or for a
+    /// contended PTY-input queue) on its stdin reader thread.
+    fn enqueue_nowait(&self, message: String, measure_latency: bool) -> io::Result<u64> {
+        let mut write = InteractiveWrite {
+            message,
+            enqueued_at: Instant::now(),
+            sequence: 0,
+            measure_latency,
+            canceled: false,
+        };
+        let message_bytes = write.message.len();
+        let Some(mut state) = self.shared.state.try_lock() else {
+            return self.queue_admission_timeout(measure_latency);
+        };
+        if let Some(failure) = &state.failure {
+            return Err(failure.to_error());
+        }
+        if state.closed {
+            return Err(io::Error::new(io::ErrorKind::BrokenPipe, "interactive writer is closed"));
+        }
+        if state.writes.len() >= INTERACTIVE_WRITE_QUEUE_CAPACITY
+            || message_bytes > INTERACTIVE_WRITE_QUEUE_BYTES.saturating_sub(state.queued_bytes)
+        {
+            return self.queue_admission_timeout(measure_latency);
+        }
+        let sequence = state
+            .last_enqueued_sequence
+            .checked_add(1)
+            .ok_or_else(|| io::Error::other("interactive writer sequence space is exhausted"))?;
+        state.last_enqueued_sequence = sequence;
+        state.queued_bytes += message_bytes;
+        write.sequence = sequence;
+        state.writes.push_back(write);
+        drop(state);
+        self.shared.changed.notify_one();
+        Ok(sequence)
+    }
+
     fn enqueue_inner(&self, message: String, measure_latency: bool) -> io::Result<u64> {
         let mut write = InteractiveWrite {
             message,
@@ -1626,17 +1721,17 @@ impl InteractiveWriter {
 
     /// Mark a queued sequence as canceled without removing its FIFO position.
     /// The writer worker consumes the tombstone in order and never sends it.
-    /// If the worker already took the sequence, return false so the caller can
-    /// abort the transport rather than risk sending an ambiguous command.
-    fn cancel_sequence(&self, sequence: u64) -> bool {
+    /// If the worker already took the sequence, report an ambiguous outcome so
+    /// the caller can abort the transport rather than report an unsent command.
+    fn cancel_sequence(&self, sequence: u64) -> InteractiveWriteCancellation {
         let Some(mut state) = self.shared.state.try_lock() else {
-            return false;
+            return InteractiveWriteCancellation::InFlight;
         };
         if state.last_written_sequence >= sequence {
-            return true;
+            return InteractiveWriteCancellation::AlreadyWritten;
         }
         let Some(index) = state.writes.iter().position(|write| write.sequence == sequence) else {
-            return false;
+            return InteractiveWriteCancellation::InFlight;
         };
         let message_bytes = state.writes[index].message.len();
         {
@@ -1649,7 +1744,7 @@ impl InteractiveWriter {
         state.queued_bytes = state.queued_bytes.saturating_sub(message_bytes);
         drop(state);
         self.shared.changed.notify_one();
-        true
+        InteractiveWriteCancellation::Canceled
     }
 
     #[cfg(test)]
@@ -3487,19 +3582,35 @@ impl RemoteSession {
         };
         if let Err(error) = deadline.write_remaining() {
             self.pending.lock().unwrap().remove(&id);
-            if !self.interactive_writer.cancel_sequence(sequence) {
-                // The worker may already be inside `send`. Closing the
-                // transport is the only safe way to prevent an ambiguous
-                // timed-out command from reaching the peer.
-                self.interactive_writer.abort(&io::Error::new(
-                    io::ErrorKind::TimedOut,
-                    "ordered remote write deadline expired",
-                ));
+            match self.interactive_writer.cancel_sequence(sequence) {
+                InteractiveWriteCancellation::Canceled => {}
+                InteractiveWriteCancellation::AlreadyWritten
+                | InteractiveWriteCancellation::InFlight => {
+                    // The worker may already have completed, or may be inside
+                    // `send`. Closing the transport is the only safe way to
+                    // prevent a caller from retrying an accepted mutation.
+                    self.reconcile_ambiguous_request();
+                    return Err(RemoteRequestError::Ambiguous.into());
+                }
             }
             return Err(error.into());
         }
-        if let Err(error) = self.wait_for_ordered_write_until(sequence, deadline.write_deadline()) {
+        if let Err(error) =
+            self.interactive_writer.wait_until_written_until(sequence, deadline.write_deadline())
+        {
             self.pending.lock().unwrap().remove(&id);
+            if error.kind() == io::ErrorKind::TimedOut {
+                match self.interactive_writer.cancel_sequence(sequence) {
+                    InteractiveWriteCancellation::Canceled => {
+                        return Err(RemoteRequestError::Timeout.into());
+                    }
+                    InteractiveWriteCancellation::AlreadyWritten
+                    | InteractiveWriteCancellation::InFlight => {
+                        self.reconcile_ambiguous_request();
+                        return Err(RemoteRequestError::Ambiguous.into());
+                    }
+                }
+            }
             return Err(RemoteRequestError::Transport(error).into());
         }
 
@@ -3508,13 +3619,20 @@ impl RemoteSession {
             return Err(self.shutdown_request_error().into());
         }
 
-        let response = match self.wait_for_response(rx, deadline, progress, attach_progress) {
+        let response = match self.wait_for_response(&rx, deadline, progress, attach_progress) {
             Ok(response) => response,
             Err(error) => {
                 // Drop the pending entry so a half-open session does not
                 // accumulate abandoned senders (and a late response is
                 // not delivered to a receiver nobody holds).
                 self.pending.lock().unwrap().remove(&id);
+                if matches!(&error, RemoteRequestError::Timeout) {
+                    // The ordered write completed, so a response deadline is
+                    // an ambiguous delivery outcome. Reconcile by closing
+                    // this transport before any retry can reuse the command.
+                    self.reconcile_ambiguous_request();
+                    return Err(RemoteRequestError::Ambiguous.into());
+                }
                 return Err(error.into());
             }
         };
@@ -3537,7 +3655,7 @@ impl RemoteSession {
 
     fn wait_for_response(
         &self,
-        rx: Receiver<Value>,
+        rx: &Receiver<Value>,
         deadline: ResolvedRequestDeadline,
         progress: Arc<AtomicU64>,
         attach_progress: Option<u64>,
@@ -3640,17 +3758,147 @@ impl RemoteSession {
         self.request_no_wait(json!({"cmd": "send", "surface": surface, "bytes": encoded}))
     }
 
-    /// Claims exclusive terminal geometry for a renderer-less pipe-IO
-    /// attachment. This mirrors `Session::claim_terminal_geometry` without
-    /// requiring a local `RemoteSurface` mirror.
-    pub(crate) fn claim_terminal_geometry(&self, surface: SurfaceId) -> anyhow::Result<()> {
-        self.request(json!({
+    /// Enqueue a geometry claim in FIFO order without waiting for its daemon
+    /// response. The returned ticket owns the response receiver; a caller can
+    /// hand it to a bounded worker and surface the result later.
+    pub(crate) fn enqueue_claim_terminal_geometry(
+        self: &Arc<Self>,
+        surface: SurfaceId,
+    ) -> anyhow::Result<RemoteRequestTicket> {
+        if self.shutdown.load(Ordering::Acquire) {
+            return Err(self.shutdown_request_error().into());
+        }
+        let deadline = RequestDeadline::Standard.resolve()?;
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let progress = Arc::new(AtomicU64::new(0));
+        let mut command = json!({
             "cmd": "set-client-sizing",
             "surface": surface,
             "enabled": true,
             "exclusive": true,
-        }))
-        .map(|_| ())
+        });
+        command["id"] = json!(id);
+        let message = serde_json::to_string(&command)
+            .map_err(RemoteRequestError::Encode)
+            .map_err(anyhow::Error::new)?;
+        if let Err(error) = deadline.write_remaining() {
+            return Err(error.into());
+        }
+        let (tx, rx) = channel();
+        self.pending.lock().unwrap().insert(
+            id,
+            PendingRemoteRequest { response: tx, progress: progress.clone(), attach_surface: None },
+        );
+        let sequence = match self.interactive_writer.enqueue_nowait(message, false) {
+            Ok(sequence) => sequence,
+            Err(error) => {
+                self.pending.lock().unwrap().remove(&id);
+                return Err(RemoteRequestError::Transport(error).into());
+            }
+        };
+        if deadline.write_remaining().is_err() {
+            self.pending.lock().unwrap().remove(&id);
+            match self.interactive_writer.cancel_sequence(sequence) {
+                InteractiveWriteCancellation::Canceled => {
+                    return Err(RemoteRequestError::Timeout.into());
+                }
+                InteractiveWriteCancellation::AlreadyWritten
+                | InteractiveWriteCancellation::InFlight => {
+                    self.reconcile_ambiguous_request();
+                    return Err(RemoteRequestError::Ambiguous.into());
+                }
+            }
+        }
+        Ok(RemoteRequestTicket {
+            id,
+            sequence,
+            response: rx,
+            deadline,
+            progress,
+            attach_progress: None,
+            remote: Arc::downgrade(self),
+            cleanup_on_drop: true,
+        })
+    }
+
+    /// Complete a previously admitted claim. A response timeout is an
+    /// ambiguous delivery, so the transport is reconciled before returning.
+    pub(crate) fn await_claim_terminal_geometry(
+        &self,
+        mut ticket: RemoteRequestTicket,
+    ) -> anyhow::Result<()> {
+        if let Err(error) = self
+            .interactive_writer
+            .wait_until_written_until(ticket.sequence, ticket.deadline.write_deadline())
+        {
+            self.pending.lock().unwrap().remove(&ticket.id);
+            if error.kind() == io::ErrorKind::TimedOut {
+                match self.interactive_writer.cancel_sequence(ticket.sequence) {
+                    InteractiveWriteCancellation::Canceled => {
+                        ticket.disarm_cleanup();
+                        return Err(RemoteRequestError::Timeout.into());
+                    }
+                    InteractiveWriteCancellation::AlreadyWritten
+                    | InteractiveWriteCancellation::InFlight => {
+                        ticket.disarm_cleanup();
+                        self.reconcile_ambiguous_request();
+                        return Err(RemoteRequestError::Ambiguous.into());
+                    }
+                }
+            }
+            ticket.disarm_cleanup();
+            return Err(RemoteRequestError::Transport(error).into());
+        }
+        if self.shutdown.load(Ordering::Acquire) {
+            self.pending.lock().unwrap().remove(&ticket.id);
+            ticket.disarm_cleanup();
+            return Err(self.shutdown_request_error().into());
+        }
+        let response = match self.wait_for_response(
+            &ticket.response,
+            ticket.deadline,
+            ticket.progress.clone(),
+            ticket.attach_progress,
+        ) {
+            Ok(response) => response,
+            Err(error) => {
+                self.pending.lock().unwrap().remove(&ticket.id);
+                if matches!(&error, RemoteRequestError::Timeout) {
+                    ticket.disarm_cleanup();
+                    self.reconcile_ambiguous_request();
+                    return Err(RemoteRequestError::Ambiguous.into());
+                }
+                ticket.disarm_cleanup();
+                return Err(error.into());
+            }
+        };
+        self.pending.lock().unwrap().remove(&ticket.id);
+        ticket.disarm_cleanup();
+        if response.get("shutdown").and_then(Value::as_bool) == Some(true) {
+            return Err(RemoteRequestError::Shutdown.into());
+        }
+        if response.get("ok").and_then(Value::as_bool) == Some(true) {
+            return Ok(());
+        }
+        let error = response.get("error").and_then(Value::as_str).unwrap_or("unknown error");
+        let code = response.get("error_code").and_then(Value::as_str).map(ToString::to_string);
+        let delivery = match response.get("error_delivery").and_then(Value::as_str) {
+            Some("known-not-delivered") => Some(ClearHistoryDelivery::KnownNotDelivered),
+            Some("ambiguous") => Some(ClearHistoryDelivery::Ambiguous),
+            _ => None,
+        };
+        Err(RemoteRequestError::Rejected { error: error.to_string(), code, delivery }.into())
+    }
+
+    /// Claims exclusive terminal geometry for a renderer-less pipe-IO
+    /// attachment. This mirrors `Session::claim_terminal_geometry` without
+    /// requiring a local `RemoteSurface` mirror.
+    pub(crate) fn claim_terminal_geometry(
+        self: &Arc<Self>,
+        surface: SurfaceId,
+    ) -> anyhow::Result<()> {
+        let ticket = self.enqueue_claim_terminal_geometry(surface)?;
+        self.await_claim_terminal_geometry(ticket)
     }
 
     #[cfg_attr(not(test), allow(dead_code))]
@@ -3774,6 +4022,18 @@ impl RemoteSession {
 
     fn disconnect_transport(&self) {
         self.disconnect_transport_with_reason(None);
+    }
+
+    /// A request that was written but did not receive a response cannot be
+    /// retried safely on this connection. Abort the independent writer first,
+    /// then run the normal disconnect path so pending requests and pipe-IO
+    /// lifecycle observers receive one consistent shutdown signal.
+    fn reconcile_ambiguous_request(&self) {
+        self.interactive_writer.abort(&io::Error::new(
+            io::ErrorKind::TimedOut,
+            "remote request delivery became ambiguous",
+        ));
+        self.disconnect_transport();
     }
 
     pub(super) fn disconnect_transport_with_reason(&self, reason: Option<String>) {
@@ -9061,7 +9321,7 @@ mod tests {
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
-            Some(RemoteRequestError::Timeout)
+            Some(RemoteRequestError::Ambiguous)
         ));
         assert!(
             started.elapsed() < REMOTE_ATTACH_IDLE_TIMEOUT * 3,
@@ -9083,7 +9343,7 @@ mod tests {
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
-            Some(RemoteRequestError::Timeout)
+            Some(RemoteRequestError::Ambiguous)
         ));
         assert!(!session.has_surface(7));
         assert!(session.pending.lock().unwrap().is_empty());
@@ -9104,7 +9364,7 @@ mod tests {
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
-            Some(RemoteRequestError::Timeout)
+            Some(RemoteRequestError::Ambiguous)
         ));
         assert!(
             started.elapsed() < Duration::from_millis(100),
@@ -9919,7 +10179,7 @@ mod tests {
         request.join().unwrap();
         assert!(matches!(
             result.as_ref().err().and_then(|error| error.downcast_ref::<RemoteRequestError>()),
-            Some(RemoteRequestError::Timeout)
+            Some(RemoteRequestError::Ambiguous)
         ));
         assert!(
             elapsed < timeout + Duration::from_millis(70),
@@ -9950,7 +10210,10 @@ mod tests {
             RequestDeadline::Fixed(Duration::from_millis(20)),
         );
 
-        assert!(result.is_err(), "a request without a response unexpectedly succeeded");
+        assert!(matches!(
+            result.as_ref().err().and_then(|error| error.downcast_ref::<RemoteRequestError>()),
+            Some(RemoteRequestError::Ambiguous)
+        ));
         assert!(
             abort.0.load(Ordering::Acquire),
             "a request that was already written did not reconcile the transport"
@@ -11363,7 +11626,7 @@ mod tests {
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
-            Some(RemoteRequestError::Timeout)
+            Some(RemoteRequestError::Ambiguous)
         ));
         assert_eq!(*session.cell_pixels.lock().unwrap(), (9, 18));
         assert_eq!(*surface.cell_pixels.lock().unwrap(), (9, 18));
@@ -11380,7 +11643,7 @@ mod tests {
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
-            Some(RemoteRequestError::Timeout)
+            Some(RemoteRequestError::Ambiguous)
         ));
         assert_eq!(
             *session.cell_pixels.lock().unwrap(),
@@ -11407,7 +11670,7 @@ mod tests {
 
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
-            Some(RemoteRequestError::Timeout)
+            Some(RemoteRequestError::Ambiguous)
         ));
         assert_eq!(*session.cell_pixels.lock().unwrap(), (10, 20));
         assert_eq!(*surface.cell_pixels.lock().unwrap(), (11, 22));

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8284,6 +8284,41 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn geometry_claim_rejection_after_surface_exit_is_terminal_ended() {
+        let (client, server) = UnixStream::pair().unwrap();
+        let session = socket_test_session(client);
+        let (finished_tx, finished_rx) = channel();
+        let sender_session = session.clone();
+        let sender = std::thread::spawn(move || {
+            finished_tx.send(sender_session.claim_terminal_geometry(7)).unwrap();
+        });
+
+        let mut peer = BufReader::new(server);
+        let mut line = String::new();
+        peer.read_line(&mut line).unwrap();
+        let command: Value = serde_json::from_str(&line).unwrap();
+        assert_eq!(command["cmd"], "set-client-sizing");
+
+        // This is the attach/claim race: the daemon reports the terminal exit
+        // while the claim request is still waiting for its rejection.
+        session.handle_line(json!({"event": "surface-exited", "surface": 7}));
+        assert!(session.surface_is_exited(7));
+        session.handle_line(json!({
+            "id": command["id"],
+            "ok": false,
+            "error": "unknown surface 7",
+        }));
+
+        let error = finished_rx.recv_timeout(Duration::from_secs(1)).unwrap().unwrap_err();
+        assert_eq!(
+            crate::pipe_io::classify_claim_failure(&session, 7, &error),
+            crate::pipe_io::PipeIoExitReason::TerminalEnded
+        );
+        sender.join().unwrap();
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn accepted_interactive_writes_remain_fifo() {
         let (client, server) = UnixStream::pair().unwrap();
         let session = socket_test_session(client);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1332,6 +1332,7 @@ struct InteractiveWrite {
     enqueued_at: Instant,
     sequence: u64,
     measure_latency: bool,
+    canceled: bool,
 }
 
 impl Drop for InteractiveWrite {
@@ -1503,8 +1504,13 @@ impl InteractiveWriter {
     }
 
     fn enqueue_inner(&self, message: String, measure_latency: bool) -> io::Result<u64> {
-        let mut write =
-            InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
+        let mut write = InteractiveWrite {
+            message,
+            enqueued_at: Instant::now(),
+            sequence: 0,
+            measure_latency,
+            canceled: false,
+        };
         let message_bytes = write.message.len();
         let mut state = self.shared.state.lock();
         if let Some(failure) = &state.failure {
@@ -1547,8 +1553,13 @@ impl InteractiveWriter {
         measure_latency: bool,
         deadline: Instant,
     ) -> io::Result<u64> {
-        let mut write =
-            InteractiveWrite { message, enqueued_at: Instant::now(), sequence: 0, measure_latency };
+        let mut write = InteractiveWrite {
+            message,
+            enqueued_at: Instant::now(),
+            sequence: 0,
+            measure_latency,
+            canceled: false,
+        };
         let message_bytes = write.message.len();
         loop {
             let Some(mut state) = self.shared.state.try_lock_until(deadline) else {
@@ -1611,6 +1622,34 @@ impl InteractiveWriter {
     fn last_enqueued_sequence(&self) -> io::Result<Option<u64>> {
         let state = self.shared.state.lock();
         Ok((state.last_enqueued_sequence != 0).then_some(state.last_enqueued_sequence))
+    }
+
+    /// Mark a queued sequence as canceled without removing its FIFO position.
+    /// The writer worker consumes the tombstone in order and never sends it.
+    /// If the worker already took the sequence, return false so the caller can
+    /// abort the transport rather than risk sending an ambiguous command.
+    fn cancel_sequence(&self, sequence: u64) -> bool {
+        let Some(mut state) = self.shared.state.try_lock() else {
+            return false;
+        };
+        if state.last_written_sequence >= sequence {
+            return true;
+        }
+        let Some(index) = state.writes.iter().position(|write| write.sequence == sequence) else {
+            return false;
+        };
+        let message_bytes = state.writes[index].message.len();
+        {
+            let write = &mut state.writes[index];
+            zeroize_string(&mut write.message);
+            write.message.clear();
+            write.measure_latency = false;
+            write.canceled = true;
+        }
+        state.queued_bytes = state.queued_bytes.saturating_sub(message_bytes);
+        drop(state);
+        self.shared.changed.notify_one();
+        true
     }
 
     #[cfg(test)]
@@ -1791,6 +1830,16 @@ fn interactive_writer_worker(
             state.queued_bytes = state.queued_bytes.saturating_sub(write.message.len());
             write
         };
+
+        if write.canceled {
+            // Preserve the sequence barrier for later writes while keeping a
+            // timed-out command out of the transport entirely.
+            let mut state = shared.state.lock();
+            state.last_written_sequence = write.sequence;
+            drop(state);
+            shared.changed.notify_all();
+            continue;
+        }
 
         let result = writer.send(&write.message);
         match result {
@@ -3438,6 +3487,15 @@ impl RemoteSession {
         };
         if let Err(error) = deadline.write_remaining() {
             self.pending.lock().unwrap().remove(&id);
+            if !self.interactive_writer.cancel_sequence(sequence) {
+                // The worker may already be inside `send`. Closing the
+                // transport is the only safe way to prevent an ambiguous
+                // timed-out command from reaching the peer.
+                self.interactive_writer.abort(&io::Error::new(
+                    io::ErrorKind::TimedOut,
+                    "ordered remote write deadline expired",
+                ));
+            }
             return Err(error.into());
         }
         if let Err(error) = self.wait_for_ordered_write_until(sequence, deadline.write_deadline()) {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -499,6 +499,21 @@ struct RemoteTerminalColors {
     palette: [Option<Rgb>; 256],
 }
 
+#[derive(Clone, Copy, Debug, Default)]
+struct PipeIoColorPresence {
+    fg: bool,
+    bg: bool,
+    cursor: bool,
+    cursor_visual: bool,
+    palette: bool,
+}
+
+#[derive(Clone, Copy, Debug)]
+struct PipeIoColorState {
+    colors: RemoteTerminalColors,
+    presence: PipeIoColorPresence,
+}
+
 impl RemoteSurface {
     #[cfg(test)]
     fn run_geometry_test_hook(&self, step: RemoteGeometryTestStep) {
@@ -1861,6 +1876,11 @@ struct PipeIoTap {
     lifecycle_sender: EventSender<PipeIoEvent>,
     byte_budget: Arc<PipeIoByteBudget>,
     token: Arc<u8>,
+    // A pipe receives color state as VT sidecars. Keep the last sparse
+    // authored palette so a live replacement can reset only entries that
+    // disappeared, while omitted entries retain the embedder's theme.
+    palette: [Option<Rgb>; 256],
+    palette_known: bool,
 }
 
 pub(super) enum RemoteSurfaceAttach {
@@ -2606,14 +2626,22 @@ impl RemoteSession {
                     id,
                     format_args!("vt-state cols={cols} rows={rows} bytes={}", replay.len()),
                 );
+                let colors_value = value.get("colors");
+                let colors = colors_value.and_then(parse_terminal_colors);
+                let pipe_colors = colors_value.and_then(parse_pipe_io_colors);
                 // A pipe-IO relay consumes the authoritative VT byte stream
                 // itself. Do not also parse the same replay into a local
                 // `RemoteSurface`: that duplicate parser can fail or mutate
                 // state even though the embedder never reads it.
-                let Some(replay) = self.pipe_io_forward_replay(id, replay) else {
-                    return;
+                let replay = match self.pipe_io_forward_owned_with_colors(
+                    id,
+                    PipeIoEvent::replay(replay),
+                    pipe_colors.as_ref(),
+                ) {
+                    Ok(()) => return,
+                    Err(PipeIoEvent::Replay { bytes, .. }) => bytes,
+                    Err(_) => return,
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
                     return;
@@ -2677,12 +2705,18 @@ impl RemoteSession {
                     return;
                 };
                 self.log_frame(id, format_args!("output bytes={}", bytes.len()));
-                let bytes = match self.pipe_io_forward_owned(id, PipeIoEvent::Output(bytes)) {
+                let colors_value = value.get("colors");
+                let colors = colors_value.and_then(parse_terminal_colors);
+                let pipe_colors = colors_value.and_then(parse_pipe_io_colors);
+                let bytes = match self.pipe_io_forward_owned_with_colors(
+                    id,
+                    PipeIoEvent::Output(bytes),
+                    pipe_colors.as_ref(),
+                ) {
                     Ok(()) => return,
                     Err(PipeIoEvent::Output(bytes)) => bytes,
                     Err(_) => return,
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     surface.scan_cursor_provenance(&bytes);
                     let mut term = surface.term.lock().unwrap();
@@ -2701,6 +2735,9 @@ impl RemoteSession {
             Some("resized") => {
                 let Some(id) = surface_id() else { return };
                 let Some((cols, rows)) = remote_terminal_size(&value) else { return };
+                let colors_value = value.get("colors");
+                let colors = colors_value.and_then(parse_terminal_colors);
+                let pipe_colors = colors_value.and_then(parse_pipe_io_colors);
                 let replay = match value.get("replay").or_else(|| value.get("data")) {
                     Some(data) => {
                         let Some(data) = data.as_str() else {
@@ -2725,14 +2762,28 @@ impl RemoteSession {
                 );
                 let replay = match replay {
                     Some(replay) => {
-                        let replay = self.pipe_io_forward_replay(id, replay);
-                        if replay.is_none() {
-                            return;
+                        match self.pipe_io_forward_owned_with_colors(
+                            id,
+                            PipeIoEvent::replay(replay),
+                            pipe_colors.as_ref(),
+                        ) {
+                            Ok(()) => return,
+                            Err(PipeIoEvent::Replay { bytes, .. }) => Some(bytes),
+                            Err(_) => return,
                         }
-                        replay
                     }
                     None => {
-                        if self.pipe_io_owns_surface(id) {
+                        if pipe_colors.is_some() {
+                            match self.pipe_io_forward_owned_with_colors(
+                                id,
+                                PipeIoEvent::Output(Vec::new()),
+                                pipe_colors.as_ref(),
+                            ) {
+                                Ok(()) => return,
+                                Err(PipeIoEvent::Output(bytes)) if bytes.is_empty() => {}
+                                Err(_) => return,
+                            }
+                        } else if self.pipe_io_owns_surface(id) {
                             return;
                         }
                         None
@@ -2746,7 +2797,6 @@ impl RemoteSession {
                     self.disconnect_transport();
                     return;
                 };
-                let colors = value.get("colors").and_then(parse_terminal_colors);
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     if surface
                         .apply_stream_resize_with_colors(
@@ -2774,10 +2824,17 @@ impl RemoteSession {
             }
             Some("colors-changed") => {
                 let Some(id) = surface_id() else { return };
-                if self.pipe_io_owns_surface(id) {
-                    return;
-                }
                 let Some(colors) = parse_terminal_colors(&value) else { return };
+                let pipe_colors = parse_pipe_io_colors(&value);
+                match self.pipe_io_forward_owned_with_colors(
+                    id,
+                    PipeIoEvent::Output(Vec::new()),
+                    pipe_colors.as_ref(),
+                ) {
+                    Ok(()) => return,
+                    Err(PipeIoEvent::Output(bytes)) if bytes.is_empty() => {}
+                    Err(_) => return,
+                }
                 if let Some(surface) = self.surfaces.lock().unwrap().get(&id).cloned() {
                     let mut term = surface.term.lock().unwrap();
                     apply_terminal_colors(&mut term, &colors);
@@ -3510,6 +3567,8 @@ impl RemoteSession {
             lifecycle_sender,
             byte_budget,
             token: token.clone(),
+            palette: [None; 256],
+            palette_known: false,
         });
         token
     }
@@ -3593,6 +3652,7 @@ impl RemoteSession {
     /// matching tap exists, the event is returned to the caller for normal
     /// terminal parsing. Once a tap owns the event, queue overflow consumes it
     /// and tears down that relay, so the caller must not parse it locally.
+    #[cfg(test)]
     fn pipe_io_forward_owned(
         &self,
         surface: SurfaceId,
@@ -3600,10 +3660,80 @@ impl RemoteSession {
     ) -> Result<(), PipeIoEvent> {
         use crossbeam_channel::TrySendError;
         let stalled_token = {
-            let tap = self.pipe_io_tap.lock().unwrap();
-            let Some(tap) = tap.as_ref() else { return Err(event) };
+            let mut tap_slot = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap_slot.as_mut() else { return Err(event) };
             if tap.surface != surface {
                 return Err(event);
+            }
+            if !tap.byte_budget.try_reserve_event(&mut event) {
+                Some(tap.token.clone())
+            } else {
+                match tap.sender.try_send(event) {
+                    Ok(()) => None,
+                    Err(TrySendError::Full(event) | TrySendError::Disconnected(event)) => {
+                        tap.byte_budget.release_event(&event);
+                        Some(tap.token.clone())
+                    }
+                }
+            }
+        };
+        if let Some(token) = stalled_token {
+            // Signal only the tap that observed the stall. A replacement tap
+            // may have been installed while this reader thread released the
+            // mutex; it must not be torn down by an older relay.
+            if self.signal_pipe_io_event(Some(surface), Some(&token), PipeIoEvent::TransportLost) {
+                self.disconnect_transport();
+            }
+        }
+        Ok(())
+    }
+
+    /// Forwards an owned byte event and appends its coupled color sidecar only
+    /// after a matching tap has been found. Keeping the ownership check and
+    /// append under one tap lock lets a missing tap return the original bytes
+    /// to the local mirror without leaking synthetic state into its parser.
+    fn pipe_io_forward_owned_with_colors(
+        &self,
+        surface: SurfaceId,
+        mut event: PipeIoEvent,
+        colors: Option<&PipeIoColorState>,
+    ) -> Result<(), PipeIoEvent> {
+        use crossbeam_channel::TrySendError;
+        let stalled_token = {
+            let mut tap_slot = self.pipe_io_tap.lock().unwrap();
+            let Some(tap) = tap_slot.as_mut() else { return Err(event) };
+            if tap.surface != surface {
+                return Err(event);
+            }
+            if let Some(colors) = colors {
+                match &mut event {
+                    PipeIoEvent::Replay { bytes, .. } => {
+                        // The relay writer emits a reset before every replay
+                        // after the first one. The reset clears authored
+                        // palette state, so replay the complete sparse set
+                        // rather than diffing against the prior live state.
+                        append_pipe_io_colors(bytes, colors, None, true);
+                    }
+                    PipeIoEvent::Output(bytes) => {
+                        let previous = tap.palette_known.then_some(&tap.palette);
+                        append_pipe_io_colors(bytes, colors, previous, false);
+                    }
+                    _ => {}
+                }
+            }
+            if matches!(&event, PipeIoEvent::Replay { .. }) {
+                // A replay replaces the terminal. Without a palette field the
+                // server gave us no authoritative authored set, so do not
+                // compare a later sparse update with stale state.
+                tap.palette_known = colors.is_some_and(|colors| colors.presence.palette);
+                if let Some(colors) = colors.filter(|colors| colors.presence.palette) {
+                    tap.palette = colors.colors.palette;
+                } else {
+                    tap.palette = [None; 256];
+                }
+            } else if let Some(colors) = colors.filter(|colors| colors.presence.palette) {
+                tap.palette = colors.colors.palette;
+                tap.palette_known = true;
             }
             if !tap.byte_budget.try_reserve_event(&mut event) {
                 Some(tap.token.clone())
@@ -3631,6 +3761,7 @@ impl RemoteSession {
     /// Forwards a replay while retaining ownership for the local mirror when
     /// no matching pipe-IO tap exists. The relay path consumes the vector, so
     /// this avoids cloning large replay frames on the session reader thread.
+    #[cfg(test)]
     fn pipe_io_forward_replay(&self, surface: SurfaceId, replay: Vec<u8>) -> Option<Vec<u8>> {
         match self.pipe_io_forward_owned(surface, PipeIoEvent::replay(replay)) {
             Ok(()) => None,
@@ -4589,6 +4720,100 @@ fn parse_terminal_colors(value: &Value) -> Option<RemoteTerminalColors> {
         cursor_blink: value.get("cursor_blink").and_then(Value::as_bool),
         palette,
     })
+}
+
+fn parse_pipe_io_colors(value: &Value) -> Option<PipeIoColorState> {
+    let colors = parse_terminal_colors(value)?;
+    let presence = PipeIoColorPresence {
+        fg: value.get("fg").is_some(),
+        bg: value.get("bg").is_some(),
+        cursor: value.get("cursor").is_some(),
+        cursor_visual: value.get("cursor_style").is_some() && value.get("cursor_blink").is_some(),
+        palette: value.get("palette").is_some(),
+    };
+    Some(PipeIoColorState { colors, presence })
+}
+
+/// Append the VT sidecar needed by a raw pipe to adopt one protocol color
+/// transition. The JSON attach stream carries this state beside replay/output
+/// bytes, but a pipe embedder only receives bytes. Dynamic colors are emitted
+/// only when their field is present, allowing legacy live palette events to
+/// preserve omitted defaults and cursor metadata. A present sparse palette is
+/// a complete authored-override snapshot. On a live transition, reset only
+/// entries removed from the previous snapshot so omitted entries retain the
+/// embedder's theme. A replay has already reset the terminal, so it emits all
+/// current authored entries without a broad palette reset.
+fn append_pipe_io_colors(
+    bytes: &mut Vec<u8>,
+    state: &PipeIoColorState,
+    previous_palette: Option<&[Option<Rgb>; 256]>,
+    replay_reset: bool,
+) {
+    fn dynamic_color(
+        bytes: &mut Vec<u8>,
+        present: bool,
+        set_code: u16,
+        reset_code: u16,
+        color: Option<Rgb>,
+    ) {
+        if !present {
+            return;
+        }
+        match color {
+            Some(color) => bytes.extend_from_slice(
+                format!(
+                    "\x1b]{set_code};rgb:{:02x}/{:02x}/{:02x}\x1b\\",
+                    color.r, color.g, color.b
+                )
+                .as_bytes(),
+            ),
+            None => bytes.extend_from_slice(format!("\x1b]{reset_code}\x1b\\").as_bytes()),
+        }
+    }
+
+    let colors = &state.colors;
+    let presence = state.presence;
+    dynamic_color(bytes, presence.fg, 10, 110, colors.fg);
+    dynamic_color(bytes, presence.bg, 11, 111, colors.bg);
+    dynamic_color(bytes, presence.cursor, 12, 112, colors.cursor);
+
+    if presence.cursor_visual
+        && let (Some(style), Some(blink)) = (colors.cursor_style, colors.cursor_blink)
+    {
+        let value = match (style, blink) {
+            (CursorShape::Block | CursorShape::BlockHollow, true) => 1,
+            (CursorShape::Block | CursorShape::BlockHollow, false) => 2,
+            (CursorShape::Underline, true) => 3,
+            (CursorShape::Underline, false) => 4,
+            (CursorShape::Bar, true) => 5,
+            (CursorShape::Bar, false) => 6,
+        };
+        // Reset any application-authored DECSCUSR before applying the
+        // resolved pair, matching apply_terminal_colors on local mirrors.
+        bytes.extend_from_slice(format!("\x1b[0 q\x1b[{value} q").as_bytes());
+    }
+
+    if presence.palette {
+        for (index, color) in colors.palette.iter().enumerate() {
+            let previous = previous_palette.map(|palette| palette[index]);
+            if !replay_reset && previous == Some(*color) {
+                continue;
+            }
+            match color {
+                Some(color) => bytes.extend_from_slice(
+                    format!(
+                        "\x1b]4;{index};rgb:{:02x}/{:02x}/{:02x}\x1b\\",
+                        color.r, color.g, color.b
+                    )
+                    .as_bytes(),
+                ),
+                None if previous.is_some_and(Option::is_some) => {
+                    bytes.extend_from_slice(format!("\x1b]104;{index}\x1b\\").as_bytes());
+                }
+                None => {}
+            }
+        }
+    }
 }
 
 fn apply_terminal_colors(terminal: &mut Terminal, colors: &RemoteTerminalColors) {
@@ -7630,15 +7855,19 @@ mod tests {
             panic!("palette replacement did not forward output");
         };
 
-        assert!(bytes.windows(b"\x1b]104;2\x1b\\".len()).any(|window| {
-            window == b"\x1b]104;2\x1b\\"
-        }));
-        assert!(!bytes.windows(b"\x1b]104\x1b\\".len()).any(|window| {
-            window == b"\x1b]104\x1b\\"
-        }));
-        assert!(bytes.windows(b"\x1b]4;3;rgb:0d/0e/0f\x1b\\".len()).any(|window| {
-            window == b"\x1b]4;3;rgb:0d/0e/0f\x1b\\"
-        }));
+        assert!(
+            bytes
+                .windows(b"\x1b]104;2\x1b\\".len())
+                .any(|window| { window == b"\x1b]104;2\x1b\\" })
+        );
+        assert!(
+            !bytes.windows(b"\x1b]104\x1b\\".len()).any(|window| { window == b"\x1b]104\x1b\\" })
+        );
+        assert!(
+            bytes
+                .windows(b"\x1b]4;3;rgb:0d/0e/0f\x1b\\".len())
+                .any(|window| { window == b"\x1b]4;3;rgb:0d/0e/0f\x1b\\" })
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7,7 +7,9 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::net::Shutdown;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel, sync_channel};
+#[cfg(test)]
+use std::sync::mpsc::sync_channel;
+use std::sync::mpsc::{Receiver, RecvTimeoutError, Sender, channel};
 use std::sync::{Arc, Mutex, Weak};
 use std::time::{Duration, Instant};
 
@@ -9659,11 +9661,13 @@ mod tests {
         let listener = UnixListener::bind(&path).unwrap();
         listener.set_nonblocking(true).unwrap();
 
-        let error = RemoteSession::connect_for_terminal_attach_until(
+        let error = match RemoteSession::connect_for_terminal_attach_until(
             &path,
             Instant::now() - Duration::from_millis(1),
-        )
-        .expect_err("an expired probe unexpectedly connected");
+        ) {
+            Ok(_) => panic!("an expired probe unexpectedly connected"),
+            Err(error) => error,
+        };
         assert!(matches!(
             error.downcast_ref::<RemoteRequestError>(),
             Some(RemoteRequestError::Timeout)

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -6800,6 +6800,25 @@ mod tests {
     }
 
     #[test]
+    fn json_line_reader_preserves_utf8_across_buffer_boundaries() {
+        let input = b"{\"text\":\"\xC3\xA9\"}\n".to_vec();
+        let mut reader = BufReader::with_capacity(1, io::Cursor::new(input));
+        let mut progress = Vec::new();
+
+        let line = read_json_line_with_progress_bounded(
+            &mut reader,
+            &mut |partial| progress.push(partial.to_vec()),
+            64,
+        )
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(line.as_bytes(), b"{\"text\":\"\xC3\xA9\"}");
+        assert!(progress.iter().any(|partial| partial.ends_with(&[0xC3])));
+        assert_eq!(progress.last().unwrap(), b"{\"text\":\"\xC3\xA9\"}");
+    }
+
+    #[test]
     fn remote_reader_end_reason_distinguishes_eof_from_read_failure() {
         let eof: io::Result<Option<String>> = Ok(None);
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -2535,15 +2535,13 @@ impl RemoteSession {
                     id,
                     format_args!("vt-state cols={cols} rows={rows} bytes={}", replay.len()),
                 );
-                let pipe_io_owned =
-                    self.pipe_io_forward(id, || PipeIoEvent::replay(replay.clone()));
                 // A pipe-IO relay consumes the authoritative VT byte stream
                 // itself. Do not also parse the same replay into a local
                 // `RemoteSurface`: that duplicate parser can fail or mutate
                 // state even though the embedder never reads it.
-                if pipe_io_owned {
+                let Some(replay) = self.pipe_io_forward_replay(id, replay) else {
                     return;
-                }
+                };
                 let colors = value.get("colors").and_then(parse_terminal_colors);
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
@@ -2654,14 +2652,21 @@ impl RemoteSession {
                         replay.as_ref().map(|bytes| bytes.len()).unwrap_or(0)
                     ),
                 );
-                let pipe_io_owned = if let Some(replay) = replay.as_ref() {
-                    self.pipe_io_forward(id, || PipeIoEvent::replay(replay.clone()))
-                } else {
-                    self.pipe_io_owns_surface(id)
+                let replay = match replay {
+                    Some(replay) => {
+                        let replay = self.pipe_io_forward_replay(id, replay);
+                        if replay.is_none() {
+                            return;
+                        }
+                        replay
+                    }
+                    None => {
+                        if self.pipe_io_owns_surface(id) {
+                            return;
+                        }
+                        None
+                    }
                 };
-                if pipe_io_owned {
-                    return;
-                }
                 let Ok(kitty_image_aliases) = parse_kitty_image_aliases(&value) else {
                     self.disconnect_transport();
                     return;
@@ -3523,6 +3528,17 @@ impl RemoteSession {
             }
         }
         Ok(())
+    }
+
+    /// Forwards a replay while retaining ownership for the local mirror when
+    /// no matching pipe-IO tap exists. The relay path consumes the vector, so
+    /// this avoids cloning large replay frames on the session reader thread.
+    fn pipe_io_forward_replay(&self, surface: SurfaceId, replay: Vec<u8>) -> Option<Vec<u8>> {
+        match self.pipe_io_forward_owned(surface, PipeIoEvent::replay(replay)) {
+            Ok(()) => None,
+            Err(PipeIoEvent::Replay { bytes, .. }) => Some(bytes),
+            Err(_) => None,
+        }
     }
 
     /// Returns the first reason recorded when the remote reader stopped.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -7410,6 +7410,42 @@ mod tests {
     }
 
     #[test]
+    fn pipe_io_budget_allows_live_output_alongside_oversized_replay() {
+        let budget = PipeIoByteBudget::new(8);
+        let mut replay = PipeIoEvent::replay(vec![b'R'; 16]);
+        let mut output = PipeIoEvent::Output(vec![b'O'; 8]);
+        let mut overflow = PipeIoEvent::Output(vec![b'X']);
+
+        assert!(budget.try_reserve_event(&mut replay));
+        assert!(budget.try_reserve_event(&mut output));
+        assert!(!budget.try_reserve_event(&mut overflow));
+
+        budget.release_event(&replay);
+        budget.release_event(&output);
+    }
+
+    #[test]
+    fn surface_exit_signal_survives_byte_sender_shutdown() {
+        let session = test_session(Box::new(CloseTrackingWriter {
+            closed: Arc::new(AtomicBool::new(false)),
+        }));
+        let (sender, receiver) = crossbeam_channel::bounded(1);
+        let (lifecycle_sender, lifecycle_receiver) = crossbeam_channel::bounded(1);
+        let token = session.install_pipe_io_tap(
+            7,
+            sender,
+            lifecycle_sender,
+            Arc::new(PipeIoByteBudget::new(1024)),
+        );
+
+        assert!(session.signal_pipe_io_event(Some(7), Some(&token), PipeIoEvent::SurfaceExited));
+        drop(token);
+        assert_eq!(lifecycle_receiver.recv().unwrap(), PipeIoEvent::SurfaceExited);
+        assert!(receiver.try_recv().is_err());
+        assert!(session.pipe_io_tap.lock().unwrap().is_none());
+    }
+
+    #[test]
     fn pipe_io_forward_does_not_build_payload_without_matching_tap() {
         let session = test_session(Box::new(CloseTrackingWriter {
             closed: Arc::new(AtomicBool::new(false)),

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4263,3 +4263,380 @@ fn unique_temp_dir(name: &str) -> PathBuf {
 fn bin() -> &'static str {
     env!("CARGO_BIN_EXE_cmux-tui")
 }
+
+// ---------------------------------------------------------------------------
+// `attach --pipe-io`: renderer-less byte relay for embedder-fed surfaces.
+//
+// Contract under test (GUI-frontend migration, manual-IO surface):
+//   stdout  = raw VT bytes (daemon replay first, then live output),
+//   stdin   = JSON lines ({"input":"<b64>"} | {"resize":{"cols":N,"rows":N}}),
+//   stderr  = one final JSON line {"exit":{"reason":...}},
+//   exit 0  = terminal ended (or parent closed stdin) — do not respawn,
+//   exit 2  = daemon connection lost — the embedder may respawn to resync.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+struct PipeIoRelay {
+    child: Child,
+    stdin: Option<std::process::ChildStdin>,
+    stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+}
+
+#[cfg(unix)]
+impl PipeIoRelay {
+    fn start(server: &HeadlessServer, terminal: &str, cols: u16, rows: u16) -> Self {
+        let mut child = Command::new(bin())
+            .args(["attach", "--socket"])
+            .arg(&server.socket)
+            .args([
+                "--terminal",
+                terminal,
+                "--pipe-io",
+                "--cols",
+                &cols.to_string(),
+                "--rows",
+                &rows.to_string(),
+            ])
+            .env_remove("CMUX_TUI_SOCKET")
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .unwrap();
+        let stdin = child.stdin.take();
+        let stdout = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let stderr = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+        let out = child.stdout.take().unwrap();
+        let err = child.stderr.take().unwrap();
+        let stdout_sink = stdout.clone();
+        std::thread::spawn(move || drain_into(out, stdout_sink));
+        let stderr_sink = stderr.clone();
+        std::thread::spawn(move || drain_into(err, stderr_sink));
+        Self { child, stdin, stdout, stderr }
+    }
+
+    fn send_input(&mut self, bytes: &[u8]) {
+        use base64::Engine as _;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(bytes);
+        let line = format!("{}\n", serde_json::json!({ "input": encoded }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn send_resize(&mut self, cols: u16, rows: u16) {
+        let line = format!("{}\n", serde_json::json!({ "resize": { "cols": cols, "rows": rows } }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn send_claim(&mut self) {
+        let line = format!("{}\n", serde_json::json!({ "claim": { "geometry": true } }));
+        self.stdin.as_mut().unwrap().write_all(line.as_bytes()).unwrap();
+    }
+
+    fn stdout_text(&self) -> String {
+        String::from_utf8_lossy(&self.stdout.lock().unwrap()).into_owned()
+    }
+
+    fn stderr_text(&self) -> String {
+        String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned()
+    }
+
+    fn wait_for_stdout(&mut self, needle: &str, what: &str) {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            if self.stdout_text().contains(needle) {
+                return;
+            }
+            if let Some(status) = self.child.try_wait().unwrap() {
+                panic!(
+                    "pipe-io relay exited ({status}) before {what}\nstdout:\n{}\nstderr:\n{}",
+                    self.stdout_text(),
+                    String::from_utf8_lossy(&self.stderr.lock().unwrap())
+                );
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("timed out waiting for {what}\nstdout:\n{}", self.stdout_text());
+    }
+
+    fn wait_for_exit(&mut self) -> (i32, serde_json::Value) {
+        let deadline = Instant::now() + Duration::from_secs(20);
+        while Instant::now() < deadline {
+            if let Some(status) = self.child.try_wait().unwrap() {
+                // Let the drain threads observe EOF.
+                std::thread::sleep(Duration::from_millis(100));
+                let stderr_text =
+                    String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
+                let exit_line = stderr_text
+                    .lines()
+                    .rev()
+                    .find(|line| line.trim_start().starts_with('{'))
+                    .unwrap_or_else(|| {
+                        panic!("pipe-io relay printed no JSON exit line\nstderr:\n{stderr_text}")
+                    })
+                    .to_string();
+                let value: serde_json::Value = serde_json::from_str(&exit_line).unwrap();
+                return (status.code().unwrap_or(-1), value);
+            }
+            std::thread::sleep(Duration::from_millis(25));
+        }
+        panic!("pipe-io relay did not exit\nstdout:\n{}", self.stdout_text());
+    }
+}
+
+#[cfg(unix)]
+fn drain_into(mut source: impl Read, sink: std::sync::Arc<std::sync::Mutex<Vec<u8>>>) {
+    let mut buffer = [0u8; 4096];
+    loop {
+        match source.read(&mut buffer) {
+            Ok(0) | Err(_) => return,
+            Ok(count) => sink.lock().unwrap().extend_from_slice(&buffer[..count]),
+        }
+    }
+}
+
+/// Reaps the adoptable terminal hosts a deliberate daemon SIGKILL leaves
+/// behind. The fixture's Drop treats any surviving host as a leak, but this
+/// test kills the daemon on purpose (host adoption after a daemon death is
+/// covered elsewhere); the orphaned hosts are part of the arranged scene.
+#[cfg(unix)]
+fn reap_orphaned_hosts_after_daemon_kill(server: &HeadlessServer) {
+    let host_root = cmux_tui_core::terminal_host_runtime::terminal_host_root(&server.state, "main");
+    for pid in terminal_host_pids(&host_root) {
+        if let Ok(pid) = libc::pid_t::try_from(pid) {
+            // SAFETY: terminating a test-owned child process group member.
+            unsafe {
+                libc::kill(pid, libc::SIGKILL);
+            }
+        }
+    }
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while terminal_host_pids(&host_root).iter().any(|pid| process_exists(*pid)) {
+        assert!(Instant::now() < deadline, "orphaned terminal hosts survived SIGKILL");
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    let _ = fs::remove_dir_all(&host_root);
+}
+
+#[cfg(unix)]
+fn pipe_io_terminal(server: &HeadlessServer) -> String {
+    let created = json_cli(server, &["workspace", "create", "--name", "pipe-io"]);
+    assert_success(&created);
+    json_output(&created)["value"]["terminal_id"].as_str().unwrap().to_string()
+}
+
+/// Count literal `^[[<digits>;<digits>R` runs, the form `cat -v` uses to
+/// render a cursor-position report that reached the inner process.
+#[cfg(unix)]
+fn visible_cursor_position_reports(text: &str) -> usize {
+    let bytes = text.as_bytes();
+    let mut count = 0;
+    let mut index = 0;
+    while let Some(offset) = text[index..].find("^[[") {
+        let mut cursor = index + offset + 3;
+        let mut digits_then_semicolon = false;
+        while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+            cursor += 1;
+        }
+        if cursor < bytes.len() && bytes[cursor] == b';' {
+            cursor += 1;
+            let row_end = cursor;
+            while cursor < bytes.len() && bytes[cursor].is_ascii_digit() {
+                cursor += 1;
+            }
+            digits_then_semicolon = cursor > row_end;
+        }
+        if digits_then_semicolon && cursor < bytes.len() && bytes[cursor] == b'R' {
+            count += 1;
+        }
+        index += offset + 3;
+    }
+    count
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_attach_streams_output_and_replays_on_reconnect() {
+    let server = HeadlessServer::start("pipe-io-basic");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut first = PipeIoRelay::start(&server, &terminal, 80, 24);
+    first.send_input(b"printf 'PIPEIO-%s\\n' FIRST\n");
+    first.wait_for_stdout("PIPEIO-FIRST", "live output of the typed marker");
+
+    // Dropping stdin tells the relay its embedder is gone: clean exit 0.
+    first.stdin = None;
+    let (code, exit) = first.wait_for_exit();
+    assert_eq!(code, 0, "stdin EOF must be a clean detach, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "parent-closed");
+
+    // A fresh relay must serve the daemon replay before live bytes: the
+    // marker typed through the first relay is visible without retyping.
+    let mut second = PipeIoRelay::start(&server, &terminal, 80, 24);
+    second.wait_for_stdout("PIPEIO-FIRST", "replayed marker after reconnect");
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_exit_distinguishes_terminal_end_from_daemon_loss() {
+    let mut server = HeadlessServer::start("pipe-io-exits");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    relay.send_input(b"printf 'PIPEIO-%s\\n' READY\n");
+    relay.wait_for_stdout("PIPEIO-READY", "shell readiness marker");
+    let closed = json_cli(&server, &["terminal", &terminal, "close"]);
+    assert_success(&closed);
+    let (code, exit) = relay.wait_for_exit();
+    assert_eq!(code, 0, "terminal close must exit 0, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "terminal-ended");
+
+    let second_terminal = pipe_io_terminal(&server);
+    let mut survivor = PipeIoRelay::start(&server, &second_terminal, 80, 24);
+    survivor.send_input(b"printf 'PIPEIO-%s\\n' TWO\n");
+    survivor.wait_for_stdout("PIPEIO-TWO", "second shell readiness marker");
+    server.child.kill().unwrap();
+    let (code, exit) = survivor.wait_for_exit();
+    assert_eq!(code, 2, "daemon loss must exit 2, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "daemon-lost");
+    reap_orphaned_hosts_after_daemon_kill(&server);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_startup_connect_failure_reports_daemon_lost() {
+    // A daemon restart window (dead socket) must read as daemon-lost so
+    // the embedder keeps retrying; only unexplained failures make it stop.
+    let dir = unique_temp_dir("pipe-io-dead-socket");
+    fs::create_dir_all(&dir).unwrap();
+    let dead_socket = dir.join("mux.sock");
+    let output = Command::new(bin())
+        .args(["attach", "--socket"])
+        .arg(&dead_socket)
+        .args(["--terminal", "term_0123456789abcdef0123456789abcdef", "--pipe-io"])
+        .env_remove("CMUX_TUI_SOCKET")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let exit_line = stderr.lines().rev().find(|line| line.trim_start().starts_with('{')).unwrap();
+    let value: serde_json::Value = serde_json::from_str(exit_line).unwrap();
+    assert_eq!(value["exit"]["reason"], "daemon-lost");
+    let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_resize_reaches_the_daemon_pty() {
+    let server = HeadlessServer::start("pipe-io-resize");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    relay.send_input(b"printf 'PIPEIO-%s\\n' SIZED\n");
+    relay.wait_for_stdout("PIPEIO-SIZED", "shell readiness marker");
+    relay.send_resize(100, 30);
+    // The daemon acknowledges the resize before the PTY winsize necessarily
+    // lands; poll stty until the new geometry is visible.
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        relay.send_input(b"stty size\n");
+        let poll_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < poll_deadline {
+            if relay.stdout_text().contains("30 100") {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for stty to report the resized PTY\nstdout:\n{}\nstderr:\n{}",
+            relay.stdout_text(),
+            relay.stderr_text()
+        );
+    }
+}
+
+/// Polls `stty size` through `relay` until `needle` (e.g. "30 100") shows,
+/// panicking with both streams on timeout. The daemon acknowledges resizes
+/// before the PTY winsize necessarily lands, hence the poll.
+#[cfg(unix)]
+fn wait_for_stty(relay: &mut PipeIoRelay, needle: &str, what: &str) {
+    let deadline = Instant::now() + Duration::from_secs(20);
+    loop {
+        relay.send_input(b"stty size\n");
+        let poll_deadline = Instant::now() + Duration::from_secs(2);
+        while Instant::now() < poll_deadline {
+            if relay.stdout_text().contains(needle) {
+                return;
+            }
+            std::thread::sleep(Duration::from_millis(50));
+        }
+        assert!(
+            Instant::now() < deadline,
+            "timed out waiting for {what}\nstdout:\n{}\nstderr:\n{}",
+            relay.stdout_text(),
+            relay.stderr_text()
+        );
+    }
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_claim_line_reclaims_geometry_authority() {
+    let server = HeadlessServer::start("pipe-io-claim");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut first = PipeIoRelay::start(&server, &terminal, 80, 24);
+    first.send_input(b"printf 'PIPEIO-%s\\n' CLAIM\n");
+    first.wait_for_stdout("PIPEIO-CLAIM", "shell readiness marker");
+
+    // A later attachment claims geometry authority (last claim wins), so
+    // the PTY follows the second relay's smaller grid.
+    let mut second = PipeIoRelay::start(&server, &terminal, 60, 20);
+    second.wait_for_stdout("PIPEIO-CLAIM", "replay on the second relay");
+    wait_for_stty(&mut first, "20 60", "the second attach claim to resize the PTY");
+
+    // The claim line is how an embedder re-asserts authority when its pane
+    // receives user input; the first relay's sizes apply again.
+    first.send_claim();
+    wait_for_stty(&mut first, "24 80", "the reclaim to restore the first relay's grid");
+    first.send_resize(100, 30);
+    wait_for_stty(&mut first, "30 100", "a post-reclaim resize to apply");
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_inner_query_is_answered_exactly_once() {
+    let server = HeadlessServer::start("pipe-io-reply-authority");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start(&server, &terminal, 80, 24);
+    // The inner program emits a DSR cursor-position query and then renders
+    // its own stdin visibly. Exactly one authority (the daemon-side
+    // terminal) must answer; the relay and any embedder mirror stay silent.
+    relay.send_input(b"sh -c 'printf \"\\033[6n\"; exec cat -v'\n");
+    let deadline = Instant::now() + Duration::from_secs(20);
+    let mut seen = 0;
+    while Instant::now() < deadline {
+        seen = visible_cursor_position_reports(&relay.stdout_text());
+        if seen >= 1 {
+            // Give a duplicated reply time to surface before asserting.
+            std::thread::sleep(Duration::from_millis(500));
+            seen = visible_cursor_position_reports(&relay.stdout_text());
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(25));
+    }
+    assert_eq!(
+        seen,
+        1,
+        "inner DSR query must be answered exactly once\nstdout:\n{}",
+        relay.stdout_text()
+    );
+}

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4286,6 +4286,16 @@ struct PipeIoRelay {
 #[cfg(unix)]
 impl PipeIoRelay {
     fn start(server: &HeadlessServer, terminal: &str, cols: u16, rows: u16) -> Self {
+        Self::start_with_stderr_delay(server, terminal, cols, rows, Duration::ZERO)
+    }
+
+    fn start_with_stderr_delay(
+        server: &HeadlessServer,
+        terminal: &str,
+        cols: u16,
+        rows: u16,
+        stderr_delay: Duration,
+    ) -> Self {
         let mut child = Command::new(bin())
             .args(["attach", "--socket"])
             .arg(&server.socket)
@@ -4312,7 +4322,12 @@ impl PipeIoRelay {
         let stdout_sink = stdout.clone();
         std::thread::spawn(move || drain_into(out, stdout_sink));
         let stderr_sink = stderr.clone();
-        std::thread::spawn(move || drain_into(err, stderr_sink));
+        std::thread::spawn(move || {
+            if !stderr_delay.is_zero() {
+                std::thread::sleep(stderr_delay);
+            }
+            drain_into(err, stderr_sink);
+        });
         Self { child, stdin, stdout, stderr }
     }
 
@@ -4529,6 +4544,25 @@ fn pipe_io_startup_connect_failure_reports_daemon_lost() {
     let value: serde_json::Value = serde_json::from_str(exit_line).unwrap();
     assert_eq!(value["exit"]["reason"], "daemon-lost");
     let _ = fs::remove_dir_all(&dir);
+}
+
+#[cfg(unix)]
+#[test]
+fn pipe_io_wait_for_exit_waits_for_delayed_stderr_drain() {
+    let server = HeadlessServer::start("pipe-io-drain-join");
+    let terminal = pipe_io_terminal(&server);
+
+    let mut relay = PipeIoRelay::start_with_stderr_delay(
+        &server,
+        &terminal,
+        80,
+        24,
+        Duration::from_millis(500),
+    );
+    relay.stdin = None;
+    let (code, exit) = relay.wait_for_exit();
+    assert_eq!(code, 0, "stdin EOF must be a clean detach, got {exit}");
+    assert_eq!(exit["exit"]["reason"], "parent-closed");
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4281,6 +4281,8 @@ struct PipeIoRelay {
     stdin: Option<std::process::ChildStdin>,
     stdout: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
     stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
+    stdout_drain: Option<std::thread::JoinHandle<()>>,
+    stderr_drain: Option<std::thread::JoinHandle<()>>,
 }
 
 #[cfg(unix)]
@@ -4320,15 +4322,22 @@ impl PipeIoRelay {
         let out = child.stdout.take().unwrap();
         let err = child.stderr.take().unwrap();
         let stdout_sink = stdout.clone();
-        std::thread::spawn(move || drain_into(out, stdout_sink));
+        let stdout_drain = std::thread::spawn(move || drain_into(out, stdout_sink));
         let stderr_sink = stderr.clone();
-        std::thread::spawn(move || {
+        let stderr_drain = std::thread::spawn(move || {
             if !stderr_delay.is_zero() {
                 std::thread::sleep(stderr_delay);
             }
             drain_into(err, stderr_sink);
         });
-        Self { child, stdin, stdout, stderr }
+        Self {
+            child,
+            stdin,
+            stdout,
+            stderr,
+            stdout_drain: Some(stdout_drain),
+            stderr_drain: Some(stderr_drain),
+        }
     }
 
     fn send_input(&mut self, bytes: &[u8]) {
@@ -4378,8 +4387,15 @@ impl PipeIoRelay {
         let deadline = Instant::now() + Duration::from_secs(20);
         while Instant::now() < deadline {
             if let Some(status) = self.child.try_wait().unwrap() {
-                // Let the drain threads observe EOF.
-                std::thread::sleep(Duration::from_millis(100));
+                // Child EOF is the completion signal for both drain threads.
+                // Join them before reading stderr so the final exit record
+                // cannot race the test's parser.
+                if let Some(drain) = self.stdout_drain.take() {
+                    drain.join().expect("stdout drain thread panicked");
+                }
+                if let Some(drain) = self.stderr_drain.take() {
+                    drain.join().expect("stderr drain thread panicked");
+                }
                 let stderr_text =
                     String::from_utf8_lossy(&self.stderr.lock().unwrap()).into_owned();
                 let exit_line = stderr_text

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4611,7 +4611,7 @@ fn pipe_io_startup_socket_validation_reports_setup_failed() {
         .unwrap();
     assert_eq!(
         output.status.code(),
-        Some(1),
+        Some(0),
         "stderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4271,8 +4271,8 @@ fn bin() -> &'static str {
 //   stdout  = raw VT bytes (daemon replay first, then live output),
 //   stdin   = JSON lines ({"input":"<b64>"} | {"resize":{"cols":N,"rows":N}}),
 //   stderr  = one final JSON line {"exit":{"reason":...}},
-//   exit 0  = terminal ended (or parent closed stdin) — do not respawn,
-//   exit 2  = daemon connection lost — the embedder may respawn to resync.
+//   exit 0  = terminal ended, parent closed stdin, or setup failed; do not respawn,
+//   exit 2  = daemon connection lost; the embedder may respawn to resync.
 // ---------------------------------------------------------------------------
 
 #[cfg(unix)]
@@ -4283,6 +4283,38 @@ struct PipeIoRelay {
     stderr: std::sync::Arc<std::sync::Mutex<Vec<u8>>>,
     stdout_drain: Option<std::thread::JoinHandle<()>>,
     stderr_drain: Option<std::thread::JoinHandle<()>>,
+}
+
+#[cfg(unix)]
+impl Drop for PipeIoRelay {
+    fn drop(&mut self) {
+        // Closing stdin lets a healthy relay finish its parent-closed path.
+        // Child does not reap on drop, so give it a bounded grace period,
+        // then kill and wait before joining the pipe drains.
+        drop(self.stdin.take());
+        let deadline = Instant::now() + Duration::from_secs(2);
+        let mut exited = false;
+        while Instant::now() < deadline {
+            match self.child.try_wait() {
+                Ok(Some(_)) => {
+                    exited = true;
+                    break;
+                }
+                Ok(None) => std::thread::sleep(Duration::from_millis(10)),
+                Err(_) => break,
+            }
+        }
+        if !exited {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
+        if let Some(drain) = self.stdout_drain.take() {
+            let _ = drain.join();
+        }
+        if let Some(drain) = self.stderr_drain.take() {
+            let _ = drain.join();
+        }
+    }
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4596,6 +4596,37 @@ fn pipe_io_startup_connect_failure_reports_daemon_lost() {
 
 #[cfg(unix)]
 #[test]
+fn pipe_io_startup_socket_validation_reports_setup_failed() {
+    // Session-name validation happens before a remote socket can be opened.
+    // Pipe-IO clients still require the structured terminal result so they do
+    // not have to parse a human-facing startup error.
+    let invalid_session = "x".repeat(256);
+    let output = Command::new(bin())
+        .args(["attach", "--session"])
+        .arg(&invalid_session)
+        .args(["--terminal", "term_0123456789abcdef0123456789abcdef", "--pipe-io"])
+        .env_remove("CMUX_TUI_SOCKET")
+        .stdin(Stdio::null())
+        .output()
+        .unwrap();
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let exit_line = stderr
+        .lines()
+        .rev()
+        .find(|line| line.trim_start().starts_with('{'))
+        .expect("pipe-io startup must emit a structured exit record");
+    let value: serde_json::Value = serde_json::from_str(exit_line).unwrap();
+    assert_eq!(value["exit"]["reason"], "setup-failed");
+}
+
+#[cfg(unix)]
+#[test]
 fn pipe_io_wait_for_exit_waits_for_delayed_stderr_drain() {
     let server = HeadlessServer::start("pipe-io-drain-join");
     let terminal = pipe_io_terminal(&server);

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4603,7 +4603,7 @@ fn pipe_io_startup_socket_validation_reports_setup_failed() {
     let invalid_session = "bad/session";
     let output = Command::new(bin())
         .args(["attach", "--session"])
-        .arg(&invalid_session)
+        .arg(invalid_session)
         .args(["--terminal", "term_0123456789abcdef0123456789abcdef", "--pipe-io"])
         .env_remove("CMUX_TUI_SOCKET")
         .stdin(Stdio::null())

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -4597,10 +4597,10 @@ fn pipe_io_startup_connect_failure_reports_daemon_lost() {
 #[cfg(unix)]
 #[test]
 fn pipe_io_startup_socket_validation_reports_setup_failed() {
-    // Session-name validation happens before a remote socket can be opened.
+    // Session-name path validation happens before a remote socket can be opened.
     // Pipe-IO clients still require the structured terminal result so they do
     // not have to parse a human-facing startup error.
-    let invalid_session = "x".repeat(256);
+    let invalid_session = "bad/session";
     let output = Command::new(bin())
         .args(["attach", "--session"])
         .arg(&invalid_session)

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -13,7 +13,7 @@ request:
 ```text
 cmux [START OPTIONS]
 cmux server start [START OPTIONS]
-cmux attach [START OPTIONS] [--terminal <terminal-id>]
+cmux attach [START OPTIONS] [--terminal <terminal-id>] [--pipe-io [--cols <n> --rows <n>]]
 cmux relay [ROUTING OPTIONS]
 cmux machine-agent [OPTIONS]
 ```
@@ -24,6 +24,25 @@ complete session TUI. `attach --terminal <terminal-id>` resolves an exact ID
 from `cmux terminal list` and renders only that terminal, without session
 chrome or unrelated event traffic. Startup attach does not accept internal
 runtime identifiers, abbreviated identifiers, names, or `current`.
+
+`attach --terminal <terminal-id> --pipe-io` is the same scoped attach without
+a renderer, for an embedder that parses terminal bytes itself. stdout carries
+raw bytes: the daemon replay first, then live output, with a full reset
+(`ESC c` plus erase-scrollback) before any replay that is not the relay's
+first output, because a replay replaces state while a byte stream appends.
+stdin takes one JSON object per line: `{"input":"<base64>"}` forwards bytes to
+the terminal, `{"resize":{"cols":N,"rows":N}}` drives the attached viewer
+size, and `{"claim":{"geometry":true}}` re-asserts this relay's geometry
+authority (authority is last-claim-wins across a terminal's attachments; an
+embedder sends it when its pane receives user input, so the typed-in pane
+owns the PTY size). Each applied resize and claim is reported as one
+`{"diag":...}` stderr line; unknown keys are ignored. stderr ends with one
+JSON line
+`{"exit":{"reason":"terminal-ended"|"daemon-lost"|"parent-closed"}}`. Exit
+code 0 means the terminal ended or the embedder closed stdin (do not
+respawn); exit code 2 means the daemon connection was lost and a respawn
+reattaches and resyncs from a fresh replay. `--cols` and `--rows` set the
+initial viewer size (default 80x24). `--pipe-io` requires `--terminal`.
 
 Interactive and headless ownership are intentionally separate:
 

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -34,7 +34,8 @@ The relay applies the attach stream's coupled `colors` metadata as ordered VT
 sidecar bytes after the replay or live output it describes. This uses OSC
 10/11/12, OSC 4/104, and DECSCUSR, so a raw embedder receives the same default,
 cursor, and sparse palette state as a byte-mode attach client. A live palette
-snapshot resets prior authored entries before applying its sparse entries;
+snapshot resets entries removed from the prior authored snapshot before applying
+its sparse entries;
 omitted live color fields remain unchanged.
 stdin takes one JSON object per line: `{"input":"<base64>"}` forwards bytes to
 the terminal, `{"resize":{"cols":N,"rows":N}}` drives the attached viewer

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -35,8 +35,12 @@ the terminal, `{"resize":{"cols":N,"rows":N}}` drives the attached viewer
 size, and `{"claim":{"geometry":true}}` re-asserts this relay's geometry
 authority (authority is last-claim-wins across a terminal's attachments; an
 embedder sends it when its pane receives user input, so the typed-in pane
-owns the PTY size). Each applied resize and claim is reported as one
-`{"diag":...}` stderr line; unknown keys are ignored. stderr ends with one
+owns the PTY size). Each resize result is reported as one
+`{"diag":{"resize":{"cols":N,"rows":N,"accepted":true|false}}}` line, or
+as `{"diag":{"resize":{"cols":N,"rows":N,"error":"..."}}}` when the
+request fails. Each claim is reported as
+`{"diag":{"claim":{"accepted":true}}}` or
+`{"diag":{"claim":{"error":"..."}}}`. Unknown keys are ignored. stderr ends with one
 JSON line
 `{"exit":{"reason":"terminal-ended"|"daemon-lost"|"parent-closed"}}`. Exit
 code 0 means the terminal ended or the embedder closed stdin (do not

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -37,15 +37,15 @@ authority (authority is last-claim-wins across a terminal's attachments; an
 embedder sends it when its pane receives user input, so the typed-in pane
 owns the PTY size). Each resize result is reported as one
 `{"diag":{"resize":{"cols":N,"rows":N,"accepted":true|false}}}` line, or
-as `{"diag":{"resize":{"cols":N,"rows":N,"error":"..."}}}` when the
+as `{"diag":{"resize":{"cols":N,"rows":N,"error":"resize-failed"}}}` when the
 request fails. Each claim is reported as
 `{"diag":{"claim":{"accepted":true}}}` or
-`{"diag":{"claim":{"error":"..."}}}`. Unknown keys are ignored. stderr ends with one
-JSON line
-`{"exit":{"reason":"terminal-ended"|"daemon-lost"|"parent-closed"}}`. Exit
-code 0 means the terminal ended or the embedder closed stdin (do not
-respawn); exit code 2 means the daemon connection was lost and a respawn
-reattaches and resyncs from a fresh replay. `--cols` and `--rows` set the
+`{"diag":{"claim":{"error":"claim-failed"}}}`. Unknown keys are ignored. stderr
+ends with one JSON line
+`{"exit":{"reason":"terminal-ended"|"daemon-lost"|"parent-closed"|"setup-failed"}}`.
+Exit code 0 means the terminal ended, the embedder closed stdin, or setup
+failed (do not respawn); exit code 2 means the daemon connection was lost and
+a respawn reattaches and resyncs from a fresh replay. `--cols` and `--rows` set the
 initial viewer size (default 80x24). `--pipe-io` requires `--terminal`.
 
 Interactive and headless ownership are intentionally separate:

--- a/cmux-tui/spec/cli.md
+++ b/cmux-tui/spec/cli.md
@@ -30,6 +30,12 @@ a renderer, for an embedder that parses terminal bytes itself. stdout carries
 raw bytes: the daemon replay first, then live output, with a full reset
 (`ESC c` plus erase-scrollback) before any replay that is not the relay's
 first output, because a replay replaces state while a byte stream appends.
+The relay applies the attach stream's coupled `colors` metadata as ordered VT
+sidecar bytes after the replay or live output it describes. This uses OSC
+10/11/12, OSC 4/104, and DECSCUSR, so a raw embedder receives the same default,
+cursor, and sparse palette state as a byte-mode attach client. A live palette
+snapshot resets prior authored entries before applying its sparse entries;
+omitted live color fields remain unchanged.
 stdin takes one JSON object per line: `{"input":"<base64>"}` forwards bytes to
 the terminal, `{"resize":{"cols":N,"rows":N}}` drives the attached viewer
 size, and `{"claim":{"geometry":true}}` re-asserts this relay's geometry


### PR DESCRIPTION
## Summary

Repair the cmux-tui pipe-IO relay compile failure from [#11705](https://github.com/manaflow-ai/cmux/pull/11705). `pipe_io.rs` uses the crate-scoped `RemoteSession::supports_pipe_io_initial_size` API. The generic `supports_capability` method remains `pub(super)`.

This replacement replays the required pipe-IO integration from [#11735](https://github.com/manaflow-ai/cmux/pull/11735), including `main.rs`, `pipe_io.rs`, `pty_input.rs`, `session` APIs, CLI behavior coverage, and the CLI specification. It excludes the later legacy attach gate and overflow reclassification commits.

The relay now accepts a replay that exceeds the normal 8 MiB queue budget when the decoded frame is within the 32 MiB remote-message limit. One bounded single-frame allowance is tracked separately, so queued retention stays bounded and a second oversized replay is rejected while the first remains queued. Resize results and geometry-claim results are emitted as structured stderr diagnostics documented in `spec/cli.md`.

The branch is rebased onto current `main` at `aaa600a016cd0cbdb6e568d3e277e9dee358ba73` and retains the test-first red/fix history for request admission, relay lifecycle, and portable output cancellation.

## Verification

- `rustfmt --edition 2024 --check` on all changed Rust files
- `git diff --check aaa600a016cd0cbdb6e568d3e277e9dee358ba73...HEAD`
- Blacksmith Testbox focused run: `cargo test --locked -p cmux-tui output_worker_interrupts_a_blocked_write_when_reader_closes -- --nocapture`, 1 passed
- Hosted exact-head focused workflow is dispatched for the same 40-character commit and test filter
- No local Cargo build or test was run; cmux-tui Rust verification uses Blacksmith Testbox


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `--pipe-io` support to `cmux attach --terminal` for streaming raw terminal data through standard input and output.
  * Added JSON commands for forwarding input, resizing terminals, and reclaiming geometry control.
  * Added configurable initial dimensions with `--cols` and `--rows` (default: 80×24).
  * Added machine-readable exit reasons, diagnostics, and status reporting through stderr.

* **Documentation**
  * Documented pipe-IO commands, output behavior, diagnostics, and exit codes.

* **Bug Fixes**
  * Improved handling of terminal closure, connection loss, replay, reconnection, and resizing events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
