### PR TITLE
fix: bind Testbox demo cleanup to its warmup run

### DIFF
--- a/.github/workflows/testbox-broker-guard.yml
+++ b/.github/workflows/testbox-broker-guard.yml
@@ -43,8 +43,11 @@ jobs:
       - name: Validate receipt-bound cleanup ownership check
         run: ./tests/test_testbox_cleanup_receipt_ref.sh
 
+      - name: Validate demo run binding and cleanup
+        run: ./tests/test_blacksmith_testbox_demo_cleanup.sh
+
       - name: Lint the Testbox lane helpers
-        run: shellcheck scripts/blacksmith-bounded-command.sh scripts/blacksmith-cmux-tui-testbox-stage.sh scripts/blacksmith-testbox-cleanup.sh scripts/blacksmith-testbox-keepalive.sh
+        run: shellcheck scripts/blacksmith-bounded-command.sh scripts/blacksmith-cmux-tui-testbox-stage.sh scripts/blacksmith-testbox-cleanup.sh scripts/blacksmith-testbox-demo.sh scripts/blacksmith-testbox-keepalive.sh tests/test_blacksmith_testbox_demo_cleanup.sh
 
       - name: Lint the Testbox warmup workflow
         env:

--- a/scripts/blacksmith-testbox-demo.sh
+++ b/scripts/blacksmith-testbox-demo.sh
@@ -10,6 +10,7 @@ set -euo pipefail
 WORKFLOW=.github/workflows/cmux-tui-testbox-warmup.yml
 JOB=cmux-tui-rust
 IDLE_TIMEOUT=30
+CLEANUP_TIMEOUT=30
 APPROVE=1
 STAGES=0
 
@@ -82,7 +83,22 @@ echo "ghostty       $GHOSTTY_SHA"
 echo "CLI           $(blacksmith --version)"
 
 say "Boxes currently running in the org (never adopt one you did not warm)"
-run_local blacksmith testbox list --all || true
+printf '\033[2m$ blacksmith testbox list --all\033[0m\n'
+preflight_inventory_ok=0
+preexisting_testboxes=""
+set +e
+preflight_inventory="$(blacksmith testbox list --all 2>&1)"
+preflight_inventory_status=$?
+set -e
+if (( preflight_inventory_status == 0 )); then
+  preflight_inventory_ok=1
+  preexisting_testboxes="$(printf '%s\n' "$preflight_inventory" \
+    | awk '$1 ~ /^tbx_[A-Za-z0-9_-]+$/ { print $1 }' | sort -u)"
+  preexisting_count="$(printf '%s\n' "$preexisting_testboxes" | awk 'NF { count += 1 } END { print count + 0 }')"
+  printf 'captured pre-dispatch Testbox inventory (%s boxes)\n' "$preexisting_count"
+else
+  echo "could not capture the pre-dispatch Testbox inventory; partial warmup cleanup will fail closed" >&2
+fi
 
 echo
 echo "Warming one 32 vCPU Linux VM: about 4 minutes of hydration, a few minutes"
@@ -91,22 +107,224 @@ echo "of building, then it stops itself. Ctrl-C also stops it."
 # ------------------------------------------------------------------- warmup --
 TBX=""
 RUN_ID=""
+warmup_log=""
+ready_log=""
+inventory_log=""
+partial_status_log=""
+pre_ready_status_log=""
+approval_status_log=""
+ready_phase_started=0
+
+extract_run_id_from_log() {
+  local log_path="$1"
+  local run_url run_id
+  [[ -s "$log_path" ]] || return 1
+
+  # The RUN URL is emitted on the row for this exact Testbox once the box is
+  # ready. Do not scan the whole transcript: another row or a pasted URL must
+  # never become the cleanup target.
+  run_url="$(awk -v testbox_id="$TBX" '
+    $1 == testbox_id {
+      for (field = 1; field <= NF; field++) {
+        if ($field ~ /^https:\/\/github\.com\/manaflow-ai\/cmux\/actions\/runs\/[0-9]+\/?$/) {
+          print $field
+          exit
+        }
+      }
+    }
+  ' "$log_path")"
+  run_id="$(printf '%s\n' "$run_url" | sed -nE 's#^https://github\.com/manaflow-ai/cmux/actions/runs/([0-9]+)/?$#\1#p')"
+  [[ "$run_id" =~ ^[0-9]+$ ]] || return 1
+  printf '%s\n' "$run_id"
+}
+
+record_run_id_from_log() {
+  local log_path="$1"
+  local discovered
+  [[ -z "$RUN_ID" ]] || return 0
+  discovered="$(extract_run_id_from_log "$log_path" 2>/dev/null || true)"
+  if [[ "$discovered" =~ ^[0-9]+$ ]]; then
+    RUN_ID="$discovered"
+    echo "recorded exact warmup run URL for cleanup"
+    return 0
+  fi
+  return 1
+}
+
+recover_partial_testbox() {
+  local log_path="$1"
+  local candidate status_status
+  [[ -z "$TBX" ]] || return 0
+
+  # A nonzero warmup status is not an ownership receipt. Treat any printed ID
+  # as an untrusted candidate, then require an exact ID-specific status row and
+  # proof that the ID was absent from the pre-dispatch inventory. If either
+  # check fails, leave TBX empty so cleanup cannot stop another operator's box.
+  set +e
+  candidate="$(grep -Eo 'tbx_[A-Za-z0-9_-]+' "$log_path" | head -1)"
+  set -e
+  [[ "$candidate" =~ ^tbx_[A-Za-z0-9_-]+$ ]] || return 1
+  if (( preflight_inventory_ok == 0 )); then
+    echo "warmup failed; pre-dispatch Testbox inventory was unavailable, refusing cleanup ownership" >&2
+    return 1
+  fi
+  if printf '%s\n' "$preexisting_testboxes" | grep -Fqx "$candidate"; then
+    echo "warmup failed; candidate existed before dispatch, refusing cleanup ownership" >&2
+    return 1
+  fi
+
+  partial_status_log="$(mktemp)"
+  set +e
+  "$BOUNDED" "$CLEANUP_TIMEOUT" blacksmith testbox status --id "$candidate" \
+    >"$partial_status_log" 2>&1
+  status_status=$?
+  set -e
+  if (( status_status != 0 )); then
+    echo "warmup failed; exact status lookup did not verify the candidate, refusing cleanup ownership" >&2
+    rm -f -- "$partial_status_log"
+    partial_status_log=""
+    return 1
+  fi
+  if ! awk -v testbox_id="$candidate" '$1 == testbox_id { found=1; exit } END { exit found ? 0 : 1 }' \
+    "$partial_status_log"; then
+    echo "warmup failed; status omitted the candidate, refusing cleanup ownership" >&2
+    rm -f -- "$partial_status_log"
+    partial_status_log=""
+    return 1
+  fi
+
+  TBX="$candidate"
+  record_run_id_from_log "$partial_status_log" || true
+  rm -f -- "$partial_status_log"
+  partial_status_log=""
+  echo "recovered Testbox after failed warmup from exact ID-specific status" >&2
+  return 0
+}
+
+discover_run_id() {
+  [[ -n "$TBX" && -z "$RUN_ID" ]] || return 0
+
+  # A ready/status transcript may already contain the authoritative RUN URL.
+  if [[ -n "$ready_log" ]]; then
+    record_run_id_from_log "$ready_log" && return 0
+  fi
+
+  # Ask Blacksmith for the row keyed by our Testbox ID. RUN URL is the
+  # authoritative binding once hydration has assigned the runner.
+  local status_log
+  status_log="$(mktemp)"
+  set +e
+  # Let the CLI poll its ID-specific endpoint while the outer command deadline
+  # guarantees that EXIT cleanup cannot wait forever. Parse the transcript even
+  # when the outer bound expires, because a complete row may have been flushed.
+  "$BOUNDED" "$CLEANUP_TIMEOUT" blacksmith testbox status --id "$TBX" \
+    --wait --wait-timeout 30s >"$status_log" 2>&1
+  set -e
+  # A transient status exit can still leave a complete, exact row in the
+  # transcript. Parse it before considering the command status.
+  record_run_id_from_log "$status_log" || true
+  rm -f -- "$status_log"
+  [[ -z "$RUN_ID" ]] || return 0
+
+  # Older CLI versions include RUN URL only in the inventory listing. Keep
+  # this fallback keyed by the exact Testbox ID for the same ownership proof.
+  inventory_log="$(mktemp)"
+  set +e
+  "$BOUNDED" "$CLEANUP_TIMEOUT" blacksmith testbox list --all >"$inventory_log" 2>&1
+  set -e
+  record_run_id_from_log "$inventory_log" || true
+  rm -f -- "$inventory_log"
+  inventory_log=""
+  [[ -z "$RUN_ID" ]] || return 0
+
+}
+
+discover_run_id_before_stop() {
+  [[ -n "$TBX" && -z "$RUN_ID" ]] || return 0
+
+  # Approval can fail before the ready phase starts. Use one exact, non-waiting
+  # row lookup before stopping so an already-assigned RUN URL remains available
+  # for the cancellation fallback. Never use the waiting-run set difference.
+  local status_status
+  pre_ready_status_log="$(mktemp)"
+  set +e
+  "$BOUNDED" "$CLEANUP_TIMEOUT" blacksmith testbox status --id "$TBX" \
+    >"$pre_ready_status_log" 2>&1
+  status_status=$?
+  set -e
+  record_run_id_from_log "$pre_ready_status_log" || true
+  rm -f -- "$pre_ready_status_log"
+  pre_ready_status_log=""
+  (( status_status == 0 )) || return 1
+  [[ -n "$RUN_ID" ]]
+}
+
+reconcile_run_id() {
+  [[ -n "$TBX" && -z "$RUN_ID" ]] || return 0
+  discover_run_id || true
+  [[ -n "$RUN_ID" ]]
+}
+
+remove_temp_files() {
+  local path
+  for path in "$warmup_log" "$ready_log" "$inventory_log" "$partial_status_log" "$pre_ready_status_log" "$approval_status_log"; do
+    if [[ -n "$path" ]]; then
+      rm -f -- "$path"
+    fi
+  done
+  return 0
+}
+
 cleanup() {
   local status=$?
+  local stop_status=0
+  trap - EXIT INT TERM
+
+  # A signal can arrive while the warmup command is still in the foreground,
+  # before its ID assignment runs. Reuse the same preflight and exact status
+  # proof used for nonzero warmups before giving up on ownership recovery.
+  if [[ -z "$TBX" && -s "$warmup_log" ]]; then
+    recover_partial_testbox "$warmup_log" || true
+  fi
+
+  # Discover before stopping the box. The RUN URL is present while the box is
+  # ready, and stopping first can remove the only authoritative row. Before
+  # approval, use one exact non-waiting row lookup because the gate cannot move.
+  if (( ready_phase_started )); then
+    reconcile_run_id || true
+  else
+    discover_run_id_before_stop || true
+  fi
   if [[ -n "$TBX" ]]; then
-    say "Stopping the box this script created ($TBX)"
-    blacksmith testbox stop --id "$TBX" || echo "stop failed; stop it by hand: blacksmith testbox stop --id $TBX" >&2
-    blacksmith testbox list --all || true
+    say "Stopping the box this script created"
+    set +e
+    "$BOUNDED" "$CLEANUP_TIMEOUT" blacksmith testbox stop --id "$TBX" >/dev/null 2>&1
+    stop_status=$?
+    set -e
+    if (( stop_status != 0 )); then
+      echo "stop failed; inspect the Testbox dashboard for the box created by this branch" >&2
+    fi
   fi
-  # Stopping the box does not end its run. The keepalive step keeps holding a
-  # 32 vCPU runner until the run itself ends, so cancel it too.
-  if [[ -n "$RUN_ID" ]]; then
-    say "Cancelling the warmup run this script approved ($RUN_ID)"
-    gh run cancel "$RUN_ID" --repo manaflow-ai/cmux >/dev/null 2>&1 \
-      || echo "cancel failed; cancel it by hand: gh run cancel $RUN_ID --repo manaflow-ai/cmux" >&2
+  # Blacksmith's documented Testbox contract stops the box and its underlying
+  # workflow run together. Issue a direct GitHub cancellation only if the
+  # Testbox stop failed and the exact row URL proved which run this invocation
+  # owns.
+  if (( stop_status != 0 )) && [[ "$RUN_ID" =~ ^[0-9]+$ ]]; then
+    say "Cancelling the warmup run this script owns after stop failure"
+    if ! "$BOUNDED" "$CLEANUP_TIMEOUT" gh run cancel "$RUN_ID" --repo manaflow-ai/cmux >/dev/null 2>&1; then
+      echo "cancel failed; inspect Actions for this branch's warmup run and cancel it" >&2
+      status=1
+    fi
     echo "cancelling takes a few minutes to land; final state:"
-    gh api "repos/manaflow-ai/cmux/actions/runs/$RUN_ID" --jq '"\(.status) \(.conclusion // "pending")"' || true
+    "$BOUNDED" "$CLEANUP_TIMEOUT" gh api "repos/manaflow-ai/cmux/actions/runs/$RUN_ID" \
+      --jq '"\(.status) \(.conclusion // "pending")"' || true
+  elif [[ -n "$TBX" ]] && ! [[ "$RUN_ID" =~ ^[0-9]+$ ]]; then
+    echo "could not bind an exact warmup RUN URL; refusing explicit run cancellation" >&2
+    if (( status == 0 )); then
+      status=1
+    fi
   fi
+  remove_temp_files
   exit "$status"
 }
 trap cleanup EXIT INT TERM
@@ -114,21 +332,42 @@ trap cleanup EXIT INT TERM
 say "Warming a box from main"
 echo "The workflow refuses any ref but main: it is the trust boundary, because"
 echo "the CLI resolves the workflow definition from the same ref it hydrates."
-# Snapshot the gates already waiting before dispatching. Set difference against
-# this identifies our run exactly; a time window cannot, because another agent
-# dispatching seconds later lands inside any window we pick.
-lane_runs_url="repos/manaflow-ai/cmux/actions/workflows/$(basename "$WORKFLOW")/runs?event=workflow_dispatch&status=waiting"
-waiting_before="$(mktemp)"
-waiting_now="$(mktemp)"
-gh api "$lane_runs_url" --jq '.workflow_runs[].id' | sort >"$waiting_before"
 warmup_log="$(mktemp)"
 printf '\033[2m$ blacksmith testbox warmup %s --ref main --job %s --idle-timeout %s\033[0m\n' \
   "$WORKFLOW" "$JOB" "$IDLE_TIMEOUT"
+set +e
 "$BOUNDED" 300 blacksmith testbox warmup "$WORKFLOW" \
   --ref main --job "$JOB" --idle-timeout "$IDLE_TIMEOUT" | tee "$warmup_log"
+pipeline_status=("${PIPESTATUS[@]}")
+warmup_status="${pipeline_status[0]}"
+tee_status="${pipeline_status[1]}"
+set -e
+if (( warmup_status != 0 )); then
+  if recover_partial_testbox "$warmup_log"; then
+    echo "warmup failed with status $warmup_status; exact status proof recovered the Testbox for cleanup" >&2
+  else
+    echo "warmup failed with status $warmup_status; refusing to adopt a Testbox ID from failed warmup transcript without an exact status proof" >&2
+  fi
+  exit "$warmup_status"
+fi
+if (( tee_status != 0 )); then
+  if recover_partial_testbox "$warmup_log"; then
+    echo "could not save the warmup transcript (tee status $tee_status); exact status proof recovered the Testbox for cleanup" >&2
+  else
+    echo "could not save the warmup transcript (tee status $tee_status); refusing to adopt a Testbox ID without an exact status proof" >&2
+  fi
+  exit "$tee_status"
+fi
+set +e
 TBX="$(grep -Eo 'tbx_[A-Za-z0-9_-]+' "$warmup_log" | head -1)"
-rm -f "$warmup_log"
-[[ -n "$TBX" ]] || { echo "warmup returned no Testbox ID" >&2; exit 66; }
+set -e
+[[ "$TBX" =~ ^tbx_[A-Za-z0-9_-]+$ ]] || { echo "warmup returned no valid Testbox ID" >&2; exit 66; }
+record_run_id_from_log "$warmup_log" || true
+rm -f -- "$warmup_log"
+warmup_log=""
+# The warmup transcript may already contain the exact row. Do not issue a
+# native wait before approval, because the gate keeps hydration from starting.
+# The ready transition below performs bounded reconciliation after approval.
 
 # ------------------------------------------------------------------ approve --
 say "Approving the deployment gate"
@@ -137,37 +376,78 @@ echo "approval is allowed on this environment."
 if (( APPROVE )); then
   approved=0
   for _ in $(seq 1 30); do
-    # Our run is the one that appeared since the snapshot. Kept portable to bash
-    # 3.2, which is what macOS ships: no mapfile, no process substitution.
-    gh api "$lane_runs_url" --jq '.workflow_runs[].id' 2>/dev/null | sort >"$waiting_now" || true
-    candidates="$(comm -13 "$waiting_before" "$waiting_now")"
-    candidate_count="$(printf '%s' "$candidates" | grep -c . || true)"
-    if (( candidate_count > 1 )); then
-      echo "$candidate_count runs appeared at once; approve yours in the GitHub UI, or rerun this script" >&2
-      break
+    # Waiting-list set differences are not ownership proof. Ask the exact
+    # Testbox row for its RUN URL, then approve only that numeric run.
+    if [[ -z "$RUN_ID" ]]; then
+      approval_status_log="$(mktemp)"
+      set +e
+      "$BOUNDED" "$CLEANUP_TIMEOUT" blacksmith testbox status --id "$TBX" \
+        >"$approval_status_log" 2>&1
+      set -e
+      record_run_id_from_log "$approval_status_log" || true
+      rm -f -- "$approval_status_log"
+      approval_status_log=""
     fi
-    if (( candidate_count == 1 )); then
-      run_id="$candidates"
-      env_id="$(gh api "repos/manaflow-ai/cmux/actions/runs/$run_id/pending_deployments" --jq '.[0].environment.id')"
-      gh api -X POST "repos/manaflow-ai/cmux/actions/runs/$run_id/pending_deployments" \
-        --input - >/dev/null <<JSON
+    if [[ "$RUN_ID" =~ ^[0-9]+$ ]]; then
+      run_id="$RUN_ID"
+      set +e
+      env_id="$("$BOUNDED" "$CLEANUP_TIMEOUT" gh api \
+        "repos/manaflow-ai/cmux/actions/runs/$run_id/pending_deployments" \
+        --jq '.[0].environment.id' 2>/dev/null)"
+      env_status=$?
+      set -e
+      if (( env_status != 0 )); then
+        echo "the exact Testbox run could not be inspected for approval; refusing approval" >&2
+        exit "$env_status"
+      fi
+      if ! [[ "$env_id" =~ ^[0-9]+$ ]]; then
+        echo "the exact Testbox run returned a malformed environment ID; refusing approval" >&2
+        break
+      fi
+      set +e
+      "$BOUNDED" "$CLEANUP_TIMEOUT" gh api -X POST \
+        "repos/manaflow-ai/cmux/actions/runs/$run_id/pending_deployments" \
+        --input - >/dev/null 2>&1 <<JSON
 {"environment_ids": [$env_id], "state": "approved", "comment": "blacksmith-testbox-demo"}
 JSON
-      echo "approved run $run_id"
-      RUN_ID="$run_id"
+      approval_status=$?
+      set -e
+      if (( approval_status != 0 )); then
+        echo "the exact Testbox run could not be approved; cleanup will continue" >&2
+        exit "$approval_status"
+      fi
+      echo "approved the exact Testbox run"
       approved=1
       break
     fi
     sleep 5
   done
-  (( approved )) || echo "not approved automatically; approve the run in the GitHub UI now" >&2
+  if (( ! approved )); then
+    echo "not approved automatically; refusing to start hydration until the run is approved" >&2
+    exit 1
+  fi
 else
   echo "approve the waiting run in the GitHub UI now"
 fi
 
 # -------------------------------------------------------------------- ready --
 say "Waiting for hydration (installs pinned Zig and Rust, fetches Cargo and Zig deps)"
-"$BOUNDED" 1200 blacksmith testbox status --id "$TBX" --wait --wait-timeout 15m
+ready_phase_started=1
+ready_log="$(mktemp)"
+set +e
+"$BOUNDED" 1200 blacksmith testbox status --id "$TBX" --wait --wait-timeout 15m | tee "$ready_log"
+pipeline_status=("${PIPESTATUS[@]}")
+ready_status="${pipeline_status[0]}"
+tee_status="${pipeline_status[1]}"
+set -e
+record_run_id_from_log "$ready_log" || true
+if (( ready_status != 0 )); then
+  exit "$ready_status"
+fi
+(( tee_status == 0 )) || exit "$tee_status"
+if ! reconcile_run_id; then
+  echo "warmup run is not yet bound; cleanup will retry from the exact Testbox row" >&2
+fi
 
 # ---------------------------------------------------------------------- pin --
 say "Pinning the box to your commit"

--- a/tests/test_blacksmith_testbox_demo_cleanup.sh
+++ b/tests/test_blacksmith_testbox_demo_cleanup.sh
@@ -1,0 +1,690 @@
+#!/usr/bin/env bash
+# Exercise the demo's run binding and EXIT cleanup without dispatching CI.
+# The fake CLI models the races that used to leave the warmup workflow running:
+# manual approval, multiple newly visible waiting runs, and a failed warmup
+# transcript that contains a stale Testbox ID, and a partial dispatch that can
+# be recovered only through an exact ID-specific status check.
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DEMO="$ROOT_DIR/scripts/blacksmith-testbox-demo.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+run_case() {
+  local mode="$1"
+  local option="$2"
+  local expected_run="$3"
+  local expected_status="${4:-0}"
+  local case_root="$TMP_DIR/$mode"
+  local bin_dir="$case_root/bin"
+  local output="$case_root/output.log"
+  local cancel_log="$case_root/cancel.log"
+  local approval_log="$case_root/approval.log"
+  local stop_log="$case_root/stop.log"
+  local blacksmith_log="$case_root/blacksmith.log"
+  local bounded_log="$case_root/bounded.log"
+  local mktemp_log="$case_root/mktemp.log"
+  local waiting_calls="$case_root/waiting-calls"
+  local status_calls="$case_root/status-calls"
+  local warmup_started="$case_root/warmup-started"
+  local warmup_release="$case_root/warmup-release"
+  local testbox_id="tbx_demo_fixture_01"
+
+  mkdir -p "$bin_dir" "$case_root/scripts" "$case_root/ghostty"
+  cp "$DEMO" "$case_root/scripts/blacksmith-testbox-demo.sh"
+  chmod +x "$case_root/scripts/blacksmith-testbox-demo.sh"
+  : > "$case_root/.github-workflow-placeholder"
+  mkdir -p "$case_root/.github/workflows"
+  : > "$case_root/.github/workflows/cmux-tui-testbox-warmup.yml"
+  : > "$case_root/ghostty/build.zig.zon"
+  : > "$cancel_log"
+  : > "$approval_log"
+  : > "$stop_log"
+  : > "$bounded_log"
+  : > "$mktemp_log"
+  rm -f "$warmup_started" "$warmup_release"
+  printf '0\n' > "$waiting_calls"
+  printf '0\n' > "$status_calls"
+
+  cat > "$case_root/scripts/blacksmith-bounded-command.sh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$CMUX_BOUNDED_LOG"
+shift
+exec "$@"
+STUB
+  chmod +x "$case_root/scripts/blacksmith-bounded-command.sh"
+
+  cat > "$bin_dir/tee" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$CMUX_TEST_MODE" == "tee-fails" ]]; then
+  /usr/bin/tee "$@"
+  exit 19
+fi
+exec /usr/bin/tee "$@"
+STUB
+  chmod +x "$bin_dir/tee"
+
+  cat > "$bin_dir/git" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+case "${1:-} ${2:-}" in
+  "rev-parse --show-toplevel")
+    printf '%s\n' "$CMUX_CASE_ROOT"
+    ;;
+  "symbolic-ref --short")
+    printf '%s\n' 'fixture-branch'
+    ;;
+  "rev-parse HEAD:ghostty")
+    printf '%s\n' '2222222222222222222222222222222222222222'
+    ;;
+  "rev-parse HEAD")
+    printf '%s\n' '1111111111111111111111111111111111111111'
+    ;;
+  status\ *)
+    ;;
+  ls-remote\ *)
+    printf '%s\trefs/heads/fixture-branch\n' '1111111111111111111111111111111111111111'
+    ;;
+  submodule\ *)
+    ;;
+  *)
+    echo "unexpected git invocation: $*" >&2
+    exit 64
+    ;;
+esac
+STUB
+  chmod +x "$bin_dir/git"
+
+  cat > "$bin_dir/blacksmith" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\n' "$*" >> "$CMUX_BLACKSMITH_LOG"
+if [[ "${1:-}" == "--version" ]]; then
+  printf '%s\n' 'blacksmith version fixture'
+  exit 0
+fi
+if [[ "${1:-}" == "auth" && "${2:-}" == "whoami" ]]; then
+  exit 0
+fi
+if [[ "${1:-}" != "testbox" ]]; then
+  echo "unexpected blacksmith invocation: $*" >&2
+  exit 64
+fi
+  case "${2:-}" in
+  list)
+    if [[ "$CMUX_TEST_MODE" == "preflight-fails" ]]; then
+      echo 'simulated pre-dispatch inventory failure' >&2
+      exit 17
+    fi
+    printf '%s\n' 'ID STATUS REPO WORKFLOW JOB REF CREATED'
+    printf '%s\n' 'tbx_existing ready cmux .github/workflows/cmux-tui-testbox-warmup.yml cmux-tui-rust main 2026-09-03T00:00:00Z'
+    ;;
+  warmup)
+    if [[ "$CMUX_TEST_MODE" == "interrupt-warmup" ]]; then
+      printf 'Testbox ID: %s\n' "$CMUX_TESTBOX_ID"
+      : > "$CMUX_WARMUP_STARTED"
+      while [[ ! -e "$CMUX_WARMUP_RELEASE" ]]; do
+        /bin/sleep 1
+      done
+      exit 0
+    fi
+    if [[ "$CMUX_TEST_MODE" == "failed-warmup" ]]; then
+      # A failed CLI transcript can contain an identifier from an earlier
+      # attempt. The demo must not adopt it for cleanup ownership.
+      printf '%s\n' 'Testbox ID: tbx_stale_transcript_99'
+      printf '%s\n' 'warmup failed after a stale Testbox ID' >&2
+      exit 23
+    fi
+    if [[ "$CMUX_TEST_MODE" == "partial-warmup" || "$CMUX_TEST_MODE" == "preflight-fails" ]]; then
+      # The dispatch created this box before the CLI connection failed. The
+      # demo may stop it only after an exact status lookup proves the ID is
+      # present now and absent from the pre-dispatch inventory.
+      printf 'Testbox ID: %s\n' "$CMUX_TESTBOX_ID"
+      printf '%s\n' 'warmup connection failed after dispatch' >&2
+      exit 23
+    fi
+    printf 'Testbox ID: %s\n' "$CMUX_TESTBOX_ID"
+    ;;
+  status)
+    calls="$(cat "$CMUX_STATUS_CALLS")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$CMUX_STATUS_CALLS"
+    requested_id=""
+    previous=""
+    for arg in "$@"; do
+      if [[ "$previous" == "--id" ]]; then
+        requested_id="$arg"
+      fi
+      previous="$arg"
+    done
+    if [[ "$CMUX_TEST_MODE" == "failed-warmup" && "$requested_id" != "$CMUX_TESTBOX_ID" ]]; then
+      echo 'testbox not found' >&2
+      exit 1
+    fi
+    if [[ "$CMUX_TEST_MODE" == "partial-warmup" && "$requested_id" != "$CMUX_TESTBOX_ID" ]]; then
+      echo 'unexpected partial warmup lookup' >&2
+      exit 1
+    fi
+    printf '%s\n' 'ID STATUS IP WORKFLOW JOB REF CREATED RUN URL'
+    run_url=""
+    if [[ "$CMUX_TEST_MODE" == "ambiguous" ]]; then
+      run_url='https://github.com/manaflow-ai/cmux/actions/runs/3003'
+    elif [[ "$CMUX_TEST_MODE" == "no-approve" || "$CMUX_TEST_MODE" == "stop-fails" || "$CMUX_TEST_MODE" == "stop-and-cancel-fails" ]]; then
+      # The no-approve case must use the exact RUN URL from its Testbox row.
+      run_url='https://github.com/manaflow-ai/cmux/actions/runs/2002'
+    elif [[ "$CMUX_TEST_MODE" == "pre-ready-stop-fails" ]]; then
+      # Approval fails before the ready phase starts. Cleanup must perform one
+      # exact, non-waiting status lookup before the stop fallback.
+      run_url='https://github.com/manaflow-ai/cmux/actions/runs/5005'
+    elif [[ "$CMUX_TEST_MODE" == "interrupt-warmup" ]]; then
+      run_url='https://github.com/manaflow-ai/cmux/actions/runs/6006'
+    elif [[ "$CMUX_TEST_MODE" == "delayed" && "$calls" -ge 2 ]]; then
+      # The first status response is URL-free. Reconciliation must use the
+      # native bounded wait and observe this later authoritative row.
+      run_url='https://github.com/manaflow-ai/cmux/actions/runs/4004'
+    fi
+    if [[ -n "$run_url" ]]; then
+      printf '%s\n' "${CMUX_TESTBOX_ID} ready 127.0.0.1 .github/workflows/cmux-tui-testbox-warmup.yml cmux-tui-rust main 2026-09-03T00:00:00Z $run_url"
+    else
+      # Leave this row URL-free to prove that cleanup fails closed.
+      printf '%s\n' "${CMUX_TESTBOX_ID} ready 127.0.0.1 .github/workflows/cmux-tui-testbox-warmup.yml cmux-tui-rust main 2026-09-03T00:00:00Z"
+    fi
+    ;;
+  stop)
+    if [[ "$CMUX_TEST_MODE" == "stop-fails" || "$CMUX_TEST_MODE" == "stop-and-cancel-fails" || "$CMUX_TEST_MODE" == "pre-ready-stop-fails" ]]; then
+      echo 'simulated stop failure' >&2
+      exit 42
+    fi
+    # Model Blacksmith's documented contract: stopping a Testbox also ends
+    # the underlying warmup workflow run.
+    printf '%s\n' "$CMUX_TESTBOX_ID" > "$CMUX_STOP_LOG"
+    ;;
+  run)
+    ;;
+  *)
+    echo "unexpected blacksmith testbox invocation: $*" >&2
+    exit 64
+    ;;
+esac
+STUB
+  chmod +x "$bin_dir/blacksmith"
+
+  cat > "$bin_dir/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+  if [[ "${1:-}" == "run" && "${2:-}" == "cancel" ]]; then
+  printf '%s\n' "${3:-}" > "$CMUX_CANCEL_LOG"
+  if [[ "$CMUX_TEST_MODE" == "stop-and-cancel-fails" ]]; then
+    echo 'simulated run cancellation failure' >&2
+    exit 43
+  fi
+  exit 0
+fi
+if [[ "${1:-}" != "api" ]]; then
+  echo "unexpected gh invocation: $*" >&2
+  exit 64
+fi
+endpoint="${2:-}"
+if [[ "$endpoint" == "-X" ]]; then
+  endpoint="${4:-}"
+fi
+case "$endpoint" in
+  *'status=waiting'*)
+    calls="$(cat "$CMUX_WAITING_CALLS")"
+    calls=$((calls + 1))
+    printf '%s\n' "$calls" > "$CMUX_WAITING_CALLS"
+    if (( calls == 1 )); then
+      printf '%s\n' '1001'
+    elif [[ "$CMUX_TEST_MODE" == "ambiguous" || "$CMUX_TEST_MODE" == "ambiguous-unresolved" || "$CMUX_TEST_MODE" == "ambiguous-approval-unresolved" ]]; then
+      printf '%s\n' '1001' '2002' '3003'
+    else
+      printf '%s\n' '1001' '2002'
+    fi
+    ;;
+  *pending_deployments*)
+    run_id_from_endpoint="$(printf '%s\n' "$endpoint" | sed -nE 's#^.*/runs/([0-9]+)/pending_deployments$#\1#p')"
+    printf '%s\n' "$run_id_from_endpoint" > "$CMUX_APPROVAL_LOG"
+    if [[ "$CMUX_TEST_MODE" == "pre-ready-stop-fails" ]]; then
+      echo 'simulated approval lookup failure' >&2
+      exit 17
+    fi
+    printf '%s\n' '42'
+    ;;
+  *actions/runs/*)
+    printf '%s\n' 'in_progress pending'
+    ;;
+  *)
+    echo "unexpected gh API endpoint: $endpoint" >&2
+    exit 64
+    ;;
+esac
+STUB
+  chmod +x "$bin_dir/gh"
+
+  cat > "$bin_dir/mktemp" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+count_file="$CMUX_CASE_ROOT/mktemp-count"
+count=0
+if [[ -s "$count_file" ]]; then
+  count="$(cat "$count_file")"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$count_file"
+path="$CMUX_CASE_ROOT/temp-$count"
+: > "$path"
+printf '%s\n' "$path" >> "$CMUX_MKTEMP_LOG"
+printf '%s\n' "$path"
+STUB
+  chmod +x "$bin_dir/mktemp"
+
+  cat > "$bin_dir/sleep" <<'STUB'
+#!/usr/bin/env bash
+exit 0
+STUB
+  chmod +x "$bin_dir/sleep"
+
+  set +e
+  if [[ "$mode" == "interrupt-warmup" ]]; then
+    CMUX_CASE_ROOT="$case_root" \
+      CMUX_TEST_MODE="$mode" \
+      CMUX_TESTBOX_ID="$testbox_id" \
+      CMUX_BLACKSMITH_LOG="$case_root/blacksmith.log" \
+      CMUX_BOUNDED_LOG="$bounded_log" \
+      CMUX_CANCEL_LOG="$cancel_log" \
+      CMUX_APPROVAL_LOG="$approval_log" \
+      CMUX_STOP_LOG="$stop_log" \
+      CMUX_MKTEMP_LOG="$mktemp_log" \
+      CMUX_STATUS_CALLS="$status_calls" \
+      CMUX_WAITING_CALLS="$waiting_calls" \
+      CMUX_WARMUP_STARTED="$warmup_started" \
+      CMUX_WARMUP_RELEASE="$warmup_release" \
+      PATH="$bin_dir:/usr/bin:/bin" \
+      "$case_root/scripts/blacksmith-testbox-demo.sh" --no-approve >"$output" 2>&1 &
+    demo_pid=$!
+    for _ in $(seq 1 100); do
+      [[ -e "$warmup_started" ]] && break
+      /bin/sleep 0.1
+    done
+    if ! [[ -e "$warmup_started" ]]; then
+      kill -TERM "$demo_pid" 2>/dev/null || true
+      : >"$warmup_release"
+      wait "$demo_pid" 2>/dev/null || true
+      cat "$output" >&2
+      echo "FAIL: interrupt fixture did not reach warmup" >&2
+      exit 1
+    fi
+    kill -TERM "$demo_pid" 2>/dev/null || true
+    : >"$warmup_release"
+    wait "$demo_pid"
+  elif [[ -n "$option" ]]; then
+    CMUX_CASE_ROOT="$case_root" \
+      CMUX_TEST_MODE="$mode" \
+      CMUX_TESTBOX_ID="$testbox_id" \
+      CMUX_BLACKSMITH_LOG="$case_root/blacksmith.log" \
+      CMUX_BOUNDED_LOG="$bounded_log" \
+      CMUX_CANCEL_LOG="$cancel_log" \
+      CMUX_APPROVAL_LOG="$approval_log" \
+      CMUX_STOP_LOG="$stop_log" \
+      CMUX_MKTEMP_LOG="$mktemp_log" \
+      CMUX_STATUS_CALLS="$status_calls" \
+      CMUX_WAITING_CALLS="$waiting_calls" \
+      CMUX_WARMUP_STARTED="$warmup_started" \
+      CMUX_WARMUP_RELEASE="$warmup_release" \
+      PATH="$bin_dir:/usr/bin:/bin" \
+      "$case_root/scripts/blacksmith-testbox-demo.sh" "$option" >"$output" 2>&1
+  else
+    CMUX_CASE_ROOT="$case_root" \
+      CMUX_TEST_MODE="$mode" \
+      CMUX_TESTBOX_ID="$testbox_id" \
+      CMUX_BLACKSMITH_LOG="$case_root/blacksmith.log" \
+      CMUX_BOUNDED_LOG="$bounded_log" \
+      CMUX_CANCEL_LOG="$cancel_log" \
+      CMUX_APPROVAL_LOG="$approval_log" \
+      CMUX_STOP_LOG="$stop_log" \
+      CMUX_MKTEMP_LOG="$mktemp_log" \
+      CMUX_STATUS_CALLS="$status_calls" \
+      CMUX_WAITING_CALLS="$waiting_calls" \
+      CMUX_WARMUP_STARTED="$warmup_started" \
+      CMUX_WARMUP_RELEASE="$warmup_release" \
+      PATH="$bin_dir:/usr/bin:/bin" \
+      "$case_root/scripts/blacksmith-testbox-demo.sh" >"$output" 2>&1
+  fi
+  local status=$?
+  set -e
+  if (( status != expected_status )); then
+    cat "$output" >&2
+    echo "FAIL: $mode case exited $status, expected $expected_status" >&2
+    exit 1
+  fi
+
+  if (( expected_status == 0 )); then
+    if [[ -n "$expected_run" ]]; then
+      if [[ "$mode" == "stop-fails" || "$mode" == "stop-and-cancel-fails" || "$mode" == "pre-ready-stop-fails" ]]; then
+        if [[ "$(cat "$cancel_log")" != "$expected_run" ]]; then
+          cat "$output" >&2
+          echo "FAIL: $mode case cancelled $(cat "$cancel_log"), expected $expected_run" >&2
+          exit 1
+        fi
+      elif [[ -s "$cancel_log" ]]; then
+        cat "$output" >&2
+        echo "FAIL: $mode case explicitly cancelled $(cat "$cancel_log") after a successful Testbox stop" >&2
+        exit 1
+      fi
+      if [[ "$mode" != "stop-fails" && "$mode" != "stop-and-cancel-fails" && "$mode" != "pre-ready-stop-fails" ]] && [[ "$(cat "$stop_log")" != "$testbox_id" ]]; then
+        cat "$output" >&2
+        echo "FAIL: $mode case did not use the successful Testbox stop as primary cleanup" >&2
+        exit 1
+      fi
+      grep -Fq 'recorded exact warmup run URL' "$output" || {
+        cat "$output" >&2
+        echo "FAIL: $mode case did not record its exact warmup run" >&2
+        exit 1
+      }
+    elif [[ -s "$cancel_log" ]]; then
+      cat "$output" >&2
+      echo "FAIL: $mode case cancelled an unbound run $(cat "$cancel_log")" >&2
+      exit 1
+    fi
+  elif [[ "$mode" == "failed-warmup" ]]; then
+    if grep -Fq 'testbox stop --id' "$blacksmith_log"; then
+      cat "$output" >&2
+      echo "FAIL: failed warmup adopted a stale Testbox ID for cleanup" >&2
+      exit 1
+    fi
+    grep -Fq 'refusing to adopt a Testbox ID from failed warmup' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: failed warmup did not reject its transcript ID" >&2
+      exit 1
+    }
+  elif [[ "$mode" == "partial-warmup" ]]; then
+    grep -Fq 'recovered Testbox after failed warmup from exact ID-specific status' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: partial warmup did not prove its Testbox ID before cleanup" >&2
+      exit 1
+    }
+    [[ "$(cat "$stop_log")" == "$testbox_id" ]] || {
+      cat "$output" >&2
+      echo "FAIL: partial warmup did not stop its verified Testbox" >&2
+      exit 1
+    }
+  elif [[ "$mode" == "tee-fails" ]]; then
+    grep -Fq 'recovered Testbox after failed warmup from exact ID-specific status' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: tee failure did not prove its Testbox ID before cleanup" >&2
+      exit 1
+    }
+    [[ "$(cat "$stop_log")" == "$testbox_id" ]] || {
+      cat "$output" >&2
+      echo "FAIL: tee failure did not stop its verified Testbox" >&2
+      exit 1
+    }
+    grep -Fq "30 blacksmith testbox status --id $testbox_id" "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: tee failure did not bound its ownership check" >&2
+      exit 1
+    }
+  elif [[ "$mode" == "preflight-fails" ]]; then
+    if grep -Fq 'testbox stop --id' "$blacksmith_log"; then
+      cat "$output" >&2
+      echo "FAIL: failed preflight inventory allowed partial warmup cleanup ownership" >&2
+      exit 1
+    fi
+    grep -Fq 'refusing to adopt a Testbox ID from failed warmup' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: failed preflight inventory did not fail closed" >&2
+      exit 1
+    }
+  elif [[ "$mode" == "stop-and-cancel-fails" ]]; then
+    [[ "$(cat "$cancel_log")" == "$expected_run" ]] || {
+      cat "$output" >&2
+      echo "FAIL: stop-and-cancel failure did not target the exact run" >&2
+      exit 1
+    }
+    grep -Fq 'cancel failed' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: stop-and-cancel failure was not reported" >&2
+      exit 1
+    }
+    grep -Fq "inspect Actions for this branch's warmup run" "$output" || {
+      cat "$output" >&2
+      echo "FAIL: stop-and-cancel failure did not provide generic recovery guidance" >&2
+      exit 1
+    }
+  elif [[ "$mode" == "pre-ready-stop-fails" ]]; then
+    [[ "$(cat "$cancel_log")" == "$expected_run" ]] || {
+      cat "$output" >&2
+      echo "FAIL: pre-ready stop failure did not target the exact run" >&2
+      exit 1
+    }
+    grep -Fq '30 blacksmith testbox status --id' "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: pre-ready cleanup did not reconcile the exact Testbox row" >&2
+      exit 1
+    }
+    if grep -Fq -- '--wait' "$bounded_log"; then
+      cat "$output" >&2
+      echo "FAIL: pre-ready cleanup waited on a deployment gate that cannot progress" >&2
+      exit 1
+    fi
+  fi
+
+  if [[ "$mode" == "interrupt-warmup" ]]; then
+    grep -Fq 'recovered Testbox after failed warmup from exact ID-specific status' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: interrupted warmup did not recover its Testbox in cleanup" >&2
+      exit 1
+    }
+    [[ "$(cat "$stop_log")" == "$testbox_id" ]] || {
+      cat "$output" >&2
+      echo "FAIL: interrupted warmup did not stop its recovered Testbox" >&2
+      exit 1
+    }
+    [[ "$(cat "$status_calls")" == "1" ]] || {
+      cat "$output" >&2
+      echo "FAIL: interrupted warmup did not use one exact ownership status lookup" >&2
+      exit 1
+    }
+  fi
+  while IFS= read -r temp_path; do
+    [[ -n "$temp_path" ]] || continue
+    if [[ -e "$temp_path" ]]; then
+      echo "FAIL: $mode case leaked temporary file $temp_path" >&2
+      exit 1
+    fi
+  done < "$mktemp_log"
+
+  if grep -Fq "testbox stop --id $testbox_id" "$blacksmith_log"; then
+    grep -Fq "30 blacksmith testbox stop --id $testbox_id" "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: $mode cleanup did not bound Testbox stop" >&2
+      exit 1
+    }
+  fi
+  if [[ "$mode" == "delayed" || "$mode" == "ambiguous-unresolved" ]]; then
+    grep -Fq "30 blacksmith testbox status --id $testbox_id --wait --wait-timeout 30s" "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: $mode cleanup did not use the native bounded status wait" >&2
+      exit 1
+    }
+  fi
+  if [[ "$mode" == "stop-fails" || "$mode" == "stop-and-cancel-fails" || "$mode" == "pre-ready-stop-fails" ]]; then
+    grep -Fq '30 gh run cancel' "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: $mode cleanup did not bound GitHub cancellation after stop failure" >&2
+      exit 1
+    }
+    grep -Fq "30 gh api repos/manaflow-ai/cmux/actions/runs/$expected_run" "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: $mode cleanup did not bound final run-state lookup" >&2
+      exit 1
+    }
+    grep -Fq 'inspect the Testbox dashboard' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: $mode cleanup did not provide generic Testbox recovery guidance" >&2
+      exit 1
+    }
+  elif grep -Fq '30 gh run cancel' "$bounded_log"; then
+    cat "$output" >&2
+    echo "FAIL: $mode cleanup explicitly cancelled after a successful Testbox stop" >&2
+    exit 1
+  fi
+
+  stop_line="$(grep -n 'testbox stop --id' "$blacksmith_log" | tail -1 | cut -d: -f1 || true)"
+  if [[ -n "$stop_line" ]] && awk -v start="$stop_line" \
+    'NR > start && /testbox list --all/ { found=1 } END { if (found) exit 0; exit 1 }' \
+    "$blacksmith_log"; then
+    cat "$output" >&2
+    echo "FAIL: $mode emitted an unfiltered Testbox inventory after cleanup" >&2
+    exit 1
+  fi
+
+  if [[ "$mode" == "ambiguous" ]]; then
+    [[ "$(cat "$approval_log")" == "3003" ]] || {
+      cat "$output" >&2
+      echo "FAIL: ambiguous case did not approve the exact Testbox run" >&2
+      exit 1
+    }
+    grep -Fq 'approved the exact Testbox run' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: ambiguous case did not report exact approval" >&2
+      exit 1
+    }
+    grep -Fq '30 gh api repos/manaflow-ai/cmux/actions/runs/3003/pending_deployments' "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: ambiguous case did not bound the approval lookup" >&2
+      exit 1
+    }
+    grep -Fq '30 gh api -X POST repos/manaflow-ai/cmux/actions/runs/3003/pending_deployments' "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: ambiguous case did not bound the approval request" >&2
+      exit 1
+    }
+    grep -Fq 'recorded exact warmup run URL' "$output" || {
+      echo "FAIL: ambiguous case did not resolve through the exact RUN URL" >&2
+      exit 1
+    }
+  fi
+  if [[ "$mode" == "ambiguous-unresolved" || "$mode" == "ambiguous-approval-unresolved" ]]; then
+    grep -Fq 'refusing explicit run cancellation' "$output" || {
+      echo "FAIL: missing RUN URL did not fail closed" >&2
+      exit 1
+    }
+    if [[ -s "$cancel_log" ]]; then
+      cat "$output" >&2
+      echo "FAIL: unresolved run binding cancelled a run" >&2
+      exit 1
+    fi
+    grep -Fq "30 blacksmith testbox status --id $testbox_id" "$bounded_log" || {
+      cat "$output" >&2
+      echo "FAIL: unresolved case did not bound Testbox status discovery" >&2
+      exit 1
+    }
+    if [[ "$mode" == "ambiguous-unresolved" ]]; then
+      grep -Fq "30 blacksmith testbox status --id $testbox_id --wait --wait-timeout 30s" "$bounded_log" || {
+        cat "$output" >&2
+        echo "FAIL: unresolved case did not use the native bounded status wait" >&2
+        exit 1
+      }
+      grep -Fq '30 blacksmith testbox list --all' "$bounded_log" || {
+        cat "$output" >&2
+        echo "FAIL: unresolved case did not bound Testbox inventory discovery" >&2
+        exit 1
+      }
+    else
+      if grep -Fq -- '--wait' "$bounded_log"; then
+        cat "$output" >&2
+        echo "FAIL: unresolved approval waited on a gate that cannot progress" >&2
+        exit 1
+      fi
+    fi
+    if [[ "$mode" == "ambiguous-approval-unresolved" ]]; then
+      [[ ! -s "$approval_log" ]] || {
+        cat "$output" >&2
+        echo "FAIL: ambiguous approval adopted a waiting-list run without an exact Testbox URL" >&2
+        exit 1
+      }
+      grep -Fq 'not approved automatically' "$output" || {
+        cat "$output" >&2
+        echo "FAIL: ambiguous approval did not fail closed for an unresolved Testbox URL" >&2
+        exit 1
+      }
+      if [[ "$(cat "$status_calls")" -lt 30 ]]; then
+        cat "$output" >&2
+        echo "FAIL: ambiguous approval did not exercise the exact-row retry path" >&2
+        exit 1
+      fi
+    fi
+  fi
+  if [[ "$mode" == "ambiguous-unresolved" || "$mode" == "ambiguous-approval-unresolved" ]]; then
+    grep -Fq 'testbox stop --id' "$blacksmith_log" || {
+      cat "$output" >&2
+      echo "FAIL: unresolved run binding did not stop the owned Testbox" >&2
+      exit 1
+    }
+    [[ "$(cat "$stop_log")" == "$testbox_id" ]] || {
+      cat "$output" >&2
+      echo "FAIL: unresolved run binding did not use the successful Testbox stop" >&2
+      exit 1
+    }
+  fi
+  if [[ "$mode" == "delayed" ]]; then
+    if [[ "$(cat "$status_calls")" -lt 2 ]]; then
+      cat "$output" >&2
+      echo "FAIL: delayed case did not retry the exact Testbox row" >&2
+      exit 1
+    fi
+    grep -Fq 'recorded exact warmup run URL' "$output" || {
+      cat "$output" >&2
+      echo "FAIL: delayed case did not record the later exact RUN URL" >&2
+      exit 1
+    }
+  fi
+  if [[ "$mode" == "ambiguous" ]]; then
+    if [[ "$(cat "$status_calls")" != "2" ]]; then
+      cat "$output" >&2
+      echo "FAIL: ambiguous approval did not use exact status reconciliation" >&2
+      exit 1
+    fi
+  elif [[ "$mode" == "no-approve" || "$mode" == "stop-fails" || "$mode" == "stop-and-cancel-fails" || "$mode" == "pre-ready-stop-fails" ]]; then
+    if [[ "$(cat "$status_calls")" != "1" ]]; then
+      cat "$output" >&2
+      echo "FAIL: $mode queried status before the deployment gate phase" >&2
+      exit 1
+    fi
+  fi
+
+  if grep -Eq 'Stopping the box this script created \(tbx_|Cancelling the warmup run this script owns after stop failure \([0-9]|stop it by hand: blacksmith|cancel it by hand: gh run|could not bind Testbox tbx_' "$output"; then
+    cat "$output" >&2
+    echo "FAIL: $mode cleanup exposed a provider identifier or manual command" >&2
+    exit 1
+  fi
+  if grep -Fq 'tbx_existing ready cmux' "$output"; then
+    cat "$output" >&2
+    echo "FAIL: $mode printed the complete pre-dispatch Testbox inventory" >&2
+    exit 1
+  fi
+  if [[ ("$mode" == "no-approve" || "$mode" == "ambiguous" || "$mode" == "ambiguous-approval-unresolved" || "$mode" == "stop-fails" || "$mode" == "stop-and-cancel-fails" || "$mode" == "delayed") && "$(cat "$waiting_calls")" != "0" ]]; then
+    cat "$output" >&2
+    echo "FAIL: $mode queried the waiting-run list instead of using the Testbox RUN URL" >&2
+    exit 1
+  fi
+  printf 'PASS: %s\n' "$mode"
+}
+
+run_case no-approve --no-approve 2002
+run_case ambiguous '' 3003
+run_case ambiguous-unresolved --no-approve '' 1
+run_case ambiguous-approval-unresolved '' '' 1
+run_case delayed --no-approve 4004
+run_case failed-warmup '' '' 23
+run_case partial-warmup --no-approve '' 23
+run_case tee-fails --no-approve '' 19
+run_case interrupt-warmup --no-approve '' 0
+run_case preflight-fails --no-approve '' 23
+run_case stop-fails --no-approve 2002
+run_case stop-and-cancel-fails --no-approve 2002 1
+run_case pre-ready-stop-fails '' 5005 17


### PR DESCRIPTION
## Summary

- record the unique pre-dispatch warmup run before approval requests
- recover the exact run from the Testbox RUN URL after manual, ambiguous, or `--no-approve` flows
- fail closed when ambiguity remains and remove every temporary discovery file from the EXIT trap
- add static shell behavior coverage for no-approve, resolved ambiguity, and unresolved ambiguity

The RUN URL and pending-deployment behavior follow the GitHub Actions workflow-runs API: https://docs.github.com/en/rest/actions/workflow-runs

## Validation

- `tests/test_blacksmith_testbox_demo_cleanup.sh`
- `shellcheck scripts/blacksmith-testbox-demo.sh tests/test_blacksmith_testbox_demo_cleanup.sh`
- `bash -n scripts/blacksmith-testbox-demo.sh tests/test_blacksmith_testbox_demo_cleanup.sh`

Two commits are intentional: regression tests first, fix second.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Testbox demo cleanup so warmup runs no longer linger after manual, `--no-approve`, or ambiguous approval flows.

**Bug Fixes**

- Binds approval and cleanup to the exact RUN URL from the Testbox row, retried from ready transcripts, status output, and inventory listings, and discovered before stopping the box.
- Fails closed when no exact run is bound: no cancellation of ambiguous runs, no approval of malformed run IDs, no continuation after failed auto-approval.
- Adopts a Testbox ID from a failed warmup only when the pre-dispatch inventory shows it absent and an exact ID-specific status verifies it.
- Bounds cleanup commands at 30s, drops the post-cleanup inventory listing, removes temporary discovery files from the EXIT trap, and prints generic recovery guidance instead of provider IDs or manual commands.
- Adds shellchecked coverage for no-approve, resolved and unresolved ambiguity, delayed RUN URL, failed and partial warmup, failed preflight inventory, tee failure, pre-ready stop failure, interrupted warmup, and stop/cancel failure cases, now run in CI.

<sup>Written for commit 6f87dd455030e8ae0832eabe862af425778b398f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11753?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved demo run tracking to identify the correct workflow run before cleanup.
  - Prevented cleanup from cancelling a run when ownership is unclear or warmup fails.
  - Added bounded cleanup and clearer failure reporting for warmup and readiness checks.
  - Ensured temporary files are removed after demo execution.

- **Tests**
  - Added coverage for run binding, ambiguous scenarios, cleanup behavior, failure handling, and temporary-file removal.
  - Expanded shell linting and automated validation for the demo workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->