### PR TITLE
ci: simplify reusable TUI package checkouts

### DIFF
--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -179,14 +179,7 @@ jobs:
       fail-fast: false
       matrix: ${{ fromJSON(needs.plan-build.outputs.matrix) }}
     steps:
-      - name: Checkout caller ref
-        if: inputs.checkout_ref == ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout requested ref
-        if: inputs.checkout_ref != ''
+      - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -379,14 +372,7 @@ jobs:
       run:
         working-directory: cmux-tui/relays/cloudflare-do
     steps:
-      - name: Checkout caller ref
-        if: inputs.checkout_ref == ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout requested ref
-        if: inputs.checkout_ref != ''
+      - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -435,14 +421,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Checkout caller ref
-        if: inputs.checkout_ref == ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout requested ref
-        if: inputs.checkout_ref != ''
+      - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -576,14 +555,7 @@ jobs:
       NPM_VERSION: ${{ inputs.version }}
       PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
     steps:
-      - name: Checkout caller ref
-        if: inputs.checkout_ref == ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout requested ref
-        if: inputs.checkout_ref != ''
+      - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -800,14 +772,7 @@ jobs:
     env:
       PYPI_VERSION: ${{ inputs.pypi_version != '' && inputs.pypi_version || inputs.version }}
     steps:
-      - name: Checkout caller ref
-        if: inputs.checkout_ref == ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout requested ref
-        if: inputs.checkout_ref != ''
+      - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -876,14 +841,7 @@ jobs:
       id-token: write
       attestations: write
     steps:
-      - name: Checkout caller ref
-        if: inputs.checkout_ref == ''
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-
-      - name: Checkout requested ref
-        if: inputs.checkout_ref != ''
+      - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -182,8 +182,8 @@ jobs:
       - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Init ghostty submodule
         run: git submodule update --init --depth 1 ghostty
@@ -375,8 +375,8 @@ jobs:
       - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Set up Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
@@ -424,8 +424,8 @@ jobs:
       - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Init ghostty submodule
         run: git submodule update --init --depth 1 ghostty
@@ -558,8 +558,8 @@ jobs:
       - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Download darwin arm64 binary
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -775,8 +775,8 @@ jobs:
       - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Download npm package archive
         if: inputs.package_npm
@@ -844,8 +844,8 @@ jobs:
       - name: Checkout caller or requested ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          persist-credentials: false
           ref: ${{ inputs.checkout_ref }}
+          persist-credentials: false
 
       - name: Download npm package archive
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0

--- a/.github/workflows/cmux-tui-build-package.yml
+++ b/.github/workflows/cmux-tui-build-package.yml
@@ -847,6 +847,21 @@ jobs:
           ref: ${{ inputs.checkout_ref }}
           persist-credentials: false
 
+      - name: Verify attestation checkout matches caller
+        env:
+          CHECKOUT_REF: ${{ inputs.checkout_ref }}
+        run: |
+          set -euo pipefail
+          checked_out_sha="$(git rev-parse HEAD)"
+          if [[ "$checked_out_sha" != "$GITHUB_SHA" ]]; then
+            echo "attest_packages requires checkout_ref to resolve to $GITHUB_SHA; got $checked_out_sha." >&2
+            exit 1
+          fi
+          if [[ -n "$CHECKOUT_REF" && "$CHECKOUT_REF" != "$GITHUB_SHA" ]]; then
+            echo "attest_packages rejects checkout_ref=$CHECKOUT_REF; it must be empty or $GITHUB_SHA." >&2
+            exit 1
+          fi
+
       - name: Download npm package archive
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
         with:

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1640,6 +1640,145 @@ def test_relay_attestations_survive_a_skipped_windows_build() -> None:
         assert "needs.package.result == 'success'" in section
 
 
+PACKAGE_BUILD_JOBS = (
+    "build",
+    "cloudflare-relay",
+    "build-windows",
+    "package",
+    "verify-linux-packages",
+    "attest-npm-packages",
+)
+
+
+def _package_workflow_document() -> dict[str, object]:
+    document = yaml.load(
+        workflow("cmux-tui-build-package.yml"),
+        Loader=yaml.BaseLoader,
+    )
+    assert isinstance(document, dict)
+    return document
+
+
+def _checkout_target(
+    ref_input: str,
+    event_ref: str,
+    event_sha: str,
+) -> tuple[str, str]:
+    """Model actions/checkout's self-repository ref/commit resolution.
+
+    An empty `ref` input delegates to the event's ref and SHA. A non-empty
+    input is an explicit branch, tag, or SHA; SHA inputs are checked out by
+    commit, while symbolic refs remain symbolic.
+    """
+
+    if not ref_input:
+        return event_ref, event_sha
+    if re.fullmatch(r"[0-9a-fA-F]{40}|[0-9a-fA-F]{64}", ref_input):
+        return "", ref_input
+    return ref_input, ""
+
+
+def test_package_jobs_use_one_optional_checkout_ref_input() -> None:
+    document = _package_workflow_document()
+    jobs = document["jobs"]
+    assert isinstance(jobs, dict)
+
+    for job_name in PACKAGE_BUILD_JOBS:
+        job = jobs[job_name]
+        assert isinstance(job, dict)
+        steps = job["steps"]
+        assert isinstance(steps, list)
+        checkouts = [
+            step
+            for step in steps
+            if isinstance(step, dict)
+            and "actions/checkout" in str(step.get("uses", ""))
+        ]
+        assert len(checkouts) == 1, job_name
+        checkout = checkouts[0]
+        assert checkout["name"] == "Checkout caller or requested ref"
+        with_config = checkout["with"]
+        assert isinstance(with_config, dict)
+        assert with_config["persist-credentials"] == "false"
+        assert with_config["ref"] == "${{ inputs.checkout_ref }}"
+
+
+def test_package_checkout_ref_preserves_workflow_call_pr_branch_tag_and_sha() -> None:
+    document = _package_workflow_document()
+    jobs = document["jobs"]
+    assert isinstance(jobs, dict)
+    build = jobs["build"]
+    assert isinstance(build, dict)
+    checkout = next(
+        step
+        for step in build["steps"]
+        if isinstance(step, dict)
+        and "actions/checkout" in str(step.get("uses", ""))
+    )
+    with_config = checkout["with"]
+    assert isinstance(with_config, dict)
+    expression = with_config["ref"]
+
+    # These values exercise the contexts that call this reusable workflow. The
+    # event ref and SHA are retained when the optional input is empty; explicit
+    # branch, tag, and SHA inputs pass through unchanged.
+    source_sha = "a" * 40
+    requested_sha = "b" * 40
+    scenarios = (
+        (
+            "workflow_call input",
+            "refs/tags/cmux-tui-v1.2.3",
+            "refs/heads/main",
+            source_sha,
+            ("refs/tags/cmux-tui-v1.2.3", ""),
+        ),
+        (
+            "PR",
+            "",
+            "refs/pull/42/merge",
+            source_sha,
+            ("refs/pull/42/merge", source_sha),
+        ),
+        (
+            "branch",
+            "",
+            "refs/heads/feature/build",
+            source_sha,
+            ("refs/heads/feature/build", source_sha),
+        ),
+        (
+            "tag",
+            "",
+            "refs/tags/cmux-tui-v1.2.3",
+            source_sha,
+            ("refs/tags/cmux-tui-v1.2.3", source_sha),
+        ),
+        (
+            "SHA",
+            requested_sha,
+            "refs/heads/main",
+            source_sha,
+            ("", requested_sha),
+        ),
+    )
+    assert expression == "${{ inputs.checkout_ref }}"
+    for name, ref_input, event_ref, event_sha, expected in scenarios:
+        assert _checkout_target(ref_input, event_ref, event_sha) == expected, name
+
+
+def test_package_attestation_stays_bound_to_caller_digest_and_ref() -> None:
+    attest = workflow_job(
+        workflow("cmux-tui-build-package.yml"),
+        "attest-npm-packages",
+    )
+    assert '--source-digest "$GITHUB_SHA"' in attest
+    assert '--source-ref "$GITHUB_REF"' in attest
+    assert (
+        '--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/'
+        'cmux-tui-build-package.yml"'
+    ) in attest
+
+
 def test_npm_builder_accepts_relay_release_candidate_versions() -> None:
     builder = ROOT / "cmux-tui" / "dist" / "scripts" / "package_npm.py"
     namespace = runpy.run_path(str(builder), run_name="cmux_tui_package_npm_test")

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1653,7 +1653,7 @@ PACKAGE_BUILD_JOBS = (
 def _package_workflow_document() -> dict[str, object]:
     document = yaml.load(
         workflow("cmux-tui-build-package.yml"),
-        Loader=yaml.BaseLoader,
+        Loader=yaml.BaseLoader,  # noqa: S506 - preserve raw workflow expressions
     )
     assert isinstance(document, dict)
     return document

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -1678,6 +1678,18 @@ def _checkout_target(
     return ref_input, ""
 
 
+def _attestation_checkout_allowed(
+    checkout_ref: str,
+    checked_out_sha: str,
+    caller_sha: str,
+) -> bool:
+    """Model the attestation job's fail-closed source guard."""
+
+    if checked_out_sha != caller_sha:
+        return False
+    return not checkout_ref or checkout_ref == caller_sha
+
+
 def test_package_jobs_use_one_optional_checkout_ref_input() -> None:
     document = _package_workflow_document()
     jobs = document["jobs"]
@@ -1777,6 +1789,42 @@ def test_package_attestation_stays_bound_to_caller_digest_and_ref() -> None:
         '--signer-workflow "$GITHUB_REPOSITORY/.github/workflows/'
         'cmux-tui-build-package.yml"'
     ) in attest
+
+
+def test_package_attestation_rejects_divergent_checkout_ref() -> None:
+    workflow_text = workflow("cmux-tui-build-package.yml")
+    attest_job = workflow_job(workflow_text, "attest-npm-packages")
+    document = _package_workflow_document()
+    jobs = document["jobs"]
+    assert isinstance(jobs, dict)
+    attest_document = jobs["attest-npm-packages"]
+    assert isinstance(attest_document, dict)
+    steps = attest_document["steps"]
+    assert isinstance(steps, list)
+    guard = next(
+        step
+        for step in steps
+        if isinstance(step, dict)
+        and step.get("name") == "Verify attestation checkout matches caller"
+    )
+    guard_run = guard["run"]
+    assert isinstance(guard_run, str)
+    guard_env = guard["env"]
+    assert isinstance(guard_env, dict)
+    assert guard_env["CHECKOUT_REF"] == "${{ inputs.checkout_ref }}"
+    assert 'git rev-parse HEAD' in guard_run
+    assert '"$checked_out_sha" != "$GITHUB_SHA"' in guard_run
+    assert '"$CHECKOUT_REF" != "$GITHUB_SHA"' in guard_run
+    assert attest_job.index("Verify attestation checkout matches caller") < attest_job.index(
+        "Download npm package archive"
+    )
+
+    caller_sha = "a" * 40
+    other_sha = "b" * 40
+    assert _attestation_checkout_allowed("", caller_sha, caller_sha)
+    assert not _attestation_checkout_allowed("refs/tags/other", caller_sha, caller_sha)
+    assert not _attestation_checkout_allowed(other_sha, other_sha, caller_sha)
+    assert not _attestation_checkout_allowed("", other_sha, caller_sha)
 
 
 def test_npm_builder_accepts_relay_release_candidate_versions() -> None:


### PR DESCRIPTION
## Summary

- Replace six duplicated caller/requested checkout pairs with one `actions/checkout` step per job.
- Pass `inputs.checkout_ref` directly. Empty input preserves actions/checkout's event ref and SHA defaults; non-empty input preserves branch, tag, and SHA requests.
- Add workflow contract tests for workflow-call input, pull request, branch, tag, and SHA cases, plus attestation source binding.

The behavior follows the official actions/checkout contract: https://github.com/actions/checkout/blob/main/README.md. Reusable-workflow caller context: https://docs.github.com/en/enterprise-cloud@latest/actions/reference/workflows-and-actions/reusing-workflow-configurations.

## Verification

- `python3 tests/test_tui_publish_workflow_security.py -v`
- `actionlint .github/workflows/cmux-tui-build-package.yml`
- `git diff --check`

The test commit precedes the workflow fix commit so the new guard fails against the old duplicated shape.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Simplifies the reusable TUI package workflow by replacing six duplicated checkout step pairs with one `actions/checkout` step per job that passes `inputs.checkout_ref` directly. An empty input preserves actions/checkout's event ref and SHA defaults; a non-empty input checks out the requested branch, tag, or SHA.

Adds a fail-closed guard to the `attest-npm-packages` job that rejects a checkout that doesn't resolve to the caller's `GITHUB_SHA`, keeping attestations bound to the caller revision. Adds workflow contract tests covering workflow-call input, PR, branch, tag, and SHA scenarios plus the attestation guard.

**Verification**
- Ran `python3 tests/test_tui_publish_workflow_security.py -v`, `actionlint .github/workflows/cmux-tui-build-package.yml`, and `git diff --check`.
- The test commit precedes the workflow fix so the new guard fails against the old duplicated shape.

<sup>Written for commit 44fc3a0dd92f9c60c29a007fc0220b484c186d88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11749?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Standardized source revision checkout across package build, relay, Windows, verification, and publishing workflows.
  - Ensured builds consistently use the requested revision when provided, while retaining secure credential handling.

- **Tests**
  - Added coverage for checkout behavior across branches, tags, pull requests, and commit revisions.
  - Added validation that package publishing remains tied to the originating workflow revision and signing configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->