### PR TITLE
fix: pass claude stop/kill/logs/rm/respawn/gateway/import through the wrapper

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -1240,9 +1240,9 @@ claude_passthrough_option_flag() {
 
 claude_builtin_command_name() {
     case "$1" in
-        agents|attach|auth|auto-mode|config|api-key|daemon|doctor|install|mcp|\
-        experimental-next|plugin|plugins|project|rc|remote-control|setup-token|\
-        ultrareview|update|upgrade)
+        agents|attach|auth|auto-mode|config|api-key|daemon|doctor|gateway|\
+        import|install|kill|logs|mcp|experimental-next|plugin|plugins|project|\
+        rc|remote-control|respawn|rm|setup-token|stop|ultrareview|update|upgrade)
             return 0
             ;;
     esac

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -1064,6 +1064,35 @@ def test_hidden_attach_subcommand_bypasses_hook_injection(failures: list[str]) -
     expect(node_options == "__UNSET__", f"attach passthrough: expected no NODE_OPTIONS injection, got {node_options!r}", failures)
 
 
+def test_background_session_subcommands_bypass_hook_injection(failures: list[str]) -> None:
+    # Claude Code 2.1.x grew a family of background-session subcommands next to
+    # `attach` (stop|kill, logs, rm, respawn) plus `gateway` and `import`. Each
+    # is a real command, so injecting --session-id/--settings ahead of it makes
+    # the CLI treat the command name as the [prompt] positional and start a
+    # fresh interactive session instead of running the command.
+    cases = [
+        ["stop", "abc12345"],
+        ["kill", "abc12345"],
+        ["logs", "abc12345"],
+        ["rm", "abc12345"],
+        ["respawn", "abc12345"],
+        ["respawn", "--all"],
+        ["gateway"],
+        ["import", "codex"],
+    ]
+    for argv in cases:
+        label = " ".join(argv)
+        code, real_argv, _, stderr, _, node_options, _, _, _, _ = run_wrapper(
+            socket_state="live",
+            argv=argv,
+        )
+        expect(code == 0, f"{label} passthrough: wrapper exited {code}: {stderr}", failures)
+        expect(real_argv == argv, f"{label} passthrough: expected raw argv, got {real_argv}", failures)
+        expect("--settings" not in real_argv, f"{label} passthrough: expected no --settings injection, got {real_argv}", failures)
+        expect("--session-id" not in real_argv, f"{label} passthrough: expected no --session-id injection, got {real_argv}", failures)
+        expect(node_options == "__UNSET__", f"{label} passthrough: expected no NODE_OPTIONS injection, got {node_options!r}", failures)
+
+
 def test_passthrough_flags_bypass_hook_injection(failures: list[str]) -> None:
     for flag in ("--help", "--version", "-h", "-v"):
         code, real_argv, _, stderr, _, node_options, _, _, _, _ = run_wrapper(
@@ -2632,6 +2661,7 @@ def main() -> int:
     test_plain_claude_launch_argv_has_no_empty_argument(failures)
     test_command_like_invocations_bypass_hook_injection(failures)
     test_hidden_attach_subcommand_bypasses_hook_injection(failures)
+    test_background_session_subcommands_bypass_hook_injection(failures)
     test_passthrough_flags_bypass_hook_injection(failures)
     test_live_socket_attaches_cmux_cua_when_available(failures)
     test_computer_use_wrapper_is_a_pure_proxy(failures)


### PR DESCRIPTION
Inside a cmux terminal, `claude stop <id>` opens a brand-new Claude Code session with the prompt "stop" instead of stopping the background session. Same for `kill`, `logs`, `rm`, `respawn`, `gateway`, and `import`. The wrapper only recognizes subcommands on a hardcoded allowlist; anything else gets `--session-id <fresh uuid> --settings ...` injected ahead of it, and the CLI then reads the command name as the `[prompt]` positional.

This is the same failure #4005 reported for `agents` and that 815724872a fixed for `attach`. Claude Code 2.1.x has since added the rest of the background-session family, and this PR adds all of them so the wrapper execs the real CLI with argv untouched. Hook settings are meaningless for these commands anyway: they act on a session that is already running in another process.

**Changes**
- `Resources/bin/cmux-claude-wrapper`: add the seven names to `claude_builtin_command_name`.
- `tests/test_claude_wrapper_hooks.py`: regression test asserting each passes through with no `--session-id`, `--settings`, or `NODE_OPTIONS` injection.

Two commits so CI shows the test failing before the fix. Verified against Claude Code 2.1.259 with `python3 tests/test_claude_wrapper_hooks.py`; every command in its `--help` output is now allowlisted.

Refs #4005

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MiwcMaECsbeFgUo7eG4zCx


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the cmux wrapper so `claude stop`, `kill`, `logs`, `rm`, `respawn`, `gateway`, and `import` pass through to the real CLI with argv untouched, instead of injecting a fresh `--session-id` that makes Claude Code treat the command name as a prompt and open a new interactive session. Adds regression tests for each command.

<sup>Written for commit c82832d37cc91f17663b37bb1c844694f667e19a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Claude Code background-session subcommands now pass through unchanged, without unwanted hook, session, or environment-setting injection.
  - Added support for `gateway`, `import`, `kill`, `logs`, `respawn`, `rm`, and `stop` invocations.

- **Tests**
  - Added regression coverage to verify correct handling of these subcommands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->