### PR TITLE
fix(cmux-tui): clear stale clippy warnings

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1442,17 +1442,6 @@ async fn run_spec(
     RunOutcome::Done { exit_code: exited.unwrap_or(0), output: text.into_owned() }
 }
 
-#[cfg(unix)]
-fn signal_process_group_id<F>(pid: Option<u32>, kill: bool, send: F) -> bool
-where
-    F: FnOnce(libc::pid_t, libc::c_int) -> libc::c_int,
-{
-    let Some(pid) = pid else { return false };
-    let signal = if kill { libc::SIGKILL } else { libc::SIGTERM };
-    let group = -(pid as i32);
-    send(group, signal) == 0
-}
-
 #[cfg(windows)]
 struct WindowsJob {
     handle: std::os::windows::io::OwnedHandle,
@@ -2124,19 +2113,6 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         // realpath so canonical checks match (macOS /tmp -> /private/tmp).
         std::fs::canonicalize(&dir).unwrap()
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn process_group_failure_does_not_fallback_to_numeric_pid() {
-        let mut targets = Vec::new();
-        let signalled = signal_process_group_id(Some(4_321), false, |target, _| {
-            targets.push(target);
-            -1
-        });
-
-        assert!(!signalled);
-        assert_eq!(targets, vec![-4_321]);
     }
 
     #[cfg(windows)]

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -437,7 +437,7 @@ mod tests {
         let path = fixture(&enrollment(), 0o600, "oversized");
         let current_len = std::fs::metadata(&path).unwrap().len() as usize;
         let padding = vec![b' '; MAX_ENROLLMENT_BYTES + 1 - current_len];
-        let mut file = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
         file.write_all(&padding).unwrap();
 
         let error = load_managed_enrollment_file(&path, NOW).expect_err("oversized enrollment");

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -883,7 +883,7 @@ mod tests {
             terminal_output: None,
         };
         assert!(restore_preview(&checkpoint, &[record.clone(), record.clone()], 4).is_err());
-        assert!(restore_preview(&checkpoint, &[record.clone()], 5).is_err());
+        assert!(restore_preview(&checkpoint, std::slice::from_ref(&record), 5).is_err());
         let mut gapped = record;
         gapped.sequence = 5;
         assert!(restore_preview(&checkpoint, &[gapped], 5).is_err());
@@ -976,7 +976,8 @@ mod tests {
         };
 
         for cursor in [None, Some(Value::Null)] {
-            let preview = restore_preview(&checkpoint(cursor), &[record.clone()], 4).unwrap();
+            let preview =
+                restore_preview(&checkpoint(cursor), std::slice::from_ref(&record), 4).unwrap();
             assert_eq!(preview["fully_reducible"], false);
         }
     }

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1291,9 +1291,9 @@ mod tests {
     fn retry_wait_releases_mux_before_waiting() {
         let mux = Mux::new("journal-retry-wait-drop", crate::SurfaceOptions::default());
         let journal = mux.shared_journal_handle();
-        let (released_tx, released_rx) = std::sync::mpsc::sync_channel(1);
-        let (proceed_tx, proceed_rx) = std::sync::mpsc::sync_channel(1);
-        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        let (released_tx, released_rx) = sync_channel(1);
+        let (proceed_tx, proceed_rx) = sync_channel(1);
+        let (done_tx, done_rx) = sync_channel(1);
         let waiter_mux = Arc::clone(&mux);
         let waiter = std::thread::spawn(move || {
             wait_for_journal_retry_after_release(waiter_mux, Duration::from_secs(60), || {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -19275,7 +19275,7 @@ mod tests {
         let expected = expected_panes_by_screen(&duplicate_panes);
         assert_eq!(expected.get(&first_screen).map(|panes| panes.len()), Some(4));
         assert_eq!(expected.get(&second_screen).map(|panes| panes.len()), Some(1));
-        assert!(expected.get(&restore_screen_id(999)).is_none());
+        assert!(!expected.contains_key(&restore_screen_id(999)));
 
         let mut mismatched = topology;
         mismatched.panes[3].screen_id = second_screen.clone();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -16665,7 +16665,7 @@ fn restore_resource_state(
     for screen in &topology.screens {
         let expected_panes =
             panes_by_screen.get(&screen.public_id).unwrap_or(&empty_expected_panes);
-        crate::workspace_registry::validate_registry_screen_projection(screen, &expected_panes)?;
+        crate::workspace_registry::validate_registry_screen_projection(screen, expected_panes)?;
         let id = screen_slots[&screen.public_id];
         let root =
             restore_layout_node(&screen.layout, &pane_slots, &mut split_slots, &mut allocate)?;

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4366,10 +4366,10 @@ impl Surface {
     }
 
     #[cfg(test)]
-    pub(crate) fn install_terminal_reaper_that_finishes_for_test(
+    fn install_terminal_reaper_that_finishes_for_test(
         self: &Arc<Self>,
-        started: std::sync::mpsc::SyncSender<()>,
-        proceed: std::sync::mpsc::Receiver<()>,
+        started: SyncSender<()>,
+        proceed: Receiver<()>,
     ) -> Arc<ReaderCompletion> {
         let pty = self.as_pty().expect("test reaper requires a PTY surface");
         pty.reaper_completion.reset();
@@ -6295,7 +6295,7 @@ struct StartupChild {
 }
 
 #[cfg(test)]
-impl cmux_pty::ChildKiller for StartupChild {
+impl ChildKiller for StartupChild {
     fn kill(&mut self) -> std::io::Result<()> {
         self.state.kill_count.fetch_add(1, Ordering::Relaxed);
         Ok(())


### PR DESCRIPTION
## Summary

Remove the unused process-group signal helper left after the process-tree owner refactor. Remove its obsolete test.

Apply the remaining mechanical clippy fixes in relay and core test code: use imported names, keep the test helper private, avoid one-element clones, and use `contains_key`.

These warnings are stale on main. They are not caused by PR #11680, which changed only Swift and Xcode files.

## Verification

On Blacksmith Testbox `tbx_01m1jf4abfssp25dq56tc1df3b`:

- `cargo fmt --check`
- `cargo clippy -p chatmux-relay --all-targets --locked -- -D warnings`
- `cargo clippy -p cmux-tui-core --all-targets --locked -- -D warnings`

Full workspace clippy reaches separate warnings in `cmux-tui`; those files are outside this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11758"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790993129&installation_model_id=21920&pr_number=11758&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11758&signature=3dd2bf1f47729ed8926f4dc585fbc4cb2b353d02d642f84b910a895b3a5a5003"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears stale clippy warnings in `cmux-tui` relay and core test code so `cargo clippy -D warnings` passes cleanly on these crates.

- Removes the unused `signal_process_group_id` helper and its obsolete test, leftover from the process-tree owner refactor.
- Applies the remaining mechanical clippy lints: use imported names, keep the test helper private, avoid one-element clones, and use `contains_key`.
- These warnings are stale on main; they are not caused by the recent Swift and Xcode changes.

<sup>Written for commit eaae29b1d2b35bcf306d7a835775d0a939883a8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal process-group termination handling.
  * Cleaned up test utilities, assertions, and type references without changing product behavior.

* **Tests**
  * Updated test setup and helper usage for clearer, more concise code.
  * Preserved existing test expectations and outcomes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->