### PR TITLE
Avoid cloning occluders during graphics cache checks

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13768,12 +13768,11 @@ impl App {
         }
         let dirty_surfaces = std::mem::take(&mut self.graphics_dirty_surfaces);
         let occluders = self.graphic_occlusion_rects();
-        let context = GraphicsSceneContextKey {
-            session_generation: self.session_generation,
-            cell_pixels: self.cell_pixels,
-            occluders: occluders.clone(),
-        };
-        let context_changed = self.graphics_scene_cache.context.as_ref() != Some(&context);
+        let context_changed = self.graphics_scene_cache.context.as_ref().is_none_or(|cached| {
+            cached.session_generation != self.session_generation
+                || cached.cell_pixels != self.cell_pixels
+                || cached.occluders.as_slice() != occluders.as_slice()
+        });
         let full_scan = !dirty_only || context_changed;
         self.mark_graphics_clean((!full_scan).then_some(&dirty_surfaces));
         let mut updates = Vec::new();
@@ -13806,7 +13805,11 @@ impl App {
         });
         let projection_changed = !updates.is_empty();
         if context_changed {
-            self.graphics_scene_cache.context = Some(context);
+            self.graphics_scene_cache.context = Some(GraphicsSceneContextKey {
+                session_generation: self.session_generation,
+                cell_pixels: self.cell_pixels,
+                occluders,
+            });
             self.graphics_scene_cache.projections.clear();
         }
         if let Some(visible) = &visible {


### PR DESCRIPTION
Summary:
- Compare graphics cache context fields directly against the freshly computed occluder slice.
- Move the original occluder Vec into the cache only when the context changes.

Validation:
- `git diff --check`
- Remote Blacksmith `cargo test --locked graphics_scene_cache` (2 tests passed)
- Hosted cmux-tui focused verification dispatched for this commit

No new test was added because allocation behavior has no independent user-visible assertion; existing graphics scene cache tests cover the unchanged and changed context paths.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops cloning the occluder list when checking the graphics scene cache. The cache check now compares the cached fields directly against the freshly computed occluders and moves the `Vec` into the cache only when the context changes, cutting per-frame allocations with no behavior change.

<sup>Written for commit 336cab7a72f86b9ab6d3badc7c0cf2dc92b63160. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11746?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved graphics scene cache comparisons by reducing temporary state and redundant processing.
  * Improved rendering update efficiency when occlusion information changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->