### PR TITLE
docs(tui): refresh SDK inventory counts

### DIFF
--- a/cmux-tui/bindings/ERGONOMICS.md
+++ b/cmux-tui/bindings/ERGONOMICS.md
@@ -74,7 +74,9 @@ and secret redaction.
 The exact-binary live matrix adds one isolated create, run, exit, restart, and
 cleanup flow per language. TypeScript repeats it over authenticated WebSocket,
 for eight live transport runs. The separate raw protocol-12 suite runs 266
-compatibility checks over its 104 commands and 47 events.
+compatibility checks across seven language adapters: 34 fake cases, one metadata
+audit, and three live cases per language. Those checks cover the 104 generated
+commands and 47 event shapes.
 
 Each package suite also opens a stream with a short request deadline, leaves it
 idle past that deadline, then delivers and cancels normally. This separates

--- a/cmux-tui/bindings/ERGONOMICS.md
+++ b/cmux-tui/bindings/ERGONOMICS.md
@@ -2,7 +2,7 @@
 
 The seven public SDKs expose handwritten resource handles over the reviewed
 125-operation `cmux.protocol/2` catalog. The raw protocol inventory is a
-separate compatibility surface with 101 commands and 46 events. Deterministic
+separate compatibility surface with 104 commands and 47 events. Deterministic
 generation is limited to those private protocol-12 models under each package's
 explicit `raw` namespace. Consumers do not run a generator or install a
 generator runtime.
@@ -74,7 +74,7 @@ and secret redaction.
 The exact-binary live matrix adds one isolated create, run, exit, restart, and
 cleanup flow per language. TypeScript repeats it over authenticated WebSocket,
 for eight live transport runs. The separate raw protocol-12 suite runs 266
-compatibility checks over its 101 commands and 46 events.
+compatibility checks over its 104 commands and 47 events.
 
 Each package suite also opens a stream with a short request deadline, leaves it
 idle past that deadline, then delivers and cancels normally. This separates

--- a/cmux-tui/bindings/conformance/raw/test_runner.py
+++ b/cmux-tui/bindings/conformance/raw/test_runner.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import json
+import re
 import socket
 import unittest
 
 from runner import (
+    BINDINGS,
     FIXTURES,
     LANGUAGES,
     RAW_CATALOGS,
@@ -96,6 +98,50 @@ class FixtureTests(unittest.TestCase):
             },
         )
         self.assertTrue(all(expected.values()))
+
+    def test_ergonomics_documents_current_inventory_and_matrix_count(self) -> None:
+        docs = (BINDINGS / "ERGONOMICS.md").read_text()
+        schema = json.loads((BINDINGS.parent / "spec" / "sdk-schema.json").read_text())
+        command_count = len(schema["commands"])
+        event_count = len(schema["events"])
+        fake_count = len(self.fixtures["fake_cases"])
+        real_count = len(self.fixtures["real_cases"])
+        check_count = len(LANGUAGES) * (fake_count + 1 + real_count)
+
+        inventory = re.search(
+            r"raw protocol inventory is a\s+separate compatibility surface with "
+            r"(?P<commands>\d+) commands and (?P<events>\d+) events\.",
+            docs,
+        )
+        self.assertIsNotNone(inventory)
+        assert inventory is not None
+        self.assertEqual(int(inventory.group("commands")), command_count)
+        self.assertEqual(int(inventory.group("events")), event_count)
+
+        go_readme = (BINDINGS / "go" / "raw" / "README.md").read_text()
+        go_inventory = re.search(
+            r"The Go SDK covers all (?P<commands>\d+) protocol-12 commands and "
+            r"(?P<events>\d+) event shapes",
+            go_readme,
+        )
+        self.assertIsNotNone(go_inventory)
+        assert go_inventory is not None
+        self.assertEqual(int(go_inventory.group("commands")), command_count)
+        self.assertEqual(int(go_inventory.group("events")), event_count)
+
+        matrix = re.search(
+            r"The separate raw protocol-12 suite runs\s+(?P<checks>\d+)\s+"
+            r"compatibility checks across seven language adapters:\s+"
+            r"(?P<fake>\d+) fake cases, one metadata\s+audit, and\s+"
+            r"(?P<real>three) live cases per language\.",
+            docs,
+        )
+        self.assertIsNotNone(matrix)
+        assert matrix is not None
+        self.assertEqual(int(matrix.group("checks")), check_count)
+        self.assertEqual(int(matrix.group("fake")), fake_count)
+        self.assertEqual(matrix.group("real"), "three")
+        self.assertEqual(real_count, 3)
 
 
 class MatchingTests(unittest.TestCase):

--- a/cmux-tui/bindings/go/raw/README.md
+++ b/cmux-tui/bindings/go/raw/README.md
@@ -1,6 +1,6 @@
 # cmux Go SDK
 
-The Go SDK covers all 101 protocol-12 commands and 46 event shapes using only
+The Go SDK covers all 104 protocol-12 commands and 47 event shapes using only
 the Go standard library.
 
 ```go


### PR DESCRIPTION
The protocol-12 SDK schema now contains 104 commands and 47 event shapes. Two documentation pages still reported the prior 101-command and 46-event inventory.

Update the SDK ergonomics report and Go raw SDK README to match the canonical generated schema. Evidence from cmux-tui/spec/sdk-schema.json: 104 commands, 47 events, including 46 emitted and one serialized-only event.

Validation:
- git diff --check
- Generated source count script matches 104 commands and 47 events

Docs-only change. No runtime or generated artifacts changed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the SDK inventory counts in the ergonomics report and Go raw README from 101 commands and 46 events to 104 and 47, matching the canonical protocol-12 schema, and adds a conformance test that fails if the docs drift from the generated schema.

- The new test in `test_runner.py` reads `sdk-schema.json` and asserts the documented counts and matrix math stay in sync.
- Docs-only change; no runtime or generated artifacts were touched.

<sup>Written for commit 6a544ff2aff549ee6fd00d4478b7f7ecf77d6b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated SDK documentation to reflect coverage of 104 protocol commands and 47 event shapes.
  * Corrected command and event counts in ergonomics, conformance, and Go SDK documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->