### PR TITLE
fix(cmux-tui): clear remaining clippy warnings

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6421,9 +6421,7 @@ const VIEWPORT_ANIMATION_SYNC_OPERATION_BUDGET: usize = PTY_OPERATION_QUEUE_CAPA
 
 #[cfg(test)]
 thread_local! {
-    static PANE_AREA_PROJECTION_WORK: std::cell::Cell<usize> = const {
-        std::cell::Cell::new(0)
-    };
+    static PANE_AREA_PROJECTION_WORK: Cell<usize> = const { Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -25112,7 +25110,7 @@ mod tests {
 
     #[test]
     fn host_input_runtime_shutdown_joins_reader_before_returning() {
-        let mut runtime = HostInputRuntime::new();
+        let runtime = HostInputRuntime::new();
         let ingress = runtime.ingress.clone();
         let (events_tx, events_rx) = crossbeam_channel::bounded(1);
         events_tx.send(AppEvent::HostInputReady).unwrap();
@@ -25139,7 +25137,7 @@ mod tests {
 
     #[test]
     fn host_input_runtime_shutdown_serializes_concurrent_callers() {
-        let mut runtime = HostInputRuntime::new();
+        let runtime = HostInputRuntime::new();
         let ingress = runtime.ingress.clone();
         let (closed_tx, closed_rx) = std::sync::mpsc::sync_channel(1);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
@@ -25161,7 +25159,7 @@ mod tests {
         });
         closed_rx.recv().unwrap();
 
-        let second_shutdown = shutdown.clone();
+        let second_shutdown = shutdown;
         let (second_done_tx, second_done_rx) = std::sync::mpsc::sync_channel(1);
         let second = std::thread::spawn(move || {
             second_shutdown.shutdown();
@@ -32894,7 +32892,7 @@ mod tests {
     #[test]
     fn graphics_changed_rect_bound_stays_within_linear_comparison_budget() {
         let mux = Mux::new("graphics-diff-complexity-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
+        let app = test_app(Session::Local(mux));
         let count = 512usize;
         let previous = (0..count)
             .map(|index| GraphicIdentity {
@@ -34933,7 +34931,7 @@ mod tests {
             surface_filter: None,
             cancellation: cancellation.clone(),
         };
-        let forwarder_recovery_generation = recovery_generation.clone();
+        let forwarder_recovery_generation = recovery_generation;
         let forwarder = std::thread::spawn(move || {
             forward_mux_events(
                 event_source,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -498,6 +498,7 @@ fn validate_git_source(source: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn is_sensitive_env_name(name: &str) -> bool {
     let name = name.to_ascii_uppercase();
     name.contains("TOKEN")
@@ -1068,12 +1069,12 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn plugin_build_command_terminates_after_timeout() {
-        let mut command = std::process::Command::new("sh");
+        let mut command = Command::new("sh");
         command.args(["-c", "while :; do :; done"]);
-        let started = std::time::Instant::now();
-        let error = run_plugin_build_command(&mut command, std::time::Duration::from_millis(20))
+        let started = Instant::now();
+        let error = run_plugin_build_command(&mut command, Duration::from_millis(20))
             .expect_err("a busy build must time out");
-        assert!(started.elapsed() < std::time::Duration::from_secs(2));
+        assert!(started.elapsed() < Duration::from_secs(2));
         assert!(error.to_string().contains("timed out"));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1087,14 +1087,17 @@ impl PendingRemoteRequests {
         progressed
     }
 
+    #[cfg(test)]
     fn is_empty(&self) -> bool {
         self.requests.is_empty()
     }
 
+    #[cfg(test)]
     fn len(&self) -> usize {
         self.requests.len()
     }
 
+    #[cfg(test)]
     fn values(&self) -> impl Iterator<Item = &PendingRemoteRequest> {
         self.requests.values()
     }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -183,6 +183,7 @@ pub struct TabNotificationView {
 }
 
 impl TreeView {
+    #[cfg(test)]
     pub(crate) fn from_parts(
         workspaces: Vec<WorkspaceView>,
         workspace_revision: u64,
@@ -349,11 +350,7 @@ impl TreeView {
         true
     }
 
-    pub fn active_workspace_mut(&mut self) -> Option<&mut WorkspaceView> {
-        self.invalidate_location_index();
-        self.workspaces.get_mut(self.active_workspace)
-    }
-
+    #[cfg(test)]
     pub fn active_workspace_mut_screen(&mut self) -> Option<&mut ScreenView> {
         self.invalidate_location_index();
         let workspace = self.workspaces.get_mut(self.active_workspace)?;
@@ -376,6 +373,7 @@ impl TreeView {
             .filter(|pane| pane.id == id)
     }
 
+    #[cfg(test)]
     pub fn pane_mut(&mut self, id: PaneId) -> Option<&mut PaneView> {
         self.invalidate_location_index();
         self.workspaces
@@ -398,6 +396,7 @@ impl TreeView {
             .filter(|tab| tab.surface == id)
     }
 
+    #[cfg(test)]
     pub(crate) fn update_surface_title(&mut self, id: SurfaceId, title: &str) -> bool {
         let (workspace_index, screen_index, pane_index, tab_index) = match self.surface_location(id)
         {
@@ -418,15 +417,12 @@ impl TreeView {
         [workspace_index, screen_index, pane_index, tab_index]: [usize; 4],
         title: &str,
     ) -> Option<bool> {
-        let Some(tab) = self
+        let tab = self
             .workspaces
             .get_mut(workspace_index)
             .and_then(|workspace| workspace.screens.get_mut(screen_index))
             .and_then(|screen| screen.panes.get_mut(pane_index))
-            .and_then(|pane| pane.tabs.get_mut(tab_index))
-        else {
-            return None;
-        };
+            .and_then(|pane| pane.tabs.get_mut(tab_index))?;
         if tab.surface != id {
             return None;
         }
@@ -833,8 +829,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                     .collect()
             })
             .unwrap_or_default(),
-        active_tab: active_tab
-            .unwrap_or_else(|| if active_tab_is_declared { usize::MAX } else { 0 }),
+        active_tab: active_tab.unwrap_or(if active_tab_is_declared { usize::MAX } else { 0 }),
     })
 }
 
@@ -967,8 +962,8 @@ pub(super) fn parse_tree_with_capabilities(
                     }
                 }
             }
-            view.active_screen = active_screen
-                .unwrap_or_else(|| if active_screen_is_invalid { usize::MAX } else { 0 });
+            view.active_screen =
+                active_screen.unwrap_or(if active_screen_is_invalid { usize::MAX } else { 0 });
         }
         tree.workspaces.push(view);
     }

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn visible_cursor_uses_terminal_cell_width() {
-        let mut input = text_input("界a");
+        let input = text_input("界a");
 
         let (shown, cursor) = input.visible_text_and_cursor(4);
 
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn visible_cursor_counts_halfwidth_sound_marks_as_terminal_cells() {
-        let mut input = text_input("ｶﾞa");
+        let input = text_input("ｶﾞa");
 
         let (shown, cursor) = input.visible_text_and_cursor(4);
 

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -872,9 +872,11 @@ mod tests {
                 columns,
                 "Ghostty width {width:?} must remain authoritative"
             );
-            let expected_diff_option = forced
-                .then(|| CellDiffOption::ForcedWidth(NonZeroU16::new(columns).unwrap()))
-                .unwrap_or(CellDiffOption::None);
+            let expected_diff_option = if forced {
+                CellDiffOption::ForcedWidth(NonZeroU16::new(columns).unwrap())
+            } else {
+                CellDiffOption::None
+            };
             assert_eq!(target.diff_option, expected_diff_option);
         }
     }


### PR DESCRIPTION
Summary:
- apply mechanical fixes for the remaining cmux-tui Clippy warnings
- restrict test-only helpers to test builds and remove one unused helper
- keep runtime behavior unchanged

Stacked on https://github.com/manaflow-ai/cmux/pull/11758.

Verification:
- Blacksmith Testbox: `cargo fmt --check`
- Blacksmith Testbox: `cargo clippy --workspace --all-targets --locked -- -D warnings`

Reference: https://doc.rust-lang.org/stable/clippy/usage.html

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the remaining Clippy warnings in `cmux-tui` and gates test-only helpers behind `#[cfg(test)]` so the workspace builds cleanly with `-D warnings`. Runtime behavior is unchanged.

- Replaces `unwrap_or_else` with `unwrap_or` where the closure was constant, converts a `then(...).unwrap_or(...)` expression to `if`, drops unneeded `mut` bindings, and simplifies imports.
- Moves `is_sensitive_env_name`, the `PendingRemoteRequests` accessors, and several `TreeView` helpers behind `#[cfg(test)]`, and removes the unused `active_workspace_mut`.
- Verified with `cargo fmt --check` and `cargo clippy --workspace --all-targets --locked -- -D warnings`.

<sup>Written for commit 73b31d6dfe0b6774017f2d95f5103ff9c0032b77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

