### PR TITLE
cloud: lgx 12 vCPU / 24 GB size, 20260903c ladder, Freestyle preconnect, one-exec attach

### DIFF
--- a/web/app/api/vm/[id]/attach-endpoint/route.ts
+++ b/web/app/api/vm/[id]/attach-endpoint/route.ts
@@ -1,3 +1,4 @@
+import { preconnectFreestyle } from "../../../../../services/vms/drivers/freestyle";
 import {
   jsonResponse,
   resolveVmRouteAccountScope,
@@ -17,6 +18,8 @@ export async function POST(
   request: Request,
   { params }: { params: Promise<{ id: string }> },
 ): Promise<Response> {
+  // Warm the Freestyle connection while the caller is being verified.
+  preconnectFreestyle();
   return withAuthedVmApiRoute(
     request,
     "/api/vm/[id]/attach-endpoint",

--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -1,6 +1,7 @@
 // Authenticated REST facade over the VM control plane. Native clients use this surface so
 // provider credentials stay behind server-side ownership checks.
 
+import { preconnectFreestyle } from "../../../services/vms/drivers/freestyle";
 import {
   unauthorized,
   verifyRequest,
@@ -173,6 +174,8 @@ export async function GET(request: Request): Promise<Response> {
 }
 
 export async function POST(request: Request): Promise<Response> {
+  // Warm the Freestyle connection while the caller is being verified.
+  preconnectFreestyle();
   return withAuthedVmApiRoute(
     request,
     "/api/vm",

--- a/web/services/vms/drivers/cmuxTuiDaemon.ts
+++ b/web/services/vms/drivers/cmuxTuiDaemon.ts
@@ -676,6 +676,100 @@ export async function isCmuxTuiDeviceEnrolled(
   );
 }
 
+/**
+ * Everything attach needs from the daemon in ONE guest exec instead of four:
+ * an optional readiness gate (exit 3 when it fails, so the caller can run the
+ * heal), the daemon build (`remote-probe`), the enrolled devices, and, unless
+ * the caller's fingerprint is already among them, a fresh invitation. Each
+ * section is fenced by a marker line so the outputs parse independently.
+ */
+export const CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT = 3;
+const BUNDLE_MARKERS = { probe: "__CMUX_PROBE__", devices: "__CMUX_DEVICES__", invite: "__CMUX_INVITE__", end: "__CMUX_END__" } as const;
+
+export function cmuxTuiAttachBundleCommand(options: {
+  readonly readyGate?: string;
+  readonly deviceFingerprint?: string;
+  readonly binary?: string;
+}): string {
+  const bin = options.binary ?? CMUX_TUI_BINARY_PATH;
+  const run = `env HOME=/root ${bin}`;
+  const fingerprint = options.deviceFingerprint?.trim();
+  if (fingerprint !== undefined && fingerprint !== "" && !/^[A-Za-z0-9._:=+/-]+$/.test(fingerprint)) {
+    throw new Error("device fingerprint has an unexpected shape");
+  }
+  // The shell decides only whether to mint; the server re-derives "enrolled"
+  // from the devices JSON and mints separately if the two disagree.
+  const needle = fingerprint ? `"fingerprint":"${fingerprint}"` : "";
+  const mint = `${run} remote enroll create --session ${CMUX_TUI_SESSION} --ttl ${CMUX_TUI_INVITATION_TTL_SECONDS} --json`;
+  const invite = needle
+    ? `case "$D" in *${shellQuote(needle)}*) ;; *) ${mint};; esac`
+    : mint;
+  return [
+    ...(options.readyGate ? [`{ ${options.readyGate}; } || exit ${CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT}`] : []),
+    `echo ${BUNDLE_MARKERS.probe}`,
+    `${run} remote-probe --json; echo`,
+    `echo ${BUNDLE_MARKERS.devices}`,
+    `D=$(${run} remote enroll devices --session ${CMUX_TUI_SESSION} --json); printf '%s\\n' "$D"`,
+    `echo ${BUNDLE_MARKERS.invite}`,
+    `${invite}; echo`,
+    `echo ${BUNDLE_MARKERS.end}`,
+  ].join("; ");
+}
+
+export type CmuxTuiAttachBundle = {
+  readonly daemonBuild: CmuxRemoteEndpoint["daemonBuild"] | null;
+  readonly enrolled: boolean;
+  readonly invitation: NonNullable<CmuxRemoteEndpoint["invitation"]> | null;
+};
+
+/** Parses the fenced stdout of {@link cmuxTuiAttachBundleCommand}. */
+export function parseCmuxTuiAttachBundle(
+  stdout: string,
+  provider: ProviderId,
+  vmId: string,
+  deviceFingerprint?: string,
+): CmuxTuiAttachBundle {
+  const section = (from: string, to: string): string => {
+    const start = stdout.indexOf(from);
+    const end = stdout.indexOf(to);
+    if (start === -1 || end === -1 || end < start) return "";
+    return stdout.slice(start + from.length, end).trim();
+  };
+  const probeText = section(BUNDLE_MARKERS.probe, BUNDLE_MARKERS.devices);
+  const devicesText = section(BUNDLE_MARKERS.devices, BUNDLE_MARKERS.invite);
+  const inviteText = section(BUNDLE_MARKERS.invite, BUNDLE_MARKERS.end);
+  let daemonBuild: CmuxTuiAttachBundle["daemonBuild"] = null;
+  try {
+    const record = parseJsonObject(probeText);
+    const commit = typeof record.build_identity === "string" ? record.build_identity : null;
+    const remoteProtocol = typeof record.remote_protocol === "number" ? record.remote_protocol : null;
+    const version = typeof record.version === "string" ? record.version : null;
+    if (commit || remoteProtocol !== null) daemonBuild = { commit, remoteProtocol, version };
+  } catch {
+    daemonBuild = null;
+  }
+  let enrolled = false;
+  if (deviceFingerprint) {
+    try {
+      enrolled = parseJsonArray(devicesText).some((device) =>
+        device.fingerprint === deviceFingerprint && (device.revoked_at_unix === null || device.revoked_at_unix === undefined)
+      );
+    } catch {
+      enrolled = false;
+    }
+  }
+  let invitation: CmuxTuiAttachBundle["invitation"] = null;
+  if (inviteText) {
+    const uri = parseJsonObject(inviteText).uri;
+    if (typeof uri !== "string" || !uri) {
+      throw new ProviderError(provider, `cmux-tui enrollment invitation in ${vmId} returned no uri`);
+    }
+    const parsed = parseEnrollmentInvitationUri(uri, provider);
+    invitation = { uri, invitationId: parsed.id, expiresAtUnix: parsed.expiresAtUnix };
+  }
+  return { daemonBuild, enrolled, invitation };
+}
+
 export async function approveCmuxTuiEnrollment(
   invoke: CmuxTuiInvoke,
   provider: ProviderId,

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -49,12 +49,14 @@ import {
   CMUX_TUI_PORT,
   CMUX_TUI_SESSION,
   approveCmuxTuiEnrollment,
+  CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT,
+  cmuxTuiAttachBundleCommand,
   cmuxTuiDaemonBuild,
   cmuxTuiDaemonCommand,
   cmuxTuiInstallCommand,
   cmuxTuiPinCheckCommand,
-  isCmuxTuiDeviceEnrolled,
   mintCmuxTuiInvitation,
+  parseCmuxTuiAttachBundle,
   resolveCmuxTuiSource,
   type CmuxTuiSource,
   waitForCmuxTuiReady,
@@ -170,6 +172,18 @@ export type FreestyleProviderDependencies = {
  * the SDK's own default — the public api.freestyle.sh — is used. The
  * stack-token pair mirrors build-devbox-freestyle.ts for interactive use.
  */
+/**
+ * Open the TCP+TLS connection to the Freestyle API before it is needed. The
+ * first Freestyle call of a function invocation paid about 130 ms of DNS, TCP,
+ * and TLS in production (vpc.get: 150 ms from pdx1, 12 ms warm); a route fires
+ * this while it is still verifying the caller so the real call finds the
+ * connection in undici's pool. Best effort, never awaited for correctness.
+ */
+export function preconnectFreestyle(): void {
+  const baseUrl = process.env.FREESTYLE_API_URL?.trim() || "https://api.freestyle.sh";
+  fetch(`${baseUrl}/`, { method: "HEAD", signal: AbortSignal.timeout(3_000) }).catch(() => undefined);
+}
+
 function freestyleClient(timeoutMs = DEFAULT_TIMEOUT_MS): Freestyle {
   const longFetch: typeof fetch = (input, init) =>
     fetch(input as Request, { ...(init ?? {}), signal: AbortSignal.timeout(timeoutMs) });
@@ -358,6 +372,21 @@ export function freestyleDesktopHealCommand(): string {
  * are allocated at create, so the create response already carries them; a
  * response without any (no network) contributes nothing.
  */
+/**
+ * The persisted network addresses (see {@link freestyleNetworkAddressMetadata})
+ * re-shaped for {@link freestyleCmuxRemoteRoute}, so attach on a private
+ * machine needs no provider read. Null when the row carries none (a public
+ * ingress machine, whose public IPv6 is only known to the provider).
+ */
+export function freestyleRouteAddressesFromMetadata(
+  metadata: Record<string, unknown> | undefined,
+): FreestyleRouteAddresses | null {
+  const ipv4 = typeof metadata?.networkIpv4 === "string" ? metadata.networkIpv4.trim() : "";
+  const ipv6 = typeof metadata?.networkIpv6 === "string" ? metadata.networkIpv6.trim() : "";
+  if (!ipv4 && !ipv6) return null;
+  return { vpcs: [{ ...(ipv4 ? { ipv4 } : {}), ...(ipv6 ? { ipv6 } : {}) }] };
+}
+
 export function freestyleNetworkAddressMetadata(
   data: FreestyleRouteAddresses,
 ): { networkIpv4?: string; networkIpv6?: string } {
@@ -1106,25 +1135,51 @@ export class FreestyleProvider implements VMProvider {
         try {
           const fs = this.deps.client(CMUX_TUI_INSTALL_TIMEOUT_MS + EXEC_OVERHEAD_TIMEOUT_MS);
           const vm = fs.vms.ref(vmId);
-          const data = await vm.data();
+          // The row already holds the private addresses from create; only a
+          // public-ingress machine needs the provider read for its IPv6.
+          const persisted = freestyleRouteAddressesFromMetadata(options?.providerMetadata);
+          const data = persisted ?? await vm.data();
           const route = freestyleCmuxRemoteRoute(data, vmId);
           span.setAttribute("cmux.vm.network.private", (data.vpcs ?? data.networks ?? []).length > 0);
-          await this.ensureCmuxTuiRunning(vm, vmId);
-          const invoke = this.cmuxTuiInvoke(vm);
+          span.setAttribute("cmux.vm.route.source", persisted ? "row" : "provider");
           // Direct-IPv6 carries no URL token; this one exists only for the
           // lease ledger. The daemon's Noise enrollment is the session gate —
           // the same trust model as E2B's public proxy route.
           const token = `cmux-freestyle-route-${randomBytes(32).toString("hex")}`;
           const expiresAtUnix = Math.floor(Date.now() / 1000) + ROUTE_TOKEN_TTL_SECONDS;
-          let invitation: CmuxRemoteEndpoint["invitation"];
-          const enrolled = options?.deviceFingerprint
-            ? await isCmuxTuiDeviceEnrolled(invoke, options.deviceFingerprint)
-            : false;
-          if (!enrolled) {
+          // One guest exec: readiness gate, daemon build, enrolled devices, and
+          // an invitation unless the caller is enrolled. Exit 3 means the daemon
+          // was not ready inside the settle budget; heal, then run it again.
+          const fingerprint = options?.deviceFingerprint;
+          let bundleResult = await this.execResult(
+            vm,
+            cmuxTuiAttachBundleCommand({ readyGate: freestyleDaemonSettledCommand(), deviceFingerprint: fingerprint }),
+            DAEMON_SETTLE_TIMEOUT_MS + EXEC_OVERHEAD_TIMEOUT_MS + EXEC_DEFAULT_TIMEOUT_MS,
+          );
+          let healed = false;
+          if (!bundleResult || bundleResult.exitCode === CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT) {
+            healed = true;
+            await this.ensureCmuxTuiRunning(vm, vmId);
+            bundleResult = await this.execResult(vm, cmuxTuiAttachBundleCommand({ deviceFingerprint: fingerprint }));
+          }
+          if (!bundleResult || bundleResult.exitCode !== 0) {
+            throw new ProviderError(
+              "freestyle",
+              `cmux-tui attach bundle in ${vmId} failed (exit ${bundleResult?.exitCode ?? "n/a"}): ${(bundleResult?.stderr || bundleResult?.stdout || "").slice(0, 500)}`,
+            );
+          }
+          const bundle = parseCmuxTuiAttachBundle(bundleResult.stdout, "freestyle", vmId, fingerprint);
+          span.setAttribute("cmux.vm.cmux_remote.healed", healed);
+          const invoke = this.cmuxTuiInvoke(vm);
+          const enrolled = bundle.enrolled;
+          let invitation: CmuxRemoteEndpoint["invitation"] = bundle.invitation ?? undefined;
+          if (!enrolled && !invitation) {
+            // The shell's substring check and the JSON parse disagreed (a
+            // revoked device with the same fingerprint): mint separately.
             invitation = await mintCmuxTuiInvitation(invoke, "freestyle", vmId);
           }
           span.setAttribute("cmux.vm.cmux_remote.invited", !enrolled);
-          const daemonBuild = await cmuxTuiDaemonBuild(invoke);
+          const daemonBuild = bundle.daemonBuild ?? await cmuxTuiDaemonBuild(invoke);
           const addresses = freestyleNetworkAddressMetadata(data);
           const networkAddresses = {
             ...(addresses.networkIpv4 ? { ipv4: addresses.networkIpv4 } : {}),

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -1351,7 +1351,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -1381,7 +1381,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -1411,7 +1411,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -1441,7 +1441,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -1471,7 +1471,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "2xl",
         "cpu": 32,
@@ -1501,7 +1501,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -1531,7 +1531,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -1561,7 +1561,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -1591,7 +1591,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -1621,6 +1621,364 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 89e4701f88, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-60effaffd5404e5ab8dbdb08bd5f5eed, md=sh-1ce6c11f5d6e4f8e98c19454e9a38751, lg=sh-bda89603f1ab41a2902ac5d781e2c6ce, xl=sh-95b526e17c234593a45edfb572e49396, 2xl=sh-236a1866dd244082ba0f06829df2358d.",
       "cmuxTuiCommit": "89e4701f88fa6b40f1c8d7c81f5af78e044ddfa0",
       "cmuxTuiSha256": "cfd1e3b79a3196ce6a321216527d899402e871003fba58955bd81ddb9a7a6fc9",
+      "defaultForKind": false,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-sm",
+      "imageId": "sh-00f5b71a50a24f9bb14983ea0084099b",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-md",
+      "imageId": "sh-feb59d2dbc234ffdbd2338b84a60afff",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-lg",
+      "imageId": "sh-b1d78856a09345e8998e893485b58ea1",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-lgx",
+      "imageId": "sh-d99b849211844f70a32b54b701ec6892",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-xl",
+      "imageId": "sh-3768588f0dbb4d9e9427a1c7b893a9fc",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-2xl",
+      "imageId": "sh-44e2dbac4a3f4deeabc156176d3ed106",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "desktop",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-sm-base",
+      "imageId": "sh-00f5b71a50a24f9bb14983ea0084099b",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-md-base",
+      "imageId": "sh-feb59d2dbc234ffdbd2338b84a60afff",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-lg-base",
+      "imageId": "sh-b1d78856a09345e8998e893485b58ea1",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-lgx-base",
+      "imageId": "sh-d99b849211844f70a32b54b701ec6892",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-xl-base",
+      "imageId": "sh-3768588f0dbb4d9e9427a1c7b893a9fc",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-20260903c-2xl-base",
+      "imageId": "sh-44e2dbac4a3f4deeabc156176d3ed106",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "18bec20718ef2e5607c16aa03e77e9fe11e6b362",
+      "builtAt": "2026-09-03T04:36:32.773Z",
+      "builderScriptVersion": "119705f786a8c73c67e13005d23314d6ed4ba73b6cb3a107580078c7626c758b",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0915892575, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-03 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-00f5b71a50a24f9bb14983ea0084099b, md=sh-feb59d2dbc234ffdbd2338b84a60afff, lg=sh-b1d78856a09345e8998e893485b58ea1, lgx=sh-d99b849211844f70a32b54b701ec6892, xl=sh-3768588f0dbb4d9e9427a1c7b893a9fc, 2xl=sh-44e2dbac4a3f4deeabc156176d3ed106.",
+      "cmuxTuiCommit": "0915892575ecdf37f0240661961aff7f1ad5b1d3",
+      "cmuxTuiSha256": "c372d19f99021af1825fc8d90bb602e9794955076156198cd0e8e26e07e11e19",
       "defaultForKind": true,
       "size": {
         "name": "2xl",

--- a/web/services/vms/images/sizes.ts
+++ b/web/services/vms/images/sizes.ts
@@ -11,7 +11,7 @@
  * `md` is Freestyle's bare default slug (`freestyle/ubuntu`); the others keep
  * Freestyle's suffixes.
  */
-export type VmImageSizeName = "sm" | "md" | "lg" | "xl" | "2xl";
+export type VmImageSizeName = "sm" | "md" | "lg" | "lgx" | "xl" | "2xl";
 
 export type VmImageSize = {
   readonly name: VmImageSizeName;
@@ -21,13 +21,16 @@ export type VmImageSize = {
   /** MiB (a "64 GB" disk is 65536, matching how Freestyle counts). */
   readonly storageMb: number;
   /** The Freestyle base snapshot with this exact shape. */
-  readonly freestyleBase: string;
+  /** The Freestyle catalog base that boots at this shape; absent for a shape cmux derives by resize only. */
+  readonly freestyleBase?: string;
 };
 
 export const VM_IMAGE_SIZES: readonly VmImageSize[] = [
   { name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384, freestyleBase: "freestyle/ubuntu-sm" },
   { name: "md", cpu: 4, memoryMb: 8192, storageMb: 32768, freestyleBase: "freestyle/ubuntu" },
   { name: "lg", cpu: 8, memoryMb: 16384, storageMb: 65536, freestyleBase: "freestyle/ubuntu-lg" },
+  // Not in Freestyle's catalog: the step the 20 GB plan machine lands on, derived by resize.
+  { name: "lgx", cpu: 12, memoryMb: 24576, storageMb: 98304 },
   { name: "xl", cpu: 16, memoryMb: 32768, storageMb: 131072, freestyleBase: "freestyle/ubuntu-xl" },
   { name: "2xl", cpu: 32, memoryMb: 65536, storageMb: 131072, freestyleBase: "freestyle/ubuntu-2xl" },
 ];

--- a/web/tests/vm-cmux-tui.test.ts
+++ b/web/tests/vm-cmux-tui.test.ts
@@ -12,6 +12,8 @@ import {
   cmuxTuiPersistentMountWait,
   parseCmuxTuiManifest,
   parseEnrollmentInvitationUri,
+  cmuxTuiAttachBundleCommand,
+  parseCmuxTuiAttachBundle,
 } from "../services/vms/drivers/cmuxTuiDaemon";
 
 const SHA = "c7a3155341a85a2f10a873d69a041bdf1855ec059a802e58e0779a7a6bdec607";
@@ -790,5 +792,54 @@ describe("enrollment invitation parsing", () => {
     expect(() => parseEnrollmentInvitationUri("cmux://enroll/!!!")).toThrow(/undecodable|id or expiry/);
     const missing = `cmux://enroll/${Buffer.from(JSON.stringify({ version: 1 })).toString("base64url")}`;
     expect(() => parseEnrollmentInvitationUri(missing)).toThrow(/id or expiry/);
+  });
+});
+
+describe("cmux-tui attach bundle", () => {
+  const stdoutFor = (probe: string, devices: string, invite: string) =>
+    ["__CMUX_PROBE__", probe, "__CMUX_DEVICES__", devices, "__CMUX_INVITE__", invite, "__CMUX_END__", ""].join("\n");
+  const invitation = `cmux://enroll/${Buffer.from(JSON.stringify({ id: "inv-abc", expires_at_unix: 1900000000 })).toString("base64url")}`;
+
+  test("one exec carries the readiness gate, the probe, the devices, and a conditional mint", () => {
+    const command = cmuxTuiAttachBundleCommand({ readyGate: "test -f /ready", deviceFingerprint: "fp-1" });
+    expect(command).toContain("{ test -f /ready; } || exit 3");
+    expect(command).toContain("remote-probe --json");
+    expect(command).toContain("remote enroll devices --session cloud --json");
+    expect(command).toContain(`case "$D" in *'"fingerprint":"fp-1"'*) ;; *) env HOME=/root /root/.cmux/bin/cmux-tui remote enroll create --session cloud --ttl 300 --json;; esac`);
+    expect(cmuxTuiAttachBundleCommand({})).not.toContain("exit 3");
+    expect(cmuxTuiAttachBundleCommand({})).not.toContain("case");
+    expect(() => cmuxTuiAttachBundleCommand({ deviceFingerprint: "bad fp; rm -rf /" })).toThrow("unexpected shape");
+  });
+
+  test("parses build, enrollment, and invitation from the fenced output", () => {
+    const parsed = parseCmuxTuiAttachBundle(
+      stdoutFor(
+        JSON.stringify({ build_identity: "abc123", remote_protocol: 12, version: "0.13.0" }),
+        JSON.stringify([{ fingerprint: "fp-2", revoked_at_unix: null }]),
+        JSON.stringify({ uri: invitation }),
+      ),
+      "freestyle",
+      "vm-1",
+      "fp-1",
+    );
+    expect(parsed.daemonBuild).toEqual({ commit: "abc123", remoteProtocol: 12, version: "0.13.0" });
+    expect(parsed.enrolled).toBe(false);
+    expect(parsed.invitation?.invitationId).toBe("inv-abc");
+  });
+
+  test("an enrolled, unrevoked fingerprint needs no invitation; a revoked one does", () => {
+    const enrolled = parseCmuxTuiAttachBundle(
+      stdoutFor("{}", JSON.stringify([{ fingerprint: "fp-1", revoked_at_unix: null }]), ""),
+      "freestyle", "vm-1", "fp-1",
+    );
+    expect(enrolled.enrolled).toBe(true);
+    expect(enrolled.invitation).toBeNull();
+    expect(enrolled.daemonBuild).toBeNull();
+    const revoked = parseCmuxTuiAttachBundle(
+      stdoutFor("{}", JSON.stringify([{ fingerprint: "fp-1", revoked_at_unix: 1 }]), ""),
+      "freestyle", "vm-1", "fp-1",
+    );
+    expect(revoked.enrolled).toBe(false);
+    expect(revoked.invitation).toBeNull();
   });
 });

--- a/web/tests/vm-freestyle-provider.test.ts
+++ b/web/tests/vm-freestyle-provider.test.ts
@@ -9,6 +9,7 @@ import {
   assertNoRouteTokenInGuestPayload,
   freestyleCmuxRemoteRoute,
   freestyleNetworkAddressMetadata,
+  freestyleRouteAddressesFromMetadata,
   freestyleDaemonHealthyCommand,
   freestyleDesktopHealCommand,
   freestyleEdgeProbeCommand,
@@ -418,6 +419,15 @@ const driverSource = readFileSync(
   path.join(import.meta.dirname, "../services/vms/drivers/freestyle.ts"),
   "utf8",
 );
+
+describe("Freestyle attach route source", () => {
+  test("attach builds the route from the persisted row addresses, falling back to the provider only without them", () => {
+    expect(freestyleRouteAddressesFromMetadata({ networkIpv4: "10.0.0.5", networkIpv6: "fd00::5" })).toEqual({ vpcs: [{ ipv4: "10.0.0.5", ipv6: "fd00::5" }] });
+    expect(freestyleCmuxRemoteRoute(freestyleRouteAddressesFromMetadata({ networkIpv4: " 10.0.0.5 " })!, VM_ID)).toBe("ws://10.0.0.5:1337/v1/link");
+    expect(freestyleRouteAddressesFromMetadata({ networkId: "vpc-1" })).toBeNull();
+    expect(freestyleRouteAddressesFromMetadata(undefined)).toBeNull();
+  });
+});
 
 describe("Freestyle client configuration", () => {
   test("every guest exec is pinned to root", () => {

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -22,21 +22,21 @@ function captureImageConfigError(fn: () => unknown): VmImageConfigError {
   throw new Error("expected VmImageConfigError to be thrown");
 }
 
-// The committed manifest default: the `freestyle-cmux-devbox-11761b` ladder
+// The committed manifest default: the `freestyle-cmux-devbox-20260903c` ladder
 // (the desktop session with owner-signalled readiness, the accessibility bus,
 // clipboard helper and published DISPLAY; epoch 2026-09-02-r4), one snapshot per Freestyle size,
 // listed under both kinds (a desktop image is a superset of a base one, so
 // the same snapshot id serves both; the base listing's version carries a
 // `-base` suffix). The manifest is the only source of truth for images; no env
 // var selects or overrides one, and the plan's memory picks the size.
-const ladderVersion = "freestyle-cmux-devbox-11761b";
+const ladderVersion = "freestyle-cmux-devbox-20260903c";
 const ladder = {
-  sm: "sh-60effaffd5404e5ab8dbdb08bd5f5eed",
-  md: "sh-1ce6c11f5d6e4f8e98c19454e9a38751",
-  lg: "sh-bda89603f1ab41a2902ac5d781e2c6ce",
-  lgx: "PENDING-20260903c",
-  xl: "sh-95b526e17c234593a45edfb572e49396",
-  "2xl": "sh-236a1866dd244082ba0f06829df2358d",
+  sm: "sh-00f5b71a50a24f9bb14983ea0084099b",
+  md: "sh-feb59d2dbc234ffdbd2338b84a60afff",
+  lg: "sh-b1d78856a09345e8998e893485b58ea1",
+  lgx: "sh-d99b849211844f70a32b54b701ec6892",
+  xl: "sh-3768588f0dbb4d9e9427a1c7b893a9fc",
+  "2xl": "sh-44e2dbac4a3f4deeabc156176d3ed106",
 } as const;
 // cmux's validated pre-ladder public-platform devbox: still listed (base only,
 // size-less) so stored rows and explicit requests keep resolving, no longer a
@@ -153,7 +153,7 @@ describe("VM image resolver: request by kind", () => {
     // Both kinds offer the whole ladder, smallest first.
     for (const kind of ["desktop", "base"] as const) {
       expect(listVmImageSizes("freestyle", kind).map((size) => size.name)).toEqual([...VM_IMAGE_SIZE_NAMES]);
-      expect(findVmImageKindDefault("freestyle", kind, 20480)?.size?.name).toBe("xl");
+      expect(findVmImageKindDefault("freestyle", kind, 20480)?.size?.name).toBe("lgx");
     }
     expect(listVmImageKinds("freestyle", deployed, { memoryMb: 20480 })).toEqual([
       { kind: "desktop", image: ladder.xl, size: vmImageSize("xl") },
@@ -169,7 +169,7 @@ describe("VM image resolver: request by kind", () => {
     );
     expect(err).toMatchObject({ provider: "freestyle", kind: "desktop", source: "default" });
     expect(err.reason).toBe(
-      "no desktop image size fits 131072 MiB for freestyle: the manifest offers sm (4096 MiB), md (8192 MiB), lg (16384 MiB), xl (32768 MiB), 2xl (65536 MiB)",
+      "no desktop image size fits 131072 MiB for freestyle: the manifest offers sm (4096 MiB), md (8192 MiB), lg (16384 MiB), lgx (24576 MiB), xl (32768 MiB), 2xl (65536 MiB)",
     );
     expect(findVmImageKindDefault("freestyle", "base", 65537)).toBeNull();
 
@@ -286,8 +286,8 @@ describe("VM image resolver", () => {
     });
     expect(resolveVmImage("freestyle", undefined, {}, { memoryMb: 20480 })).toMatchObject({
       provider: "freestyle",
-      image: ladder.xl,
-      imageVersion: `${ladderVersion}-xl-base`,
+      image: ladder.lgx,
+      imageVersion: `${ladderVersion}-lgx-base`,
     });
   });
 

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -34,6 +34,7 @@ const ladder = {
   sm: "sh-60effaffd5404e5ab8dbdb08bd5f5eed",
   md: "sh-1ce6c11f5d6e4f8e98c19454e9a38751",
   lg: "sh-bda89603f1ab41a2902ac5d781e2c6ce",
+  lgx: "PENDING-20260903c",
   xl: "sh-95b526e17c234593a45edfb572e49396",
   "2xl": "sh-236a1866dd244082ba0f06829df2358d",
 } as const;
@@ -122,9 +123,11 @@ describe("VM image resolver: request by kind", () => {
       [4097, "md"],
       [8192, "md"],
       [16384, "lg"],
-      // cmux's paid plan machine (20 GiB) is between lg and xl: it boots xl.
-      [20480, "xl"],
-      [24576, "xl"],
+      // cmux's paid plan machine (20 GiB) lands on lgx (12 vCPU / 24 GB), the
+      // step added for it; anything above boots xl.
+      [20480, "lgx"],
+      [24576, "lgx"],
+      [24577, "xl"],
       [32768, "xl"],
       [65536, "2xl"],
     ];

--- a/web/tests/vm-image-resolver.test.ts
+++ b/web/tests/vm-image-resolver.test.ts
@@ -156,8 +156,8 @@ describe("VM image resolver: request by kind", () => {
       expect(findVmImageKindDefault("freestyle", kind, 20480)?.size?.name).toBe("lgx");
     }
     expect(listVmImageKinds("freestyle", deployed, { memoryMb: 20480 })).toEqual([
-      { kind: "desktop", image: ladder.xl, size: vmImageSize("xl") },
-      { kind: "base", image: ladder.xl, size: vmImageSize("xl") },
+      { kind: "desktop", image: ladder.lgx, size: vmImageSize("lgx") },
+      { kind: "base", image: ladder.lgx, size: vmImageSize("lgx") },
     ]);
   });
 

--- a/web/tests/vm-image-sizes.test.ts
+++ b/web/tests/vm-image-sizes.test.ts
@@ -33,11 +33,12 @@ const entry = (overrides: Partial<DevboxManifestEntry> = {}): DevboxManifestEntr
 
 describe("size ladder", () => {
   test("mirrors Freestyle's catalog exactly, smallest first", () => {
-    expect(VM_IMAGE_SIZE_NAMES).toEqual(["sm", "md", "lg", "xl", "2xl"]);
+    expect(VM_IMAGE_SIZE_NAMES).toEqual(["sm", "md", "lg", "lgx", "xl", "2xl"]);
     expect(VM_IMAGE_SIZES.map((s) => [s.name, s.cpu, s.memoryMb, s.storageMb, s.freestyleBase])).toEqual([
       ["sm", 2, 4096, 16384, "freestyle/ubuntu-sm"],
       ["md", 4, 8192, 32768, "freestyle/ubuntu"],
       ["lg", 8, 16384, 65536, "freestyle/ubuntu-lg"],
+      ["lgx", 12, 24576, 98304, undefined],
       ["xl", 16, 32768, 131072, "freestyle/ubuntu-xl"],
       ["2xl", 32, 65536, 131072, "freestyle/ubuntu-2xl"],
     ]);
@@ -58,7 +59,9 @@ describe("size ladder", () => {
     expect(pickVmImageSizeForMemory(4096)?.name).toBe("sm");
     expect(pickVmImageSizeForMemory(4097)?.name).toBe("md");
     // cmux's paid default (24 GiB) is between lg and xl: it gets xl.
-    expect(pickVmImageSizeForMemory(24576)?.name).toBe("xl");
+    expect(pickVmImageSizeForMemory(20480)?.name).toBe("lgx");
+    expect(pickVmImageSizeForMemory(24576)?.name).toBe("lgx");
+    expect(pickVmImageSizeForMemory(24577)?.name).toBe("xl");
     expect(pickVmImageSizeForMemory(32768)?.name).toBe("xl");
     expect(pickVmImageSizeForMemory(65536)?.name).toBe("2xl");
     expect(pickVmImageSizeForMemory(65537)).toBeNull();


### PR DESCRIPTION
Three latency items from the per-call Freestyle table, plus the size ladder you asked for.

**Sizes.** `lgx` = 12 vCPU / 24 GB / 96 GB joins the ladder between `lg` and `xl`. It is not in Freestyle's catalog; like every size it is derived from the one bake by resize, so `freestyleBase` is now optional. The 20 GB plan machine lands on `lgx` instead of `xl`. The ladder `freestyle-cmux-devbox-20260903c` (sm, md, lg, lgx, xl, 2xl, both kinds) was baked from this branch with `promote-devbox-image.ts`: bake, verify (baked daemon up 311 ms after the first probe, distinct identities across two machines, desktop checks), derive each size, boot each derived snapshot and check its shape and units. It demotes `11761b`; earlier ladders stay listed for rollback. BusyBox is a different base image (1 vCPU, 128 MiB) that cannot run the devbox, so it is not a size of this ladder.

**Preconnect.** The first Freestyle call of a cold invocation paid about 130 ms of DNS, TCP, and TLS in production (`vpc.get` 150 ms from pdx1 against 12 ms warm). The create and attach routes fire a `HEAD` at the API while the caller is still being verified, so the real call finds the connection in undici's pool. Best effort, never awaited.

**Attach in one exec.** `openCmuxRemote` ran `vm.data()` plus four guest execs (settle check, `remote-probe`, `enroll devices`, `enroll create`), 244 to 309 ms in production after the settle fix. Now the route comes from the row's persisted network addresses (`vm.data()` only for a public-ingress machine), and one guest exec carries the readiness gate, the probe, the devices, and a conditional mint (`cmuxTuiAttachBundleCommand`, parsed by `parseCmuxTuiAttachBundle`). Exit 3 from the gate runs the heal and retries once; if the shell's fingerprint check and the JSON parse disagree (a revoked device), the server mints separately. Expected: `open_cmux_remote` about 60 to 120 ms.

Measured floors this was built from (from a laptop, 13 ms RTT): `vms.create` with VPC inline 258 to 299 ms, public 65 to 101 ms; `vm.data()` 11 to 14 ms; a guest exec 20 to 58 ms; `fs.writeTextFile` 33 to 83 ms; `vpc.get` 9 to 12 ms.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `lgx` VM size (12 vCPU / 24 GB / 96 GB) between `lg` and `xl`, so the 20 GB plan machine now lands on `lgx` instead of `xl`. Also cuts Freestyle attach latency by preconnecting to the API and running all attach checks in a single guest exec.

**Sizes and image ladder**
- `lgx` is not in Freestyle's catalog; it's derived by resize, so `freestyleBase` is now optional.
- The new `freestyle-cmux-devbox-20260903c` ladder includes all six sizes, is baked and validated, and demotes the previous `11761b` ladder (older ladders stay listed for rollback).

**Attach latency**
- Create and attach routes fire a `HEAD` to the Freestyle API while the caller is being verified, so the first real call finds a warm connection (~130 ms saved on cold invocations).
- `openCmuxRemote` now uses persisted network addresses for the route (only public-ingress machines need a provider read) and runs readiness gate, daemon probe, device list, and conditional invitation in one guest exec; exit 3 triggers the heal and one retry.

<sup>Written for commit 7ab9c54f7922414ecfa356ffcd9d0a6082583654. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the new **lgx** VM size with 12 CPUs, 24 GiB memory, and 96 GiB storage.
  * Updated default VM images to the latest Freestyle development image family.
  * Improved VM attachment by reusing available network addresses and streamlining connection setup.

* **Performance**
  * Freestyle connections now begin warming before request verification and VM provisioning, reducing attachment wait times.

* **Bug Fixes**
  * Improved attachment handling for device enrollment, readiness checks, and invitation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->