### PR TITLE
cmux-tui: simplify JoinSet shutdown drains

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/preview_proxy.rs
+++ b/cmux-tui/crates/chatmux-relay/src/preview_proxy.rs
@@ -474,8 +474,7 @@ async fn spawn_proxy(target_port: u16, ring: Arc<ConsoleRing>) -> Result<ProxyRu
                 }
             }
         }
-        connections.abort_all();
-        while connections.join_next().await.is_some() {}
+        connections.shutdown().await;
         let upgrades = shared
             .upgrades
             .lock()

--- a/cmux-tui/crates/cmux-remote/src/bridge.rs
+++ b/cmux-tui/crates/cmux-remote/src/bridge.rs
@@ -30,8 +30,7 @@ impl ForwardConnections {
 
     async fn shutdown(&self) {
         let mut tasks = self.tasks.lock().await;
-        tasks.abort_all();
-        while tasks.join_next().await.is_some() {}
+        tasks.shutdown().await;
     }
 
     fn abort_all(&self) {
@@ -205,8 +204,7 @@ pub async fn serve_mux_bridge(
             }
         }
     }
-    connections.abort_all();
-    while connections.join_next().await.is_some() {}
+    connections.shutdown().await;
 }
 
 #[derive(Debug, Default, PartialEq, Eq)]

--- a/cmux-tui/crates/cmux-remote/src/services.rs
+++ b/cmux-tui/crates/cmux-remote/src/services.rs
@@ -330,8 +330,7 @@ impl DaemonServices {
             }
         }
         self.workspace.shutdown().await;
-        handlers.abort_all();
-        while handlers.join_next().await.is_some() {}
+        handlers.shutdown().await;
         self.workspace.shutdown().await;
     }
 


### PR DESCRIPTION
## Summary

Replace production `JoinSet::abort_all()` plus ignored `join_next()` drain loops with `JoinSet::shutdown().await` at the four equivalent cleanup sites:

- `cmux-tui/crates/cmux-remote/src/bridge.rs:31-34`, `ForwardConnections::shutdown`
- `cmux-tui/crates/cmux-remote/src/bridge.rs:207`, `serve_mux_bridge`
- `cmux-tui/crates/cmux-remote/src/services.rs:332-334`, `DaemonServices::run_local`
- `cmux-tui/crates/chatmux-relay/src/preview_proxy.rs:477`, preview proxy task cleanup

Error-observing joins and intentional graceful-then-forced two-phase shutdown paths remain explicit.

Tokio documents that [`JoinSet::shutdown`](https://docs.rs/tokio/latest/tokio/task/struct.JoinSet.html#method.shutdown) is equivalent to aborting all tasks and joining until the set is empty, while ignoring shutdown panics.

Base: `b2a984ed59d6f7bfb109ebfbb90247dcc881465e`
Head: `90e856ba3973d56e11a2264a11f1d4e5e839b0f2`

## Verification

- `rustfmt --edition 2024 --check` on all three changed Rust files: passed
- `git diff --check`: passed
- `cargo fmt --all -- --check`: blocked by the local cmux-tui artifact guard because free space was 159.3 GiB, below the 250 GiB floor
- No build or tests run, per the requested rustfmt/diff-only scope
