### PR TITLE
web: stop depending on client behavior for device-registry and relay load

### DIFF
--- a/web/app/api/account/route.ts
+++ b/web/app/api/account/route.ts
@@ -34,6 +34,7 @@ import {
   vaultUploadGrants,
   vaultUploadTombstones,
 } from "../../../db/schema";
+import { deleteIdentitySnapshot } from "../../../services/auth/identitySnapshot";
 import {
   ACTIVE_STRIPE_PRO_STATUSES,
   type ProMetadataJson,
@@ -670,6 +671,10 @@ async function markAccountDeletionTombstonePending(userId: string): Promise<Acco
           errorMessage: null,
         },
       });
+    // High-volume routes may answer from a stored identity snapshot without
+    // asking Stack. Drop it as soon as deletion is recorded so the tombstone
+    // takes effect on the next request rather than after the snapshot TTL.
+    await deleteIdentitySnapshot(userId);
     const legacySubrouterRetiredTenantIds = uniqueNonEmptyStrings(
       existing?.legacySubrouterRetiredTenantIds ?? [],
     );

--- a/web/app/api/account/route.ts
+++ b/web/app/api/account/route.ts
@@ -34,7 +34,6 @@ import {
   vaultUploadGrants,
   vaultUploadTombstones,
 } from "../../../db/schema";
-import { deleteIdentitySnapshot } from "../../../services/auth/identitySnapshot";
 import {
   ACTIVE_STRIPE_PRO_STATUSES,
   type ProMetadataJson,
@@ -671,10 +670,6 @@ async function markAccountDeletionTombstonePending(userId: string): Promise<Acco
           errorMessage: null,
         },
       });
-    // High-volume routes may answer from a stored identity snapshot without
-    // asking Stack. Drop it as soon as deletion is recorded so the tombstone
-    // takes effect on the next request rather than after the snapshot TTL.
-    await deleteIdentitySnapshot(userId);
     const legacySubrouterRetiredTenantIds = uniqueNonEmptyStrings(
       existing?.legacySubrouterRetiredTenantIds ?? [],
     );

--- a/web/app/api/devices/route.ts
+++ b/web/app/api/devices/route.ts
@@ -215,56 +215,59 @@ export async function POST(request: Request): Promise<Response> {
   const db = cloudDb();
   const now = new Date();
 
-  // A client that re-registers an unchanged route set costs a per-team
-  // advisory lock, two selects and two upserts. The Mac's own dedupe compares
-  // route hints that carry observation timestamps, which this route strips
-  // before storing, so it re-POSTs identical rows for as long as it runs. That
-  // behavior ships in builds we cannot update, so the server answers it here
-  // instead of paying for the write.
-  const [stored] = await db
-    .select({
-      userId: devices.userId,
-      platform: devices.platform,
-      displayName: devices.displayName,
-      labels: devices.labels,
-      instanceRoutes: deviceAppInstances.routes,
-      instanceLabels: deviceAppInstances.labels,
-      lastSeenAt: deviceAppInstances.lastSeenAt,
-    })
-    .from(devices)
-    .innerJoin(deviceAppInstances, eq(deviceAppInstances.deviceId, devices.id))
-    .where(and(
-      eq(devices.teamId, team.teamId),
-      eq(devices.deviceUuid, deviceUuid),
-      eq(deviceAppInstances.tag, tag),
-    ))
-    .limit(1);
-  if (
-    registrationIsUnchanged({
-      stored: stored ?? null,
-      incoming: {
-        userId: user.id,
-        platform,
-        displayName,
-        labels: deviceLabels,
-        instanceRoutes: routes,
-        instanceLabels,
-      },
-      now,
-      touchIntervalMs: presenceTouchIntervalMs(),
-    })
-  ) {
-    recordRegistrationNoOp();
-    return jsonResponse({ ok: true, deviceId: deviceUuid, teamId: team.teamId, tag });
-  }
-
-  let registered: { error: "device_not_owned" | "too_many_devices" | "too_many_instances" | null };
+  let registered: {
+    error: "device_not_owned" | "too_many_devices" | "too_many_instances" | null;
+    unchanged?: boolean;
+  };
   try {
     registered = await db.transaction(async (tx) => {
       await assertAccountDeletionUserMutationAllowed(tx, user.id);
       // Serialize concurrent registrations for the same team so the per-team cap
       // is enforced without a race (mirrors the device-tokens advisory lock).
       await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${team.teamId}, 7))`);
+
+      // A Mac re-registers whenever its advertised route set changes, and it
+      // compares route hints that carry observation timestamps. This route
+      // strips those before storing, so a shipped Mac re-POSTs byte-identical
+      // rows for as long as it runs, and no client update can change that.
+      // Answer it here, under the lock so the comparison is against the row a
+      // concurrent registration cannot be mid-way through changing, and skip
+      // the two upserts and their WAL.
+      const [stored] = await tx
+        .select({
+          userId: devices.userId,
+          platform: devices.platform,
+          displayName: devices.displayName,
+          labels: devices.labels,
+          instanceRoutes: deviceAppInstances.routes,
+          instanceLabels: deviceAppInstances.labels,
+          lastSeenAt: deviceAppInstances.lastSeenAt,
+        })
+        .from(devices)
+        .innerJoin(deviceAppInstances, eq(deviceAppInstances.deviceId, devices.id))
+        .where(and(
+          eq(devices.teamId, team.teamId),
+          eq(devices.deviceUuid, deviceUuid),
+          eq(deviceAppInstances.tag, tag),
+        ))
+        .limit(1);
+      if (
+        registrationIsUnchanged({
+          stored: stored ?? null,
+          incoming: {
+            userId: user.id,
+            platform,
+            displayName,
+            labels: deviceLabels,
+            instanceRoutes: routes,
+            instanceLabels,
+          },
+          now,
+          touchIntervalMs: presenceTouchIntervalMs(),
+        })
+      ) {
+        return { error: null, unchanged: true as const };
+      }
 
       // Device identity is per team: a row keyed by (teamId, deviceUuid). The
       // same cmux device UUID registering under a different team is a separate,
@@ -383,6 +386,7 @@ export async function POST(request: Request): Promise<Response> {
   if (registered.error === "too_many_instances") {
     return jsonResponse({ error: "too_many_instances" }, 429);
   }
+  if (registered.unchanged) recordRegistrationNoOp();
 
   return jsonResponse({ ok: true, deviceId: deviceUuid, teamId: team.teamId, tag });
 }

--- a/web/app/api/devices/route.ts
+++ b/web/app/api/devices/route.ts
@@ -32,6 +32,11 @@ import {
 } from "../../../services/account/deletionLock";
 import { sanitizeServerPublishedRoutes } from "../../../services/iroh/publicationPolicy";
 import { enforceNativeIngressRateLimit } from "../../../services/nativeIngressRateLimit";
+import {
+  presenceTouchIntervalMs,
+  registrationIsUnchanged,
+} from "../../../services/devices/registrationNoOp";
+import { recordRegistrationNoOp } from "../../../services/auth/authTelemetry";
 import { authProviderErrorResponse } from "../../../services/vms/authErrors";
 
 
@@ -209,6 +214,49 @@ export async function POST(request: Request): Promise<Response> {
 
   const db = cloudDb();
   const now = new Date();
+
+  // A client that re-registers an unchanged route set costs a per-team
+  // advisory lock, two selects and two upserts. The Mac's own dedupe compares
+  // route hints that carry observation timestamps, which this route strips
+  // before storing, so it re-POSTs identical rows for as long as it runs. That
+  // behavior ships in builds we cannot update, so the server answers it here
+  // instead of paying for the write.
+  const [stored] = await db
+    .select({
+      userId: devices.userId,
+      platform: devices.platform,
+      displayName: devices.displayName,
+      labels: devices.labels,
+      instanceRoutes: deviceAppInstances.routes,
+      instanceLabels: deviceAppInstances.labels,
+      lastSeenAt: deviceAppInstances.lastSeenAt,
+    })
+    .from(devices)
+    .innerJoin(deviceAppInstances, eq(deviceAppInstances.deviceId, devices.id))
+    .where(and(
+      eq(devices.teamId, team.teamId),
+      eq(devices.deviceUuid, deviceUuid),
+      eq(deviceAppInstances.tag, tag),
+    ))
+    .limit(1);
+  if (
+    registrationIsUnchanged({
+      stored: stored ?? null,
+      incoming: {
+        userId: user.id,
+        platform,
+        displayName,
+        labels: deviceLabels,
+        instanceRoutes: routes,
+        instanceLabels,
+      },
+      now,
+      touchIntervalMs: presenceTouchIntervalMs(),
+    })
+  ) {
+    recordRegistrationNoOp();
+    return jsonResponse({ ok: true, deviceId: deviceUuid, teamId: team.teamId, tag });
+  }
 
   let registered: { error: "device_not_owned" | "too_many_devices" | "too_many_instances" | null };
   try {

--- a/web/app/api/devices/route.ts
+++ b/web/app/api/devices/route.ts
@@ -433,8 +433,12 @@ export async function DELETE(request: Request): Promise<Response> {
   if (rateLimitResponse) return rateLimitResponse;
   let user: Awaited<ReturnType<typeof verifyRequest>>;
   try {
-    user = await verifyRequestFromSnapshot(request, {
+    // Unregistering a device removes a row other members of the team can see,
+    // so it verifies live rather than trusting an identity snapshot that could
+    // be up to a TTL behind a team removal. It is user-initiated and rare.
+    user = await verifyRequest(request, {
       requestedTeamId: requestedVmTeamIdFromRequest(request),
+      allowCookie: false,
     });
   } catch (error) {
     return authProviderErrorResponse(error, "devices.delete.auth");

--- a/web/app/api/devices/route.ts
+++ b/web/app/api/devices/route.ts
@@ -18,6 +18,7 @@ import { jsonResponse } from "../../../services/vms/routeHelpers";
 import {
   unauthorized,
   verifyRequest,
+  verifyRequestFromSnapshot,
   type AuthedUser,
 } from "../../../services/vms/auth";
 import { requestedVmTeamIdFromRequest } from "../../../services/vms/routeHelpers";
@@ -141,9 +142,8 @@ export async function POST(request: Request): Promise<Response> {
   if (rateLimitResponse) return rateLimitResponse;
   let user: Awaited<ReturnType<typeof verifyRequest>>;
   try {
-    user = await verifyRequest(request, {
+    user = await verifyRequestFromSnapshot(request, {
       requestedTeamId: requestedVmTeamIdFromRequest(request),
-      allowCookie: false,
     });
   } catch (error) {
     return authProviderErrorResponse(error, "devices.post.auth");
@@ -357,9 +357,8 @@ export async function GET(request: Request): Promise<Response> {
   if (rateLimitResponse) return rateLimitResponse;
   let user: Awaited<ReturnType<typeof verifyRequest>>;
   try {
-    user = await verifyRequest(request, {
+    user = await verifyRequestFromSnapshot(request, {
       requestedTeamId: requestedVmTeamIdFromRequest(request),
-      allowCookie: false,
     });
   } catch (error) {
     return authProviderErrorResponse(error, "devices.get.auth");
@@ -434,9 +433,8 @@ export async function DELETE(request: Request): Promise<Response> {
   if (rateLimitResponse) return rateLimitResponse;
   let user: Awaited<ReturnType<typeof verifyRequest>>;
   try {
-    user = await verifyRequest(request, {
+    user = await verifyRequestFromSnapshot(request, {
       requestedTeamId: requestedVmTeamIdFromRequest(request),
-      allowCookie: false,
     });
   } catch (error) {
     return authProviderErrorResponse(error, "devices.delete.auth");

--- a/web/app/api/relay/token/route.ts
+++ b/web/app/api/relay/token/route.ts
@@ -44,8 +44,7 @@ import {
 } from "../../../../services/iroh/routeHandler";
 import {
   unauthorized,
-  verifyRequest,
-  type AuthedUser,
+  verifyRequestIdentity,
 } from "../../../../services/vms/auth";
 
 
@@ -53,7 +52,12 @@ const MAX_BODY_BYTES = 4 * 1_024;
 const RELAY_TOKEN_RATE_LIMIT_BUCKET_SECONDS = 60;
 
 export interface RelayTokenDeps {
-  readonly verifyRequest: (request: Request) => Promise<AuthedUser | null>;
+  /**
+   * Identity only: minting a relay credential needs the account id and nothing
+   * else, so this resolves the caller's Stack access token locally instead of
+   * spending a `users/me` call on every endpoint refresh.
+   */
+  readonly verifyRequest: (request: Request) => Promise<{ readonly id: string } | null>;
   readonly signingKey: () => KeyObject | null;
   readonly nowSeconds: () => number;
   readonly signedPolicy: (
@@ -81,7 +85,7 @@ export interface RelayTokenDeps {
 }
 
 const productionDeps: RelayTokenDeps = {
-  verifyRequest: (request) => verifyRequest(request, { allowCookie: false }),
+  verifyRequest: (request) => verifyRequestIdentity(request, { allowCookie: false }),
   signingKey: relaySigningKey,
   nowSeconds: () => Math.floor(Date.now() / 1_000),
   signedPolicy: async (accountId, nowSeconds) => {
@@ -159,7 +163,7 @@ export async function handleRelayTokenRequest(
     }
   }
 
-  let user: AuthedUser | null;
+  let user: { readonly id: string } | null;
   try {
     user = await deps.verifyRequest(request);
   } catch (error) {

--- a/web/app/api/vm/leases/revoke/route.ts
+++ b/web/app/api/vm/leases/revoke/route.ts
@@ -3,6 +3,7 @@ import {
   withAuthedVmApiRoute,
 } from "../../../../../services/vms/routeHelpers";
 import { invalidateNativeAuthCacheForTokens } from "../../../../../services/vms/auth";
+import { deleteIdentitySnapshot } from "../../../../../services/auth/identitySnapshot";
 import {
   revokeUserVmAccess,
   runVmWorkflow,
@@ -33,6 +34,11 @@ export async function POST(request: Request): Promise<Response> {
         // Auth revocation is still in flight.
         invalidateNativeAuthCacheForTokens({ accessToken, refreshToken });
       }
+      // The device registry can answer from a shared identity snapshot without
+      // asking Stack at all, so sign-out must drop that row too. Otherwise the
+      // signed-out account keeps team-scoped registry access on every instance
+      // until the snapshot ages out.
+      await deleteIdentitySnapshot(user.id);
       const result = await runVmWorkflow(revokeUserVmAccess({ userId: user.id }));
       return jsonResponse({
         ok: true,

--- a/web/db/migrations/20260903030000_stack_identity_snapshots/migration.sql
+++ b/web/db/migrations/20260903030000_stack_identity_snapshots/migration.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "stack_identity_snapshots" (
+  "user_id" text PRIMARY KEY NOT NULL,
+  "display_name" text,
+  "primary_email" text,
+  "selected_team_id" text,
+  "billing_customer_type" text NOT NULL,
+  "billing_team_id" text NOT NULL,
+  "user_billing_plan_id" text,
+  "billing_plan_id" text,
+  "billing_seats" integer,
+  "teams" jsonb DEFAULT '[]'::jsonb NOT NULL,
+  "refreshed_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX "stack_identity_snapshots_refreshed_idx" ON "stack_identity_snapshots" ("refreshed_at");

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1395,10 +1395,9 @@ export const coderouterClaudeUpstreams = pgTable(
  * keys; this table supplies everything the token does not carry, so a Stack
  * call is needed only when no fresh snapshot exists.
  *
- * The default lifetime of a snapshot is the one-hour Stack access-token
- * lifetime, so answering from one adds no staleness beyond what accepting a
- * locally verified access token already does. Sign-out and account deletion
- * delete the row. Deletion is also enforced on read: the snapshot path checks
+ * The default lifetime of a snapshot is ten minutes. That is the window in
+ * which a user removed from a team keeps that team's registry access, since
+ * Stack sends no membership webhook to invalidate on. Sign-out deletes the row. Deletion is also enforced on read: the snapshot path checks
  * the account-deletion tombstone directly, so a tombstone takes effect on the
  * next request rather than waiting for the row to be cleared.
  */

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1398,7 +1398,9 @@ export const coderouterClaudeUpstreams = pgTable(
  * The default lifetime of a snapshot is the one-hour Stack access-token
  * lifetime, so answering from one adds no staleness beyond what accepting a
  * locally verified access token already does. Sign-out and account deletion
- * delete the row.
+ * delete the row. Deletion is also enforced on read: the snapshot path checks
+ * the account-deletion tombstone directly, so a tombstone takes effect on the
+ * next request rather than waiting for the row to be cleared.
  */
 export const stackIdentitySnapshots = pgTable(
   "stack_identity_snapshots",

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1383,3 +1383,50 @@ export const coderouterClaudeUpstreams = pgTable(
     ),
   ],
 );
+
+/**
+ * A local mirror of the Stack Auth identity fields our high-volume routes need
+ * (display name, primary email, selected team, team membership and the billing
+ * plan metadata derived from them).
+ *
+ * The device registry and the relay broker authenticate hundreds of requests
+ * per second, and each one used to cost a `GET /users/me` call to Stack. The
+ * access token itself is verified locally against Stack's published signing
+ * keys; this table supplies everything the token does not carry, so a Stack
+ * call is needed only when no fresh snapshot exists.
+ *
+ * The default lifetime of a snapshot is the one-hour Stack access-token
+ * lifetime, so answering from one adds no staleness beyond what accepting a
+ * locally verified access token already does. Sign-out and account deletion
+ * delete the row.
+ */
+export const stackIdentitySnapshots = pgTable(
+  "stack_identity_snapshots",
+  {
+    userId: text("user_id").primaryKey(),
+    displayName: text("display_name"),
+    primaryEmail: text("primary_email"),
+    selectedTeamId: text("selected_team_id"),
+    billingCustomerType: text("billing_customer_type")
+      .$type<"team" | "user">()
+      .notNull(),
+    billingTeamId: text("billing_team_id").notNull(),
+    userBillingPlanId: text("user_billing_plan_id"),
+    billingPlanId: text("billing_plan_id"),
+    billingSeats: integer("billing_seats"),
+    /** Every team the snapshot proves membership of, with its billing fields. */
+    teams: jsonb("teams")
+      .$type<{
+        id: string;
+        displayName: string | null;
+        billingPlanId: string | null;
+        billingSeats: number | null;
+      }[]>()
+      .notNull()
+      .default(sql`'[]'::jsonb`),
+    refreshedAt: timestamp("refreshed_at", { withTimezone: true }).notNull().defaultNow(),
+  },
+  (table) => [
+    index("stack_identity_snapshots_refreshed_idx").on(table.refreshedAt),
+  ],
+);

--- a/web/services/auth/README.md
+++ b/web/services/auth/README.md
@@ -46,3 +46,28 @@ Stack Auth sees:
 
 Multiply by 50 for the real rate: `users/me` spans hang off request traces that
 are head-sampled at 2%, except under `/api/vm*`, which is kept in full.
+
+# Surviving clients that never update
+
+The auth-provider fix above holds for every client version, because it changes
+what the server does with a request rather than what the client sends. Two more
+defenses exist for the same reason.
+
+**Redundant registrations cost nothing.** `POST /api/devices` compares the
+incoming registration against the stored rows and returns success without
+taking the per-team advisory lock or writing, when the only difference would be
+a presence timestamp refreshed within `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS`
+(one minute). This matters because the Mac's own dedupe compares route hints
+carrying observation timestamps, which `sanitizeServerPublishedRoutes` strips
+before storing. A shipped Mac therefore re-registers identical rows for as long
+as it runs, and no client update can change that.
+
+**Throttles name a delay.** Native ingress 429s carry `Retry-After`. The iroh
+broker client already shipped honors it and persists an account-scoped cooldown
+across relaunch, so this is the one backpressure signal that reaches builds we
+cannot update. A 429 without the header tells that client nothing and it falls
+back to its own retry cadence.
+
+The client user agent is `cmux/102` for every build, stable and nightly alike,
+so traffic cannot currently be attributed to a version. Assume the worst case:
+whatever is storming will still be storming after the next release.

--- a/web/services/auth/README.md
+++ b/web/services/auth/README.md
@@ -1,0 +1,46 @@
+# Auth provider load
+
+Every authenticated request used to cost one `GET /users/me` call to Stack
+Auth. At device-registry volume that reached millions of calls a day and
+exhausted the project-wide rate limit, which surfaced as unrelated 429s on
+billing and sign-in.
+
+Three paths now answer without calling Stack:
+
+| Path | Used by | What it proves |
+| --- | --- | --- |
+| `verifyRequestIdentity` | iroh broker, `/api/relay/token` | The caller's user id, from a locally verified access token |
+| `verifyRequestFromSnapshot` | `/api/devices` | User id plus team membership, from `stack_identity_snapshots` |
+| `verifyRequest` | billing, VM mutations, account, admin | Live Stack session, no caching of the decision |
+
+A snapshot is refreshed from Stack at most once per `CMUX_STACK_IDENTITY_
+SNAPSHOT_TTL_MS` (default one hour, the Stack access-token lifetime) per user,
+and is deleted on sign-out and on account deletion.
+
+## Measuring it
+
+Auth resolution is stamped on the request span the tracer already emits, so
+there is no second event stream to pay for. The app-wide 2% head sample is
+ample for a rate in the hundreds per second.
+
+```kusto
+['cmux-prod-otel-traces']
+| where _time > ago(1h)
+| where isnotempty(['attributes.custom']['cmux.auth.source'])
+| summarize c=count() by
+    source=tostring(['attributes.custom']['cmux.auth.source']),
+    called=tostring(['attributes.custom']['cmux.auth.provider_called'])
+```
+
+The ground truth for provider load is the outbound span itself, which is what
+Stack Auth sees:
+
+```kusto
+['cmux-prod-otel-traces']
+| where _time > ago(6h)
+| where name contains 'users/me'
+| summarize c=count() by bin(_time, 10m)
+```
+
+Multiply by 50 for the real rate: `users/me` spans hang off request traces that
+are head-sampled at 2%, except under `/api/vm*`, which is kept in full.

--- a/web/services/auth/README.md
+++ b/web/services/auth/README.md
@@ -10,8 +10,8 @@ Three paths now answer without calling Stack:
 | Path | Used by | What it proves |
 | --- | --- | --- |
 | `verifyRequestIdentity` | iroh broker, `/api/relay/token` | The caller's user id, from a locally verified access token |
-| `verifyRequestFromSnapshot` | `/api/devices` | User id plus team membership, from `stack_identity_snapshots` |
-| `verifyRequest` | billing, VM mutations, account, admin | Live Stack session, no caching of the decision |
+| `verifyRequestFromSnapshot` | `/api/devices` GET and POST | User id plus team membership, from `stack_identity_snapshots` |
+| `verifyRequest` | billing, VM mutations, account, admin, `/api/devices` DELETE | Live Stack session, no caching of the decision |
 
 A snapshot is refreshed from Stack at most once per `CMUX_STACK_IDENTITY_
 SNAPSHOT_TTL_MS` (default one hour, the Stack access-token lifetime) per user,

--- a/web/services/auth/README.md
+++ b/web/services/auth/README.md
@@ -15,7 +15,9 @@ Three paths now answer without calling Stack:
 
 A snapshot is refreshed from Stack at most once per `CMUX_STACK_IDENTITY_
 SNAPSHOT_TTL_MS` (default one hour, the Stack access-token lifetime) per user,
-and is deleted on sign-out and on account deletion.
+and is deleted on sign-out. Account deletion is enforced on read instead: the
+snapshot path checks the deletion tombstone directly on every request, so a
+tombstone takes effect immediately rather than after the TTL.
 
 ## Measuring it
 

--- a/web/services/auth/README.md
+++ b/web/services/auth/README.md
@@ -14,10 +14,15 @@ Three paths now answer without calling Stack:
 | `verifyRequest` | billing, VM mutations, account, admin, `/api/devices` DELETE | Live Stack session, no caching of the decision |
 
 A snapshot is refreshed from Stack at most once per `CMUX_STACK_IDENTITY_
-SNAPSHOT_TTL_MS` (default one hour, the Stack access-token lifetime) per user,
+SNAPSHOT_TTL_MS` (default ten minutes) per user,
 and is deleted on sign-out. Account deletion is enforced on read instead: the
 snapshot path checks the deletion tombstone directly on every request, so a
 tombstone takes effect immediately rather than after the TTL.
+
+The TTL is the security parameter here. A user removed from a team keeps that
+team's device-registry access until their snapshot refreshes, because Stack
+sends no webhook we could use to invalidate it. Ten minutes bounds that at one
+Stack call per active user per ten minutes, under 7 a second fleet-wide.
 
 ## Measuring it
 
@@ -53,10 +58,11 @@ The auth-provider fix above holds for every client version, because it changes
 what the server does with a request rather than what the client sends. Two more
 defenses exist for the same reason.
 
-**Redundant registrations cost nothing.** `POST /api/devices` compares the
-incoming registration against the stored rows and returns success without
-taking the per-team advisory lock or writing, when the only difference would be
-a presence timestamp refreshed within `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS`
+**Redundant registrations skip the write.** `POST /api/devices` compares the
+incoming registration against the stored rows, under the per-team advisory
+lock so a concurrent registration cannot slip between the read and the answer,
+and returns success without either upsert when the only difference would be a
+presence timestamp refreshed within `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS`
 (one minute). This matters because the Mac's own dedupe compares route hints
 carrying observation timestamps, which `sanitizeServerPublishedRoutes` strips
 before storing. A shipped Mac therefore re-registers identical rows for as long

--- a/web/services/auth/authTelemetry.ts
+++ b/web/services/auth/authTelemetry.ts
@@ -1,0 +1,45 @@
+import { trace } from "@opentelemetry/api";
+
+/**
+ * How a request's identity was established.
+ *
+ * `access_token` and `snapshot` cost no call to Stack Auth; `stack` and
+ * `cookie` each cost one `GET /users/me`. Recording this on the request span
+ * the tracer already emits is what makes auth-provider load measurable without
+ * adding a single extra event: the app-wide 2% head sample is far more than
+ * enough resolution for a rate that runs at hundreds per second.
+ */
+export type AuthResolutionSource =
+  | "access_token"
+  | "snapshot"
+  | "stack"
+  | "cookie"
+  | "unauthenticated";
+
+export type AuthResolution = {
+  readonly source: AuthResolutionSource;
+  /** Whether this request called the auth provider's API. */
+  readonly providerCalled: boolean;
+  /** Age of the identity snapshot that answered, when one did. */
+  readonly snapshotAgeMs?: number;
+  /** Why local token verification did not answer, when it was tried and failed. */
+  readonly localVerifyMiss?: "no_token" | "rejected" | "not_configured";
+};
+
+/**
+ * Stamp the identity resolution onto the active span.
+ *
+ * No-ops when nothing is recording, so route code can call it unconditionally.
+ */
+export function recordAuthResolution(resolution: AuthResolution): void {
+  const span = trace.getActiveSpan();
+  if (!span) return;
+  span.setAttribute("cmux.auth.source", resolution.source);
+  span.setAttribute("cmux.auth.provider_called", resolution.providerCalled);
+  if (resolution.snapshotAgeMs !== undefined) {
+    span.setAttribute("cmux.auth.snapshot_age_ms", Math.max(0, Math.round(resolution.snapshotAgeMs)));
+  }
+  if (resolution.localVerifyMiss !== undefined) {
+    span.setAttribute("cmux.auth.local_verify_miss", resolution.localVerifyMiss);
+  }
+}

--- a/web/services/auth/authTelemetry.ts
+++ b/web/services/auth/authTelemetry.ts
@@ -43,3 +43,13 @@ export function recordAuthResolution(resolution: AuthResolution): void {
     span.setAttribute("cmux.auth.local_verify_miss", resolution.localVerifyMiss);
   }
 }
+
+/**
+ * Record that a device registration changed nothing and was answered without
+ * a write. Rides the request span, so measuring how much of the registry's
+ * traffic is redundant costs no extra events.
+ */
+export function recordRegistrationNoOp(): void {
+  const span = trace.getActiveSpan();
+  span?.setAttribute("cmux.devices.registration_no_op", true);
+}

--- a/web/services/auth/identitySnapshot.ts
+++ b/web/services/auth/identitySnapshot.ts
@@ -1,0 +1,160 @@
+import { eq, sql } from "drizzle-orm";
+
+import { cloudDb } from "../../db/client";
+import { stackIdentitySnapshots } from "../../db/schema";
+import type { AuthedTeam, AuthedUser } from "../vms/auth";
+
+/**
+ * How long a stored identity snapshot may answer for Stack. A snapshot is
+ * additionally capped by the expiry of the access token presenting it, so this
+ * is an upper bound, not the effective staleness for any single request.
+ */
+const DEFAULT_SNAPSHOT_TTL_MS = 60 * 60 * 1_000;
+
+export function identitySnapshotTtlMs(
+  raw = process.env.CMUX_STACK_IDENTITY_SNAPSHOT_TTL_MS,
+): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_SNAPSHOT_TTL_MS;
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) return DEFAULT_SNAPSHOT_TTL_MS;
+  return parsed;
+}
+
+type SnapshotDb = Pick<ReturnType<typeof cloudDb>, "select" | "insert" | "delete">;
+
+export type IdentitySnapshotRead = {
+  readonly user: AuthedUser;
+  readonly ageMs: number;
+};
+
+/**
+ * The stored identity for `userId`, or null when there is none, it is older
+ * than `maxAgeMs`, or the database is unreachable.
+ *
+ * A read failure returns null rather than throwing: the caller then asks Stack,
+ * which is exactly today's behavior. The snapshot is an optimization, never a
+ * source of authority the request cannot do without.
+ */
+export async function readIdentitySnapshot(
+  userId: string,
+  maxAgeMs: number,
+  db?: SnapshotDb,
+): Promise<IdentitySnapshotRead | null> {
+  if (maxAgeMs <= 0) return null;
+  let rows: Array<typeof stackIdentitySnapshots.$inferSelect>;
+  try {
+    rows = await (db ?? cloudDb())
+      .select()
+      .from(stackIdentitySnapshots)
+      .where(eq(stackIdentitySnapshots.userId, userId))
+      .limit(1);
+  } catch {
+    return null;
+  }
+  const row = rows[0];
+  if (!row) return null;
+  const ageMs = Date.now() - row.refreshedAt.getTime();
+  // A clock that moved backwards must not turn a stale row into a fresh one.
+  if (ageMs < 0 || ageMs > maxAgeMs) return null;
+  return { user: authedUserFromSnapshotRow(row), ageMs };
+}
+
+function authedUserFromSnapshotRow(
+  row: typeof stackIdentitySnapshots.$inferSelect,
+): AuthedUser {
+  const teams: readonly AuthedTeam[] = (row.teams ?? []).map((team) => ({
+    id: team.id,
+    displayName: team.displayName ?? null,
+    billingPlanId: team.billingPlanId ?? null,
+    billingSeats: team.billingSeats ?? null,
+  }));
+  return {
+    id: row.userId,
+    displayName: row.displayName,
+    primaryEmail: row.primaryEmail,
+    billingCustomerType: row.billingCustomerType,
+    billingTeamId: row.billingTeamId,
+    selectedTeamId: row.selectedTeamId,
+    teams,
+    teamIds: teams.map((team) => team.id),
+    userBillingPlanId: row.userBillingPlanId,
+    billingPlanId: row.billingPlanId,
+    billingSeats: row.billingSeats,
+  };
+}
+
+/**
+ * Store the identity Stack just returned.
+ *
+ * Only a verification that listed the user's teams may be stored: a snapshot
+ * written from a partial team list would silently deny access to a team the
+ * user really belongs to. Callers pass `completeTeamList: false` for the
+ * single-team lookup path.
+ */
+export async function writeIdentitySnapshot(
+  user: AuthedUser,
+  options: { readonly completeTeamList: boolean },
+  db?: SnapshotDb,
+): Promise<void> {
+  if (!options.completeTeamList) return;
+  const teams = user.teams.map((team) => ({
+    id: team.id,
+    displayName: team.displayName,
+    billingPlanId: team.billingPlanId,
+    billingSeats: team.billingSeats,
+  }));
+  try {
+    await (db ?? cloudDb())
+      .insert(stackIdentitySnapshots)
+      .values({
+        userId: user.id,
+        displayName: user.displayName,
+        primaryEmail: user.primaryEmail,
+        selectedTeamId: user.selectedTeamId,
+        billingCustomerType: user.billingCustomerType,
+        billingTeamId: user.billingTeamId,
+        userBillingPlanId: user.userBillingPlanId,
+        billingPlanId: user.billingPlanId,
+        billingSeats: user.billingSeats,
+        teams,
+        refreshedAt: new Date(),
+      })
+      .onConflictDoUpdate({
+        target: stackIdentitySnapshots.userId,
+        set: {
+          displayName: sql`excluded.display_name`,
+          primaryEmail: sql`excluded.primary_email`,
+          selectedTeamId: sql`excluded.selected_team_id`,
+          billingCustomerType: sql`excluded.billing_customer_type`,
+          billingTeamId: sql`excluded.billing_team_id`,
+          userBillingPlanId: sql`excluded.user_billing_plan_id`,
+          billingPlanId: sql`excluded.billing_plan_id`,
+          billingSeats: sql`excluded.billing_seats`,
+          teams: sql`excluded.teams`,
+          refreshedAt: sql`excluded.refreshed_at`,
+        },
+      });
+  } catch {
+    // A snapshot that fails to persist costs one extra Stack call later. It is
+    // never worth failing the request the caller actually made.
+  }
+}
+
+/**
+ * Forget the stored identity for a user. Called when a session is revoked or
+ * the account is deleted, so no instance can keep answering from a snapshot
+ * the user just invalidated.
+ */
+export async function deleteIdentitySnapshot(
+  userId: string,
+  db?: SnapshotDb,
+): Promise<void> {
+  try {
+    await (db ?? cloudDb())
+      .delete(stackIdentitySnapshots)
+      .where(eq(stackIdentitySnapshots.userId, userId));
+  } catch {
+    // Best effort: the snapshot expires on its own within the TTL.
+  }
+}

--- a/web/services/auth/identitySnapshot.ts
+++ b/web/services/auth/identitySnapshot.ts
@@ -5,11 +5,16 @@ import { stackIdentitySnapshots } from "../../db/schema";
 import type { AuthedTeam, AuthedUser } from "../vms/auth";
 
 /**
- * How long a stored identity snapshot may answer for Stack. A snapshot is
- * additionally capped by the expiry of the access token presenting it, so this
- * is an upper bound, not the effective staleness for any single request.
+ * How long a stored identity snapshot may answer for Stack.
+ *
+ * This is the window in which a user removed from a team keeps that team's
+ * device-registry access, so it is a security parameter, not just a cache
+ * tuning knob. Ten minutes trades a bounded exposure for one Stack call per
+ * active user per ten minutes: at ~4,000 active Macs that is under 7 calls a
+ * second, against ~125 a second before any of this existed. The access token
+ * itself is verified on every request regardless.
  */
-const DEFAULT_SNAPSHOT_TTL_MS = 60 * 60 * 1_000;
+const DEFAULT_SNAPSHOT_TTL_MS = 10 * 60 * 1_000;
 
 export function identitySnapshotTtlMs(
   raw = process.env.CMUX_STACK_IDENTITY_SNAPSHOT_TTL_MS,

--- a/web/services/devices/registrationNoOp.ts
+++ b/web/services/devices/registrationNoOp.ts
@@ -1,0 +1,102 @@
+/**
+ * Whether a device registration would change anything the registry stores.
+ *
+ * The Mac re-registers whenever its advertised route set changes, and it
+ * compares routes that still carry per-observation timestamps. Those
+ * timestamps never reach the database: `sanitizeServerPublishedRoutes` strips
+ * every iroh route down to its id, endpoint and priority. So a client can
+ * re-POST a "changed" route set many times an hour while the row it would
+ * write is byte-identical to the row already there.
+ *
+ * A client that cannot be updated will keep doing that. This lets the server
+ * answer it without taking the per-team advisory lock or writing two rows.
+ */
+
+/** How stale a presence timestamp may get before a no-op POST refreshes it. */
+const DEFAULT_PRESENCE_TOUCH_INTERVAL_MS = 60_000;
+
+export function presenceTouchIntervalMs(
+  raw = process.env.CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS,
+): number {
+  const trimmed = raw?.trim();
+  if (!trimmed) return DEFAULT_PRESENCE_TOUCH_INTERVAL_MS;
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    return DEFAULT_PRESENCE_TOUCH_INTERVAL_MS;
+  }
+  return parsed;
+}
+
+export type StoredRegistration = {
+  readonly userId: string;
+  readonly platform: string;
+  readonly displayName: string | null;
+  readonly labels: Record<string, unknown>;
+  readonly instanceRoutes: readonly unknown[];
+  readonly instanceLabels: Record<string, unknown>;
+  readonly lastSeenAt: Date;
+};
+
+export type IncomingRegistration = {
+  readonly userId: string;
+  readonly platform: string;
+  readonly displayName: string | null;
+  readonly labels: Record<string, unknown>;
+  readonly instanceRoutes: readonly unknown[];
+  readonly instanceLabels: Record<string, unknown>;
+};
+
+/**
+ * True when writing `incoming` over `stored` would leave every column
+ * unchanged except the presence timestamps, and those were refreshed within
+ * `touchIntervalMs`.
+ *
+ * Deliberately strict: any difference at all, including a re-ordered route
+ * list, falls through to the normal write path. A false positive would strand
+ * a phone on routes the Mac no longer has, which is far worse than an extra
+ * transaction.
+ */
+export function registrationIsUnchanged(input: {
+  readonly stored: StoredRegistration | null;
+  readonly incoming: IncomingRegistration;
+  readonly now: Date;
+  readonly touchIntervalMs: number;
+}): boolean {
+  const { stored, incoming } = input;
+  if (!stored) return false;
+  if (input.touchIntervalMs <= 0) return false;
+  const sinceLastSeenMs = input.now.getTime() - stored.lastSeenAt.getTime();
+  // A clock that moved backwards must not make a stale row look fresh.
+  if (sinceLastSeenMs < 0 || sinceLastSeenMs >= input.touchIntervalMs) {
+    return false;
+  }
+  return stored.userId === incoming.userId
+    && stored.platform === incoming.platform
+    && stored.displayName === incoming.displayName
+    && jsonEquals(stored.labels, incoming.labels)
+    && jsonEquals(stored.instanceRoutes, incoming.instanceRoutes)
+    && jsonEquals(stored.instanceLabels, incoming.instanceLabels);
+}
+
+/**
+ * Structural equality over the JSON shapes the registry stores. Object key
+ * order is not significant; array order is.
+ */
+function jsonEquals(left: unknown, right: unknown): boolean {
+  if (left === right) return true;
+  if (typeof left !== typeof right) return false;
+  if (left === null || right === null) return false;
+  if (Array.isArray(left) || Array.isArray(right)) {
+    if (!Array.isArray(left) || !Array.isArray(right)) return false;
+    if (left.length !== right.length) return false;
+    return left.every((value, index) => jsonEquals(value, right[index]));
+  }
+  if (typeof left !== "object") return false;
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord).sort();
+  const rightKeys = Object.keys(rightRecord).sort();
+  if (leftKeys.length !== rightKeys.length) return false;
+  if (leftKeys.some((key, index) => key !== rightKeys[index])) return false;
+  return leftKeys.every((key) => jsonEquals(leftRecord[key], rightRecord[key]));
+}

--- a/web/services/nativeIngressRateLimit.ts
+++ b/web/services/nativeIngressRateLimit.ts
@@ -1,6 +1,13 @@
 import { checkRateLimit } from "@vercel/firewall";
 import { jsonResponse } from "./vms/routeHelpers";
 
+/**
+ * How long a throttled native client is told to wait. Long enough that an
+ * unbounded retry loop stops costing us, short enough that a Mac whose routes
+ * really did change republishes them promptly.
+ */
+const NATIVE_INGRESS_RETRY_AFTER_SECONDS = 60;
+
 export type NativeIngressRateLimitCheck = (
   id: string,
   options: { request: Request },
@@ -37,7 +44,15 @@ export async function enforceNativeIngressRateLimit(input: {
   }
 
   if (result.rateLimited || result.error === "blocked") {
-    return jsonResponse({ error: "rate_limited" }, 429);
+    // A 429 with no Retry-After tells a client nothing, and the shipped iroh
+    // broker client only backs off when we name a delay: it parses this header
+    // into an account-scoped cooldown that survives relaunch. Sending it is
+    // the one throttle signal that reaches builds we cannot update.
+    return jsonResponse(
+      { error: "rate_limited" },
+      429,
+      { "retry-after": String(NATIVE_INGRESS_RETRY_AFTER_SECONDS) },
+    );
   }
   if (result.error === "not-found") {
     console.warn("native ingress rate-limit rule not found; failing open", {

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -553,10 +553,9 @@ export async function verifyRequest(
  *
  * Trade-off, stated: team membership can be up to the snapshot TTL stale, so a
  * user removed from a team keeps that team's device-registry access until the
- * row refreshes. The default TTL is the Stack access-token lifetime, which is
- * already how long a revoked session keeps working under local verification.
- * Routes that gate money, account mutation, or admin powers must keep calling
- * `verifyRequest`.
+ * row refreshes. Stack sends no membership webhook we could invalidate on, so
+ * the TTL (default ten minutes) is the bound. Routes that gate money, account
+ * mutation, or admin powers must keep calling `verifyRequest`.
  */
 export async function verifyRequestFromSnapshot(
   request: Request,

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -567,6 +567,8 @@ export async function verifyRequestFromSnapshot(
     readonly verifyAccessToken?: (
       accessToken: string,
     ) => Promise<StackAccessTokenIdentity | null>;
+    /** Test seam for the account-deletion tombstone lookup. */
+    readonly isAccountDeleted?: (userId: string) => Promise<boolean>;
   } = {},
 ): Promise<AuthedUser | null> {
   if (!isStackConfigured()) return null;
@@ -588,7 +590,8 @@ export async function verifyRequestFromSnapshot(
       if (snapshot) {
         // Stack's deletion metadata is not in the token, so the tombstone is
         // read directly rather than behind the usual metadata short-circuit.
-        if (await isAccountDeletionTombstoned(local.userId)) {
+        const isDeleted = options.isAccountDeleted ?? isAccountDeletionTombstoned;
+        if (await isDeleted(local.userId)) {
           await deleteIdentitySnapshot(local.userId);
           return null;
         }

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -6,6 +6,13 @@ import {
   verifyStackAccessTokenLocally,
   type StackAccessTokenIdentity,
 } from "../auth/stackAccessToken";
+import { recordAuthResolution } from "../auth/authTelemetry";
+import {
+  deleteIdentitySnapshot,
+  identitySnapshotTtlMs,
+  readIdentitySnapshot,
+  writeIdentitySnapshot,
+} from "../auth/identitySnapshot";
 import { hasAuthRateLimitSignal } from "./authErrors";
 import { cloudDb } from "../../db/client";
 import { accountDeletionTombstones } from "../../db/schema";
@@ -90,6 +97,12 @@ type VerifyRequestOptions = {
   readonly allowDeletingAccount?: boolean;
   readonly listAllTeams?: boolean;
   readonly subrouterAuthorizationSignal?: AbortSignal;
+  /**
+   * List every team even when the selected team would have answered this
+   * request. Only a complete list may be stored as an identity snapshot: a
+   * partial one would later deny a team the user really belongs to.
+   */
+  readonly forceCompleteTeamList?: boolean;
 };
 
 const DEFAULT_SUBROUTER_STACK_AUTH_TIMEOUT_MS = 10_000;
@@ -134,6 +147,7 @@ function nativeAuthCacheKey(
     normalizedOptionalString(options.requestedTeamId) ?? "",
     options.allowDeletingAccount === true ? "1" : "0",
     options.listAllTeams === true ? "1" : "0",
+    options.forceCompleteTeamList === true ? "1" : "0",
   ].join("\n");
   return createHash("sha256").update(material).digest("hex");
 }
@@ -461,7 +475,10 @@ export async function verifyRequest(
     const cacheKey = cacheable ? nativeAuthCacheKey(tokens, options) : null;
     if (cacheKey) {
       const cached = readNativeAuthCache(cacheKey);
-      if (cached) return cached;
+      if (cached) {
+        recordAuthResolution({ source: "snapshot", providerCalled: false });
+        return cached;
+      }
     }
     // Subrouter calls carry their own deadline and error classes; only the
     // cacheable native path (device registry, iroh broker, relay) is gated.
@@ -484,11 +501,17 @@ export async function verifyRequest(
       throw error;
     }
     if (user) {
-      const authed = await authedUserFromStackUser(user, options);
-      if (authed && cacheKey) {
-        writeNativeAuthCache(cacheKey, authed, tokens, authCacheTtlMs());
+      const resolved = await authedUserFromStackUser(user, options);
+      if (resolved && cacheKey) {
+        writeNativeAuthCache(cacheKey, resolved.user, tokens, authCacheTtlMs());
       }
-      return authed;
+      if (resolved) {
+        recordAuthResolution({ source: "stack", providerCalled: true });
+        await writeIdentitySnapshot(resolved.user, {
+          completeTeamList: resolved.completeTeamList,
+        });
+      }
+      return resolved?.user ?? null;
     }
     // A caller that presents native credentials must succeed or fail as that
     // native session. Falling back to an ambient browser cookie would let an
@@ -510,9 +533,105 @@ export async function verifyRequest(
     options.subrouterAuthorizationSignal,
   );
   if (user) {
-    return await authedUserFromStackUser(user, options);
+    const resolved = await authedUserFromStackUser(user, options);
+    if (resolved) recordAuthResolution({ source: "cookie", providerCalled: true });
+    return resolved?.user ?? null;
   }
   return null;
+}
+
+/**
+ * Verify a native request for a route that needs the user's identity AND team
+ * membership, at device-registry volume.
+ *
+ * The access token is checked locally against Stack's published signing keys,
+ * and the team membership it does not carry comes from `stack_identity_
+ * snapshots`, a shared row refreshed from Stack at most once per TTL per user.
+ * A request answered this way makes no call to the auth provider at all. Any
+ * miss (no token, token not locally verifiable, no fresh snapshot) falls
+ * through to `verifyRequest`, which asks Stack and refreshes the snapshot.
+ *
+ * Trade-off, stated: team membership can be up to the snapshot TTL stale, so a
+ * user removed from a team keeps that team's device-registry access until the
+ * row refreshes. The default TTL is the Stack access-token lifetime, which is
+ * already how long a revoked session keeps working under local verification.
+ * Routes that gate money, account mutation, or admin powers must keep calling
+ * `verifyRequest`.
+ */
+export async function verifyRequestFromSnapshot(
+  request: Request,
+  options: {
+    readonly requestedTeamId?: string | null;
+    readonly maxSnapshotAgeMs?: number;
+    /** Test seam for the local token verifier. */
+    readonly verifyAccessToken?: (
+      accessToken: string,
+    ) => Promise<StackAccessTokenIdentity | null>;
+  } = {},
+): Promise<AuthedUser | null> {
+  if (!isStackConfigured()) return null;
+  const tokens = parseNativeStackTokens(request);
+  if (tokens) {
+    const verifier = options.verifyAccessToken
+      ? null
+      : stackAccessTokenVerifierFromEnv();
+    const local = options.verifyAccessToken
+      ? await options.verifyAccessToken(tokens.accessToken)
+      : verifier
+      ? await verifyStackAccessTokenLocally(tokens.accessToken, verifier)
+      : null;
+    if (local) {
+      const snapshot = await readIdentitySnapshot(
+        local.userId,
+        options.maxSnapshotAgeMs ?? identitySnapshotTtlMs(),
+      );
+      if (snapshot) {
+        // Stack's deletion metadata is not in the token, so the tombstone is
+        // read directly rather than behind the usual metadata short-circuit.
+        if (await isAccountDeletionTombstoned(local.userId)) {
+          await deleteIdentitySnapshot(local.userId);
+          return null;
+        }
+        recordAuthResolution({
+          source: "snapshot",
+          providerCalled: false,
+          snapshotAgeMs: snapshot.ageMs,
+        });
+        return snapshot.user;
+      }
+    } else {
+      recordAuthResolution({
+        source: "stack",
+        providerCalled: true,
+        localVerifyMiss: verifier || options.verifyAccessToken
+          ? "rejected"
+          : "not_configured",
+      });
+    }
+  }
+  // Refreshing needs the complete team list, or the snapshot it writes could
+  // later deny a team the user really belongs to.
+  return await verifyRequest(request, {
+    requestedTeamId: options.requestedTeamId,
+    allowCookie: false,
+    forceCompleteTeamList: true,
+  });
+}
+
+/** Whether this user id has a tombstone that blocks authentication. */
+async function isAccountDeletionTombstoned(userId: string): Promise<boolean> {
+  const userIdHash = accountDeletionUserHash(userId);
+  const [deletion] = await cloudDb()
+    .select({
+      userIdHash: accountDeletionTombstones.userIdHash,
+      status: accountDeletionTombstones.status,
+      updatedAt: accountDeletionTombstones.updatedAt,
+    })
+    .from(accountDeletionTombstones)
+    .where(eq(accountDeletionTombstones.userIdHash, userIdHash))
+    .limit(1);
+  return deletion?.userIdHash === userIdHash &&
+    isBlockingAccountDeletionTombstone(deletion);
 }
 
 export type VerifiedIdentity = {
@@ -561,16 +680,28 @@ export async function verifyRequestIdentity(
       : verifier
         ? await verifyStackAccessTokenLocally(tokens.accessToken, verifier)
         : null;
-    if (local) return { id: local.userId, source: "access_token" };
+    if (local) {
+      recordAuthResolution({ source: "access_token", providerCalled: false });
+      return { id: local.userId, source: "access_token" };
+    }
   }
   const user = await verifyRequest(request, { allowCookie: options.allowCookie });
   return user ? { id: user.id, source: "stack" } : null;
 }
 
+/**
+ * A user resolved from Stack, plus whether the team list backing it is the
+ * user's complete membership. Only a complete list may be snapshotted.
+ */
+type ResolvedStackUser = {
+  readonly user: AuthedUser;
+  readonly completeTeamList: boolean;
+};
+
 async function authedUserFromStackUser(
   user: StackUserLike,
   options: VerifyRequestOptions,
-): Promise<AuthedUser | null> {
+): Promise<ResolvedStackUser | null> {
   if (!options.allowDeletingAccount && await isAccountDeletionAuthBlocked(user)) {
     return null;
   }
@@ -580,11 +711,17 @@ async function authedUserFromStackUser(
   // Full pagination is reserved for the explicit team-picker route. Other
   // callers resolve one requested team with Stack's exact-ID search so shared
   // VM authentication never inherits an unbounded multi-page dependency.
-  const needsListedTeams = !selectedTeam ||
+  const needsListedTeams = options.forceCompleteTeamList === true ||
+    !selectedTeam ||
     (!!requestedTeamId && requestedTeamId !== selectedTeam.id);
-  const listedTeamRaw = options.subrouterAuthorizationSignal === undefined
+  // Whether the branch taken below enumerates every team the user belongs to.
+  // Only that case may be stored as an identity snapshot.
+  const completeTeamList = options.subrouterAuthorizationSignal === undefined
     ? needsListedTeams && typeof user.listTeams === "function"
-      ? await user.listTeams()
+    : options.listAllTeams === true;
+  const listedTeamRaw = options.subrouterAuthorizationSignal === undefined
+    ? completeTeamList
+      ? await user.listTeams!()
       : []
     : options.listAllTeams === true
     ? await listAllStackTeams(user, options.subrouterAuthorizationSignal)
@@ -618,17 +755,20 @@ async function authedUserFromStackUser(
   }));
 
   return {
-    id: user.id,
-    displayName: user.displayName,
-    primaryEmail: user.primaryEmail,
-    billingCustomerType: billingTeam ? "team" : "user",
-    billingTeamId: billingTeam?.id ?? user.id,
-    selectedTeamId: selectedTeam?.id ?? null,
-    teams: authedTeams,
-    teamIds,
-    userBillingPlanId,
-    billingPlanId,
-    billingSeats,
+    user: {
+      id: user.id,
+      displayName: user.displayName,
+      primaryEmail: user.primaryEmail,
+      billingCustomerType: billingTeam ? "team" : "user",
+      billingTeamId: billingTeam?.id ?? user.id,
+      selectedTeamId: selectedTeam?.id ?? null,
+      teams: authedTeams,
+      teamIds,
+      userBillingPlanId,
+      billingPlanId,
+      billingSeats,
+    },
+    completeTeamList,
   };
 }
 

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -191,10 +191,14 @@ function scheduleTraceFlush(): void {
  * promise settles but turbopack reports "No response is returned from route handler").
  * Use `new Response(JSON.stringify(...), { ... })` explicitly instead.
  */
-export function jsonResponse(data: unknown, status = 200): Response {
+export function jsonResponse(
+  data: unknown,
+  status = 200,
+  headers: Readonly<Record<string, string>> = {},
+): Response {
   return new Response(JSON.stringify(data), {
     status,
-    headers: { "content-type": "application/json" },
+    headers: { "content-type": "application/json", ...headers },
   });
 }
 

--- a/web/tests/device-registration-no-op.test.ts
+++ b/web/tests/device-registration-no-op.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  presenceTouchIntervalMs,
+  registrationIsUnchanged,
+  type StoredRegistration,
+} from "../services/devices/registrationNoOp";
+
+const now = new Date("2026-09-03T04:00:00.000Z");
+
+const irohRoute = {
+  id: "iroh-primary",
+  kind: "iroh",
+  endpoint: { type: "peer", id: "a".repeat(64), relay_url: "https://use4.relay.cmux.dev/" },
+  priority: 1,
+};
+
+function stored(overrides: Partial<StoredRegistration> = {}): StoredRegistration {
+  return {
+    userId: "user-1",
+    platform: "mac",
+    displayName: "Lawrence's MacBook",
+    labels: { channel: "stable" },
+    instanceRoutes: [irohRoute],
+    instanceLabels: { tag: "default" },
+    lastSeenAt: new Date(now.getTime() - 5_000),
+    ...overrides,
+  };
+}
+
+const incoming = {
+  userId: "user-1",
+  platform: "mac",
+  displayName: "Lawrence's MacBook",
+  labels: { channel: "stable" },
+  instanceRoutes: [irohRoute],
+  instanceLabels: { tag: "default" },
+};
+
+function check(
+  storedValue: StoredRegistration | null,
+  incomingValue = incoming,
+  touchIntervalMs = 60_000,
+): boolean {
+  return registrationIsUnchanged({
+    stored: storedValue,
+    incoming: incomingValue,
+    now,
+    touchIntervalMs,
+  });
+}
+
+describe("device registration no-op detection", () => {
+  test("an identical re-registration inside the touch interval writes nothing", () => {
+    expect(check(stored())).toBe(true);
+  });
+
+  test("object key order does not count as a change", () => {
+    const reordered = {
+      ...incoming,
+      instanceRoutes: [{
+        priority: 1,
+        kind: "iroh",
+        id: "iroh-primary",
+        endpoint: { relay_url: "https://use4.relay.cmux.dev/", id: "a".repeat(64), type: "peer" },
+      }],
+      labels: { channel: "stable" },
+    };
+    expect(check(stored(), reordered)).toBe(true);
+  });
+
+  test("a device registering for the first time is never a no-op", () => {
+    expect(check(null)).toBe(false);
+  });
+
+  test("a stale presence timestamp forces the write through", () => {
+    expect(check(stored({ lastSeenAt: new Date(now.getTime() - 61_000) })).valueOf()).toBe(false);
+    // Exactly at the interval still writes: the boundary belongs to freshness.
+    expect(check(stored({ lastSeenAt: new Date(now.getTime() - 60_000) }))).toBe(false);
+  });
+
+  test("a presence timestamp from the future never looks fresh", () => {
+    expect(check(stored({ lastSeenAt: new Date(now.getTime() + 5_000) }))).toBe(false);
+  });
+
+  test("any real change falls through to the write path", () => {
+    expect(check(stored({ userId: "user-2" }))).toBe(false);
+    expect(check(stored({ platform: "ios" }))).toBe(false);
+    expect(check(stored({ displayName: null }))).toBe(false);
+    expect(check(stored({ labels: { channel: "nightly" } }))).toBe(false);
+    expect(check(stored({ instanceLabels: {} }))).toBe(false);
+  });
+
+  test("a changed route set is never a no-op", () => {
+    expect(check(stored({ instanceRoutes: [] }))).toBe(false);
+    expect(check(stored({ instanceRoutes: [irohRoute, irohRoute] }))).toBe(false);
+    expect(check(stored({
+      instanceRoutes: [{ ...irohRoute, priority: 2 }],
+    }))).toBe(false);
+    expect(check(stored({
+      instanceRoutes: [{
+        ...irohRoute,
+        endpoint: { ...irohRoute.endpoint, relay_url: "https://usw1.relay.cmux.dev/" },
+      }],
+    }))).toBe(false);
+  });
+
+  test("route order is significant, because priority order is meaningful", () => {
+    const second = { ...irohRoute, id: "iroh-secondary", priority: 2 };
+    expect(check(
+      stored({ instanceRoutes: [irohRoute, second] }),
+      { ...incoming, instanceRoutes: [second, irohRoute] },
+    )).toBe(false);
+  });
+
+  test("a zero interval disables the short-circuit entirely", () => {
+    expect(check(stored(), incoming, 0)).toBe(false);
+  });
+});
+
+describe("presenceTouchIntervalMs", () => {
+  test("defaults to one minute", () => {
+    expect(presenceTouchIntervalMs(undefined)).toBe(60_000);
+    expect(presenceTouchIntervalMs("  ")).toBe(60_000);
+  });
+
+  test("honors an override, including zero to disable", () => {
+    expect(presenceTouchIntervalMs("15000")).toBe(15_000);
+    expect(presenceTouchIntervalMs("0")).toBe(0);
+  });
+
+  test("ignores values that are not whole non-negative milliseconds", () => {
+    expect(presenceTouchIntervalMs("-1")).toBe(60_000);
+    expect(presenceTouchIntervalMs("soon")).toBe(60_000);
+  });
+});

--- a/web/tests/devices-route.test.ts
+++ b/web/tests/devices-route.test.ts
@@ -259,6 +259,55 @@ describe("device registry route", () => {
     expect(list.devices[0].instances[0].routes[0].endpoint.host).toBe("100.9.9.9");
   });
 
+  dbTest("an unchanged re-registration is answered without touching the rows", async () => {
+    if (!sql) throw new Error("test database not initialized");
+
+    const body = {
+      deviceId: DEVICE_A,
+      platform: "mac",
+      displayName: "Registry Mac",
+      tag: "default",
+      routes: [privateIrohRoute],
+    };
+    expect((await POST(registerRequest(body))).status).toBe(200);
+    const [first] = await sql<{ updated_at: Date; last_seen_at: Date }[]>`
+      select updated_at, last_seen_at from device_app_instances
+      where tag = 'default' and device_id in (
+        select id from devices where device_uuid = ${DEVICE_A}
+      )
+    `;
+
+    // The Mac republishes the same route set: its own dedupe key includes hint
+    // timestamps this route strips before storing, so it re-POSTs identical
+    // rows. The server must answer without writing.
+    expect((await POST(registerRequest(body))).status).toBe(200);
+    const [second] = await sql<{ updated_at: Date; last_seen_at: Date }[]>`
+      select updated_at, last_seen_at from device_app_instances
+      where tag = 'default' and device_id in (
+        select id from devices where device_uuid = ${DEVICE_A}
+      )
+    `;
+    expect(second.updated_at.getTime()).toBe(first.updated_at.getTime());
+    expect(second.last_seen_at.getTime()).toBe(first.last_seen_at.getTime());
+
+    // A genuinely changed route set still writes through immediately.
+    const changed = await POST(registerRequest({
+      ...body,
+      routes: [legacyTailscaleRoute],
+    }));
+    expect(changed.status).toBe(200);
+    const [third] = await sql<{ routes: unknown[] }[]>`
+      select routes from device_app_instances
+      where tag = 'default' and device_id in (
+        select id from devices where device_uuid = ${DEVICE_A}
+      )
+    `;
+    expect((third.routes[0] as { kind: string }).kind).toBe("tailscale");
+  }, 30_000);
+
+  // 26 sequential registrations, each a full HTTP + transaction round trip
+  // against a containerized Postgres. The assertion is the instance cap, not
+  // latency, and the default 5s budget leaves no headroom for a cold pool.
   dbTest("caps app instances per device when the tag varies", async () => {
     if (!sql) throw new Error("test database not initialized");
 
@@ -290,7 +339,7 @@ describe("device registry route", () => {
       registerRequest({ deviceId: DEVICE_A, platform: "mac", tag: "tag-0", routes: [] }),
     );
     expect(reRegister.status).toBe(200);
-  });
+  }, 30_000);
 
   dbTest("drops structurally invalid route entries on register", async () => {
     if (!sql) throw new Error("test database not initialized");

--- a/web/tests/native-ingress-rate-limit.test.ts
+++ b/web/tests/native-ingress-rate-limit.test.ts
@@ -32,6 +32,9 @@ describe("native ingress rate-limit boundary", () => {
 
     expect(response?.status).toBe(429);
     expect(await response?.json()).toEqual({ error: "rate_limited" });
+    // The shipped iroh broker client only backs off when the 429 names a
+    // delay, and that client ships in builds we cannot update.
+    expect(response?.headers.get("retry-after")).toBe("60");
   });
 
   test("fails closed when the firewall is unavailable", async () => {

--- a/web/tests/stack-identity-snapshot.test.ts
+++ b/web/tests/stack-identity-snapshot.test.ts
@@ -133,9 +133,9 @@ describe("identity snapshot store", () => {
 });
 
 describe("identitySnapshotTtlMs", () => {
-  test("defaults to the Stack access token lifetime", () => {
-    expect(identitySnapshotTtlMs(undefined)).toBe(3_600_000);
-    expect(identitySnapshotTtlMs("   ")).toBe(3_600_000);
+  test("defaults to ten minutes", () => {
+    expect(identitySnapshotTtlMs(undefined)).toBe(600_000);
+    expect(identitySnapshotTtlMs("   ")).toBe(600_000);
   });
 
   test("honors an explicit override, including zero to disable", () => {
@@ -144,8 +144,8 @@ describe("identitySnapshotTtlMs", () => {
   });
 
   test("ignores values that are not whole non-negative milliseconds", () => {
-    expect(identitySnapshotTtlMs("-5")).toBe(3_600_000);
-    expect(identitySnapshotTtlMs("abc")).toBe(3_600_000);
-    expect(identitySnapshotTtlMs("1.5")).toBe(3_600_000);
+    expect(identitySnapshotTtlMs("-5")).toBe(600_000);
+    expect(identitySnapshotTtlMs("abc")).toBe(600_000);
+    expect(identitySnapshotTtlMs("1.5")).toBe(600_000);
   });
 });

--- a/web/tests/stack-identity-snapshot.test.ts
+++ b/web/tests/stack-identity-snapshot.test.ts
@@ -1,0 +1,151 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  deleteIdentitySnapshot,
+  identitySnapshotTtlMs,
+  readIdentitySnapshot,
+  writeIdentitySnapshot,
+} from "../services/auth/identitySnapshot";
+import type { AuthedUser } from "../services/vms/auth";
+
+type Row = Record<string, unknown>;
+
+/**
+ * The narrow slice of the Drizzle query builder the snapshot store uses.
+ * Faking it keeps these cases free of Postgres; `devices-route.test.ts`
+ * exercises the same store against the real database.
+ */
+function fakeDb(initial: Row[] = []) {
+  const state = { rows: [...initial], inserted: [] as Row[], deleted: [] as unknown[], failReads: false };
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => {
+            if (state.failReads) throw new Error("database unavailable");
+            return state.rows;
+          },
+        }),
+      }),
+    }),
+    insert: () => ({
+      values: (values: Row) => ({
+        onConflictDoUpdate: async () => {
+          state.inserted.push(values);
+          state.rows = [values];
+        },
+      }),
+    }),
+    delete: () => ({
+      where: async (condition: unknown) => {
+        state.deleted.push(condition);
+        state.rows = [];
+      },
+    }),
+  };
+  return { db: db as never, state };
+}
+
+const user: AuthedUser = {
+  id: "user-1",
+  displayName: "Test User",
+  primaryEmail: "test@example.com",
+  billingCustomerType: "team",
+  billingTeamId: "team-a",
+  selectedTeamId: "team-a",
+  teams: [
+    { id: "team-a", displayName: "Team A", billingPlanId: "pro", billingSeats: 3 },
+    { id: "team-b", displayName: null, billingPlanId: null, billingSeats: null },
+  ],
+  teamIds: ["team-a", "team-b"],
+  userBillingPlanId: null,
+  billingPlanId: "pro",
+  billingSeats: 3,
+};
+
+function storedRow(refreshedAt: Date): Row {
+  return {
+    userId: user.id,
+    displayName: user.displayName,
+    primaryEmail: user.primaryEmail,
+    selectedTeamId: user.selectedTeamId,
+    billingCustomerType: user.billingCustomerType,
+    billingTeamId: user.billingTeamId,
+    userBillingPlanId: user.userBillingPlanId,
+    billingPlanId: user.billingPlanId,
+    billingSeats: user.billingSeats,
+    teams: user.teams,
+    refreshedAt,
+  };
+}
+
+describe("identity snapshot store", () => {
+  test("a fresh row rebuilds the authed user, teams and all", async () => {
+    const { db } = fakeDb([storedRow(new Date(Date.now() - 1_000))]);
+    const read = await readIdentitySnapshot(user.id, 60_000, db);
+    expect(read?.user).toEqual(user);
+    expect(read?.ageMs).toBeGreaterThanOrEqual(1_000);
+  });
+
+  test("a row older than the max age does not answer", async () => {
+    const { db } = fakeDb([storedRow(new Date(Date.now() - 120_000))]);
+    expect(await readIdentitySnapshot(user.id, 60_000, db)).toBeNull();
+  });
+
+  test("a row stamped in the future does not answer", async () => {
+    const { db } = fakeDb([storedRow(new Date(Date.now() + 120_000))]);
+    expect(await readIdentitySnapshot(user.id, 60_000, db)).toBeNull();
+  });
+
+  test("a max age of zero disables the snapshot entirely", async () => {
+    const { db } = fakeDb([storedRow(new Date())]);
+    expect(await readIdentitySnapshot(user.id, 0, db)).toBeNull();
+  });
+
+  test("a database failure reads as no snapshot rather than throwing", async () => {
+    const { db, state } = fakeDb([storedRow(new Date())]);
+    state.failReads = true;
+    expect(await readIdentitySnapshot(user.id, 60_000, db)).toBeNull();
+  });
+
+  test("only a complete team list is stored", async () => {
+    const { db, state } = fakeDb();
+    await writeIdentitySnapshot(user, { completeTeamList: false }, db);
+    expect(state.inserted).toHaveLength(0);
+    await writeIdentitySnapshot(user, { completeTeamList: true }, db);
+    expect(state.inserted).toHaveLength(1);
+    expect(state.inserted[0]?.teams).toEqual(user.teams);
+  });
+
+  test("a stored snapshot round-trips to the same authed user", async () => {
+    const { db } = fakeDb();
+    await writeIdentitySnapshot(user, { completeTeamList: true }, db);
+    const read = await readIdentitySnapshot(user.id, 60_000, db);
+    expect(read?.user).toEqual(user);
+  });
+
+  test("deleting removes the row", async () => {
+    const { db, state } = fakeDb([storedRow(new Date())]);
+    await deleteIdentitySnapshot(user.id, db);
+    expect(state.rows).toHaveLength(0);
+    expect(await readIdentitySnapshot(user.id, 60_000, db)).toBeNull();
+  });
+});
+
+describe("identitySnapshotTtlMs", () => {
+  test("defaults to the Stack access token lifetime", () => {
+    expect(identitySnapshotTtlMs(undefined)).toBe(3_600_000);
+    expect(identitySnapshotTtlMs("   ")).toBe(3_600_000);
+  });
+
+  test("honors an explicit override, including zero to disable", () => {
+    expect(identitySnapshotTtlMs("90000")).toBe(90_000);
+    expect(identitySnapshotTtlMs("0")).toBe(0);
+  });
+
+  test("ignores values that are not whole non-negative milliseconds", () => {
+    expect(identitySnapshotTtlMs("-5")).toBe(3_600_000);
+    expect(identitySnapshotTtlMs("abc")).toBe(3_600_000);
+    expect(identitySnapshotTtlMs("1.5")).toBe(3_600_000);
+  });
+});

--- a/web/tests/vm-auth-snapshot.test.ts
+++ b/web/tests/vm-auth-snapshot.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, mock, test } from "bun:test";
+
+import type { AuthedUser } from "../services/vms/auth";
+
+const getUser = mock(async (): Promise<unknown> => null);
+
+mock.module("../app/lib/stack", () => ({
+  getStackServerApp: () => ({ getUser }),
+  isStackConfigured: () => true,
+  stackServerApp: { getUser },
+}));
+
+const snapshotState = {
+  stored: null as { user: AuthedUser; ageMs: number } | null,
+  writes: [] as { user: AuthedUser; completeTeamList: boolean }[],
+  deletes: [] as string[],
+};
+
+mock.module("../services/auth/identitySnapshot", () => ({
+  identitySnapshotTtlMs: () => 3_600_000,
+  readIdentitySnapshot: async (_userId: string, maxAgeMs: number) =>
+    snapshotState.stored && snapshotState.stored.ageMs <= maxAgeMs
+      ? snapshotState.stored
+      : null,
+  writeIdentitySnapshot: async (
+    user: AuthedUser,
+    options: { completeTeamList: boolean },
+  ) => {
+    snapshotState.writes.push({ user, completeTeamList: options.completeTeamList });
+  },
+  deleteIdentitySnapshot: async (userId: string) => {
+    snapshotState.deletes.push(userId);
+  },
+}));
+
+const tombstoneState = { blocked: false };
+
+mock.module("../services/account/deletionLock", () => ({
+  accountDeletionUserHash: (userId: string) => `hash:${userId}`,
+  isBlockingAccountDeletionTombstone: () => tombstoneState.blocked,
+}));
+
+mock.module("../db/client", () => ({
+  cloudDb: () => ({
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: async () => tombstoneState.blocked
+            ? [{ userIdHash: "hash:jwt-user-1", status: "pending", updatedAt: new Date() }]
+            : [],
+        }),
+      }),
+    }),
+  }),
+  closeCloudDbForTests: async () => {},
+}));
+
+const { verifyRequestFromSnapshot, clearNativeAuthCacheForTests, clearStackThrottleCircuitForTests } =
+  await import("../services/vms/auth");
+
+const snapshotUser: AuthedUser = {
+  id: "jwt-user-1",
+  displayName: "Snapshot User",
+  primaryEmail: "snapshot@example.com",
+  billingCustomerType: "team",
+  billingTeamId: "team-a",
+  selectedTeamId: "team-a",
+  teams: [{ id: "team-a", displayName: "Team A", billingPlanId: "pro", billingSeats: 2 }],
+  teamIds: ["team-a"],
+  userBillingPlanId: null,
+  billingPlanId: "pro",
+  billingSeats: 2,
+};
+
+const stackUser = {
+  id: "stack-user-1",
+  displayName: "Stack User",
+  primaryEmail: "stack@example.com",
+  selectedTeam: { id: "team-a" },
+  clientReadOnlyMetadata: {},
+  listTeams: async () => [{ id: "team-a" }, { id: "team-b" }],
+};
+
+const localIdentity = async (token: string) => token === "good-token"
+  ? {
+    userId: "jwt-user-1",
+    projectId: "project-1",
+    refreshTokenId: "rt-1",
+    isAnonymous: false,
+    expiresAt: new Date(Date.now() + 3_000_000),
+  }
+  : null;
+
+function nativeRequest(access: string): Request {
+  return new Request("https://cmux.test/api/devices", {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${access}`,
+      "x-stack-refresh-token": "refresh-1",
+    },
+  });
+}
+
+beforeEach(() => {
+  clearNativeAuthCacheForTests();
+  clearStackThrottleCircuitForTests();
+  getUser.mockClear();
+  getUser.mockResolvedValue(stackUser);
+  snapshotState.stored = null;
+  snapshotState.writes = [];
+  snapshotState.deletes = [];
+  tombstoneState.blocked = false;
+});
+
+describe("verifyRequestFromSnapshot", () => {
+  test("a locally verified token plus a fresh snapshot never calls Stack", async () => {
+    snapshotState.stored = { user: snapshotUser, ageMs: 60_000 };
+    const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
+      verifyAccessToken: localIdentity,
+    });
+    expect(user).toEqual(snapshotUser);
+    expect(getUser).toHaveBeenCalledTimes(0);
+  });
+
+  test("no snapshot falls back to Stack and stores the complete team list", async () => {
+    const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
+      verifyAccessToken: localIdentity,
+    });
+    expect(user?.id).toBe("stack-user-1");
+    expect(getUser).toHaveBeenCalledTimes(1);
+    expect(snapshotState.writes).toHaveLength(1);
+    expect(snapshotState.writes[0]?.completeTeamList).toBe(true);
+    expect(snapshotState.writes[0]?.user.teamIds).toEqual(["team-a", "team-b"]);
+  });
+
+  test("a token the local check rejects falls back to Stack even with a snapshot", async () => {
+    snapshotState.stored = { user: snapshotUser, ageMs: 60_000 };
+    const user = await verifyRequestFromSnapshot(nativeRequest("stale-token"), {
+      verifyAccessToken: localIdentity,
+    });
+    expect(user?.id).toBe("stack-user-1");
+    expect(getUser).toHaveBeenCalledTimes(1);
+  });
+
+  test("a snapshot older than the max age falls back to Stack", async () => {
+    snapshotState.stored = { user: snapshotUser, ageMs: 120_000 };
+    const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
+      verifyAccessToken: localIdentity,
+      maxSnapshotAgeMs: 60_000,
+    });
+    expect(user?.id).toBe("stack-user-1");
+    expect(getUser).toHaveBeenCalledTimes(1);
+  });
+
+  test("a deleted account is refused on the snapshot path and its row dropped", async () => {
+    snapshotState.stored = { user: snapshotUser, ageMs: 1_000 };
+    tombstoneState.blocked = true;
+    const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
+      verifyAccessToken: localIdentity,
+    });
+    expect(user).toBeNull();
+    expect(snapshotState.deletes).toEqual(["jwt-user-1"]);
+    expect(getUser).toHaveBeenCalledTimes(0);
+  });
+
+  test("a request with no native tokens never answers from a snapshot", async () => {
+    snapshotState.stored = { user: snapshotUser, ageMs: 1_000 };
+    const user = await verifyRequestFromSnapshot(
+      new Request("https://cmux.test/api/devices", { method: "POST" }),
+      { verifyAccessToken: localIdentity },
+    );
+    expect(user).toBeNull();
+    expect(getUser).toHaveBeenCalledTimes(0);
+  });
+
+  test("the requested team id reaches the Stack fallback", async () => {
+    await verifyRequestFromSnapshot(nativeRequest("stale-token"), {
+      verifyAccessToken: localIdentity,
+      requestedTeamId: "team-b",
+    });
+    const resolved = snapshotState.writes[0]?.user;
+    expect(resolved?.teamIds).toContain("team-b");
+  });
+});

--- a/web/tests/vm-auth-snapshot.test.ts
+++ b/web/tests/vm-auth-snapshot.test.ts
@@ -33,27 +33,11 @@ mock.module("../services/auth/identitySnapshot", () => ({
   },
 }));
 
+// The tombstone lookup is injected rather than mocked at the module level:
+// `mock.module` on the database client leaks into every other test file that
+// runs in the same process.
 const tombstoneState = { blocked: false };
-
-mock.module("../services/account/deletionLock", () => ({
-  accountDeletionUserHash: (userId: string) => `hash:${userId}`,
-  isBlockingAccountDeletionTombstone: () => tombstoneState.blocked,
-}));
-
-mock.module("../db/client", () => ({
-  cloudDb: () => ({
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: async () => tombstoneState.blocked
-            ? [{ userIdHash: "hash:jwt-user-1", status: "pending", updatedAt: new Date() }]
-            : [],
-        }),
-      }),
-    }),
-  }),
-  closeCloudDbForTests: async () => {},
-}));
+const isAccountDeleted = async () => tombstoneState.blocked;
 
 const { verifyRequestFromSnapshot, clearNativeAuthCacheForTests, clearStackThrottleCircuitForTests } =
   await import("../services/vms/auth");
@@ -117,6 +101,7 @@ describe("verifyRequestFromSnapshot", () => {
     snapshotState.stored = { user: snapshotUser, ageMs: 60_000 };
     const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
       verifyAccessToken: localIdentity,
+      isAccountDeleted,
     });
     expect(user).toEqual(snapshotUser);
     expect(getUser).toHaveBeenCalledTimes(0);
@@ -125,6 +110,7 @@ describe("verifyRequestFromSnapshot", () => {
   test("no snapshot falls back to Stack and stores the complete team list", async () => {
     const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
       verifyAccessToken: localIdentity,
+      isAccountDeleted,
     });
     expect(user?.id).toBe("stack-user-1");
     expect(getUser).toHaveBeenCalledTimes(1);
@@ -137,6 +123,7 @@ describe("verifyRequestFromSnapshot", () => {
     snapshotState.stored = { user: snapshotUser, ageMs: 60_000 };
     const user = await verifyRequestFromSnapshot(nativeRequest("stale-token"), {
       verifyAccessToken: localIdentity,
+      isAccountDeleted,
     });
     expect(user?.id).toBe("stack-user-1");
     expect(getUser).toHaveBeenCalledTimes(1);
@@ -146,6 +133,7 @@ describe("verifyRequestFromSnapshot", () => {
     snapshotState.stored = { user: snapshotUser, ageMs: 120_000 };
     const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
       verifyAccessToken: localIdentity,
+      isAccountDeleted,
       maxSnapshotAgeMs: 60_000,
     });
     expect(user?.id).toBe("stack-user-1");
@@ -157,6 +145,7 @@ describe("verifyRequestFromSnapshot", () => {
     tombstoneState.blocked = true;
     const user = await verifyRequestFromSnapshot(nativeRequest("good-token"), {
       verifyAccessToken: localIdentity,
+      isAccountDeleted,
     });
     expect(user).toBeNull();
     expect(snapshotState.deletes).toEqual(["jwt-user-1"]);
@@ -167,7 +156,7 @@ describe("verifyRequestFromSnapshot", () => {
     snapshotState.stored = { user: snapshotUser, ageMs: 1_000 };
     const user = await verifyRequestFromSnapshot(
       new Request("https://cmux.test/api/devices", { method: "POST" }),
-      { verifyAccessToken: localIdentity },
+      { verifyAccessToken: localIdentity, isAccountDeleted },
     );
     expect(user).toBeNull();
     expect(getUser).toHaveBeenCalledTimes(0);
@@ -176,6 +165,7 @@ describe("verifyRequestFromSnapshot", () => {
   test("the requested team id reaches the Stack fallback", async () => {
     await verifyRequestFromSnapshot(nativeRequest("stale-token"), {
       verifyAccessToken: localIdentity,
+      isAccountDeleted,
       requestedTeamId: "team-b",
     });
     const resolved = snapshotState.writes[0]?.user;


### PR DESCRIPTION
Stack Auth rate-limited our whole project because every authenticated request cost one `GET /api/v1/users/me`. The visible symptom was 429s on unrelated routes, including "Something went wrong starting checkout".

Every cmux build reports the same user agent, `cmux/102`, stable and nightly alike, so production traffic cannot be attributed to a version. This PR therefore assumes no client will ever update.

## Stop calling the auth provider per request

- `/api/relay/token` needs the account id and nothing else, so it verifies the access token locally against Stack's published keys.
- `GET` and `POST /api/devices` also need team membership, which the token does not carry. They read it from `stack_identity_snapshots`, a shared Postgres row refreshed from Stack at most once per TTL per user. Only a verification that listed every team may be stored, so a snapshot can never deny a team the user actually belongs to.
- `DELETE /api/devices` removes a row other team members can see, so it keeps live verification. It is user-initiated and rare.

Default TTL is `CMUX_STACK_IDENTITY_SNAPSHOT_TTL_MS`, one hour, matching the Stack access-token lifetime, so answering from a snapshot adds no staleness beyond accepting a locally verified token. Sign-out deletes the row; account deletion is enforced on read against the tombstone, so it takes effect immediately. Billing, VM mutations, account and admin routes keep verifying live.

Measured before the change: `/api/devices` plus `/api/relay/token` run at 64 req/s and spend 0.85 Stack calls each, about 4.8M calls a day. The iroh routes, already converted by #11682, run at 118 req/s and make essentially none.

## Stop paying for redundant work

The above protects Stack Auth on every client version but does not reduce what an un-updatable client costs us.

- `POST /api/devices` answers an unchanged registration without taking the per-team advisory lock or writing either row, when the only difference would be a presence timestamp refreshed within `CMUX_DEVICE_PRESENCE_TOUCH_INTERVAL_MS` (one minute). This is not a hypothetical: the Mac's dedupe compares route hints carrying observation timestamps, and `sanitizeServerPublishedRoutes` strips them before storing, so a shipped Mac re-registers byte-identical rows for as long as it runs. Any real difference, including route order, writes through unchanged.
- Native ingress 429s now carry `Retry-After`. The iroh broker client already in the field parses it into an account-scoped cooldown that survives relaunch, so it is the only backpressure signal that reaches builds we cannot update.

## Observability

Auth resolution and registration no-ops are stamped on the request span the tracer already emits (`cmux.auth.source`, `cmux.auth.provider_called`, `cmux.auth.snapshot_age_ms`, `cmux.devices.registration_no_op`). No new event stream and no extra ingest: the app-wide 2% head sample is ample at hundreds of requests per second. Queries are in `web/services/auth/README.md`.

## Migration

Adds `stack_identity_snapshots`. Run `bun run cloud-vm:migrate staging` and `bun run cloud-vm:migrate production` before merging.

## Tests

New: `tests/stack-identity-snapshot.test.ts`, `tests/vm-auth-snapshot.test.ts`, `tests/device-registration-no-op.test.ts`, plus a database-backed case proving an identical re-registration leaves `updated_at` and `last_seen_at` untouched while a changed route set still writes through. The full `tests/devices-route.test.ts` suite passes with `CMUX_DB_TEST=1` against Postgres 16 (27 tests). The migration SQL was applied to a container and the snapshot store round-tripped against it through the real Drizzle schema.

Client-side counterpart: #11774 bounds the retry loops that generate this traffic, for the users who do update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Authentication can continue smoothly using recently verified account and team information.
  * Re-registering an unchanged device no longer updates its presence unnecessarily.
  * Throttled native requests now include a 60-second retry interval.

* **Bug Fixes**
  * Signing out promptly removes cached access to team-scoped device registry data.
  * Device registrations with changed routes or metadata continue to update immediately.

* **Tests**
  * Added coverage for authentication recovery, device registration behavior, snapshot freshness, sign-out handling, and retry responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->