### PR TITLE
ci(tui): scope Valgrind test compilation

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -198,7 +198,14 @@ jobs:
           VALGRIND_SHARD: ${{ matrix.shard }}
         run: |
           mkdir -p target
-          cargo test --workspace --locked --no-run --message-format=json > target/cargo-test-binaries.jsonl
+          # Cargo target selectors keep this startup shard from compiling the
+          # unrelated workspace test harnesses. The selected targets map to
+          # the cmux_tui-* and terminal-* binaries checked below.
+          cargo test \
+            -p cmux-tui --bin cmux-tui \
+            -p ghostty-vt --test terminal \
+            --locked --no-run --message-format=json \
+            > target/cargo-test-binaries.jsonl
           python3 <<'PY'
           import json
           import os

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -87,6 +87,53 @@ def test_macos_tui_tests_use_a_short_temp_root_for_unix_sockets() -> None:
     assert 'echo "TMPDIR=/tmp" >> "$GITHUB_ENV"' in test_job
 
 
+def valgrind_build_step() -> str:
+    job = workflow_job(workflow("cmux-tui.yml"), "valgrind-leak-check-shard")
+    marker = "      - name: Build test binaries\n"
+    assert marker in job
+    return job.split(marker, 1)[1].split(
+        "      - name: Verify baseline terminal replay behavior", 1
+    )[0]
+
+
+def test_valgrind_build_selects_only_startup_cargo_targets() -> None:
+    build = valgrind_build_step()
+
+    assert re.findall(
+        r"(?m)^\s+-p ([A-Za-z0-9_-]+) --(bin|test) "
+        r"([A-Za-z0-9_-]+) \\\s*$",
+        build,
+    ) == [
+        ("cmux-tui", "bin", "cmux-tui"),
+        ("ghostty-vt", "test", "terminal"),
+    ]
+    assert re.search(
+        r"cargo test \\\s+-p cmux-tui --bin cmux-tui \\\s+"
+        r"-p ghostty-vt --test terminal \\\s+"
+        r"--locked --no-run --message-format=json",
+        build,
+    )
+    assert "cargo test --workspace" not in build
+    assert build.count("cargo test") == 1
+
+
+def test_valgrind_runner_keeps_binary_and_test_safety_guards() -> None:
+    job = workflow_job(workflow("cmux-tui.yml"), "valgrind-leak-check-shard")
+
+    assert 're.fullmatch(r"(?:cmux_tui|terminal)-[0-9a-f]+", name)' in job
+    assert 'if not seen:\n              raise SystemExit("cargo did not report any test binaries")' in job
+    assert 'if not selected:\n              raise SystemExit(f"Valgrind shard {shard} selected no test binaries")' in job
+    assert 'if [[ -z "$cmux_tui_bin" || -z "$terminal_bin" ]]; then' in job
+    assert 'require_exact_test()' in job
+    assert 'pending_wrap_replay_preserves_cursor_with_origin_mode' in job
+    for test_name in (
+        "config::tests::load_uses_file_ghostty_defaults_without_invoking_external_resolver",
+        "config::tests::ghostty_file_reader_enforces_byte_limit_during_read",
+        "config::tests::ghostty_config_helper_output_reader_enforces_byte_limit",
+    ):
+        assert test_name in job
+
+
 def test_sdk_registry_names_do_not_overlap_tui_cli_packages() -> None:
     bindings = ROOT / "cmux-tui" / "bindings"
     typescript = json.loads(


### PR DESCRIPTION
## Summary

The startup Valgrind shard now asks Cargo to compile only the two targets its runner accepts: the `cmux-tui` binary test target and the `ghostty-vt` `terminal` integration test. The existing JSON artifact filter, shard checks, binary presence check, and exact-test guards remain in place.

Cargo documents repeatable package and target selectors in [cargo test](https://doc.rust-lang.org/cargo/commands/cargo-test.html).

## Verification

- `python3 tests/test_tui_publish_workflow_security.py -v` (57 passed)
- `actionlint .github/workflows/cmux-tui.yml`
- `git diff --check`
- No local Cargo build or Rust test run, per cmux-tui Linux build policy.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The Valgrind startup shard now compiles only the two test targets its runner accepts instead of the whole workspace, so unrelated test harnesses no longer get built.

- Adds a Cargo target selector for the `cmux-tui` binary and the `ghostty-vt` terminal integration test.
- Keeps the existing JSON artifact filter, shard checks, binary presence check, and exact-test guards unchanged.
- Updates workflow security tests to assert the scoped build command and the preserved safety guards.

<sup>Written for commit 655b4ff097b2c2a13e1f219ee29de1c378e34003. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11750?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added security checks for the Valgrind workflow to ensure only required test binaries are built.
  * Added coverage for binary selection, safety checks, required tests, and configuration safeguards.

* **Chores**
  * Streamlined Valgrind test builds to compile only the relevant terminal and TUI binaries, avoiding unnecessary workspace-wide builds and improving verification efficiency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->