### PR TITLE
cloud: surface whether after() has waitUntil for deferred create work

### DIFF
--- a/web/services/vms/routeHelpers.ts
+++ b/web/services/vms/routeHelpers.ts
@@ -1,4 +1,5 @@
 import type { Span } from "@opentelemetry/api";
+import { trace } from "@opentelemetry/api";
 import { after } from "next/server";
 import {
   activeTraceIds,
@@ -1069,9 +1070,16 @@ function normalizedOptionalString(value: string | null | undefined): string | nu
  */
 export function runAfterResponse(work: () => Promise<void>): void {
   const guarded = () => work().catch((err) => console.error("[VM] deferred work failed", err));
+  let mode: "after" | "detached" = "after";
   try {
     after(guarded);
-  } catch {
+  } catch (err) {
+    // Next throws E91 when the platform gave it no `waitUntil`. Detached work
+    // then dies the moment the function is frozen, so say so where it can be
+    // seen: a log line before the response and an attribute on the request span.
+    mode = "detached";
+    console.warn(`[VM] after() unavailable, running deferred work detached: ${err instanceof Error ? err.message : String(err)}`);
     void guarded();
   }
+  trace.getActiveSpan()?.setAttribute("cmux.after_response.mode", mode);
 }


### PR DESCRIPTION
Deferred create work from https://github.com/manaflow-ai/cmux/pull/11756 and https://github.com/manaflow-ai/cmux/pull/11771 (plan reconcile, coderouter edge probe) shows in production traces as fetch spans of 0.5 to 4 ms with no log lines, which is what a function frozen right after the response looks like. Next's `after()` throws E91 when the platform provides no `waitUntil`; `runAfterResponse` caught that silently and ran the work detached.

This PR keeps the behaviour and makes it visible: a `console.warn` before the response when `after()` is unavailable, and `cmux.after_response.mode` (`after` or `detached`) on the request span. The next production create tells us which path we are on; if it is `detached`, the follow-up is wiring `waitUntil` (or moving the probe to the reconcile cron), not more guessing.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1790999285&installation_model_id=21920&pr_number=11782&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11782&signature=01a7aaf81586dbe0da3f76249b4e73db8fc5c5dd16ce63eb1d62260bdd75c01f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes deferred create work's execution mode visible so production traces show whether `after()` had `waitUntil` support.

`runAfterResponse` previously swallowed Next's E91 error and ran the work detached without a trace. It now logs a warning before the response and sets `cmux.after_response.mode` (`after` or `detached`) on the request span, so Axiom and function logs show which path ran.

<sup>Written for commit 37d42043cb6fbf3123a817e2a0fdc74e6a8f1871. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

