### PR TITLE
cloud: run the coderouter edge probe after the create response

### DIFF
--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -44,7 +44,6 @@ import {
   type VmImageKind,
 } from "../../../services/vms/images/resolver";
 import { reconcileProPlanMetadata } from "../../../services/billing/pro";
-import { after } from "next/server";
 import { getStackServerApp, isStackConfigured } from "../../lib/stack";
 import {
   jsonResponse,
@@ -54,6 +53,7 @@ import {
   withAuthedVmApiRoute,
   vmActiveLimitExceededResponse,
   resolveVmProvisioningAccountScope,
+  runAfterResponse,
 } from "../../../services/vms/routeHelpers";
 import { vmRequestLocale } from "../../../services/vms/vmErrorMessages";
 import { captureVmProvisionOutcome } from "../../../services/vms/observability";
@@ -488,6 +488,7 @@ export async function POST(request: Request): Promise<Response> {
             perMachineHome: candidate.perMachineHome === true,
             memoryMb,
             imageSize: imageSelection.size ?? undefined,
+            afterResponse: runAfterResponse,
             modelPlane,
             timing,
           }));
@@ -561,19 +562,6 @@ export async function POST(request: Request): Promise<Response> {
 // awaited) and VM create proceeds with the user's current plan metadata.
 const BILLING_RECONCILE_DEADLINE_MS = 5_000;
 
-/**
- * Run best-effort work once the response has been sent. Vercel keeps the
- * function alive for `after` callbacks; outside a request scope (tests, a
- * plain Node server) `after` throws, and the work runs detached instead.
- */
-function runAfterResponse(work: () => Promise<void>): void {
-  const guarded = () => work().catch((err) => console.error("[VM] deferred work failed", err));
-  try {
-    after(guarded);
-  } catch {
-    void guarded();
-  }
-}
 
 export async function withBillingReconcileDeadline(
   reconcile: Promise<boolean>

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -752,7 +752,7 @@ export class FreestyleProvider implements VMProvider {
             // The baked supervisor is already bringing the daemon up; the only
             // per-machine input it needs is the model-plane env file.
             if (options.envs) await this.writeModelPlaneEnv(vm, vmId, options.envs);
-            await this.probeEdgeRules(vm, vmId, options.edgeRules);
+            await this.verifyEdgeRules(vm, vmId, options.edgeRules, options.afterResponse);
           } catch (err) {
             // A VM that failed to size or configure must not survive as an
             // orphan, and an undersized machine must not ship as if it were
@@ -976,7 +976,7 @@ export class FreestyleProvider implements VMProvider {
           await this.ensureCmuxTuiRunning(vm, vmId).catch(() => undefined);
           try {
             if (options?.envs) await this.writeModelPlaneEnv(vm, vmId, options.envs);
-            await this.probeEdgeRules(vm, vmId, options?.edgeRules);
+            await this.verifyEdgeRules(vm, vmId, options?.edgeRules, options?.afterResponse);
           } catch (err) {
             await vm.delete().catch((cleanupErr) => {
               console.error(`[freestyle] restore rollback failed; VM ${vmId} may be orphaned`, cleanupErr);
@@ -1124,6 +1124,45 @@ export class FreestyleProvider implements VMProvider {
    * inside the guest before handing the machine out; an inactive rule means
    * the machine can never reach a model, so the caller rolls it back.
    */
+  /**
+   * The edge rule is written inline by vms.create, but Freestyle activates it
+   * asynchronously (seconds; measured 3 to 11 s in production). Blocking the
+   * create on that activation made the whole request wait for the edge, so
+   * with a scheduler the probe runs after the response and reports on its own
+   * span (`cmux.vm.provider.edge_probe`): success as an attribute, failure as
+   * a recorded span error plus a log line. Without a scheduler the probe is
+   * awaited and a failure rolls the machine back, as before.
+   */
+  private async verifyEdgeRules(
+    vm: Vm,
+    vmId: string,
+    edgeRules: readonly VmEdgeRule[] | undefined,
+    afterResponse: CreateOptions["afterResponse"],
+  ): Promise<void> {
+    if (!edgeRules || edgeRules.length === 0) return;
+    if (!afterResponse) {
+      await this.probeEdgeRules(vm, vmId, edgeRules);
+      return;
+    }
+    afterResponse(() =>
+      withVmSpan(
+        "cmux.vm.provider.edge_probe",
+        { "cmux.vm.provider": "freestyle", "cmux.vm.operation": "edge_probe", "cmux.vm.id": vmId, "cmux.vm.edge_rules": edgeRules.length },
+        async (span) => {
+          const startedAt = performance.now();
+          try {
+            await this.probeEdgeRules(vm, vmId, edgeRules);
+            setSpanAttributes(span, { "cmux.vm.edge_probe.ok": true, "cmux.vm.edge_probe.ms": Math.round(performance.now() - startedAt) });
+          } catch (err) {
+            setSpanAttributes(span, { "cmux.vm.edge_probe.ok": false, "cmux.vm.edge_probe.ms": Math.round(performance.now() - startedAt) });
+            recordSpanError(span, err);
+            console.error(`[freestyle] edge rule probe failed for ${vmId} after the response`, err);
+          }
+        },
+      ),
+    );
+  }
+
   private async probeEdgeRules(vm: Vm, vmId: string, edgeRules: readonly VmEdgeRule[] | undefined): Promise<void> {
     if (!edgeRules || edgeRules.length === 0) return;
     for (const rule of edgeRules) {

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -105,6 +105,13 @@ export type CreateOptions = {
    */
   edgeRules?: readonly VmEdgeRule[];
   /**
+   * Scheduler for work that must not delay the create response: the guest
+   * probe that waits for the provider's TLS edge to activate the coderouter
+   * rule (Freestyle takes seconds). The route passes its after-response hook;
+   * a caller without one (scripts, tests) gets the work awaited inline.
+   */
+  afterResponse?: (work: () => Promise<void>) => void;
+  /**
    * The owner's private network to attach the machine to. When present the
    * machine takes an address on it and its session daemon is reachable only
    * from other members — the owner's other machines, and the owner's computer
@@ -128,7 +135,7 @@ export type VmEdgeRule = {
 };
 
 /** Create-time inputs a restore-from-snapshot shares with a fresh create. */
-export type RestoreOptions = Pick<CreateOptions, "envs" | "edgeRules" | "providerMetadata"> & {
+export type RestoreOptions = Pick<CreateOptions, "envs" | "edgeRules" | "providerMetadata" | "afterResponse"> & {
   /** The owner's private network; see {@link CreateOptions.network}. */
   network?: ProviderNetworkRef;
 };

--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -1060,3 +1060,18 @@ function normalizedOptionalString(value: string | null | undefined): string | nu
   const normalized = value?.trim();
   return normalized ? normalized : null;
 }
+
+/**
+ * Run best-effort work once the response has been sent. Vercel keeps the
+ * function alive for `after` callbacks; outside a request scope (tests, a
+ * plain Node server) `after` throws, and the work runs detached instead.
+ * Failures are logged, never surfaced to the response that already left.
+ */
+export function runAfterResponse(work: () => Promise<void>): void {
+  const guarded = () => work().catch((err) => console.error("[VM] deferred work failed", err));
+  try {
+    after(guarded);
+  } catch {
+    void guarded();
+  }
+}

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -378,6 +378,8 @@ export function createVm(input: {
   readonly memoryMb?: number;
   /** See CreateOptions.imageSize: a sized ladder image boots at its shape and is never resized. */
   readonly imageSize?: CreateOptions["imageSize"];
+  /** See CreateOptions.afterResponse: the edge probe runs here instead of inside the request. */
+  readonly afterResponse?: CreateOptions["afterResponse"];
   /**
    * Wires the machine to coderouter. Provisioned after the row exists (its id
    * is the token binding) and before the provider call; a failure fails the
@@ -488,6 +490,7 @@ export function createVm(input: {
             : undefined,
         memoryMb: input.memoryMb,
         imageSize: input.imageSize,
+        afterResponse: input.afterResponse,
         envs: materials?.envs,
         edgeRules: materials?.edgeRules,
         ...(network ? { network: { id: network.providerNetworkId } } : {}),

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -1664,6 +1664,8 @@ describe("VM Effect workflows", () => {
     let providerCreateCalls = 0;
     let providerMemoryMb: number | undefined;
     let providerImageSize: { name: string; cpu: number; memoryMb: number; storageMb: number } | null = null;
+    let providerAfterResponse: ((work: () => Promise<void>) => void) | null = null;
+    const afterResponse = (work: () => Promise<void>) => { void work(); };
     let usageEventAttempts = 0;
     const repo: VmRepositoryShape = {
       listUserVms: () => Effect.succeed([]),
@@ -1707,6 +1709,7 @@ describe("VM Effect workflows", () => {
           providerCreateCalls += 1;
           providerMemoryMb = options.memoryMb;
           providerImageSize = options.imageSize ?? null;
+          providerAfterResponse = options.afterResponse ?? null;
           return {
             provider: "freestyle" as const,
             providerVmId: "provider-vm-usage-events",
@@ -1739,6 +1742,7 @@ describe("VM Effect workflows", () => {
         imageVersion: "test-version",
         memoryMb: 3072,
         imageSize: { name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384 },
+        afterResponse,
         idempotencyKey: "usage-events",
       }).pipe(Effect.provide(layer)),
     );
@@ -1748,6 +1752,8 @@ describe("VM Effect workflows", () => {
     expect(providerMemoryMb).toBe(3072);
     // A sized image reaches the driver as the shape to boot at, never to resize to.
     expect(providerImageSize).toEqual({ name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384 });
+    // The route's after-response scheduler reaches the driver, so the edge probe never blocks the request.
+    expect(providerAfterResponse).toBe(afterResponse);
     expect(usageEventAttempts).toBe(2);
   });
 


### PR DESCRIPTION
After https://github.com/manaflow-ai/cmux/pull/11756 deployed, production `POST /api/vm` route spans showed `provider_create` at 2.9 to 11.6 s (total 3.4 to 12.4 s). The snapshot size is not the cause: creating from the xl snapshot takes 82 to 114 ms from a laptop. The slow trace has one `exec-await` of 5 s: `probeEdgeRules` from https://github.com/manaflow-ai/cmux/pull/11622, a guest curl loop (30 attempts, 5 s timeout, 2 s sleep, 240 s budget) that waits for Freestyle to activate the machine's coderouter TLS edge rule. Freestyle activates the rule asynchronously, in seconds, so every create waited for the edge.

The rule is still written inline by `vms.create`. The probe now runs after the response: `CreateOptions.afterResponse` is an injected scheduler, the route passes `runAfterResponse` (shared helper in `routeHelpers.ts`, `next/server` `after()` with a detached fallback outside a request scope), and the driver reports the probe on its own span `cmux.vm.provider.edge_probe` with `cmux.vm.edge_probe.ok` and `cmux.vm.edge_probe.ms`, recording a span error and a log line on failure. Restore takes the same path. A caller without a scheduler (scripts, tests) keeps the awaited probe and the rollback.

Trade-off: a machine returned before its edge rule is active cannot reach coderouter for the first few seconds. That window is Freestyle's activation time and existed before PR 11622 too, when nothing waited for it. A failed probe no longer deletes the machine; it is a recorded error for alerting.

Expected after deploy: `provider_create` back to about 300 ms (`vms.create` 270 ms plus the env file write), total create about 500 ms for a returning user.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves the coderouter edge probe to run after the create response so `POST /api/vm` no longer blocks 3 to 11 s waiting for Freestyle to activate the TLS edge rule.

- The rule is still written inline by `vms.create`; the probe now goes through `runAfterResponse` (`next/server` `after()` with a detached fallback outside a request scope).
- The probe reports on its own span `cmux.vm.provider.edge_probe` with `cmux.vm.edge_probe.ok` and `cmux.vm.edge_probe.ms`; failure records a span error and log line instead of deleting the machine.
- Callers without a scheduler (scripts, tests) keep the awaited probe and rollback.
- Trade-off: a machine returned before its edge rule is active can't reach coderouter briefly, a window that existed before PR 11622 when nothing waited for the edge.

<sup>Written for commit d3c66abf83d2a883b44a8f44573d5777b13e5f4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * VM creation and restoration requests now return without waiting for edge connectivity checks when background scheduling is available.

* **Reliability**
  * Edge connectivity checks continue after the response and record failures without affecting an already-completed request.
  * Non-request workflows continue to wait for verification and handle failures synchronously.

* **Tests**
  * Added coverage confirming post-response scheduling is passed through to VM providers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->