### PR TITLE
perf(cmux-tui): frontend never waits, per-target input ordering, delta apply, local drag preview (IX1)

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -3543,7 +3543,31 @@ impl Mux {
     }
 
     fn next_id(&self) -> u64 {
-        self.next_id.fetch_add(1, Ordering::Relaxed)
+        // The TUI reserves the top 2^32 IDs for client-local placeholders.
+        // Keep daemon IDs in the disjoint low range, even if this counter is
+        // restored or wraps after an extremely long-lived process.
+        const MAX_DAEMON_ID: u64 = u64::MAX - (1 << 32);
+        loop {
+            let current = self.next_id.load(Ordering::Relaxed);
+            if current == 0 || current > MAX_DAEMON_ID {
+                if self
+                    .next_id
+                    .compare_exchange(current, 1, Ordering::Relaxed, Ordering::Relaxed)
+                    .is_ok()
+                {
+                    continue;
+                }
+                continue;
+            }
+            let next = if current == MAX_DAEMON_ID { 1 } else { current + 1 };
+            if self
+                .next_id
+                .compare_exchange(current, next, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
+            {
+                return current;
+            }
+        }
     }
 
     fn next_active_at(&self) -> u64 {
@@ -17568,6 +17592,16 @@ mod tests {
 
     fn test_mux() -> Arc<Mux> {
         Mux::new_for_test("test", SurfaceOptions::default())
+    }
+
+    #[test]
+    fn resource_ids_skip_the_tui_placeholder_namespace() {
+        const MAX_DAEMON_ID: u64 = u64::MAX - (1 << 32);
+        let mux = test_mux();
+        mux.next_id.store(MAX_DAEMON_ID, Ordering::Relaxed);
+        assert_eq!(mux.next_id(), MAX_DAEMON_ID);
+        assert_eq!(mux.next_id(), 1);
+        assert!(!((MAX_DAEMON_ID + 1)..=u64::MAX).contains(&mux.next_id()));
     }
 
     /// A machine resume reconnects every hosted terminal at once. Checkpoint

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13019,10 +13019,10 @@ impl App {
                 }
                 continue;
             }
-            if self.session.has_pending_mutations()
-                || self.session.remote_tree_is_stale()
-                || self.mux_recovery_generation.load(Ordering::Acquire) != 0
-            {
+            // Replay is gated by each input's own target (its semantic
+            // dependency below), never by pending mutations or a stale tree.
+            // The only global barrier is a daemon reconnect.
+            if self.mux_recovery_generation.load(Ordering::Acquire) != 0 {
                 return Ok(DeferredReplayOutcome {
                     action,
                     disposition: DeferredReplayDisposition::Blocked,
@@ -13123,9 +13123,12 @@ impl App {
     }
 
     fn pointer_route_is_globally_stale(&self) -> bool {
-        self.session.has_pending_pointer_mutations()
-            || self.session.remote_tree_is_stale()
-            || self.mux_recovery_generation.load(Ordering::Acquire) != 0
+        // Pending pointer mutations and a stale remote tree no longer stall
+        // pointer routes: the rendered frame already includes placeholders
+        // and the client's predicted layout, so a click routes against what
+        // the user sees (`input_waits_for_target`). Only a daemon reconnect or
+        // a frame-level route invalidation remains global.
+        self.mux_recovery_generation.load(Ordering::Acquire) != 0
             || self.pointer_route_phase.invalidates_all_pointer_routes()
     }
 
@@ -15590,10 +15593,7 @@ impl App {
             ) if !matches!(
                 &input,
                 TerminalInput::Mouse(MouseEvent { kind: MouseEventKind::Moved, .. })
-            ) && (self.session.has_pending_mutations()
-                || self.session.remote_tree_is_stale()
-                || self.mux_recovery_generation.load(Ordering::Acquire) != 0
-                || matches!(&input, TerminalInput::Mouse(mouse) if self.pointer_route_is_stale_for_mouse(mouse)))
+            ) && self.input_waits_for_target(&input)
                 && !self.input_can_update_pending_mutation(&input) =>
             {
                 return Ok(self.defer_input_with_sequence(
@@ -16651,8 +16651,20 @@ impl App {
             self.clear_finished_semantic_destinations();
             let destination_started = self.session.destination_mutation_started();
             let client_owned = self.input_is_client_owned(&input);
-            let semantic_dependency =
-                if client_owned { None } else { self.latest_semantic_destination_intent };
+            let destination = self.input_destination(&input);
+            // Input aimed at a placeholder depends on that placeholder's own
+            // create, not merely on the latest one.
+            let placeholder_intent = destination.filter(|id| is_placeholder_id(*id)).and_then(|id| {
+                self.create_placeholders
+                    .iter()
+                    .find(|placeholder| placeholder.surface() == id)
+                    .map(|placeholder| placeholder.intent)
+            });
+            let semantic_dependency = if client_owned {
+                None
+            } else {
+                placeholder_intent.or(self.latest_semantic_destination_intent)
+            };
             let semantic_result = self
                 .input_creates_session_destination(&input)
                 .then(|| self.allocate_semantic_destination_intent());
@@ -16660,7 +16672,7 @@ impl App {
                 self.latest_semantic_destination_intent = Some(intent);
             }
             DeferredInputAdmission {
-                destination: self.input_destination(&input),
+                destination,
                 destination_intent: (destination_started > self.applied_destination_generation)
                     .then_some(destination_started),
                 semantic_dependency,
@@ -16899,14 +16911,104 @@ impl App {
         {
             return false;
         }
+        // Order is preserved per target. Navigation is frontend-local and
+        // never queues behind deferred PTY input; input to a target that no
+        // deferred input shares is sent at once (see `input_waits_for_target`).
+        if self.input_is_client_owned(input) {
+            return false;
+        }
+        let target = self.input_destination(input);
+        let shares_target = target.is_none()
+            || self.deferred_input.iter().any(|deferred| deferred.admission.destination == target)
+            || self.pending_pointer_motion.is_some_and(|pointer| {
+                self.input_destination(&TerminalInput::Mouse(pointer.event)) == target
+            });
         match input {
             TerminalInput::Keyboard(_)
             | TerminalInput::FrontendAction { .. }
             | TerminalInput::ClearHistoryKey(_)
-            | TerminalInput::Paste(_) => true,
+            | TerminalInput::Paste(_) => shares_target,
             TerminalInput::Mouse(MouseEvent { kind: MouseEventKind::Moved, .. }) => false,
-            TerminalInput::Mouse(_) => self.active_pointer_buttons.is_empty(),
+            TerminalInput::Mouse(_) => shares_target && self.active_pointer_buttons.is_empty(),
             _ => false,
+        }
+    }
+
+    /// **Input is deferred by target, never by global state.**
+    ///
+    /// The frame law forbids representing a wait as an absent response, so
+    /// pending mutations and a stale remote tree never gate input:
+    ///
+    /// 1. Navigation and focus actions (`action_is_frontend_local`) act at
+    ///    once on the adopted tree plus placeholders; a placeholder target
+    ///    simply takes focus.
+    /// 2. Create actions are never deferred: each press enqueues its mutation
+    ///    and adds its placeholder, FIFO on the worker. The exception is a
+    ///    create anchored on a placeholder pane whose real id is unknown
+    ///    (splitting a placeholder); Alt-n re-anchors on the placeholder's
+    ///    real anchor because the daemon redistributes the whole column.
+    /// 3. PTY input (keys, paste, clicks, wheel) waits only when its target
+    ///    pane is a placeholder, and then only for that placeholder through
+    ///    the semantic destination. Input to a real pane is sent at once even
+    ///    while creates are in flight and while the tree is marked stale.
+    /// 4. Mutations whose target is a placeholder (close, split, rename, tab
+    ///    ops on it) queue behind that placeholder's resolution and block
+    ///    nothing else.
+    /// 5. The only global gate is `mux_recovery_generation != 0`: the daemon
+    ///    connection is being recovered and no target can be trusted.
+    ///
+    /// `remote_tree_is_stale()` gates nothing. No action needs the refetched
+    /// tree for correctness: creates and closes are keyed by ids the adopted
+    /// tree already has, and a stale tree only delays visibility, which the
+    /// deltas and placeholders cover.
+    fn input_waits_for_target(&self, input: &TerminalInput) -> bool {
+        if self.mux_recovery_generation.load(Ordering::Acquire) != 0 {
+            return true;
+        }
+        match input {
+            TerminalInput::FrontendAction { action, .. } => {
+                if action_is_frontend_local(*action) {
+                    return false;
+                }
+                if action_creates_destination(*action) {
+                    return match action {
+                        Action::NewWorkspace => false,
+                        Action::NewPaneSmart => self.active_pane_real_anchor().is_none(),
+                        _ => self.active_pane().is_some_and(is_placeholder_id),
+                    };
+                }
+                self.active_pane().is_some_and(is_placeholder_id)
+                    || self.active_surface().is_some_and(is_placeholder_id)
+            }
+            TerminalInput::Keyboard(_)
+            | TerminalInput::ClearHistoryKey(_)
+            | TerminalInput::Paste(_) => {
+                self.input_destination(input).is_some_and(is_placeholder_id)
+            }
+            TerminalInput::Mouse(mouse) => {
+                self.pointer_route_is_stale_for_mouse(mouse)
+                    || self.input_destination(input).is_some_and(is_placeholder_id)
+            }
+            _ => false,
+        }
+    }
+
+    /// The real pane an Alt-n on the active pane should anchor on: the pane
+    /// itself, or for a placeholder the real pane it was created from. None
+    /// for a placeholder workspace, whose panes have no real ancestor yet.
+    fn active_pane_real_anchor(&self) -> Option<PaneId> {
+        let pane = self.active_pane()?;
+        if !is_placeholder_id(pane) {
+            return Some(pane);
+        }
+        let placeholder =
+            self.create_placeholders.iter().find(|placeholder| placeholder.pane() == pane)?;
+        match placeholder.kind {
+            CreatePlaceholderKind::Pane { anchor } | CreatePlaceholderKind::Split { anchor, .. } => {
+                Some(anchor)
+            }
+            CreatePlaceholderKind::Tab { pane } => Some(pane),
+            CreatePlaceholderKind::Workspace => None,
         }
     }
 
@@ -18160,7 +18262,7 @@ impl App {
         fallback_pane: Option<PaneId>,
         semantic_intent: Option<u64>,
     ) -> anyhow::Result<()> {
-        let Some(pane) = pane.or_else(|| self.active_pane()) else {
+        let Some(pane) = pane.or_else(|| self.active_pane_real_anchor()) else {
             return Ok(());
         };
         let Some(hint) = self.tree.active_screen().and_then(|screen| {
@@ -30912,6 +31014,240 @@ mod tests {
             later.iter().all(|request| request["cmd"] != "send"),
             "typed input must not be replayed elsewhere: {later:?}"
         );
+    }
+
+    fn two_pane_tree_json() -> Value {
+        serde_json::json!({
+            "workspaces": [{
+                "id": 1, "name": "one", "active": true,
+                "resource_id": "ws_00000000000000000000000000000001",
+                "screens": [{
+                    "id": 2, "active": true, "active_pane": 3,
+                    "resource_id": "screen_00000000000000000000000000000002",
+                    "layout": {"type": "split", "split": 9, "dir": "right", "ratio": 0.5,
+                        "a": {"type": "leaf", "pane": 3}, "b": {"type": "leaf", "pane": 4}},
+                    "panes": [
+                        {"id": 3, "resource_id": "pane_00000000000000000000000000000003",
+                         "tabs": [{"surface": 7, "title": "a", "kind": "pty"}]},
+                        {"id": 4, "resource_id": "pane_00000000000000000000000000000004",
+                         "tabs": [{"surface": 8, "title": "b", "kind": "pty"}]}
+                    ]
+                }]
+            }]
+        })
+    }
+
+    /// A remote session whose creates block until `release` receives a token
+    /// per create, then are refused with the PTY-exhausted cause.
+    fn blocked_create_session(
+    ) -> (Session, StdReceiver<Value>, std::sync::mpsc::Sender<()>) {
+        let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
+        let release_rx = Mutex::new(release_rx);
+        let tree_json = two_pane_tree_json();
+        let (session, requests) = crate::session::test_remote_session_answering(Arc::new(
+            move |request: &Value| match request.get("cmd").and_then(Value::as_str) {
+                Some("list-workspaces") => tree_json.clone(),
+                Some("list-agents") => serde_json::json!({"agents": []}),
+                Some(
+                    "new-pane" | "new-tab" | "split" | "new-workspace"
+                    | "create-surface-with-receipt",
+                ) => {
+                    let _ = release_rx.lock().unwrap().recv();
+                    serde_json::json!({
+                        "__reject": PTY_EXHAUSTED_REJECTION
+                            .strip_prefix("remote command rejected: ")
+                            .unwrap()
+                    })
+                }
+                _ => serde_json::json!({}),
+            },
+        ));
+        session.refresh_tree().unwrap();
+        (session, requests, release_tx)
+    }
+
+    fn alt(c: char) -> AppEvent {
+        AppEvent::Input(Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::ALT)))
+    }
+
+    fn key(c: char) -> AppEvent {
+        AppEvent::Input(Event::Key(KeyEvent::new(KeyCode::Char(c), KeyModifiers::NONE)))
+    }
+
+    fn drain_until_settled(app: &mut App, events: &Receiver<AppEvent>) {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while app.session.has_pending_mutations() && Instant::now() < deadline {
+            if let Ok(event) = events.recv_timeout(Duration::from_millis(200)) {
+                app.handle(event).unwrap();
+            }
+        }
+        assert!(!app.session.has_pending_mutations(), "mutations did not settle");
+    }
+
+    #[test]
+    fn ten_alt_n_presses_produce_ten_placeholders_before_any_response() {
+        let (session, _requests, release) = blocked_create_session();
+        let (mut app, events) = test_app_with_events(session);
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        // Wide and tall enough that ten more panes all keep visible content;
+        // a pane that would have none is refused before any request.
+        app.sync_layout((600, 200));
+
+        for _ in 0..10 {
+            app.handle(alt('n')).unwrap();
+        }
+        assert_eq!(app.create_placeholders.len(), 10, "every press adds a placeholder at once");
+        assert!(app.deferred_input.is_empty(), "creates are never deferred");
+        let last = app.create_placeholders.last().unwrap().pane();
+        assert_eq!(app.active_pane(), Some(last), "focus follows the last create");
+        app.sync_layout((600, 200));
+        assert_eq!(app.pane_areas.len(), 12, "two real panes plus ten placeholders are laid out");
+        assert!(app.pane_areas.iter().any(|area| area.pane == last));
+
+        for _ in 0..10 {
+            release.send(()).unwrap();
+        }
+        drain_until_settled(&mut app, &events);
+        assert!(app.create_placeholders.iter().all(|placeholder| matches!(
+            placeholder.state,
+            CreatePlaceholderState::Failed { .. }
+        )));
+    }
+
+    #[test]
+    fn navigation_moves_focus_immediately_while_a_create_is_pending_and_the_tree_is_stale() {
+        let (session, _requests, release) = blocked_create_session();
+        let (mut app, events) = test_app_with_events(session);
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((200, 40));
+        assert_eq!(app.active_pane(), Some(3));
+
+        app.handle(alt('n')).unwrap();
+        let placeholder = app.active_pane().unwrap();
+        assert!(is_placeholder_id(placeholder));
+        app.session.invalidate_remote_tree();
+        assert!(app.session.remote_tree_is_stale());
+        app.sync_layout((200, 40));
+
+        // Every direction acts at once: nothing is deferred, no request is
+        // waited on, and focus can land on real panes and on the placeholder.
+        let mut visited = HashSet::new();
+        for direction in ['h', 'j', 'k', 'l', 'h', 'j', 'k', 'l'] {
+            app.handle(alt(direction)).unwrap();
+            assert!(app.deferred_input.is_empty(), "Alt-{direction} was deferred");
+            visited.insert(app.active_pane().unwrap());
+            app.sync_layout((200, 40));
+        }
+        assert!(visited.iter().any(|pane| !is_placeholder_id(*pane)), "reached a real pane");
+        assert!(visited.contains(&placeholder), "navigation can focus the placeholder");
+        assert!(app.session.has_pending_mutations(), "the create is still in flight");
+
+        release.send(()).unwrap();
+        drain_until_settled(&mut app, &events);
+    }
+
+    #[test]
+    fn typing_into_a_real_pane_is_sent_while_a_create_is_pending() {
+        let (mux, surface) = test_mux("typing-during-pending-create-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((200, 40));
+        drain_until_settled(&mut app, &events);
+        let (writes_tx, writes_rx) = std::sync::mpsc::channel::<(SurfaceId, Vec<u8>)>();
+        app.pty_input.set_delivered_write_observer(Some(Arc::new(move |surface, bytes| {
+            let _ = writes_tx.send((surface, bytes.to_vec()));
+        })));
+
+        // A create is in flight somewhere else; this pane is real.
+        app.session.pending_mutations.fetch_add(1, Ordering::AcqRel);
+        app.handle(key('x')).unwrap();
+        assert!(app.deferred_input.is_empty(), "input to a real pane must not be deferred");
+        let (written_to, bytes) = writes_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!((written_to, bytes.as_slice()), (surface.id, b"x".as_slice()));
+        app.session.pending_mutations.fetch_sub(1, Ordering::AcqRel);
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn typing_into_a_placeholder_defers_to_it_and_is_delivered_after_it_resolves() {
+        let (mux, original) = test_mux("typing-into-placeholder-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((200, 40));
+        drain_until_settled(&mut app, &events);
+        let (writes_tx, writes_rx) = std::sync::mpsc::channel::<(SurfaceId, Vec<u8>)>();
+        app.pty_input.set_delivered_write_observer(Some(Arc::new(move |surface, bytes| {
+            let _ = writes_tx.send((surface, bytes.to_vec()));
+        })));
+
+        app.handle(alt('n')).unwrap();
+        assert!(is_placeholder_id(app.active_pane().unwrap()));
+        app.handle(key('x')).unwrap();
+        assert!(!app.deferred_input.is_empty(), "input to the placeholder waits for it");
+        assert!(writes_rx.try_recv().is_err());
+
+        drain_until_settled(&mut app, &events);
+        app.sync_layout((200, 40));
+        app.replay_deferred_input().unwrap();
+        assert!(app.create_placeholders.is_empty());
+        let created = app.active_surface().unwrap();
+        assert_ne!(created, original.id);
+        let (written_to, bytes) = writes_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        assert_eq!((written_to, bytes.as_slice()), (created, b"x".as_slice()));
+
+        let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
+        for surface in surfaces {
+            mux.close_surface(surface).unwrap();
+        }
+    }
+
+    #[test]
+    fn closing_a_placeholder_queues_behind_its_resolution_then_closes_the_real_pane() {
+        let (mux, _) = test_mux("close-placeholder-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((200, 40));
+        drain_until_settled(&mut app, &events);
+
+        app.handle(alt('n')).unwrap();
+        let placeholder = app.active_pane().unwrap();
+        assert!(is_placeholder_id(placeholder));
+        // Prefix, then X: close the focused pane, which is the placeholder.
+        app.handle(AppEvent::Input(Event::Key(KeyEvent::new(
+            KeyCode::Char('b'),
+            KeyModifiers::CONTROL,
+        ))))
+        .unwrap();
+        app.handle(AppEvent::Input(Event::Key(KeyEvent::new(
+            KeyCode::Char('X'),
+            KeyModifiers::SHIFT,
+        ))))
+        .unwrap();
+        assert!(!app.deferred_input.is_empty(), "a close aimed at a placeholder queues");
+        assert_eq!(app.tree.active_screen().unwrap().panes.len(), 2);
+
+        drain_until_settled(&mut app, &events);
+        app.sync_layout((200, 40));
+        app.replay_deferred_input().unwrap();
+        drain_until_settled(&mut app, &events);
+        app.sync_layout((200, 40));
+        assert!(app.create_placeholders.is_empty());
+        assert_eq!(
+            app.tree.active_screen().unwrap().panes.len(),
+            1,
+            "the queued close removed the pane the placeholder became"
+        );
+        assert_eq!(app.session.tree().active_screen().unwrap().panes.len(), 1);
+
+        let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
+        for surface in surfaces {
+            mux.close_surface(surface).unwrap();
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -30870,6 +30870,10 @@ mod tests {
         let placeholder = app.active_pane().expect("placeholder takes focus");
         assert!(is_placeholder_id(placeholder));
         assert_eq!(app.tree.active_screen().unwrap().panes.len(), 2);
+        // The overlay may be reapplied before the next authoritative tree
+        // adoption. Reapplying it directly must not duplicate the pane.
+        app.apply_create_placeholders();
+        assert_eq!(app.tree.active_screen().unwrap().panes.len(), 2);
         app.sync_layout((200, 40));
         assert!(app.pane_areas.iter().any(|area| area.pane == placeholder));
         assert_eq!(app.pane_areas.len(), 2);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16654,12 +16654,13 @@ impl App {
             let destination = self.input_destination(&input);
             // Input aimed at a placeholder depends on that placeholder's own
             // create, not merely on the latest one.
-            let placeholder_intent = destination.filter(|id| is_placeholder_id(*id)).and_then(|id| {
-                self.create_placeholders
-                    .iter()
-                    .find(|placeholder| placeholder.surface() == id)
-                    .map(|placeholder| placeholder.intent)
-            });
+            let placeholder_intent =
+                destination.filter(|id| is_placeholder_id(*id)).and_then(|id| {
+                    self.create_placeholders
+                        .iter()
+                        .find(|placeholder| placeholder.surface() == id)
+                        .map(|placeholder| placeholder.intent)
+                });
             let semantic_dependency = if client_owned {
                 None
             } else {
@@ -17004,9 +17005,8 @@ impl App {
         let placeholder =
             self.create_placeholders.iter().find(|placeholder| placeholder.pane() == pane)?;
         match placeholder.kind {
-            CreatePlaceholderKind::Pane { anchor } | CreatePlaceholderKind::Split { anchor, .. } => {
-                Some(anchor)
-            }
+            CreatePlaceholderKind::Pane { anchor }
+            | CreatePlaceholderKind::Split { anchor, .. } => Some(anchor),
             CreatePlaceholderKind::Tab { pane } => Some(pane),
             CreatePlaceholderKind::Workspace => None,
         }
@@ -31039,29 +31039,32 @@ mod tests {
 
     /// A remote session whose creates block until `release` receives a token
     /// per create, then are refused with the PTY-exhausted cause.
-    fn blocked_create_session(
-    ) -> (Session, StdReceiver<Value>, std::sync::mpsc::Sender<()>) {
+    fn blocked_create_session() -> (Session, StdReceiver<Value>, std::sync::mpsc::Sender<()>) {
         let (release_tx, release_rx) = std::sync::mpsc::channel::<()>();
         let release_rx = Mutex::new(release_rx);
         let tree_json = two_pane_tree_json();
-        let (session, requests) = crate::session::test_remote_session_answering(Arc::new(
-            move |request: &Value| match request.get("cmd").and_then(Value::as_str) {
-                Some("list-workspaces") => tree_json.clone(),
-                Some("list-agents") => serde_json::json!({"agents": []}),
-                Some(
-                    "new-pane" | "new-tab" | "split" | "new-workspace"
-                    | "create-surface-with-receipt",
-                ) => {
-                    let _ = release_rx.lock().unwrap().recv();
-                    serde_json::json!({
-                        "__reject": PTY_EXHAUSTED_REJECTION
-                            .strip_prefix("remote command rejected: ")
-                            .unwrap()
-                    })
+        let (session, requests) =
+            crate::session::test_remote_session_answering(Arc::new(move |request: &Value| {
+                match request.get("cmd").and_then(Value::as_str) {
+                    Some("list-workspaces") => tree_json.clone(),
+                    Some("list-agents") => serde_json::json!({"agents": []}),
+                    Some(
+                        "new-pane"
+                        | "new-tab"
+                        | "split"
+                        | "new-workspace"
+                        | "create-surface-with-receipt",
+                    ) => {
+                        let _ = release_rx.lock().unwrap().recv();
+                        serde_json::json!({
+                            "__reject": PTY_EXHAUSTED_REJECTION
+                                .strip_prefix("remote command rejected: ")
+                                .unwrap()
+                        })
+                    }
+                    _ => serde_json::json!({}),
                 }
-                _ => serde_json::json!({}),
-            },
-        ));
+            }));
         session.refresh_tree().unwrap();
         (session, requests, release_tx)
     }
@@ -31109,10 +31112,12 @@ mod tests {
             release.send(()).unwrap();
         }
         drain_until_settled(&mut app, &events);
-        assert!(app.create_placeholders.iter().all(|placeholder| matches!(
-            placeholder.state,
-            CreatePlaceholderState::Failed { .. }
-        )));
+        assert!(
+            app.create_placeholders.iter().all(|placeholder| matches!(
+                placeholder.state,
+                CreatePlaceholderState::Failed { .. }
+            ))
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2244,13 +2244,12 @@ impl OrderedSession {
     fn restore_client_focus_async(&self, client_id: String, epoch: u64) {
         let session = self.inner.clone();
         let events = self.events.clone();
-        let spawn = std::thread::Builder::new().name("client-focus-restore".into()).spawn(
-            move || {
+        let spawn =
+            std::thread::Builder::new().name("client-focus-restore".into()).spawn(move || {
                 if let Some(focus) = session.client_focus(&client_id) {
                     let _ = events.send(AppEvent::ClientFocusRestored { focus, epoch });
                 }
-            },
-        );
+            });
         if spawn.is_err() {
             crate::client_log::stderr_log!(
                 "session",
@@ -2404,7 +2403,7 @@ impl OrderedSession {
         self.inner.has_surface(id)
     }
 
-    fn surface_is_ready_for_input(&self, id: SurfaceId) -> bool {
+    pub(crate) fn surface_is_ready_for_input(&self, id: SurfaceId) -> bool {
         // Remote attach caches its mirror before the initial VT state arrives.
         // The claim outlives that initialization, so cache presence alone is not readiness.
         self.has_surface(id) && !self.surface_attach_claims.lock().unwrap().contains_key(&id)
@@ -5819,6 +5818,17 @@ fn split_ratio_in_node(node: &Node, split: SplitId) -> Option<f32> {
     }
 }
 
+/// A rename the user submitted whose delta has not arrived yet. The name is
+/// overlaid on the adopted tree so the sidebar and tab bar show it at once;
+/// `None` means the user cleared the name (screens and tabs fall back to
+/// their generated label).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+enum PendingRenameTarget {
+    Workspace(WorkspaceId),
+    Screen(ScreenId),
+    Surface(SurfaceId),
+}
+
 /// Mouse drag in progress.
 enum Drag {
     /// Left press on a tab chip; becomes `Tab` after moving cells.
@@ -7337,6 +7347,7 @@ pub struct App {
     /// `client-focus` answers (see `AppEvent::ClientFocusRestored`).
     client_focus_epoch: u64,
     split_drag_preview: Option<SplitDragPreview>,
+    pending_renames: HashMap<PendingRenameTarget, Option<String>>,
     /// Terminal cells actually represented by the last rendered snapshot.
     /// Foreign-viewer padding outside these bounds is display-only.
     pub(crate) rendered_terminal_bounds: HashMap<SurfaceId, Rect>,
@@ -9621,6 +9632,7 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         client_focus_id: client_focus_identity(),
         client_focus_epoch: 0,
         split_drag_preview: None,
+        pending_renames: HashMap::new(),
         rendered_terminal_bounds: HashMap::new(),
         rendered_kitty_graphics: HashMap::new(),
         visible_size_surfaces: HashSet::new(),
@@ -14761,6 +14773,7 @@ impl App {
         }
         self.pane_areas.clear();
         self.reconcile_split_drag_preview();
+        self.apply_pending_renames();
         let Some(mut screen) = self.tree.active_screen().cloned() else {
             self.viewport_projection.clear();
             self.viewport_layout.clear();
@@ -19603,12 +19616,26 @@ impl App {
         match prompt.target {
             PromptTarget::Workspace(id) => {
                 if !input.is_empty() {
+                    self.pending_renames
+                        .insert(PendingRenameTarget::Workspace(id), Some(input.clone()));
                     self.request_rename_workspace(id, input);
                 }
             }
             // Empty screen/tab names clear back to the default.
-            PromptTarget::Screen(id) => self.session.rename_screen(id, input),
-            PromptTarget::Surface(id) => self.session.rename_surface(id, input),
+            PromptTarget::Screen(id) => {
+                self.pending_renames.insert(
+                    PendingRenameTarget::Screen(id),
+                    (!input.is_empty()).then(|| input.clone()),
+                );
+                self.session.rename_screen(id, input);
+            }
+            PromptTarget::Surface(id) => {
+                self.pending_renames.insert(
+                    PendingRenameTarget::Surface(id),
+                    (!input.is_empty()).then(|| input.clone()),
+                );
+                self.session.rename_surface(id, input);
+            }
             PromptTarget::ConnectMachine(_)
             | PromptTarget::ClientMachine(_)
             | PromptTarget::ManagedMachine(_)
@@ -23762,14 +23789,88 @@ impl App {
         match self.split_drag_preview {
             Some(preview) if !preview.committed => {
                 if self.prepare_pty_input_before_mutation() {
-                    self.split_drag_preview =
-                        Some(SplitDragPreview { committed: true, ..preview });
+                    self.split_drag_preview = Some(SplitDragPreview { committed: true, ..preview });
                     self.session.set_split_ratio(preview.split, preview.ratio);
                 } else {
                     self.split_drag_preview = None;
                 }
             }
             _ => self.session.settle_split_ratio(),
+        }
+    }
+
+    /// Overlay submitted renames on the adopted tree until the authoritative
+    /// tree carries them. A pending rename is dropped once the tree agrees,
+    /// once every mutation has settled and the tree is current (the rename
+    /// was refused), or when its target no longer exists.
+    fn apply_pending_renames(&mut self) {
+        if self.pending_renames.is_empty() {
+            return;
+        }
+        let settled = !self.session.has_pending_mutations() && !self.session.remote_tree_is_stale();
+        let targets = self.pending_renames.keys().copied().collect::<Vec<_>>();
+        for target in targets {
+            let Some(pending) = self.pending_renames.get(&target).cloned() else { continue };
+            let current: Option<Option<String>> = match target {
+                PendingRenameTarget::Workspace(id) => self
+                    .tree
+                    .workspaces
+                    .iter()
+                    .find(|workspace| workspace.id == id)
+                    .map(|workspace| Some(workspace.name.clone())),
+                PendingRenameTarget::Screen(id) => self
+                    .tree
+                    .workspaces
+                    .iter()
+                    .flat_map(|workspace| workspace.screens.iter())
+                    .find(|screen| screen.id == id)
+                    .map(|screen| screen.name.clone()),
+                PendingRenameTarget::Surface(id) => {
+                    self.tree.surface(id).map(|tab| tab.name.clone())
+                }
+            };
+            let Some(current) = current else {
+                self.pending_renames.remove(&target);
+                continue;
+            };
+            if current == pending || settled {
+                self.pending_renames.remove(&target);
+                continue;
+            }
+            match target {
+                PendingRenameTarget::Workspace(id) => {
+                    if let Some(workspace) =
+                        self.tree.workspaces.iter_mut().find(|workspace| workspace.id == id)
+                        && let Some(name) = pending
+                    {
+                        workspace.name = name;
+                    }
+                }
+                PendingRenameTarget::Screen(id) => {
+                    if let Some(screen) = self
+                        .tree
+                        .workspaces
+                        .iter_mut()
+                        .flat_map(|workspace| workspace.screens.iter_mut())
+                        .find(|screen| screen.id == id)
+                    {
+                        screen.name = pending;
+                    }
+                }
+                PendingRenameTarget::Surface(id) => {
+                    if let Some(tab) = self
+                        .tree
+                        .workspaces
+                        .iter_mut()
+                        .flat_map(|workspace| workspace.screens.iter_mut())
+                        .flat_map(|screen| screen.panes.iter_mut())
+                        .flat_map(|pane| pane.tabs.iter_mut())
+                        .find(|tab| tab.surface == id)
+                    {
+                        tab.name = pending;
+                    }
+                }
+            }
         }
     }
 
@@ -23791,8 +23892,7 @@ impl App {
             .tree
             .active_screen()
             .and_then(|screen| split_ratio_in_node(&screen.layout, preview.split));
-        let settled =
-            !self.session.has_pending_mutations() && !self.session.remote_tree_is_stale();
+        let settled = !self.session.has_pending_mutations() && !self.session.remote_tree_is_stale();
         let drop = match tree_ratio {
             None => true,
             Some(ratio) if (ratio - preview.ratio).abs() < 1e-3 => true,
@@ -25082,24 +25182,23 @@ mod tests {
         HostInputMessage, HostInputRuntime, MachineActionWorker, MachineConnectRoute, MenuAction,
         MenuItem, MutationImpact, MuxTitleIngress, OmnibarHit, OmnibarState, OrderedSession,
         OuterCursorSpec, PaneArea, PaneAreaProjection, PaneContentGeneration, PaneEdge,
-        PaneFocusHistory, PaneResizeDragTarget, PaneViewportClip, PendingSessionMutation,
-        PendingSessionMutationState, PointerHitIdentity, PointerRouteIdentity, PointerRoutePhase,
-        Prompt, PromptTarget, PtyFailureIngress, PtyMousePressResult, RailKind, RenderAction,
-        RenderedMenuLevel, RenderedPaneRoute, RenderedPointerFrame, Selection, SelectionMode,
-        SessionCompletion, SessionCompletionAction, SessionEventSender, ShortcutHelp,
-        SidebarActionTarget, SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState,
-        SidebarWidthOverrides, SplitDragPreview, StatusTemplateValues, StatusWorkerStop,
-        StdoutLock,
-        SurfaceAttachClaimState, SurfaceResizeDecision, SurfaceResizeOwnership,
-        TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer, TerminalPointerAdmission,
-        TerminalPointerAdmissionResult, TerminalPointerEncoding, TextInput, Toast,
-        VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
-        WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
-        browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
-        canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
-        client_menu_item, clip_horizontal_rect, content_size_for_rect,
-        disable_host_keyboard_protocol, enable_host_keyboard_protocol, expand_status_tokens,
-        first_pane_by_id, forward_host_input, forward_mux_event, forward_mux_events,
+        PaneFocusHistory, PaneResizeDragTarget, PaneViewportClip, PendingRenameTarget,
+        PendingSessionMutation, PendingSessionMutationState, PointerHitIdentity,
+        PointerRouteIdentity, PointerRoutePhase, Prompt, PromptTarget, PtyFailureIngress,
+        PtyMousePressResult, RailKind, RenderAction, RenderedMenuLevel, RenderedPaneRoute,
+        RenderedPointerFrame, Selection, SelectionMode, SessionCompletion, SessionCompletionAction,
+        SessionEventSender, ShortcutHelp, SidebarActionTarget, SidebarLayout,
+        SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarWidthOverrides, SplitDragPreview,
+        StatusTemplateValues, StatusWorkerStop, StdoutLock, SurfaceAttachClaimState,
+        SurfaceResizeDecision, SurfaceResizeOwnership, TERMINAL_PAINT_CADENCE, TerminalInput,
+        TerminalPaintPacer, TerminalPointerAdmission, TerminalPointerAdmissionResult,
+        TerminalPointerEncoding, TextInput, Toast, VIEWPORT_ANIMATION_DURATION, ViewportMotion,
+        ViewportPaneAreaProjection, WorkspaceRailSelection, action_available_in_mode,
+        browser_content_size_for_rect, browser_frame_source_crop, browser_hover_forward_allowed,
+        browser_source_crop, canonical_terminal_content, catch_renderer_panic,
+        clamp_split_ratio_for_tab_bars, client_menu_item, clip_horizontal_rect,
+        content_size_for_rect, disable_host_keyboard_protocol, enable_host_keyboard_protocol,
+        expand_status_tokens, first_pane_by_id, forward_host_input, forward_mux_event, forward_mux_events,
         host_mouse_capture_escape_if_changed, host_startup_input_modes,
         initial_applied_outer_cursor, initial_host_mouse_capture, keyboard_protocol_accepts,
         layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,
@@ -29908,7 +30007,11 @@ mod tests {
         let preview = app.split_drag_preview.expect("motion records a local preview");
         assert_eq!(preview.split, split);
         assert!(!preview.committed);
-        assert!(preview.ratio < 0.4, "pointer at x=25 of 100 must move the divider left: {}", preview.ratio);
+        assert!(
+            preview.ratio < 0.4,
+            "pointer at x=25 of 100 must move the divider left: {}",
+            preview.ratio
+        );
 
         // The preview drives layout while the drag is in progress.
         app.sync_layout((100, 20));
@@ -29966,8 +30069,7 @@ mod tests {
     fn committed_split_preview_holds_until_the_tree_carries_the_ratio() {
         let (mut app, events, mux, split, _first) =
             split_drag_test_app("split-drag-preview-hold-test");
-        app.split_drag_preview =
-            Some(SplitDragPreview { split, ratio: 0.3, committed: true });
+        app.split_drag_preview = Some(SplitDragPreview { split, ratio: 0.3, committed: true });
         // The authoritative tree still says 0.5 and a mutation is pending: the
         // preview holds so the divider does not snap back for a frame.
         app.session.pending_mutations.fetch_add(1, Ordering::AcqRel);
@@ -29989,10 +30091,14 @@ mod tests {
         let tree_json = serde_json::json!({
             "workspaces": [{
                 "id": 1, "name": "one", "active": true,
+                "resource_id": "ws_00000000000000000000000000000001",
                 "screens": [{
                     "id": 2, "active": true, "active_pane": 3,
+                    "resource_id": "screen_00000000000000000000000000000002",
                     "layout": {"type": "leaf", "pane": 3},
-                    "panes": [{"id": 3, "tabs": [
+                    "panes": [{"id": 3,
+                        "resource_id": "pane_00000000000000000000000000000003",
+                        "tabs": [
                         {"surface": 7, "title": "a", "kind": "pty"},
                         {"surface": 8, "title": "b", "kind": "pty"}
                     ]}]
@@ -30002,14 +30108,15 @@ mod tests {
         // The daemon's tab-added delta has already been applied to the cache
         // (here: the snapshot already contains surface 8), and the create
         // response names that surface.
-        let (session, requests) = crate::session::test_remote_session_answering(Arc::new(
-            move |request: &Value| match request.get("cmd").and_then(Value::as_str) {
-                Some("list-workspaces") => tree_json.clone(),
-                Some("list-agents") => serde_json::json!({"agents": []}),
-                Some("new-tab") => serde_json::json!({"surface": 8}),
-                _ => serde_json::json!({}),
-            },
-        ));
+        let (session, requests) =
+            crate::session::test_remote_session_answering(Arc::new(move |request: &Value| {
+                match request.get("cmd").and_then(Value::as_str) {
+                    Some("list-workspaces") => tree_json.clone(),
+                    Some("list-agents") => serde_json::json!({"agents": []}),
+                    Some("new-tab") => serde_json::json!({"surface": 8}),
+                    _ => serde_json::json!({}),
+                }
+            }));
         session.refresh_tree().unwrap();
         let (mut app, events) = test_app_with_events(session);
         app.sidebar_visible = false;
@@ -30021,12 +30128,29 @@ mod tests {
         while !settled {
             let event = events.recv_timeout(Duration::from_secs(2)).unwrap();
             if let AppEvent::SessionMutationSettled { outcome, .. } = &event {
+                let described = match outcome {
+                    super::SessionMutationOutcome::AuthoritativeMutationSucceeded { .. } => None,
+                    super::SessionMutationOutcome::CommittedTreeStale { error, .. } => {
+                        Some(format!("CommittedTreeStale({error:?})"))
+                    }
+                    super::SessionMutationOutcome::Failed(error) => {
+                        Some(format!("Failed({error})"))
+                    }
+                    super::SessionMutationOutcome::MutationTimedOut(error) => {
+                        Some(format!("MutationTimedOut({error})"))
+                    }
+                    super::SessionMutationOutcome::CreationResponseAmbiguous(error) => {
+                        Some(format!("CreationResponseAmbiguous({error})"))
+                    }
+                    super::SessionMutationOutcome::SemanticIntent { .. } => {
+                        Some("SemanticIntent".to_string())
+                    }
+                    _ => Some("other outcome".to_string()),
+                };
                 assert!(
-                    matches!(
-                        outcome,
-                        super::SessionMutationOutcome::AuthoritativeMutationSucceeded { .. }
-                    ),
-                    "expected the cached tree to be authoritative without a refetch"
+                    described.is_none(),
+                    "expected the cached tree to be authoritative without a refetch, got {}",
+                    described.unwrap_or_default()
                 );
                 settled = true;
             }
@@ -30039,6 +30163,95 @@ mod tests {
             "the create must not refetch the tree it already has: {later:?}"
         );
         assert_eq!(app.tree.active_surface(), Some(8), "the created tab is selected");
+    }
+
+    #[test]
+    fn submitted_tab_rename_shows_at_once_and_yields_to_the_authoritative_name() {
+        let (mux, surface) = test_mux("pending-rename-overlay-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((80, 20));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        assert_eq!(app.tree.surface(surface.id).unwrap().name, None);
+
+        // Submitting the rename overlays the typed name before any mutation
+        // has settled, even though the session tree still has no name.
+        app.pending_renames
+            .insert(PendingRenameTarget::Surface(surface.id), Some("logs".to_string()));
+        app.session.pending_mutations.fetch_add(1, Ordering::AcqRel);
+        app.sync_layout((80, 20));
+        assert_eq!(app.tree.surface(surface.id).unwrap().name.as_deref(), Some("logs"));
+        assert_eq!(app.session.tree().surface(surface.id).unwrap().name, None);
+        app.session.pending_mutations.fetch_sub(1, Ordering::AcqRel);
+
+        app.session.rename_surface(surface.id, "logs".to_string());
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        app.sync_layout((80, 20));
+        assert!(app.pending_renames.is_empty(), "the tree agrees; the overlay must drop");
+        assert_eq!(app.tree.surface(surface.id).unwrap().name.as_deref(), Some("logs"));
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn refused_rename_overlay_drops_once_mutations_settle() {
+        let (mux, surface) = test_mux("pending-rename-refused-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((80, 20));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        app.pending_renames
+            .insert(PendingRenameTarget::Surface(surface.id), Some("never".to_string()));
+        // Nothing is pending and the tree is current, so the rename was
+        // refused or lost: the overlay must not stick.
+        app.sync_layout((80, 20));
+        assert!(app.pending_renames.is_empty());
+        assert_eq!(app.tree.surface(surface.id).unwrap().name, None);
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn attaching_pane_shows_a_starting_line_instead_of_an_empty_grid() {
+        let surface = 7;
+        let (session, attach_started, _release_attach) = test_remote_session_with_deferred_attach();
+        crate::session::test_seed_remote_tree(&session, notify_tree(surface, false));
+        let (mut app, _events) = test_app_with_events(session);
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        let mut terminal = Terminal::new(TestBackend::new(60, 12)).unwrap();
+        app.sync_layout((60, 12));
+        // Layout queues the attach; the deferred writer holds it before the
+        // first frame, so the pane has either no mirror yet or a mirror with
+        // its attach claim outstanding. Both must read as starting.
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(
+            text.contains(localization::catalog().terminal.pane_starting),
+            "attaching pane must say it is starting:\n{text}"
+        );
+        attach_started.recv_timeout(Duration::from_secs(2)).unwrap();
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(
+            text.contains(localization::catalog().terminal.pane_starting),
+            "attaching pane must say it is starting:\n{text}"
+        );
+    }
+
+    #[test]
+    fn pane_lifecycle_text_prefers_exit_over_pending_attach() {
+        use crate::ui::pane::{PaneLifecycleText, pane_lifecycle_text};
+        assert_eq!(pane_lifecycle_text(false, true), None);
+        assert_eq!(pane_lifecycle_text(false, false), Some(PaneLifecycleText::Starting));
+        assert_eq!(pane_lifecycle_text(true, true), Some(PaneLifecycleText::Exited));
+        assert_eq!(pane_lifecycle_text(true, false), Some(PaneLifecycleText::Exited));
     }
 
     #[test]
@@ -46472,6 +46685,7 @@ mod tests {
             client_focus_id: None,
             client_focus_epoch: 0,
             split_drag_preview: None,
+            pending_renames: HashMap::new(),
             rendered_terminal_bounds: HashMap::new(),
             rendered_kitty_graphics: HashMap::new(),
             visible_size_surfaces: HashSet::new(),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2817,10 +2817,57 @@ impl OrderedSession {
         label: &'static str,
         operation: impl FnOnce(Session) -> anyhow::Result<()> + Send + 'static,
     ) {
-        self.enqueue_with_completion(label, MutationImpact::Destination, move |session| {
-            operation(session)?;
-            Ok(None)
-        });
+        self.enqueue_destination_mutation_targeting(
+            label,
+            crate::pty_input::MutationTargets::new(),
+            operation,
+        );
+    }
+
+    /// A destination mutation that destroys `targets`. Input to those
+    /// surfaces is ordered around the mutation on the PTY input worker; input
+    /// to every other surface is not (see `pty_input` module docs).
+    fn enqueue_destination_mutation_targeting(
+        &self,
+        label: &'static str,
+        targets: crate::pty_input::MutationTargets,
+        operation: impl FnOnce(Session) -> anyhow::Result<()> + Send + 'static,
+    ) {
+        self.enqueue_with_completion_internal(
+            label,
+            MutationImpact::Destination,
+            None,
+            None,
+            targets,
+            move |session| {
+                operation(session)?;
+                Ok(None)
+            },
+        );
+    }
+
+    fn surfaces_in_pane(&self, pane: PaneId) -> crate::pty_input::MutationTargets {
+        self.inner
+            .tree()
+            .workspaces
+            .iter()
+            .flat_map(|workspace| workspace.screens.iter())
+            .flat_map(|screen| screen.panes.iter())
+            .filter(|candidate| candidate.id == pane)
+            .flat_map(|pane| pane.tabs.iter().map(|tab| tab.surface))
+            .collect()
+    }
+
+    fn surfaces_in_workspace(&self, workspace: WorkspaceId) -> crate::pty_input::MutationTargets {
+        self.inner
+            .tree()
+            .workspaces
+            .iter()
+            .filter(|candidate| candidate.id == workspace)
+            .flat_map(|workspace| workspace.screens.iter())
+            .flat_map(|screen| screen.panes.iter())
+            .flat_map(|pane| pane.tabs.iter().map(|tab| tab.surface))
+            .collect()
     }
 
     fn enqueue_with_completion(
@@ -2843,7 +2890,14 @@ impl OrderedSession {
         + Send
         + 'static,
     ) {
-        self.enqueue_with_completion_internal(label, impact, semantic_intent, None, operation);
+        self.enqueue_with_completion_internal(
+            label,
+            impact,
+            semantic_intent,
+            None,
+            crate::pty_input::MutationTargets::new(),
+            operation,
+        );
     }
 
     fn enqueue_creation_with_completion_for_semantic_intent(
@@ -2868,6 +2922,7 @@ impl OrderedSession {
             MutationImpact::Destination,
             semantic_intent,
             Some(kind),
+            crate::pty_input::MutationTargets::new(),
             move |session| {
                 let surface = operation(session)?;
                 Ok(Some(kind.completion(surface)))
@@ -2881,6 +2936,7 @@ impl OrderedSession {
         impact: MutationImpact,
         semantic_intent: Option<u64>,
         creation_attempt: Option<CreationCompletionKind>,
+        target_surfaces: crate::pty_input::MutationTargets,
         operation: impl FnOnce(Session) -> anyhow::Result<Option<SessionCompletionAction>>
         + Send
         + 'static,
@@ -2895,8 +2951,9 @@ impl OrderedSession {
             .then(|| self.destination_mutation_started.fetch_add(1, Ordering::AcqRel) + 1);
         let destination_mutation_committed = self.destination_mutation_committed.clone();
         let settlement = pending.clone();
-        self.operations.enqueue_session_mutation_with_settlement(
+        self.operations.enqueue_session_mutation_with_settlement_targeting(
             label,
+            target_surfaces,
             self.remote,
             move || settlement.publish_deferred(),
             move || {
@@ -3568,7 +3625,17 @@ impl OrderedSession {
     }
 
     pub fn close_screen(&self, screen: ScreenId) {
-        self.enqueue_destination_mutation("close screen", move |session| {
+        let targets = self
+            .inner
+            .tree()
+            .workspaces
+            .iter()
+            .flat_map(|workspace| workspace.screens.iter())
+            .filter(|candidate| candidate.id == screen)
+            .flat_map(|screen| screen.panes.iter())
+            .flat_map(|pane| pane.tabs.iter().map(|tab| tab.surface))
+            .collect();
+        self.enqueue_destination_mutation_targeting("close screen", targets, move |session| {
             session.close_screen(screen)
         });
     }
@@ -3725,9 +3792,11 @@ impl OrderedSession {
     }
 
     pub fn close_surface(&self, surface: SurfaceId) {
-        self.enqueue_destination_mutation("close tab", move |session| {
-            session.close_surface(surface)
-        });
+        self.enqueue_destination_mutation_targeting(
+            "close tab",
+            std::iter::once(surface).collect(),
+            move |session| session.close_surface(surface),
+        );
     }
 
     pub fn clear_history(
@@ -3788,7 +3857,11 @@ impl OrderedSession {
     }
 
     pub fn close_pane(&self, pane: PaneId) {
-        self.enqueue_destination_mutation("close pane", move |session| session.close_pane(pane));
+        self.enqueue_destination_mutation_targeting(
+            "close pane",
+            self.surfaces_in_pane(pane),
+            move |session| session.close_pane(pane),
+        );
     }
 
     pub fn swap_pane(&self, pane: PaneId, target: PaneId) {
@@ -3796,9 +3869,11 @@ impl OrderedSession {
     }
 
     pub fn close_workspace(&self, workspace: WorkspaceId) {
-        self.enqueue_destination_mutation("close workspace", move |session| {
-            session.close_workspace(workspace)
-        });
+        self.enqueue_destination_mutation_targeting(
+            "close workspace",
+            self.surfaces_in_workspace(workspace),
+            move |session| session.close_workspace(workspace),
+        );
     }
 
     pub fn mark_workspaces_provider_managed(&self) -> anyhow::Result<()> {
@@ -3810,9 +3885,11 @@ impl OrderedSession {
     }
 
     pub fn close_provider_managed_workspace(&self, workspace: WorkspaceId, key: String) {
-        self.enqueue_destination_mutation("close managed workspace", move |session| {
-            session.close_provider_managed_workspace(workspace, key)
-        });
+        self.enqueue_destination_mutation_targeting(
+            "close managed workspace",
+            self.surfaces_in_workspace(workspace),
+            move |session| session.close_provider_managed_workspace(workspace, key),
+        );
     }
 
     pub fn rename_surface(&self, surface: SurfaceId, name: String) {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -30536,11 +30536,18 @@ mod tests {
         let (mut app, _events) = test_app_with_events(Session::Local(mux.clone()));
         let (started_tx, started_rx) = std::sync::mpsc::channel();
         let (unblock_tx, unblock_rx) = std::sync::mpsc::channel();
-        app.session.operations.enqueue_session_mutation("block input lane", false, move || {
-            started_tx.send(()).unwrap();
-            let _ = unblock_rx.recv();
-            Ok(())
-        });
+        // A session mutation blocks only the surfaces it names, so the blocker
+        // must target this surface for the fallback operations to stay queued.
+        app.session.operations.enqueue_session_mutation_targeting(
+            "block input lane",
+            &[surface.id],
+            false,
+            move || {
+                started_tx.send(()).unwrap();
+                let _ = unblock_rx.recv();
+                Ok(())
+            },
+        );
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
 
         let fallback_key = KeyInput { utf8: "x".repeat(1024), ..Default::default() };

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24145,6 +24145,8 @@ impl App {
         if expired.is_empty() {
             return false;
         }
+        let retired =
+            expired.iter().map(|(intent, _)| placeholder_id(*intent)).collect::<HashSet<_>>();
         for (intent, prior_focus) in expired {
             self.create_placeholders.retain(|placeholder| placeholder.intent != intent);
             if let Some(prior) = prior_focus
@@ -24153,8 +24155,9 @@ impl App {
                 self.pane_focus_history.record(prior);
             }
         }
-        self.deferred_input
-            .retain(|input| !input.admission.destination.is_some_and(is_placeholder_id));
+        self.deferred_input.retain(|input| {
+            !input.admission.destination.is_some_and(|surface| retired.contains(&surface))
+        });
         self.rebuild_tab_locations();
         true
     }
@@ -24191,6 +24194,11 @@ impl App {
         for placeholder in placeholders {
             let pane_id = placeholder.pane();
             let surface = placeholder.surface();
+            // The overlay persists in `self.tree` until the next adoption, so
+            // redraws must not insert the same placeholder more than once.
+            if self.tree.pane(pane_id).is_some() || self.tree.surface(surface).is_some() {
+                continue;
+            }
             let split_id: SplitId = placeholder_id(placeholder.intent);
             let focus_follows = self.active_pane() == placeholder.prior_focus;
             let mut placed = false;
@@ -30756,6 +30764,10 @@ mod tests {
         app.sync_layout((200, 40));
         assert!(app.pane_areas.iter().any(|area| area.pane == placeholder));
         assert_eq!(app.pane_areas.len(), 2);
+        // A second frame must not insert the client-local placeholder again.
+        app.sync_layout((200, 40));
+        assert_eq!(app.tree.active_screen().unwrap().panes.len(), 2);
+        assert_eq!(app.pane_areas.len(), 2);
 
         while app.session.has_pending_mutations() {
             app.handle(events.recv_timeout(Duration::from_secs(5)).unwrap()).unwrap();
@@ -30833,6 +30845,25 @@ mod tests {
         .unwrap();
         assert!(!app.deferred_input.is_empty(), "input to the placeholder must be deferred");
 
+        // Keep a second create pending with its own deferred input. Expiring
+        // the first placeholder must not discard input for the second one.
+        let second_intent = 2;
+        let second_surface = placeholder_id(second_intent);
+        app.create_placeholders.push(CreatePlaceholder {
+            intent: second_intent,
+            kind: CreatePlaceholderKind::Tab { pane: 3 },
+            workspace: Some(1),
+            screen: Some(2),
+            prior_focus: Some(3),
+            state: CreatePlaceholderState::Pending,
+            timed_out_cause: None,
+        });
+        app.deferred_input.push_back(queued_input(
+            KeyEvent::new(KeyCode::Char('y'), KeyModifiers::NONE),
+            Some(second_surface),
+            2,
+        ));
+
         let mut failed = false;
         while !failed {
             let event = events.recv_timeout(Duration::from_secs(5)).unwrap();
@@ -30864,7 +30895,11 @@ mod tests {
             *since = Instant::now() - super::DURABLE_NOTICE_DISPLAY_DURATION;
         }
         assert!(app.expire_failed_create_placeholders());
-        assert!(app.create_placeholders.is_empty());
+        assert_eq!(app.create_placeholders.len(), 1);
+        assert_eq!(app.deferred_input.len(), 1);
+        assert_eq!(app.deferred_input.front().unwrap().admission.destination, Some(second_surface));
+        app.create_placeholders.clear();
+        app.deferred_input.clear();
         app.sync_layout((200, 40));
         assert_eq!(app.active_pane(), Some(3));
         assert_eq!(app.pane_areas.len(), 1);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1331,6 +1331,32 @@ enum SessionCompletionAction {
     LayoutUndoStale,
 }
 
+/// True when the remote session's cached tree already reflects a committed
+/// mutation: a created surface is present, or every destroyed surface is gone,
+/// and no `tree-changed` resync is pending. Mutations with neither a created
+/// nor a destroyed surface (renames, layout) always refetch.
+fn remote_postcondition_visible(
+    session: &Session,
+    completion: Option<&SessionCompletion>,
+    destroyed_surfaces: &crate::pty_input::MutationTargets,
+) -> bool {
+    if session.remote_tree_is_stale() {
+        return false;
+    }
+    let tree = session.tree();
+    match completion.map(|completion| &completion.action) {
+        Some(
+            SessionCompletionAction::SurfaceCreated { surface }
+            | SessionCompletionAction::BrowserTabCreated { surface },
+        ) => tree.surface(*surface).is_some(),
+        Some(_) => false,
+        None if !destroyed_surfaces.is_empty() => {
+            destroyed_surfaces.iter().all(|surface| tree.surface(*surface).is_none())
+        }
+        None => false,
+    }
+}
+
 fn layout_undo_error_completion(error: &anyhow::Error) -> Option<SessionCompletionAction> {
     match error.downcast_ref::<LayoutUndoError>() {
         Some(LayoutUndoError::Unavailable) => Some(SessionCompletionAction::LayoutUndoUnavailable),
@@ -2980,6 +3006,7 @@ impl OrderedSession {
             .then(|| self.destination_mutation_started.fetch_add(1, Ordering::AcqRel) + 1);
         let destination_mutation_committed = self.destination_mutation_committed.clone();
         let settlement = pending.clone();
+        let destroyed_surfaces = target_surfaces.clone();
         self.operations.enqueue_session_mutation_with_settlement_targeting(
             label,
             target_surfaces,
@@ -3022,13 +3049,33 @@ impl OrderedSession {
                     semantic_intent,
                     action,
                 });
-                session.invalidate_remote_tree();
                 if remote {
-                    pending.defer(SessionMutationOutcome::CommittedTreeStale {
-                        error: None,
-                        completion,
-                    });
+                    // Tree deltas that arrived before this response may
+                    // already show the outcome; then the cached tree is the
+                    // authoritative result and no refetch is needed. Any
+                    // pending `tree-changed` keeps the refetch path.
+                    if remote_postcondition_visible(
+                        &session,
+                        completion.as_ref(),
+                        &destroyed_surfaces,
+                    ) {
+                        let destination_generation =
+                            destination_mutation_committed.load(Ordering::Acquire);
+                        pending.defer(SessionMutationOutcome::AuthoritativeMutationSucceeded {
+                            tree: session.tree(),
+                            authoritative_generation: mutation_generation,
+                            destination_generation,
+                            completion,
+                        });
+                    } else {
+                        session.invalidate_remote_tree();
+                        pending.defer(SessionMutationOutcome::CommittedTreeStale {
+                            error: None,
+                            completion,
+                        });
+                    }
                 } else {
+                    session.invalidate_remote_tree();
                     match session.refresh_tree() {
                         Ok(tree) => {
                             let destination_generation =
@@ -25047,8 +25094,7 @@ mod tests {
         TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer, TerminalPointerAdmission,
         TerminalPointerAdmissionResult, TerminalPointerEncoding, TextInput, Toast,
         VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
-        WorkspaceRailSelection, action_available_in_mode, apply_split_ratio_preview,
-        browser_content_size_for_rect,
+        WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
         browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
         canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
         client_menu_item, clip_horizontal_rect, content_size_for_rect,
@@ -29936,6 +29982,63 @@ mod tests {
         app.sync_layout((100, 20));
         assert!(app.split_drag_preview.is_none(), "tree agrees; preview must clear");
         close_all_surfaces(&mux);
+    }
+
+    #[test]
+    fn remote_creation_skips_the_refetch_when_the_cached_tree_already_shows_it() {
+        let tree_json = serde_json::json!({
+            "workspaces": [{
+                "id": 1, "name": "one", "active": true,
+                "screens": [{
+                    "id": 2, "active": true, "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{"id": 3, "tabs": [
+                        {"surface": 7, "title": "a", "kind": "pty"},
+                        {"surface": 8, "title": "b", "kind": "pty"}
+                    ]}]
+                }]
+            }]
+        });
+        // The daemon's tab-added delta has already been applied to the cache
+        // (here: the snapshot already contains surface 8), and the create
+        // response names that surface.
+        let (session, requests) = crate::session::test_remote_session_answering(Arc::new(
+            move |request: &Value| match request.get("cmd").and_then(Value::as_str) {
+                Some("list-workspaces") => tree_json.clone(),
+                Some("list-agents") => serde_json::json!({"agents": []}),
+                Some("new-tab") => serde_json::json!({"surface": 8}),
+                _ => serde_json::json!({}),
+            },
+        ));
+        session.refresh_tree().unwrap();
+        let (mut app, events) = test_app_with_events(session);
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        for _ in requests.try_iter() {}
+
+        app.session.new_tab_for_semantic_intent(Some(3), None, Vec::new(), None).unwrap();
+        let mut settled = false;
+        while !settled {
+            let event = events.recv_timeout(Duration::from_secs(2)).unwrap();
+            if let AppEvent::SessionMutationSettled { outcome, .. } = &event {
+                assert!(
+                    matches!(
+                        outcome,
+                        super::SessionMutationOutcome::AuthoritativeMutationSucceeded { .. }
+                    ),
+                    "expected the cached tree to be authoritative without a refetch"
+                );
+                settled = true;
+            }
+            app.handle(event).unwrap();
+        }
+        let later = requests.try_iter().collect::<Vec<_>>();
+        assert!(later.iter().any(|request| request["cmd"] == "new-tab"));
+        assert!(
+            later.iter().all(|request| request["cmd"] != "list-workspaces"),
+            "the create must not refetch the tree it already has: {later:?}"
+        );
+        assert_eq!(app.tree.active_surface(), Some(8), "the created tab is selected");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2903,7 +2903,7 @@ impl OrderedSession {
     fn surfaces_in_pane(&self, pane: PaneId) -> crate::pty_input::MutationTargets {
         self.inner
             .tree()
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .flat_map(|screen| screen.panes.iter())
@@ -2915,7 +2915,7 @@ impl OrderedSession {
     fn surfaces_in_workspace(&self, workspace: WorkspaceId) -> crate::pty_input::MutationTargets {
         self.inner
             .tree()
-            .workspaces
+            .workspaces()
             .iter()
             .filter(|candidate| candidate.id == workspace)
             .flat_map(|workspace| workspace.screens.iter())
@@ -3703,7 +3703,7 @@ impl OrderedSession {
         let targets = self
             .inner
             .tree()
-            .workspaces
+            .workspaces()
             .iter()
             .flat_map(|workspace| workspace.screens.iter())
             .filter(|candidate| candidate.id == screen)
@@ -23814,13 +23814,13 @@ impl App {
             let current: Option<Option<String>> = match target {
                 PendingRenameTarget::Workspace(id) => self
                     .tree
-                    .workspaces
+                    .workspaces()
                     .iter()
                     .find(|workspace| workspace.id == id)
                     .map(|workspace| Some(workspace.name.clone())),
                 PendingRenameTarget::Screen(id) => self
                     .tree
-                    .workspaces
+                    .workspaces()
                     .iter()
                     .flat_map(|workspace| workspace.screens.iter())
                     .find(|screen| screen.id == id)
@@ -23840,7 +23840,7 @@ impl App {
             match target {
                 PendingRenameTarget::Workspace(id) => {
                     if let Some(workspace) =
-                        self.tree.workspaces.iter_mut().find(|workspace| workspace.id == id)
+                        self.tree.workspaces_mut().iter_mut().find(|workspace| workspace.id == id)
                         && let Some(name) = pending
                     {
                         workspace.name = name;
@@ -23849,7 +23849,7 @@ impl App {
                 PendingRenameTarget::Screen(id) => {
                     if let Some(screen) = self
                         .tree
-                        .workspaces
+                        .workspaces_mut()
                         .iter_mut()
                         .flat_map(|workspace| workspace.screens.iter_mut())
                         .find(|screen| screen.id == id)
@@ -23860,7 +23860,7 @@ impl App {
                 PendingRenameTarget::Surface(id) => {
                     if let Some(tab) = self
                         .tree
-                        .workspaces
+                        .workspaces_mut()
                         .iter_mut()
                         .flat_map(|workspace| workspace.screens.iter_mut())
                         .flat_map(|screen| screen.panes.iter_mut())
@@ -25198,8 +25198,8 @@ mod tests {
         browser_source_crop, canonical_terminal_content, catch_renderer_panic,
         clamp_split_ratio_for_tab_bars, client_menu_item, clip_horizontal_rect,
         content_size_for_rect, disable_host_keyboard_protocol, enable_host_keyboard_protocol,
-        expand_status_tokens, first_pane_by_id, forward_host_input, forward_mux_event, forward_mux_events,
-        host_mouse_capture_escape_if_changed, host_startup_input_modes,
+        expand_status_tokens, first_pane_by_id, forward_host_input, forward_mux_event,
+        forward_mux_events, host_mouse_capture_escape_if_changed, host_startup_input_modes,
         initial_applied_outer_cursor, initial_host_mouse_capture, keyboard_protocol_accepts,
         layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,
         outer_cursor_escape_if_changed, pane_area_projection_work, pane_context_menu_groups,
@@ -29931,7 +29931,7 @@ mod tests {
         app.sidebar_visible = false;
         app.replace_tree(app.session.tree());
         let epoch = app.client_focus_epoch;
-        let remembered_pane = app.tree.workspaces[1].screens[0].active_pane;
+        let remembered_pane = app.tree.workspaces()[1].screens[0].active_pane;
 
         // A late answer while the user has stayed put applies.
         app.handle(AppEvent::ClientFocusRestored {
@@ -29944,7 +29944,7 @@ mod tests {
         // A late answer after the user navigated is ignored, even when the
         // user navigated back to where the adoption started.
         app.select_workspace_for_client(Some(0), None);
-        let first_pane = app.tree.workspaces[0].screens[0].active_pane;
+        let first_pane = app.tree.workspaces()[0].screens[0].active_pane;
         assert_eq!(app.tree.active_workspace, 0);
         app.handle(AppEvent::ClientFocusRestored {
             focus: crate::session::ClientFocus { pane: remembered_pane, tab: 0 },
@@ -29952,7 +29952,7 @@ mod tests {
         })
         .unwrap();
         assert_eq!(app.tree.active_workspace, 0);
-        assert_eq!(app.tree.workspaces[0].screens[0].active_pane, first_pane);
+        assert_eq!(app.tree.workspaces()[0].screens[0].active_pane, first_pane);
 
         let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
         for surface in surfaces {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -268,6 +268,13 @@ enum AppEvent {
         generation: u64,
         result: Result<Vec<ClientInfo>, String>,
     },
+    /// The remote server answered `client-focus` for this client. `epoch` is
+    /// `App::client_focus_epoch` when the question was asked; the answer
+    /// applies only if no adoption or user navigation happened since.
+    ClientFocusRestored {
+        focus: crate::session::ClientFocus,
+        epoch: u64,
+    },
     SidebarPluginUpdated {
         status: SidebarPluginSurface,
         relaunch: bool,
@@ -2202,6 +2209,28 @@ impl OrderedSession {
 
     fn client_focus(&self, client_id: &str) -> Option<crate::session::ClientFocus> {
         self.inner.client_focus(client_id)
+    }
+
+    /// Ask the remote server for this client's remembered focus without
+    /// blocking the caller. The answer arrives as `AppEvent::ClientFocusRestored`
+    /// and is applied only if `App::client_focus_epoch` is still `epoch`.
+    /// The draw thread must never wait on a control-socket round trip.
+    fn restore_client_focus_async(&self, client_id: String, epoch: u64) {
+        let session = self.inner.clone();
+        let events = self.events.clone();
+        let spawn = std::thread::Builder::new().name("client-focus-restore".into()).spawn(
+            move || {
+                if let Some(focus) = session.client_focus(&client_id) {
+                    let _ = events.send(AppEvent::ClientFocusRestored { focus, epoch });
+                }
+            },
+        );
+        if spawn.is_err() {
+            crate::client_log::stderr_log!(
+                "session",
+                "cmux-tui: could not start the client focus restore worker; keeping the tree's default focus"
+            );
+        }
     }
 
     fn agents(&self) -> Vec<AgentInfo> {
@@ -7221,6 +7250,9 @@ pub struct App {
     /// Durable identity for per-client focus memory on the mux
     /// (client-focus-v1); None when no config directory is available.
     client_focus_id: Option<String>,
+    /// Bumped on every tree adoption and user focus report; fences late
+    /// `client-focus` answers (see `AppEvent::ClientFocusRestored`).
+    client_focus_epoch: u64,
     /// Terminal cells actually represented by the last rendered snapshot.
     /// Foreign-viewer padding outside these bounds is display-only.
     pub(crate) rendered_terminal_bounds: HashMap<SurfaceId, Rect>,
@@ -9503,6 +9535,7 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         pane_focus_history: PaneFocusHistory::default(),
         reported_focus: None,
         client_focus_id: client_focus_identity(),
+        client_focus_epoch: 0,
         rendered_terminal_bounds: HashMap::new(),
         rendered_kitty_graphics: HashMap::new(),
         visible_size_surfaces: HashSet::new(),
@@ -15937,6 +15970,16 @@ impl App {
                 }
                 Ok(RenderAction::Draw)
             }
+            AppEvent::ClientFocusRestored { focus, epoch } => {
+                if self.client_focus_epoch != epoch {
+                    // The user navigated (or a new tree was adopted) before
+                    // the server answered; that wins over remembered focus.
+                    return Ok(RenderAction::None);
+                }
+                self.apply_restored_client_focus(focus);
+                self.rebuild_tab_locations();
+                Ok(RenderAction::Draw)
+            }
             AppEvent::ClientsUpdated { generation, result } => {
                 if generation != self.session.client_refresh_generation() {
                     return Ok(RenderAction::None);
@@ -16804,8 +16847,21 @@ impl App {
     /// server has one whose pane still exists in the adopted tree; otherwise
     /// the tree's own focus stays. Sets the report baseline either way.
     fn restore_client_focus_from_session(&mut self) {
+        // Every adoption starts a new focus epoch so an answer to an earlier
+        // question can never land on a later tree.
+        self.client_focus_epoch = self.client_focus_epoch.wrapping_add(1);
         let Some(client_id) = self.client_focus_id.clone() else { return };
+        if self.session.remote {
+            // A remote answer is a control-socket round trip. First draw uses
+            // the tree's own focus; the answer is applied when it arrives.
+            self.session.restore_client_focus_async(client_id, self.client_focus_epoch);
+            return;
+        }
         let Some(focus) = self.session.client_focus(&client_id) else { return };
+        self.apply_restored_client_focus(focus);
+    }
+
+    fn apply_restored_client_focus(&mut self, focus: crate::session::ClientFocus) {
         let mut location = None;
         for (workspace_index, workspace) in self.tree.workspaces().iter().enumerate() {
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
@@ -16845,6 +16901,8 @@ impl App {
             Some(previous) => {
                 self.session.report_focus(Some(previous), focus, self.client_focus_id.as_deref());
                 self.reported_focus = Some(focus);
+                // User navigation supersedes any focus answer still in flight.
+                self.client_focus_epoch = self.client_focus_epoch.wrapping_add(1);
             }
         }
     }
@@ -29570,6 +29628,77 @@ mod tests {
         // Reconnection restores this client's own remembered focus, not the
         // session focus another client reported afterwards.
         assert_eq!(second.tree.active_workspace, 1);
+
+        let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
+        for surface in surfaces {
+            mux.close_surface(surface).unwrap();
+        }
+    }
+
+    #[test]
+    fn remote_client_focus_restore_does_not_block_tree_adoption() {
+        // A remote session whose control socket never answers: `client-focus`
+        // would block for the full request timeout if it ran on the caller.
+        let session = crate::session::test_remote_session_with_silent_requests(HashSet::from([
+            server::CLIENT_FOCUS_CAPABILITY.to_string(),
+        ]));
+        let (mut app, events) = test_app_with_events(session);
+        app.sidebar_visible = false;
+        app.client_focus_id = Some("alice".to_string());
+        let tree = crate::session::tree::parse_tree(&serde_json::json!({
+            "workspaces": [{
+                "id": 1, "name": "one", "active": true,
+                "screens": [{
+                    "id": 1, "layout": {"type": "leaf", "pane": 1}, "active_pane": 1,
+                    "panes": [{"id": 1, "tabs": [{"surface": 1, "title": "sh", "kind": "pty"}]}]
+                }]
+            }]
+        }));
+        let started = Instant::now();
+        app.replace_tree(tree);
+        assert!(
+            started.elapsed() < Duration::from_secs(2),
+            "first tree adoption waited on the client-focus round trip"
+        );
+        assert_eq!(app.tree.active_workspace, 0);
+        assert!(
+            events.try_recv().is_err(),
+            "no focus answer can arrive from a silent server before the timeout"
+        );
+    }
+
+    #[test]
+    fn restored_client_focus_yields_to_user_navigation() {
+        let mux = Mux::new("client-focus-late-answer-test", SurfaceOptions::default());
+        mux.new_workspace(None, Some((80, 30))).unwrap();
+        mux.new_workspace(None, Some((80, 30))).unwrap();
+        mux.select_workspace(Some(0), None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        let epoch = app.client_focus_epoch;
+        let remembered_pane = app.tree.workspaces[1].screens[0].active_pane;
+
+        // A late answer while the user has stayed put applies.
+        app.handle(AppEvent::ClientFocusRestored {
+            focus: crate::session::ClientFocus { pane: remembered_pane, tab: 0 },
+            epoch,
+        })
+        .unwrap();
+        assert_eq!(app.tree.active_workspace, 1);
+
+        // A late answer after the user navigated is ignored, even when the
+        // user navigated back to where the adoption started.
+        app.select_workspace_for_client(Some(0), None);
+        let first_pane = app.tree.workspaces[0].screens[0].active_pane;
+        assert_eq!(app.tree.active_workspace, 0);
+        app.handle(AppEvent::ClientFocusRestored {
+            focus: crate::session::ClientFocus { pane: remembered_pane, tab: 0 },
+            epoch,
+        })
+        .unwrap();
+        assert_eq!(app.tree.active_workspace, 0);
+        assert_eq!(app.tree.workspaces[0].screens[0].active_pane, first_pane);
 
         let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
         for surface in surfaces {
@@ -46006,6 +46135,7 @@ mod tests {
             pane_focus_history: PaneFocusHistory::default(),
             reported_focus: None,
             client_focus_id: None,
+            client_focus_epoch: 0,
             rendered_terminal_bounds: HashMap::new(),
             rendered_kitty_graphics: HashMap::new(),
             visible_size_surfaces: HashSet::new(),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2397,6 +2397,13 @@ impl OrderedSession {
         self.inner.cached_surface(id)
     }
 
+    /// Whether a remote surface was retired after its process exited while
+    /// the authoritative tree still lists its tab. Local sessions keep the
+    /// handle until removal, so they always report false.
+    pub(crate) fn surface_is_exited(&self, id: SurfaceId) -> bool {
+        self.inner.surface_is_exited(id)
+    }
+
     fn has_surface(&self, id: SurfaceId) -> bool {
         self.inner.has_surface(id)
     }
@@ -38734,6 +38741,14 @@ mod tests {
             events.recv_timeout(Duration::from_secs(1)).unwrap(),
             AppEvent::SurfaceAttachSettled { outcome: super::SurfaceAttachOutcome::Attached }
         ));
+    }
+
+    #[test]
+    fn ordered_session_forwards_surface_exit_state_to_inner_session() {
+        let (mux, surface) = test_mux("ordered-session-exit-state-test", None);
+        let app = test_app(Session::Local(mux));
+
+        assert!(!app.session.surface_is_exited(surface.id));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -5736,6 +5736,42 @@ enum PaneResizeDragTarget {
     },
 }
 
+/// Client-local divider position while a split drag is in progress. Motion
+/// updates only this value; the daemon receives one `set-split-ratio` on
+/// release (`committed`), and the preview stays until the authoritative tree
+/// carries that ratio so the divider never snaps back for a frame.
+#[derive(Clone, Copy, Debug, PartialEq)]
+struct SplitDragPreview {
+    split: SplitId,
+    ratio: f32,
+    committed: bool,
+}
+
+fn apply_split_ratio_preview(node: &mut Node, split: SplitId, ratio: f32) -> bool {
+    match node {
+        Node::Split { id, ratio: current, a, b, .. } => {
+            if *id == split {
+                *current = ratio;
+                return true;
+            }
+            apply_split_ratio_preview(a, split, ratio) || apply_split_ratio_preview(b, split, ratio)
+        }
+        _ => false,
+    }
+}
+
+fn split_ratio_in_node(node: &Node, split: SplitId) -> Option<f32> {
+    match node {
+        Node::Split { id, ratio, a, b, .. } => {
+            if *id == split {
+                return Some(*ratio);
+            }
+            split_ratio_in_node(a, split).or_else(|| split_ratio_in_node(b, split))
+        }
+        _ => None,
+    }
+}
+
 /// Mouse drag in progress.
 enum Drag {
     /// Left press on a tab chip; becomes `Tab` after moving cells.
@@ -7253,6 +7289,7 @@ pub struct App {
     /// Bumped on every tree adoption and user focus report; fences late
     /// `client-focus` answers (see `AppEvent::ClientFocusRestored`).
     client_focus_epoch: u64,
+    split_drag_preview: Option<SplitDragPreview>,
     /// Terminal cells actually represented by the last rendered snapshot.
     /// Foreign-viewer padding outside these bounds is display-only.
     pub(crate) rendered_terminal_bounds: HashMap<SurfaceId, Rect>,
@@ -9536,6 +9573,7 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         reported_focus: None,
         client_focus_id: client_focus_identity(),
         client_focus_epoch: 0,
+        split_drag_preview: None,
         rendered_terminal_bounds: HashMap::new(),
         rendered_kitty_graphics: HashMap::new(),
         visible_size_surfaces: HashSet::new(),
@@ -14675,7 +14713,8 @@ impl App {
             self.sync_sidebar_files_to_focus(false);
         }
         self.pane_areas.clear();
-        let Some(screen) = self.tree.active_screen().cloned() else {
+        self.reconcile_split_drag_preview();
+        let Some(mut screen) = self.tree.active_screen().cloned() else {
             self.viewport_projection.clear();
             self.viewport_layout.clear();
             self.viewport_stacked_headers.clear();
@@ -14695,6 +14734,9 @@ impl App {
             }
             return;
         };
+        if let Some(preview) = self.split_drag_preview {
+            apply_split_ratio_preview(&mut screen.layout, preview.split, preview.ratio);
+        }
         let viewport_enabled = self.surface_only.is_none()
             && screen.zoomed_pane.is_none()
             && !screen.viewport_splits.is_empty();
@@ -18506,11 +18548,27 @@ impl App {
         self.handle_direct_keyboard_to(input, None)
     }
 
+    fn handle_direct_keyboard_to_inner_guard(&mut self, input: &keys::KeyboardInput) -> bool {
+        // Escape during a split drag drops the local preview and sends
+        // nothing; the key is consumed.
+        if !input.is_release()
+            && input.ui_key().code == KeyCode::Esc
+            && matches!(self.drag, Some(Drag::ResizeSplit { .. }))
+        {
+            self.cancel_split_drag();
+            return true;
+        }
+        false
+    }
+
     fn handle_direct_keyboard_to(
         &mut self,
         input: keys::KeyboardInput,
         destination: Option<SurfaceId>,
     ) -> anyhow::Result<RenderAction> {
+        if self.handle_direct_keyboard_to_inner_guard(&input) {
+            return Ok(RenderAction::Draw);
+        }
         let visible_state = self.visible_input_state(destination);
         let action = self.handle_direct_keyboard_to_inner(input, destination)?;
         Ok(action.merge(self.visible_input_action(visible_state)))
@@ -21705,7 +21763,7 @@ impl App {
             let settle_split = matches!(self.drag, Some(Drag::ResizeSplit { .. }));
             self.drag = None;
             if settle_split {
-                self.session.settle_split_ratio();
+                self.commit_split_drag_preview();
             }
         }
         self.active_pointer_buttons.clear();
@@ -21783,7 +21841,7 @@ impl App {
                     BrowserMouseDispatch::new("mouseReleased", Some("left"), Some(1)),
                 );
             }
-            Some(Drag::ResizeSplit { .. }) => self.session.settle_split_ratio(),
+            Some(Drag::ResizeSplit { .. }) => self.commit_split_drag_preview(),
             Some(
                 Drag::TabArm { .. }
                 | Drag::Tab { .. }
@@ -23160,7 +23218,7 @@ impl App {
         }
         if matches!(self.drag, Some(Drag::ResizeSplit { .. })) {
             self.drag = None;
-            self.session.settle_split_ratio();
+            self.commit_split_drag_preview();
             return Ok(RenderAction::Draw);
         }
         if matches!(self.drag, Some(Drag::StatusMessage { .. })) {
@@ -23642,10 +23700,59 @@ impl App {
                 }
                 let requested = (coord.saturating_sub(start) as f64 / extent as f64) as f32;
                 let ratio = requested.clamp(minimum_ratio, maximum_ratio);
+                // Motion is client-local: the divider follows the pointer from
+                // this preview every frame, and one durable mutation is sent
+                // on release (`commit_split_drag_preview`).
+                self.split_drag_preview = Some(SplitDragPreview { split, ratio, committed: false });
+            }
+        }
+    }
+
+    /// Release of a split drag: send exactly one `set-split-ratio` for the
+    /// previewed value (plus its settle barrier), or only settle when the drag
+    /// moved a viewport column, whose width mutations are still coalesced.
+    fn commit_split_drag_preview(&mut self) {
+        match self.split_drag_preview {
+            Some(preview) if !preview.committed => {
                 if self.prepare_pty_input_before_mutation() {
-                    self.session.set_split_ratio_deferred(split, ratio);
+                    self.split_drag_preview =
+                        Some(SplitDragPreview { committed: true, ..preview });
+                    self.session.set_split_ratio(preview.split, preview.ratio);
+                } else {
+                    self.split_drag_preview = None;
                 }
             }
+            _ => self.session.settle_split_ratio(),
+        }
+    }
+
+    /// Escape during a split drag: drop the preview, send nothing.
+    fn cancel_split_drag(&mut self) {
+        self.drag = None;
+        self.split_drag_preview = None;
+    }
+
+    /// Drop a committed preview once the authoritative tree carries its
+    /// ratio, or once every mutation has settled and the tree is current
+    /// (the commit was refused), or when the split no longer exists.
+    fn reconcile_split_drag_preview(&mut self) {
+        let Some(preview) = self.split_drag_preview else { return };
+        if matches!(self.drag, Some(Drag::ResizeSplit { .. })) {
+            return;
+        }
+        let tree_ratio = self
+            .tree
+            .active_screen()
+            .and_then(|screen| split_ratio_in_node(&screen.layout, preview.split));
+        let settled =
+            !self.session.has_pending_mutations() && !self.session.remote_tree_is_stale();
+        let drop = match tree_ratio {
+            None => true,
+            Some(ratio) if (ratio - preview.ratio).abs() < 1e-3 => true,
+            Some(_) => !preview.committed || settled,
+        };
+        if drop {
+            self.split_drag_preview = None;
         }
     }
 
@@ -24934,12 +25041,14 @@ mod tests {
         RenderedMenuLevel, RenderedPaneRoute, RenderedPointerFrame, Selection, SelectionMode,
         SessionCompletion, SessionCompletionAction, SessionEventSender, ShortcutHelp,
         SidebarActionTarget, SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState,
-        SidebarWidthOverrides, StatusTemplateValues, StatusWorkerStop, StdoutLock,
+        SidebarWidthOverrides, SplitDragPreview, StatusTemplateValues, StatusWorkerStop,
+        StdoutLock,
         SurfaceAttachClaimState, SurfaceResizeDecision, SurfaceResizeOwnership,
         TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer, TerminalPointerAdmission,
         TerminalPointerAdmissionResult, TerminalPointerEncoding, TextInput, Toast,
         VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
-        WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
+        WorkspaceRailSelection, action_available_in_mode, apply_split_ratio_preview,
+        browser_content_size_for_rect,
         browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
         canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
         client_menu_item, clip_horizontal_rect, content_size_for_rect,
@@ -24970,7 +25079,7 @@ mod tests {
     use cmux_tui_core::resource::FrontendProjectionPublicId;
     use cmux_tui_core::{
         AgentSource, AgentState, BrowserFrame, BrowserStatus, Direction, LayoutUndoError, Mux,
-        MuxEvent, Node, PointerSnapshotProbe, Rect, SplitDir, SurfaceId, SurfaceKind,
+        MuxEvent, Node, PointerSnapshotProbe, Rect, SplitDir, SplitId, SurfaceId, SurfaceKind,
         SurfaceOptions, VirtualRect, ZoomMode, layout_screen, server,
     };
     use crossterm::event::{
@@ -29704,6 +29813,129 @@ mod tests {
         for surface in surfaces {
             mux.close_surface(surface).unwrap();
         }
+    }
+
+    fn split_drag_test_app(
+        name: &str,
+    ) -> (App, Receiver<AppEvent>, Arc<Mux>, SplitId, cmux_tui_core::PaneId) {
+        let mux = Mux::new(name, SurfaceOptions::default());
+        mux.new_workspace(None, Some((80, 30))).unwrap();
+        let first = Session::Local(mux.clone()).tree().active_screen().unwrap().active_pane;
+        mux.split(first, SplitDir::Right, Some((40, 30))).unwrap();
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((100, 20));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        let split = match &app.tree.active_screen().unwrap().layout {
+            Node::Split { id, .. } => *id,
+            other => panic!("expected a split layout, got {other:?}"),
+        };
+        (app, events, mux, split, first)
+    }
+
+    fn pane_width(app: &App, pane: cmux_tui_core::PaneId) -> u16 {
+        app.pane_areas.iter().find(|area| area.pane == pane).expect("pane area").rect.width
+    }
+
+    fn close_all_surfaces(mux: &Arc<Mux>) {
+        let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
+        for surface in surfaces {
+            mux.close_surface(surface).unwrap();
+        }
+    }
+
+    #[test]
+    fn split_drag_previews_locally_and_commits_once_on_release() {
+        let (mut app, events, mux, split, first) =
+            split_drag_test_app("split-drag-preview-commit-test");
+        let initial_width = pane_width(&app, first);
+        let target = app.resolve_pane_resize_drag(first, PaneEdge::Right).expect("split divider");
+        app.drag = Some(Drag::ResizeSplit { horizontal: Some(target), vertical: None });
+
+        let pending = |app: &App| app.session.pending_mutations.load(Ordering::Acquire);
+        let before = pending(&app);
+        app.handle_left_drag(25, 5).unwrap();
+        assert_eq!(pending(&app), before, "drag motion must not send a request");
+        let preview = app.split_drag_preview.expect("motion records a local preview");
+        assert_eq!(preview.split, split);
+        assert!(!preview.committed);
+        assert!(preview.ratio < 0.4, "pointer at x=25 of 100 must move the divider left: {}", preview.ratio);
+
+        // The preview drives layout while the drag is in progress.
+        app.sync_layout((100, 20));
+        assert!(pane_width(&app, first) < initial_width, "divider did not follow the pointer");
+        assert!(app.split_drag_preview.is_some(), "preview must survive layout during a drag");
+
+        let before = pending(&app);
+        app.handle_left_drag(60, 5).unwrap();
+        assert_eq!(pending(&app), before, "drag motion must not send a request");
+        let moved = app.split_drag_preview.unwrap();
+        assert!(moved.ratio > 0.5, "pointer at x=60 must move the divider right: {}", moved.ratio);
+
+        let before = pending(&app);
+        app.handle_left_up(60, 5).unwrap();
+        assert!(app.drag.is_none());
+        // Exactly one set-split-ratio plus its settle barrier.
+        assert_eq!(pending(&app) - before, 2);
+        let committed =
+            app.split_drag_preview.expect("committed preview stays until the tree agrees");
+        assert!(committed.committed);
+        assert!((committed.ratio - moved.ratio).abs() < 1e-6);
+
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        app.sync_layout((100, 20));
+        let tree_ratio =
+            super::split_ratio_in_node(&app.tree.active_screen().unwrap().layout, split).unwrap();
+        assert!((tree_ratio - committed.ratio).abs() < 1e-3, "tree ratio {tree_ratio}");
+        assert!(app.split_drag_preview.is_none(), "preview clears once the tree carries it");
+        close_all_surfaces(&mux);
+    }
+
+    #[test]
+    fn escape_cancels_split_drag_without_a_request() {
+        let (mut app, _events, mux, _split, first) =
+            split_drag_test_app("split-drag-preview-escape-test");
+        let initial_width = pane_width(&app, first);
+        let target = app.resolve_pane_resize_drag(first, PaneEdge::Right).expect("split divider");
+        app.drag = Some(Drag::ResizeSplit { horizontal: Some(target), vertical: None });
+        app.handle_left_drag(25, 5).unwrap();
+        assert!(app.split_drag_preview.is_some());
+
+        let before = app.session.pending_mutations.load(Ordering::Acquire);
+        app.handle_key(KeyEvent::new(KeyCode::Esc, KeyModifiers::NONE)).unwrap();
+        assert!(app.drag.is_none());
+        assert!(app.split_drag_preview.is_none());
+        assert_eq!(app.session.pending_mutations.load(Ordering::Acquire), before);
+        app.sync_layout((100, 20));
+        assert_eq!(pane_width(&app, first), initial_width);
+        close_all_surfaces(&mux);
+    }
+
+    #[test]
+    fn committed_split_preview_holds_until_the_tree_carries_the_ratio() {
+        let (mut app, events, mux, split, _first) =
+            split_drag_test_app("split-drag-preview-hold-test");
+        app.split_drag_preview =
+            Some(SplitDragPreview { split, ratio: 0.3, committed: true });
+        // The authoritative tree still says 0.5 and a mutation is pending: the
+        // preview holds so the divider does not snap back for a frame.
+        app.session.pending_mutations.fetch_add(1, Ordering::AcqRel);
+        app.sync_layout((100, 20));
+        assert!(app.split_drag_preview.is_some());
+        app.session.pending_mutations.fetch_sub(1, Ordering::AcqRel);
+
+        app.session.set_split_ratio(split, 0.3);
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
+        }
+        app.sync_layout((100, 20));
+        assert!(app.split_drag_preview.is_none(), "tree agrees; preview must clear");
+        close_all_surfaces(&mux);
     }
 
     #[test]
@@ -46136,6 +46368,7 @@ mod tests {
             reported_focus: None,
             client_focus_id: None,
             client_focus_epoch: 0,
+            split_drag_preview: None,
             rendered_terminal_bounds: HashMap::new(),
             rendered_kitty_graphics: HashMap::new(),
             visible_size_surfaces: HashSet::new(),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1331,20 +1331,17 @@ enum SessionCompletionAction {
     LayoutUndoStale,
 }
 
-/// True when the remote session's cached tree already reflects a committed
-/// mutation: a created surface is present, or every destroyed surface is gone,
-/// and no `tree-changed` resync is pending. Mutations with neither a created
-/// nor a destroyed surface (renames, layout) always refetch.
-fn remote_postcondition_visible(
+/// Return the cached tree snapshot that proves a remote mutation is visible.
+fn remote_postcondition_tree(
     session: &Session,
     completion: Option<&SessionCompletion>,
     destroyed_surfaces: &crate::pty_input::MutationTargets,
-) -> bool {
+) -> Option<TreeView> {
     if session.remote_tree_is_stale() {
-        return false;
+        return None;
     }
     let tree = session.tree();
-    match completion.map(|completion| &completion.action) {
+    let visible = match completion.map(|completion| &completion.action) {
         Some(
             SessionCompletionAction::SurfaceCreated { surface }
             | SessionCompletionAction::BrowserTabCreated { surface },
@@ -1354,7 +1351,8 @@ fn remote_postcondition_visible(
             destroyed_surfaces.iter().all(|surface| tree.surface(*surface).is_none())
         }
         None => false,
-    }
+    };
+    visible.then_some(tree)
 }
 
 fn layout_undo_error_completion(error: &anyhow::Error) -> Option<SessionCompletionAction> {
@@ -3053,7 +3051,7 @@ impl OrderedSession {
                     // already show the outcome; then the cached tree is the
                     // authoritative result and no refetch is needed. Any
                     // pending `tree-changed` keeps the refetch path.
-                    if remote_postcondition_visible(
+                    if let Some(tree) = remote_postcondition_tree(
                         &session,
                         completion.as_ref(),
                         &destroyed_surfaces,
@@ -3061,7 +3059,7 @@ impl OrderedSession {
                         let destination_generation =
                             destination_mutation_committed.load(Ordering::Acquire);
                         pending.defer(SessionMutationOutcome::AuthoritativeMutationSucceeded {
-                            tree: session.tree(),
+                            tree,
                             authoritative_generation: mutation_generation,
                             destination_generation,
                             completion,
@@ -5951,9 +5949,17 @@ fn split_leaf_for_placeholder(
     }
 }
 
-/// The daemon's reason for a refused mutation, without the transport prefix.
+/// Map daemon failures to product-safe user-facing causes. The complete error
+/// remains in the client log; only a small, stable category reaches the UI.
 fn mutation_failure_cause(error: &str) -> String {
-    error.strip_prefix("remote command rejected: ").unwrap_or(error).trim().to_string()
+    let cause = error.strip_prefix("remote command rejected: ").unwrap_or(error).trim();
+    if cause.to_ascii_lowercase().contains("pty capacity")
+        || cause.to_ascii_lowercase().contains("no pseudo-terminal")
+    {
+        localization::catalog().runtime.terminal_capacity_exhausted.to_string()
+    } else {
+        localization::catalog().session.operation_failed_generic_cause.to_string()
+    }
 }
 
 /// Mouse drag in progress.
@@ -16598,13 +16604,21 @@ impl App {
     }
 
     fn allocate_semantic_destination_intent(&mut self) -> u64 {
-        self.next_semantic_destination_intent =
-            self.next_semantic_destination_intent.wrapping_add(1).max(1);
-        let intent = self.next_semantic_destination_intent;
-        let previous =
+        const MAX_INTENT: u64 = u32::MAX as u64;
+        loop {
+            self.next_semantic_destination_intent =
+                if self.next_semantic_destination_intent >= MAX_INTENT {
+                    1
+                } else {
+                    self.next_semantic_destination_intent + 1
+                };
+            let intent = self.next_semantic_destination_intent;
+            if self.semantic_destination_outcomes.contains_key(&intent) {
+                continue;
+            }
             self.semantic_destination_outcomes.insert(intent, SemanticDestinationOutcome::Pending);
-        debug_assert!(previous.is_none(), "live semantic destination intent reused");
-        intent
+            return intent;
+        }
     }
 
     fn advance_pointer_focus_generation(&mut self) {
@@ -23981,25 +23995,24 @@ impl App {
             return;
         }
         let settled = !self.session.has_pending_mutations() && !self.session.remote_tree_is_stale();
+        let authoritative = self.session.tree();
         let targets = self.pending_renames.keys().copied().collect::<Vec<_>>();
         for target in targets {
             let Some(pending) = self.pending_renames.get(&target).cloned() else { continue };
             let current: Option<Option<String>> = match target {
-                PendingRenameTarget::Workspace(id) => self
-                    .tree
+                PendingRenameTarget::Workspace(id) => authoritative
                     .workspaces()
                     .iter()
                     .find(|workspace| workspace.id == id)
                     .map(|workspace| Some(workspace.name.clone())),
-                PendingRenameTarget::Screen(id) => self
-                    .tree
+                PendingRenameTarget::Screen(id) => authoritative
                     .workspaces()
                     .iter()
                     .flat_map(|workspace| workspace.screens.iter())
                     .find(|screen| screen.id == id)
                     .map(|screen| screen.name.clone()),
                 PendingRenameTarget::Surface(id) => {
-                    self.tree.surface(id).map(|tab| tab.name.clone())
+                    authoritative.surface(id).map(|tab| tab.name.clone())
                 }
             };
             let Some(current) = current else {
@@ -30595,6 +30608,11 @@ mod tests {
         app.sync_layout((80, 20));
         assert_eq!(app.tree.surface(surface.id).unwrap().name.as_deref(), Some("logs"));
         assert_eq!(app.session.tree().surface(surface.id).unwrap().name, None);
+        // A second frame must keep the overlay while the daemon has not
+        // acknowledged the rename.
+        app.sync_layout((80, 20));
+        assert_eq!(app.tree.surface(surface.id).unwrap().name.as_deref(), Some("logs"));
+        assert!(app.pending_renames.contains_key(&PendingRenameTarget::Surface(surface.id)));
         app.session.pending_mutations.fetch_sub(1, Ordering::AcqRel);
 
         app.session.rename_surface(surface.id, "logs".to_string());
@@ -30667,7 +30685,7 @@ mod tests {
     const PTY_EXHAUSTED_REJECTION: &str = "remote command rejected: terminal launch failed: PTY capacity exhausted; close unused terminals or tmux sessions and retry: Device not configured (os error 6)";
 
     #[test]
-    fn failed_mutation_status_shows_the_daemon_cause() {
+    fn failed_mutation_status_shows_a_safe_actionable_cause() {
         let (mux, surface) = test_mux("failed-cause-status-test", None);
         let mut app = test_app(Session::Local(mux.clone()));
         app.sidebar_visible = false;
@@ -30681,11 +30699,11 @@ mod tests {
         assert_eq!(
             app.status_message.as_deref(),
             Some(
-                "Session operation failed: terminal launch failed: PTY capacity exhausted; close unused terminals or tmux sessions and retry: Device not configured (os error 6)"
+                "Session operation failed: No pseudo-terminals are available. Close an unused terminal session, then retry."
             )
         );
 
-        // A narrow status line keeps the head of the cause and marks the cut.
+        // A narrow status line remains bounded and keeps the action visible.
         app.outer_size = (48, 10);
         app.session.pending_mutations.fetch_add(1, Ordering::AcqRel);
         app.handle(AppEvent::SessionMutationSettled {
@@ -30694,10 +30712,22 @@ mod tests {
         })
         .unwrap();
         let status = app.status_message.clone().unwrap();
-        assert!(status.starts_with("Session operation failed: terminal launch"), "{status}");
-        assert!(status.ends_with('…'), "{status}");
+        assert!(status.starts_with("Session operation failed: No pseudo-terminals"), "{status}");
         assert!(status.chars().count() <= 48, "{status}");
         mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn semantic_destination_intents_wrap_without_reusing_live_ids() {
+        let mux = Mux::new("semantic-intent-wrap-test", SurfaceOptions::default());
+        let (mut app, _events) = test_app_with_events(Session::Local(mux));
+        app.next_semantic_destination_intent = u32::MAX as u64;
+        let first = app.allocate_semantic_destination_intent();
+        assert_eq!(first, 1);
+        app.next_semantic_destination_intent = u32::MAX as u64;
+        let second = app.allocate_semantic_destination_intent();
+        assert_eq!(second, 2);
+        assert!(second <= u32::MAX as u64);
     }
 
     #[test]
@@ -30815,9 +30845,11 @@ mod tests {
             CreatePlaceholderState::Failed { cause, .. } => cause.clone(),
             other => panic!("placeholder should have failed, got {other:?}"),
         };
-        assert!(cause.contains("PTY capacity exhausted"), "{cause}");
+        assert_eq!(cause, localization::catalog().runtime.terminal_capacity_exhausted);
         assert!(
-            app.status_message.as_deref().is_some_and(|status| status.contains("PTY capacity")),
+            app.status_message
+                .as_deref()
+                .is_some_and(|status| status.contains("No pseudo-terminals")),
             "{:?}",
             app.status_message
         );
@@ -39010,7 +39042,7 @@ mod tests {
         assert!(app.deferred_input.is_empty());
         assert!(!app.prefix_armed);
         assert_eq!(app.pointer_route_phase, PointerRoutePhase::DrawPending);
-        // The status line names the operation and carries the daemon's cause.
+        // The status line names the operation and gives a safe next action.
         assert_eq!(
             app.status_message.as_deref(),
             Some(
@@ -39018,7 +39050,10 @@ mod tests {
                     .session
                     .operation_failed_with_cause
                     .replace("{operation}", localization::catalog().session.operation_failed)
-                    .replace("{cause}", "selection rejected")
+                    .replace(
+                        "{cause}",
+                        localization::catalog().session.operation_failed_generic_cause,
+                    )
                     .as_str()
             )
         );
@@ -43500,7 +43535,7 @@ mod tests {
             app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
         }
 
-        // The status line names the operation and carries the daemon's cause.
+        // The status line names the operation and gives a safe next action.
         assert_eq!(
             app.status_message.as_deref(),
             Some(
@@ -43508,7 +43543,10 @@ mod tests {
                     .session
                     .operation_failed_with_cause
                     .replace("{operation}", localization::catalog().session.operation_failed)
-                    .replace("{cause}", "workspace id and key do not identify the same workspace")
+                    .replace(
+                        "{cause}",
+                        localization::catalog().session.operation_failed_generic_cause,
+                    )
                     .as_str()
             )
         );

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8,7 +8,7 @@
 
 #[cfg(test)]
 use std::cell::Cell;
-use std::collections::{HashMap, HashSet, VecDeque};
+use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
 use std::io::Write;
 use std::panic::AssertUnwindSafe;
 use std::path::PathBuf;
@@ -79,7 +79,7 @@ use crate::pty_input::{
     PtyInputEvent, PtyInputKind, PtyInputSender, PtyOperationDelivery, PtyOperationFailure,
     TERMINAL_EXITED_LABEL, mark_operation_known_not_delivered,
 };
-use crate::session::tree::{PaneView, ScreenView};
+use crate::session::tree::{PaneView, ScreenView, WorkspaceView};
 use crate::session::{
     AgentInfo, AmbiguousCreation, CLEAR_HISTORY_UNSUPPORTED_ERROR, ClientInfo, CreationReceipt,
     Session, SidebarPluginSurface, SurfaceAttach, SurfaceHandle, TreeView,
@@ -5829,6 +5829,133 @@ enum PendingRenameTarget {
     Surface(SurfaceId),
 }
 
+/// Ids above this value belong to client placeholders, never to the daemon.
+const PLACEHOLDER_ID_BASE: u64 = u64::MAX - (1 << 32);
+
+fn placeholder_id(intent: u64) -> u64 {
+    u64::MAX - (intent & 0xffff_ffff)
+}
+
+pub(crate) fn is_placeholder_id(id: u64) -> bool {
+    id > PLACEHOLDER_ID_BASE
+}
+
+/// Where a create placeholder goes in the tree; mirrors the slot the daemon
+/// will produce so the real entity replaces it without a visual jump.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum CreatePlaceholderKind {
+    /// Alt-n: the daemon reapplies the Zellij default distribution.
+    Pane {
+        anchor: PaneId,
+    },
+    Split {
+        anchor: PaneId,
+        dir: SplitDir,
+    },
+    Tab {
+        pane: PaneId,
+    },
+    Workspace,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+enum CreatePlaceholderState {
+    Pending,
+    /// The daemon refused; the cause is shown where the pane would have been
+    /// for `DURABLE_NOTICE_DISPLAY_DURATION`, then the placeholder dissolves.
+    Failed {
+        cause: String,
+        since: Instant,
+    },
+}
+
+/// A client-local stand-in for a create the daemon has not answered. It is
+/// presentation only: never sent to the daemon, never in a projection, keyed by
+/// the mutation's semantic intent, cleared on session generation change.
+#[derive(Clone, Debug)]
+struct CreatePlaceholder {
+    intent: u64,
+    kind: CreatePlaceholderKind,
+    workspace: Option<WorkspaceId>,
+    screen: Option<ScreenId>,
+    prior_focus: Option<PaneId>,
+    state: CreatePlaceholderState,
+    /// A timeout's error text, used as the cause if the refetch settles the
+    /// intent as failed.
+    timed_out_cause: Option<String>,
+}
+
+impl CreatePlaceholder {
+    fn surface(&self) -> SurfaceId {
+        placeholder_id(self.intent)
+    }
+
+    fn pane(&self) -> PaneId {
+        placeholder_id(self.intent)
+    }
+}
+
+fn placeholder_tab(surface: SurfaceId) -> crate::session::tree::TabView {
+    crate::session::tree::TabView {
+        surface,
+        public_id: None,
+        content_id: None,
+        terminal_id: None,
+        short_id: String::new(),
+        name: None,
+        title: localization::catalog().terminal.pane_starting.to_string(),
+        kind: SurfaceKind::Pty,
+        browser_source: None,
+        browser_frames_stalled: false,
+        supports_clear_history_key_fallback: false,
+        notification: None,
+    }
+}
+
+fn placeholder_pane(pane: PaneId, surface: SurfaceId) -> PaneView {
+    PaneView {
+        id: pane,
+        resource_id: None,
+        short_id: String::new(),
+        name: None,
+        tabs: vec![placeholder_tab(surface)],
+        active_tab: 0,
+        focused_at: 0,
+    }
+}
+
+/// Replace the leaf `anchor` with a split whose second child is `pane`.
+fn split_leaf_for_placeholder(
+    node: &mut Node,
+    anchor: PaneId,
+    dir: SplitDir,
+    split: SplitId,
+    pane: PaneId,
+) -> bool {
+    match node {
+        Node::Leaf(leaf) if *leaf == anchor => {
+            *node = Node::Split {
+                id: split,
+                dir,
+                ratio: 0.5,
+                a: Box::new(Node::Leaf(anchor)),
+                b: Box::new(Node::Leaf(pane)),
+            };
+            true
+        }
+        Node::Split { a, b, .. } => {
+            split_leaf_for_placeholder(a, anchor, dir, split, pane)
+                || split_leaf_for_placeholder(b, anchor, dir, split, pane)
+        }
+        _ => false,
+    }
+}
+
+/// The daemon's reason for a refused mutation, without the transport prefix.
+fn mutation_failure_cause(error: &str) -> String {
+    error.strip_prefix("remote command rejected: ").unwrap_or(error).trim().to_string()
+}
+
 /// Mouse drag in progress.
 enum Drag {
     /// Left press on a tab chip; becomes `Tab` after moving cells.
@@ -7348,6 +7475,7 @@ pub struct App {
     client_focus_epoch: u64,
     split_drag_preview: Option<SplitDragPreview>,
     pending_renames: HashMap<PendingRenameTarget, Option<String>>,
+    create_placeholders: Vec<CreatePlaceholder>,
     /// Terminal cells actually represented by the last rendered snapshot.
     /// Foreign-viewer padding outside these bounds is display-only.
     pub(crate) rendered_terminal_bounds: HashMap<SurfaceId, Rect>,
@@ -9633,6 +9761,7 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         client_focus_epoch: 0,
         split_drag_preview: None,
         pending_renames: HashMap::new(),
+        create_placeholders: Vec::new(),
         rendered_terminal_bounds: HashMap::new(),
         rendered_kitty_graphics: HashMap::new(),
         visible_size_surfaces: HashSet::new(),
@@ -10904,6 +11033,7 @@ impl App {
             } else if self.shake_frames > 0
                 || self.selection_auto_scroll_active()
                 || self.toast.is_some()
+                || self.has_failed_create_placeholder()
             {
                 Duration::from_millis(30)
             } else {
@@ -10922,6 +11052,9 @@ impl App {
                     }
                     if self.expire_toast() {
                         toast_expired_on_timeout = true;
+                        action = action.merge(RenderAction::Draw);
+                    }
+                    if self.expire_failed_create_placeholders() {
                         action = action.merge(RenderAction::Draw);
                     }
                     if self.tick_sidebar_files() {
@@ -12082,6 +12215,7 @@ impl App {
         // value arrives from its background refresh.
         self.machine_usage = None;
         self.tab_locations.clear();
+        self.create_placeholders.clear();
         self.rebuild_tab_locations();
         self.render_states.clear();
         self.pane_areas.clear();
@@ -13131,10 +13265,12 @@ impl App {
         let semantic_intent = completion.semantic_intent;
         match completion.action {
             SessionCompletionAction::SurfaceCreated { surface } => {
+                self.resolve_create_placeholder(semantic_intent);
                 self.resolve_semantic_destination(semantic_intent, surface);
                 self.select_created_surface(surface);
             }
             SessionCompletionAction::BrowserTabCreated { surface } => {
+                self.resolve_create_placeholder(semantic_intent);
                 self.resolve_semantic_destination(semantic_intent, surface);
                 self.select_created_surface(surface);
                 let pane = self
@@ -13245,6 +13381,7 @@ impl App {
     }
 
     fn apply_session_cancellation(&mut self) {
+        self.create_placeholders.clear();
         self.deferred_input.clear();
         self.latest_semantic_destination_intent = None;
         self.semantic_destination_outcomes.clear();
@@ -14774,6 +14911,7 @@ impl App {
         self.pane_areas.clear();
         self.reconcile_split_drag_preview();
         self.apply_pending_renames();
+        self.apply_create_placeholders();
         let Some(mut screen) = self.tree.active_screen().cloned() else {
             self.viewport_projection.clear();
             self.viewport_layout.clear();
@@ -14937,7 +15075,8 @@ impl App {
                 let size = (tab.surface == lease.surface)
                     .then_some(content_size)
                     .filter(|(cols, rows)| *cols > 0 && *rows > 0);
-                if self.session.can_attach_surface(tab.surface)
+                if !is_placeholder_id(tab.surface)
+                    && self.session.can_attach_surface(tab.surface)
                     && self.prepare_pty_input_before_mutation()
                 {
                     self.session.attach_surface(tab.surface, size);
@@ -15871,6 +16010,7 @@ impl App {
                         self.background_refresh_attempts = 0;
                         self.background_refresh_retry_at = None;
                         self.apply_session_completions_through(authoritative_generation);
+                        self.settle_orphaned_create_placeholders();
                         self.complete_remote_tree_refresh(true);
                         self.session.reconcile_ambiguous_creations();
                     }
@@ -15989,6 +16129,14 @@ impl App {
                             // Fail only that route so dependent input is never
                             // guessed onto whichever surface became active.
                             self.mark_semantic_destination_failed(intent);
+                            // The placeholder stays until the refetch decides.
+                            if let Some(placeholder) = self
+                                .create_placeholders
+                                .iter_mut()
+                                .find(|placeholder| placeholder.intent == intent)
+                            {
+                                placeholder.timed_out_cause = Some(mutation_failure_cause(&error));
+                            }
                         }
                         self.status_message =
                             Some(localization::catalog().session.operation_reconciling.to_string());
@@ -15998,26 +16146,28 @@ impl App {
                         return Ok(RenderAction::Draw);
                     }
                     SessionMutationOutcome::Failed(error) => {
+                        // The client log keeps the full daemon text; the status
+                        // line shows the cause, not just a label.
                         crate::client_log::stderr_log!(
                             "session",
                             "cmux-tui: session operation failed: {error}"
                         );
+                        let cause = mutation_failure_cause(&error);
+                        self.status_message = Some(self.operation_failed_message(&cause));
                         if let Some(intent) = semantic_intent {
                             self.mark_semantic_destination_failed(intent);
-                            self.status_message =
-                                Some(localization::catalog().session.operation_failed.to_string());
+                            self.fail_create_placeholder(intent, cause);
                             return Ok(RenderAction::Draw);
                         }
                         self.deferred_input.clear();
                         self.prefix_armed = false;
                         self.pending_session_completions.clear();
-                        self.status_message =
-                            Some(localization::catalog().session.operation_failed.to_string());
                         return Ok(RenderAction::Draw);
                     }
                     SessionMutationOutcome::Canceled => {
                         if let Some(intent) = semantic_intent {
                             self.mark_semantic_destination_failed(intent);
+                            self.resolve_create_placeholder(Some(intent));
                             self.status_message = Some(
                                 localization::catalog().session.operation_canceled.to_string(),
                             );
@@ -16997,6 +17147,9 @@ impl App {
 
     fn report_client_focus(&mut self) {
         let Some(focus) = self.current_client_focus() else { return };
+        if is_placeholder_id(focus.pane) {
+            return;
+        }
         match self.reported_focus {
             None => self.reported_focus = Some(focus),
             Some(previous) if previous == focus => {}
@@ -17020,6 +17173,10 @@ impl App {
             self.geometry_authority_surface = None;
             return;
         };
+        if is_placeholder_id(surface) {
+            // Keep the previous terminal authoritative until the create lands.
+            return;
+        }
         if !force && self.geometry_authority_surface == Some(surface) {
             return;
         }
@@ -17070,7 +17227,9 @@ impl App {
     }
 
     fn queue_surface_attach(&mut self, surface: SurfaceId) {
-        if !self.session.can_attach_surface(surface) {
+        // A placeholder has no daemon surface to attach; its input waits for
+        // the real one through the semantic destination.
+        if is_placeholder_id(surface) || !self.session.can_attach_surface(surface) {
             return;
         }
         let size = self
@@ -17191,7 +17350,8 @@ impl App {
                     }
                     SurfaceResizeDecision::NeedsQueue(_) => {}
                 }
-            } else if self.session.can_attach_surface(area.surface)
+            } else if !is_placeholder_id(area.surface)
+                && self.session.can_attach_surface(area.surface)
                 && self.prepare_pty_input_before_mutation()
             {
                 self.session.attach_surface(area.surface, Some(desired));
@@ -17915,7 +18075,12 @@ impl App {
             hint,
             selector_candidates,
             semantic_intent,
-        )
+        )?;
+        self.add_create_placeholder(
+            semantic_intent,
+            CreatePlaceholderKind::Split { anchor: pane, dir },
+        );
+        Ok(())
     }
 
     fn new_terminal_tab(
@@ -17934,7 +18099,11 @@ impl App {
             self.terminal_tab_size_hint(pane),
             selector_candidates,
             semantic_intent,
-        )
+        )?;
+        if let Some(pane) = pane {
+            self.add_create_placeholder(semantic_intent, CreatePlaceholderKind::Tab { pane });
+        }
+        Ok(())
     }
 
     /// Run one configured user command as a new PTY tab in the target pane.
@@ -18016,7 +18185,9 @@ impl App {
             Some(hint),
             selector_candidates,
             semantic_intent,
-        )
+        )?;
+        self.add_create_placeholder(semantic_intent, CreatePlaceholderKind::Pane { anchor: pane });
+        Ok(())
     }
 
     fn new_pane_right(
@@ -18082,7 +18253,9 @@ impl App {
         self.session.new_workspace_for_semantic_intent(
             self.size_of_rect(self.content_area),
             semantic_intent,
-        )
+        )?;
+        self.add_create_placeholder(semantic_intent, CreatePlaceholderKind::Workspace);
+        Ok(())
     }
 
     fn request_managed_workspace(&mut self, mode: WorkspaceCreationMode) {
@@ -23874,6 +24047,241 @@ impl App {
         }
     }
 
+    fn operation_failed_message(&self, cause: &str) -> String {
+        let catalog = &localization::catalog().session;
+        let message = catalog
+            .operation_failed_with_cause
+            .replace("{operation}", catalog.operation_failed)
+            .replace("{cause}", cause);
+        let width = usize::from(self.outer_size.0.saturating_sub(self.total_sidebar_width()));
+        if width == 0 { message } else { crate::ui::truncate(&message, width) }
+    }
+
+    /// Record a client placeholder for a create the daemon has not answered
+    /// and show it at once. `None` intent means the create carries no
+    /// semantic destination (a programmatic caller); nothing is drawn then.
+    fn add_create_placeholder(&mut self, intent: Option<u64>, kind: CreatePlaceholderKind) {
+        let Some(intent) = intent else { return };
+        if self.surface_only.is_some() {
+            return;
+        }
+        let workspace = self.tree.active_workspace().map(|workspace| workspace.id);
+        let screen = self.tree.active_screen().map(|screen| screen.id);
+        self.create_placeholders.push(CreatePlaceholder {
+            intent,
+            kind,
+            workspace,
+            screen,
+            prior_focus: self.active_pane(),
+            state: CreatePlaceholderState::Pending,
+            timed_out_cause: None,
+        });
+        self.apply_create_placeholders();
+        self.rebuild_tab_locations();
+    }
+
+    /// The daemon produced the real entity: drop the stand-in. The real pane
+    /// occupies the slot the placeholder held, so nothing moves.
+    fn resolve_create_placeholder(&mut self, intent: Option<u64>) {
+        let Some(intent) = intent else { return };
+        self.create_placeholders.retain(|placeholder| placeholder.intent != intent);
+    }
+
+    fn fail_create_placeholder(&mut self, intent: u64, cause: String) {
+        if let Some(placeholder) =
+            self.create_placeholders.iter_mut().find(|placeholder| placeholder.intent == intent)
+        {
+            placeholder.state = CreatePlaceholderState::Failed { cause, since: Instant::now() };
+        }
+    }
+
+    fn has_failed_create_placeholder(&self) -> bool {
+        self.create_placeholders
+            .iter()
+            .any(|placeholder| matches!(placeholder.state, CreatePlaceholderState::Failed { .. }))
+    }
+
+    /// The cause shown in a placeholder pane whose create was refused.
+    pub(crate) fn create_placeholder_failure(&self, surface: SurfaceId) -> Option<String> {
+        self.create_placeholders.iter().find_map(|placeholder| {
+            match (&placeholder.state, placeholder.surface() == surface) {
+                (CreatePlaceholderState::Failed { cause, .. }, true) => Some(cause.clone()),
+                _ => None,
+            }
+        })
+    }
+
+    /// Dissolve refused placeholders after their notice period and return
+    /// focus to the pane the user was in. Input deferred to them was already
+    /// retired through the failed semantic destination; it is never replayed
+    /// elsewhere.
+    fn expire_failed_create_placeholders(&mut self) -> bool {
+        let now = Instant::now();
+        let expired = self
+            .create_placeholders
+            .iter()
+            .filter(|placeholder| {
+                matches!(
+                    placeholder.state,
+                    CreatePlaceholderState::Failed { since, .. }
+                        if now.duration_since(since) >= DURABLE_NOTICE_DISPLAY_DURATION
+                )
+            })
+            .map(|placeholder| (placeholder.intent, placeholder.prior_focus))
+            .collect::<Vec<_>>();
+        if expired.is_empty() {
+            return false;
+        }
+        for (intent, prior_focus) in expired {
+            self.create_placeholders.retain(|placeholder| placeholder.intent != intent);
+            if let Some(prior) = prior_focus
+                && self.tree.set_active_pane_if_present(prior)
+            {
+                self.pane_focus_history.record(prior);
+            }
+        }
+        self.deferred_input
+            .retain(|input| !input.admission.destination.is_some_and(is_placeholder_id));
+        self.rebuild_tab_locations();
+        true
+    }
+
+    /// A refetch has settled with nothing pending: a placeholder whose intent
+    /// was marked failed (timeout) becomes a failure notice with its cause.
+    fn settle_orphaned_create_placeholders(&mut self) {
+        if self.session.has_pending_mutations() || self.session.remote_tree_is_stale() {
+            return;
+        }
+        let reconciling = localization::catalog().session.operation_reconciling;
+        for placeholder in &mut self.create_placeholders {
+            if placeholder.state != CreatePlaceholderState::Pending {
+                continue;
+            }
+            if self.semantic_destination_outcomes.get(&placeholder.intent)
+                == Some(&SemanticDestinationOutcome::Failed)
+            {
+                let cause =
+                    placeholder.timed_out_cause.clone().unwrap_or_else(|| reconciling.to_string());
+                placeholder.state = CreatePlaceholderState::Failed { cause, since: Instant::now() };
+            }
+        }
+    }
+
+    /// Overlay every placeholder on the adopted tree in the slot the daemon
+    /// will produce, and give a fresh placeholder focus so focus-follow input
+    /// defers to it. Nothing here reaches the daemon.
+    fn apply_create_placeholders(&mut self) {
+        if self.create_placeholders.is_empty() {
+            return;
+        }
+        let placeholders = self.create_placeholders.clone();
+        for placeholder in placeholders {
+            let pane_id = placeholder.pane();
+            let surface = placeholder.surface();
+            let split_id: SplitId = placeholder_id(placeholder.intent);
+            let focus_follows = self.active_pane() == placeholder.prior_focus;
+            let mut placed = false;
+            match placeholder.kind {
+                CreatePlaceholderKind::Workspace => {
+                    let index = self.tree.workspaces().len();
+                    self.tree.workspaces_mut().push(WorkspaceView {
+                        id: placeholder_id(placeholder.intent),
+                        resource_id: None,
+                        key: String::new(),
+                        short_id: String::new(),
+                        name: String::new(),
+                        screens: vec![ScreenView {
+                            id: placeholder_id(placeholder.intent),
+                            resource_id: None,
+                            short_id: String::new(),
+                            name: None,
+                            layout: Node::Leaf(pane_id),
+                            active_pane: pane_id,
+                            zoomed_pane: None,
+                            viewport_base_width: None,
+                            viewport_splits: BTreeMap::new(),
+                            panes: vec![placeholder_pane(pane_id, surface)],
+                        }],
+                        active_screen: 0,
+                    });
+                    if focus_follows {
+                        self.tree.active_workspace = index;
+                    }
+                    placed = true;
+                }
+                CreatePlaceholderKind::Pane { anchor }
+                | CreatePlaceholderKind::Split { anchor, .. } => {
+                    let dir = match placeholder.kind {
+                        CreatePlaceholderKind::Split { dir, .. } => Some(dir),
+                        _ => None,
+                    };
+                    let Some(screen) = self
+                        .tree
+                        .workspaces_mut()
+                        .iter_mut()
+                        .filter(|workspace| Some(workspace.id) == placeholder.workspace)
+                        .flat_map(|workspace| workspace.screens.iter_mut())
+                        .find(|screen| Some(screen.id) == placeholder.screen)
+                    else {
+                        continue;
+                    };
+                    if !screen.panes.iter().any(|pane| pane.id == anchor) {
+                        continue;
+                    }
+                    let inserted = match dir {
+                        None if screen.viewport_splits.is_empty() => {
+                            let mut panes = Vec::new();
+                            screen.layout.pane_ids(&mut panes);
+                            panes.push(pane_id);
+                            match zellij_default_pane_layout(&panes) {
+                                Some(layout) => {
+                                    screen.layout = layout;
+                                    true
+                                }
+                                None => false,
+                            }
+                        }
+                        None => split_leaf_for_placeholder(
+                            &mut screen.layout,
+                            anchor,
+                            SplitDir::Down,
+                            split_id,
+                            pane_id,
+                        ),
+                        Some(dir) => split_leaf_for_placeholder(
+                            &mut screen.layout,
+                            anchor,
+                            dir,
+                            split_id,
+                            pane_id,
+                        ),
+                    };
+                    if inserted {
+                        screen.panes.push(placeholder_pane(pane_id, surface));
+                        placed = true;
+                    }
+                }
+                CreatePlaceholderKind::Tab { pane } => {
+                    if let Some(pane) = self
+                        .tree
+                        .workspaces_mut()
+                        .iter_mut()
+                        .flat_map(|workspace| workspace.screens.iter_mut())
+                        .flat_map(|screen| screen.panes.iter_mut())
+                        .find(|candidate| candidate.id == pane)
+                    {
+                        pane.tabs.push(placeholder_tab(surface));
+                        placed = true;
+                    }
+                }
+            }
+            // Focus follows the user's create unless they moved on since.
+            if placed && (focus_follows || placeholder.prior_focus.is_none()) {
+                self.tree.select_surface(surface);
+            }
+        }
+    }
+
     /// Escape during a split drag: drop the preview, send nothing.
     fn cancel_split_drag(&mut self) {
         self.drag = None;
@@ -25175,36 +25583,38 @@ mod tests {
 
     use super::{
         App, AppEvent, BACKGROUND_REFRESH_RETRIES, BrowserResizeFailure, ContextMenu,
-        DEFERRED_INPUT_CAPACITY, DeferredInput, DeferredInputAdmission, DeferredInputQueue,
-        DeferredReplayDisposition, Drag, EventCancellation, FocusTarget, ForwardMuxOutcome,
-        FrontendJournalQueue, FrontendJournalWorker, GraphicIdentity, GraphicPlacement,
-        GraphicSourceRect, GraphicsSceneCache, GuardedMouseEncode, HostInputIngress,
-        HostInputMessage, HostInputRuntime, MachineActionWorker, MachineConnectRoute, MenuAction,
-        MenuItem, MutationImpact, MuxTitleIngress, OmnibarHit, OmnibarState, OrderedSession,
-        OuterCursorSpec, PaneArea, PaneAreaProjection, PaneContentGeneration, PaneEdge,
-        PaneFocusHistory, PaneResizeDragTarget, PaneViewportClip, PendingRenameTarget,
-        PendingSessionMutation, PendingSessionMutationState, PointerHitIdentity,
-        PointerRouteIdentity, PointerRoutePhase, Prompt, PromptTarget, PtyFailureIngress,
-        PtyMousePressResult, RailKind, RenderAction, RenderedMenuLevel, RenderedPaneRoute,
-        RenderedPointerFrame, Selection, SelectionMode, SessionCompletion, SessionCompletionAction,
-        SessionEventSender, ShortcutHelp, SidebarActionTarget, SidebarLayout,
-        SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarWidthOverrides, SplitDragPreview,
-        StatusTemplateValues, StatusWorkerStop, StdoutLock, SurfaceAttachClaimState,
-        SurfaceResizeDecision, SurfaceResizeOwnership, TERMINAL_PAINT_CADENCE, TerminalInput,
-        TerminalPaintPacer, TerminalPointerAdmission, TerminalPointerAdmissionResult,
-        TerminalPointerEncoding, TextInput, Toast, VIEWPORT_ANIMATION_DURATION, ViewportMotion,
-        ViewportPaneAreaProjection, WorkspaceRailSelection, action_available_in_mode,
-        browser_content_size_for_rect, browser_frame_source_crop, browser_hover_forward_allowed,
-        browser_source_crop, canonical_terminal_content, catch_renderer_panic,
-        clamp_split_ratio_for_tab_bars, client_menu_item, clip_horizontal_rect,
-        content_size_for_rect, disable_host_keyboard_protocol, enable_host_keyboard_protocol,
-        expand_status_tokens, first_pane_by_id, forward_host_input, forward_mux_event,
-        forward_mux_events, host_mouse_capture_escape_if_changed, host_startup_input_modes,
-        initial_applied_outer_cursor, initial_host_mouse_capture, keyboard_protocol_accepts,
-        layout_undo_error_completion, negotiate_host_keyboard_protocol_with, outer_cursor_escape,
-        outer_cursor_escape_if_changed, pane_area_projection_work, pane_context_menu_groups,
-        pane_parts_for_rect, prepare_ordered_session, preserve_client_view, rail_drag_width,
-        rebuild_pane_areas, record_surface_resize_dispatch_result, report_after_unwind,
+        CreatePlaceholderState, DEFERRED_INPUT_CAPACITY, DeferredInput, DeferredInputAdmission,
+        DeferredInputQueue, DeferredReplayDisposition, Drag, EventCancellation, FocusTarget,
+        ForwardMuxOutcome, FrontendJournalQueue, FrontendJournalWorker, GraphicIdentity,
+        GraphicPlacement, GraphicSourceRect, GraphicsSceneCache, GuardedMouseEncode,
+        HostInputIngress, HostInputMessage, HostInputRuntime, MachineActionWorker,
+        MachineConnectRoute, MenuAction, MenuItem, MutationImpact, MuxTitleIngress, OmnibarHit,
+        OmnibarState, OrderedSession, OuterCursorSpec, PaneArea, PaneAreaProjection,
+        PaneContentGeneration, PaneEdge, PaneFocusHistory, PaneResizeDragTarget, PaneViewportClip,
+        PendingRenameTarget, PendingSessionMutation, PendingSessionMutationState,
+        PointerHitIdentity, PointerRouteIdentity, PointerRoutePhase, Prompt, PromptTarget,
+        PtyFailureIngress, PtyMousePressResult, RailKind, RenderAction, RenderedMenuLevel,
+        RenderedPaneRoute, RenderedPointerFrame, Selection, SelectionMode, SessionCompletion,
+        SessionCompletionAction, SessionEventSender, ShortcutHelp, SidebarActionTarget,
+        SidebarLayout, SidebarPluginSyncClaim, SidebarPluginSyncState, SidebarWidthOverrides,
+        SplitDragPreview, StatusTemplateValues, StatusWorkerStop, StdoutLock,
+        SurfaceAttachClaimState, SurfaceResizeDecision, SurfaceResizeOwnership,
+        TERMINAL_PAINT_CADENCE, TerminalInput, TerminalPaintPacer, TerminalPointerAdmission,
+        TerminalPointerAdmissionResult, TerminalPointerEncoding, TextInput, Toast,
+        VIEWPORT_ANIMATION_DURATION, ViewportMotion, ViewportPaneAreaProjection,
+        WorkspaceRailSelection, action_available_in_mode, browser_content_size_for_rect,
+        browser_frame_source_crop, browser_hover_forward_allowed, browser_source_crop,
+        canonical_terminal_content, catch_renderer_panic, clamp_split_ratio_for_tab_bars,
+        client_menu_item, clip_horizontal_rect, content_size_for_rect,
+        disable_host_keyboard_protocol, enable_host_keyboard_protocol, expand_status_tokens,
+        first_pane_by_id, forward_host_input, forward_mux_event, forward_mux_events,
+        host_mouse_capture_escape_if_changed, host_startup_input_modes,
+        initial_applied_outer_cursor, initial_host_mouse_capture, is_placeholder_id,
+        keyboard_protocol_accepts, layout_undo_error_completion,
+        negotiate_host_keyboard_protocol_with, outer_cursor_escape, outer_cursor_escape_if_changed,
+        pane_area_projection_work, pane_context_menu_groups, pane_parts_for_rect,
+        prepare_ordered_session, preserve_client_view, rail_drag_width, rebuild_pane_areas,
+        record_surface_resize_dispatch_result, report_after_unwind,
         reset_pane_area_projection_work, run_status_command, send_bounded_cancelable,
         should_claim_clear_history_shortcut, sidebar_layout_for, sidebar_layout_for_state,
         sidebar_plugin_status_settles_passive_claim, start_ordered_session,
@@ -30252,6 +30662,189 @@ mod tests {
         assert_eq!(pane_lifecycle_text(false, false), Some(PaneLifecycleText::Starting));
         assert_eq!(pane_lifecycle_text(true, true), Some(PaneLifecycleText::Exited));
         assert_eq!(pane_lifecycle_text(true, false), Some(PaneLifecycleText::Exited));
+    }
+
+    const PTY_EXHAUSTED_REJECTION: &str = "remote command rejected: terminal launch failed: PTY capacity exhausted; close unused terminals or tmux sessions and retry: Device not configured (os error 6)";
+
+    #[test]
+    fn failed_mutation_status_shows_the_daemon_cause() {
+        let (mux, surface) = test_mux("failed-cause-status-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.outer_size = (200, 40);
+        app.session.pending_mutations.fetch_add(1, Ordering::AcqRel);
+        app.handle(AppEvent::SessionMutationSettled {
+            outcome: super::SessionMutationOutcome::Failed(PTY_EXHAUSTED_REJECTION.to_string()),
+            impact: MutationImpact::Ordered,
+        })
+        .unwrap();
+        assert_eq!(
+            app.status_message.as_deref(),
+            Some(
+                "Session operation failed: terminal launch failed: PTY capacity exhausted; close unused terminals or tmux sessions and retry: Device not configured (os error 6)"
+            )
+        );
+
+        // A narrow status line keeps the head of the cause and marks the cut.
+        app.outer_size = (48, 10);
+        app.session.pending_mutations.fetch_add(1, Ordering::AcqRel);
+        app.handle(AppEvent::SessionMutationSettled {
+            outcome: super::SessionMutationOutcome::Failed(PTY_EXHAUSTED_REJECTION.to_string()),
+            impact: MutationImpact::Ordered,
+        })
+        .unwrap();
+        let status = app.status_message.clone().unwrap();
+        assert!(status.starts_with("Session operation failed: terminal launch"), "{status}");
+        assert!(status.ends_with('…'), "{status}");
+        assert!(status.chars().count() <= 48, "{status}");
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn alt_n_shows_a_placeholder_pane_before_the_daemon_answers_and_resolves_it() {
+        let (mux, _) = test_mux("alt-n-placeholder-test", None);
+        let (mut app, events) = test_app_with_events(Session::Local(mux.clone()));
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((200, 40));
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(5)).unwrap()).unwrap();
+        }
+        let original = app.active_pane().unwrap();
+
+        app.handle(AppEvent::Input(Event::Key(KeyEvent::new(
+            KeyCode::Char('n'),
+            KeyModifiers::ALT,
+        ))))
+        .unwrap();
+        // Before any response: the placeholder is in the tree, has focus, and
+        // occupies the second Zellij slot.
+        assert_eq!(app.create_placeholders.len(), 1);
+        let placeholder = app.active_pane().expect("placeholder takes focus");
+        assert!(is_placeholder_id(placeholder));
+        assert_eq!(app.tree.active_screen().unwrap().panes.len(), 2);
+        app.sync_layout((200, 40));
+        assert!(app.pane_areas.iter().any(|area| area.pane == placeholder));
+        assert_eq!(app.pane_areas.len(), 2);
+
+        while app.session.has_pending_mutations() {
+            app.handle(events.recv_timeout(Duration::from_secs(5)).unwrap()).unwrap();
+        }
+        app.sync_layout((200, 40));
+        assert!(app.create_placeholders.is_empty(), "the real pane resolves the placeholder");
+        let active = app.active_pane().unwrap();
+        assert!(!is_placeholder_id(active));
+        assert_ne!(active, original, "focus lands on the created pane");
+        assert_eq!(app.tree.active_screen().unwrap().panes.len(), 2);
+        assert_eq!(app.pane_areas.len(), 2);
+
+        let surfaces = mux.with_state(|state| state.surfaces.keys().copied().collect::<Vec<_>>());
+        for surface in surfaces {
+            mux.close_surface(surface).unwrap();
+        }
+    }
+
+    #[test]
+    fn refused_create_placeholder_shows_the_cause_then_dissolves_and_drops_typed_input() {
+        let tree_json = serde_json::json!({
+            "workspaces": [{
+                "id": 1, "name": "one", "active": true,
+                "resource_id": "ws_00000000000000000000000000000001",
+                "screens": [{
+                    "id": 2, "active": true, "active_pane": 3,
+                    "resource_id": "screen_00000000000000000000000000000002",
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{"id": 3,
+                        "resource_id": "pane_00000000000000000000000000000003",
+                        "tabs": [{"surface": 7, "title": "a", "kind": "pty"}]}]
+                }]
+            }]
+        });
+        let (session, requests) =
+            crate::session::test_remote_session_answering(Arc::new(move |request: &Value| {
+                match request.get("cmd").and_then(Value::as_str) {
+                    Some("list-workspaces") => tree_json.clone(),
+                    Some("list-agents") => serde_json::json!({"agents": []}),
+                    Some(
+                        "new-pane"
+                        | "new-tab"
+                        | "split"
+                        | "new-workspace"
+                        | "create-surface-with-receipt",
+                    ) => serde_json::json!({
+                        "__reject": PTY_EXHAUSTED_REJECTION
+                            .strip_prefix("remote command rejected: ")
+                            .unwrap()
+                    }),
+                    _ => serde_json::json!({}),
+                }
+            }));
+        session.refresh_tree().unwrap();
+        let (mut app, events) = test_app_with_events(session);
+        app.sidebar_visible = false;
+        app.replace_tree(app.session.tree());
+        app.sync_layout((200, 40));
+        for _ in requests.try_iter() {}
+
+        app.handle(AppEvent::Input(Event::Key(KeyEvent::new(
+            KeyCode::Char('n'),
+            KeyModifiers::ALT,
+        ))))
+        .unwrap();
+        assert_eq!(app.create_placeholders.len(), 1);
+        let placeholder = app.active_pane().unwrap();
+        assert!(is_placeholder_id(placeholder));
+
+        // Typing while the placeholder is focused is deferred to it.
+        app.handle(AppEvent::Input(Event::Key(KeyEvent::new(
+            KeyCode::Char('x'),
+            KeyModifiers::NONE,
+        ))))
+        .unwrap();
+        assert!(!app.deferred_input.is_empty(), "input to the placeholder must be deferred");
+
+        let mut failed = false;
+        while !failed {
+            let event = events.recv_timeout(Duration::from_secs(5)).unwrap();
+            if let AppEvent::SessionMutationSettled { .. } = &event {
+                failed = true;
+            }
+            app.handle(event).unwrap();
+        }
+        let cause = match &app.create_placeholders[0].state {
+            CreatePlaceholderState::Failed { cause, .. } => cause.clone(),
+            other => panic!("placeholder should have failed, got {other:?}"),
+        };
+        assert!(cause.contains("PTY capacity exhausted"), "{cause}");
+        assert!(
+            app.status_message.as_deref().is_some_and(|status| status.contains("PTY capacity")),
+            "{:?}",
+            app.status_message
+        );
+        // The failure is shown where the pane would have been.
+        app.sync_layout((200, 40));
+        assert!(app.pane_areas.iter().any(|area| area.pane == placeholder));
+        assert_eq!(app.create_placeholder_failure(placeholder).as_deref(), Some(cause.as_str()));
+
+        // After the notice period it dissolves and focus returns.
+        if let CreatePlaceholderState::Failed { since, .. } = &mut app.create_placeholders[0].state
+        {
+            *since = Instant::now() - super::DURABLE_NOTICE_DISPLAY_DURATION;
+        }
+        assert!(app.expire_failed_create_placeholders());
+        assert!(app.create_placeholders.is_empty());
+        app.sync_layout((200, 40));
+        assert_eq!(app.active_pane(), Some(3));
+        assert_eq!(app.pane_areas.len(), 1);
+
+        // The deferred keystroke is dropped, never sent to the surviving pane.
+        app.replay_deferred_input().unwrap();
+        assert!(app.deferred_input.is_empty());
+        let later = requests.try_iter().collect::<Vec<_>>();
+        assert!(
+            later.iter().all(|request| request["cmd"] != "send"),
+            "typed input must not be replayed elsewhere: {later:?}"
+        );
     }
 
     #[test]
@@ -38417,9 +39010,17 @@ mod tests {
         assert!(app.deferred_input.is_empty());
         assert!(!app.prefix_armed);
         assert_eq!(app.pointer_route_phase, PointerRoutePhase::DrawPending);
+        // The status line names the operation and carries the daemon's cause.
         assert_eq!(
             app.status_message.as_deref(),
-            Some(localization::catalog().session.operation_failed)
+            Some(
+                localization::catalog()
+                    .session
+                    .operation_failed_with_cause
+                    .replace("{operation}", localization::catalog().session.operation_failed)
+                    .replace("{cause}", "selection rejected")
+                    .as_str()
+            )
         );
 
         app.pointer_route_phase = PointerRoutePhase::Fresh;
@@ -42899,9 +43500,17 @@ mod tests {
             app.handle(events.recv_timeout(Duration::from_secs(1)).unwrap()).unwrap();
         }
 
+        // The status line names the operation and carries the daemon's cause.
         assert_eq!(
             app.status_message.as_deref(),
-            Some(localization::catalog().session.operation_failed)
+            Some(
+                localization::catalog()
+                    .session
+                    .operation_failed_with_cause
+                    .replace("{operation}", localization::catalog().session.operation_failed)
+                    .replace("{cause}", "workspace id and key do not identify the same workspace")
+                    .as_str()
+            )
         );
         assert!(app.tree.workspaces().iter().any(|workspace| workspace.id == placement.workspace));
     }
@@ -46693,6 +47302,7 @@ mod tests {
             client_focus_epoch: 0,
             split_drag_preview: None,
             pending_renames: HashMap::new(),
+            create_placeholders: Vec::new(),
             rendered_terminal_bounds: HashMap::new(),
             rendered_kitty_graphics: HashMap::new(),
             visible_size_surfaces: HashSet::new(),

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -115,7 +115,7 @@ pub(crate) struct TerminalMessages {
     /// One inline line under the last frame of a PTY pane whose process exited.
     pub pane_exited: &'static str,
     /// One inline line where a pane would have appeared, when its create
-    /// was refused. `{cause}` is the daemon's reason.
+    /// was refused. `{cause}` is a product-safe failure category.
     pub pane_create_failed: &'static str,
 }
 
@@ -124,9 +124,9 @@ pub(crate) struct SessionMessages {
     pub creation_reconciling: &'static str,
     pub operation_reconciling: &'static str,
     pub operation_failed: &'static str,
-    /// `{operation}` is `operation_failed`; `{cause}` is the daemon's reason
-    /// with the transport prefix removed.
+    /// `{operation}` is `operation_failed`; `{cause}` is a product-safe failure category.
     pub operation_failed_with_cause: &'static str,
+    pub operation_failed_generic_cause: &'static str,
     pub operation_canceled: &'static str,
     pub mux_subscription_recovered: &'static str,
     mux_subscription_recovery_failed: &'static str,
@@ -1283,6 +1283,7 @@ static ENGLISH: Catalog = Catalog {
         operation_reconciling: "Session operation may have completed; refreshing the layout",
         operation_failed: "Session operation failed",
         operation_failed_with_cause: "{operation}: {cause}",
+        operation_failed_generic_cause: "the operation was rejected; check the session and retry",
         operation_canceled: "Session operation was canceled",
         mux_subscription_recovered: "Mux event backlog overflowed; subscription recovered",
         mux_subscription_recovery_failed: "Mux event backlog recovery failed; queued input was discarded while retrying: {error}",
@@ -1935,6 +1936,7 @@ static JAPANESE: Catalog = Catalog {
         operation_reconciling: "セッション操作が完了している可能性があります。レイアウトを更新しています",
         operation_failed: "セッション操作に失敗しました",
         operation_failed_with_cause: "{operation}: {cause}",
+        operation_failed_generic_cause: "操作が拒否されました。セッションを確認して再試行してください",
         operation_canceled: "セッション操作はキャンセルされました",
         mux_subscription_recovered: "Mux イベントの滞留が上限を超えました。購読を復旧しました",
         mux_subscription_recovery_failed: "Mux イベントの滞留から復旧できませんでした。再試行中のキュー入力を破棄しました: {error}",

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -114,6 +114,9 @@ pub(crate) struct TerminalMessages {
     pub pane_starting: &'static str,
     /// One inline line under the last frame of a PTY pane whose process exited.
     pub pane_exited: &'static str,
+    /// One inline line where a pane would have appeared, when its create
+    /// was refused. `{cause}` is the daemon's reason.
+    pub pane_create_failed: &'static str,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -121,6 +124,9 @@ pub(crate) struct SessionMessages {
     pub creation_reconciling: &'static str,
     pub operation_reconciling: &'static str,
     pub operation_failed: &'static str,
+    /// `{operation}` is `operation_failed`; `{cause}` is the daemon's reason
+    /// with the transport prefix removed.
+    pub operation_failed_with_cause: &'static str,
     pub operation_canceled: &'static str,
     pub mux_subscription_recovered: &'static str,
     mux_subscription_recovery_failed: &'static str,
@@ -1270,11 +1276,13 @@ static ENGLISH: Catalog = Catalog {
         operation_failed: "Terminal input failed",
         pane_starting: "starting…",
         pane_exited: "process exited",
+        pane_create_failed: "could not open: {cause}",
     },
     session: SessionMessages {
         creation_reconciling: "Session creation may have completed; checking its receipt",
         operation_reconciling: "Session operation may have completed; refreshing the layout",
         operation_failed: "Session operation failed",
+        operation_failed_with_cause: "{operation}: {cause}",
         operation_canceled: "Session operation was canceled",
         mux_subscription_recovered: "Mux event backlog overflowed; subscription recovered",
         mux_subscription_recovery_failed: "Mux event backlog recovery failed; queued input was discarded while retrying: {error}",
@@ -1920,11 +1928,13 @@ static JAPANESE: Catalog = Catalog {
         operation_failed: "ターミナル入力に失敗しました",
         pane_starting: "起動中…",
         pane_exited: "プロセスが終了しました",
+        pane_create_failed: "開けませんでした: {cause}",
     },
     session: SessionMessages {
         creation_reconciling: "セッションの作成が完了している可能性があります。結果を確認しています",
         operation_reconciling: "セッション操作が完了している可能性があります。レイアウトを更新しています",
         operation_failed: "セッション操作に失敗しました",
+        operation_failed_with_cause: "{operation}: {cause}",
         operation_canceled: "セッション操作はキャンセルされました",
         mux_subscription_recovered: "Mux イベントの滞留が上限を超えました。購読を復旧しました",
         mux_subscription_recovery_failed: "Mux イベントの滞留から復旧できませんでした。再試行中のキュー入力を破棄しました: {error}",

--- a/cmux-tui/crates/cmux-tui/src/localization.rs
+++ b/cmux-tui/crates/cmux-tui/src/localization.rs
@@ -110,6 +110,10 @@ pub(crate) struct TerminalMessages {
     pub pty_input_exited: &'static str,
     pub attach_outcome_unknown: &'static str,
     pub operation_failed: &'static str,
+    /// One inline line in a PTY pane whose attach has not delivered a frame.
+    pub pane_starting: &'static str,
+    /// One inline line under the last frame of a PTY pane whose process exited.
+    pub pane_exited: &'static str,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -1264,6 +1268,8 @@ static ENGLISH: Catalog = Catalog {
         pty_input_exited: "Terminal exited; input was not sent",
         attach_outcome_unknown: "Surface attach outcome is unknown. Detach and reconnect before sending more input",
         operation_failed: "Terminal input failed",
+        pane_starting: "starting…",
+        pane_exited: "process exited",
     },
     session: SessionMessages {
         creation_reconciling: "Session creation may have completed; checking its receipt",
@@ -1912,6 +1918,8 @@ static JAPANESE: Catalog = Catalog {
         pty_input_exited: "ターミナルが終了したため、入力は送信されませんでした",
         attach_outcome_unknown: "サーフェスの接続結果を確認できません。入力を再開する前に切断して再接続してください",
         operation_failed: "ターミナル入力に失敗しました",
+        pane_starting: "起動中…",
+        pane_exited: "プロセスが終了しました",
     },
     session: SessionMessages {
         creation_reconciling: "セッションの作成が完了している可能性があります。結果を確認しています",

--- a/cmux-tui/crates/cmux-tui/src/pty_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/pty_input.rs
@@ -6,6 +6,25 @@
 //! unrelated panes to keep accepting input while preserving each surface's
 //! order. Consecutive byte-stream writes are batched, motion is coalesced, and
 //! every accepted mouse press reserves its release capacity.
+//!
+//! Ordering rule for session mutations (the "per-target barrier"):
+//!
+//! * Session mutations form one lane of their own. They run off the worker
+//!   thread, one at a time, in enqueue order. A mutation never waits for, and
+//!   is never waited on by, input to a surface it does not name.
+//! * A mutation names the surfaces it destroys as its targets. Input to a
+//!   target that was enqueued before the mutation runs first; input to a
+//!   target enqueued after the mutation waits for it, and then fails closed
+//!   against the retired surface exactly as before. A mutation with no
+//!   targets (a create, a rename, a layout change) blocks no surface input.
+//! * Input to the surface a create will produce does not exist yet from this
+//!   queue's point of view. The frontend defers it by semantic intent until
+//!   the created surface is known, so that ordering is the frontend's job.
+//!
+//! The old rule made every mutation a global barrier: a keystroke to an
+//! existing pane waited for a create round trip to a different pane. The
+//! frontend contract in `plans/cmux-tui-zero-wait-interaction.md` (hq) forbids
+//! that; unrelated input must reach its PTY within one frame.
 
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::sync::{Arc, Condvar, Mutex};
@@ -94,10 +113,15 @@ pub struct PtyInputEvent {
     coalesce_key: Option<MutationCoalesceKey>,
     failure_surface_id: Option<SurfaceId>,
     concurrent_surface_operation: bool,
+    /// Surfaces a session mutation destroys. Input to these lanes is ordered
+    /// around the mutation; every other lane ignores it.
+    target_surfaces: MutationTargets,
     remote: bool,
     reservation_id: Option<u64>,
     remote_release_attempts: u8,
 }
+
+pub type MutationTargets = SmallVec<[SurfaceId; 4]>;
 
 impl PtyInputEvent {
     pub fn input(
@@ -121,6 +145,7 @@ impl PtyInputEvent {
             coalesce_key: None,
             failure_surface_id: None,
             concurrent_surface_operation: false,
+            target_surfaces: MutationTargets::new(),
             remote,
             reservation_id: None,
             remote_release_attempts: 0,
@@ -202,10 +227,22 @@ impl PtyInputEvent {
             coalesce_key: identity.coalesce_key,
             failure_surface_id: identity.failure_surface_id,
             concurrent_surface_operation: identity.concurrent_surface_operation,
+            target_surfaces: identity.target_surfaces.clone(),
             remote,
             reservation_id: None,
             remote_release_attempts: 0,
         }
+    }
+
+    fn is_session_mutation(&self) -> bool {
+        self.kind == PtyInputKind::Mutation && !self.concurrent_surface_operation
+    }
+
+    fn target_lanes(&self) -> impl Iterator<Item = PtyInputLane> + '_ {
+        let session_generation = self.session_generation;
+        self.target_surfaces
+            .iter()
+            .map(move |surface_id| PtyInputLane { session_generation, surface_id: *surface_id })
     }
 
     fn queued_byte_len(&self) -> usize {
@@ -246,6 +283,9 @@ struct QueueState {
     release_reservations: ReleaseReservations,
     in_flight: Option<InFlightInput>,
     in_flight_surface_operations: HashMap<PtyInputLane, usize>,
+    /// The one session mutation currently executing off the worker thread,
+    /// with the lanes it blocks and its retained byte budget.
+    in_flight_mutation: Option<InFlightMutation>,
     failed_lanes: HashSet<PtyInputLane>,
     retired_in_flight_lanes: HashSet<PtyInputLane>,
     failed_remote_generations: HashSet<u64>,
@@ -262,6 +302,7 @@ impl Default for QueueState {
             release_reservations: ReleaseReservations::default(),
             in_flight: None,
             in_flight_surface_operations: HashMap::new(),
+            in_flight_mutation: None,
             failed_lanes: HashSet::new(),
             retired_in_flight_lanes: HashSet::new(),
             failed_remote_generations: HashSet::new(),
@@ -331,6 +372,12 @@ struct InFlightInput {
     kind: PtyInputKind,
 }
 
+#[derive(Debug, Clone)]
+struct InFlightMutation {
+    targets: Vec<PtyInputLane>,
+    bytes: usize,
+}
+
 #[derive(Default)]
 struct SharedQueue {
     state: Mutex<QueueState>,
@@ -353,12 +400,13 @@ pub struct PtyInputSender {
     session_generation: u64,
 }
 
-#[derive(Clone, Copy, Default)]
+#[derive(Clone, Default)]
 struct PtyMutationIdentity {
     coalesce_key: Option<MutationCoalesceKey>,
     failure_surface_id: Option<SurfaceId>,
     retained_bytes: usize,
     concurrent_surface_operation: bool,
+    target_surfaces: MutationTargets,
 }
 
 impl PtyInputDispatcher {
@@ -423,6 +471,7 @@ impl PtyInputDispatcher {
         self.sender.queue.changed.notify_all();
         while (!state.events.is_empty()
             || state.in_flight.is_some()
+            || state.in_flight_mutation.is_some()
             || !state.in_flight_surface_operations.is_empty())
             && Instant::now() < deadline
         {
@@ -432,6 +481,7 @@ impl PtyInputDispatcher {
         }
         let drained = state.events.is_empty()
             && state.in_flight.is_none()
+            && state.in_flight_mutation.is_none()
             && state.in_flight_surface_operations.is_empty();
         let canceled = if drained {
             Vec::new()
@@ -520,8 +570,10 @@ impl PtyInputSender {
             return (PtyInputEnqueueResult::Oversized, None);
         }
         let reserves_release = event.kind == PtyInputKind::Press;
-        let active_operations = state.in_flight_surface_operations.len();
-        let active_bytes = state.in_flight_surface_operations.values().copied().sum::<usize>();
+        let active_operations = state.in_flight_surface_operations.len()
+            + usize::from(state.in_flight_mutation.is_some());
+        let active_bytes = state.in_flight_surface_operations.values().copied().sum::<usize>()
+            + state.in_flight_mutation.as_ref().map_or(0, |mutation| mutation.bytes);
         let available_capacity = PTY_OPERATION_QUEUE_CAPACITY.saturating_sub(active_operations);
         let available_bytes = MAX_QUEUED_BYTES.saturating_sub(active_bytes);
         let QueueState { events, queued_bytes, release_reservations, .. } = &mut *state;
@@ -590,6 +642,27 @@ impl PtyInputSender {
         );
     }
 
+    #[cfg(test)]
+    pub fn enqueue_session_mutation_targeting(
+        &self,
+        label: &'static str,
+        target_surfaces: &[SurfaceId],
+        remote: bool,
+        operation: impl FnOnce() -> anyhow::Result<()> + Send + 'static,
+    ) {
+        let _ = self.enqueue_mutation(
+            label,
+            PtyMutationIdentity {
+                target_surfaces: target_surfaces.iter().copied().collect(),
+                ..Default::default()
+            },
+            remote,
+            None,
+            None,
+            operation,
+        );
+    }
+
     pub fn enqueue_session_mutation_with_settlement(
         &self,
         label: &'static str,
@@ -597,9 +670,28 @@ impl PtyInputSender {
         after_operation: impl FnOnce() + Send + 'static,
         operation: impl FnOnce() -> anyhow::Result<()> + Send + 'static,
     ) {
+        self.enqueue_session_mutation_with_settlement_targeting(
+            label,
+            MutationTargets::new(),
+            remote,
+            after_operation,
+            operation,
+        );
+    }
+
+    /// Enqueue a session mutation that destroys `target_surfaces`. Input to
+    /// those surfaces is ordered around the mutation; see the module doc.
+    pub fn enqueue_session_mutation_with_settlement_targeting(
+        &self,
+        label: &'static str,
+        target_surfaces: MutationTargets,
+        remote: bool,
+        after_operation: impl FnOnce() + Send + 'static,
+        operation: impl FnOnce() -> anyhow::Result<()> + Send + 'static,
+    ) {
         let _ = self.enqueue_mutation(
             label,
-            PtyMutationIdentity::default(),
+            PtyMutationIdentity { target_surfaces, ..Default::default() },
             remote,
             None,
             Some(Box::new(after_operation)),
@@ -680,6 +772,7 @@ impl PtyInputSender {
         after_operation: Option<Box<dyn FnOnce() + Send>>,
         operation: impl FnOnce() -> anyhow::Result<()> + Send + 'static,
     ) -> PtyInputEnqueueResult {
+        let failure_surface_id = identity.failure_surface_id;
         let result = self.enqueue(PtyInputEvent::mutation_for_surface(
             label,
             identity,
@@ -691,7 +784,7 @@ impl PtyInputSender {
         if result != PtyInputEnqueueResult::Accepted {
             (self.on_failure)(PtyOperationFailure {
                 session_generation: self.session_generation,
-                surface_id: identity.failure_surface_id,
+                surface_id: failure_surface_id,
                 kind: None,
                 reservation_id: None,
                 label,
@@ -899,7 +992,7 @@ fn worker(queue: Arc<SharedQueue>, on_failure: Arc<dyn Fn(PtyOperationFailure) +
             }
         };
 
-        if event.concurrent_surface_operation {
+        if event.concurrent_surface_operation || event.is_session_mutation() {
             spawn_surface_operation(queue.clone(), on_failure.clone(), event);
         } else {
             process_event(queue.clone(), on_failure.clone(), event);
@@ -909,15 +1002,32 @@ fn worker(queue: Arc<SharedQueue>, on_failure: Arc<dyn Fn(PtyOperationFailure) +
 
 fn dequeue_ready_event(state: &mut QueueState) -> Option<PtyInputEvent> {
     let mut ready_index = None;
+    // Lanes that later queued work must not overtake: a lane with an
+    // in-flight or earlier-queued blocked operation, or a lane named as the
+    // target of an in-flight or earlier-queued session mutation.
     let mut blocked_queued_lanes = HashSet::new();
+    // Session mutations are one FIFO lane: at most one in flight, and an
+    // earlier queued mutation that cannot run yet holds every later one.
+    let mut mutation_blocked = state.in_flight_mutation.is_some();
+    if let Some(mutation) = &state.in_flight_mutation {
+        blocked_queued_lanes.extend(mutation.targets.iter().copied());
+    }
     for (index, event) in state.events.iter().enumerate() {
-        if event.kind == PtyInputKind::Mutation && !event.concurrent_surface_operation {
-            if index == 0 && state.in_flight_surface_operations.is_empty() {
+        if event.is_session_mutation() {
+            let target_busy = event.target_lanes().any(|lane| {
+                blocked_queued_lanes.contains(&lane)
+                    || state.in_flight_surface_operations.contains_key(&lane)
+                    || state.in_flight.is_some_and(|input| input.lane == Some(lane))
+            });
+            if !mutation_blocked && !target_busy {
                 ready_index = Some(index);
+                break;
             }
-            // A session mutation is a global ordering barrier. If earlier
-            // surface work keeps it from running, later input must wait too.
-            break;
+            // Not ready: it stays the barrier for later mutations and for
+            // later input to the surfaces it will destroy, and nothing else.
+            mutation_blocked = true;
+            blocked_queued_lanes.extend(event.target_lanes());
+            continue;
         }
         let lane = event
             .ordering_lane()
@@ -947,6 +1057,12 @@ fn dequeue_ready_event(state: &mut QueueState) -> Option<PtyInputEvent> {
         let lane =
             event.ordering_lane().expect("concurrent surface operation has an ordering lane");
         assert!(state.in_flight_surface_operations.insert(lane, event.queued_byte_len()).is_none());
+    } else if event.is_session_mutation() {
+        debug_assert!(state.in_flight_mutation.is_none(), "two session mutations in flight");
+        state.in_flight_mutation = Some(InFlightMutation {
+            targets: event.target_lanes().collect(),
+            bytes: event.queued_byte_len(),
+        });
     } else {
         state.in_flight = Some(InFlightInput { lane: event.ordering_lane(), kind: event.kind });
     }
@@ -962,7 +1078,13 @@ fn spawn_surface_operation(
     let worker_pending = pending.clone();
     let worker_queue = queue.clone();
     let worker_failure = on_failure.clone();
-    let spawn = std::thread::Builder::new().name("mux-surface-operation".into()).spawn(move || {
+    let name = if pending.lock().unwrap().as_ref().is_some_and(PtyInputEvent::is_session_mutation)
+    {
+        "mux-session-mutation"
+    } else {
+        "mux-surface-operation"
+    };
+    let spawn = std::thread::Builder::new().name(name.into()).spawn(move || {
         let event = worker_pending.lock().unwrap().take().unwrap();
         process_event(worker_queue, worker_failure, event);
     });
@@ -978,11 +1100,11 @@ fn fail_surface_operation_spawn(
     mut event: PtyInputEvent,
     error: std::io::Error,
 ) {
-    let lane = event.ordering_lane().expect("concurrent surface operation has an ordering lane");
+    let lane = event.ordering_lane();
     let after_operation = event.after_operation.take();
     on_failure(PtyOperationFailure {
         session_generation: event.session_generation,
-        surface_id: Some(lane.surface_id),
+        surface_id: lane.map(|lane| lane.surface_id).or(event.failure_surface_id),
         kind: None,
         reservation_id: None,
         label: event.label,
@@ -991,8 +1113,12 @@ fn fail_surface_operation_spawn(
         delivery: PtyOperationDelivery::KnownNotDelivered,
     });
     let mut state = queue.state.lock().unwrap();
-    state.in_flight_surface_operations.remove(&lane);
-    state.retired_in_flight_lanes.remove(&lane);
+    if let Some(lane) = lane {
+        state.in_flight_surface_operations.remove(&lane);
+        state.retired_in_flight_lanes.remove(&lane);
+    } else {
+        state.in_flight_mutation = None;
+    }
     queue.changed.notify_all();
     drop(state);
     if let Some(after_operation) = after_operation {
@@ -1010,6 +1136,7 @@ fn process_event(
     mut event: PtyInputEvent,
 ) {
     let concurrent_surface = event.concurrent_surface_operation;
+    let session_mutation = event.is_session_mutation();
     let ordering_lane = event.ordering_lane();
     let kind = (event.kind != PtyInputKind::Mutation).then_some(event.kind);
     let surface_id = kind.map(|_| event.surface_id).or(event.failure_surface_id);
@@ -1180,6 +1307,8 @@ fn process_event(
     let mut state = queue.state.lock().unwrap();
     if let Some(lane) = concurrent_surface.then_some(ordering_lane).flatten() {
         state.in_flight_surface_operations.remove(&lane);
+    } else if session_mutation {
+        state.in_flight_mutation = None;
     } else {
         state.in_flight = None;
     }
@@ -1550,7 +1679,9 @@ mod tests {
             sender.enqueue(event(7, 1, PtyInputKind::Motion)),
             PtyInputEnqueueResult::Accepted
         );
-        for _ in 0..PTY_OPERATION_QUEUE_CAPACITY - 1 {
+        // The executing blocker holds one slot of the bounded queue, like any
+        // in-flight operation, so one fewer fill reaches the capacity.
+        for _ in 0..PTY_OPERATION_QUEUE_CAPACITY - 2 {
             assert_eq!(
                 sender.enqueue(PtyInputEvent::mutation("fill", None, false, || Ok(()))),
                 PtyInputEnqueueResult::Accepted
@@ -1999,7 +2130,7 @@ mod tests {
     }
 
     #[test]
-    fn session_mutation_blocks_later_input_behind_surface_operation() {
+    fn targeted_session_mutation_blocks_later_input_to_its_target_behind_surface_operation() {
         let dispatcher = PtyInputDispatcher::spawn(|_| {}).unwrap();
         let sender = dispatcher.sender();
         let (started_tx, started_rx) = std::sync::mpsc::channel();
@@ -2022,22 +2153,142 @@ mod tests {
         );
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
 
+        // The close targets surface 41, so it waits for the in-flight work on
+        // 41, and input to 41 enqueued after the close waits for the close.
         let mutation_tx = order_tx.clone();
-        sender.enqueue_session_mutation("close pane", false, move || {
+        sender.enqueue_session_mutation_targeting("close pane", &[41], false, move || {
             mutation_tx.send("mutation").unwrap();
             Ok(())
         });
-        let mut input = event(42, 1, PtyInputKind::Ordered);
+        let mut input = event(41, 1, PtyInputKind::Ordered);
         input.after_operation = Some(Box::new(move || order_tx.send("input").unwrap()));
         assert_eq!(sender.enqueue(input), PtyInputEnqueueResult::Accepted);
 
         assert!(
             order_rx.recv_timeout(Duration::from_millis(50)).is_err(),
-            "input overtook the earlier session mutation"
+            "input overtook the earlier session mutation on its own surface"
         );
         unblock_tx.send(()).unwrap();
         assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "mutation");
         assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "input");
+    }
+
+    #[test]
+    fn slow_untargeted_session_mutation_does_not_delay_input_to_other_surfaces() {
+        let dispatcher = PtyInputDispatcher::spawn(|_| {}).unwrap();
+        let sender = dispatcher.sender();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (unblock_tx, unblock_rx) = std::sync::mpsc::channel();
+        let (input_tx, input_rx) = std::sync::mpsc::channel();
+        let (mutation_tx, mutation_rx) = std::sync::mpsc::channel();
+
+        // A create: it names no surface because its surface does not exist.
+        sender.enqueue_session_mutation("new tab", false, move || {
+            started_tx.send(()).unwrap();
+            let _ = unblock_rx.recv();
+            mutation_tx.send(()).unwrap();
+            Ok(())
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let mut input = event(7, 1, PtyInputKind::Ordered);
+        input.after_operation = Some(Box::new(move || input_tx.send(()).unwrap()));
+        assert_eq!(sender.enqueue(input), PtyInputEnqueueResult::Accepted);
+
+        input_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("input to an unrelated surface waited for a create round trip");
+        assert!(mutation_rx.try_recv().is_err(), "the create completed before it was unblocked");
+        unblock_tx.send(()).unwrap();
+        mutation_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+    }
+
+    #[test]
+    fn input_to_a_close_target_enqueued_before_the_close_runs_first() {
+        let dispatcher = PtyInputDispatcher::spawn(|_| {}).unwrap();
+        let sender = dispatcher.sender();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (unblock_tx, unblock_rx) = std::sync::mpsc::channel();
+        let (order_tx, order_rx) = std::sync::mpsc::channel();
+
+        // Hold the worker on an unrelated blocking surface operation so the
+        // queue can be populated deterministically before anything runs.
+        assert_eq!(
+            sender.enqueue_surface_operation_with_retained_bytes(
+                "blocking surface operation",
+                9,
+                false,
+                0,
+                move || {
+                    started_tx.send(()).unwrap();
+                    let _ = unblock_rx.recv();
+                    Ok(())
+                },
+            ),
+            PtyInputEnqueueResult::Accepted
+        );
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let (hold_tx, hold_rx) = std::sync::mpsc::channel::<()>();
+        let hold_input_tx = order_tx.clone();
+        let mut earlier = event(41, 1, PtyInputKind::Ordered);
+        earlier.mutation = Some(Box::new(move || {
+            let _ = hold_rx.recv();
+            Ok(())
+        }));
+        earlier.after_operation = Some(Box::new(move || hold_input_tx.send("earlier").unwrap()));
+        assert_eq!(sender.enqueue(earlier), PtyInputEnqueueResult::Accepted);
+        let mutation_tx = order_tx.clone();
+        sender.enqueue_session_mutation_targeting("close tab", &[41], false, move || {
+            mutation_tx.send("close").unwrap();
+            Ok(())
+        });
+        let mut later = event(41, 2, PtyInputKind::Ordered);
+        later.after_operation = Some(Box::new(move || order_tx.send("later").unwrap()));
+        assert_eq!(sender.enqueue(later), PtyInputEnqueueResult::Accepted);
+
+        // While the earlier input is executing on the worker, the close must
+        // not start: its target lane is busy.
+        std::thread::sleep(Duration::from_millis(30));
+        assert!(order_rx.try_recv().is_err());
+        hold_tx.send(()).unwrap();
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "earlier");
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "close");
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "later");
+        unblock_tx.send(()).unwrap();
+    }
+
+    #[test]
+    fn session_mutations_stay_in_enqueue_order() {
+        let dispatcher = PtyInputDispatcher::spawn(|_| {}).unwrap();
+        let sender = dispatcher.sender();
+        let (started_tx, started_rx) = std::sync::mpsc::channel();
+        let (unblock_tx, unblock_rx) = std::sync::mpsc::channel();
+        let (order_tx, order_rx) = std::sync::mpsc::channel();
+
+        let first_tx = order_tx.clone();
+        sender.enqueue_session_mutation("split", false, move || {
+            started_tx.send(()).unwrap();
+            let _ = unblock_rx.recv();
+            first_tx.send("first").unwrap();
+            Ok(())
+        });
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        let second_tx = order_tx.clone();
+        sender.enqueue_session_mutation("rename", false, move || {
+            second_tx.send("second").unwrap();
+            Ok(())
+        });
+        sender.enqueue_session_mutation_targeting("close tab", &[3], false, move || {
+            order_tx.send("third").unwrap();
+            Ok(())
+        });
+
+        assert!(order_rx.recv_timeout(Duration::from_millis(50)).is_err());
+        unblock_tx.send(()).unwrap();
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "first");
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "second");
+        assert_eq!(order_rx.recv_timeout(Duration::from_secs(1)).unwrap(), "third");
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/pty_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/pty_input.rs
@@ -1078,8 +1078,7 @@ fn spawn_surface_operation(
     let worker_pending = pending.clone();
     let worker_queue = queue.clone();
     let worker_failure = on_failure.clone();
-    let name = if pending.lock().unwrap().as_ref().is_some_and(PtyInputEvent::is_session_mutation)
-    {
+    let name = if pending.lock().unwrap().as_ref().is_some_and(PtyInputEvent::is_session_mutation) {
         "mux-session-mutation"
     } else {
         "mux-surface-operation"

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -2871,6 +2871,16 @@ pub(crate) fn test_remote_session_with_silent_requests(capabilities: HashSet<Str
     Session::Remote(remote::test_session_with_silent_requests(capabilities))
 }
 
+/// A remote session whose control socket answers every request with
+/// `responder(&request)` and records the requests it received.
+#[cfg(test)]
+pub(crate) fn test_remote_session_answering(
+    responder: Arc<dyn Fn(&Value) -> Value + Send + Sync>,
+) -> (Session, std::sync::mpsc::Receiver<Value>) {
+    let (session, requests) = remote::test_session_answering(responder);
+    (Session::Remote(session), requests)
+}
+
 /// A remote session whose event transport already died with `reason`, the
 /// state the reader thread leaves behind before it synthesizes
 /// `MuxEvent::Empty` on connection loss.

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -718,6 +718,16 @@ impl Session {
         }
     }
 
+    /// Whether a remote surface was retired after its process exited while
+    /// the authoritative tree still lists its tab. Local surfaces retain the
+    /// handle until removal, so the missing-mirror fallback does not apply.
+    pub fn surface_is_exited(&self, id: SurfaceId) -> bool {
+        match self {
+            Session::Local(_) => false,
+            Session::Remote(remote) => remote.surface_is_exited(id),
+        }
+    }
+
     pub fn refresh_tree(&self) -> anyhow::Result<TreeView> {
         match self {
             Session::Local(_) => Ok(self.tree()),

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -2937,6 +2937,14 @@ pub(crate) fn test_remote_session_with_provider_authority_without_guard() -> Ses
     Session::Remote(remote::test_session_with_provider_authority_without_guard())
 }
 
+/// Seed a remote session's cached tree for app tests. Local sessions ignore it.
+#[cfg(test)]
+pub(crate) fn test_seed_remote_tree(session: &Session, tree: TreeView) {
+    if let Session::Remote(remote) = session {
+        remote.test_replace_cached_tree(tree);
+    }
+}
+
 #[cfg(test)]
 pub(crate) fn test_remote_session_with_deferred_attach()
 -> (Session, std::sync::mpsc::Receiver<()>, std::sync::mpsc::Sender<()>) {

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -2865,6 +2865,12 @@ pub(crate) fn test_remote_session_without_provider_authority() -> Session {
     Session::Remote(remote::test_session_without_provider_authority())
 }
 
+/// A remote session whose control socket accepts requests and never answers.
+#[cfg(test)]
+pub(crate) fn test_remote_session_with_silent_requests(capabilities: HashSet<String>) -> Session {
+    Session::Remote(remote::test_session_with_silent_requests(capabilities))
+}
+
 /// A remote session whose event transport already died with `reason`, the
 /// state the reader thread leaves behind before it synthesizes
 /// `MuxEvent::Empty` on connection loss.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -392,17 +392,23 @@ impl RemoteTreeCache {
         let screen_id = value.get("screen").and_then(Value::as_u64);
         let pane_id = value.get("pane").and_then(Value::as_u64);
         let surface_id = value.get("surface").and_then(Value::as_u64);
-        let index = value.get("index").and_then(Value::as_u64).map(|index| index as usize);
+        let index = value
+            .get("index")
+            .and_then(Value::as_u64)
+            .and_then(|index| usize::try_from(index).ok());
         let entity = value.get("entity").cloned().unwrap_or(Value::Null);
         let workspace_revision = value.get("workspace_revision").and_then(Value::as_u64);
         let applied = match kind {
             K::WorkspaceAdded | K::WorkspaceClosed | K::WorkspaceRenamed | K::WorkspaceMoved => {
                 let Some(revision) = workspace_revision else { return TreeDeltaApply::Resync };
-                if revision != self.view.workspace_revision.wrapping_add(1) {
+                if self.view.workspace_revision.checked_add(1) != Some(revision) {
                     return TreeDeltaApply::Resync;
                 }
                 let applied = match kind {
                     K::WorkspaceAdded => {
+                        if entity.get("id").and_then(Value::as_u64) != Some(workspace_id) {
+                            return TreeDeltaApply::Resync;
+                        }
                         let view = parse_workspace(&entity, capabilities);
                         let index = index.unwrap_or(self.view.workspaces().len());
                         let index = index.min(self.view.workspaces().len());
@@ -497,7 +503,10 @@ impl RemoteTreeCache {
                             workspace.screens.insert(index, screen);
                             if active {
                                 workspace.active_screen = index;
-                            } else if had_screens && index <= workspace.active_screen {
+                            } else if had_screens
+                                && workspace.active_screen != usize::MAX
+                                && index <= workspace.active_screen
+                            {
                                 workspace.active_screen += 1;
                             }
                             true
@@ -562,7 +571,8 @@ impl RemoteTreeCache {
                             let index = index.unwrap_or(pane.tabs.len()).min(pane.tabs.len());
                             let had_tabs = !pane.tabs.is_empty();
                             pane.tabs.insert(index, tab);
-                            if had_tabs && index <= pane.active_tab {
+                            if had_tabs && pane.active_tab != usize::MAX && index <= pane.active_tab
+                            {
                                 pane.active_tab += 1;
                             }
                             true
@@ -603,7 +613,9 @@ impl RemoteTreeCache {
         if !applied {
             return TreeDeltaApply::Resync;
         }
-        self.reindex();
+        if !matches!(kind, K::WorkspaceRenamed | K::ScreenRenamed | K::TabRenamed) {
+            self.reindex();
+        }
         self.delta_generation = self.delta_generation.wrapping_add(1);
         TreeDeltaApply::Applied(TreeDelta {
             kind,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -8302,9 +8302,33 @@ mod tests {
         }));
         assert_eq!(session.cached_tree().workspaces()[1].name, "renamed");
 
-        // Revision 8 skips 7: a gap is a resync barrier.
+        // Moving the active workspace must preserve focus by workspace id,
+        // rather than leaving the active index at its old position.
         session.handle_line(json!({
-            "event": "workspace-closed", "workspace": 20, "index": 1, "workspace_revision": 8,
+            "event": "workspace-moved", "workspace": 1, "index": 1,
+            "workspace_revision": 7, "registry_id": "r", "generation": "g",
+            "entity": {"id": 1}
+        }));
+        let tree = session.cached_tree();
+        assert_eq!(tree.workspaces().iter().map(|ws| ws.id).collect::<Vec<_>>(), vec![20, 1]);
+        assert_eq!(tree.active_workspace, 1);
+
+        // An active workspace insertion sets focus to its inserted index.
+        session.handle_line(json!({
+            "event": "workspace-added", "workspace": 30, "index": 0,
+            "workspace_revision": 8, "registry_id": "r", "generation": "g",
+            "entity": {"id": 30, "name": "active", "active": true,
+                "screens": [{"id": 31, "active_pane": 32,
+                    "layout": {"type": "leaf", "pane": 32},
+                    "panes": [{"id": 32, "tabs": [{"surface": 33, "title": "e"}]}]}]}
+        }));
+        let tree = session.cached_tree();
+        assert_eq!(tree.workspaces().iter().map(|ws| ws.id).collect::<Vec<_>>(), vec![30, 20, 1]);
+        assert_eq!(tree.active_workspace, 0);
+
+        // Revision 10 skips 9: a gap is a resync barrier.
+        session.handle_line(json!({
+            "event": "workspace-closed", "workspace": 20, "index": 1, "workspace_revision": 10,
             "registry_id": "r", "generation": "g", "entity": {"id": 20, "name": "renamed"}
         }));
         assert!(session.tree_is_stale(), "a revision gap must force a refetch");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4521,7 +4521,9 @@ fn test_session_with_provider_context(
 }
 
 /// A remote session whose writer answers every request synchronously with
-/// `responder(&request)` as the `data` payload and records each request.
+/// `responder(&request)` as the `data` payload and records each request. A
+/// returned object with a string `__reject` field is sent as a rejection with
+/// that error text instead.
 #[cfg(test)]
 pub(super) fn test_session_answering(
     responder: Arc<dyn Fn(&Value) -> Value + Send + Sync>,
@@ -4551,9 +4553,13 @@ pub(super) fn test_session_answering(
                 .remove(&id)
                 .ok_or_else(|| io::Error::other("remote request was not pending"))?;
             let data = (self.responder)(&request);
+            let response = match data.get("__reject").and_then(Value::as_str) {
+                Some(error) => json!({"id": id, "ok": false, "error": error}),
+                None => json!({"id": id, "ok": true, "data": data}),
+            };
             pending
                 .response
-                .send(json!({"id": id, "ok": true, "data": data}))
+                .send(response)
                 .map_err(|_| io::Error::other("remote response receiver was dropped"))
         }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -18,7 +18,7 @@ use cmux_tui_core::{
     ClearHistoryFailure, GraphicsStatus, GuardedMouseEncode, MuxEvent, MuxEventBroadcaster,
     MuxEventReceiver, NotificationEvent, NotificationLevel, PairingChallenge, PointerSemanticProbe,
     PointerSnapshotProbe, REMOTE_SESSION_MESSAGE_MAX_BYTES, Rgb, SurfaceId, SurfaceKind,
-    TerminalPointerSnapshot,
+    TerminalPointerSnapshot, TreeDelta, TreeDeltaKind,
     platform::transport,
     server::{
         CLEAR_HISTORY_CAPABILITY, CLEAR_HISTORY_KEY_CAPABILITY, CREATION_RECEIPTS_CAPABILITY,
@@ -39,7 +39,10 @@ use super::cursor_provenance::CursorStyleProvenance;
 use super::parse_identity_capabilities;
 #[cfg(test)]
 use super::tree::parse_tree;
-use super::tree::{TreeCapabilities, TreeView, parse_tree_with_capabilities};
+use super::tree::{
+    TreeCapabilities, TreeView, parse_screen, parse_tab, parse_tree_with_capabilities,
+    parse_workspace,
+};
 use super::{AgentInfo, CLEAR_HISTORY_UNSUPPORTED_ERROR};
 
 const SUPPORTED_PROTOCOL_VERSION: u64 = 12;
@@ -296,6 +299,22 @@ struct RemoteTreeCache {
     title_updates: HashMap<SurfaceId, TitleUpdate>,
     agent_generation: u64,
     agent_updates: HashMap<SurfaceId, AgentUpdate>,
+    /// Counts applied tree deltas. A `list-workspaces` snapshot captured while
+    /// this advanced may predate the delta's mutation, so the refresh marks
+    /// the tree stale again instead of trusting the older snapshot.
+    delta_generation: u64,
+    /// True once a full snapshot has been adopted; deltas before that have no
+    /// baseline and force a refetch.
+    has_snapshot: bool,
+}
+
+/// Outcome of applying one tree delta event to the cached tree.
+enum TreeDeltaApply {
+    /// The cache now reflects the mutation; frontends redraw from it.
+    Applied(TreeDelta),
+    /// The delta cannot be applied exactly (revision gap, unknown parent,
+    /// or a kind whose entity does not carry the affected layout); refetch.
+    Resync,
 }
 
 #[derive(Clone, Copy)]
@@ -317,9 +336,9 @@ struct AgentUpdate {
 }
 
 impl RemoteTreeCache {
-    fn replace(&mut self, view: TreeView, refresh_generation: u64) {
+    fn reindex(&mut self) {
         self.surface_tabs.clear();
-        for (workspace_index, workspace) in view.workspaces().iter().enumerate() {
+        for (workspace_index, workspace) in self.view.workspaces().iter().enumerate() {
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
                 for (pane_index, pane) in screen.panes.iter().enumerate() {
                     for (tab_index, tab) in pane.tabs.iter().enumerate() {
@@ -331,7 +350,260 @@ impl RemoteTreeCache {
                 }
             }
         }
+    }
+
+    /// Apply one `tree_events:"deltas"` event in stream order.
+    ///
+    /// Applied exactly: workspace added/closed/renamed/moved (fenced by
+    /// `workspace_revision`, exact next revision only), screen
+    /// added/closed/renamed, tab added/closed/renamed. Pane added/closed
+    /// return `Resync`: their `Pane` entity does not carry the screen's split
+    /// tree, which the same mutation changed, and the daemon emits no
+    /// `layout-changed` for a split to delta subscribers, so the layout can
+    /// only come from `list-workspaces`.
+    fn apply_tree_delta(
+        &mut self,
+        event: &str,
+        value: &Value,
+        capabilities: TreeCapabilities,
+    ) -> TreeDeltaApply {
+        use TreeDeltaKind as K;
+        let kind = match event {
+            "workspace-added" => K::WorkspaceAdded,
+            "workspace-closed" => K::WorkspaceClosed,
+            "workspace-renamed" => K::WorkspaceRenamed,
+            "workspace-moved" => K::WorkspaceMoved,
+            "screen-added" => K::ScreenAdded,
+            "screen-closed" => K::ScreenClosed,
+            "screen-renamed" => K::ScreenRenamed,
+            "pane-added" => K::PaneAdded,
+            "pane-closed" => K::PaneClosed,
+            "tab-added" => K::TabAdded,
+            "tab-closed" => K::TabClosed,
+            "tab-renamed" => K::TabRenamed,
+            _ => return TreeDeltaApply::Resync,
+        };
+        if !self.has_snapshot {
+            return TreeDeltaApply::Resync;
+        }
+        let Some(workspace_id) = value.get("workspace").and_then(Value::as_u64) else {
+            return TreeDeltaApply::Resync;
+        };
+        let screen_id = value.get("screen").and_then(Value::as_u64);
+        let pane_id = value.get("pane").and_then(Value::as_u64);
+        let surface_id = value.get("surface").and_then(Value::as_u64);
+        let index = value.get("index").and_then(Value::as_u64).map(|index| index as usize);
+        let entity = value.get("entity").cloned().unwrap_or(Value::Null);
+        let workspace_revision = value.get("workspace_revision").and_then(Value::as_u64);
+        let applied = match kind {
+            K::WorkspaceAdded | K::WorkspaceClosed | K::WorkspaceRenamed | K::WorkspaceMoved => {
+                let Some(revision) = workspace_revision else { return TreeDeltaApply::Resync };
+                if revision != self.view.workspace_revision.wrapping_add(1) {
+                    return TreeDeltaApply::Resync;
+                }
+                let applied = match kind {
+                    K::WorkspaceAdded => {
+                        let view = parse_workspace(&entity, capabilities);
+                        let index = index.unwrap_or(self.view.workspaces().len());
+                        let index = index.min(self.view.workspaces().len());
+                        let active = entity.get("active").and_then(Value::as_bool) == Some(true);
+                        let had_workspaces = !self.view.workspaces().is_empty();
+                        self.view.workspaces_mut().insert(index, view);
+                        if active {
+                            self.view.active_workspace = index;
+                        } else if had_workspaces && index <= self.view.active_workspace {
+                            self.view.active_workspace += 1;
+                        }
+                        true
+                    }
+                    K::WorkspaceClosed => {
+                        match self.view.workspaces().iter().position(|ws| ws.id == workspace_id) {
+                            Some(position) => {
+                                self.view.workspaces_mut().remove(position);
+                                if position < self.view.active_workspace {
+                                    self.view.active_workspace -= 1;
+                                }
+                                self.view.active_workspace = self
+                                    .view
+                                    .active_workspace
+                                    .min(self.view.workspaces().len().saturating_sub(1));
+                                true
+                            }
+                            None => false,
+                        }
+                    }
+                    K::WorkspaceRenamed => {
+                        match self.view.workspaces_mut().iter_mut().find(|ws| ws.id == workspace_id) {
+                            Some(workspace) => {
+                                workspace.name = entity
+                                    .get("name")
+                                    .and_then(Value::as_str)
+                                    .unwrap_or_default()
+                                    .to_string();
+                                true
+                            }
+                            None => false,
+                        }
+                    }
+                    K::WorkspaceMoved => {
+                        match (
+                            self.view.workspaces().iter().position(|ws| ws.id == workspace_id),
+                            index,
+                        ) {
+                            (Some(from), Some(to)) if to < self.view.workspaces().len() => {
+                                let active_id =
+                                    self.view.workspaces().get(self.view.active_workspace).map(|ws| ws.id);
+                                let moved = self.view.workspaces_mut().remove(from);
+                                self.view.workspaces_mut().insert(to, moved);
+                                if let Some(active_id) = active_id
+                                    && let Some(position) =
+                                        self.view.workspaces().iter().position(|ws| ws.id == active_id)
+                                {
+                                    self.view.active_workspace = position;
+                                }
+                                true
+                            }
+                            _ => false,
+                        }
+                    }
+                    _ => unreachable!("workspace kinds only"),
+                };
+                if applied {
+                    self.view.workspace_revision = revision;
+                }
+                applied
+            }
+            K::ScreenAdded | K::ScreenClosed | K::ScreenRenamed => {
+                let Some(workspace) =
+                    self.view.workspaces_mut().iter_mut().find(|ws| ws.id == workspace_id)
+                else {
+                    return TreeDeltaApply::Resync;
+                };
+                match kind {
+                    K::ScreenAdded => match parse_screen(&entity, capabilities) {
+                        Some(screen) => {
+                            let index = index.unwrap_or(workspace.screens.len());
+                            let index = index.min(workspace.screens.len());
+                            let active =
+                                entity.get("active").and_then(Value::as_bool) == Some(true);
+                            let had_screens = !workspace.screens.is_empty();
+                            workspace.screens.insert(index, screen);
+                            if active {
+                                workspace.active_screen = index;
+                            } else if had_screens && index <= workspace.active_screen {
+                                workspace.active_screen += 1;
+                            }
+                            true
+                        }
+                        None => false,
+                    },
+                    K::ScreenClosed => {
+                        match workspace.screens.iter().position(|screen| Some(screen.id) == screen_id)
+                        {
+                            Some(position) => {
+                                workspace.screens.remove(position);
+                                if position < workspace.active_screen {
+                                    workspace.active_screen -= 1;
+                                }
+                                workspace.active_screen = workspace
+                                    .active_screen
+                                    .min(workspace.screens.len().saturating_sub(1));
+                                true
+                            }
+                            None => false,
+                        }
+                    }
+                    K::ScreenRenamed => {
+                        match workspace.screens.iter_mut().find(|screen| Some(screen.id) == screen_id)
+                        {
+                            Some(screen) => {
+                                screen.name =
+                                    entity.get("name").and_then(Value::as_str).map(str::to_string);
+                                true
+                            }
+                            None => false,
+                        }
+                    }
+                    _ => unreachable!("screen kinds only"),
+                }
+            }
+            K::PaneAdded | K::PaneClosed => return TreeDeltaApply::Resync,
+            K::TabAdded | K::TabClosed | K::TabRenamed => {
+                let Some(pane) = self
+                    .view
+                    .workspaces
+                    .iter_mut()
+                    .find(|ws| ws.id == workspace_id)
+                    .and_then(|ws| ws.screens.iter_mut().find(|screen| Some(screen.id) == screen_id))
+                    .and_then(|screen| screen.panes.iter_mut().find(|pane| Some(pane.id) == pane_id))
+                else {
+                    return TreeDeltaApply::Resync;
+                };
+                match kind {
+                    K::TabAdded => match parse_tab(&entity) {
+                        Some(tab) => {
+                            let index = index.unwrap_or(pane.tabs.len()).min(pane.tabs.len());
+                            let had_tabs = !pane.tabs.is_empty();
+                            pane.tabs.insert(index, tab);
+                            if had_tabs && index <= pane.active_tab {
+                                pane.active_tab += 1;
+                            }
+                            true
+                        }
+                        None => false,
+                    },
+                    K::TabClosed => {
+                        match pane.tabs.iter().position(|tab| Some(tab.surface) == surface_id) {
+                            Some(position) => {
+                                pane.tabs.remove(position);
+                                if position < pane.active_tab {
+                                    pane.active_tab -= 1;
+                                }
+                                pane.active_tab =
+                                    pane.active_tab.min(pane.tabs.len().saturating_sub(1));
+                                true
+                            }
+                            None => false,
+                        }
+                    }
+                    K::TabRenamed => {
+                        match (
+                            pane.tabs.iter_mut().find(|tab| Some(tab.surface) == surface_id),
+                            parse_tab(&entity),
+                        ) {
+                            (Some(tab), Some(renamed)) => {
+                                tab.name = renamed.name;
+                                tab.title = renamed.title;
+                                true
+                            }
+                            _ => false,
+                        }
+                    }
+                    _ => unreachable!("tab kinds only"),
+                }
+            }
+        };
+        if !applied {
+            return TreeDeltaApply::Resync;
+        }
+        self.reindex();
+        self.delta_generation = self.delta_generation.wrapping_add(1);
+        TreeDeltaApply::Applied(TreeDelta {
+            kind,
+            workspace: workspace_id,
+            screen: screen_id,
+            pane: pane_id,
+            surface: surface_id,
+            index,
+            entity,
+            workspace_revision,
+        })
+    }
+
+    fn replace(&mut self, view: TreeView, refresh_generation: u64) {
         self.view = view;
+        self.has_snapshot = true;
+        self.reindex();
 
         // A response snapshot can predate title events received while its
         // request was in flight. Reapply only those later authoritative
@@ -2120,11 +2392,14 @@ impl RemoteSession {
     }
 
     fn subscription_request(&self) -> Value {
+        // Typed tree deltas (protocol 7+) let the cached tree follow ordinary
+        // mutations without a `list-workspaces` refetch; `tree-changed` stays
+        // the resync barrier (see `RemoteTreeCache::apply_tree_delta`).
         let surface = self.event_surface_filter.load(Ordering::Acquire);
         if surface == 0 {
-            json!({"cmd": "subscribe"})
+            json!({"cmd": "subscribe", "tree_events": "deltas"})
         } else {
-            json!({"cmd": "subscribe", "surface": surface})
+            json!({"cmd": "subscribe", "tree_events": "deltas", "surface": surface})
         }
     }
 
@@ -2397,6 +2672,37 @@ impl RemoteSession {
                 if let Some(id) = surface_id() {
                     self.surfaces.lock().unwrap().remove(&id);
                     self.emit(MuxEvent::SurfaceOutput(id));
+                }
+            }
+            Some(
+                event @ ("workspace-added"
+                | "workspace-closed"
+                | "workspace-renamed"
+                | "workspace-moved"
+                | "screen-added"
+                | "screen-closed"
+                | "screen-renamed"
+                | "pane-added"
+                | "pane-closed"
+                | "tab-added"
+                | "tab-closed"
+                | "tab-renamed"),
+            ) => {
+                let capabilities = {
+                    let capabilities = self.capabilities.lock().unwrap();
+                    TreeCapabilities {
+                        viewport_splits: capabilities.contains(VIEWPORT_SPLITS_CAPABILITY),
+                        viewport_column_resize: capabilities
+                            .contains(VIEWPORT_COLUMN_RESIZE_CAPABILITY),
+                    }
+                };
+                let applied = self.tree.lock().unwrap().apply_tree_delta(event, &value, capabilities);
+                match applied {
+                    TreeDeltaApply::Applied(delta) => self.emit(MuxEvent::TreeDelta(delta)),
+                    TreeDeltaApply::Resync => {
+                        self.tree_stale.store(true, Ordering::Release);
+                        self.emit(MuxEvent::TreeChanged);
+                    }
                 }
             }
             Some("tree-changed") => {
@@ -3458,9 +3764,9 @@ impl RemoteSession {
         if identity_refresh {
             self.tree_stale.store(false, Ordering::Release);
         }
-        let (title_refresh_generation, agent_refresh_generation) = {
+        let (title_refresh_generation, agent_refresh_generation, delta_generation_before) = {
             let cache = self.tree.lock().unwrap();
-            (cache.title_generation(), cache.agent_generation())
+            (cache.title_generation(), cache.agent_generation(), cache.delta_generation)
         };
         let data = match self.request(json!({"cmd": "list-workspaces"})) {
             Ok(data) => data,
@@ -3523,14 +3829,22 @@ impl RemoteSession {
             .unwrap()
             .retain(|surface_id, _| live_surface_ids.contains(surface_id));
         let retired_surfaces = self.retired_surfaces.lock().unwrap();
-        let tree = {
+        let (tree, deltas_raced) = {
             let mut cache = self.tree.lock().unwrap();
             tree.retain_not_retired(&retired_surfaces);
             cache.replace(tree, title_refresh_generation);
             cache.replace_agents(agents, agent_refresh_generation, &retired_surfaces);
-            cache.view.clone()
+            (cache.view.clone(), cache.delta_generation != delta_generation_before)
         };
         drop(retired_surfaces);
+        if deltas_raced {
+            // A delta arrived while the snapshot request was in flight. The
+            // snapshot may predate that mutation, so it cannot be trusted as
+            // the newest state; ask again rather than replay the delta onto
+            // an unknown baseline.
+            self.tree_stale.store(true, Ordering::Release);
+            self.emit(MuxEvent::TreeChanged);
+        }
         let browser_sources = browser_sources_from_tree(&tree);
         *self.browser_sources.lock().unwrap() = browser_sources.clone();
         let surfaces = self.surfaces.lock().unwrap().clone();
@@ -4186,6 +4500,59 @@ fn test_session_with_provider_context(
     }
 
     test_session_with_writer(Box::new(NoopWriter), provider_workspace_authority, capabilities)
+}
+
+/// A remote session whose writer answers every request synchronously with
+/// `responder(&request)` as the `data` payload and records each request.
+#[cfg(test)]
+pub(super) fn test_session_answering(
+    responder: Arc<dyn Fn(&Value) -> Value + Send + Sync>,
+) -> (Arc<RemoteSession>, std::sync::mpsc::Receiver<Value>) {
+    struct AnsweringWriter {
+        session: Arc<Mutex<Option<Weak<RemoteSession>>>>,
+        responder: Arc<dyn Fn(&Value) -> Value + Send + Sync>,
+        requests: std::sync::mpsc::Sender<Value>,
+    }
+
+    impl RemoteMessageWriter for AnsweringWriter {
+        fn send(&mut self, message: &str) -> io::Result<()> {
+            let request = serde_json::from_str::<Value>(message).map_err(io::Error::other)?;
+            let _ = self.requests.send(request.clone());
+            let Some(id) = request.get("id").and_then(Value::as_u64) else { return Ok(()) };
+            let session = self
+                .session
+                .lock()
+                .unwrap()
+                .as_ref()
+                .and_then(Weak::upgrade)
+                .ok_or_else(|| io::Error::other("test remote session was dropped"))?;
+            let pending = session
+                .pending
+                .lock()
+                .unwrap()
+                .remove(&id)
+                .ok_or_else(|| io::Error::other("remote request was not pending"))?;
+            let data = (self.responder)(&request);
+            pending
+                .response
+                .send(json!({"id": id, "ok": true, "data": data}))
+                .map_err(|_| io::Error::other("remote response receiver was dropped"))
+        }
+
+        fn close(&mut self) -> io::Result<()> {
+            Ok(())
+        }
+    }
+
+    let slot = Arc::new(Mutex::new(None));
+    let (requests, received) = std::sync::mpsc::channel();
+    let session = test_session_with_writer(
+        Box::new(AnsweringWriter { session: slot.clone(), responder, requests }),
+        None,
+        HashSet::new(),
+    );
+    *slot.lock().unwrap() = Some(Arc::downgrade(&session));
+    (session, received)
 }
 
 /// A remote session whose writer accepts every request and never answers, so
@@ -7745,7 +8112,148 @@ mod tests {
 
         assert_eq!(cache.agents, vec![agent]);
         assert_eq!(cache.agent_updates.len(), 1);
+
+    fn delta_test_tree() -> Value {
+        json!({
+            "workspace_revision": 4,
+            "workspaces": [{
+                "id": 1, "name": "one", "active": true,
+                "screens": [{
+                    "id": 2, "active": true, "active_pane": 3,
+                    "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{"id": 3, "active_tab": 0, "tabs": [
+                        {"surface": 7, "title": "a", "kind": "pty"}
+                    ]}]
+                }]
+            }]
+        })
     }
+
+    #[test]
+    fn tab_and_screen_deltas_apply_to_the_cached_tree_without_a_refetch() {
+        let (session, _requests) = recording_acknowledging_session();
+        session.tree.lock().unwrap().replace(parse_tree(&delta_test_tree()), 0);
+        session.tree_stale.store(false, Ordering::Release);
+        let events = session.subscribe();
+
+        session.handle_line(json!({
+            "event": "tab-added", "workspace": 1, "screen": 2, "pane": 3, "surface": 8,
+            "index": 1, "entity": {"surface": 8, "title": "b", "kind": "pty"}
+        }));
+        assert!(!session.tree_is_stale(), "an exact tab delta must not force a refetch");
+        assert!(matches!(
+            events.recv_timeout(Duration::from_secs(1)),
+            Ok(MuxEvent::TreeDelta(delta)) if delta.kind == cmux_tui_core::TreeDeltaKind::TabAdded
+        ));
+        let tree = session.cached_tree();
+        let tabs = &tree.workspaces[0].screens[0].panes[0].tabs;
+        assert_eq!(tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![7, 8]);
+        assert_eq!(tree.surface(8).unwrap().title, "b");
+
+        session.handle_line(json!({
+            "event": "tab-renamed", "workspace": 1, "screen": 2, "pane": 3, "surface": 8,
+            "entity": {"surface": 8, "title": "b", "name": "logs", "kind": "pty"}
+        }));
+        assert_eq!(session.cached_tree().surface(8).unwrap().name.as_deref(), Some("logs"));
+
+        session.handle_line(json!({
+            "event": "tab-closed", "workspace": 1, "screen": 2, "pane": 3, "surface": 7,
+            "index": 0, "entity": {"surface": 7, "title": "a", "kind": "pty"}
+        }));
+        let tree = session.cached_tree();
+        let pane = &tree.workspaces[0].screens[0].panes[0];
+        assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8]);
+        assert_eq!(pane.active_tab, 0);
+
+        session.handle_line(json!({
+            "event": "screen-added", "workspace": 1, "screen": 9, "index": 1,
+            "entity": {"id": 9, "active_pane": 10, "layout": {"type": "leaf", "pane": 10},
+                       "panes": [{"id": 10, "tabs": [{"surface": 11, "title": "c"}]}]}
+        }));
+        let tree = session.cached_tree();
+        assert_eq!(tree.workspaces[0].screens.len(), 2);
+        assert_eq!(tree.workspaces[0].screens[1].id, 9);
+        assert_eq!(tree.workspaces[0].active_screen, 0);
+        assert!(!session.tree_is_stale());
+        assert!(events.try_iter().all(|event| matches!(event, MuxEvent::TreeDelta(_))));
+    }
+
+    #[test]
+    fn workspace_deltas_apply_only_the_exact_next_revision() {
+        let (session, _requests) = recording_acknowledging_session();
+        session.tree.lock().unwrap().replace(parse_tree(&delta_test_tree()), 0);
+        session.tree_stale.store(false, Ordering::Release);
+        let events = session.subscribe();
+
+        session.handle_line(json!({
+            "event": "workspace-added", "workspace": 20, "index": 1, "workspace_revision": 5,
+            "registry_id": "r", "generation": "g",
+            "entity": {"id": 20, "name": "two", "screens": [{"id": 21, "active_pane": 22,
+                "layout": {"type": "leaf", "pane": 22},
+                "panes": [{"id": 22, "tabs": [{"surface": 23, "title": "d"}]}]}]}
+        }));
+        let tree = session.cached_tree();
+        assert_eq!(tree.workspaces.iter().map(|ws| ws.id).collect::<Vec<_>>(), vec![1, 20]);
+        assert_eq!(tree.workspace_revision, 5);
+        assert_eq!(tree.active_workspace, 0);
+        assert!(!session.tree_is_stale());
+        assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeDelta(_))));
+
+        session.handle_line(json!({
+            "event": "workspace-renamed", "workspace": 20, "workspace_revision": 6,
+            "registry_id": "r", "generation": "g", "entity": {"id": 20, "name": "renamed"}
+        }));
+        assert_eq!(session.cached_tree().workspaces[1].name, "renamed");
+
+        // Revision 8 skips 7: a gap is a resync barrier.
+        session.handle_line(json!({
+            "event": "workspace-closed", "workspace": 20, "index": 1, "workspace_revision": 8,
+            "registry_id": "r", "generation": "g", "entity": {"id": 20, "name": "renamed"}
+        }));
+        assert!(session.tree_is_stale(), "a revision gap must force a refetch");
+        assert_eq!(session.cached_tree().workspaces.len(), 2, "a gapped delta is not applied");
+        let _renamed = events.recv_timeout(Duration::from_secs(1)).unwrap();
+        assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeChanged)));
+    }
+
+    #[test]
+    fn pane_deltas_and_tree_changed_force_a_refetch() {
+        let (session, _requests) = recording_acknowledging_session();
+        session.tree.lock().unwrap().replace(parse_tree(&delta_test_tree()), 0);
+        session.tree_stale.store(false, Ordering::Release);
+        let events = session.subscribe();
+
+        // The pane entity does not carry the split tree the mutation changed.
+        session.handle_line(json!({
+            "event": "pane-added", "workspace": 1, "screen": 2, "pane": 30, "index": 1,
+            "entity": {"id": 30, "tabs": [{"surface": 31, "title": "e"}]}
+        }));
+        assert!(session.tree_is_stale());
+        assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeChanged)));
+        assert_eq!(session.cached_tree().workspaces[0].screens[0].panes.len(), 1);
+
+        session.tree_stale.store(false, Ordering::Release);
+        session.handle_line(json!({"event": "tree-changed"}));
+        assert!(session.tree_is_stale());
+        assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeChanged)));
+    }
+
+    #[test]
+    fn deltas_without_a_snapshot_baseline_force_a_refetch() {
+        let (session, _requests) = recording_acknowledging_session();
+        session.tree_stale.store(false, Ordering::Release);
+        session.handle_line(json!({
+            "event": "tab-added", "workspace": 1, "screen": 2, "pane": 3, "surface": 8,
+            "index": 0, "entity": {"surface": 8, "title": "b"}
+        }));
+        assert!(session.tree_is_stale());
+    }
+
+    #[test]
+    fn subscription_requests_tree_deltas() {
+        let (session, requests) = recording_acknowledging_session();
+        assert_eq!(session.subscription_request()["tree_events"], json!("deltas"));
+        drop(requests);    }
 
     #[test]
     fn surface_event_scope_filters_before_remote_cache_invalidation() {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4188,6 +4188,16 @@ fn test_session_with_provider_context(
     test_session_with_writer(Box::new(NoopWriter), provider_workspace_authority, capabilities)
 }
 
+/// A remote session whose writer accepts every request and never answers, so
+/// any blocking request runs to its timeout. Used to prove a code path does
+/// not wait on the control socket.
+#[cfg(test)]
+pub(super) fn test_session_with_silent_requests(
+    capabilities: HashSet<String>,
+) -> Arc<RemoteSession> {
+    test_session_with_provider_context(None, capabilities)
+}
+
 #[cfg(test)]
 pub(super) fn test_session_without_provider_authority() -> Arc<RemoteSession> {
     test_session_with_provider_context(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -520,6 +520,9 @@ impl RemoteTreeCache {
                             .position(|screen| Some(screen.id) == screen_id)
                         {
                             Some(position) => {
+                                if workspace.active_screen == usize::MAX {
+                                    return TreeDeltaApply::Resync;
+                                }
                                 workspace.screens.remove(position);
                                 if position < workspace.active_screen {
                                     workspace.active_screen -= 1;
@@ -582,6 +585,9 @@ impl RemoteTreeCache {
                     K::TabClosed => {
                         match pane.tabs.iter().position(|tab| Some(tab.surface) == surface_id) {
                             Some(position) => {
+                                if pane.active_tab == usize::MAX {
+                                    return TreeDeltaApply::Resync;
+                                }
                                 pane.tabs.remove(position);
                                 if position < pane.active_tab {
                                     pane.active_tab -= 1;
@@ -8213,6 +8219,60 @@ mod tests {
         assert_eq!(tree.workspaces()[0].active_screen, 0);
         assert!(!session.tree_is_stale());
         assert!(events.try_iter().all(|event| matches!(event, MuxEvent::TreeDelta(_))));
+    }
+
+    #[test]
+    fn close_deltas_resync_when_active_child_is_the_fail_closed_sentinel() {
+        let (session, _requests) = recording_acknowledging_session();
+        let tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1,
+                "screens": [
+                    {"id": 2, "active": true, "layout": {"type": "invalid"}},
+                    {"id": 9, "layout": {"type": "leaf", "pane": 10},
+                     "panes": [{"id": 10, "tabs": [{"surface": 11, "title": "b"}]}]}
+                ]
+            }]
+        }));
+        assert_eq!(tree.workspaces()[0].active_screen, usize::MAX);
+        session.tree.lock().unwrap().replace(tree, 0);
+        session.tree_stale.store(false, Ordering::Release);
+        let events = session.subscribe();
+
+        session.handle_line(json!({
+            "event": "screen-closed", "workspace": 1, "screen": 9,
+            "entity": {"id": 9}
+        }));
+        assert!(session.tree_is_stale());
+        assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeChanged)));
+        let tree = session.cached_tree();
+        assert_eq!(tree.workspaces()[0].active_screen, usize::MAX);
+        assert_eq!(tree.workspaces()[0].screens.len(), 2);
+
+        let (session, _requests) = recording_acknowledging_session();
+        let tree = parse_tree(&json!({
+            "workspaces": [{
+                "id": 1, "screens": [{
+                    "id": 2, "active": true, "layout": {"type": "leaf", "pane": 3},
+                    "panes": [{"id": 3, "active_tab": 9,
+                               "tabs": [{"surface": 7, "title": "a"}]}]
+                }]
+            }]
+        }));
+        assert_eq!(tree.workspaces()[0].screens[0].panes[0].active_tab, usize::MAX);
+        session.tree.lock().unwrap().replace(tree, 0);
+        session.tree_stale.store(false, Ordering::Release);
+        let events = session.subscribe();
+
+        session.handle_line(json!({
+            "event": "tab-closed", "workspace": 1, "screen": 2, "pane": 3,
+            "surface": 7, "entity": {"surface": 7}
+        }));
+        assert!(session.tree_is_stale());
+        assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeChanged)));
+        let tree = session.cached_tree();
+        assert_eq!(tree.workspaces()[0].screens[0].panes[0].active_tab, usize::MAX);
+        assert_eq!(tree.workspaces()[0].screens[0].panes[0].tabs.len(), 1);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -498,7 +498,10 @@ impl RemoteTreeCache {
                         None => false,
                     },
                     K::ScreenClosed => {
-                        match workspace.screens.iter().position(|screen| Some(screen.id) == screen_id)
+                        match workspace
+                            .screens
+                            .iter()
+                            .position(|screen| Some(screen.id) == screen_id)
                         {
                             Some(position) => {
                                 workspace.screens.remove(position);
@@ -514,7 +517,10 @@ impl RemoteTreeCache {
                         }
                     }
                     K::ScreenRenamed => {
-                        match workspace.screens.iter_mut().find(|screen| Some(screen.id) == screen_id)
+                        match workspace
+                            .screens
+                            .iter_mut()
+                            .find(|screen| Some(screen.id) == screen_id)
                         {
                             Some(screen) => {
                                 screen.name =
@@ -534,8 +540,12 @@ impl RemoteTreeCache {
                     .workspaces
                     .iter_mut()
                     .find(|ws| ws.id == workspace_id)
-                    .and_then(|ws| ws.screens.iter_mut().find(|screen| Some(screen.id) == screen_id))
-                    .and_then(|screen| screen.panes.iter_mut().find(|pane| Some(pane.id) == pane_id))
+                    .and_then(|ws| {
+                        ws.screens.iter_mut().find(|screen| Some(screen.id) == screen_id)
+                    })
+                    .and_then(|screen| {
+                        screen.panes.iter_mut().find(|pane| Some(pane.id) == pane_id)
+                    })
                 else {
                     return TreeDeltaApply::Resync;
                 };
@@ -2675,17 +2685,9 @@ impl RemoteSession {
                 }
             }
             Some(
-                event @ ("workspace-added"
-                | "workspace-closed"
-                | "workspace-renamed"
-                | "workspace-moved"
-                | "screen-added"
-                | "screen-closed"
-                | "screen-renamed"
-                | "pane-added"
-                | "pane-closed"
-                | "tab-added"
-                | "tab-closed"
+                event @ ("workspace-added" | "workspace-closed" | "workspace-renamed"
+                | "workspace-moved" | "screen-added" | "screen-closed" | "screen-renamed"
+                | "pane-added" | "pane-closed" | "tab-added" | "tab-closed"
                 | "tab-renamed"),
             ) => {
                 let capabilities = {
@@ -2696,7 +2698,8 @@ impl RemoteSession {
                             .contains(VIEWPORT_COLUMN_RESIZE_CAPABILITY),
                     }
                 };
-                let applied = self.tree.lock().unwrap().apply_tree_delta(event, &value, capabilities);
+                let applied =
+                    self.tree.lock().unwrap().apply_tree_delta(event, &value, capabilities);
                 match applied {
                     TreeDeltaApply::Applied(delta) => self.emit(MuxEvent::TreeDelta(delta)),
                     TreeDeltaApply::Resync => {
@@ -3743,6 +3746,14 @@ impl RemoteSession {
         self.tree.lock().unwrap().view.surface_kind(id)
     }
 
+    /// Seed the cached tree directly, as if a `list-workspaces` snapshot had
+    /// been adopted, so app tests can exercise remote panes without a server.
+    #[cfg(test)]
+    pub(super) fn test_replace_cached_tree(&self, tree: TreeView) {
+        self.tree.lock().unwrap().replace(tree, 0);
+        self.tree_stale.store(false, Ordering::Release);
+    }
+
     pub fn cached_tree(&self) -> TreeView {
         self.tree.lock().unwrap().view.clone()
     }
@@ -4507,11 +4518,11 @@ fn test_session_with_provider_context(
 #[cfg(test)]
 pub(super) fn test_session_answering(
     responder: Arc<dyn Fn(&Value) -> Value + Send + Sync>,
-) -> (Arc<RemoteSession>, std::sync::mpsc::Receiver<Value>) {
+) -> (Arc<RemoteSession>, Receiver<Value>) {
     struct AnsweringWriter {
         session: Arc<Mutex<Option<Weak<RemoteSession>>>>,
         responder: Arc<dyn Fn(&Value) -> Value + Send + Sync>,
-        requests: std::sync::mpsc::Sender<Value>,
+        requests: Sender<Value>,
     }
 
     impl RemoteMessageWriter for AnsweringWriter {
@@ -4545,7 +4556,7 @@ pub(super) fn test_session_answering(
     }
 
     let slot = Arc::new(Mutex::new(None));
-    let (requests, received) = std::sync::mpsc::channel();
+    let (requests, received) = channel();
     let session = test_session_with_writer(
         Box::new(AnsweringWriter { session: slot.clone(), responder, requests }),
         None,
@@ -8143,7 +8154,7 @@ mod tests {
         assert!(!session.tree_is_stale(), "an exact tab delta must not force a refetch");
         assert!(matches!(
             events.recv_timeout(Duration::from_secs(1)),
-            Ok(MuxEvent::TreeDelta(delta)) if delta.kind == cmux_tui_core::TreeDeltaKind::TabAdded
+            Ok(MuxEvent::TreeDelta(delta)) if delta.kind == TreeDeltaKind::TabAdded
         ));
         let tree = session.cached_tree();
         let tabs = &tree.workspaces[0].screens[0].panes[0].tabs;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -433,7 +433,8 @@ impl RemoteTreeCache {
                         }
                     }
                     K::WorkspaceRenamed => {
-                        match self.view.workspaces_mut().iter_mut().find(|ws| ws.id == workspace_id) {
+                        match self.view.workspaces_mut().iter_mut().find(|ws| ws.id == workspace_id)
+                        {
                             Some(workspace) => {
                                 workspace.name = entity
                                     .get("name")
@@ -451,13 +452,19 @@ impl RemoteTreeCache {
                             index,
                         ) {
                             (Some(from), Some(to)) if to < self.view.workspaces().len() => {
-                                let active_id =
-                                    self.view.workspaces().get(self.view.active_workspace).map(|ws| ws.id);
+                                let active_id = self
+                                    .view
+                                    .workspaces()
+                                    .get(self.view.active_workspace)
+                                    .map(|ws| ws.id);
                                 let moved = self.view.workspaces_mut().remove(from);
                                 self.view.workspaces_mut().insert(to, moved);
                                 if let Some(active_id) = active_id
-                                    && let Some(position) =
-                                        self.view.workspaces().iter().position(|ws| ws.id == active_id)
+                                    && let Some(position) = self
+                                        .view
+                                        .workspaces()
+                                        .iter()
+                                        .position(|ws| ws.id == active_id)
                                 {
                                     self.view.active_workspace = position;
                                 }
@@ -537,7 +544,7 @@ impl RemoteTreeCache {
             K::TabAdded | K::TabClosed | K::TabRenamed => {
                 let Some(pane) = self
                     .view
-                    .workspaces
+                    .workspaces_mut()
                     .iter_mut()
                     .find(|ws| ws.id == workspace_id)
                     .and_then(|ws| {
@@ -8123,6 +8130,7 @@ mod tests {
 
         assert_eq!(cache.agents, vec![agent]);
         assert_eq!(cache.agent_updates.len(), 1);
+    }
 
     fn delta_test_tree() -> Value {
         json!({
@@ -8157,7 +8165,7 @@ mod tests {
             Ok(MuxEvent::TreeDelta(delta)) if delta.kind == TreeDeltaKind::TabAdded
         ));
         let tree = session.cached_tree();
-        let tabs = &tree.workspaces[0].screens[0].panes[0].tabs;
+        let tabs = &tree.workspaces()[0].screens[0].panes[0].tabs;
         assert_eq!(tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![7, 8]);
         assert_eq!(tree.surface(8).unwrap().title, "b");
 
@@ -8172,7 +8180,7 @@ mod tests {
             "index": 0, "entity": {"surface": 7, "title": "a", "kind": "pty"}
         }));
         let tree = session.cached_tree();
-        let pane = &tree.workspaces[0].screens[0].panes[0];
+        let pane = &tree.workspaces()[0].screens[0].panes[0];
         assert_eq!(pane.tabs.iter().map(|tab| tab.surface).collect::<Vec<_>>(), vec![8]);
         assert_eq!(pane.active_tab, 0);
 
@@ -8182,9 +8190,9 @@ mod tests {
                        "panes": [{"id": 10, "tabs": [{"surface": 11, "title": "c"}]}]}
         }));
         let tree = session.cached_tree();
-        assert_eq!(tree.workspaces[0].screens.len(), 2);
-        assert_eq!(tree.workspaces[0].screens[1].id, 9);
-        assert_eq!(tree.workspaces[0].active_screen, 0);
+        assert_eq!(tree.workspaces()[0].screens.len(), 2);
+        assert_eq!(tree.workspaces()[0].screens[1].id, 9);
+        assert_eq!(tree.workspaces()[0].active_screen, 0);
         assert!(!session.tree_is_stale());
         assert!(events.try_iter().all(|event| matches!(event, MuxEvent::TreeDelta(_))));
     }
@@ -8204,7 +8212,7 @@ mod tests {
                 "panes": [{"id": 22, "tabs": [{"surface": 23, "title": "d"}]}]}]}
         }));
         let tree = session.cached_tree();
-        assert_eq!(tree.workspaces.iter().map(|ws| ws.id).collect::<Vec<_>>(), vec![1, 20]);
+        assert_eq!(tree.workspaces().iter().map(|ws| ws.id).collect::<Vec<_>>(), vec![1, 20]);
         assert_eq!(tree.workspace_revision, 5);
         assert_eq!(tree.active_workspace, 0);
         assert!(!session.tree_is_stale());
@@ -8214,7 +8222,7 @@ mod tests {
             "event": "workspace-renamed", "workspace": 20, "workspace_revision": 6,
             "registry_id": "r", "generation": "g", "entity": {"id": 20, "name": "renamed"}
         }));
-        assert_eq!(session.cached_tree().workspaces[1].name, "renamed");
+        assert_eq!(session.cached_tree().workspaces()[1].name, "renamed");
 
         // Revision 8 skips 7: a gap is a resync barrier.
         session.handle_line(json!({
@@ -8222,7 +8230,7 @@ mod tests {
             "registry_id": "r", "generation": "g", "entity": {"id": 20, "name": "renamed"}
         }));
         assert!(session.tree_is_stale(), "a revision gap must force a refetch");
-        assert_eq!(session.cached_tree().workspaces.len(), 2, "a gapped delta is not applied");
+        assert_eq!(session.cached_tree().workspaces().len(), 2, "a gapped delta is not applied");
         let _renamed = events.recv_timeout(Duration::from_secs(1)).unwrap();
         assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeChanged)));
     }
@@ -8241,7 +8249,7 @@ mod tests {
         }));
         assert!(session.tree_is_stale());
         assert!(matches!(events.recv_timeout(Duration::from_secs(1)), Ok(MuxEvent::TreeChanged)));
-        assert_eq!(session.cached_tree().workspaces[0].screens[0].panes.len(), 1);
+        assert_eq!(session.cached_tree().workspaces()[0].screens[0].panes.len(), 1);
 
         session.tree_stale.store(false, Ordering::Release);
         session.handle_line(json!({"event": "tree-changed"}));
@@ -8264,7 +8272,8 @@ mod tests {
     fn subscription_requests_tree_deltas() {
         let (session, requests) = recording_acknowledging_session();
         assert_eq!(session.subscription_request()["tree_events"], json!("deltas"));
-        drop(requests);    }
+        drop(requests);
+    }
 
     #[test]
     fn surface_event_scope_filters_before_remote_cache_invalidation() {

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -290,17 +290,9 @@ impl TreeView {
     /// Make `pane_id` the active pane of its screen, and that screen and
     /// workspace active, wherever the pane lives. False if it is absent.
     pub(crate) fn set_active_pane_if_present(&mut self, pane_id: PaneId) -> bool {
-        let location =
-            self.workspaces.iter().enumerate().find_map(|(workspace_index, workspace)| {
-                workspace.screens.iter().enumerate().find_map(|(screen_index, screen)| {
-                    screen
-                        .panes
-                        .iter()
-                        .any(|pane| pane.id == pane_id)
-                        .then_some((workspace_index, screen_index))
-                })
-            });
-        let Some((workspace_index, screen_index)) = location else { return false };
+        let Some((workspace_index, screen_index, _)) = self.pane_location(pane_id) else {
+            return false;
+        };
         self.active_workspace = workspace_index;
         let workspace = &mut self.workspaces[workspace_index];
         workspace.active_screen = screen_index;

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -287,6 +287,27 @@ impl TreeView {
     }
 
     /// Update focus state without invalidating topology locations.
+    /// Make `pane_id` the active pane of its screen, and that screen and
+    /// workspace active, wherever the pane lives. False if it is absent.
+    pub(crate) fn set_active_pane_if_present(&mut self, pane_id: PaneId) -> bool {
+        let location =
+            self.workspaces.iter().enumerate().find_map(|(workspace_index, workspace)| {
+                workspace.screens.iter().enumerate().find_map(|(screen_index, screen)| {
+                    screen
+                        .panes
+                        .iter()
+                        .any(|pane| pane.id == pane_id)
+                        .then_some((workspace_index, screen_index))
+                })
+            });
+        let Some((workspace_index, screen_index)) = location else { return false };
+        self.active_workspace = workspace_index;
+        let workspace = &mut self.workspaces[workspace_index];
+        workspace.active_screen = screen_index;
+        workspace.screens[screen_index].active_pane = pane_id;
+        true
+    }
+
     pub(crate) fn set_active_pane(
         &mut self,
         workspace_index: usize,

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -789,39 +789,26 @@ pub(super) fn parse_tab(tab: &Value) -> Option<TabView> {
             .get("tab_resource_id")
             .and_then(Value::as_str)
             .and_then(|value| TabPublicId::parse(value.to_string()).ok()),
-        content_id: tab
-            .get("content_resource_id")
-            .and_then(Value::as_str)
-            .and_then(|value| {
-                TerminalPublicId::parse(value.to_string())
-                    .map(ContentPublicId::Terminal)
-                    .or_else(|_| {
-                        BrowserPublicId::parse(value.to_string())
-                            .map(ContentPublicId::Browser)
-                    })
-                    .ok()
-            }),
+        content_id: tab.get("content_resource_id").and_then(Value::as_str).and_then(|value| {
+            TerminalPublicId::parse(value.to_string())
+                .map(ContentPublicId::Terminal)
+                .or_else(|_| {
+                    BrowserPublicId::parse(value.to_string()).map(ContentPublicId::Browser)
+                })
+                .ok()
+        }),
         terminal_id: tab
             .get("terminal_resource_id")
             .and_then(Value::as_str)
             .and_then(|value| TerminalPublicId::parse(value.to_string()).ok()),
-        short_id: tab
-            .get("short_id")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string(),
+        short_id: tab.get("short_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
         name: tab.get("name").and_then(|v| v.as_str()).map(|s| s.to_string()),
-        title: tab
-            .get("title")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string(),
+        title: tab.get("title").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
         kind: match tab.get("kind").and_then(|v| v.as_str()) {
             Some("browser") => SurfaceKind::Browser,
             _ => SurfaceKind::Pty,
         },
-        browser_source: match tab.get("browser_source").and_then(|v| v.as_str())
-        {
+        browser_source: match tab.get("browser_source").and_then(|v| v.as_str()) {
             Some("external") => Some(BrowserSource::External),
             Some("launched") => Some(BrowserSource::Launched),
             _ => None,
@@ -835,7 +822,7 @@ pub(super) fn parse_tab(tab: &Value) -> Option<TabView> {
             .and_then(Value::as_bool)
             .unwrap_or(false),
         notification: tab.get("notification").and_then(parse_notification),
-    }
+    })
 }
 
 fn parse_notification(value: &Value) -> Option<TabNotificationView> {
@@ -975,8 +962,8 @@ pub(super) fn parse_workspace(ws: &Value, capabilities: TreeCapabilities) -> Wor
                 }
             }
         }
-        view.active_screen = active_screen
-            .unwrap_or_else(|| if active_screen_is_invalid { usize::MAX } else { 0 });
+        view.active_screen =
+            active_screen.unwrap_or_else(|| if active_screen_is_invalid { usize::MAX } else { 0 });
     }
     view
 }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -743,7 +743,7 @@ fn parse_layout(value: &Value) -> Option<Node> {
     }
 }
 
-fn parse_pane(value: &Value) -> Option<PaneView> {
+pub(super) fn parse_pane(value: &Value) -> Option<PaneView> {
     let raw_active_tab = value
         .get("active_tab")
         .and_then(Value::as_u64)
@@ -767,59 +767,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                 tabs.iter()
                     .enumerate()
                     .filter_map(|(raw_index, tab)| {
-                        let parsed = Some(TabView {
-                            surface: tab.get("surface")?.as_u64()?,
-                            public_id: tab
-                                .get("tab_resource_id")
-                                .and_then(Value::as_str)
-                                .and_then(|value| TabPublicId::parse(value.to_string()).ok()),
-                            content_id: tab
-                                .get("content_resource_id")
-                                .and_then(Value::as_str)
-                                .and_then(|value| {
-                                    TerminalPublicId::parse(value.to_string())
-                                        .map(ContentPublicId::Terminal)
-                                        .or_else(|_| {
-                                            BrowserPublicId::parse(value.to_string())
-                                                .map(ContentPublicId::Browser)
-                                        })
-                                        .ok()
-                                }),
-                            terminal_id: tab
-                                .get("terminal_resource_id")
-                                .and_then(Value::as_str)
-                                .and_then(|value| TerminalPublicId::parse(value.to_string()).ok()),
-                            short_id: tab
-                                .get("short_id")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            name: tab.get("name").and_then(|v| v.as_str()).map(|s| s.to_string()),
-                            title: tab
-                                .get("title")
-                                .and_then(|v| v.as_str())
-                                .unwrap_or_default()
-                                .to_string(),
-                            kind: match tab.get("kind").and_then(|v| v.as_str()) {
-                                Some("browser") => SurfaceKind::Browser,
-                                _ => SurfaceKind::Pty,
-                            },
-                            browser_source: match tab.get("browser_source").and_then(|v| v.as_str())
-                            {
-                                Some("external") => Some(BrowserSource::External),
-                                Some("launched") => Some(BrowserSource::Launched),
-                                _ => None,
-                            },
-                            browser_frames_stalled: tab
-                                .get("browser_frames_stalled")
-                                .and_then(|v| v.as_bool())
-                                .unwrap_or(false),
-                            supports_clear_history_key_fallback: tab
-                                .get("supports_clear_history_key_fallback")
-                                .and_then(Value::as_bool)
-                                .unwrap_or(false),
-                            notification: tab.get("notification").and_then(parse_notification),
-                        })?;
+                        let parsed = parse_tab(tab)?;
                         if raw_active_tab == Some(raw_index) {
                             active_tab = Some(compact_index);
                         }
@@ -831,6 +779,63 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
             .unwrap_or_default(),
         active_tab: active_tab.unwrap_or(if active_tab_is_declared { usize::MAX } else { 0 }),
     })
+}
+
+/// Parse one `Tab` entity as carried by `list-workspaces` and by tab deltas.
+pub(super) fn parse_tab(tab: &Value) -> Option<TabView> {
+    Some(TabView {
+        surface: tab.get("surface")?.as_u64()?,
+        public_id: tab
+            .get("tab_resource_id")
+            .and_then(Value::as_str)
+            .and_then(|value| TabPublicId::parse(value.to_string()).ok()),
+        content_id: tab
+            .get("content_resource_id")
+            .and_then(Value::as_str)
+            .and_then(|value| {
+                TerminalPublicId::parse(value.to_string())
+                    .map(ContentPublicId::Terminal)
+                    .or_else(|_| {
+                        BrowserPublicId::parse(value.to_string())
+                            .map(ContentPublicId::Browser)
+                    })
+                    .ok()
+            }),
+        terminal_id: tab
+            .get("terminal_resource_id")
+            .and_then(Value::as_str)
+            .and_then(|value| TerminalPublicId::parse(value.to_string()).ok()),
+        short_id: tab
+            .get("short_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        name: tab.get("name").and_then(|v| v.as_str()).map(|s| s.to_string()),
+        title: tab
+            .get("title")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string(),
+        kind: match tab.get("kind").and_then(|v| v.as_str()) {
+            Some("browser") => SurfaceKind::Browser,
+            _ => SurfaceKind::Pty,
+        },
+        browser_source: match tab.get("browser_source").and_then(|v| v.as_str())
+        {
+            Some("external") => Some(BrowserSource::External),
+            Some("launched") => Some(BrowserSource::Launched),
+            _ => None,
+        },
+        browser_frames_stalled: tab
+            .get("browser_frames_stalled")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false),
+        supports_clear_history_key_fallback: tab
+            .get("supports_clear_history_key_fallback")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        notification: tab.get("notification").and_then(parse_notification),
+    }
 }
 
 fn parse_notification(value: &Value) -> Option<TabNotificationView> {
@@ -851,7 +856,7 @@ pub(super) struct TreeCapabilities {
     pub viewport_column_resize: bool,
 }
 
-fn parse_screen(value: &Value, capabilities: TreeCapabilities) -> Option<ScreenView> {
+pub(super) fn parse_screen(value: &Value, capabilities: TreeCapabilities) -> Option<ScreenView> {
     Some(ScreenView {
         id: value.get("id")?.as_u64()?,
         resource_id: value
@@ -929,45 +934,51 @@ pub(super) fn parse_tree_with_capabilities(
         if ws.get("active").and_then(|v| v.as_bool()) == Some(true) {
             tree.active_workspace = i;
         }
-        let mut view = WorkspaceView {
-            id: ws.get("id").and_then(|v| v.as_u64()).unwrap_or(0),
-            resource_id: ws
-                .get("resource_id")
-                .and_then(Value::as_str)
-                .and_then(|value| WorkspacePublicId::parse(value.to_string()).ok()),
-            key: ws.get("key").and_then(Value::as_str).unwrap_or_default().to_string(),
-            short_id: ws.get("short_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
-            name: ws.get("name").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
-            screens: Vec::new(),
-            active_screen: 0,
-        };
-        if let Some(screens) = ws.get("screens").and_then(|v| v.as_array()) {
-            let mut active_screen = None;
-            let mut active_screen_is_invalid = false;
-            for screen in screens {
-                let is_active = screen.get("active").and_then(|v| v.as_bool()) == Some(true);
-                match parse_screen(screen, capabilities) {
-                    Some(parsed) => {
-                        if is_active {
-                            active_screen = Some(view.screens.len());
-                            active_screen_is_invalid = false;
-                        }
-                        view.screens.push(parsed);
+        tree.workspaces.push(parse_workspace(ws, capabilities));
+    }
+    tree
+}
+
+/// Parse one `Workspace` entity as carried by `list-workspaces` and by
+/// workspace deltas. The caller decides whether it is the active workspace.
+pub(super) fn parse_workspace(ws: &Value, capabilities: TreeCapabilities) -> WorkspaceView {
+    let mut view = WorkspaceView {
+        id: ws.get("id").and_then(|v| v.as_u64()).unwrap_or(0),
+        resource_id: ws
+            .get("resource_id")
+            .and_then(Value::as_str)
+            .and_then(|value| WorkspacePublicId::parse(value.to_string()).ok()),
+        key: ws.get("key").and_then(Value::as_str).unwrap_or_default().to_string(),
+        short_id: ws.get("short_id").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        name: ws.get("name").and_then(|v| v.as_str()).unwrap_or_default().to_string(),
+        screens: Vec::new(),
+        active_screen: 0,
+    };
+    if let Some(screens) = ws.get("screens").and_then(|v| v.as_array()) {
+        let mut active_screen = None;
+        let mut active_screen_is_invalid = false;
+        for screen in screens {
+            let is_active = screen.get("active").and_then(|v| v.as_bool()) == Some(true);
+            match parse_screen(screen, capabilities) {
+                Some(parsed) => {
+                    if is_active {
+                        active_screen = Some(view.screens.len());
+                        active_screen_is_invalid = false;
                     }
-                    None => {
-                        if is_active {
-                            active_screen = None;
-                            active_screen_is_invalid = true;
-                        }
+                    view.screens.push(parsed);
+                }
+                None => {
+                    if is_active {
+                        active_screen = None;
+                        active_screen_is_invalid = true;
                     }
                 }
             }
-            view.active_screen =
-                active_screen.unwrap_or(if active_screen_is_invalid { usize::MAX } else { 0 });
         }
-        tree.workspaces.push(view);
+        view.active_screen = active_screen
+            .unwrap_or_else(|| if active_screen_is_invalid { usize::MAX } else { 0 });
     }
-    tree
+    view
 }
 
 #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -467,9 +467,17 @@ fn draw_content(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         return DrawCursors::default();
     }
     let Some(surface) = app.session.surface(area.surface) else {
-        // The tree lists the tab but no mirror exists yet: the attach has not
-        // started. Say so rather than leaving the grid blank.
-        if app.tree.surface_kind(area.surface) != SurfaceKind::Browser {
+        // The tree lists the tab but no mirror exists yet: either a client
+        // placeholder for a create still in flight (or refused), or an attach
+        // that has not started. Say so rather than leaving the grid blank.
+        if let Some(cause) = app.create_placeholder_failure(area.surface) {
+            draw_lifecycle_line(
+                frame,
+                rect,
+                PaneLifecycleText::Failed(cause),
+                app.chrome.browser_message_fg,
+            );
+        } else if app.tree.surface_kind(area.surface) != SurfaceKind::Browser {
             draw_lifecycle_line(
                 frame,
                 rect,
@@ -570,17 +578,22 @@ pub(crate) fn pane_lifecycle_text(dead: bool, ready_for_input: bool) -> Option<P
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum PaneLifecycleText {
     Starting,
     Exited,
+    /// A create the daemon refused; carries the daemon's cause.
+    Failed(String),
 }
 
 impl PaneLifecycleText {
-    fn message(self) -> &'static str {
+    fn message(&self) -> String {
         match self {
-            Self::Starting => localization::catalog().terminal.pane_starting,
-            Self::Exited => localization::catalog().terminal.pane_exited,
+            Self::Starting => localization::catalog().terminal.pane_starting.to_string(),
+            Self::Exited => localization::catalog().terminal.pane_exited.to_string(),
+            Self::Failed(cause) => {
+                localization::catalog().terminal.pane_create_failed.replace("{cause}", cause)
+            }
         }
     }
 }
@@ -594,10 +607,10 @@ fn draw_lifecycle_line(frame: &mut Frame, rect: Rect, lifecycle: PaneLifecycleTe
     if max_cols == 0 || max_rows == 0 {
         return;
     }
-    let text = truncate(lifecycle.message(), max_cols as usize);
+    let text = truncate(&lifecycle.message(), max_cols as usize);
     let text_w = text.width() as u16;
     let (x, y) = match lifecycle {
-        PaneLifecycleText::Starting => {
+        PaneLifecycleText::Starting | PaneLifecycleText::Failed(_) => {
             (rect.x + max_cols.saturating_sub(text_w) / 2, rect.y + max_rows / 2)
         }
         PaneLifecycleText::Exited => (rect.x, rect.y + max_rows - 1),

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -467,6 +467,16 @@ fn draw_content(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         return DrawCursors::default();
     }
     let Some(surface) = app.session.surface(area.surface) else {
+        // The tree lists the tab but no mirror exists yet: the attach has not
+        // started. Say so rather than leaving the grid blank.
+        if app.tree.surface_kind(area.surface) != SurfaceKind::Browser {
+            draw_lifecycle_line(
+                frame,
+                rect,
+                PaneLifecycleText::Starting,
+                app.chrome.browser_message_fg,
+            );
+        }
         return DrawCursors::default();
     };
     surface.take_dirty();
@@ -525,6 +535,14 @@ fn draw_content(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         &app.chrome,
         |col, row| selection.is_some_and(|s| s.contains_viewport(col, row, selection_offset)),
     );
+    // Lifecycle is state, not silence: a pane that is still attaching says so
+    // instead of showing an empty grid, and an exited pane keeps its last
+    // frame with one line saying the process is gone.
+    if let Some(lifecycle) =
+        pane_lifecycle_text(surface.is_dead(), app.session.surface_is_ready_for_input(area.surface))
+    {
+        draw_lifecycle_line(frame, rect, lifecycle, app.chrome.browser_message_fg);
+    }
     if !focused && theme.dim_inactive {
         let screen = frame.area();
         let max_x = rect.x.saturating_add(rect.width).min(screen.width);
@@ -538,6 +556,59 @@ fn draw_content(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
         }
     }
     DrawCursors { input: None, terminal: focused.then_some(cursor).flatten() }
+}
+
+/// Which lifecycle line a PTY pane shows, if any. Exit wins over a pending
+/// attach because an exited surface never becomes ready.
+pub(crate) fn pane_lifecycle_text(dead: bool, ready_for_input: bool) -> Option<PaneLifecycleText> {
+    if dead {
+        Some(PaneLifecycleText::Exited)
+    } else if !ready_for_input {
+        Some(PaneLifecycleText::Starting)
+    } else {
+        None
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum PaneLifecycleText {
+    Starting,
+    Exited,
+}
+
+impl PaneLifecycleText {
+    fn message(self) -> &'static str {
+        match self {
+            Self::Starting => localization::catalog().terminal.pane_starting,
+            Self::Exited => localization::catalog().terminal.pane_exited,
+        }
+    }
+}
+
+/// `Starting` is centered in the (empty) grid; `Exited` sits on the last
+/// content row so the final frame stays readable above it.
+fn draw_lifecycle_line(frame: &mut Frame, rect: Rect, lifecycle: PaneLifecycleText, fg: Color) {
+    let screen = frame.area();
+    let max_cols = rect.width.min(screen.width.saturating_sub(rect.x));
+    let max_rows = rect.height.min(screen.height.saturating_sub(rect.y));
+    if max_cols == 0 || max_rows == 0 {
+        return;
+    }
+    let text = truncate(lifecycle.message(), max_cols as usize);
+    let text_w = text.width() as u16;
+    let (x, y) = match lifecycle {
+        PaneLifecycleText::Starting => {
+            (rect.x + max_cols.saturating_sub(text_w) / 2, rect.y + max_rows / 2)
+        }
+        PaneLifecycleText::Exited => (rect.x, rect.y + max_rows - 1),
+    };
+    frame.buffer_mut().set_stringn(
+        x,
+        y,
+        &text,
+        max_cols as usize,
+        Style::default().fg(fg).add_modifier(Modifier::DIM),
+    );
 }
 
 fn draw_browser_content(

--- a/cmux-tui/crates/cmux-tui/src/ui/pane.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/pane.rs
@@ -477,6 +477,13 @@ fn draw_content(app: &mut App, frame: &mut Frame, area: &PaneArea, focused: bool
                 PaneLifecycleText::Failed(cause),
                 app.chrome.browser_message_fg,
             );
+        } else if app.session.surface_is_exited(area.surface) {
+            draw_lifecycle_line(
+                frame,
+                rect,
+                PaneLifecycleText::Exited,
+                app.chrome.browser_message_fg,
+            );
         } else if app.tree.surface_kind(area.surface) != SurfaceKind::Browser {
             draw_lifecycle_line(
                 frame,
@@ -609,12 +616,19 @@ fn draw_lifecycle_line(frame: &mut Frame, rect: Rect, lifecycle: PaneLifecycleTe
     }
     let text = truncate(&lifecycle.message(), max_cols as usize);
     let text_w = text.width() as u16;
+    let exited = matches!(&lifecycle, PaneLifecycleText::Exited);
     let (x, y) = match lifecycle {
         PaneLifecycleText::Starting | PaneLifecycleText::Failed(_) => {
             (rect.x + max_cols.saturating_sub(text_w) / 2, rect.y + max_rows / 2)
         }
         PaneLifecycleText::Exited => (rect.x, rect.y + max_rows - 1),
     };
+    if exited {
+        let buf = frame.buffer_mut();
+        for col in 0..max_cols {
+            buf[(rect.x + col, y)].set_symbol(" ").set_style(Style::default());
+        }
+    }
     frame.buffer_mut().set_stringn(
         x,
         y,


### PR DESCRIPTION
Frontend-only slice of the zero-wait interaction plan. No daemon (`cmux-tui-core`) code changes. Design: hq plans/cmux-tui-zero-wait-interaction.md (IX1).

Each item is prior-bad → now, with the mechanism and the test that pins it.

1. **Per-target input ordering.** Prior: every session mutation on the PTY input worker was a global barrier and ran inline on the worker thread, so a keystroke to an existing pane waited for a create round trip to a different pane (up to the 10 s request timeout). Now: mutations form their own FIFO lane on a separate thread and block only input addressed to the surfaces they destroy (close tab/pane/screen/workspace name them; creates name nothing, their input is deferred by semantic intent in the frontend as before). Principled: the ordering rule is stated by cause in the `pty_input` module doc. Tests: `slow_untargeted_session_mutation_does_not_delay_input_to_other_surfaces`, `targeted_session_mutation_blocks_later_input_to_its_target_behind_surface_operation`, `input_to_a_close_target_enqueued_before_the_close_runs_first`, `session_mutations_stay_in_enqueue_order`.
2. **`client-focus` off the draw thread.** Prior: first tree adoption inside the first `terminal.draw` called `client-focus` synchronously on remote sessions. Now: remote sessions ask on a worker; first draw uses the tree's default focus; the answer applies via `AppEvent::ClientFocusRestored` only while `client_focus_epoch` is unchanged (bumped on adoption and on user focus reports). Local sessions keep the synchronous path (no I/O). Tests: `remote_client_focus_restore_does_not_block_tree_adoption`, `restored_client_focus_yields_to_user_navigation`.
3. **Local split-drag preview, one commit on release.** Prior: each pointer motion enqueued a coalesced `set-split-ratio` and the divider moved after `layout-changed` triggered a refetch. Now: motion updates a client-local preview ratio applied during layout; release sends one `set-split-ratio` plus its settle barrier; Escape drops the preview and sends nothing; the committed preview holds until the tree carries the ratio or the commit is refused. Viewport column width drags keep their coalesced path. Tests: `split_drag_previews_locally_and_commits_once_on_release`, `escape_cancels_split_drag_without_a_request`, `committed_split_preview_holds_until_the_tree_carries_the_ratio`.
4. **Tree deltas applied to the cached tree.** Prior: the client subscribed to the coarse tree stream and refetched `list-workspaces` after every mutation. Now: it subscribes with `tree_events:"deltas"` and applies workspace added/closed/renamed/moved (exact next `workspace_revision` only), screen added/closed/renamed, and tab added/closed/renamed in stream order, emitting `MuxEvent::TreeDelta` so the frontend redraws from the cache; a gap, unknown parent, delta before any snapshot, `tree-changed`, or `layout-changed` keeps the refetch; a snapshot racing an applied delta marks the tree stale again. A committed remote mutation whose outcome the cache already shows settles as authoritative without a refetch. Kept on the refetch path on purpose: `pane-added`/`pane-closed`, because the Pane entity does not carry the split tree the mutation changed and the daemon emits no `layout-changed` to delta subscribers for a split. Also, the daemon today still emits `tree-changed` alongside most deltas, so the refetch still runs after them; deltas make the change visible one round trip earlier now, and the skip becomes effective once IX2 stops the redundant `tree-changed`. Tests: `tab_and_screen_deltas_apply_to_the_cached_tree_without_a_refetch`, `workspace_deltas_apply_only_the_exact_next_revision`, `pane_deltas_and_tree_changed_force_a_refetch`, `deltas_without_a_snapshot_baseline_force_a_refetch`, `subscription_requests_tree_deltas`, `remote_creation_skips_the_refetch_when_the_cached_tree_already_shows_it`.
5. **Lifecycle text and instant renames.** Prior: an attaching pane was an empty grid; an exited pane gave no sign; a rename showed only after the refetch. Now: one dim localized line, "starting" centered while the attach is outstanding (or before the mirror exists), "process exited" under the last frame once the surface is dead (exit cause is not carried by protocol v12 events, so only the state is named); submitted renames overlay the adopted tree until the authoritative name arrives or the rename is refused. Tests: `attaching_pane_shows_a_starting_line_instead_of_an_empty_grid`, `pane_lifecycle_text_prefers_exit_over_pending_attach`, `submitted_tab_rename_shows_at_once_and_yields_to_the_authoritative_name`, `refused_rename_overlay_drops_once_mutations_settle`.

**Hosted runs.** Focused (`attaching_pane_shows`, head bf85278): https://github.com/manaflow-ai/cmux/actions/runs/33703283056 passed. Full (head bf85278): https://github.com/manaflow-ai/cmux/actions/runs/33704944911 failed on: `clear_history_fallback_operations_remain_ordered` (Linux; relied on the old global barrier, fixed in the last commit and green 3/3 on the testbox), `final_browser_pointer_admission_accepts_exact_presented_frame` (Linux and macOS; also fails on `main` e341deb on the testbox, so not from this branch), `agent_hook_install::hermes_command_reaps_child_when_reaper_spawn_fails` (macOS; file untouched here), and the `x86_64-pc-windows-gnu` artifact job, which also failed in the other full runs of the night (33704596386, 33704249078). Testbox: full `cargo test -p cmux-tui` 1587 passed at 4 threads with only the two environment failures above; `cargo clippy -p cmux-tui --all-targets -D warnings` clean; `cargo fmt --check` clean.

**Measurement.** `bench interact` (IX0, PR #11697 head 5a7f2ab) drives the daemon over the raw protocol, so it does not exercise the TUI client paths this PR changes; the same-connection typing probe tracks daemon create latency in both builds by construction. Numbers are recorded for the environment, not as evidence for this PR. Before = main + IX0, after = this branch + IX0 (scratch merge, not pushed for review). Linux testbox, 30 creates: 1 client create.response p50/p99 4657/5148 ms before vs 708/1228 ms after, 8 clients 9350/26922 vs 9548/25994 ms. This Mac was under heavy load: the IX0 binary alone gave create.response p50 7250 ms, then 2494 ms on an immediate rerun; the merge binary gave 4793 ms between them. The IX1 evidence is the unit tests above (input to another surface flows while a create is blocked; drag motion sends zero requests; first draw does not wait on the focus round trip).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Frontend slice of the zero-wait interaction plan (IX1), plus one `cmux-tui-core` change keeping daemon resource IDs out of the top 2^32 range the TUI reserves for client-local placeholders. Removes the round trips that made the TUI feel slow: input to one pane no longer waits on mutations to another, the first frame no longer waits on a focus query, split drags preview locally, tree deltas update the cache without a refetch, and lifecycle text, renames, and create placeholders show immediately.

**Input and first frame**
- Session mutations form their own FIFO lane and block only input to the surfaces they destroy; creates and renames block nothing.
- Input is deferred by target, never by global state: navigation acts immediately, creates are never deferred, and PTY input waits only for its own placeholder's create.
- `client-focus` is answered on a worker thread; the first draw uses the tree's default focus and applies the answer only while the user hasn't navigated.
- Split drags preview locally and send one `set-split-ratio` on release; Escape cancels without a request.
- New-pane, split, new-tab, and new-workspace render a client-local placeholder on keypress that shows a "starting" line and takes focus; the real pane occupies the same slot on resolution, and input deferred to a failed placeholder is retired, never replayed.

**Tree and lifecycle feedback**
- The client applies workspace/screen/tab deltas to the cached tree in stream order instead of refetching after every mutation; workspace moves preserve active workspace focus.
- Refetch stays for revision gaps, unknown parents, missing snapshots, `tree-changed`, `layout-changed`, and `pane-added`/`pane-closed`; the daemon still emits `tree-changed` alongside most deltas, so the skip becomes effective once IX2 stops that.
- Attaching panes show a "starting" line and exited panes show "process exited" instead of a blank grid.
- Submitted renames overlay the tree until the authoritative name arrives or the rename is refused.
- Failed mutations show the daemon's cause in the status line and where the pane would have appeared.

<sup>Written for commit 51b6ad0ea88daa21e6067ee5f850c251f4798247. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11767?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added live previews while dragging pane splits, with commit on release and cancellation via Escape.
  * Added temporary rename feedback and creation placeholders for workspaces, screens, tabs, and panes.
  * Added clear terminal status messages for starting, exited, or failed panes.
  * Improved remote session updates so visible changes appear faster and remain consistent during navigation.

* **Bug Fixes**
  * Improved input handling during surface operations, keeping unrelated panes responsive while targeted changes complete.
  * Failed operations now display the daemon’s reported cause.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->