### PR TITLE
Remove unused native child status wrapper

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -144,17 +144,6 @@ impl TerminalExit {
     }
 }
 
-/// Wait for the native child hidden behind cmux-pty without collapsing Unix
-/// signal/core information into its display-only fallback status.
-///
-/// cmux-pty's Unix backend returns `std::process::Child`, so failure to downcast
-/// is an alternate backend and becomes an explicit unknown outcome.
-pub(crate) fn wait_for_native_child_status(
-    child: &mut (dyn cmux_pty::Child + Send + Sync),
-) -> TerminalExit {
-    wait_for_native_child_status_with_reap_result(child).0
-}
-
 /// Wait for a PTY child and report whether the wait reaped it successfully.
 ///
 /// Callers that retain an owning guard can use the boolean to avoid issuing a

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -806,7 +806,7 @@ impl FrameDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Arc, Mutex, mpsc};
+    use std::sync::{mpsc, Arc, Mutex};
 
     /// Test-only stand-in for a direct pipe reader. The bounded queue models
     /// the byte pump, while the mutex is the single parser owner.
@@ -1115,7 +1115,7 @@ mod tests {
             let mut command = cmux_pty::PtyCommand::new("/bin/sh");
             command.args(["-c", script]);
             let mut spawned = pty.spawn(command).unwrap();
-            wait_for_native_child_status(spawned.child.as_mut()).outcome
+            wait_for_native_child_status_with_reap_result(spawned.child.as_mut()).0.outcome
         }
 
         assert_eq!(run("exit 17"), TerminalExitOutcome::Exit { code: 17 });


### PR DESCRIPTION
The native-child status wrapper became unused after callers switched to the reap-result API. Remove it and update the existing native PTY exit-status test to call the canonical helper.

Validation: cargo test -p cmux-tui-core --locked cmux_pty_native_child_retains_real_exit_and_signal_status; cargo check -p cmux-tui-core --locked (Blacksmith Testbox). Full clippy remains blocked by pre-existing warnings in mux.rs, journal_ingress.rs, surface.rs, and journal_checkpoint.rs.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the unused `wait_for_native_child_status` wrapper and updates the native PTY exit-status test to call the canonical `wait_for_native_child_status_with_reap_result` helper directly. No behavior changes.

<sup>Written for commit 579beb5782cfb5d0a3b51f8cb8c66f30c3fb1dba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

