### PR TITLE
cloud: attach waits for the baked supervisor; edge probe span joins the create trace

### DIFF
--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -35,6 +35,7 @@ import {
   type VMStatus,
 } from "./types";
 import { PLAN_MACHINE_MEMORY_MB, vcpusForMemoryMb, vmDiskMb } from "../machineSpec";
+import { context as otelContext } from "@opentelemetry/api";
 import { recordSpanError, setSpanAttributes, withVmSpan } from "../telemetry";
 import {
   CMUX_TUI_BINARY_PATH,
@@ -442,6 +443,27 @@ export function freestylePinCheckCommand(source: CmuxTuiSource): string {
     "if [ -s /etc/cmux/cmux-tui-pin ]; then " +
     `test -x ${CMUX_TUI_BINARY_PATH} && printf '%s  %s\\n' "$(cut -d' ' -f1 /etc/cmux/cmux-tui-pin)" ${CMUX_TUI_BINARY_PATH} | sha256sum -c >/dev/null 2>&1; ` +
     `else ${cmuxTuiPinCheckCommand(source)}; fi`
+  );
+}
+
+/** How long the heal lets a baked supervisor bring the daemon up before restarting it. */
+const DAEMON_SETTLE_TIMEOUT_MS = 3_000;
+
+/**
+ * Healthy now, or healthy within the settle budget on an image whose
+ * supervisor binds the daemon to the instance id (it ships
+ * /etc/cmux/bake-instance-id) and is active. A machine attached right after
+ * create is inside the sub-second window before that supervisor has started
+ * the daemon; restarting the unit there costs a second and a half, waiting
+ * costs a few hundred milliseconds. Older images take the immediate check.
+ */
+export function freestyleDaemonSettledCommand(): string {
+  const healthy = freestyleDaemonHealthyCommand();
+  const ticks = Math.floor(DAEMON_SETTLE_TIMEOUT_MS / 100);
+  return (
+    "if [ -f /etc/cmux/bake-instance-id ] && systemctl is-active cmux-tui-daemon >/dev/null 2>&1; then " +
+    `for i in $(seq 1 ${ticks}); do { ${healthy}; } && exit 0; sleep 0.1; done; exit 1; ` +
+    `else ${healthy}; fi`
   );
 }
 
@@ -1144,21 +1166,31 @@ export class FreestyleProvider implements VMProvider {
       await this.probeEdgeRules(vm, vmId, edgeRules);
       return;
     }
+    // The callback runs after the response, outside the request's active
+    // span, where a fresh root span would fall under the 2% default sampling
+    // and lose its attributes. Carry the request context so the probe span is
+    // a child of the create trace (sampled with it), and log the outcome too.
+    const requestContext = otelContext.active();
     afterResponse(() =>
-      withVmSpan(
-        "cmux.vm.provider.edge_probe",
-        { "cmux.vm.provider": "freestyle", "cmux.vm.operation": "edge_probe", "cmux.vm.id": vmId, "cmux.vm.edge_rules": edgeRules.length },
-        async (span) => {
-          const startedAt = performance.now();
-          try {
-            await this.probeEdgeRules(vm, vmId, edgeRules);
-            setSpanAttributes(span, { "cmux.vm.edge_probe.ok": true, "cmux.vm.edge_probe.ms": Math.round(performance.now() - startedAt) });
-          } catch (err) {
-            setSpanAttributes(span, { "cmux.vm.edge_probe.ok": false, "cmux.vm.edge_probe.ms": Math.round(performance.now() - startedAt) });
-            recordSpanError(span, err);
-            console.error(`[freestyle] edge rule probe failed for ${vmId} after the response`, err);
-          }
-        },
+      otelContext.with(requestContext, () =>
+        withVmSpan(
+          "cmux.vm.provider.edge_probe",
+          { "cmux.vm.provider": "freestyle", "cmux.vm.operation": "edge_probe", "cmux.vm.id": vmId, "cmux.vm.edge_rules": edgeRules.length },
+          async (span) => {
+            const startedAt = performance.now();
+            try {
+              await this.probeEdgeRules(vm, vmId, edgeRules);
+              const ms = Math.round(performance.now() - startedAt);
+              setSpanAttributes(span, { "cmux.vm.edge_probe.ok": true, "cmux.vm.edge_probe.ms": ms });
+              console.info("cmux vm edge probe", JSON.stringify({ vmId, ok: true, ms }));
+            } catch (err) {
+              const ms = Math.round(performance.now() - startedAt);
+              setSpanAttributes(span, { "cmux.vm.edge_probe.ok": false, "cmux.vm.edge_probe.ms": ms });
+              recordSpanError(span, err);
+              console.error("cmux vm edge probe", JSON.stringify({ vmId, ok: false, ms, error: errorMessage(err) }));
+            }
+          },
+        ),
       ),
     );
   }
@@ -1187,7 +1219,7 @@ export class FreestyleProvider implements VMProvider {
    * the public-IPv6 route cannot reach.
    */
   private async ensureCmuxTuiRunning(vm: Vm, vmId: string): Promise<void> {
-    const healthy = await this.execResult(vm, freestyleDaemonHealthyCommand());
+    const healthy = await this.execResult(vm, freestyleDaemonSettledCommand(), DAEMON_SETTLE_TIMEOUT_MS + EXEC_OVERHEAD_TIMEOUT_MS);
     if (healthy?.exitCode === 0) return;
     const source = await resolveCmuxTuiSource("freestyle");
     const pinned = await this.execResult(vm, freestylePinCheckCommand(source));

--- a/web/tests/freestyle-cloud-shell-repair.test.ts
+++ b/web/tests/freestyle-cloud-shell-repair.test.ts
@@ -1,11 +1,19 @@
 import { describe, expect, test } from "bun:test";
 import {
   freestyleDaemonHealthyCommand,
+  freestyleDaemonSettledCommand,
   freestyleStartDaemonCommand,
 } from "../services/vms/drivers/freestyle";
 
 describe("Freestyle Cloud VM daemon repair", () => {
   test("health checks require the managed daemon and its dual-stack listener", () => {
+    // Attach right after create lands in the supervisor's start window: on a
+    // baked image the heal waits up to the settle budget before restarting.
+    const settled = freestyleDaemonSettledCommand();
+    expect(settled).toContain("if [ -f /etc/cmux/bake-instance-id ] && systemctl is-active cmux-tui-daemon");
+    expect(settled).toContain("for i in $(seq 1 30); do {");
+    expect(settled).toContain("sleep 0.1");
+    expect(settled).toContain(`else ${freestyleDaemonHealthyCommand()}; fi`);
     const healthy = freestyleDaemonHealthyCommand();
     // [s]tart keeps the pattern from matching the exec shell that carries it.
     expect(healthy).toContain("pgrep -f 'cmux-tui server [s]tart' >/dev/null 2>&1 && grep -qi ':0539 ' /proc/net/tcp6");


### PR DESCRIPTION
Two follow-ups from watching production after https://github.com/manaflow-ai/cmux/pull/11771.

**Edge probe span had no attributes.** The deferred probe ran from `after()`, outside the request's active span, so `cmux.vm.provider.edge_probe` started a new root trace that fell under the 2% default sampling and arrived in Axiom as a 6 ms span with `attributes.custom = null`. The probe now runs inside the captured request context (`context.with`), so its span is a child of the create trace and is sampled with it, and it logs `cmux vm edge probe {vmId, ok, ms}` on success and failure.

**Attach right after create took 2.4 s in the daemon heal.** The smoke (and the Mac) attaches within a second of create, inside the window before the baked supervisor has the daemon listening. The heal saw "not healthy", restarted the unit, and polled `server status` at 1 s: seven guest execs, 2.4 s. On images that bind the daemon identity to the instance id (they ship `/etc/cmux/bake-instance-id`) with the unit active, the heal now waits up to 3 s in one guest exec at 100 ms ticks before falling back to the restart. Older images keep the immediate check.

Expected in production: attach-endpoint back to about 700 ms (Stack auth plus two daemon execs), and edge probe results visible as `cmux.vm.edge_probe.ok` and `.ms` on the create trace.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two follow-ups from watching production: the edge probe span lost its attributes, and attach right after create took 2.4 s in the daemon heal.

- The probe now runs inside the captured request context, so its span is a child of the create trace and logs `cmux vm edge probe {vmId, ok, ms}`.
- On images that ship `/etc/cmux/bake-instance-id` with the unit active, the heal waits up to 3 s in one guest exec before restarting; older images keep the immediate check.
- Expected attach time drops back to about 700 ms.

<sup>Written for commit 09983dc8bb5a4bbc2bd7b1958658c2f34314ab41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved VM startup reliability by waiting for the daemon to become ready before proceeding.
  * Enhanced edge-rule verification tracing and added timing and outcome logs for easier troubleshooting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->