### PR TITLE
Axiom: failure rate and latency per third-party endpoint (Freestyle, Stack Auth, Stripe, ...)

### DIFF
--- a/web/instrumentation.ts
+++ b/web/instrumentation.ts
@@ -1,4 +1,5 @@
 import { registerOTel } from "@vercel/otel";
+import { DependencySpanProcessor } from "./services/observability/dependencies";
 import { buildCmuxTraceSampler } from "./services/observability/sampler";
 import {
   scrubSentryEvent,
@@ -11,6 +12,10 @@ export async function register() {
     // Keep 100% of Cloud VM traces, sample the rest (CMUX_OTEL_BASE_SAMPLE_RATIO,
     // default 2%). The unsampled firehose measured ~4M spans/15min in production.
     traceSampler: buildCmuxTraceSampler(),
+    // "auto" keeps the default OTLP export; the dependency processor stamps
+    // cmux.dep.* (third party name, templated route) on every outbound span so
+    // Axiom can report failure rate and latency per dependency and endpoint.
+    spanProcessors: ["auto", new DependencySpanProcessor()],
   });
   if (process.env.NEXT_RUNTIME === "nodejs" && process.env.SENTRY_DSN) {
     const Sentry = await import("@sentry/nextjs");
@@ -22,6 +27,12 @@ export async function register() {
       // Vercel OpenTelemetry owns tracing. This project is intentionally only
       // for coderouter errors, not every request served by the shared cmux app.
       tracesSampleRate: 0,
+      // Sentry's NodeFetch integration instruments undici on the global OTel
+      // provider and emitted a bare "GET"/"POST" client span next to every
+      // @vercel/otel fetch span (~175k duplicate spans per 6h in production,
+      // no URL attributes). Sentry sends no traces here, so the duplicate has
+      // no consumer. Postgres and the rest of the defaults stay.
+      integrations: (defaults) => defaults.filter((integration) => integration.name !== "NodeFetch"),
       beforeSend: (event) =>
         shouldSendCoderouterSentryEvent(event) ? scrubSentryEvent(event) : null,
     });

--- a/web/services/observability/dependencies.ts
+++ b/web/services/observability/dependencies.ts
@@ -1,0 +1,152 @@
+import { SpanKind, type Attributes } from "@opentelemetry/api";
+import type { Span, SpanProcessor } from "@opentelemetry/sdk-trace-base";
+
+/**
+ * Stable names for the third parties the web app calls, keyed by host. The
+ * name is what dashboards group by; a host that is not listed keeps its
+ * hostname as the name so a new dependency is visible the day it appears.
+ */
+const DEPENDENCY_NAMES: ReadonlyArray<readonly [RegExp, string]> = [
+  [/(^|\.)freestyle\.sh$/, "freestyle"],
+  [/(^|\.)stack-auth\.com$/, "stack-auth"],
+  [/(^|\.)stripe\.com$/, "stripe"],
+  [/(^|\.)posthog\.com$/, "posthog"],
+  [/^r\.cmux\.com$/, "posthog"],
+  [/(^|\.)sentry\.io$/, "sentry"],
+  [/(^|\.)slack\.com$/, "slack"],
+  [/(^|\.)github\.com$/, "github"],
+  [/(^|\.)googleapis\.com$/, "google"],
+  [/(^|\.)apple\.com$/, "apple"],
+  [/(^|\.)axiom\.co$/, "axiom"],
+  [/(^|\.)vercel\.com$/, "vercel"],
+  [/(^|\.)blob\.vercel-storage\.com$/, "vercel-blob"],
+  [/(^|\.)resend\.com$/, "resend"],
+  [/(^|\.)openai\.com$/, "openai"],
+  [/(^|\.)anthropic\.com$/, "anthropic"],
+  [/(^|\.)amazonaws\.com$/, "aws"],
+  [/(^|\.)cloudflare\.com$/, "cloudflare"],
+  [/(^|\.)cmux\.com$/, "cmux"],
+  [/(^|\.)cmux\.sh$/, "cmux-vm"],
+];
+
+export function dependencyNameForHost(host: string): string {
+  const normalized = host.trim().toLowerCase().replace(/:\d+$/, "");
+  for (const [pattern, name] of DEPENDENCY_NAMES) {
+    if (pattern.test(normalized)) return name;
+  }
+  return normalized || "unknown";
+}
+
+const UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+// vm-<hex>, sh-<alnum>, cus_<alnum>, price_<alnum>, dpl_<alnum>, prj_<alnum>, ...
+const PREFIXED_ID = /^[a-z]{1,12}[-_][A-Za-z0-9_-]{6,}$/;
+const HEX_ID = /^[0-9a-f]{12,}$/i;
+const NUMERIC_ID = /^\d{2,}$/;
+const LONG_TOKEN = /^[A-Za-z0-9_-]{20,}$/;
+
+/**
+ * Replace the id-shaped segments of a URL path with `{id}` so one endpoint
+ * is one route: `/v5/vms/vm-c29e0db6/exec-await` -> `/v5/vms/{id}/exec-await`,
+ * `/api/v1/users/98c67a48-...` -> `/api/v1/users/{id}`. Segments that read as
+ * words (`vms`, `exec-await`, `oauth`) are kept.
+ */
+export function templateDependencyPath(path: string): string {
+  const [pathname] = path.split("?", 1);
+  const segments = pathname.split("/");
+  const templated = segments.map((segment) => {
+    if (segment.length === 0) return segment;
+    if (UUID.test(segment) || HEX_ID.test(segment) || NUMERIC_ID.test(segment)) return "{id}";
+    if (LONG_TOKEN.test(segment) && /\d/.test(segment)) return "{id}";
+    if (PREFIXED_ID.test(segment) && /\d/.test(segment)) return "{id}";
+    return segment;
+  });
+  return templated.join("/") || "/";
+}
+
+export type DependencyAttributes = {
+  readonly "cmux.dep.name": string;
+  readonly "cmux.dep.host"?: string;
+  readonly "cmux.dep.method"?: string;
+  readonly "cmux.dep.path"?: string;
+  /** `POST /v5/vms/{id}/exec-await`: the grouping key for failure rate and latency. */
+  readonly "cmux.dep.route": string;
+};
+
+function firstString(attributes: Attributes, keys: readonly string[]): string | undefined {
+  for (const key of keys) {
+    const value = attributes[key];
+    if (typeof value === "string" && value.length > 0) return value;
+  }
+  return undefined;
+}
+
+/**
+ * Derive the dependency attributes for one outbound span from what its
+ * instrumentation set at start: an HTTP client span carries the URL and
+ * method (`@vercel/otel/fetch`: `http.url`, `http.method`; semconv:
+ * `url.full`, `http.request.method`), a database span carries `db.system`.
+ * Returns undefined for spans that are not calls to another system.
+ */
+export function dependencyAttributes(
+  kind: SpanKind,
+  attributes: Attributes,
+): DependencyAttributes | undefined {
+  if (kind !== SpanKind.CLIENT && kind !== SpanKind.PRODUCER) return undefined;
+  const url = firstString(attributes, ["http.url", "url.full"]);
+  if (url) {
+    let parsed: URL;
+    try {
+      parsed = new URL(url);
+    } catch {
+      return undefined;
+    }
+    const method = (firstString(attributes, ["http.request.method", "http.method"]) ?? "GET").toUpperCase();
+    const path = templateDependencyPath(parsed.pathname);
+    return {
+      "cmux.dep.name": dependencyNameForHost(parsed.host),
+      "cmux.dep.host": parsed.host.toLowerCase(),
+      "cmux.dep.method": method,
+      "cmux.dep.path": path,
+      "cmux.dep.route": `${method} ${path}`,
+    };
+  }
+  const dbSystem = firstString(attributes, ["db.system", "db.system.name"]);
+  if (dbSystem) {
+    const operation = firstString(attributes, ["db.operation.name", "db.operation"]) ?? "query";
+    const target = firstString(attributes, ["db.collection.name", "db.sql.table", "db.name"]);
+    return {
+      "cmux.dep.name": dbSystem.toLowerCase(),
+      "cmux.dep.route": target ? `${operation} ${target}` : operation,
+    };
+  }
+  return undefined;
+}
+
+/**
+ * Stamps `cmux.dep.*` on every outbound span as it starts, so Axiom can
+ * report failure rate and latency per third party and per endpoint
+ * (`summarize ... by ['cmux.dep.name'], ['cmux.dep.route']`) without regex
+ * over raw URLs full of machine and user ids. Read-only after start: the
+ * response status stays where the instrumentation puts it
+ * (`http.status_code` / `http.response.status_code`).
+ */
+export class DependencySpanProcessor implements SpanProcessor {
+  onStart(span: Span): void {
+    try {
+      const attributes = dependencyAttributes(span.kind, span.attributes);
+      if (attributes) span.setAttributes(attributes);
+    } catch {
+      // Telemetry decoration must never break a request.
+    }
+  }
+
+  onEnd(): void {}
+
+  forceFlush(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  shutdown(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -309,7 +309,7 @@ Every outbound call (Freestyle, Stack Auth, Stripe, PostHog, Slack, Postgres, ..
 | where _time > ago(1h) and isnotempty(['attributes.custom']['cmux.dep.name'])
 | extend status = toint(coalesce(['attributes.custom']['http.status_code'], ['attributes.custom']['http.response.status_code']))
 | summarize calls = count(), failures = countif(status >= 400 or isnotempty(error)),
-            p50_ms = percentile(duration, 50) / 1ms, p95_ms = percentile(duration, 95) / 1ms
+            p50_ms = round(percentile(duration, 50) / 1000000, 0), p95_ms = round(percentile(duration, 95) / 1000000, 0)
   by dep = tostring(['attributes.custom']['cmux.dep.name']), route = tostring(['attributes.custom']['cmux.dep.route'])
 | extend failure_rate = round(100.0 * failures / calls, 2)
 | order by failures desc, calls desc

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -302,6 +302,21 @@ Every `/api/vm*` request runs inside `withAuthedVmApiRoute` (`routeHelpers.ts`),
 
 Client side, `VMClientTelemetry` (`Sources/Cloud/VMClientTelemetry.swift`) measures every request: `os.log` category `CloudVM` for all of them, a Sentry breadcrumb for all, PostHog `cmux_cloud_vm_request` for failures plus non-polled successes, and a Sentry event for failures (5xx and transport failures `error`, 4xx `warning`). Client failures are throttled per operation and code (60 s PostHog, 300 s Sentry) so a polling loop during an outage produces one event per window.
 
+Every outbound call (Freestyle, Stack Auth, Stripe, PostHog, Slack, Postgres, ...) is a client span inside the request trace, so the Axiom trace view shows the waterfall of third-party calls under each route span. `DependencySpanProcessor` (`services/observability/dependencies.ts`) stamps `cmux.dep.name` (third party) and `cmux.dep.route` (method plus id-templated path, `POST /v5/vms/{id}/exec-await`) on each of them at start. Failure rate and latency per dependency and endpoint, VM traces at 100%, everything else sampled at the base ratio:
+
+```
+['cmux-prod-otel-traces']
+| where _time > ago(1h) and isnotempty(['attributes.custom']['cmux.dep.name'])
+| extend status = toint(coalesce(['attributes.custom']['http.status_code'], ['attributes.custom']['http.response.status_code']))
+| summarize calls = count(), failures = countif(status >= 400 or isnotempty(error)),
+            p50_ms = percentile(duration, 50) / 1ms, p95_ms = percentile(duration, 95) / 1ms
+  by dep = tostring(['attributes.custom']['cmux.dep.name']), route = tostring(['attributes.custom']['cmux.dep.route'])
+| extend failure_rate = round(100.0 * failures / calls, 2)
+| order by failures desc, calls desc
+```
+
+Freestyle only, per endpoint over time: add `| where dep == 'freestyle'` and `bin(_time, 5m)` to the `by` clause. Sentry's NodeFetch integration is disabled in `instrumentation.ts` because it duplicated every fetch span as a bare `GET`/`POST` client span without a URL.
+
 To investigate one failure: take the reference id, query Axiom `['cmux-prod-otel-traces'] | where trace_id == '<id>'`, open the PostHog `$exception` or `cloud_vm_request` row with `trace_id = <id>`, and search Sentry for `trace_id:<id>`.
 
 ## GitHub operations

--- a/web/tests/dependency-spans.test.ts
+++ b/web/tests/dependency-spans.test.ts
@@ -1,0 +1,112 @@
+import { afterAll, describe, expect, test } from "bun:test";
+import { SpanKind, trace } from "@opentelemetry/api";
+import {
+  BasicTracerProvider,
+  InMemorySpanExporter,
+  SimpleSpanProcessor,
+} from "@opentelemetry/sdk-trace-base";
+
+import {
+  DependencySpanProcessor,
+  dependencyAttributes,
+  dependencyNameForHost,
+  templateDependencyPath,
+} from "../services/observability/dependencies";
+
+describe("dependencyNameForHost", () => {
+  test("maps known third parties and keeps unknown hosts by name", () => {
+    expect(dependencyNameForHost("api.freestyle.sh")).toBe("freestyle");
+    expect(dependencyNameForHost("api2.stack-auth.com")).toBe("stack-auth");
+    expect(dependencyNameForHost("api.stripe.com:443")).toBe("stripe");
+    expect(dependencyNameForHost("us.i.posthog.com")).toBe("posthog");
+    expect(dependencyNameForHost("r.cmux.com")).toBe("posthog");
+    expect(dependencyNameForHost("hooks.slack.com")).toBe("slack");
+    expect(dependencyNameForHost("machine-abc.vm.cmux.sh")).toBe("cmux-vm");
+    expect(dependencyNameForHost("files.cmux.com")).toBe("cmux");
+    expect(dependencyNameForHost("example.internal")).toBe("example.internal");
+  });
+});
+
+describe("templateDependencyPath", () => {
+  test("replaces machine, user, snapshot and billing ids but keeps words", () => {
+    expect(templateDependencyPath("/v5/vms/vm-c29e0db6601a4aa39c7d6d9136b55df3/exec-await")).toBe("/v5/vms/{id}/exec-await");
+    expect(templateDependencyPath("/api/v1/users/98c67a48-aeeb-41bd-8a81-182e1824f1fa")).toBe("/api/v1/users/{id}");
+    expect(templateDependencyPath("/api/v1/users/me")).toBe("/api/v1/users/me");
+    expect(templateDependencyPath("/api/v1/auth/oauth/token")).toBe("/api/v1/auth/oauth/token");
+    expect(templateDependencyPath("/v5/snapshots/sh-17agfasevrc18c8f15nn")).toBe("/v5/snapshots/{id}");
+    expect(templateDependencyPath("/v1/customers/cus_Qx8Yz1AbCdEf/subscriptions")).toBe("/v1/customers/{id}/subscriptions");
+    expect(templateDependencyPath("/v1/prices/price_1PqRsTuVwXyZ0123")).toBe("/v1/prices/{id}");
+    expect(templateDependencyPath("/vm/abc/attach-endpoint")).toBe("/vm/abc/attach-endpoint");
+    expect(templateDependencyPath("/capture/?ip=1")).toBe("/capture/");
+    expect(templateDependencyPath("/repos/manaflow-ai/cmux/issues/11755")).toBe("/repos/manaflow-ai/cmux/issues/{id}");
+    expect(templateDependencyPath("")).toBe("/");
+  });
+});
+
+describe("dependencyAttributes", () => {
+  test("derives name, host, method and templated route from a fetch span", () => {
+    expect(dependencyAttributes(SpanKind.CLIENT, {
+      "http.url": "https://api.freestyle.sh/v5/vms/vm-c29e0db6601a4aa39c7d6d9136b55df3/exec-await",
+      "http.method": "POST",
+    })).toEqual({
+      "cmux.dep.name": "freestyle",
+      "cmux.dep.host": "api.freestyle.sh",
+      "cmux.dep.method": "POST",
+      "cmux.dep.path": "/v5/vms/{id}/exec-await",
+      "cmux.dep.route": "POST /v5/vms/{id}/exec-await",
+    });
+  });
+
+  test("understands semconv url.full and http.request.method", () => {
+    const attributes = dependencyAttributes(SpanKind.CLIENT, {
+      "url.full": "https://api.stack-auth.com/api/v1/users/98c67a48-aeeb-41bd-8a81-182e1824f1fa?x=1",
+      "http.request.method": "get",
+    });
+    expect(attributes?.["cmux.dep.name"]).toBe("stack-auth");
+    expect(attributes?.["cmux.dep.route"]).toBe("GET /api/v1/users/{id}");
+  });
+
+  test("database spans are dependencies too", () => {
+    expect(dependencyAttributes(SpanKind.CLIENT, { "db.system": "postgresql", "db.operation": "SELECT", "db.sql.table": "cloud_vms" })).toEqual({
+      "cmux.dep.name": "postgresql",
+      "cmux.dep.route": "SELECT cloud_vms",
+    });
+  });
+
+  test("server and internal spans, and unparsable urls, are left alone", () => {
+    expect(dependencyAttributes(SpanKind.SERVER, { "http.url": "https://cmux.com/api/vm" })).toBeUndefined();
+    expect(dependencyAttributes(SpanKind.INTERNAL, { "db.system": "postgresql" })).toBeUndefined();
+    expect(dependencyAttributes(SpanKind.CLIENT, { "http.url": "not a url" })).toBeUndefined();
+    expect(dependencyAttributes(SpanKind.CLIENT, { "cmux.subsystem": "vm-cloud" })).toBeUndefined();
+  });
+});
+
+describe("DependencySpanProcessor", () => {
+  const exporter = new InMemorySpanExporter();
+  const provider = new BasicTracerProvider({
+    spanProcessors: [new DependencySpanProcessor(), new SimpleSpanProcessor(exporter)],
+  });
+  const tracer = provider.getTracer("test");
+
+  afterAll(async () => {
+    await provider.shutdown();
+  });
+
+  test("exported outbound spans carry cmux.dep.* alongside the instrumentation's own attributes", async () => {
+    tracer
+      .startSpan("fetch POST https://api.freestyle.sh/v5/vms", {
+        kind: SpanKind.CLIENT,
+        attributes: { "http.url": "https://api.freestyle.sh/v5/vms", "http.method": "POST" },
+      })
+      .setAttribute("http.status_code", 502)
+      .end();
+    tracer.startSpan("cmux.api.POST /api/vm", { kind: SpanKind.SERVER }).end();
+    await provider.forceFlush();
+    const [outbound, inbound] = exporter.getFinishedSpans();
+    expect(outbound.attributes["cmux.dep.name"]).toBe("freestyle");
+    expect(outbound.attributes["cmux.dep.route"]).toBe("POST /v5/vms");
+    expect(outbound.attributes["http.status_code"]).toBe(502);
+    expect(inbound.attributes["cmux.dep.name"]).toBeUndefined();
+    expect(trace.isSpanContextValid(outbound.spanContext())).toBe(true);
+  });
+});


### PR DESCRIPTION
Every outbound call already lands in the Axiom trace waterfall as an `@vercel/otel` fetch span with `http.status_code` and duration, Freestyle included (`fetch POST https://api.freestyle.sh/v5/vms/vm-.../exec-await`). Two things blocked "failure rate and latency per API": span names and `resource.name` carry raw URLs full of machine and user ids, so grouping by endpoint needed regex, and Sentry's NodeFetch integration exported a duplicate bare `GET`/`POST` client span for every fetch (about 175k per 6 hours in production, no URL attributes, no consumer because Sentry traces are off).

`DependencySpanProcessor` (`web/services/observability/dependencies.ts`) runs on every span start and stamps `cmux.dep.name` (host mapped to a stable name: freestyle, stack-auth, stripe, posthog, slack, github, cmux-vm, ...; unknown hosts keep their hostname) and `cmux.dep.route` (method plus id-templated path, for example `POST /v5/vms/{id}/exec-await`, `GET /api/v1/users/{id}`), plus host, method and path. Database spans get `cmux.dep.name=postgresql` and `cmux.dep.route=<operation> <table>`. `instrumentation.ts` registers it next to the default export (`spanProcessors: ["auto", ...]`) and filters `NodeFetch` out of Sentry's default integrations.

The per-dependency query is in the README Telemetry section:

```
['cmux-prod-otel-traces']
| where _time > ago(1h) and isnotempty(['attributes.custom']['cmux.dep.name'])
| extend status = toint(coalesce(['attributes.custom']['http.status_code'], ['attributes.custom']['http.response.status_code']))
| summarize calls = count(), failures = countif(status >= 400 or isnotempty(error)),
            p50_ms = percentile(duration, 50) / 1ms, p95_ms = percentile(duration, 95) / 1ms
  by dep = tostring(['attributes.custom']['cmux.dep.name']), route = tostring(['attributes.custom']['cmux.dep.route'])
| extend failure_rate = round(100.0 * failures / calls, 2)
```

Coverage note: Cloud VM traces are kept at 100%, so every Freestyle call is counted. Third-party calls made from other routes follow the 2% base sample.

Verification: `bun test tests/dependency-spans.test.ts tests/telemetry-sampler.test.ts tests/vm-request-telemetry.test.ts` (36 pass, includes an in-process tracer provider export check), `tsgo` and eslint clean. Prod check after deploy: any `/api/vm` request's trace shows `cmux.dep.name=stack-auth` on its `fetch ... api.stack-auth.com` span and no bare `GET`/`POST` `@sentry/node` spans.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds stable dependency names and templated routes to every outbound trace span, so Axiom can report failure rate and latency per third-party endpoint (Freestyle, Stack Auth, Stripe, Postgres, ...) without regex over raw URLs. Also disables Sentry's NodeFetch integration, which duplicated every fetch as a bare GET/POST client span (~175k per 6h in production) with no consumer since Sentry traces are off.

- `DependencySpanProcessor` stamps `cmux.dep.name` (host mapped to a stable name, unknown hosts keep hostname) and `cmux.dep.route` (method plus id-templated path, e.g. `POST /v5/vms/{id}/exec-await`) on every HTTP client and database span at start.
- Database spans get `cmux.dep.name=postgresql` and `<operation> <table>` as route.
- `instrumentation.ts` registers the processor via `spanProcessors: ["auto", ...]` and filters `NodeFetch` from Sentry's defaults; Postgres and the rest stay.
- The Axiom query for failure rate and latency per dependency and endpoint is documented in the README; durations are divided by 1e6 since Axiom reports them in nanoseconds.
- Tests cover host mapping, path templating, and the processor's behavior on exported spans.

<sup>Written for commit b4799f1fdac7682036cd332abff7ba7aafc24470. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

