### PR TITLE
Cloud VMs: trace ids end to end, every error to Sentry and PostHog, latency on every request

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -127010,6 +127010,23 @@
         }
       }
     },
+    "cloudVM.error.reference": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Reference: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参照番号: %@"
+          }
+        }
+      }
+    },
     "cloudVM.error.requiresPro.action": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -99,7 +99,20 @@ private func formattedCloudVMHTTPError(status: Int, body: String) -> String {
         lines.append("Details:")
         lines.append(contentsOf: details.map { "  \($0)" })
     }
+    if let traceId = cloudVMString(object["traceId"]) ?? cloudVMString(ui?["traceId"]) {
+        // The support reference. Operators open the exact server trace,
+        // PostHog row and Sentry event from this one id.
+        lines.append("")
+        lines.append(cloudVMReferenceLine(traceId: traceId))
+    }
     return lines.joined(separator: "\n")
+}
+
+func cloudVMReferenceLine(traceId: String) -> String {
+    String(
+        format: String(localized: "cloudVM.error.reference", defaultValue: "Reference: %@"),
+        traceId
+    )
 }
 
 private func defaultCloudVMMessage(status: Int) -> String {
@@ -539,10 +552,12 @@ actor VMClient {
 
     private let session: URLSession
     private let auth: AuthCoordinator
+    private let telemetry: VMClientTelemetry
 
-    init(session: URLSession = .shared, auth: AuthCoordinator) {
+    init(session: URLSession = .shared, auth: AuthCoordinator, telemetry: VMClientTelemetry = .shared) {
         self.session = session
         self.auth = auth
+        self.telemetry = telemetry
     }
 
     func list() async throws -> [VMSummary] {
@@ -1224,12 +1239,117 @@ actor VMClient {
 
     // MARK: - HTTP
 
+    /// Every Cloud VM API call goes through here. Mints the trace context,
+    /// sends the client identity headers, measures wall-clock latency and
+    /// records the outcome (success, HTTP error with the server's code and
+    /// trace id, or transport failure) with `VMClientTelemetry`.
     private func request(
         _ method: String,
         path: String,
         jsonBody: [String: Any]? = nil,
         extraHeaders: [String: String] = [:],
         timeoutSeconds: TimeInterval? = nil
+    ) async throws -> (Data, HTTPURLResponse) {
+        let trace = VMRequestTraceContext.mint()
+        let route = VMClientTelemetry.normalizedRoute(path: path)
+        let startedAt = DispatchTime.now().uptimeNanoseconds
+        var retryCount = 0
+        func elapsedMs() -> Double {
+            Double(DispatchTime.now().uptimeNanoseconds - startedAt) / 1_000_000
+        }
+        func record(_ outcome: VMRequestOutcome) {
+            telemetry.record(VMRequestTelemetryRecord(
+                method: method,
+                route: route,
+                outcome: outcome,
+                durationMs: elapsedMs(),
+                retryCount: retryCount,
+                trace: trace
+            ))
+        }
+        var headers = VMClientTelemetry.clientIdentityHeaders()
+        headers.merge(trace.headers) { _, new in new }
+        headers.merge(extraHeaders) { _, new in new }
+        do {
+            let (data, http) = try await performRequest(
+                method,
+                path: path,
+                jsonBody: jsonBody,
+                extraHeaders: headers,
+                timeoutSeconds: timeoutSeconds,
+                onRetry: { retryCount += 1 }
+            )
+            record(.response(
+                status: http.statusCode,
+                errorCode: http.statusCode >= 400 ? Self.cloudVMErrorCode(http: http, data: data) : nil,
+                serverTraceId: Self.cloudVMServerTraceId(http: http, data: data)
+            ))
+            return (data, http)
+        } catch let error as VMClientError {
+            record(.transportFailure(kind: Self.transportFailureKind(error), detail: Self.transportFailureDetail(error)))
+            throw error
+        } catch is CancellationError {
+            record(.transportFailure(kind: .cancelled, detail: "cancelled"))
+            throw CancellationError()
+        } catch let error as URLError {
+            record(.transportFailure(kind: error.code == .cancelled ? .cancelled : .urlError, detail: "URLError \(error.code.rawValue): \(error.localizedDescription)"))
+            throw error
+        } catch {
+            record(.transportFailure(kind: .unknown, detail: String(describing: error).prefix(300).description))
+            throw error
+        }
+    }
+
+    private static func transportFailureKind(_ error: VMClientError) -> VMTransportFailureKind {
+        switch error {
+        case .notSignedIn: return .notSignedIn
+        case .sessionRefreshFailed: return .sessionRefreshFailed
+        case .backendUnreachable: return .backendUnreachable
+        case .malformedResponse: return .malformedResponse
+        case .httpStatus: return .unknown
+        }
+    }
+
+    private static func transportFailureDetail(_ error: VMClientError) -> String {
+        switch error {
+        case .backendUnreachable(let url, let detail): return "\(url): \(detail)"
+        case .malformedResponse(let message): return message
+        case .notSignedIn, .sessionRefreshFailed, .httpStatus: return ""
+        }
+    }
+
+    /// The server's `x-cmux-vm-error` header, else the body's `error` field.
+    private static func cloudVMErrorCode(http: HTTPURLResponse, data: Data) -> String? {
+        if let header = http.value(forHTTPHeaderField: "x-cmux-vm-error"), !header.isEmpty {
+            return header
+        }
+        guard let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+              let code = object["error"] as? String, !code.isEmpty else {
+            return nil
+        }
+        return code
+    }
+
+    /// The server's `x-cmux-trace-id` header, else the body's `traceId`.
+    private static func cloudVMServerTraceId(http: HTTPURLResponse, data: Data) -> String? {
+        if let header = http.value(forHTTPHeaderField: VMRequestTraceContext.serverTraceIdHeader), !header.isEmpty {
+            return header
+        }
+        guard http.statusCode >= 400,
+              let object = try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any],
+              let traceId = object["traceId"] as? String, !traceId.isEmpty else {
+            return nil
+        }
+        return traceId
+    }
+
+    private func performRequest(
+        _ method: String,
+        path: String,
+        jsonBody: [String: Any]?,
+        extraHeaders: [String: String],
+        timeoutSeconds: TimeInterval?,
+        onRetry: () -> Void
     ) async throws -> (Data, HTTPURLResponse) {
         // Bind every control-plane request to the currently published auth
         // session. A request that was already queued when sign-out began must
@@ -1302,6 +1422,7 @@ actor VMClient {
             }
             if http.statusCode == 429, retriesLeft > 0 {
                 retriesLeft -= 1
+                onRetry()
                 let retryAfterSeconds = (http.value(forHTTPHeaderField: "Retry-After")).flatMap(Double.init)
                 let delaySeconds = min(max(retryAfterSeconds ?? 2, 1), 10)
                 try await Task.sleep(nanoseconds: UInt64(delaySeconds * 1_000_000_000))

--- a/Sources/Cloud/VMClientTelemetry.swift
+++ b/Sources/Cloud/VMClientTelemetry.swift
@@ -1,0 +1,340 @@
+import Foundation
+import os
+
+/// W3C trace context the client mints for one Cloud VM API request.
+///
+/// The server keeps the trace id when it can (its sampler still makes its own
+/// sampling decision) and always answers with `x-cmux-trace-id`, so a failure
+/// seen on the Mac and the span stored in Axiom share a key even when the
+/// response never arrived.
+struct VMRequestTraceContext: Sendable, Equatable {
+    /// 32 lowercase hex characters, never all zero.
+    let traceId: String
+    /// 16 lowercase hex characters, never all zero.
+    let spanId: String
+    /// Stable id for the logical request across 429 retries.
+    let clientRequestId: String
+
+    static let traceparentHeader = "traceparent"
+    static let clientRequestIdHeader = "X-Cmux-Client-Request-Id"
+    static let serverTraceIdHeader = "x-cmux-trace-id"
+
+    /// `00-<trace id>-<span id>-01`; sampled flag set so intermediaries keep it.
+    var traceparent: String { "00-\(traceId)-\(spanId)-01" }
+
+    var headers: [String: String] {
+        [
+            Self.traceparentHeader: traceparent,
+            Self.clientRequestIdHeader: clientRequestId,
+        ]
+    }
+
+    static func mint() -> VMRequestTraceContext {
+        VMRequestTraceContext(
+            traceId: randomHex(bytes: 16),
+            spanId: randomHex(bytes: 8),
+            clientRequestId: UUID().uuidString.lowercased()
+        )
+    }
+
+    private static func randomHex(bytes count: Int) -> String {
+        var bytes = [UInt8](repeating: 0, count: count)
+        repeat {
+            for index in bytes.indices {
+                bytes[index] = UInt8.random(in: .min ... .max)
+            }
+        } while bytes.allSatisfy { $0 == 0 }
+        return bytes.map { String(format: "%02x", $0) }.joined()
+    }
+}
+
+/// How one Cloud VM API request ended, as seen by the client.
+enum VMRequestOutcome: Sendable, Equatable {
+    /// The server answered. `errorCode` is its machine-readable `error` for a
+    /// 4xx/5xx body, `nil` on success.
+    case response(status: Int, errorCode: String?, serverTraceId: String?)
+    /// No HTTP response: DNS, connect, TLS, timeout, or a local precondition.
+    case transportFailure(kind: VMTransportFailureKind, detail: String)
+
+    var isSuccess: Bool {
+        if case .response(let status, _, _) = self { return status < 400 }
+        return false
+    }
+
+    var httpStatus: Int? {
+        if case .response(let status, _, _) = self { return status }
+        return nil
+    }
+
+    /// One token that names the failure class for grouping.
+    var errorCode: String? {
+        switch self {
+        case .response(let status, let errorCode, _):
+            if status < 400 { return nil }
+            return errorCode ?? "http_\(status)"
+        case .transportFailure(let kind, _):
+            return kind.rawValue
+        }
+    }
+
+    var serverTraceId: String? {
+        if case .response(_, _, let traceId) = self { return traceId }
+        return nil
+    }
+}
+
+enum VMTransportFailureKind: String, Sendable {
+    case notSignedIn = "not_signed_in"
+    case sessionRefreshFailed = "session_refresh_failed"
+    case backendUnreachable = "backend_unreachable"
+    case malformedResponse = "malformed_response"
+    case cancelled = "cancelled"
+    case urlError = "url_error"
+    case unknown = "unknown"
+}
+
+/// One measured Cloud VM API request.
+struct VMRequestTelemetryRecord: Sendable, Equatable {
+    let method: String
+    /// Request path with machine ids replaced by `{id}` (`/api/vm/{id}/exec`).
+    let route: String
+    let outcome: VMRequestOutcome
+    let durationMs: Double
+    let retryCount: Int
+    let trace: VMRequestTraceContext
+
+    /// `"POST /api/vm"`; the same shape the server's `cmux.api.*` span names use.
+    var operation: String { "\(method) \(route)" }
+
+    /// The id operators look up: the server's when it answered, else ours.
+    var referenceTraceId: String { outcome.serverTraceId ?? trace.traceId }
+}
+
+enum VMRequestFailureSeverity: String, Sendable {
+    case error
+    case warning
+}
+
+/// Client-side telemetry for the Cloud VM control plane. Sinks:
+///
+/// - `os.log` (subsystem `com.cmuxterm.app`, category `CloudVM`) for every
+///   request, readable from release builds with `log show`;
+/// - a Sentry breadcrumb for every request and a Sentry event for failures
+///   (5xx and transport failures are `error`, 4xx are `warning`);
+/// - PostHog `cmux_cloud_vm_request` for every failure and for the successes a
+///   user waits on (create, attach, base open, ...), with the duration.
+///
+/// Failures are throttled per operation and error code so a polling loop
+/// during an outage yields one event per window instead of hundreds. Every
+/// event carries the trace id and client request id.
+final class VMClientTelemetry: @unchecked Sendable {
+    static let shared = VMClientTelemetry()
+
+    static let postHogEvent = "cmux_cloud_vm_request"
+    static let sentryCategory = "cloud_vm"
+    static let postHogFailureThrottle: TimeInterval = 60
+    static let sentryFailureThrottle: TimeInterval = 300
+
+    typealias Capture = @Sendable (String, [String: Any]) -> Void
+    typealias SentryCapture = @Sendable (String, VMRequestFailureSeverity, [String: Any]) -> Void
+    typealias Breadcrumb = @Sendable (String, [String: Any]) -> Void
+
+    private let logger = Logger(subsystem: "com.cmuxterm.app", category: "CloudVM")
+    private let capturePostHog: Capture
+    private let captureSentry: SentryCapture
+    private let addBreadcrumb: Breadcrumb
+    private let now: @Sendable () -> Date
+    private let channel: String
+    private let lock = NSLock()
+    private var lastPostHogFailure: [String: Date] = [:]
+    private var lastSentryFailure: [String: Date] = [:]
+
+    init(
+        capturePostHog: @escaping Capture = { event, properties in
+            PostHogAnalytics.shared.capture(event, properties: properties)
+        },
+        captureSentry: @escaping SentryCapture = { message, severity, data in
+            switch severity {
+            case .error:
+                sentryCaptureError(message, category: VMClientTelemetry.sentryCategory, data: data)
+            case .warning:
+                sentryCaptureWarning(message, category: VMClientTelemetry.sentryCategory, data: data)
+            }
+        },
+        addBreadcrumb: @escaping Breadcrumb = { message, data in
+            sentryBreadcrumb(message, category: VMClientTelemetry.sentryCategory, data: data)
+        },
+        now: @escaping @Sendable () -> Date = { Date() },
+        channel: String = BuildFlavor.current.rawValue
+    ) {
+        self.capturePostHog = capturePostHog
+        self.captureSentry = captureSentry
+        self.addBreadcrumb = addBreadcrumb
+        self.now = now
+        self.channel = channel
+    }
+
+    /// Identity headers sent with every request so server spans and events can
+    /// be broken down by client, version, build and channel.
+    static func clientIdentityHeaders(
+        infoDictionary: [String: Any] = Bundle.main.infoDictionary ?? [:],
+        channel: String = BuildFlavor.current.rawValue
+    ) -> [String: String] {
+        var headers = ["X-Cmux-Client": "cmux-mac", "X-Cmux-Channel": channel]
+        if let version = infoDictionary["CFBundleShortVersionString"] as? String, !version.isEmpty {
+            headers["X-Cmux-App-Version"] = version
+        }
+        if let build = infoDictionary["CFBundleVersion"] as? String, !build.isEmpty {
+            headers["X-Cmux-App-Build"] = build
+        }
+        return headers
+    }
+
+    func record(_ record: VMRequestTelemetryRecord) {
+        log(record)
+        addBreadcrumb(
+            "\(record.operation) \(record.outcome.isSuccess ? "ok" : "failed")",
+            Self.breadcrumbData(record)
+        )
+        if Self.shouldCaptureToPostHog(record), allow(record, in: &lastPostHogFailure, window: Self.postHogFailureThrottle) {
+            capturePostHog(Self.postHogEvent, Self.postHogProperties(record, channel: channel))
+        }
+        if let severity = Self.sentrySeverity(record),
+           allow(record, in: &lastSentryFailure, window: Self.sentryFailureThrottle) {
+            captureSentry(
+                "cloud VM \(record.operation) failed: \(record.outcome.errorCode ?? "unknown")",
+                severity,
+                Self.sentryData(record)
+            )
+        }
+    }
+
+    // MARK: - Decisions (pure, tested)
+
+    /// Reads a client polls on a timer. Their successes stay out of PostHog.
+    static func isPolledOperation(method: String, route: String) -> Bool {
+        guard method.uppercased() == "GET" else { return false }
+        switch route {
+        case "/api/vm", "/api/vm/{id}", "/api/vm/{id}/stats", "/api/vm/{id}/sessions", "/api/vm/tunnel":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// `/api/vm/<machine id>/exec` -> `/api/vm/{id}/exec`. Machine ids are the
+    /// segment after `/api/vm/` unless it is a fixed sub-resource.
+    static func normalizedRoute(path: String) -> String {
+        let fixed: Set<String> = ["base", "leases", "restore", "tunnel"]
+        var segments = path.split(separator: "?", maxSplits: 1)[0].split(separator: "/").map(String.init)
+        if segments.count >= 3, segments[0] == "api", segments[1] == "vm", !fixed.contains(segments[2]) {
+            segments[2] = "{id}"
+        }
+        return "/" + segments.joined(separator: "/")
+    }
+
+    static func shouldCaptureToPostHog(_ record: VMRequestTelemetryRecord) -> Bool {
+        if !record.outcome.isSuccess { return true }
+        return !isPolledOperation(method: record.method, route: record.route)
+    }
+
+    /// Server faults and transport failures are errors. Client-side
+    /// preconditions (not signed in, cancelled) are not incidents. 4xx are the
+    /// caller's fault and stay visible as warnings.
+    static func sentrySeverity(_ record: VMRequestTelemetryRecord) -> VMRequestFailureSeverity? {
+        switch record.outcome {
+        case .response(let status, _, _):
+            if status < 400 { return nil }
+            return status >= 500 ? .error : .warning
+        case .transportFailure(let kind, _):
+            switch kind {
+            case .notSignedIn, .sessionRefreshFailed, .cancelled:
+                return nil
+            case .backendUnreachable, .malformedResponse, .urlError, .unknown:
+                return .error
+            }
+        }
+    }
+
+    static func throttleKey(_ record: VMRequestTelemetryRecord) -> String {
+        "\(record.operation)|\(record.outcome.errorCode ?? "ok")"
+    }
+
+    static func postHogProperties(_ record: VMRequestTelemetryRecord, channel: String) -> [String: Any] {
+        var properties: [String: Any] = [
+            "operation": record.operation,
+            "method": record.method,
+            "route": record.route,
+            "success": record.outcome.isSuccess,
+            "duration_ms": (record.durationMs * 100).rounded() / 100,
+            "retry_count": record.retryCount,
+            "trace_id": record.referenceTraceId,
+            "client_trace_id": record.trace.traceId,
+            "client_request_id": record.trace.clientRequestId,
+            "channel": channel,
+            "schema_version": 1,
+        ]
+        if let status = record.outcome.httpStatus {
+            properties["status"] = status
+        }
+        if let errorCode = record.outcome.errorCode {
+            properties["error_code"] = errorCode
+            properties["operator_fault"] = sentrySeverity(record) == .error
+        }
+        if case .transportFailure(let kind, _) = record.outcome {
+            properties["transport_failure"] = kind.rawValue
+        }
+        return properties
+    }
+
+    static func sentryData(_ record: VMRequestTelemetryRecord) -> [String: Any] {
+        var data = postHogProperties(record, channel: "")
+        data.removeValue(forKey: "channel")
+        data.removeValue(forKey: "schema_version")
+        if case .transportFailure(_, let detail) = record.outcome {
+            data["detail"] = String(detail.prefix(300))
+        }
+        return data
+    }
+
+    static func breadcrumbData(_ record: VMRequestTelemetryRecord) -> [String: Any] {
+        var data: [String: Any] = [
+            "duration_ms": (record.durationMs * 100).rounded() / 100,
+            "trace_id": record.referenceTraceId,
+            "client_request_id": record.trace.clientRequestId,
+        ]
+        if let status = record.outcome.httpStatus { data["status"] = status }
+        if let errorCode = record.outcome.errorCode { data["error_code"] = errorCode }
+        return data
+    }
+
+    // MARK: - Private
+
+    private func log(_ record: VMRequestTelemetryRecord) {
+        let duration = Int(record.durationMs.rounded())
+        switch record.outcome {
+        case .response(let status, let errorCode, _):
+            if status < 400 {
+                logger.info("\(record.operation, privacy: .public) \(status) \(duration)ms trace=\(record.referenceTraceId, privacy: .public) req=\(record.trace.clientRequestId, privacy: .public)")
+            } else {
+                logger.error("\(record.operation, privacy: .public) \(status) \(errorCode ?? "-", privacy: .public) \(duration)ms trace=\(record.referenceTraceId, privacy: .public) req=\(record.trace.clientRequestId, privacy: .public)")
+            }
+        case .transportFailure(let kind, let detail):
+            logger.error("\(record.operation, privacy: .public) \(kind.rawValue, privacy: .public) \(duration)ms trace=\(record.trace.traceId, privacy: .public) req=\(record.trace.clientRequestId, privacy: .public) detail=\(detail, privacy: .public)")
+        }
+    }
+
+    /// Successes always pass; failures pass once per key per window.
+    private func allow(_ record: VMRequestTelemetryRecord, in table: inout [String: Date], window: TimeInterval) -> Bool {
+        guard !record.outcome.isSuccess else { return true }
+        let key = Self.throttleKey(record)
+        let current = now()
+        lock.lock()
+        defer { lock.unlock() }
+        if let last = table[key], current.timeIntervalSince(last) < window {
+            return false
+        }
+        table[key] = current
+        return true
+    }
+}

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -101,6 +101,20 @@ final class PostHogAnalytics: @unchecked Sendable {
         }
     }
 
+    /// Capture one product event with the app version properties attached.
+    /// No-op when telemetry is disabled or the SDK never started. Used by the
+    /// Cloud VM request telemetry (`VMClientTelemetry`).
+    func capture(_ event: String, properties: [String: Any]) {
+        dispatchAsyncOnWorkQueue { [weak self] in
+            guard let self else { return }
+            self.startIfNeededOnWorkQueue()
+            guard self.didStart else { return }
+            var merged = properties
+            merged.merge(Self.versionProperties(infoDictionary: Bundle.main.infoDictionary ?? [:])) { current, _ in current }
+            self.capturePostHog(event, merged)
+        }
+    }
+
     func trackDailyActive(reason: String) {
         dispatchAsyncOnWorkQueue { [weak self] in
             self?.trackDailyActiveOnWorkQueue(reason: reason, flush: true)

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3976,7 +3976,13 @@ class TerminalController {
               !code.isEmpty else {
             return nil
         }
-        return ["backend_code": code, "http_status": status]
+        var payload: [String: Any] = ["backend_code": code, "http_status": status]
+        // The server trace id (support reference) travels with the structured
+        // error so the CLI and scripts can log it without parsing display text.
+        if let traceId = object["traceId"] as? String, !traceId.isEmpty {
+            payload["trace_id"] = traceId
+        }
+        return payload
     }
 
     private nonisolated static func isCloudVMAuthenticationError(_ error: VMClientError) -> Bool {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2835,6 +2835,8 @@
 		A3340002A3340002A3340002 /* ViewerNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3340001A3340001A3340001 /* ViewerNavigationTests.swift */; };
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
 		ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */; };
+		93AF7E8EC956FE883E252322 /* VMClientTelemetry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 831145877779546B628FCAFC /* VMClientTelemetry.swift */; };
+		6EE115A36CAD9082FBC4593E /* VMClientTelemetryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F8A0358C8DD0A7D998A86E9 /* VMClientTelemetryTests.swift */; };
 		C37800000000000000000003 /* VMDefaultCloudCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */; };
 		DCFD2C3A4F04C00C62720EE5 /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
 		F1C699902D31503EE3D492DF /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
@@ -5869,6 +5871,8 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		A3340001A3340001A3340001 /* ViewerNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewerNavigationTests.swift; sourceTree = "<group>"; };
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
 		9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientSocketCommands.swift; sourceTree = "<group>"; };
+		831145877779546B628FCAFC /* VMClientTelemetry.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClientTelemetry.swift; sourceTree = "<group>"; };
+		8F8A0358C8DD0A7D998A86E9 /* VMClientTelemetryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMClientTelemetryTests.swift; sourceTree = "<group>"; };
 		C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMDefaultCloudCommandTests.swift; sourceTree = "<group>"; };
 		6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMMachineKind.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
@@ -6521,6 +6525,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				5DE6021305BAAE21622C5DFD /* MachineCreateRequest.swift */,
 				6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */,
 				9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */,
+				831145877779546B628FCAFC /* VMClientTelemetry.swift */,
 				REE0CA0000000000000000E1 /* AIAccountsClient.swift */,
 				REE0CA0000000000000000F1 /* AIAccountCredentialSources.swift */,
 				REE0CA0000000000000000A1 /* RemotesClient.swift */,
@@ -8556,6 +8561,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				806100020000000000000002 /* RemoteSessionCleanupLifecycleTests.swift */,
 				F4000001A1B2C3D4E5F60718 /* GhosttyConfigTests.swift */,
 				B8E9500A0000000000000002 /* PostHogAnalyticsPropertiesTests.swift */,
+				8F8A0358C8DD0A7D998A86E9 /* VMClientTelemetryTests.swift */,
 				604100010000000000000002 /* GhosttyDrawableSizeRetryTests.swift */,
 				BCBC0A0E0000000000000D02 /* BrowserChromeMetricsTests.swift */,
 				B5A5E55B0000000000000002 /* BrowserEphemeralRestorationTests.swift */,
@@ -11612,6 +11618,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				A28B087F0000000000000005 /* ViewerNavigationKeyRouter.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
+				93AF7E8EC956FE883E252322 /* VMClientTelemetry.swift in Sources */,
 				F1C699902D31503EE3D492DF /* VMMachineKind.swift in Sources */,
 				B43AFCE7099305905825EA0A /* VMTunnelManager.swift in Sources */,
 				A10020000000000000000019 /* WebSurfaceSelectionEvaluationOwner.swift in Sources */,
@@ -12714,6 +12721,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				992300019923000199230010 /* VaultQueuedRestoreIdentityTests.swift in Sources */,
 				992300019923000199230006 /* VaultRestoreRelaunchPersistenceTests.swift in Sources */,
 				A3340002A3340002A3340002 /* ViewerNavigationTests.swift in Sources */,
+				6EE115A36CAD9082FBC4593E /* VMClientTelemetryTests.swift in Sources */,
 				C37800000000000000000003 /* VMDefaultCloudCommandTests.swift in Sources */,
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */,

--- a/cmuxTests/VMClientTelemetryTests.swift
+++ b/cmuxTests/VMClientTelemetryTests.swift
@@ -1,0 +1,173 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+
+@Suite
+struct VMClientTelemetryTests {
+    private func record(
+        method: String = "POST",
+        route: String = "/api/vm",
+        outcome: VMRequestOutcome,
+        durationMs: Double = 1234.567,
+        trace: VMRequestTraceContext = VMRequestTraceContext(
+            traceId: "0af7651916cd43dd8448eb211c80319c",
+            spanId: "b7ad6b7169203331",
+            clientRequestId: "req-1"
+        )
+    ) -> VMRequestTelemetryRecord {
+        VMRequestTelemetryRecord(method: method, route: route, outcome: outcome, durationMs: durationMs, retryCount: 0, trace: trace)
+    }
+
+    @Test("minted trace context is a valid W3C traceparent")
+    func mintedTraceContextIsValidTraceparent() {
+        let trace = VMRequestTraceContext.mint()
+        #expect(trace.traceId.count == 32)
+        #expect(trace.spanId.count == 16)
+        #expect(trace.traceId.allSatisfy { $0.isHexDigit && !$0.isUppercase })
+        #expect(trace.traceId != String(repeating: "0", count: 32))
+        #expect(trace.traceparent == "00-\(trace.traceId)-\(trace.spanId)-01")
+        #expect(trace.headers["traceparent"] == trace.traceparent)
+        #expect(trace.headers["X-Cmux-Client-Request-Id"] == trace.clientRequestId)
+        #expect(VMRequestTraceContext.mint().traceId != trace.traceId)
+    }
+
+    @Test("client identity headers name the app, version, build and channel")
+    func clientIdentityHeaders() {
+        let headers = VMClientTelemetry.clientIdentityHeaders(
+            infoDictionary: ["CFBundleShortVersionString": "1.2.3", "CFBundleVersion": "456"],
+            channel: "nightly"
+        )
+        #expect(headers == [
+            "X-Cmux-Client": "cmux-mac",
+            "X-Cmux-Channel": "nightly",
+            "X-Cmux-App-Version": "1.2.3",
+            "X-Cmux-App-Build": "456",
+        ])
+    }
+
+    @Test("machine ids normalize to {id} but fixed sub-resources do not")
+    func normalizedRoute() {
+        #expect(VMClientTelemetry.normalizedRoute(path: "/api/vm") == "/api/vm")
+        #expect(VMClientTelemetry.normalizedRoute(path: "/api/vm/abc-123") == "/api/vm/{id}")
+        #expect(VMClientTelemetry.normalizedRoute(path: "/api/vm/abc-123/exec") == "/api/vm/{id}/exec")
+        #expect(VMClientTelemetry.normalizedRoute(path: "/api/vm/abc-123/cmux-remote/approve") == "/api/vm/{id}/cmux-remote/approve")
+        #expect(VMClientTelemetry.normalizedRoute(path: "/api/vm/base/open") == "/api/vm/base/open")
+        #expect(VMClientTelemetry.normalizedRoute(path: "/api/vm/tunnel?x=1") == "/api/vm/tunnel")
+        #expect(VMClientTelemetry.normalizedRoute(path: "/api/vm/leases/revoke") == "/api/vm/leases/revoke")
+    }
+
+    @Test("polled reads succeed silently, user-waited operations and every failure reach PostHog")
+    func postHogCaptureDecision() {
+        let listOk = record(method: "GET", route: "/api/vm", outcome: .response(status: 200, errorCode: nil, serverTraceId: nil))
+        #expect(VMClientTelemetry.isPolledOperation(method: "GET", route: "/api/vm"))
+        #expect(!VMClientTelemetry.shouldCaptureToPostHog(listOk))
+
+        let statusOk = record(method: "GET", route: "/api/vm/{id}", outcome: .response(status: 200, errorCode: nil, serverTraceId: nil))
+        #expect(!VMClientTelemetry.shouldCaptureToPostHog(statusOk))
+
+        let listFailed = record(method: "GET", route: "/api/vm", outcome: .response(status: 503, errorCode: "vm_cloud_state_unavailable", serverTraceId: "t"))
+        #expect(VMClientTelemetry.shouldCaptureToPostHog(listFailed))
+
+        let createOk = record(outcome: .response(status: 200, errorCode: nil, serverTraceId: "t"))
+        #expect(VMClientTelemetry.shouldCaptureToPostHog(createOk))
+
+        let attachOk = record(route: "/api/vm/{id}/attach-endpoint", outcome: .response(status: 200, errorCode: nil, serverTraceId: "t"))
+        #expect(VMClientTelemetry.shouldCaptureToPostHog(attachOk))
+    }
+
+    @Test("severity: 5xx and transport failures are errors, 4xx warnings, local preconditions nothing")
+    func sentrySeverity() {
+        #expect(VMClientTelemetry.sentrySeverity(record(outcome: .response(status: 502, errorCode: "vm_cloud_service_unavailable", serverTraceId: nil))) == .error)
+        #expect(VMClientTelemetry.sentrySeverity(record(outcome: .response(status: 409, errorCode: "vm_billing_team_required", serverTraceId: nil))) == .warning)
+        #expect(VMClientTelemetry.sentrySeverity(record(outcome: .response(status: 200, errorCode: nil, serverTraceId: nil))) == nil)
+        #expect(VMClientTelemetry.sentrySeverity(record(outcome: .transportFailure(kind: .backendUnreachable, detail: "x"))) == .error)
+        #expect(VMClientTelemetry.sentrySeverity(record(outcome: .transportFailure(kind: .notSignedIn, detail: ""))) == nil)
+        #expect(VMClientTelemetry.sentrySeverity(record(outcome: .transportFailure(kind: .cancelled, detail: ""))) == nil)
+    }
+
+    @Test("PostHog properties carry the server trace id, code, status, latency and channel")
+    func postHogProperties() {
+        let failed = record(outcome: .response(status: 503, errorCode: "vm_image_config_error", serverTraceId: "server-trace"))
+        let properties = VMClientTelemetry.postHogProperties(failed, channel: "nightly")
+        #expect(properties["operation"] as? String == "POST /api/vm")
+        #expect(properties["status"] as? Int == 503)
+        #expect(properties["error_code"] as? String == "vm_image_config_error")
+        #expect(properties["operator_fault"] as? Bool == true)
+        #expect(properties["trace_id"] as? String == "server-trace")
+        #expect(properties["client_trace_id"] as? String == "0af7651916cd43dd8448eb211c80319c")
+        #expect(properties["client_request_id"] as? String == "req-1")
+        #expect(properties["duration_ms"] as? Double == 1234.57)
+        #expect(properties["channel"] as? String == "nightly")
+        #expect(properties["success"] as? Bool == false)
+
+        let unreachable = record(outcome: .transportFailure(kind: .backendUnreachable, detail: "https://x: timed out"))
+        let unreachableProperties = VMClientTelemetry.postHogProperties(unreachable, channel: "stable")
+        // No server answer: the client trace id is the reference.
+        #expect(unreachableProperties["trace_id"] as? String == "0af7651916cd43dd8448eb211c80319c")
+        #expect(unreachableProperties["error_code"] as? String == "backend_unreachable")
+        #expect(unreachableProperties["transport_failure"] as? String == "backend_unreachable")
+        #expect(unreachableProperties["status"] == nil)
+        // The raw detail never reaches PostHog; Sentry gets a bounded copy.
+        #expect(unreachableProperties["detail"] == nil)
+        #expect(VMClientTelemetry.sentryData(unreachable)["detail"] as? String == "https://x: timed out")
+    }
+
+    @Test("failures are throttled per operation and code; successes never are")
+    func throttling() {
+        let clock = ManualClock()
+        let captured = CaptureLog()
+        let telemetry = VMClientTelemetry(
+            capturePostHog: { event, properties in captured.postHog.append((event, properties)) },
+            captureSentry: { message, severity, _ in captured.sentry.append((message, severity)) },
+            addBreadcrumb: { _, _ in captured.breadcrumbs += 1 },
+            now: { clock.now },
+            channel: "dev"
+        )
+        let failure = record(outcome: .response(status: 503, errorCode: "vm_cloud_state_unavailable", serverTraceId: "t1"))
+        telemetry.record(failure)
+        telemetry.record(failure)
+        #expect(captured.postHog.count == 1)
+        #expect(captured.sentry.count == 1)
+        #expect(captured.sentry.first?.1 == .error)
+        #expect(captured.breadcrumbs == 2)
+
+        // A different code on the same operation is a different failure.
+        telemetry.record(record(outcome: .response(status: 409, errorCode: "vm_billing_team_required", serverTraceId: "t2")))
+        #expect(captured.postHog.count == 2)
+        #expect(captured.sentry.count == 2)
+        #expect(captured.sentry.last?.1 == .warning)
+
+        clock.now = clock.now.addingTimeInterval(VMClientTelemetry.postHogFailureThrottle)
+        telemetry.record(failure)
+        #expect(captured.postHog.count == 3)
+        #expect(captured.sentry.count == 2, "Sentry window is longer than the PostHog window")
+
+        clock.now = clock.now.addingTimeInterval(VMClientTelemetry.sentryFailureThrottle)
+        telemetry.record(failure)
+        #expect(captured.sentry.count == 3)
+
+        let success = record(outcome: .response(status: 200, errorCode: nil, serverTraceId: "t3"))
+        telemetry.record(success)
+        telemetry.record(success)
+        #expect(captured.postHog.count == 6, "successes are never throttled")
+        #expect(captured.postHog.last?.0 == VMClientTelemetry.postHogEvent)
+    }
+
+    @Test("the reference line carries the server trace id")
+    func referenceLine() {
+        #expect(cloudVMReferenceLine(traceId: "abc123").contains("abc123"))
+    }
+}
+
+private final class ManualClock: @unchecked Sendable {
+    var now = Date(timeIntervalSince1970: 1_800_000_000)
+}
+
+private final class CaptureLog: @unchecked Sendable {
+    var postHog: [(String, [String: Any])] = []
+    var sentry: [(String, VMRequestFailureSeverity)] = []
+    var breadcrumbs = 0
+}
+#endif

--- a/web/services/observability/report.ts
+++ b/web/services/observability/report.ts
@@ -1,19 +1,41 @@
 import { after } from "next/server";
 
+import { activeTraceIds } from "../telemetry";
+
+export type ReportErrorLevel = "error" | "warning" | "info";
+
+export type ReportErrorOptions = {
+  readonly fingerprint?: readonly string[];
+  /** Sentry level; defaults to `error`. User-fault conditions report as `warning`. */
+  readonly level?: ReportErrorLevel;
+  /** Indexed Sentry tags (searchable); values are stringified and bounded. */
+  readonly tags?: Record<string, string | number | boolean | undefined>;
+  /**
+   * Trace ids to attach as the event's trace context. Defaults to the active
+   * OpenTelemetry span, so a Sentry issue links to its Axiom trace.
+   */
+  readonly trace?: { readonly traceId: string; readonly spanId?: string };
+};
+
 const SENSITIVE_KEY_PATTERN = /authorization|cookie|credential|dsn|key|password|providerMetadata|secret|token|webhook/i;
 
 export function reportError(
   error: unknown,
   context: Record<string, unknown>,
-  options: { readonly fingerprint?: readonly string[] } = {},
+  options: ReportErrorOptions = {},
 ): void {
-  const safeContext = scrubContext(context);
+  const trace = options.trace ?? activeTraceIds();
+  const safeContext = scrubContext(
+    trace ? { ...context, trace_id: trace.traceId, span_id: trace.spanId } : context,
+  );
+  const level = options.level ?? "error";
   try {
     // Log a scrubbed summary, never the raw error: provider error messages can
     // embed credential-bearing URLs/headers and logs must stay secret-free.
     // Sentry still receives the original exception below (its own scrubbing
     // applies, and grouping needs the real error).
-    console.error("cmux.observability.error", safeContext, scrubErrorForLog(error));
+    const log = level === "error" ? console.error : console.warn;
+    log("cmux.observability.error", safeContext, scrubErrorForLog(error));
   } catch {
     // Reporting must never change the caller's control flow.
   }
@@ -21,11 +43,22 @@ export function reportError(
   if (!process.env.SENTRY_DSN?.trim()) return;
 
   const fingerprint = options.fingerprint;
+  const tags = boundedTags(options.tags, trace);
   const send = () =>
     import("@sentry/nextjs")
       .then(async (Sentry) => {
         Sentry.withScope((scope) => {
+          scope.setLevel(level);
           scope.setContext("cmux", safeContext);
+          scope.setTags(tags);
+          if (trace) {
+            // The Sentry trace context is how an issue links to its trace; we
+            // export traces to Axiom, so this is the cross-tool join key.
+            scope.setContext("trace", {
+              trace_id: trace.traceId,
+              span_id: trace.spanId ?? undefined,
+            });
+          }
           // A stable fingerprint groups every occurrence of one operational
           // condition (e.g. one misconfigured image env) into one Sentry issue,
           // so alert rules can fire on "first seen" without per-request noise.
@@ -51,6 +84,22 @@ export function reportError(
   } catch {
     void send();
   }
+}
+
+const TAG_VALUE_MAX = 200;
+
+function boundedTags(
+  tags: ReportErrorOptions["tags"],
+  trace: { readonly traceId: string; readonly spanId?: string } | undefined,
+): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const [key, value] of Object.entries(tags ?? {})) {
+    if (value === undefined || value === null) continue;
+    if (SENSITIVE_KEY_PATTERN.test(key)) continue;
+    out[key] = String(value).slice(0, TAG_VALUE_MAX);
+  }
+  if (trace) out.trace_id = trace.traceId;
+  return out;
 }
 
 function scrubContext(context: Record<string, unknown>): Record<string, unknown> {

--- a/web/services/telemetry.ts
+++ b/web/services/telemetry.ts
@@ -11,6 +11,13 @@ import {
 
 import { isVmPriorityPath } from "./observability/sampler";
 
+/**
+ * Response headers that hand the caller its Axiom lookup keys. A user who
+ * pastes a failed request's reference gives operators the exact trace.
+ */
+export const TRACE_ID_RESPONSE_HEADER = "x-cmux-trace-id";
+export const SPAN_ID_RESPONSE_HEADER = "x-cmux-span-id";
+
 type AttributeValue = string | number | boolean;
 export type MaybeAttributes = Record<string, AttributeValue | null | undefined>;
 export type SpanCallback<T> = (span: Span) => T | Promise<T>;
@@ -77,7 +84,7 @@ export async function withApiRouteSpan<T extends Response>(
       if (response.status >= 500) {
         span.setStatus({ code: SpanStatusCode.ERROR, message: `HTTP ${response.status}` });
       }
-      return response;
+      return withTraceIdHeaders(response, span);
     },
     // deleteSpan, not ROOT_CONTEXT: only the dropped parent span leaves the
     // context; baggage and other context values stay with the request.
@@ -95,8 +102,17 @@ export function recordSpanError(span: Span, err: unknown): void {
     span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
     span.setAttributes({
       "cmux.error_name": err.name,
-      "cmux.error_message": err.message,
+      "cmux.error_message": scrubText(err.message),
     });
+    const causes = summarizeErrorCauses(err);
+    if (causes) {
+      span.setAttributes(cleanAttributes({
+        "cmux.error_cause_chain": causes.chain,
+        "cmux.error_cause_depth": causes.depth,
+        "cmux.error_cause_http_status": causes.httpStatus,
+        "cmux.error_cause_code": causes.code,
+      }));
+    }
     return;
   }
   const message = String(err);
@@ -106,6 +122,132 @@ export function recordSpanError(span: Span, err: unknown): void {
     "cmux.error_name": "NonError",
     "cmux.error_message": message,
   });
+}
+
+export type TraceIds = { readonly traceId: string; readonly spanId: string };
+
+/** Trace and span id of a span when its context is valid, else undefined. */
+export function spanTraceIds(span: Span | undefined): TraceIds | undefined {
+  if (!span || typeof span.spanContext !== "function") return undefined;
+  const context = span.spanContext();
+  if (!trace.isSpanContextValid(context)) return undefined;
+  return { traceId: context.traceId, spanId: context.spanId };
+}
+
+/** Trace ids of the active span, when one is recording. */
+export function activeTraceIds(): TraceIds | undefined {
+  return spanTraceIds(trace.getActiveSpan());
+}
+
+/**
+ * Stamp the route span's ids on the response. Responses built by route
+ * handlers have mutable headers; a response whose headers are immutable
+ * (a passthrough `fetch` result) is re-wrapped around the same body.
+ */
+export function withTraceIdHeaders<T extends Response>(response: T, span: Span): T {
+  const ids = spanTraceIds(span);
+  if (!ids) return response;
+  try {
+    response.headers.set(TRACE_ID_RESPONSE_HEADER, ids.traceId);
+    response.headers.set(SPAN_ID_RESPONSE_HEADER, ids.spanId);
+    return response;
+  } catch {
+    const headers = new Headers(response.headers);
+    headers.set(TRACE_ID_RESPONSE_HEADER, ids.traceId);
+    headers.set(SPAN_ID_RESPONSE_HEADER, ids.spanId);
+    return new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers,
+    }) as T;
+  }
+}
+
+/**
+ * Flush buffered spans now instead of trusting the runtime's post-response
+ * flush. Nine consecutive Cloud VM failures on 2026-09-01 produced no Axiom
+ * spans while PostHog captures from the same requests arrived: the batch
+ * exporter's deferred flush is the weak link on an error-heavy instance.
+ * Best effort and bounded; never throws.
+ */
+export async function forceFlushTraces(timeoutMs = 3_000): Promise<boolean> {
+  try {
+    const provider = trace.getTracerProvider() as {
+      getDelegate?: () => unknown;
+      forceFlush?: () => Promise<void>;
+    };
+    const delegate = (provider.getDelegate?.() ?? provider) as { forceFlush?: () => Promise<void> };
+    if (typeof delegate.forceFlush !== "function") return false;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<boolean>((resolve) => {
+      timer = setTimeout(() => resolve(false), timeoutMs);
+    });
+    const flushed = delegate.forceFlush().then(() => true, () => false);
+    try {
+      return await Promise.race([flushed, timeout]);
+    } finally {
+      if (timer) clearTimeout(timer);
+    }
+  } catch {
+    return false;
+  }
+}
+
+const ERROR_CAUSE_MAX_DEPTH = 6;
+const ERROR_CAUSE_MESSAGE_MAX = 300;
+const SENSITIVE_TEXT = /(srt_[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{8,}|Bearer\s+\S+|eyJ[A-Za-z0-9_-]{10,}|crt_[A-Za-z0-9_-]{16,})/g;
+
+type ErrorCauseSummary = {
+  readonly chain: string;
+  readonly depth: number;
+  readonly httpStatus?: number;
+  readonly code?: string;
+};
+
+/**
+ * Walk `error.cause` and summarize the chain for a span: the innermost
+ * provider/HTTP failure is what an operator needs, and wrapper classes such
+ * as ProviderError otherwise hide it. Secrets are redacted, lengths bounded.
+ */
+export function summarizeErrorCauses(err: unknown): ErrorCauseSummary | undefined {
+  const parts: string[] = [];
+  let httpStatus: number | undefined;
+  let code: string | undefined;
+  let current = (err as { cause?: unknown } | null)?.cause;
+  let depth = 0;
+  const seen = new Set<unknown>();
+  while (current && depth < ERROR_CAUSE_MAX_DEPTH && !seen.has(current)) {
+    seen.add(current);
+    depth += 1;
+    const record = current as {
+      name?: unknown;
+      message?: unknown;
+      code?: unknown;
+      status?: unknown;
+      statusCode?: unknown;
+      response?: { status?: unknown };
+      body?: { code?: unknown };
+      cause?: unknown;
+    };
+    const name = typeof record.name === "string" ? record.name : typeof current;
+    const message = typeof record.message === "string" ? record.message : String(current);
+    parts.push(`${name}: ${scrubText(message).slice(0, ERROR_CAUSE_MESSAGE_MAX)}`);
+    const status = [record.status, record.statusCode, record.response?.status].find(
+      (value) => typeof value === "number" && Number.isFinite(value),
+    );
+    if (httpStatus === undefined && typeof status === "number") httpStatus = status;
+    const causeCode = [record.body?.code, record.code].find(
+      (value) => typeof value === "string" && value.length > 0,
+    );
+    if (code === undefined && typeof causeCode === "string") code = causeCode.slice(0, 80);
+    current = record.cause;
+  }
+  if (depth === 0) return undefined;
+  return { chain: parts.join(" <- "), depth, httpStatus, code };
+}
+
+function scrubText(text: string): string {
+  return text.replace(SENSITIVE_TEXT, "[redacted]");
 }
 
 function cleanAttributes(attributes: MaybeAttributes): Attributes {

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -287,6 +287,18 @@ bun run cloud-vm:stress -- staging --count 8 --concurrency 4 --provider default
 bun run cloud-vm:stress -- production --count 12 --concurrency 4 --provider default
 ```
 
+## Telemetry
+
+Every `/api/vm*` request runs inside `withAuthedVmApiRoute` (`routeHelpers.ts`), which owns one request context (`requestContext.ts`) and one route span. The client mints a W3C `traceparent` and an `X-Cmux-Client-Request-Id` per call and sends `X-Cmux-Client`, `X-Cmux-App-Version`, `X-Cmux-App-Build`, `X-Cmux-Channel`. The server answers every response with `x-cmux-trace-id` and `x-cmux-span-id`, and every error body carries `traceId` (also `ui.traceId`). The Mac app prints it as `Reference: <trace id>` on every Cloud VM error, and the socket `vm_error` payload carries it as `data.trace_id`. That id is the join key across the three sinks:
+
+- Axiom (`cmux-prod-otel-traces`, 100% of VM traces): route span with `cmux.vm.timing.<stage>_ms`, `cmux.vm.request_duration_ms`, `cmux.vm.request_success`, `cmux.vm.error_*` (code, phase, provider, image, env var, reason), `cmux.client.*`, `cmux.user_id`, `cmux.vercel.request_id`; provider spans under it record the wrapped cause chain (`cmux.error_cause_chain`, `cmux.error_cause_http_status`, `cmux.error_cause_code`). Error and non-polled responses force a bounded span flush in `after()` so an error-heavy instance cannot drop the trace.
+- PostHog (production, or `CMUX_VM_ANALYTICS_FORCE=1`): `cloud_vm_request` for every failure and for the successes a user waits on (create, attach, base open, restore, fork, ...) with `duration_ms`, `status`, `error_code`, `error_phase`, `operator_fault`, `trace_id`, `client_*`; polled reads (`list`, `status`, `stats`, `list_sessions`, `get_tunnel`) succeed silently. Every failure also emits a `$exception` (Error Tracking) fingerprinted by error code. `cloud_vm_provision` (schema 2, failures of create-like operations, feeds the alert) now also carries `trace_id`, `duration_ms`, `error_phase` and client fields.
+- Sentry (shared project, `subsystem: cloud_vm_api`): every VM error, `error` level for operator faults and `warning` for user faults, fingerprint `["cmux-vm-error", code, provider]`, tags `vm.error_code`, `vm.phase`, `vm.operation`, `vm.provider`, `client.*`, `trace_id`, and a trace context holding the same ids.
+
+Client side, `VMClientTelemetry` (`Sources/Cloud/VMClientTelemetry.swift`) measures every request: `os.log` category `CloudVM` for all of them, a Sentry breadcrumb for all, PostHog `cmux_cloud_vm_request` for failures plus non-polled successes, and a Sentry event for failures (5xx and transport failures `error`, 4xx `warning`). Client failures are throttled per operation and code (60 s PostHog, 300 s Sentry) so a polling loop during an outage produces one event per window.
+
+To investigate one failure: take the reference id, query Axiom `['cmux-prod-otel-traces'] | where trace_id == '<id>'`, open the PostHog `$exception` or `cloud_vm_request` row with `trace_id = <id>`, and search Sentry for `trace_id:<id>`.
+
 ## GitHub operations
 
 Cloud VM migrations and smoke checks are exposed as manual GitHub Actions:

--- a/web/services/vms/observability.ts
+++ b/web/services/vms/observability.ts
@@ -4,7 +4,8 @@ import { trace, type Span } from "@opentelemetry/api";
 
 import { POSTHOG_HOST, POSTHOG_PROJECT_KEY } from "../analytics/iosEventPolicy";
 import { reportError } from "../observability/report";
-import { setSpanAttributes } from "../telemetry";
+import { setSpanAttributes, spanTraceIds } from "../telemetry";
+import { currentVmRequestContext, type VmRequestContext } from "./requestContext";
 import type { VmErrorResponseInput } from "./routeHelpers";
 
 /**
@@ -70,19 +71,24 @@ export function annotateVmErrorSpan(span: Span, input: VmErrorResponseInput): vo
 }
 
 /**
- * Log leg of the VM error choke point. Called from `vmErrorResponse` for
- * every error response; emits a scrubbed structured log line for
- * operator-fault errors (Vercel runtime logs) and annotates the active
- * span so the full error context reaches Axiom. The Sentry delivery inside
- * `reportError` is intentionally inert for this app: `instrumentation.ts`
- * filters the shared Sentry project to coderouter events only.
+ * Log, Sentry and request-context leg of the VM error choke point. Called
+ * from `vmErrorResponse` for EVERY error response:
+ *
+ * - annotates the active span so the full operator context reaches Axiom;
+ * - records the error on the request context so the response finalizer can
+ *   ship it to PostHog with the user, client, duration and trace ids;
+ * - reports to Sentry. Operator faults are `error` level, user faults are
+ *   `warning`, both fingerprinted by code and provider so one condition is
+ *   one issue. Every event carries the trace id as a tag and trace context.
  */
 export function reportVmErrorResponse(input: VmErrorResponseInput): void {
   const activeSpan = trace.getActiveSpan();
   if (activeSpan) annotateVmErrorSpan(activeSpan, input);
-  if (!isOperatorFaultVmError(input)) return;
+  const context = currentVmRequestContext();
+  if (context) context.lastError = input;
   const diagnostics = input.diagnostics ?? {};
-  const provider = typeof diagnostics.provider === "string" ? diagnostics.provider : undefined;
+  const provider = stringOrUndefined(diagnostics.provider);
+  const operatorFault = isOperatorFaultVmError(input);
   reportError(
     new Error(`cloud VM ${input.error}: ${input.message}`),
     {
@@ -90,12 +96,211 @@ export function reportVmErrorResponse(input: VmErrorResponseInput): void {
       code: input.error,
       status: input.status,
       phase: input.phase ?? "unknown",
+      operator_fault: operatorFault,
       reason: input.reason ?? input.message,
+      operation: context?.operation,
+      route: context?.route,
+      user_id: context?.userId,
+      client: context?.client,
+      vercel_request_id: context?.vercelRequestId,
       ...(input.details ?? {}),
       ...diagnostics,
     },
-    { fingerprint: ["cmux-vm-error", input.error, provider ?? "unknown"] },
+    {
+      fingerprint: ["cmux-vm-error", input.error, provider ?? "unknown"],
+      level: operatorFault ? "error" : "warning",
+      tags: {
+        "vm.error_code": input.error,
+        "vm.phase": input.phase ?? "unknown",
+        "vm.status": input.status,
+        "vm.operator_fault": operatorFault,
+        "vm.operation": context?.operation,
+        "vm.provider": provider,
+        "client.name": context?.client.name,
+        "client.version": context?.client.version,
+        "client.channel": context?.client.channel,
+        user_id: context?.userId,
+      },
+    },
   );
+}
+
+/**
+ * Operations a client polls on a timer. Their successes stay out of PostHog
+ * (Axiom keeps 100% of them); their failures are captured like any other.
+ */
+const POLLED_VM_OPERATIONS: ReadonlySet<string> = new Set([
+  "list",
+  "status",
+  "stats",
+  "list_sessions",
+  "get_tunnel",
+]);
+
+/** PostHog event carrying one Cloud VM API request outcome with latency. */
+export const VM_REQUEST_POSTHOG_EVENT = "cloud_vm_request";
+
+type PostHogProperties = Record<string, string | number | boolean>;
+
+function vmAnalyticsEnabled(env: Record<string, string | undefined>): boolean {
+  return env.VERCEL_ENV === "production" || env.CMUX_VM_ANALYTICS_FORCE === "1";
+}
+
+function requestTelemetryProperties(
+  context: VmRequestContext,
+  ids: { traceId?: string; spanId?: string } | undefined,
+): PostHogProperties {
+  const properties: PostHogProperties = {
+    operation: context.operation,
+    route: context.route,
+    method: context.method,
+  };
+  const optional: Record<string, string | undefined> = {
+    trace_id: ids?.traceId ?? context.traceId,
+    span_id: ids?.spanId ?? context.spanId,
+    client_trace_id: context.client.traceId,
+    client_request_id: context.client.requestId,
+    vercel_request_id: context.vercelRequestId,
+    client_name: context.client.name,
+    client_version: context.client.version,
+    client_build: context.client.build,
+    client_channel: context.client.channel,
+  };
+  for (const [key, value] of Object.entries(optional)) {
+    if (value) properties[key] = value;
+  }
+  return properties;
+}
+
+/**
+ * Per-request outcome choke point, run as the response finalizer of every
+ * Cloud VM route (`withAuthedVmApiRoute`). Three legs:
+ *
+ * - Span (Axiom): success flag, wall-clock duration, error code, user id.
+ * - PostHog `cloud_vm_request`: every failure, plus successes of the
+ *   operations a user waits on (create, attach, base open, ...) with their
+ *   duration. Polled reads succeed silently.
+ * - PostHog `$exception` (Error Tracking): every failure, fingerprinted by
+ *   error code, with the scrubbed reason, phase and the same ids.
+ *
+ * Every event carries the server trace id, so a PostHog row, a Sentry issue
+ * and an Axiom trace of one failure share one key. Reads only the status
+ * and the `x-cmux-vm-error` header, never the body stream.
+ */
+export function captureVmRequestOutcome(
+  input: {
+    readonly context: VmRequestContext;
+    readonly response: Response;
+    readonly span?: Span;
+    readonly durationMs: number;
+  },
+  options: {
+    readonly fetch?: typeof fetch;
+    readonly env?: Record<string, string | undefined>;
+  } = {},
+): void {
+  const { context, response } = input;
+  const status = response.status;
+  const success = status < 400;
+  const code = response.headers.get(VM_ERROR_CODE_HEADER) ?? undefined;
+  const span = input.span ?? trace.getActiveSpan();
+  const ids = spanTraceIds(span) ?? (context.traceId ? { traceId: context.traceId, spanId: context.spanId ?? "" } : undefined);
+  const durationMs = Math.round(input.durationMs * 100) / 100;
+  if (span) {
+    setSpanAttributes(span, {
+      "cmux.vm.request_success": success,
+      "cmux.vm.request_duration_ms": durationMs,
+      "cmux.vm.request_error_code": code,
+      "cmux.user_id": context.userId,
+      "cmux.client.name": context.client.name,
+      "cmux.client.version": context.client.version,
+      "cmux.client.build": context.client.build,
+      "cmux.client.channel": context.client.channel,
+      "cmux.client.request_id": context.client.requestId,
+      "cmux.client.trace_id": context.client.traceId,
+      "cmux.vercel.request_id": context.vercelRequestId,
+    });
+  }
+  if (success && POLLED_VM_OPERATIONS.has(context.operation)) return;
+  const env = options.env ?? process.env;
+  if (!vmAnalyticsEnabled(env)) return;
+  const distinctId = context.userId ?? "cmux-vm-anonymous";
+  const lastError = context.lastError;
+  const errorCode = code ?? lastError?.error;
+  const operatorFault = success ? false : isOperatorFaultVmError({ error: errorCode ?? "", status });
+  const base = requestTelemetryProperties(context, ids);
+  const requestProperties: PostHogProperties = {
+    ...base,
+    success,
+    status,
+    duration_ms: durationMs,
+    operator_fault: operatorFault,
+    schema_version: 1,
+    $insert_id: randomUUID(),
+    $geoip_disable: true,
+  };
+  if (errorCode) requestProperties.error_code = errorCode;
+  if (lastError?.phase) requestProperties.error_phase = lastError.phase;
+  if (lastError?.retryable !== undefined) requestProperties.retryable = lastError.retryable;
+  const provider = stringOrUndefined(lastError?.diagnostics?.provider);
+  if (provider) requestProperties.provider = provider;
+  const timestamp = new Date().toISOString();
+  const batch: Array<{ event: string; properties: PostHogProperties }> = [
+    { event: VM_REQUEST_POSTHOG_EVENT, properties: requestProperties },
+  ];
+  if (!success) {
+    const reason = scrubForAnalytics(lastError?.reason ?? lastError?.message ?? `HTTP ${status}`);
+    batch.push({
+      event: "$exception",
+      properties: {
+        ...base,
+        status,
+        duration_ms: durationMs,
+        operator_fault: operatorFault,
+        error_code: errorCode ?? `http_${status}`,
+        error_phase: lastError?.phase ?? "unknown",
+        $exception_level: operatorFault ? "error" : "warning",
+        $exception_fingerprint: `cmux-vm-error:${errorCode ?? `http_${status}`}`,
+        $exception_list: JSON.stringify([
+          {
+            type: errorCode ?? `http_${status}`,
+            value: reason,
+            mechanism: { handled: true, type: "cmux_vm_api", synthetic: true },
+          },
+        ]),
+        schema_version: 1,
+        $insert_id: randomUUID(),
+        $geoip_disable: true,
+      },
+    });
+  }
+  const body = JSON.stringify({
+    api_key: POSTHOG_PROJECT_KEY,
+    batch: batch.map((entry) => ({
+      event: entry.event,
+      distinct_id: distinctId,
+      properties: entry.properties,
+      timestamp,
+    })),
+  });
+  const fetchImpl = options.fetch ?? fetch;
+  const task = fetchImpl(`${POSTHOG_HOST}/batch/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body,
+    signal: AbortSignal.timeout(2_000),
+  }).then(() => undefined).catch(() => undefined);
+  try {
+    after(() => task);
+  } catch {
+    void task;
+  }
+}
+
+const ANALYTICS_SENSITIVE_TEXT = /(srt_[A-Za-z0-9_-]+|sk-[A-Za-z0-9_-]{8,}|Bearer\s+\S+|eyJ[A-Za-z0-9_-]{10,}|crt_[A-Za-z0-9_-]{16,})/g;
+
+function scrubForAnalytics(text: string): string {
+  return text.replace(ANALYTICS_SENSITIVE_TEXT, "[redacted]").slice(0, 500);
 }
 
 export type VmProvisionOperation = "create" | "fork" | "restore" | "base_open" | "base_reset";
@@ -272,7 +477,9 @@ export function captureVmProvisionOutcome(
   }
   if (success) return;
   const env = options.env ?? process.env;
-  if (env.VERCEL_ENV !== "production" && env.CMUX_VM_ANALYTICS_FORCE !== "1") return;
+  if (!vmAnalyticsEnabled(env)) return;
+  const context = currentVmRequestContext();
+  const ids = spanTraceIds(span);
   const properties: Record<string, string | number | boolean> = {
     operation: input.operation,
     success,
@@ -285,6 +492,18 @@ export function captureVmProvisionOutcome(
     $geoip_disable: true,
   };
   if (code) properties.error_code = code;
+  // Schema 2 additive fields: the same lookup keys `cloud_vm_request` carries,
+  // so the alerting event can be joined to its trace without a second query.
+  const traceId = ids?.traceId ?? context?.traceId;
+  if (traceId) properties.trace_id = traceId;
+  if (context) {
+    properties.duration_ms = Math.round((performance.now() - context.startedAtMs) * 100) / 100;
+    if (context.lastError?.phase) properties.error_phase = context.lastError.phase;
+    if (context.client.name) properties.client_name = context.client.name;
+    if (context.client.version) properties.client_version = context.client.version;
+    if (context.client.channel) properties.client_channel = context.client.channel;
+    if (context.client.requestId) properties.client_request_id = context.client.requestId;
+  }
   const body = JSON.stringify({
     api_key: POSTHOG_PROJECT_KEY,
     event: "cloud_vm_provision",

--- a/web/services/vms/requestContext.ts
+++ b/web/services/vms/requestContext.ts
@@ -1,0 +1,91 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { VmErrorResponseInput } from "./routeHelpers";
+
+/**
+ * Client identity a cmux app or CLI attaches to every Cloud VM request. All
+ * headers are optional; older nightlies send none of them and still work.
+ */
+export type VmClientIdentity = {
+  readonly name?: string;
+  readonly version?: string;
+  readonly build?: string;
+  readonly channel?: string;
+  readonly userAgent?: string;
+  /** Client-minted id for one logical request (echoed back, spans, PostHog). */
+  readonly requestId?: string;
+  /** Trace id the client minted before calling us (W3C `traceparent`). */
+  readonly traceId?: string;
+};
+
+/**
+ * One Cloud VM API request as seen by telemetry. Created by
+ * `withAuthedVmApiRoute` before auth and enriched as the request proceeds;
+ * read by the error choke point (`vmErrorResponse`) and the response
+ * finalizer so a single error carries user, operation, client, trace ids and
+ * the full scrubbed error input without threading them through every call.
+ */
+export type VmRequestContext = {
+  readonly route: string;
+  readonly method: string;
+  readonly operation: string;
+  readonly startedAtMs: number;
+  readonly client: VmClientIdentity;
+  /** Vercel's per-invocation request id (`x-vercel-id`), when present. */
+  readonly vercelRequestId?: string;
+  /** Server trace/span ids of the route span (Axiom lookup keys). */
+  traceId?: string;
+  spanId?: string;
+  userId?: string;
+  /** The last error input that flowed through `vmErrorResponse`. */
+  lastError?: VmErrorResponseInput;
+};
+
+const storage = new AsyncLocalStorage<VmRequestContext>();
+
+export function runWithVmRequestContext<T>(context: VmRequestContext, fn: () => T): T {
+  return storage.run(context, fn);
+}
+
+export function currentVmRequestContext(): VmRequestContext | undefined {
+  return storage.getStore();
+}
+
+const CLIENT_HEADER_MAX = 120;
+
+export const VM_CLIENT_REQUEST_ID_HEADER = "x-cmux-client-request-id";
+
+/** Read the client identity headers into a bounded, printable shape. */
+export function vmClientIdentityFromRequest(request: Request): VmClientIdentity {
+  const header = (name: string): string | undefined => {
+    const raw = request.headers.get(name);
+    if (!raw) return undefined;
+    const trimmed = raw.trim();
+    if (!trimmed) return undefined;
+    // Drop control characters; header values reach span attributes and logs.
+    const printable = trimmed.replace(/[^\x20-\x7e]/g, "");
+    return printable.length > 0 ? printable.slice(0, CLIENT_HEADER_MAX) : undefined;
+  };
+  const requestIdRaw = header(VM_CLIENT_REQUEST_ID_HEADER);
+  return {
+    name: header("x-cmux-client"),
+    version: header("x-cmux-app-version"),
+    build: header("x-cmux-app-build"),
+    channel: header("x-cmux-channel"),
+    userAgent: header("user-agent"),
+    requestId: requestIdRaw && /^[A-Za-z0-9._:-]{1,80}$/.test(requestIdRaw) ? requestIdRaw : undefined,
+    traceId: traceIdFromTraceparent(request.headers.get("traceparent")),
+  };
+}
+
+const TRACEPARENT = /^[0-9a-f]{2}-([0-9a-f]{32})-[0-9a-f]{16}-[0-9a-f]{2}$/i;
+
+/** The trace id of a syntactically valid W3C traceparent, else undefined. */
+export function traceIdFromTraceparent(value: string | null | undefined): string | undefined {
+  if (!value) return undefined;
+  const match = TRACEPARENT.exec(value.trim());
+  if (!match) return undefined;
+  const traceId = match[1].toLowerCase();
+  if (/^0+$/.test(traceId)) return undefined;
+  return traceId;
+}

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -1,5 +1,13 @@
 import type { Span } from "@opentelemetry/api";
-import { recordSpanError, withApiRouteSpan, type MaybeAttributes } from "../telemetry";
+import { after } from "next/server";
+import {
+  activeTraceIds,
+  forceFlushTraces,
+  recordSpanError,
+  spanTraceIds,
+  withApiRouteSpan,
+  type MaybeAttributes,
+} from "../telemetry";
 import {
   parseNativeStackTokens,
   unauthorized,
@@ -35,7 +43,16 @@ import {
 } from "./errors";
 import { recordSpanTiming } from "./timings";
 import { authProviderErrorResponse } from "./authErrors";
-import { reportVmErrorResponse, VM_ERROR_CODE_HEADER } from "./observability";
+import {
+  captureVmRequestOutcome,
+  reportVmErrorResponse,
+  VM_ERROR_CODE_HEADER,
+} from "./observability";
+import {
+  runWithVmRequestContext,
+  vmClientIdentityFromRequest,
+  type VmRequestContext,
+} from "./requestContext";
 import { vmRequestLocale, vmRequiresProCopy, vmUnsupportedCopy } from "./vmErrorMessages";
 import type { Locale } from "../../i18n/routing";
 
@@ -61,28 +78,62 @@ export async function withAuthedVmApiRoute(
   failureLog: string,
   handler: (context: AuthedVmRouteContext) => Promise<Response>,
 ): Promise<Response> {
-  return withApiRouteSpan(
+  const operation = typeof attributes["cmux.vm.operation"] === "string"
+    ? attributes["cmux.vm.operation"]
+    : "unknown";
+  const requestContext: VmRequestContext = {
+    route,
+    method: request.method,
+    operation,
+    startedAtMs: performance.now(),
+    client: vmClientIdentityFromRequest(request),
+    vercelRequestId: request.headers.get("x-vercel-id")?.slice(0, 120) ?? undefined,
+  };
+  return runWithVmRequestContext(requestContext, () => withApiRouteSpan(
     request,
     route,
     { "cmux.subsystem": "vm-cloud", ...attributes },
     async (span) => {
+      const ids = spanTraceIds(span);
+      if (ids) {
+        requestContext.traceId = ids.traceId;
+        requestContext.spanId = ids.spanId;
+      }
       let responseFinalizer: ((response: Response) => void) | null = null;
       const setResponseFinalizer = (finalizer: ((response: Response) => void) | null) => {
         responseFinalizer = finalizer;
       };
       const finalize = (response: Response): Response => {
-        if (!responseFinalizer) return response;
+        if (responseFinalizer) {
+          try {
+            responseFinalizer(response);
+          } catch (err) {
+            recordSpanError(span, err);
+            console.error(`${failureLog}: response finalizer failed`, err);
+          }
+        }
+        // Every VM response, every route: outcome + latency to the span and
+        // PostHog, then a bounded span flush so an error-heavy instance cannot
+        // lose the trace the PostHog row points at.
         try {
-          responseFinalizer(response);
+          captureVmRequestOutcome({
+            context: requestContext,
+            response,
+            span,
+            durationMs: performance.now() - requestContext.startedAtMs,
+          });
         } catch (err) {
           recordSpanError(span, err);
-          console.error(`${failureLog}: response finalizer failed`, err);
+          console.error(`${failureLog}: outcome capture failed`, err);
+        }
+        if (response.status >= 400 || !isPolledVmOperation(operation)) {
+          scheduleTraceFlush();
         }
         return response;
       };
 
       try {
-        const routeStartedAtMs = performance.now();
+        const routeStartedAtMs = requestContext.startedAtMs;
         const bearer = parseBearer(request);
         const authStart = performance.now();
         let user: AuthedUser | null;
@@ -93,9 +144,10 @@ export async function withAuthedVmApiRoute(
         }
         const authDurationMs = performance.now() - authStart;
         recordSpanTiming(span, "auth", authDurationMs);
-        if (!user) return unauthorized();
+        if (!user) return finalize(unauthorized());
+        requestContext.userId = user.id;
         const mutationForbidden = enforceBrowserMutationProtection(request, bearer);
-        if (mutationForbidden) return mutationForbidden;
+        if (mutationForbidden) return finalize(mutationForbidden);
         return finalize(await handler({ user, span, authDurationMs, routeStartedAtMs, setResponseFinalizer }));
       } catch (err) {
         recordSpanError(span, err);
@@ -111,7 +163,25 @@ export async function withAuthedVmApiRoute(
         }));
       }
     },
-  );
+  ));
+}
+
+const POLLED_OPERATIONS: ReadonlySet<string> = new Set(["list", "status", "stats", "list_sessions", "get_tunnel"]);
+
+function isPolledVmOperation(operation: string): boolean {
+  return POLLED_OPERATIONS.has(operation);
+}
+
+function scheduleTraceFlush(): void {
+  const flush = () => forceFlushTraces();
+  try {
+    // Past the response, inside the request lifecycle (Vercel keeps the
+    // function alive for `after` callbacks). Outside a request scope `after`
+    // throws; there is no batch exporter to flush there.
+    after(flush);
+  } catch {
+    // Not in a request scope (tests, scripts).
+  }
 }
 
 /**
@@ -181,6 +251,10 @@ export type VmLifecyclePhase =
 
 export function vmErrorResponse(input: VmErrorResponseInput): Response {
   const retryAfterSeconds = normalizedRetryAfterSeconds(input.retryAfterSeconds);
+  // The trace id is the support reference: a user pastes it, an operator opens
+  // the exact Axiom trace, PostHog row and Sentry event. Safe to expose (random
+  // 128-bit id, no meaning outside our telemetry).
+  const traceId = activeTraceIds()?.traceId;
   const payload = {
     ...(input.extra ?? {}),
     ...(input.details ? { details: {
@@ -199,11 +273,13 @@ export function vmErrorResponse(input: VmErrorResponseInput): Response {
       severity: input.severity ?? (input.status >= 500 ? "warning" : "error"),
       retryable: input.retryable ?? false,
       ...(retryAfterSeconds !== undefined ? { retryAfterSeconds } : {}),
+      ...(traceId ? { traceId } : {}),
     },
     error: input.error,
     message: input.message,
     reason: input.reason ?? input.message,
     action: input.action,
+    ...(traceId ? { traceId } : {}),
   };
   const headers: Record<string, string> = {};
   if (retryAfterSeconds !== undefined) {

--- a/web/tests/vm-request-telemetry.test.ts
+++ b/web/tests/vm-request-telemetry.test.ts
@@ -1,0 +1,359 @@
+import { describe, expect, test } from "bun:test";
+import type { Span } from "@opentelemetry/api";
+
+import {
+  SPAN_ID_RESPONSE_HEADER,
+  TRACE_ID_RESPONSE_HEADER,
+  recordSpanError,
+  spanTraceIds,
+  summarizeErrorCauses,
+  withTraceIdHeaders,
+} from "../services/telemetry";
+import {
+  captureVmRequestOutcome,
+  VM_ERROR_CODE_HEADER,
+  VM_REQUEST_POSTHOG_EVENT,
+} from "../services/vms/observability";
+import {
+  currentVmRequestContext,
+  runWithVmRequestContext,
+  traceIdFromTraceparent,
+  vmClientIdentityFromRequest,
+  type VmRequestContext,
+} from "../services/vms/requestContext";
+import { vmErrorResponse } from "../services/vms/routeHelpers";
+import { ProviderError } from "../services/vms/drivers/types";
+
+const TRACE_ID = "0af7651916cd43dd8448eb211c80319c";
+const SPAN_ID = "b7ad6b7169203331";
+
+function fakeSpan(options: { readonly valid?: boolean } = {}): { span: Span; attributes: Record<string, unknown> } {
+  const attributes: Record<string, unknown> = {};
+  const span = {
+    setAttributes(values: Record<string, unknown>) {
+      Object.assign(attributes, values);
+      return span;
+    },
+    setAttribute(key: string, value: unknown) {
+      attributes[key] = value;
+      return span;
+    },
+    setStatus() {
+      return span;
+    },
+    recordException() {},
+    spanContext() {
+      return options.valid === false
+        ? { traceId: "0".repeat(32), spanId: "0".repeat(16), traceFlags: 0 }
+        : { traceId: TRACE_ID, spanId: SPAN_ID, traceFlags: 1 };
+    },
+  } as unknown as Span;
+  return { span, attributes };
+}
+
+function context(overrides: Partial<VmRequestContext> = {}): VmRequestContext {
+  return {
+    route: "/api/vm",
+    method: "POST",
+    operation: "create",
+    startedAtMs: 0,
+    client: { name: "cmux-mac", version: "1.2.3", channel: "nightly", requestId: "req-1" },
+    userId: "user-1",
+    traceId: TRACE_ID,
+    spanId: SPAN_ID,
+    ...overrides,
+  };
+}
+
+type Captured = { batch: Array<{ event: string; distinct_id: string; properties: Record<string, unknown> }> } | null;
+
+function capture(
+  ctx: VmRequestContext,
+  response: Response,
+  span?: Span,
+): { body: Captured; url: string | null } {
+  let body: Captured = null;
+  let url: string | null = null;
+  const fakeFetch = ((input: string | URL | Request, init?: RequestInit) => {
+    url = String(input);
+    body = JSON.parse(String(init?.body)) as Captured;
+    return Promise.resolve(new Response("ok"));
+  }) as typeof fetch;
+  captureVmRequestOutcome(
+    { context: ctx, response, span, durationMs: 42.123 },
+    { fetch: fakeFetch, env: { CMUX_VM_ANALYTICS_FORCE: "1" } },
+  );
+  return { body, url };
+}
+
+describe("trace ids on responses", () => {
+  test("route responses carry the trace and span id headers", () => {
+    const { span } = fakeSpan();
+    const response = withTraceIdHeaders(new Response("{}", { status: 200 }), span);
+    expect(response.headers.get(TRACE_ID_RESPONSE_HEADER)).toBe(TRACE_ID);
+    expect(response.headers.get(SPAN_ID_RESPONSE_HEADER)).toBe(SPAN_ID);
+  });
+
+  test("an invalid span context adds no headers", () => {
+    const { span } = fakeSpan({ valid: false });
+    const response = withTraceIdHeaders(new Response("{}"), span);
+    expect(response.headers.get(TRACE_ID_RESPONSE_HEADER)).toBeNull();
+    expect(spanTraceIds(span)).toBeUndefined();
+  });
+
+  test("immutable headers are re-wrapped instead of thrown", async () => {
+    const { span } = fakeSpan();
+    const immutable = await fetch(`data:application/json,${encodeURIComponent('{"ok":true}')}`);
+    const response = withTraceIdHeaders(immutable, span);
+    expect(response.headers.get(TRACE_ID_RESPONSE_HEADER)).toBe(TRACE_ID);
+    expect(await response.json()).toEqual({ ok: true });
+  });
+
+  test("fake spans without a context are tolerated", () => {
+    expect(spanTraceIds({} as Span)).toBeUndefined();
+  });
+});
+
+describe("client identity and trace context from request headers", () => {
+  test("reads the cmux client headers, a valid traceparent and the client request id", () => {
+    const request = new Request("https://cmux.test/api/vm", {
+      headers: {
+        "x-cmux-client": "cmux-mac",
+        "x-cmux-app-version": "0.65.0",
+        "x-cmux-app-build": "1234",
+        "x-cmux-channel": "nightly",
+        "x-cmux-client-request-id": "8d2a6c1e-7f1b-4a3e-9a2c-0c1d2e3f4a5b",
+        traceparent: `00-${TRACE_ID}-${SPAN_ID}-01`,
+        "user-agent": "cmux/0.65.0",
+      },
+    });
+    expect(vmClientIdentityFromRequest(request)).toEqual({
+      name: "cmux-mac",
+      version: "0.65.0",
+      build: "1234",
+      channel: "nightly",
+      userAgent: "cmux/0.65.0",
+      requestId: "8d2a6c1e-7f1b-4a3e-9a2c-0c1d2e3f4a5b",
+      traceId: TRACE_ID,
+    });
+  });
+
+  test("malformed ids and control characters are dropped, values are bounded", () => {
+    const request = new Request("https://cmux.test/api/vm", {
+      headers: {
+        "x-cmux-client-request-id": "not valid because of spaces",
+        traceparent: "garbage",
+        "x-cmux-app-version": `${"a".repeat(200)}`,
+      },
+    });
+    const identity = vmClientIdentityFromRequest(request);
+    expect(identity.requestId).toBeUndefined();
+    expect(identity.traceId).toBeUndefined();
+    expect(identity.version).toBe("a".repeat(120));
+    expect(identity.name).toBeUndefined();
+  });
+
+  test("traceparent parsing rejects all-zero trace ids", () => {
+    expect(traceIdFromTraceparent(`00-${"0".repeat(32)}-${SPAN_ID}-01`)).toBeUndefined();
+    expect(traceIdFromTraceparent(`00-${TRACE_ID.toUpperCase()}-${SPAN_ID}-00`)).toBe(TRACE_ID);
+    expect(traceIdFromTraceparent(null)).toBeUndefined();
+  });
+
+  test("the request context is visible inside the run scope only", () => {
+    const ctx = context();
+    expect(currentVmRequestContext()).toBeUndefined();
+    runWithVmRequestContext(ctx, () => {
+      expect(currentVmRequestContext()).toBe(ctx);
+    });
+    expect(currentVmRequestContext()).toBeUndefined();
+  });
+});
+
+describe("vm error payloads", () => {
+  test("record the error on the request context for the finalizer", () => {
+    const ctx = context();
+    runWithVmRequestContext(ctx, () => {
+      vmErrorResponse({
+        error: "vm_billing_team_required",
+        status: 409,
+        message: "Select a team.",
+        action: "Select a team in cmux, then retry.",
+        phase: "billing",
+      });
+    });
+    expect(ctx.lastError?.error).toBe("vm_billing_team_required");
+    expect(ctx.lastError?.phase).toBe("billing");
+  });
+
+  test("carry no trace id when no span is active", async () => {
+    const response = vmErrorResponse({
+      error: "vm_internal_error",
+      status: 500,
+      message: "boom",
+      action: "retry",
+    });
+    const payload = await response.json() as { traceId?: string; ui: { traceId?: string } };
+    expect(payload.traceId).toBeUndefined();
+    expect(payload.ui.traceId).toBeUndefined();
+  });
+});
+
+describe("error cause chains on spans", () => {
+  test("the innermost provider failure reaches the span", () => {
+    const apiError = Object.assign(new Error("snapshot 'sh-abc' not found; Bearer secret-token-value"), {
+      name: "FreestyleApiError",
+      status: 404,
+      body: { code: "SNAPSHOT_NOT_FOUND" },
+    });
+    const wrapped = new ProviderError("freestyle", "create(sh-abc) failed", apiError);
+    const summary = summarizeErrorCauses(wrapped);
+    expect(summary?.depth).toBe(1);
+    expect(summary?.httpStatus).toBe(404);
+    expect(summary?.code).toBe("SNAPSHOT_NOT_FOUND");
+    expect(summary?.chain).toContain("FreestyleApiError: snapshot 'sh-abc' not found");
+    expect(summary?.chain).not.toContain("secret-token-value");
+
+    const { span, attributes } = fakeSpan();
+    recordSpanError(span, wrapped);
+    expect(attributes["cmux.error_name"]).toBe("ProviderError");
+    expect(attributes["cmux.error_cause_http_status"]).toBe(404);
+    expect(attributes["cmux.error_cause_code"]).toBe("SNAPSHOT_NOT_FOUND");
+    expect(attributes["cmux.error_cause_depth"]).toBe(1);
+  });
+
+  test("errors without a cause add no cause attributes and cycles terminate", () => {
+    expect(summarizeErrorCauses(new Error("plain"))).toBeUndefined();
+    const a: Error & { cause?: unknown } = new Error("a");
+    const b: Error & { cause?: unknown } = new Error("b");
+    a.cause = b;
+    b.cause = a;
+    const summary = summarizeErrorCauses(a);
+    expect(summary?.depth).toBe(2);
+  });
+});
+
+describe("cloud_vm_request capture", () => {
+  test("a failure ships cloud_vm_request and $exception with the trace id and error detail", () => {
+    const ctx = context();
+    const { span, attributes } = fakeSpan();
+    const response = runWithVmRequestContext(ctx, () => vmErrorResponse({
+      error: "vm_cloud_service_unavailable",
+      status: 502,
+      message: "Cloud VM service is temporarily unavailable.",
+      action: "retry",
+      reason: "Cloud VM service is temporarily unavailable: upstream 503",
+      phase: "create",
+      retryable: true,
+      diagnostics: { provider: "freestyle" },
+    }));
+    expect(response.headers.get(VM_ERROR_CODE_HEADER)).toBe("vm_cloud_service_unavailable");
+    const { body, url } = capture(ctx, response, span);
+    expect(url).toContain("/batch/");
+    expect(body?.batch.map((entry) => entry.event)).toEqual([VM_REQUEST_POSTHOG_EVENT, "$exception"]);
+    const [request, exception] = body!.batch;
+    expect(request.distinct_id).toBe("user-1");
+    expect(request.properties).toMatchObject({
+      operation: "create",
+      route: "/api/vm",
+      method: "POST",
+      success: false,
+      status: 502,
+      duration_ms: 42.12,
+      error_code: "vm_cloud_service_unavailable",
+      error_phase: "create",
+      retryable: true,
+      operator_fault: true,
+      provider: "freestyle",
+      trace_id: TRACE_ID,
+      span_id: SPAN_ID,
+      client_request_id: "req-1",
+      client_name: "cmux-mac",
+      client_version: "1.2.3",
+      client_channel: "nightly",
+      schema_version: 1,
+    });
+    expect(exception.properties).toMatchObject({
+      trace_id: TRACE_ID,
+      error_code: "vm_cloud_service_unavailable",
+      $exception_level: "error",
+      $exception_fingerprint: "cmux-vm-error:vm_cloud_service_unavailable",
+    });
+    const list = JSON.parse(String(exception.properties.$exception_list)) as Array<{ type: string; value: string }>;
+    expect(list[0].type).toBe("vm_cloud_service_unavailable");
+    expect(list[0].value).toContain("upstream 503");
+    expect(attributes["cmux.vm.request_success"]).toBe(false);
+    expect(attributes["cmux.vm.request_duration_ms"]).toBe(42.12);
+    expect(attributes["cmux.vm.request_error_code"]).toBe("vm_cloud_service_unavailable");
+    expect(attributes["cmux.user_id"]).toBe("user-1");
+    expect(attributes["cmux.client.request_id"]).toBe("req-1");
+  });
+
+  test("a user-fault failure is a warning-level exception", () => {
+    const ctx = context({ operation: "status", method: "GET", route: "/api/vm/[id]" });
+    const response = runWithVmRequestContext(ctx, () => vmErrorResponse({
+      error: "vm_not_found",
+      status: 404,
+      message: "not found",
+      action: "list",
+      phase: "status",
+    }));
+    const { body } = capture(ctx, response);
+    expect(body?.batch).toHaveLength(2);
+    expect(body?.batch[0].properties.operator_fault).toBe(false);
+    expect(body?.batch[1].properties.$exception_level).toBe("warning");
+  });
+
+  test("an error that bypassed vmErrorResponse is still captured by status", () => {
+    const ctx = context({ operation: "open_attach" });
+    const { body } = capture(ctx, new Response('{"error":"invalid_request"}', { status: 400 }));
+    expect(body?.batch[0].properties).toMatchObject({ success: false, status: 400, operator_fault: false });
+    expect(body?.batch[0].properties.error_code).toBeUndefined();
+    expect(body?.batch[1].properties.error_code).toBe("http_400");
+  });
+
+  test("a create success ships one cloud_vm_request with its latency and no exception", () => {
+    const ctx = context();
+    const { body } = capture(ctx, new Response("{}", { status: 200 }));
+    expect(body?.batch.map((entry) => entry.event)).toEqual([VM_REQUEST_POSTHOG_EVENT]);
+    expect(body?.batch[0].properties).toMatchObject({ success: true, status: 200, duration_ms: 42.12, operation: "create" });
+    expect(body?.batch[0].properties.error_code).toBeUndefined();
+  });
+
+  test("polled read successes stay out of PostHog but still annotate the span", () => {
+    for (const operation of ["list", "status", "stats", "list_sessions", "get_tunnel"]) {
+      const ctx = context({ operation, method: "GET" });
+      const { span, attributes } = fakeSpan();
+      const { body } = capture(ctx, new Response("{}", { status: 200 }), span);
+      expect(body).toBeNull();
+      expect(attributes["cmux.vm.request_success"]).toBe(true);
+    }
+  });
+
+  test("polled read failures are captured", () => {
+    const ctx = context({ operation: "list", method: "GET" });
+    const { body } = capture(ctx, new Response("{}", { status: 503 }));
+    expect(body?.batch).toHaveLength(2);
+  });
+
+  test("an unauthenticated failure uses the anonymous distinct id", () => {
+    const ctx = context({ userId: undefined });
+    const { body } = capture(ctx, new Response('{"error":"unauthorized"}', { status: 401 }));
+    expect(body?.batch[0].distinct_id).toBe("cmux-vm-anonymous");
+  });
+
+  test("nothing is sent outside production without the force flag", () => {
+    let called = false;
+    captureVmRequestOutcome(
+      { context: context(), response: new Response("{}", { status: 500 }), durationMs: 1 },
+      { fetch: (() => { called = true; return Promise.resolve(new Response("ok")); }) as typeof fetch, env: {} },
+    );
+    expect(called).toBe(false);
+  });
+
+  test("the client trace id is the fallback reference when the span has none", () => {
+    const ctx = context({ traceId: undefined, spanId: undefined, client: { traceId: "c".repeat(32) } });
+    const { body } = capture(ctx, new Response("{}", { status: 500 }));
+    expect(body?.batch[0].properties.trace_id).toBeUndefined();
+    expect(body?.batch[0].properties.client_trace_id).toBe("c".repeat(32));
+  });
+});


### PR DESCRIPTION
Nightly Cloud VM failures were hard to debug: the Mac client sent no trace context and recorded nothing, the server returned no trace id, Sentry saw only operator faults, PostHog saw only create-like failures, and provider spans recorded the `ProviderError` wrapper instead of the Freestyle status code. This PR gives every Cloud VM request one trace id shared by the client, Axiom, PostHog and Sentry, and records every error and every latency.

**Server (`web/`).** `withAuthedVmApiRoute` owns one request context per call (route, operation, client identity from `X-Cmux-*` headers and `traceparent`, Vercel request id, user id, last error) and a finalizer that runs on every VM route. Every response carries `x-cmux-trace-id` and `x-cmux-span-id`; every error body carries `traceId`. The finalizer stamps success, duration, error code, user and client on the span, sends PostHog `cloud_vm_request` for every failure and for the successes a user waits on (polled reads succeed silently), sends a PostHog `$exception` per failure fingerprinted by error code, and force-flushes the tracer in `after()` so an error-heavy instance stops dropping the trace the PostHog row points at. `reportError` gained level, tags and a trace context: every VM error now reaches Sentry, operator faults as `error`, user faults as `warning`, tagged with `trace_id`. `recordSpanError` walks `cause` so provider spans record the inner HTTP status and code. `cloud_vm_provision` keeps schema 2 and gains `trace_id`, `duration_ms`, `error_phase` and client fields, so the existing alert insight keeps working.

**Mac app.** `VMClient.request()` is the single choke point for the control plane. It mints a W3C `traceparent` and `X-Cmux-Client-Request-Id`, sends `X-Cmux-Client`, `X-Cmux-App-Version`, `X-Cmux-App-Build`, `X-Cmux-Channel`, measures latency, and records the outcome through the new `VMClientTelemetry`: `os.log` category `CloudVM` and a Sentry breadcrumb for every request, PostHog `cmux_cloud_vm_request` for failures and non-polled successes, a Sentry event for failures (5xx and transport failures `error`, 4xx `warning`), throttled per operation and code. Every Cloud VM error message ends with a localized `Reference: <trace id>` line and the socket `vm_error` payload carries `data.trace_id`, so the CLI shows it too.

Verification: `bun test` for `vm-request-telemetry`, `vm-observability`, `vm-route-auth`, `telemetry-sampler`, `vm-timings`, `observability-alerts`, `coderouter-sentry`, `vm-alerts` pass; `tsgo` and eslint clean. `vm-auth-cache` + `vm-route-auth` fail when run in one process on `main` as well (leaked `setSystemTime` throttle state), unrelated. Tagged build `cvobs` compiles on the fleet; `VMClientTelemetryTests` dispatched on `test-e2e.yml`. Runbook added to `web/services/vms/README.md` (Telemetry section).

Decisions to confirm: successes of non-polled operations now reach PostHog with latency (the 2026-08-27 split kept all successes out); user-fault 4xx now reach Sentry as warnings.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790992709&installation_model_id=21920&pr_number=11755&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11755&signature=a043da953fd1afb77490a55e6f2a0321d96e71a786ced7fe875bb161373cff92"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives every Cloud VM request one trace id shared across the Mac client, Axiom, PostHog, and Sentry, and records every error and latency so nightly failures are debuggable.

**Behavior changes**
- Non-polled operation successes now reach PostHog with latency; previously all successes were excluded.
- User-fault 4xx errors now reach Sentry as warnings; previously only operator faults did.

**What changed**
- Server responses carry `x-cmux-trace-id`/`x-cmux-span-id`, error bodies carry `traceId`, and every error message ends with a localized `Reference: <trace id>` line.
- The Mac client mints a W3C `traceparent` per request and records latency and outcome via the new `VMClientTelemetry`.
- Every VM error reaches Sentry (operator faults `error`, user faults `warning`) and PostHog (`cloud_vm_request` plus `$exception` per failure, fingerprinted by code).
- Provider spans now record the inner HTTP status and code from the cause chain instead of the `ProviderError` wrapper.
- `cloud_vm_provision` keeps schema 2 and gains `trace_id`, `duration_ms`, `error_phase`, and client fields.
- Error-heavy instances force a bounded trace flush in `after()` so the trace a PostHog row points at is not dropped.

<sup>Written for commit ba0a63bc94930062ae2453fe4e9955c57c139d31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

