### PR TITLE
ci: poll Gatekeeper after stapling the Computer Use helper

### DIFF
--- a/scripts/ci/notarize-computer-use-helper.sh
+++ b/scripts/ci/notarize-computer-use-helper.sh
@@ -47,6 +47,28 @@ DITTO_TOOL="${CMUX_DITTO_TOOL:-/usr/bin/ditto}"
 XCRUN_TOOL="${CMUX_XCRUN_TOOL:-xcrun}"
 CODESIGN_TOOL="${CMUX_CODESIGN_TOOL:-/usr/bin/codesign}"
 SPCTL_TOOL="${CMUX_SPCTL_TOOL:-spctl}"
+# Gatekeeper learns about a fresh notarization ticket from Apple's CDN, which
+# lags the notarytool "Accepted" status by up to a few minutes. A stapled,
+# valid helper can therefore still assess as "Unnotarized Developer ID" right
+# after stapling. Poll until it is accepted or the budget runs out.
+GATEKEEPER_ASSESS_ATTEMPTS="${CMUX_GATEKEEPER_ASSESS_ATTEMPTS:-20}"
+GATEKEEPER_ASSESS_DELAY_SECONDS="${CMUX_GATEKEEPER_ASSESS_DELAY_SECONDS:-15}"
+
+assess_with_gatekeeper() {
+  local target="$1" attempt=1
+  while :; do
+    if "$SPCTL_TOOL" -a -vv --type execute "$target"; then
+      return 0
+    fi
+    if [ "$attempt" -ge "$GATEKEEPER_ASSESS_ATTEMPTS" ]; then
+      echo "Gatekeeper still rejects $target after $attempt attempts" >&2
+      return 3
+    fi
+    echo "Gatekeeper rejected $target (attempt $attempt/$GATEKEEPER_ASSESS_ATTEMPTS); ticket may not have propagated yet, retrying in ${GATEKEEPER_ASSESS_DELAY_SECONDS}s"
+    attempt=$((attempt + 1))
+    sleep "$GATEKEEPER_ASSESS_DELAY_SECONDS"
+  done
+}
 SIGN_BUNDLE_TOOL="${CMUX_SIGN_BUNDLE_TOOL:-$ROOT_DIR/scripts/sign-cmux-bundle.sh}"
 HELPER_ENTITLEMENTS="${CMUX_HELPER_ENTITLEMENTS:-$ROOT_DIR/cmux-helper.entitlements}"
 HELPER_PATH="$APP_PATH/Contents/Library/cmux Computer Use.app"
@@ -203,7 +225,7 @@ finish_submission() {
   "$DITTO_TOOL" "$HELPER_PATH" "$STANDALONE_HELPER"
   "$XCRUN_TOOL" stapler validate "$STANDALONE_HELPER"
   "$CODESIGN_TOOL" --verify --strict --verbose=2 "$STANDALONE_HELPER"
-  "$SPCTL_TOOL" -a -vv --type execute "$STANDALONE_HELPER"
+  assess_with_gatekeeper "$STANDALONE_HELPER"
 
   # Stapling the nested app changes the host's resource seal. Re-sign only the
   # outer app: re-signing nested code here would discard the helper's ticket.

--- a/tests/test_notarize_computer_use_helper.sh
+++ b/tests/test_notarize_computer_use_helper.sh
@@ -57,6 +57,18 @@ cat > "$FAKE_BIN/spctl" <<'EOF'
 #!/usr/bin/env bash
 set -euo pipefail
 printf 'spctl %s\n' "$*" >> "$CMUX_TEST_CALL_LOG"
+# Simulate Gatekeeper not yet seeing the notarization ticket: reject the first
+# CMUX_TEST_SPCTL_REJECTS assessments, then accept.
+count_file="${CMUX_TEST_SPCTL_COUNT_FILE:-}"
+if [ -n "$count_file" ]; then
+  n=0; [ -f "$count_file" ] && n="$(cat "$count_file")"
+  n=$((n + 1)); printf '%s' "$n" > "$count_file"
+  if [ "$n" -le "${CMUX_TEST_SPCTL_REJECTS:-0}" ]; then
+    echo "$*: rejected" >&2
+    echo "source=Unnotarized Developer ID" >&2
+    exit 3
+  fi
+fi
 EOF
 
 cat > "$FAKE_BIN/sign-bundle" <<'EOF'
@@ -74,6 +86,7 @@ run_helper() {
   CMUX_XCRUN_TOOL="$FAKE_BIN/xcrun" \
   CMUX_CODESIGN_TOOL="$FAKE_BIN/codesign" \
   CMUX_SPCTL_TOOL="$FAKE_BIN/spctl" \
+  CMUX_GATEKEEPER_ASSESS_DELAY_SECONDS=0 \
   CMUX_SIGN_BUNDLE_TOOL="$FAKE_BIN/sign-bundle" \
   APPLE_ID=fixture@example.com \
   APPLE_APP_SPECIFIC_PASSWORD=fixture-password \
@@ -184,6 +197,32 @@ if grep -Fq 'sign-bundle mode=main-only' "$LOG"; then
 fi
 if ! grep -Fq 'xcrun notarytool log helper-fixture-id' "$LOG"; then
   echo "FAIL: rejected helper notarization did not retrieve its diagnostic log" >&2
+  exit 1
+fi
+
+# Gatekeeper may not see a fresh ticket immediately after stapling. The
+# assessment polls: two rejections then acceptance must still succeed, and the
+# accepted assessment must be the one that ends the poll.
+: > "$LOG"
+rm -f "$TMP_DIR/spctl-count"
+if ! CMUX_TEST_SPCTL_COUNT_FILE="$TMP_DIR/spctl-count" CMUX_TEST_SPCTL_REJECTS=2 run_helper >/dev/null 2>&1; then
+  echo "FAIL: helper notarization gave up while the Gatekeeper ticket was still propagating" >&2
+  exit 1
+fi
+if [ "$(grep -c '^spctl -a -vv --type execute .*/standalone/cmux Computer Use\.app$' "$LOG")" -ne 3 ]; then
+  echo "FAIL: expected three Gatekeeper assessments (two rejected, one accepted)" >&2
+  exit 1
+fi
+
+# A ticket that never propagates within the budget still fails the release.
+: > "$LOG"
+rm -f "$TMP_DIR/spctl-count"
+if CMUX_TEST_SPCTL_COUNT_FILE="$TMP_DIR/spctl-count" CMUX_TEST_SPCTL_REJECTS=5 CMUX_GATEKEEPER_ASSESS_ATTEMPTS=3 run_helper >/dev/null 2>&1; then
+  echo "FAIL: helper notarization passed although Gatekeeper never accepted the helper" >&2
+  exit 1
+fi
+if [ "$(grep -c '^spctl -a -vv --type execute .*/standalone/cmux Computer Use\.app$' "$LOG")" -ne 3 ]; then
+  echo "FAIL: Gatekeeper assessment must stop after the attempt budget" >&2
   exit 1
 fi
 


### PR DESCRIPTION
The first per-architecture nightly on main (https://github.com/manaflow-ai/cmux/actions/runs/33707452450) published arm64 and x86_64 fine but lost the universal variant to a transient: `stapler validate` passed, yet the immediate `spctl` assessment of the standalone helper copy returned `Unnotarized Developer ID` because Apple's ticket CDN had not caught up. With three variants notarizing in parallel this window is hit more often, and one failed variant skips the whole publish.

`assess_with_gatekeeper` now retries the assessment for up to 20 attempts 15 s apart (about 5 minutes, tunable through `CMUX_GATEKEEPER_ASSESS_ATTEMPTS` and `CMUX_GATEKEEPER_ASSESS_DELAY_SECONDS`) and still fails the release if Gatekeeper never accepts the helper.

Test: `tests/test_notarize_computer_use_helper.sh` gains two scenarios through the `spctl` stub, two rejections then acceptance succeeds with exactly three assessments, and a never-accepted helper stops after the attempt budget and fails.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the post-stapling Gatekeeper check in the notarization script retry instead of failing the release when Apple's ticket CDN hasn't propagated yet.

**Bug Fixes**
- Retries the `spctl` assessment up to 20 times, 15 seconds apart, before failing the release.
- Retry count and delay are tunable via `CMUX_GATEKEEPER_ASSESS_ATTEMPTS` and `CMUX_GATEKEEPER_ASSESS_DELAY_SECONDS`.
- Adds tests covering transient rejections followed by acceptance, and a helper that never gets accepted within the attempt budget.

<sup>Written for commit c58b56fe2d194c5ee7fc931279c7e1d637d98ad2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

