### PR TITLE
Cloud VMs: give every machine a generated three-word name

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5813,7 +5813,7 @@ struct CMUXCLI {
                 let rows: [(String, String, String, String, String)] = vms.map { vm in
                     (
                         (vm["id"] as? String) ?? "?",
-                        (vm["displayName"] as? String) ?? "",
+                        (vm["displayName"] as? String) ?? (vm["slug"] as? String) ?? "",
                         (vm["status"] as? String) ?? "unknown",
                         (vm["provider"] as? String) ?? "?",
                         (vm["image"] as? String) ?? "?"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5813,7 +5813,7 @@ struct CMUXCLI {
                 let rows: [(String, String, String, String, String)] = vms.map { vm in
                     (
                         (vm["id"] as? String) ?? "?",
-                        (vm["displayName"] as? String) ?? (vm["slug"] as? String) ?? "",
+                        (vm["displayName"] as? String) ?? (vm["slug"] as? String) ?? (vm["id"] as? String) ?? "?",
                         (vm["status"] as? String) ?? "unknown",
                         (vm["provider"] as? String) ?? "?",
                         (vm["image"] as? String) ?? "?"

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -5813,7 +5813,9 @@ struct CMUXCLI {
                 let rows: [(String, String, String, String, String)] = vms.map { vm in
                     (
                         (vm["id"] as? String) ?? "?",
-                        (vm["displayName"] as? String) ?? (vm["slug"] as? String) ?? (vm["id"] as? String) ?? "?",
+                        (vm["displayName"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+                            ?? (vm["slug"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+                            ?? (vm["id"] as? String) ?? "?",
                         (vm["status"] as? String) ?? "unknown",
                         (vm["provider"] as? String) ?? "?",
                         (vm["image"] as? String) ?? "?"

--- a/Sources/Cloud/CloudTreeRowContentView.swift
+++ b/Sources/Cloud/CloudTreeRowContentView.swift
@@ -757,8 +757,8 @@ struct CloudTreeMachineRowContent: View {
     /// about the machine. "Locked" stays — it explains a dead machine row.
     static func subtitle(_ machine: MachineSnapshot) -> String {
         var parts: [String] = []
-        if machine.label?.isEmpty == false {
-            // Labeled machines keep their address visible: the id is what CLI
+        if machine.showsName {
+            // Named machines keep their address visible: the id is what CLI
             // verbs and URLs use.
             parts.append(machine.id)
         }

--- a/Sources/Cloud/MachinesPanelViewModel.swift
+++ b/Sources/Cloud/MachinesPanelViewModel.swift
@@ -41,6 +41,8 @@ struct MachineSnapshot: Equatable, Identifiable {
     let createdAt: Date?
     /// User-chosen label; nil when the machine has no label.
     let label: String?
+    /// Server-generated three-word name; nil for machines older than naming.
+    var slug: String? = nil
     /// Free-plan access window position; `.unrestricted` on paid plans.
     var freeAccess: FreeAccessState = .unrestricted
     /// Latest activity reading; nil until the first sample lands.
@@ -53,7 +55,16 @@ struct MachineSnapshot: Equatable, Identifiable {
     /// anywhere), v6 is the fallback.
     var privateAddress: String?
 
-    var displayName: String { label?.isEmpty == false ? label! : id }
+    /// The label when set, else the generated name, else the machine id.
+    var displayName: String {
+        if let label, !label.isEmpty { return label }
+        if let slug, !slug.isEmpty { return slug }
+        return id
+    }
+
+    /// True when the row shows something other than the id, so the id still
+    /// needs a home on the second line (CLI verbs and URLs use it).
+    var showsName: Bool { displayName != id }
 
     var kindLabel: String {
         isDesktop
@@ -182,6 +193,7 @@ enum MachineSnapshotBuilder {
             activity: activity(fromStatus: summary.status),
             createdAt: createdAt,
             label: summary.displayName,
+            slug: summary.slug,
             freeAccess: freeAccess,
             stats: nil,
             privateAddress: summary.preferredPrivateAddress

--- a/Sources/Cloud/VMClient.swift
+++ b/Sources/Cloud/VMClient.swift
@@ -283,6 +283,10 @@ struct VMSummary {
     var capabilities: VMCapabilities = .all
     /// User-chosen label; the id stays the machine's address.
     var displayName: String?
+    /// Server-generated three-word name (`sleepy-teal-otter`), fixed for the
+    /// machine's life and unique among the owner's live machines. Nil on
+    /// machines created before the backend assigned names.
+    var slug: String?
     /// When the free plan's access window closes for this machine (epoch ms);
     /// nil on paid plans or when the window is disabled server-side.
     var freeAccessExpiresAt: Int64?
@@ -291,8 +295,13 @@ struct VMSummary {
     var addressIPv4: String?
     var addressIPv6: String?
 
-    /// The name to show people: the label when set, otherwise the machine id.
-    var preferredName: String { displayName?.isEmpty == false ? displayName! : id }
+    /// The name to show people: the label when set, else the generated slug,
+    /// else the machine id.
+    var preferredName: String {
+        if let displayName, !displayName.isEmpty { return displayName }
+        if let slug, !slug.isEmpty { return slug }
+        return id
+    }
 
     /// The address to hand a person who asked for "the IP": v4 when the network
     /// allocated one (shorter, pasteable anywhere), else v6.
@@ -735,6 +744,7 @@ actor VMClient {
             if let label = dict["displayName"] as? String, !label.isEmpty {
                 summary.displayName = label
             }
+            summary.slug = (dict["slug"] as? String).flatMap { $0.isEmpty ? nil : $0 }
             summary.freeAccessExpiresAt = Self.epochMilliseconds(dict["freeAccessExpiresAt"])
             if let address = dict["address"] as? [String: Any] {
                 summary.addressIPv4 = (address["ipv4"] as? String).flatMap { $0.isEmpty ? nil : $0 }
@@ -1084,6 +1094,8 @@ actor VMClient {
         var summary = VMSummary(id: id, provider: providerValue, status: displayStatus, image: imageValue, createdAt: createdAt, base: nil)
         summary.kind = Self.decodeKind(obj["kind"])
         summary.capabilities = VMCapabilities(json: obj["capabilities"])
+        summary.displayName = (obj["displayName"] as? String).flatMap { $0.isEmpty ? nil : $0 }
+        summary.slug = (obj["slug"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         return summary
     }
 
@@ -1152,6 +1164,7 @@ actor VMClient {
         if let label = obj["displayName"] as? String, !label.isEmpty {
             summary.displayName = label
         }
+        summary.slug = (obj["slug"] as? String).flatMap { $0.isEmpty ? nil : $0 }
         return summary
     }
 

--- a/Sources/Cloud/VMClientSocketCommands.swift
+++ b/Sources/Cloud/VMClientSocketCommands.swift
@@ -672,6 +672,9 @@ extension TerminalController {
         if let displayName = vm.displayName, !displayName.isEmpty {
             payload["displayName"] = displayName
         }
+        if let slug = vm.slug, !slug.isEmpty {
+            payload["slug"] = slug
+        }
         if let freeAccessExpiresAt = vm.freeAccessExpiresAt {
             payload["freeAccessExpiresAt"] = freeAccessExpiresAt
         }

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -77,6 +77,30 @@ final class MachinesPanelModelTests: XCTestCase {
         XCTAssertEqual(snapshot.id, "noble-wren")
     }
 
+    func testSnapshotShowsGeneratedSlugWhenUnlabeled() {
+        var summary = VMSummary(
+            id: "8f1c2a64-0b3e-4d5f-9a7b-1c2d3e4f5a6b",
+            provider: "freestyle",
+            status: "running",
+            image: "cmuxd-ws:tooling-20260509f",
+            createdAt: 0,
+            base: nil
+        )
+        summary.slug = "sleepy-teal-otter"
+        let unlabeled = MachineSnapshotBuilder.snapshot(from: summary)
+        XCTAssertNil(unlabeled.label)
+        XCTAssertEqual(unlabeled.slug, "sleepy-teal-otter")
+        XCTAssertEqual(unlabeled.displayName, "sleepy-teal-otter")
+        XCTAssertEqual(summary.preferredName, "sleepy-teal-otter")
+        // The id stays reachable on the second line: CLI verbs and URLs use it.
+        XCTAssertTrue(CloudTreeMachineRowContent.subtitle(unlabeled).contains(summary.id))
+
+        summary.displayName = "dev box"
+        let labeled = MachineSnapshotBuilder.snapshot(from: summary)
+        XCTAssertEqual(labeled.displayName, "dev box", "a person's label wins over the generated name")
+        XCTAssertEqual(summary.preferredName, "dev box")
+    }
+
     func testActivityMapping() {
         XCTAssertEqual(MachineSnapshotBuilder.activity(fromStatus: "running"), .ready)
         XCTAssertEqual(MachineSnapshotBuilder.activity(fromStatus: "STANDBY"), .ready)

--- a/cmuxTests/MachinesPanelModelTests.swift
+++ b/cmuxTests/MachinesPanelModelTests.swift
@@ -77,30 +77,6 @@ final class MachinesPanelModelTests: XCTestCase {
         XCTAssertEqual(snapshot.id, "noble-wren")
     }
 
-    func testSnapshotShowsGeneratedSlugWhenUnlabeled() {
-        var summary = VMSummary(
-            id: "8f1c2a64-0b3e-4d5f-9a7b-1c2d3e4f5a6b",
-            provider: "freestyle",
-            status: "running",
-            image: "cmuxd-ws:tooling-20260509f",
-            createdAt: 0,
-            base: nil
-        )
-        summary.slug = "sleepy-teal-otter"
-        let unlabeled = MachineSnapshotBuilder.snapshot(from: summary)
-        XCTAssertNil(unlabeled.label)
-        XCTAssertEqual(unlabeled.slug, "sleepy-teal-otter")
-        XCTAssertEqual(unlabeled.displayName, "sleepy-teal-otter")
-        XCTAssertEqual(summary.preferredName, "sleepy-teal-otter")
-        // The id stays reachable on the second line: CLI verbs and URLs use it.
-        XCTAssertTrue(CloudTreeMachineRowContent.subtitle(unlabeled).contains(summary.id))
-
-        summary.displayName = "dev box"
-        let labeled = MachineSnapshotBuilder.snapshot(from: summary)
-        XCTAssertEqual(labeled.displayName, "dev box", "a person's label wins over the generated name")
-        XCTAssertEqual(summary.preferredName, "dev box")
-    }
-
     func testActivityMapping() {
         XCTAssertEqual(MachineSnapshotBuilder.activity(fromStatus: "running"), .ready)
         XCTAssertEqual(MachineSnapshotBuilder.activity(fromStatus: "STANDBY"), .ready)

--- a/cmuxTests/MachinesPanelUncappedPlanTests.swift
+++ b/cmuxTests/MachinesPanelUncappedPlanTests.swift
@@ -43,4 +43,24 @@ struct MachinesPanelUncappedPlanTests {
         #expect(plan?.countLabel == "2 of 5 machines")
         #expect(plan?.isAtLimit == false)
     }
+
+    @Test("A generated slug names an unlabeled machine and labels still win")
+    func generatedSlugFallback() {
+        var summary = VMSummary(
+            id: "8f1c2a64-0b3e-4d5f-9a7b-1c2d3e4f5a6b",
+            provider: "freestyle",
+            status: "running",
+            image: "cmuxd-ws:tooling-20260509f",
+            createdAt: 0,
+            base: nil
+        )
+        summary.slug = "sleepy-teal-otter"
+        let unlabeled = MachineSnapshotBuilder.snapshot(from: summary)
+        #expect(unlabeled.label == nil)
+        #expect(unlabeled.displayName == "sleepy-teal-otter")
+        #expect(CloudTreeMachineRowContent.subtitle(unlabeled).contains(summary.id))
+
+        summary.displayName = "dev box"
+        #expect(MachineSnapshotBuilder.snapshot(from: summary).displayName == "dev box")
+    }
 }

--- a/web/app/api/vm/[id]/route.ts
+++ b/web/app/api/vm/[id]/route.ts
@@ -42,6 +42,7 @@ export async function GET(
           status: vm.status,
           createdAt: vm.createdAt,
           displayName: vm.displayName,
+          slug: vm.slug,
         });
       } catch (err) {
         if (isVmNotFoundError(err)) return notFoundVm(id);
@@ -107,6 +108,7 @@ export async function PATCH(
         return jsonResponse({
           id: vm.providerVmId,
           displayName: vm.displayName,
+          slug: vm.slug,
         });
       } catch (err) {
         if (isVmNotFoundError(err)) return notFoundVm(id);

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -142,6 +142,9 @@ export async function GET(request: Request): Promise<Response> {
         capabilities: vmCapabilitiesFor(entry.provider),
         createdAt: entry.createdAt,
         displayName: entry.displayName,
+        // Generated three-word name; clients show it when no displayName is
+        // set. Null on rows created before names were assigned.
+        slug: entry.slug,
         // The machine's address on its owner's private network (reachable over
         // the WireGuard tunnel); null for machines created before private
         // networking. Clients surface it as "Copy IP Address".
@@ -555,6 +558,8 @@ export async function POST(request: Request): Promise<Response> {
           kind: imageSelection.kind,
           ...(imageSelection.size ? { size: imageSelection.size } : {}),
           createdAt: created.createdAt,
+          displayName: created.displayName,
+          slug: created.slug,
         });
       }
     },

--- a/web/db/migrations/20260902130000_cloud_vm_slugs/migration.sql
+++ b/web/db/migrations/20260902130000_cloud_vm_slugs/migration.sql
@@ -1,0 +1,4 @@
+ALTER TABLE "cloud_vms" ADD COLUMN "slug" text;
+--> statement-breakpoint
+CREATE UNIQUE INDEX "cloud_vms_billing_team_slug_live_unique" ON "cloud_vms" ("billing_team_id", "slug")
+  WHERE "billing_team_id" IS NOT NULL AND "slug" IS NOT NULL AND "status" IN ('provisioning', 'running', 'paused');

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -63,7 +63,7 @@ export const cloudVms = pgTable(
     displayName: text("display_name"),
     // Generated three-word name (`sleepy-teal-otter`, services/vms/vmNaming.ts).
     // Assigned once at create, never renamed, unique among the owner's live
-    // machines, so it doubles as a human-typable machine address. Rows created
+    // machines. The provider VM id remains the machine address. Rows created
     // before the column existed have none and show the provider id instead.
     slug: text("slug"),
     imageId: text("image_id").notNull(),

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -61,6 +61,11 @@ export const cloudVms = pgTable(
     // User-chosen label shown in machine lists. The provider VM id stays the
     // machine's address (URLs, CLI verbs); this is display-only.
     displayName: text("display_name"),
+    // Generated three-word name (`sleepy-teal-otter`, services/vms/vmNaming.ts).
+    // Assigned once at create, never renamed, unique among the owner's live
+    // machines, so it doubles as a human-typable machine address. Rows created
+    // before the column existed have none and show the provider id instead.
+    slug: text("slug"),
     imageId: text("image_id").notNull(),
     imageVersion: text("image_version"),
     status: vmStatus("status").notNull().default("provisioning"),
@@ -81,6 +86,10 @@ export const cloudVms = pgTable(
     uniqueIndex("cloud_vms_provider_vm_id_unique")
       .on(table.provider, table.providerVmId)
       .where(sql`${table.providerVmId} is not null`),
+    // Live rows only: a destroyed or failed machine releases its name.
+    uniqueIndex("cloud_vms_billing_team_slug_live_unique")
+      .on(table.billingTeamId, table.slug)
+      .where(sql`${table.billingTeamId} is not null and ${table.slug} is not null and ${table.status} in ('provisioning', 'running', 'paused')`),
   ],
 );
 

--- a/web/services/vms/README.md
+++ b/web/services/vms/README.md
@@ -64,6 +64,8 @@ The auth regression tests live in `web/tests/vm-route-auth.test.ts`. They verify
   fingerprint, the client's **public** key, and its address inside the network. No private
   key is ever sent to or stored by the backend.
 
+Every create row gets a `slug`, a generated `adjective-color-animal` name (`sleepy-teal-otter`, `services/vms/vmNaming.ts`) picked inside the create transaction and never changed afterwards. It is unique among the team's live rows (`provisioning`, `running`, `paused`) via a partial unique index, so a destroyed or failed machine releases its name. Clients show it when no `display_name` is set; the provider VM id stays the machine's address. The same name is sent to the provider as its console label.
+
 Create idempotency is enforced by the partial unique index on `(user_id, idempotency_key)`. A retry with the same key returns the existing VM after provisioning succeeds. A concurrent retry while the first create is still provisioning returns `409` instead of starting a second paid provider VM.
 
 Active VM limits are enforced inside the same Postgres transaction that inserts the create row. The transaction takes a billing-team advisory lock before counting active VMs, so two concurrent creates for the same team cannot both pass the free-plan limit.

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -818,7 +818,7 @@ export class FreestyleProvider implements VMProvider {
           const networkId = options.network?.id;
           const { vm, vmId, data } = await fs.vms.create({
             snapshotId: image,
-            displayName: "cmux Cloud VM",
+            displayName: options.displayName ?? "cmux Cloud VM",
             // Do not let an account/provider idle default turn a persistent
             // machine into a one-shot box. Explicit pause/stop still works.
             idleTimeoutSeconds: FREESTYLE_PERSISTENT_IDLE_TIMEOUT_SECONDS,

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -68,6 +68,12 @@ export type VMHandle = {
 
 export type CreateOptions = {
   image: string; // provider-specific template/snapshot identifier
+  /**
+   * The machine's generated three-word name, shown in the provider's own
+   * console so it matches what cmux shows. Cosmetic: providers that name
+   * machines uniquely must not fail the create over it.
+   */
+  displayName?: string;
   providerMetadata?: Record<string, unknown>;
   /**
    * Name of a persistent volume to mount as the machine's home directory. Providers that

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -22,6 +22,7 @@ import {
   isBlockingAccountDeletionTombstone,
 } from "../account/deletionLock";
 import type { ProviderId } from "./drivers";
+import { allocateVmSlug } from "./vmNaming";
 import {
   VmCreateDisabledError,
   VmCreateInProgressError,
@@ -358,6 +359,32 @@ function dbEffect<A>(
 }
 
 type CloudDbTransaction = Parameters<Parameters<ReturnType<typeof cloudDb>["transaction"]>[0]>[0];
+
+/** Statuses whose rows hold their slug (mirrors the partial unique index). */
+const SLUG_LIVE_STATUSES = ["provisioning", "running", "paused"] as const;
+
+/**
+ * Picks the new row's three-word name inside the create transaction. Callers
+ * hold an advisory lock that serializes creates in the scope, so the free
+ * candidate is still free at insert; the partial unique index backstops the
+ * base-open path, whose lock is per base rather than per team.
+ */
+async function allocateSlugInTx(tx: CloudDbTransaction, billingTeamId: string): Promise<string> {
+  return allocateVmSlug(async (candidate) => {
+    const [taken] = await tx
+      .select({ id: cloudVms.id })
+      .from(cloudVms)
+      .where(
+        and(
+          eq(cloudVms.billingTeamId, billingTeamId),
+          eq(cloudVms.slug, candidate),
+          inArray(cloudVms.status, [...SLUG_LIVE_STATUSES]),
+        ),
+      )
+      .limit(1);
+    return !!taken;
+  });
+}
 
 async function assertAccountVmCreateAllowed(
   tx: CloudDbTransaction,
@@ -789,6 +816,7 @@ export const vmRepositoryLiveShape: VmRepositoryShape = {
                 imageVersion: input.imageVersion ?? null,
                 status: "provisioning",
                 idempotencyKey,
+                slug: await allocateSlugInTx(tx, input.billingTeamId),
               })
               .returning();
             if (!vm) throw new Error("insert returned no VM row");
@@ -895,6 +923,7 @@ export const vmRepositoryLiveShape: VmRepositoryShape = {
                 imageVersion: input.imageVersion ?? null,
                 status: "provisioning",
                 idempotencyKey,
+                slug: await allocateSlugInTx(tx, input.billingTeamId),
               })
               .returning();
             if (!vm) throw new Error("insert returned no VM row");
@@ -1094,6 +1123,7 @@ export const vmRepositoryLiveShape: VmRepositoryShape = {
               imageVersion: input.imageVersion ?? null,
               status: "provisioning",
               idempotencyKey,
+              slug: await allocateSlugInTx(tx, input.billingTeamId),
             })
             .returning();
           if (!vm) throw new Error("insert returned no VM row");

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -364,12 +364,14 @@ type CloudDbTransaction = Parameters<Parameters<ReturnType<typeof cloudDb>["tran
 const SLUG_LIVE_STATUSES = ["provisioning", "running", "paused"] as const;
 
 /**
- * Picks the new row's three-word name inside the create transaction. Callers
- * hold an advisory lock that serializes creates in the scope, so the free
- * candidate is still free at insert; the partial unique index backstops the
- * base-open path, whose lock is per base rather than per team.
+ * Picks the new row's three-word name inside the create transaction. Takes
+ * the billing-team advisory lock first (re-entrant for beginCreate, which
+ * already holds it; new for the base paths, whose own lock is per base), so
+ * every create in the team serializes here and a free candidate is still
+ * free at insert. The partial unique index stays as the backstop.
  */
 async function allocateSlugInTx(tx: CloudDbTransaction, billingTeamId: string): Promise<string> {
+  await tx.execute(sql`select pg_advisory_xact_lock(hashtextextended(${billingTeamId}, 0))`);
   return allocateVmSlug(async (candidate) => {
     const [taken] = await tx
       .select({ id: cloudVms.id })

--- a/web/services/vms/vmNaming.ts
+++ b/web/services/vms/vmNaming.ts
@@ -83,7 +83,9 @@ const SUFFIX_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
 export type VmSlugRandom = (upperExclusive: number) => number;
 
 function pick(list: readonly string[], random: VmSlugRandom): string {
-  return list[random(list.length)]!;
+  const value = list[random(list.length)];
+  if (value === undefined) throw new Error("VM slug word list is empty");
+  return value;
 }
 
 /** A fresh `adjective-color-animal` slug. `random` is injectable for tests. */

--- a/web/services/vms/vmNaming.ts
+++ b/web/services/vms/vmNaming.ts
@@ -105,6 +105,8 @@ export function suffixVmSlug(slug: string, random: VmSlugRandom = randomInt): st
 
 /** How many plain candidates to try before falling back to a suffixed one. */
 export const VM_SLUG_PLAIN_ATTEMPTS = 8;
+/** Maximum suffixed candidates to probe before failing the transaction. */
+export const VM_SLUG_SUFFIX_ATTEMPTS = 64;
 
 /**
  * Picks a slug no live machine in the scope already uses. `isTaken` answers
@@ -122,8 +124,9 @@ export async function allocateVmSlug(
     plain = generateVmSlug(random);
     if (!(await isTaken(plain))) return plain;
   }
-  for (;;) {
+  for (let attempt = 0; attempt < VM_SLUG_SUFFIX_ATTEMPTS; attempt += 1) {
     const candidate = suffixVmSlug(plain, random);
     if (!(await isTaken(candidate))) return candidate;
   }
+  throw new Error("Unable to allocate a unique VM slug");
 }

--- a/web/services/vms/vmNaming.ts
+++ b/web/services/vms/vmNaming.ts
@@ -1,0 +1,127 @@
+import { randomInt } from "node:crypto";
+
+/**
+ * Three-word machine names (`sleepy-teal-otter`). The slug is generated once
+ * per machine at create, never changes, and is unique among the owner's live
+ * machines, so it can stand in for the provider id anywhere a person types a
+ * machine address. `displayName` stays the free-text label people rename.
+ *
+ * The grammar is deliberately narrow (lowercase ASCII words joined by single
+ * hyphens) so the slug is safe in URLs, hostnames, shell arguments, and file
+ * names without escaping.
+ */
+export const VM_SLUG_PATTERN = /^[a-z]+-[a-z]+-[a-z]+(?:-[a-z0-9]{4})?$/;
+
+export function isVmSlug(value: unknown): value is string {
+  return typeof value === "string" && VM_SLUG_PATTERN.test(value);
+}
+
+/** Words that read badly next to any other word in the lists. Kept here so a
+ * list edit that reintroduces one fails the test instead of shipping. */
+export const VM_SLUG_BANNED_WORDS: ReadonlySet<string> = new Set([
+  "dead", "dumb", "fat", "lazy", "ugly", "sick", "mad", "evil", "dirty", "crazy",
+  "stupid", "wet", "hairy", "naked", "bloody", "cursed", "toxic", "rabid",
+]);
+
+export const VM_SLUG_ADJECTIVES: readonly string[] = [
+  "agile", "ancient", "artful", "bashful", "bold", "bouncy", "brave",
+  "breezy", "bright", "brisk", "bubbly", "calm", "cheeky", "cheery", "chilly",
+  "chirpy", "clever", "cosmic", "cozy", "crisp", "curious", "dainty", "dapper",
+  "daring", "dashing", "dreamy", "eager", "early", "easy", "elegant", "fancy",
+  "fearless", "fluffy", "fuzzy", "gentle", "giddy", "gleeful", "glossy", "golden",
+  "graceful", "groovy", "happy", "hardy", "hasty", "hearty", "humble", "hungry",
+  "jaunty", "jolly", "jovial", "keen", "kind", "lively", "lofty", "loyal",
+  "lucky", "lunar", "mellow", "merry", "mighty", "misty", "modest", "nimble",
+  "noble", "nifty", "peppy", "perky", "playful", "plucky", "polite", "proud",
+  "puffy", "quiet", "quick", "quirky", "rapid", "rosy", "rustic", "shiny",
+  "silky", "sleepy", "slick", "smart", "snappy", "sneaky", "snug", "soft",
+  "solar", "sparkly", "speedy", "spry", "steady", "sturdy", "sunny", "swift",
+  "tidy", "tiny", "toasty", "tranquil", "trusty", "velvet", "vivid", "wandering",
+  "warm", "whimsical", "wild", "wise", "witty", "zany", "zesty", "zippy",
+];
+
+export const VM_SLUG_COLORS: readonly string[] = [
+  "amber", "aqua", "azure", "beige", "blue", "bronze", "cerulean", "cherry",
+  "cobalt", "coral", "cream", "crimson", "cyan", "emerald", "fuchsia", "gold",
+  "green", "indigo", "ivory", "jade", "lavender", "lemon", "lilac", "lime",
+  "magenta", "maroon", "mauve", "mint", "navy", "ochre", "olive", "orange",
+  "peach", "pearl", "pink", "plum", "purple", "red", "rose", "ruby", "saffron",
+  "sage", "sapphire", "scarlet", "silver", "slate", "tan", "teal", "topaz",
+  "violet", "white", "yellow",
+];
+
+export const VM_SLUG_ANIMALS: readonly string[] = [
+  "alpaca", "ant", "antelope", "armadillo", "axolotl", "badger", "bat", "bear",
+  "beaver", "bee", "beetle", "bison", "bobcat", "buffalo", "bunny", "butterfly",
+  "camel", "capybara", "cardinal", "caribou", "cat", "chameleon", "cheetah",
+  "chickadee", "chinchilla", "chipmunk", "cobra", "condor", "corgi", "cougar",
+  "coyote", "crab", "crane", "cricket", "crow", "cuttlefish", "deer", "dingo",
+  "dolphin", "donkey", "dove", "dragonfly", "duck", "eagle", "eel", "egret",
+  "elephant", "elk", "emu", "falcon", "ferret", "finch", "firefly", "flamingo",
+  "fox", "frog", "gazelle", "gecko", "gerbil", "gibbon", "giraffe", "goat",
+  "goose", "gopher", "gorilla", "grouse", "gull", "hamster", "hare", "hawk",
+  "hedgehog", "heron", "hippo", "hornet", "horse", "hummingbird", "husky",
+  "ibex", "ibis", "iguana", "impala", "jackal", "jaguar", "jay", "jellyfish",
+  "kangaroo", "kestrel", "kingfisher", "kitten", "kiwi", "koala", "koi",
+  "ladybug", "lark", "lemur", "leopard", "lion", "lizard", "llama", "lobster",
+  "loon", "lynx", "macaw", "magpie", "manatee", "mantis", "marmot", "meerkat",
+  "mink", "mole", "mongoose", "moose", "moth", "mouse", "narwhal", "newt",
+  "nightingale", "ocelot", "octopus", "okapi", "oriole", "osprey", "otter",
+  "owl", "ox", "oyster", "panda", "panther", "parrot", "peacock", "pelican",
+  "penguin", "pheasant", "pigeon", "piglet", "pika", "platypus", "pony",
+  "porcupine", "puffin", "puma", "python", "quail", "quokka", "rabbit",
+  "raccoon", "raven", "reindeer", "robin", "salamander", "salmon", "sandpiper",
+  "seahorse", "seal", "shrimp", "skunk", "sloth", "snail", "sparrow", "squid",
+  "squirrel", "starling", "stoat", "stork", "swan", "tapir", "tern",
+  "tiger", "toad", "tortoise", "toucan", "trout", "turtle", "urchin", "viper",
+  "vole", "wallaby", "walrus", "warbler", "weasel", "whale", "wolf", "wombat",
+  "woodpecker", "wren", "yak", "zebra",
+];
+
+const SUFFIX_ALPHABET = "abcdefghijklmnopqrstuvwxyz0123456789";
+
+export type VmSlugRandom = (upperExclusive: number) => number;
+
+function pick(list: readonly string[], random: VmSlugRandom): string {
+  return list[random(list.length)]!;
+}
+
+/** A fresh `adjective-color-animal` slug. `random` is injectable for tests. */
+export function generateVmSlug(random: VmSlugRandom = randomInt): string {
+  return `${pick(VM_SLUG_ADJECTIVES, random)}-${pick(VM_SLUG_COLORS, random)}-${pick(VM_SLUG_ANIMALS, random)}`;
+}
+
+/**
+ * The same slug with a short random tail, for the case where every plain
+ * candidate collided with a live machine. Still matches VM_SLUG_PATTERN.
+ */
+export function suffixVmSlug(slug: string, random: VmSlugRandom = randomInt): string {
+  let tail = "";
+  for (let i = 0; i < 4; i += 1) tail += SUFFIX_ALPHABET[random(SUFFIX_ALPHABET.length)];
+  return `${slug}-${tail}`;
+}
+
+/** How many plain candidates to try before falling back to a suffixed one. */
+export const VM_SLUG_PLAIN_ATTEMPTS = 8;
+
+/**
+ * Picks a slug no live machine in the scope already uses. `isTaken` answers
+ * for one candidate; the caller serializes concurrent creates in the scope
+ * (the create transaction holds the per-team advisory lock), so a candidate
+ * that is free here is free at insert. After VM_SLUG_PLAIN_ATTEMPTS misses a
+ * suffixed candidate is returned; the unique index remains the backstop.
+ */
+export async function allocateVmSlug(
+  isTaken: (candidate: string) => Promise<boolean>,
+  random: VmSlugRandom = randomInt,
+): Promise<string> {
+  let plain = "";
+  for (let attempt = 0; attempt < VM_SLUG_PLAIN_ATTEMPTS; attempt += 1) {
+    plain = generateVmSlug(random);
+    if (!(await isTaken(plain))) return plain;
+  }
+  for (;;) {
+    const candidate = suffixVmSlug(plain, random);
+    if (!(await isTaken(candidate))) return candidate;
+  }
+}

--- a/web/services/vms/vmNaming.ts
+++ b/web/services/vms/vmNaming.ts
@@ -3,8 +3,8 @@ import { randomInt } from "node:crypto";
 /**
  * Three-word machine names (`sleepy-teal-otter`). The slug is generated once
  * per machine at create, never changes, and is unique among the owner's live
- * machines, so it can stand in for the provider id anywhere a person types a
- * machine address. `displayName` stays the free-text label people rename.
+ * machines. `displayName` stays the free-text label people rename, and the
+ * provider id remains the machine address for API and CLI operations.
  *
  * The grammar is deliberately narrow (lowercase ASCII words joined by single
  * hyphens) so the slug is safe in URLs, hostnames, shell arguments, and file

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -103,6 +103,8 @@ export type VmEntry = {
   readonly status: CloudVmStatus;
   readonly createdAt: number;
   readonly displayName: string | null;
+  /** Generated three-word name (services/vms/vmNaming.ts); null on rows older than the column. */
+  readonly slug: string | null;
   /** The machine's address on its owner's private network, when it has one. */
   readonly addressIpv4: string | null;
   readonly addressIpv6: string | null;
@@ -511,6 +513,7 @@ export function createVm(input: {
       "provider_create",
       providers.create(input.provider, {
         image: input.image,
+        displayName: create.vm.slug ?? undefined,
         providerMetadata: create.vm.providerMetadata,
         homeVolume: input.perMachineHome
           ? homeVolumeTemplateForUser(input.userId)
@@ -754,6 +757,7 @@ function finishBaseCreate(
       "provider_create",
       providers.create(input.provider, {
         image: input.image,
+        displayName: create.vm.slug ?? undefined,
         providerMetadata: create.vm.providerMetadata,
         ...(network ? { network: { id: network.providerNetworkId } } : {}),
       }),
@@ -2875,6 +2879,7 @@ function vmEntryFromRow(row: CloudVmRow): VmEntry {
     status: row.status,
     createdAt: row.createdAt.getTime(),
     displayName: row.displayName ?? null,
+    slug: row.slug ?? null,
     addressIpv4: typeof addressIpv4 === "string" && addressIpv4 ? addressIpv4 : null,
     addressIpv6: typeof addressIpv6 === "string" && addressIpv6 ? addressIpv6 : null,
   };

--- a/web/tests/vm-limit-refresh.test.ts
+++ b/web/tests/vm-limit-refresh.test.ts
@@ -20,6 +20,7 @@ function row(overrides: Partial<CloudVmRow>): CloudVmRow {
     provider: "freestyle",
     providerVmId: null,
     displayName: null,
+    slug: null,
     imageId: "snapshot-test",
     imageVersion: null,
     status: "provisioning",

--- a/web/tests/vm-model-plane-workflow.test.ts
+++ b/web/tests/vm-model-plane-workflow.test.ts
@@ -50,6 +50,7 @@ function row(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
     provider: "freestyle",
     providerVmId: null,
     displayName: null,
+    slug: null,
     imageId: "snapshot-test",
     imageVersion: null,
     status: "provisioning",

--- a/web/tests/vm-naming.test.ts
+++ b/web/tests/vm-naming.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import {
+  allocateVmSlug,
+  generateVmSlug,
+  isVmSlug,
+  suffixVmSlug,
+  VM_SLUG_ADJECTIVES,
+  VM_SLUG_ANIMALS,
+  VM_SLUG_BANNED_WORDS,
+  VM_SLUG_COLORS,
+  VM_SLUG_PATTERN,
+  VM_SLUG_PLAIN_ATTEMPTS,
+} from "../services/vms/vmNaming";
+
+const WORD = /^[a-z]{2,12}$/;
+
+describe("vm slug word lists", () => {
+  test("every word is lowercase ascii, unique across lists, and not banned", () => {
+    const seen = new Map<string, string>();
+    for (const [list, words] of [
+      ["adjective", VM_SLUG_ADJECTIVES],
+      ["color", VM_SLUG_COLORS],
+      ["animal", VM_SLUG_ANIMALS],
+    ] as const) {
+      for (const word of words) {
+        expect(word).toMatch(WORD);
+        expect(VM_SLUG_BANNED_WORDS.has(word)).toBe(false);
+        const prior = seen.get(word);
+        if (prior) throw new Error(`${word} is in both ${prior} and ${list}`);
+        seen.set(word, list);
+      }
+    }
+    // Enough combinations that a per-team collision is a retry, not a plan.
+    expect(VM_SLUG_ADJECTIVES.length * VM_SLUG_COLORS.length * VM_SLUG_ANIMALS.length).toBeGreaterThan(100_000);
+  });
+});
+
+describe("generateVmSlug", () => {
+  test("produces adjective-color-animal that matches the pattern", () => {
+    for (let i = 0; i < 500; i += 1) {
+      const slug = generateVmSlug();
+      expect(slug).toMatch(VM_SLUG_PATTERN);
+      const [adjective, color, animal] = slug.split("-");
+      expect(VM_SLUG_ADJECTIVES).toContain(adjective);
+      expect(VM_SLUG_COLORS).toContain(color);
+      expect(VM_SLUG_ANIMALS).toContain(animal);
+    }
+  });
+
+  test("is deterministic under an injected random source", () => {
+    const zero = () => 0;
+    expect(generateVmSlug(zero)).toBe(`${VM_SLUG_ADJECTIVES[0]}-${VM_SLUG_COLORS[0]}-${VM_SLUG_ANIMALS[0]}`);
+    expect(suffixVmSlug("sleepy-teal-otter", zero)).toBe("sleepy-teal-otter-aaaa");
+    expect(isVmSlug("sleepy-teal-otter-aaaa")).toBe(true);
+  });
+});
+
+describe("isVmSlug", () => {
+  test("rejects anything outside the url-safe grammar", () => {
+    for (const bad of ["", "Sleepy-Teal-Otter", "sleepy teal otter", "sleepy-teal", "a-b-c-d-e", "sleepy--teal-otter", "sleepy-teal-otter-", "sleepy-teal-otter-ab", 42, null]) {
+      expect(isVmSlug(bad)).toBe(false);
+    }
+    expect(isVmSlug("sleepy-teal-otter")).toBe(true);
+  });
+});
+
+describe("allocateVmSlug", () => {
+  test("returns the first free plain candidate", async () => {
+    const asked: string[] = [];
+    const slug = await allocateVmSlug(async (candidate) => {
+      asked.push(candidate);
+      return asked.length < 3;
+    });
+    expect(asked).toHaveLength(3);
+    expect(slug).toBe(asked[2]);
+    expect(slug).toMatch(/^[a-z]+-[a-z]+-[a-z]+$/);
+  });
+
+  test("falls back to a suffixed candidate once every plain one is taken", async () => {
+    const asked: string[] = [];
+    const slug = await allocateVmSlug(async (candidate) => {
+      asked.push(candidate);
+      // Plain candidates have three words; only the suffixed one has four.
+      return candidate.split("-").length === 3;
+    });
+    expect(asked).toHaveLength(VM_SLUG_PLAIN_ATTEMPTS + 1);
+    expect(slug).toMatch(VM_SLUG_PATTERN);
+    expect(slug.startsWith(asked[VM_SLUG_PLAIN_ATTEMPTS - 1]!)).toBe(true);
+  });
+});

--- a/web/tests/vm-naming.test.ts
+++ b/web/tests/vm-naming.test.ts
@@ -10,6 +10,7 @@ import {
   VM_SLUG_COLORS,
   VM_SLUG_PATTERN,
   VM_SLUG_PLAIN_ATTEMPTS,
+  VM_SLUG_SUFFIX_ATTEMPTS,
 } from "../services/vms/vmNaming";
 
 const WORD = /^[a-z]{2,12}$/;
@@ -86,5 +87,14 @@ describe("allocateVmSlug", () => {
     expect(asked).toHaveLength(VM_SLUG_PLAIN_ATTEMPTS + 1);
     expect(slug).toMatch(VM_SLUG_PATTERN);
     expect(slug.startsWith(asked[VM_SLUG_PLAIN_ATTEMPTS - 1]!)).toBe(true);
+  });
+
+  test("fails after a bounded suffix search", async () => {
+    const asked: string[] = [];
+    await expect(allocateVmSlug(async (candidate) => {
+      asked.push(candidate);
+      return true;
+    })).rejects.toThrow("Unable to allocate a unique VM slug");
+    expect(asked).toHaveLength(VM_SLUG_PLAIN_ATTEMPTS + VM_SLUG_SUFFIX_ATTEMPTS);
   });
 });

--- a/web/tests/vm-reaper.test.ts
+++ b/web/tests/vm-reaper.test.ts
@@ -89,6 +89,7 @@ function vmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
     provider: "freestyle",
     providerVmId: "stale-sandbox",
     displayName: null,
+    slug: null,
     imageId: "cmux-devbox:devbox-20260828b",
     imageVersion: null,
     status: "provisioning",

--- a/web/tests/vm-retired-provider-rows.test.ts
+++ b/web/tests/vm-retired-provider-rows.test.ts
@@ -27,6 +27,7 @@ function row(overrides: Partial<CloudVmRow>): CloudVmRow {
     provider: "freestyle",
     providerVmId: "live-machine",
     displayName: null,
+    slug: null,
     imageId: "cmux-devbox",
     imageVersion: null,
     status: "running",

--- a/web/tests/vm-slug-db.test.ts
+++ b/web/tests/vm-slug-db.test.ts
@@ -1,4 +1,5 @@
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { randomUUID } from "node:crypto";
 import * as Effect from "effect/Effect";
 import postgres, { type Sql } from "postgres";
 import { closeCloudDbForTests } from "../db/client";
@@ -45,43 +46,47 @@ function beginCreate(input: { userId: string; billingTeamId: string; idempotency
 
 describe("cloud VM slugs", () => {
   dbTest("every create row gets a distinct three-word slug in its team", async () => {
-    const team = `team-slug-${Date.now()}`;
-    const first = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-1` });
-    const second = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-2` });
-    expect(first.inserted).toBe(true);
-    expect(second.inserted).toBe(true);
-    expect(first.vm.slug).toMatch(VM_SLUG_PATTERN);
-    expect(second.vm.slug).toMatch(VM_SLUG_PATTERN);
-    expect(first.vm.slug).not.toBe(second.vm.slug);
+    const team = `team-slug-${randomUUID()}`;
+    try {
+      const first = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-1` });
+      const second = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-2` });
+      expect(first.inserted).toBe(true);
+      expect(second.inserted).toBe(true);
+      expect(first.vm.slug).toMatch(VM_SLUG_PATTERN);
+      expect(second.vm.slug).toMatch(VM_SLUG_PATTERN);
+      expect(first.vm.slug).not.toBe(second.vm.slug);
 
-    // A same-key retry returns the existing row, so the name is stable.
-    const replay = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-1` });
-    expect(replay.inserted).toBe(false);
-    expect(replay.vm.slug).toBe(first.vm.slug);
-
-    await sql!`delete from cloud_vms where billing_team_id = ${team}`;
+      // A same-key retry returns the existing row, so the name is stable.
+      const replay = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-1` });
+      expect(replay.inserted).toBe(false);
+      expect(replay.vm.slug).toBe(first.vm.slug);
+    } finally {
+      await sql!`delete from cloud_vms where billing_team_id = ${team}`;
+    }
   });
 
   dbTest("the live-row index rejects a duplicate name and frees it once the machine is gone", async () => {
-    const team = `team-slug-index-${Date.now()}`;
-    const insert = (status: string) =>
-      sql!`insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, image_id, status, slug)
-           values ('user-slug-b', ${team}, 'pro', 'freestyle', 'test-image', ${status}::vm_status, 'sleepy-teal-otter')`;
-    await insert("running");
-    let duplicate: unknown = null;
+    const team = `team-slug-index-${randomUUID()}`;
     try {
-      await insert("provisioning");
-    } catch (err) {
-      duplicate = err;
+      const insert = (status: string) =>
+        sql!`insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, image_id, status, slug)
+             values ('user-slug-b', ${team}, 'pro', 'freestyle', 'test-image', ${status}::vm_status, 'sleepy-teal-otter')`;
+      await insert("running");
+      let duplicate: unknown = null;
+      try {
+        await insert("provisioning");
+      } catch (err) {
+        duplicate = err;
+      }
+      expect(duplicate).toMatchObject({ code: "23505" });
+      // Destroyed and failed rows keep their slug for the audit trail but do
+      // not hold the name.
+      await insert("destroyed");
+      await insert("failed");
+      await sql!`update cloud_vms set status = 'destroyed' where billing_team_id = ${team} and status = 'running'`;
+      await insert("running");
+    } finally {
+      await sql!`delete from cloud_vms where billing_team_id = ${team}`;
     }
-    expect(duplicate).toMatchObject({ code: "23505" });
-    // Destroyed and failed rows keep their slug for the audit trail but do
-    // not hold the name.
-    await insert("destroyed");
-    await insert("failed");
-    await sql!`update cloud_vms set status = 'destroyed' where billing_team_id = ${team} and status = 'running'`;
-    await insert("running");
-
-    await sql!`delete from cloud_vms where billing_team_id = ${team}`;
   });
 });

--- a/web/tests/vm-slug-db.test.ts
+++ b/web/tests/vm-slug-db.test.ts
@@ -1,0 +1,87 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import postgres, { type Sql } from "postgres";
+import { closeCloudDbForTests } from "../db/client";
+import { VmRepository, VmRepositoryLive } from "../services/vms/repository";
+import { VM_SLUG_PATTERN } from "../services/vms/vmNaming";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+let sql: Sql | null = null;
+
+function databaseURL() {
+  const url = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!url) throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  return url;
+}
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  sql = postgres(databaseURL(), { max: 1 });
+});
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await sql?.end();
+});
+
+function beginCreate(input: { userId: string; billingTeamId: string; idempotencyKey: string }) {
+  return Effect.runPromise(
+    Effect.gen(function* () {
+      const repo = yield* VmRepository;
+      return yield* repo.beginCreate({
+        userId: input.userId,
+        billingTeamId: input.billingTeamId,
+        billingPlanId: "pro",
+        provider: "freestyle",
+        image: "test-image",
+        maxActiveVms: null,
+        idempotencyKey: input.idempotencyKey,
+      });
+    }).pipe(Effect.provide(VmRepositoryLive)),
+  );
+}
+
+describe("cloud VM slugs", () => {
+  dbTest("every create row gets a distinct three-word slug in its team", async () => {
+    const team = `team-slug-${Date.now()}`;
+    const first = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-1` });
+    const second = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-2` });
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(true);
+    expect(first.vm.slug).toMatch(VM_SLUG_PATTERN);
+    expect(second.vm.slug).toMatch(VM_SLUG_PATTERN);
+    expect(first.vm.slug).not.toBe(second.vm.slug);
+
+    // A same-key retry returns the existing row, so the name is stable.
+    const replay = await beginCreate({ userId: "user-slug-a", billingTeamId: team, idempotencyKey: `${team}-1` });
+    expect(replay.inserted).toBe(false);
+    expect(replay.vm.slug).toBe(first.vm.slug);
+
+    await sql!`delete from cloud_vms where billing_team_id = ${team}`;
+  });
+
+  dbTest("the live-row index rejects a duplicate name and frees it once the machine is gone", async () => {
+    const team = `team-slug-index-${Date.now()}`;
+    const insert = (status: string) =>
+      sql!`insert into cloud_vms (user_id, billing_team_id, billing_plan_id, provider, image_id, status, slug)
+           values ('user-slug-b', ${team}, 'pro', 'freestyle', 'test-image', ${status}::vm_status, 'sleepy-teal-otter')`;
+    await insert("running");
+    let duplicate: unknown = null;
+    try {
+      await insert("provisioning");
+    } catch (err) {
+      duplicate = err;
+    }
+    expect(duplicate).toMatchObject({ code: "23505" });
+    // Destroyed and failed rows keep their slug for the audit trail but do
+    // not hold the name.
+    await insert("destroyed");
+    await insert("failed");
+    await sql!`update cloud_vms set status = 'destroyed' where billing_team_id = ${team} and status = 'running'`;
+    await insert("running");
+
+    await sql!`delete from cloud_vms where billing_team_id = ${team}`;
+  });
+});

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -1919,13 +1919,16 @@ describe("VM Effect workflows", () => {
     const requested = testCloudVmRow({
       status: "provisioning",
       providerVmId: null,
+      slug: "sleepy-teal-otter",
     });
     const running = testCloudVmRow({
       status: "running",
       providerVmId: "provider-vm-usage-events",
       imageVersion: "test-version",
+      slug: "sleepy-teal-otter",
     });
     let providerCreateCalls = 0;
+    let providerDisplayName: string | undefined;
     let providerMemoryMb: number | undefined;
     let providerImageSize: { name: string; cpu: number; memoryMb: number; storageMb: number } | null = null;
     let usageEventAttempts = 0;
@@ -1969,6 +1972,7 @@ describe("VM Effect workflows", () => {
       create: (_provider, options) =>
         Effect.sync(() => {
           providerCreateCalls += 1;
+          providerDisplayName = options.displayName;
           providerMemoryMb = options.memoryMb;
           providerImageSize = options.imageSize ?? null;
           return {
@@ -2008,7 +2012,10 @@ describe("VM Effect workflows", () => {
     );
 
     expect(created.providerVmId).toBe("provider-vm-usage-events");
+    expect(created.slug).toBe("sleepy-teal-otter");
     expect(providerCreateCalls).toBe(1);
+    // The row's generated name is what the provider console shows too.
+    expect(providerDisplayName).toBe("sleepy-teal-otter");
     expect(providerMemoryMb).toBe(3072);
     // A sized image reaches the driver as the shape to boot at, never to resize to.
     expect(providerImageSize).toEqual({ name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384 });
@@ -4709,6 +4716,7 @@ function testCloudVmRow(overrides: Partial<CloudVmRow> = {}): CloudVmRow {
     provider: "freestyle",
     providerVmId: null,
     displayName: null,
+    slug: null,
     imageId: "snapshot-test",
     imageVersion: null,
     status: "provisioning",


### PR DESCRIPTION
New machines had no label, so the sidebar and `cmux vm list` showed the Freestyle UUID.

Each create row now gets a `slug` like `sleepy-teal-otter`, picked inside the create transaction from curated adjective, color, and animal lists (`web/services/vms/vmNaming.ts`). It is unique among the team's live rows (`provisioning`, `running`, `paused`) via a partial unique index, so a destroyed or failed machine releases its name, and it never changes afterwards. `displayName` stays the free-text label people rename. Clients show label, then slug, then id, and keep the id on the row's second line because CLI verbs and URLs still use it. The slug is also sent to Freestyle as the console label so both sides match.

API: `GET /api/vm`, `GET/PATCH /api/vm/[id]`, and `POST /api/vm` now return `slug` (and `POST` also returns `displayName`).

Migration `20260902130000_cloud_vm_slugs` adds the column and index. Run the staging and production migrations before merging.

Not in this PR: accepting the slug as a machine address in `/api/vm/[id]` verbs. Several workflows pass the path id straight to the provider, so that needs its own audit.

Tests: `web/tests/vm-naming.test.ts` (grammar, list hygiene, retry and suffix fallback), `web/tests/vm-slug-db.test.ts` (Postgres: distinct slugs per team, idempotent replay keeps the name, live-row index rejects duplicates and frees names), `vm-workflows` asserts the slug reaches the provider as `displayName`, `cmuxTests/MachinesPanelModelTests` covers the label > slug > id order.

https://claude.ai/code/session_01G5tPNbbjodsxngXZt3Fgng

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790999225&installation_model_id=21920&pr_number=11781&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11781&signature=18c628f79abee84bf60a050c52e42f4828b693d1df417ad4ec0d2852bee36fc9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives every new Cloud VM a generated three-word name like `sleepy-teal-otter`, so the sidebar and `cmux vm list` no longer show the raw Freestyle UUID for unlabeled machines. Machines created before this change still show the id.

- Each create row gets a `slug`, picked inside the create transaction from validated word lists and unique among the team's live (`provisioning`, `running`, `paused`) machines via a partial unique index; destroyed or failed machines release the name. If every plain candidate is taken, a short random suffix is appended (`sleepy-teal-otter-a1b2`).
- Slug allocation holds a per-team advisory lock, so concurrent creates on the base paths can't pick the same name (their per-base lock wouldn't catch it).
- The slug never changes; `displayName` stays the user-editable label. Clients show label, then slug, then id, and keep the id reachable since CLI verbs and URLs still use it.
- The slug is also passed to Freestyle as the console label so provider and client match.
- API routes (`GET /api/vm`, `GET/PATCH /api/vm/[id]`, `POST /api/vm`) now return `slug`.

**Migration**
- Run migration `20260902130000_cloud_vm_slugs` on staging and production before merging; it adds the column and the partial unique index.

<sup>Written for commit 53f2f5572ee1d2fd8575f42d4787e5c2e8c667a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cloud VMs now receive unique, human-readable three-word names.
  * VM names appear in the app and API responses.
  * Generated names are shown in supported provider consoles.
  * Existing labels remain unchanged; older unlabeled VMs fall back to provider IDs.

* **Bug Fixes**
  * Improved VM row naming and subtitle display when labels are unavailable.

* **Documentation**
  * Documented VM naming behavior and uniqueness rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->