### PR TITLE
ci(tui): make ignored coverage and browser smoke explicit

### DIFF
--- a/.github/scripts/run-cmux-tui-core-tests-isolated.py
+++ b/.github/scripts/run-cmux-tui-core-tests-isolated.py
@@ -61,9 +61,12 @@ def test_binaries(cargo_messages: Path, core_root: Path) -> list[Path]:
     return sorted(binaries)
 
 
-def tests_in(binary: Path) -> list[str]:
+def tests_in(binary: Path, *, ignored: bool = False) -> list[str]:
+    command = [str(binary), "--list"]
+    if ignored:
+        command.append("--ignored")
     result = subprocess.run(
-        [str(binary), "--list"],
+        command,
         check=True,
         stdout=subprocess.PIPE,
         text=True,
@@ -73,6 +76,8 @@ def tests_in(binary: Path) -> list[str]:
         name, separator, kind = line.rpartition(": ")
         if separator and kind == "test":
             tests.append(name)
+    if not tests and ignored:
+        return []
     if not tests:
         raise SystemExit(f"{binary.name} did not list any tests")
     if len(tests) != len(set(tests)):
@@ -80,14 +85,43 @@ def tests_in(binary: Path) -> list[str]:
     return tests
 
 
+def partition_tests(all_tests: list[str], ignored_tests: list[str]) -> tuple[list[str], list[str]]:
+    all_test_set = set(all_tests)
+    ignored_test_set = set(ignored_tests)
+    unknown = sorted(ignored_test_set - all_test_set)
+    if unknown:
+        raise ValueError(
+            "libtest reported ignored tests that were absent from its complete list: "
+            + ", ".join(unknown)
+        )
+    ignored = [test_name for test_name in all_tests if test_name in ignored_test_set]
+    runnable = [test_name for test_name in all_tests if test_name not in ignored_test_set]
+    if all_tests and not runnable:
+        raise ValueError(
+            f"all listed tests are ignored ({len(ignored)}); refusing an ignored-only run"
+        )
+    return runnable, ignored
+
+
 def main() -> int:
     args = parse_args()
     core_root = args.core_root.resolve()
     binaries = test_binaries(args.cargo_messages, core_root)
     total = 0
+    skipped = 0
     for binary in binaries:
-        tests = tests_in(binary)
+        all_tests = tests_in(binary)
+        ignored_tests = tests_in(binary, ignored=True)
+        try:
+            tests, ignored = partition_tests(all_tests, ignored_tests)
+        except ValueError as error:
+            raise SystemExit(str(error)) from error
         print(f"Running {len(tests)} tests from {binary.name} in fresh processes")
+        if ignored:
+            print(f"Skipping {len(ignored)} ignored/manual tests from {binary.name}:")
+            for test_name in ignored:
+                print(f"  {test_name}")
+            skipped += len(ignored)
         for index, test_name in enumerate(tests, start=1):
             print(f"[{index}/{len(tests)}] {test_name}", flush=True)
             subprocess.run(
@@ -96,6 +130,7 @@ def main() -> int:
             )
             total += 1
     print(f"Passed {total} isolated cmux-tui-core tests")
+    print(f"Skipped {skipped} ignored/manual cmux-tui-core tests")
     return 0
 
 

--- a/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
+++ b/.github/scripts/test_run_cmux_tui_core_tests_isolated.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Behavior tests for the isolated cmux-tui-core test runner."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+import unittest
+
+
+SCRIPT = Path(__file__).with_name("run-cmux-tui-core-tests-isolated.py")
+SPEC = importlib.util.spec_from_file_location("isolated_runner", SCRIPT)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"could not load {SCRIPT}")
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class PartitionTests(unittest.TestCase):
+    def test_ignored_tests_are_manual_and_not_runnable(self) -> None:
+        runnable, ignored = MODULE.partition_tests(
+            ["active_test", "manual_probe"],
+            ["manual_probe"],
+        )
+        self.assertEqual(runnable, ["active_test"])
+        self.assertEqual(ignored, ["manual_probe"])
+
+    def test_unknown_ignored_test_is_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            MODULE.partition_tests(["active_test"], ["missing_probe"])
+
+    def test_ignored_only_inventory_is_rejected(self) -> None:
+        with self.assertRaisesRegex(ValueError, "all listed tests are ignored"):
+            MODULE.partition_tests(["manual_probe"], ["manual_probe"])
+
+
+class InventoryTests(unittest.TestCase):
+    def test_ignored_inventory_uses_libtest_ignored_selector(self) -> None:
+        with patch.object(
+            MODULE.subprocess,
+            "run",
+            return_value=SimpleNamespace(stdout="manual_probe: test\n"),
+        ) as run:
+            self.assertEqual(MODULE.tests_in(Path("runner"), ignored=True), ["manual_probe"])
+
+        run.assert_called_once_with(
+            ["runner", "--list", "--ignored"],
+            check=True,
+            stdout=MODULE.subprocess.PIPE,
+            text=True,
+        )
+
+    def test_empty_ignored_inventory_is_allowed(self) -> None:
+        with patch.object(MODULE.subprocess, "run", return_value=SimpleNamespace(stdout="")):
+            self.assertEqual(MODULE.tests_in(Path("empty"), ignored=True), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -403,6 +403,9 @@ jobs:
       - name: Set up pinned Rust
         uses: ./.github/actions/setup-cmux-tui-rust
 
+      - name: Test isolated TUI test-runner policy
+        run: python3 .github/scripts/test_run_cmux_tui_core_tests_isolated.py
+
       - name: cargo fmt
         id: rustfmt-check
         working-directory: cmux-tui
@@ -530,6 +533,84 @@ jobs:
         working-directory: cmux-tui
         run: python3 scripts/smoke-attach.py
 
+  cdp-browser-smoke:
+    name: CDP browser smoke (${{ matrix.os }})
+    needs: validate-inputs
+    if: inputs.mode == 'full'
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos
+            runner: blacksmith-6vcpu-macos-15
+          - os: linux
+            runner: blacksmith-4vcpu-ubuntu-2404
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
+
+      - name: Set up pinned Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install pinned Playwright dependencies
+        working-directory: web
+        run: bun install --frozen-lockfile
+
+      - name: Install pinned Playwright Chromium (Linux)
+        if: runner.os == 'Linux'
+        working-directory: web
+        run: bunx playwright install --with-deps chromium
+
+      - name: Install pinned Playwright Chromium (macOS)
+        if: runner.os == 'macOS'
+        working-directory: web
+        run: bunx playwright install chromium
+
+      - name: Resolve Playwright Chromium executable
+        id: chromium
+        working-directory: web
+        shell: bash
+        run: |
+          set -euo pipefail
+          path="$(bun -e 'const { chromium } = require("@playwright/test"); process.stdout.write(chromium.executablePath())')"
+          test -n "$path"
+          test -x "$path"
+          printf 'path=%s\n' "$path" >> "$GITHUB_OUTPUT"
+          echo "Using Playwright Chromium at $path"
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Run configured Chrome CDP smoke
+        working-directory: cmux-tui
+        env:
+          CMUX_MUX_BROWSER_TEST: "1"
+          CMUX_MUX_BROWSER_TEST_CHROME: ${{ steps.chromium.outputs.path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo test -p cmux-tui-cdp --test chrome_smoke --locked -- \
+            --ignored --exact chrome_smoke_requires_configured_browser --list \
+            | tee "$RUNNER_TEMP/cdp-smoke-tests.txt"
+          grep -Eq '^chrome_smoke_requires_configured_browser: test$' \
+            "$RUNNER_TEMP/cdp-smoke-tests.txt" || {
+            echo "::error::chrome_smoke_requires_configured_browser selected no exact test" >&2
+            exit 1
+          }
+          cargo test -p cmux-tui-cdp --test chrome_smoke --locked -- \
+            --ignored --exact chrome_smoke_requires_configured_browser
+
   bindings-e2e:
     needs: validate-inputs
     if: inputs.mode == 'full'
@@ -648,6 +729,7 @@ jobs:
       - web-frontend
       - valgrind-leak-check
       - test
+      - cdp-browser-smoke
       - bindings-e2e
       - build-artifacts
     runs-on: blacksmith-4vcpu-ubuntu-2404
@@ -659,6 +741,7 @@ jobs:
       WEB_RESULT: ${{ needs.web-frontend.result }}
       VALGRIND_RESULT: ${{ needs.valgrind-leak-check.result }}
       TEST_RESULT: ${{ needs.test.result }}
+      CDP_BROWSER_RESULT: ${{ needs.cdp-browser-smoke.result }}
       BINDINGS_RESULT: ${{ needs.bindings-e2e.result }}
       ARTIFACT_RESULT: ${{ needs.build-artifacts.result }}
     steps:
@@ -681,5 +764,6 @@ jobs:
           if [[ "$MODE" == "full" ]]; then
             require_success "web frontend" "$WEB_RESULT"
             require_success "Valgrind" "$VALGRIND_RESULT"
+            require_success "Chrome CDP smoke" "$CDP_BROWSER_RESULT"
             require_success "binding end-to-end tests" "$BINDINGS_RESULT"
           fi

--- a/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
@@ -19,3 +19,10 @@ fn chrome_smoke_is_env_gated() {
     let session = client.attach_to_target(&target).unwrap();
     client.page_enable(&session).unwrap();
 }
+
+#[test]
+fn missing_browser_configuration_is_an_error_when_explicitly_requested() {
+    assert!(configured_browser_binary(None, None).is_err());
+    assert!(configured_browser_binary(Some("1"), None).is_err());
+    assert!(configured_browser_binary(Some("1"), Some(std::ffi::OsString::new())).is_err());
+}

--- a/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
+++ b/cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs
@@ -1,23 +1,40 @@
 #[test]
-fn chrome_smoke_is_env_gated() {
-    if std::env::var("CMUX_MUX_BROWSER_TEST").ok().as_deref() != Some("1") {
-        eprintln!("skipping Chrome smoke test; set CMUX_MUX_BROWSER_TEST=1 to run it");
-        return;
-    }
-
-    let Some(binary) = std::env::var_os("CMUX_MUX_BROWSER_TEST_CHROME") else {
-        eprintln!(
-            "skipping Chrome smoke test; set CMUX_MUX_BROWSER_TEST_CHROME to a Chrome binary"
-        );
-        return;
-    };
-    let chrome = cmux_tui_cdp::Chrome::launch(binary.into()).unwrap();
+#[ignore = "requires a configured Chrome or Chromium binary; invoke explicitly with --ignored"]
+fn chrome_smoke_requires_configured_browser() -> anyhow::Result<()> {
+    let binary = configured_browser_binary(
+        std::env::var("CMUX_MUX_BROWSER_TEST").ok().as_deref(),
+        std::env::var_os("CMUX_MUX_BROWSER_TEST_CHROME"),
+    )?;
+    let chrome = cmux_tui_cdp::Chrome::launch_with(&cmux_tui_cdp::ChromeLaunchOptions {
+        binary,
+        mode: cmux_tui_cdp::BrowserMode::Headless,
+        user_data_dir: None,
+        ephemeral: true,
+    })?;
     let (tx, _rx) = std::sync::mpsc::sync_channel(cmux_tui_cdp::CDP_EVENT_QUEUE_CAPACITY);
-    let client = cmux_tui_cdp::CdpClient::connect(chrome.web_socket_url(), tx).unwrap();
-    client.set_discover_targets(true).unwrap();
-    let target = client.create_target("about:blank").unwrap();
-    let session = client.attach_to_target(&target).unwrap();
-    client.page_enable(&session).unwrap();
+    let client = cmux_tui_cdp::CdpClient::connect(chrome.web_socket_url(), tx)?;
+    client.set_discover_targets(true)?;
+    let target = client.create_target("about:blank")?;
+    let session = client.attach_to_target(&target)?;
+    client.page_enable(&session)?;
+    Ok(())
+}
+
+fn configured_browser_binary(
+    enabled: Option<&str>,
+    binary: Option<std::ffi::OsString>,
+) -> anyhow::Result<std::path::PathBuf> {
+    if enabled != Some("1") {
+        anyhow::bail!(
+            "Chrome smoke requires CMUX_MUX_BROWSER_TEST=1; run this ignored test explicitly when a browser is configured"
+        );
+    }
+    let binary = binary.filter(|value| !value.is_empty()).ok_or_else(|| {
+        anyhow::anyhow!(
+            "Chrome smoke requires CMUX_MUX_BROWSER_TEST_CHROME to name a Chrome or Chromium binary"
+        )
+    })?;
+    Ok(binary.into())
 }
 
 #[test]


### PR DESCRIPTION
## Summary

This PR replaces the unique runner and CDP gaps tracked by https://github.com/manaflow-ai/cmux/issues/10271. The focused ignored-only filter guard is already merged in https://github.com/manaflow-ai/cmux/pull/11741 and is intentionally omitted here.

- Partition each cmux-tui-core libtest inventory into runnable and ignored tests, report ignored manual probes, and reject inconsistent or ignored-only inventories.
- Mark the CDP smoke as an explicit ignored test, require both browser settings, launch Playwright Chromium headless with an ephemeral profile, and propagate CDP errors.
- Add a full-mode Linux and macOS job that installs Chromium from the pinned `web/bun.lock`, verifies the exact ignored test is listed, runs it with `--ignored --exact`, and gates hosted verification on both legs.

## Regression history

1. `8085bfd9988` adds failing runner and browser configuration behavior tests.
2. `e8d16e346e9` implements the runner policy and browser smoke job.

## Verification

- `python3 .github/scripts/test_run_cmux_tui_core_tests_isolated.py`
- `python3 -m py_compile .github/scripts/run-cmux-tui-core-tests-isolated.py .github/scripts/test_run_cmux_tui_core_tests_isolated.py`
- `python3 -m pytest -q tests/test_tui_focused_filter_guard.py`
- `actionlint .github/workflows/cmux-tui.yml`
- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-cdp/tests/chrome_smoke.rs`
- `git diff --check`

No local Cargo, Rust test, Zig, browser install, or Xcode commands were run.

Rust test harness semantics: https://doc.rust-lang.org/rustc/tests/index.html
Playwright browser installation and executable resolution: https://playwright.dev/docs/browsers and https://playwright.dev/docs/api/class-browsertype