### PR TITLE
ci(tui): avoid duplicate focused sentinels in full mode

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -424,7 +424,7 @@ jobs:
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
       - name: focused Linux journal process-fence test
-        if: runner.os == 'Linux'
+        if: inputs.mode == 'focused' && runner.os == 'Linux'
         working-directory: cmux-tui
         run: >-
           cargo test -p cmux-tui-core --lib
@@ -432,11 +432,12 @@ jobs:
           -- --exact
 
       - name: focused macOS journal process-fence tests
-        if: runner.os == 'macOS'
+        if: inputs.mode == 'focused' && runner.os == 'macOS'
         working-directory: cmux-tui
         run: cargo test -p cmux-tui-core --lib unix_process_scope::tests::mac_process_scope_
 
       - name: focused journal writer shutdown test
+        if: inputs.mode == 'focused'
         working-directory: cmux-tui
         run: >-
           cargo test -p cmux-tui-core --lib
@@ -444,6 +445,7 @@ jobs:
           -- --exact
 
       - name: focused final journal ownership tests
+        if: inputs.mode == 'focused'
         working-directory: cmux-tui
         run: |
           cargo test -p cmux-tui-core --lib \

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -4,9 +4,23 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "cmux-tui.yml"
+
+FOCUSED_SENTINEL_STEPS = (
+    "focused Linux journal process-fence test",
+    "focused macOS journal process-fence tests",
+    "focused journal writer shutdown test",
+    "focused final journal ownership tests",
+)
+
+
+def _test_job() -> dict:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    return workflow["jobs"]["test"]
 
 
 def test_ignored_only_listing_has_no_runnable_test_names() -> None:
@@ -56,3 +70,39 @@ fi
         )
 
     assert result.returncode == 17
+
+
+def test_journal_sentinels_are_focused_only_and_full_uses_isolated_core_runner() -> None:
+    job = _test_job()
+    steps = {step.get("name"): step for step in job["steps"]}
+
+    linux_condition = str(steps[FOCUSED_SENTINEL_STEPS[0]]["if"])
+    assert "inputs.mode == 'focused'" in linux_condition
+    assert "runner.os == 'Linux'" in linux_condition
+
+    macos_condition = str(steps[FOCUSED_SENTINEL_STEPS[1]]["if"])
+    assert "inputs.mode == 'focused'" in macos_condition
+    assert "runner.os == 'macOS'" in macos_condition
+
+    for name in FOCUSED_SENTINEL_STEPS[2:]:
+        condition = str(steps[name]["if"])
+        assert "inputs.mode == 'focused'" in condition
+        assert "full" not in condition
+
+    final_sentinels = steps[FOCUSED_SENTINEL_STEPS[3]]["run"]
+    assert "cargo test -p cmux-tui-core --test browser_runtime" in final_sentinels
+    assert "socket_browser_attach_streams_frames_input_and_cell_pixels" in final_sentinels
+
+    cargo_test = steps["cargo test"]["run"]
+    assert 'if [[ "$MODE" == "full" ]]; then' in cargo_test
+    assert "run-cmux-tui-core-tests-isolated.py" in cargo_test
+    assert "crates/cmux-tui-core" in cargo_test
+
+
+def test_tui_status_names_remain_stable() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    assert workflow["jobs"]["test"]["name"] == "test (${{ matrix.os }})"
+    assert (
+        workflow["jobs"]["hosted-verification"]["name"]
+        == "${{ inputs.mode == 'full' && 'hosted verification' || 'focused hosted verification' }}"
+    )


### PR DESCRIPTION
Summary:
- Gate the four focused journal sentinel steps on focused mode.
- Keep browser_runtime in the focused sentinel coverage while full mode runs every cmux-tui-core test through the isolated runner.
- Add a workflow structure test that protects mode ownership and existing status names.

Validation:
- actionlint .github/workflows/cmux-tui.yml
- python3 -m pytest -q tests/test_tui_focused_filter_guard.py tests/test_tui_publish_workflow_security.py
- git diff --check

The workflow conditions follow GitHub Actions job and step `if` expression semantics: https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restricts four focused journal sentinel tests to focused mode so full mode no longer runs them twice through the isolated core runner.

- Adds a workflow structure test that locks mode ownership of the sentinel steps and existing job status names.

<sup>Written for commit 1b0e438630d46725dc05a890bafe4aaea91b1ece. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

