### PR TITLE
ci: avoid duplicate TUI spec inventory checks

### DIFF
--- a/.github/workflows/cmux-tui-sdks.yml
+++ b/.github/workflows/cmux-tui-sdks.yml
@@ -95,14 +95,8 @@ jobs:
             --disable-pip-version-check \
             "PyYAML==6.0.3"
 
-      - name: Test protocol inventory
-        run: python3 cmux-tui/scripts/test_check_spec_inventory.py
-
       - name: Test published artifact manifest verifier
         run: python3 -m unittest discover -s cmux-tui/scripts -p 'test_verify_published_manifest.py' -v
-
-      - name: Check protocol and TUI action inventory
-        run: python3 cmux-tui/scripts/check-spec-inventory.py
 
       - name: Test SDK schema drift checker
         run: python3 cmux-tui/scripts/test_check_sdk_schema.py

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -78,6 +78,19 @@ def test_sdk_ci_tracks_tui_verification_and_packaging_workflows() -> None:
         assert required_paths <= set(paths)
 
 
+def test_spec_inventory_checks_are_not_duplicated_in_sdk_contract() -> None:
+    spec = workflow("cmux-tui-spec.yml")
+    sdk_contract = workflow_job(workflow("cmux-tui-sdks.yml"), "contract")
+
+    inventory_checks = (
+        "python3 cmux-tui/scripts/test_check_spec_inventory.py",
+        "python3 cmux-tui/scripts/check-spec-inventory.py",
+    )
+    for command in inventory_checks:
+        assert command in spec
+        assert command not in sdk_contract
+
+
 def test_macos_tui_tests_use_a_short_temp_root_for_unix_sockets() -> None:
     tui = workflow("cmux-tui.yml")
     test_job = workflow_job(tui, "test")


### PR DESCRIPTION
Summary:
- Keep protocol inventory checks in the dedicated cmux-tui spec workflow.
- Remove the duplicate test and check steps from the SDK contract workflow.
- Add a workflow security test that asserts single ownership and retained coverage.

Verification:
- `python3 -m unittest tests/test_tui_publish_workflow_security.py -v` (64 passed)
- `actionlint .github/workflows/cmux-tui-spec.yml .github/workflows/cmux-tui-sdks.yml`
- `git diff --check`

The test commit precedes the workflow change commit so CI fails before the deduplication and passes after it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791004034&installation_model_id=21920&pr_number=11786&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11786&signature=89e4bd5a3b9916362f12f6e33cbd9bf61cd7ee3c246f74cc3da274ab85f7914f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate TUI spec inventory checks from the SDK contract workflow so those checks run only in the dedicated `cmux-tui-spec.yml` workflow.

- Adds a workflow security test that asserts the inventory commands are present in `cmux-tui-spec.yml` and absent from `cmux-tui-sdks.yml`.
- The test commit precedes the workflow change, so CI fails before deduplication and passes after.

<sup>Written for commit 26cfc750db548711ee7efefc1c9acaacb401afa5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

