### PR TITLE
test(tui): include machine usage in active event inventory

### DIFF
--- a/cmux-tui/bindings/typescript/test/generated.test.ts
+++ b/cmux-tui/bindings/typescript/test/generated.test.ts
@@ -27,7 +27,9 @@ test("generated active events exclude serialized-only shapes", () => {
   const emitted = Object.entries(EVENT_METADATA)
     .filter(([, metadata]) => metadata.emission === "emitted")
     .map(([name]) => name);
-  assert.equal(emitted.length, 45);
+  assert.equal(emitted.length, 46);
+  assert.equal(EVENT_METADATA["machine-usage-changed"].emission, "emitted");
+  assert.equal(emitted.includes("machine-usage-changed"), true);
   assert.equal(EVENT_METADATA["client-list-invalidated"].emission, "serialized-never-emitted");
   assert.equal(emitted.includes("client-list-invalidated"), false);
 });


### PR DESCRIPTION
The protocol-12 schema now contains 46 emitted events. The TypeScript generated inventory test still expected 45 after machine-usage-changed was added, so CI failed with 46 !== 45.

Update the canonical assertion to 46 and assert that machine-usage-changed is emitted and included. Keep client-list-invalidated excluded as the serialized-only shape.

Validation:
- Before this change on main: generated active events test failed, 46 !== 45.
- npm ci
- npm test (254 passed, generated check, TypeScript build, packaged consumer compile)
- git diff --check

No runtime code or generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the generated active event inventory test so CI passes after `machine-usage-changed` was added to the protocol-12 schema.

The test now expects 46 emitted events and asserts `machine-usage-changed` is emitted and included. `client-list-invalidated` remains asserted as serialized-only and excluded.

<sup>Written for commit 615e78ec8e9e598dcada4a3b62a65536f273140f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

