### PR TITLE
cloud: drop the Freestyle calls create and attach do not need

### DIFF
--- a/web/app/api/vm/route.ts
+++ b/web/app/api/vm/route.ts
@@ -491,7 +491,6 @@ export async function POST(request: Request): Promise<Response> {
             perMachineHome: candidate.perMachineHome === true,
             memoryMb,
             imageSize: imageSelection.size ?? undefined,
-            afterResponse: runAfterResponse,
             modelPlane,
             timing,
           }));

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -9,7 +9,6 @@ import {
   type VpcData,
 } from "freestyle";
 import { randomBytes } from "node:crypto";
-import { VM_PLACEHOLDER_API_KEY } from "../../coderouter/routeTokenAuth";
 import {
   ProviderError,
   type AttachEndpoint,
@@ -35,7 +34,6 @@ import {
   type VMStatus,
 } from "./types";
 import { PLAN_MACHINE_MEMORY_MB, vcpusForMemoryMb, vmDiskMb } from "../machineSpec";
-import { context as otelContext } from "@opentelemetry/api";
 import {
   DEVBOX_DESKTOP_NOVNC_PORT,
   DEVBOX_DESKTOP_START_SCRIPT,
@@ -150,10 +148,6 @@ const EXEC_OVERHEAD_TIMEOUT_MS = 15_000;
 const ROUTE_TOKEN_TTL_SECONDS = 12 * 60 * 60;
 const MODEL_PLANE_ENV_PATH = "/root/.config/cmux/model-plane.env";
 /** Guest-side edge probe: 30 attempts x (5 s curl + 2 s sleep) worst case, under the 300 s exec cap. */
-const EDGE_PROBE_ATTEMPTS = 30;
-const EDGE_PROBE_PATH = "/api/coderouter/vm-usage/self";
-const EDGE_PROBE_URL = (host: string) => `https://${host}${EDGE_PROBE_PATH}`;
-const EDGE_PROBE_TIMEOUT_MS = 240_000;
 const ENV_NAME = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const EDGE_DOMAIN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
 const ROUTE_TOKEN_GRAMMAR = /\bcrt_[A-Za-z0-9._-]+/;
@@ -447,24 +441,6 @@ export function freestyleEdgeRules(edgeRules: readonly VmEdgeRule[] | undefined)
 }
 
 /**
- * Bounded guest-side loop, one exec: succeeds as soon as a request to the
- * edge-steered host returns 2xx (the injected token is live), fails after
- * ~60 s of 401s (injection not active yet) or connection errors. `-f` makes
- * curl exit non-zero on 401, and the CA the platform installed makes the
- * edge's certificate trusted without any flag.
- */
-export function freestyleEdgeProbeCommand(host: string): string {
-  if (!EDGE_DOMAIN.test(host)) {
-    throw new ProviderError("freestyle", `edge probe host ${JSON.stringify(host)} is not a bare host name`);
-  }
-  // The self-usage route answers 200 only when the edge injected a token
-  // bound to this machine together with its vm id; the placeholder bearer is
-  // ignored by the server. /v1/models is not usable here: the upstream
-  // requires a client_version query the guest does not know.
-  return `for i in $(seq 1 ${EDGE_PROBE_ATTEMPTS}); do curl -fsS -o /dev/null --max-time 5 -H 'authorization: Bearer ${VM_PLACEHOLDER_API_KEY}' ${EDGE_PROBE_URL(host)} && exit 0; sleep 2; done; exit 1`;
-}
-
-/**
  * Nothing that reaches the guest (env file, exec command) may carry a route
  * token: the token lives only in the edge rule. Throws on the `crt_` grammar.
  */
@@ -624,20 +600,26 @@ function isNotFound(err: unknown): boolean {
  * the provider match what it is asked for.
  */
 class FreestylePrivateNetworking implements VMPrivateNetworking {
-  async ensureNetwork(options: { slug: string; displayName?: string }): Promise<ProviderNetwork> {
+  /**
+   * Create-first: a returning user's network id lives in our row, so this runs
+   * for an account's first machine (or a heal). The create is the one call
+   * that has to happen; a slug conflict means another create won the race or
+   * a row went missing, and the read recovers the winner. `heal` (the
+   * reconcile cron) reads by slug and re-creates the members rule instead;
+   * it is off the request path because a rule deleted out of band is an
+   * operator event, not something every create should pay to re-check.
+   */
+  async ensureNetwork(options: { slug: string; displayName?: string; heal?: boolean }): Promise<ProviderNetwork> {
     const slug = options.slug.trim();
     if (!slug) throw new ProviderError("freestyle", "ensureNetwork requires a slug");
     return withVmSpan(
       "cmux.vm.provider.ensure_network",
-      { "cmux.vm.provider": "freestyle", "cmux.vm.operation": "ensure_network", "cmux.vm.network.slug": slug },
+      { "cmux.vm.provider": "freestyle", "cmux.vm.operation": "ensure_network", "cmux.vm.network.slug": slug, "cmux.vm.network.heal": options.heal === true },
       async (span) => {
         const fs = freestyleClient();
-        const existing = await this.readNetworkBySlug(fs, slug);
-        if (existing) {
-          // Create-time rules can be deleted out of band (dashboard, scripts),
-          // and a network without its members rule strands every machine on
-          // it. Heal on every reuse: listing is cheap, the create is
-          // conditional, and the rule is what the whole feature stands on.
+        if (options.heal) {
+          const existing = await this.readNetworkBySlug(fs, slug);
+          if (!existing) throw new ProviderError("freestyle", `ensureNetwork(${slug}): no network to heal`);
           await this.ensureMembersRule(fs, existing.id);
           setSpanAttributes(span, { "cmux.vm.network.id": existing.id, "cmux.vm.network.created": false });
           return existing;
@@ -645,8 +627,7 @@ class FreestylePrivateNetworking implements VMPrivateNetworking {
         try {
           // The CIDRs are deliberately left to the platform: a derived /24 out
           // of 10.0.0.0/8 and a unique-local /64 both sit inside a tunnel's
-          // default routes, so no cmux code has to allocate address space or
-          // keep two accounts from colliding.
+          // default routes, so no cmux code has to allocate address space.
           const { data } = await fs.vpc.create({
             slug,
             displayName: options.displayName,
@@ -655,13 +636,13 @@ class FreestylePrivateNetworking implements VMPrivateNetworking {
           setSpanAttributes(span, { "cmux.vm.network.id": data.id, "cmux.vm.network.created": true });
           return mapFreestyleNetwork(data);
         } catch (err) {
-          // Two machines created at once both miss the read and both create.
-          // The slug is unique per account, so the loser is told the name is
-          // taken — and the winner's network is the right answer for both.
-          const raced = await this.readNetworkBySlug(fs, slug);
-          if (raced) {
-            setSpanAttributes(span, { "cmux.vm.network.id": raced.id, "cmux.vm.network.created": false });
-            return raced;
+          // The slug is unique per account: the loser of a race, or a create
+          // for a user whose row was lost, is told the name is taken, and the
+          // existing network is the right answer.
+          const existing = await this.readNetworkBySlug(fs, slug);
+          if (existing) {
+            setSpanAttributes(span, { "cmux.vm.network.id": existing.id, "cmux.vm.network.created": false });
+            return existing;
           }
           throw new ProviderError("freestyle", `ensureNetwork(${slug})`, err);
         }
@@ -878,7 +859,6 @@ export class FreestyleProvider implements VMProvider {
             // The baked supervisor is already bringing the daemon up; the only
             // per-machine input it needs is the model-plane env file.
             if (options.envs) await this.writeModelPlaneEnv(vm, vmId, options.envs);
-            await this.verifyEdgeRules(vm, vmId, options.edgeRules, options.afterResponse);
           } catch (err) {
             // A VM that failed to size or configure must not survive as an
             // orphan, and an undersized machine must not ship as if it were
@@ -1102,7 +1082,6 @@ export class FreestyleProvider implements VMProvider {
           await this.ensureCmuxTuiRunning(vm, vmId).catch(() => undefined);
           try {
             if (options?.envs) await this.writeModelPlaneEnv(vm, vmId, options.envs);
-            await this.verifyEdgeRules(vm, vmId, options?.edgeRules, options?.afterResponse);
           } catch (err) {
             await vm.delete().catch((cleanupErr) => {
               console.error(`[freestyle] restore rollback failed; VM ${vmId} may be orphaned`, cleanupErr);
@@ -1324,69 +1303,6 @@ export class FreestyleProvider implements VMProvider {
    * inside the guest before handing the machine out; an inactive rule means
    * the machine can never reach a model, so the caller rolls it back.
    */
-  /**
-   * The edge rule is written inline by vms.create, but Freestyle activates it
-   * asynchronously (seconds; measured 3 to 11 s in production). Blocking the
-   * create on that activation made the whole request wait for the edge, so
-   * with a scheduler the probe runs after the response and reports on its own
-   * span (`cmux.vm.provider.edge_probe`): success as an attribute, failure as
-   * a recorded span error plus a log line. Without a scheduler the probe is
-   * awaited and a failure rolls the machine back, as before.
-   */
-  private async verifyEdgeRules(
-    vm: Vm,
-    vmId: string,
-    edgeRules: readonly VmEdgeRule[] | undefined,
-    afterResponse: CreateOptions["afterResponse"],
-  ): Promise<void> {
-    if (!edgeRules || edgeRules.length === 0) return;
-    if (!afterResponse) {
-      await this.probeEdgeRules(vm, vmId, edgeRules);
-      return;
-    }
-    // The callback runs after the response, outside the request's active
-    // span, where a fresh root span would fall under the 2% default sampling
-    // and lose its attributes. Carry the request context so the probe span is
-    // a child of the create trace (sampled with it), and log the outcome too.
-    const requestContext = otelContext.active();
-    afterResponse(() =>
-      otelContext.with(requestContext, () =>
-        withVmSpan(
-          "cmux.vm.provider.edge_probe",
-          { "cmux.vm.provider": "freestyle", "cmux.vm.operation": "edge_probe", "cmux.vm.id": vmId, "cmux.vm.edge_rules": edgeRules.length },
-          async (span) => {
-            const startedAt = performance.now();
-            try {
-              await this.probeEdgeRules(vm, vmId, edgeRules);
-              const ms = Math.round(performance.now() - startedAt);
-              setSpanAttributes(span, { "cmux.vm.edge_probe.ok": true, "cmux.vm.edge_probe.ms": ms });
-              console.info("cmux vm edge probe", JSON.stringify({ vmId, ok: true, ms }));
-            } catch (err) {
-              const ms = Math.round(performance.now() - startedAt);
-              setSpanAttributes(span, { "cmux.vm.edge_probe.ok": false, "cmux.vm.edge_probe.ms": ms });
-              recordSpanError(span, err);
-              console.error("cmux vm edge probe", JSON.stringify({ vmId, ok: false, ms, error: errorMessage(err) }));
-            }
-          },
-        ),
-      ),
-    );
-  }
-
-  private async probeEdgeRules(vm: Vm, vmId: string, edgeRules: readonly VmEdgeRule[] | undefined): Promise<void> {
-    if (!edgeRules || edgeRules.length === 0) return;
-    for (const rule of edgeRules) {
-      const command = freestyleEdgeProbeCommand(rule.domain);
-      assertNoRouteTokenInGuestPayload([command], "edge probe");
-      const probe = await this.execResult(vm, command, EDGE_PROBE_TIMEOUT_MS);
-      if (probe?.exitCode === 0) continue;
-      throw new ProviderError(
-        "freestyle",
-        `edge rule for ${rule.domain} in ${vmId} is inactive: the guest probe of ${EDGE_PROBE_URL(rule.domain)} did not succeed (exit ${probe?.exitCode ?? "n/a"})`,
-      );
-    }
-  }
-
   /**
    * Attach-time heal: a daemon that is running AND listening dual-stack is
    * left alone; anything else is repaired, reinstalling first when the binary

--- a/web/services/vms/drivers/types.ts
+++ b/web/services/vms/drivers/types.ts
@@ -105,13 +105,6 @@ export type CreateOptions = {
    */
   edgeRules?: readonly VmEdgeRule[];
   /**
-   * Scheduler for work that must not delay the create response: the guest
-   * probe that waits for the provider's TLS edge to activate the coderouter
-   * rule (Freestyle takes seconds). The route passes its after-response hook;
-   * a caller without one (scripts, tests) gets the work awaited inline.
-   */
-  afterResponse?: (work: () => Promise<void>) => void;
-  /**
    * The owner's private network to attach the machine to. When present the
    * machine takes an address on it and its session daemon is reachable only
    * from other members — the owner's other machines, and the owner's computer
@@ -135,7 +128,7 @@ export type VmEdgeRule = {
 };
 
 /** Create-time inputs a restore-from-snapshot shares with a fresh create. */
-export type RestoreOptions = Pick<CreateOptions, "envs" | "edgeRules" | "providerMetadata" | "afterResponse"> & {
+export type RestoreOptions = Pick<CreateOptions, "envs" | "edgeRules" | "providerMetadata"> & {
   /** The owner's private network; see {@link CreateOptions.network}. */
   network?: ProviderNetworkRef;
 };
@@ -360,7 +353,7 @@ export interface VMPrivateNetworking {
    * under concurrent calls with the same slug: two machines created at once
    * must land on one network, not two.
    */
-  ensureNetwork(options: { slug: string; displayName?: string }): Promise<ProviderNetwork>;
+  ensureNetwork(options: { slug: string; displayName?: string; heal?: boolean }): Promise<ProviderNetwork>;
   /** Read a network back, or null when it no longer exists at the provider. */
   getNetwork(networkId: string): Promise<ProviderNetwork | null>;
   /** Delete a network. Must succeed when it is already gone. */

--- a/web/services/vms/providerGateway.ts
+++ b/web/services/vms/providerGateway.ts
@@ -105,7 +105,7 @@ export type VmProviderGatewayShape = {
   readonly supportsPrivateNetworking?: (provider: ProviderId) => boolean;
   readonly ensureNetwork?: (
     provider: ProviderId,
-    options: { slug: string; displayName?: string },
+    options: { slug: string; displayName?: string; heal?: boolean },
   ) => Effect.Effect<ProviderNetwork, VmProviderOperationError>;
   readonly deleteNetwork?: (
     provider: ProviderId,

--- a/web/services/vms/workflows.ts
+++ b/web/services/vms/workflows.ts
@@ -45,7 +45,7 @@ import {
   type VmWorkflowError,
 } from "./errors";
 import { isVmFreeAccessExpired, maxActiveVmsForPlan, vmFreeAccessWindowDays } from "./entitlements";
-import { resolveOwnerNetwork } from "./privateNetwork";
+import { networkSlugForUser, privateNetworkUnavailableReason, resolveOwnerNetwork } from "./privateNetwork";
 import { isProviderIdentityNotFoundError, isProviderNotFoundError } from "./providerErrors";
 import { VmProviderGateway, VmProviderGatewayLive, type VmProviderGatewayShape } from "./providerGateway";
 import {
@@ -277,6 +277,24 @@ export function reconcileVmProviderStatuses(input: {
       (vm) => reconcileObservedProviderStatus(repo, getStatus, vm, "provider_status_cron", input.modelPlane),
       { concurrency: 10 },
     );
+    // Network heal moved here from the create path: re-create the members
+    // rule of every owner network this batch touches if it went missing.
+    const ensureNetwork = providers.ensureNetwork;
+    if (ensureNetwork) {
+      const owners = new Map<string, { userId: string; provider: ProviderId }>();
+      for (const vm of candidates) {
+        if (vm.status === "destroyed" || privateNetworkUnavailableReason(vm.provider, true)) continue;
+        owners.set(`${vm.provider}:${vm.userId}`, { userId: vm.userId, provider: vm.provider });
+      }
+      yield* Effect.forEach(
+        [...owners.values()],
+        (owner) =>
+          ensureNetwork(owner.provider, { slug: networkSlugForUser(owner.userId), heal: true }).pipe(
+            Effect.catchAll(() => Effect.void),
+          ),
+        { concurrency: 4, discard: true },
+      );
+    }
     let updated = 0;
     let destroyed = 0;
     let skipped = 0;
@@ -378,8 +396,6 @@ export function createVm(input: {
   readonly memoryMb?: number;
   /** See CreateOptions.imageSize: a sized ladder image boots at its shape and is never resized. */
   readonly imageSize?: CreateOptions["imageSize"];
-  /** See CreateOptions.afterResponse: the edge probe runs here instead of inside the request. */
-  readonly afterResponse?: CreateOptions["afterResponse"];
   /**
    * Wires the machine to coderouter. Provisioned after the row exists (its id
    * is the token binding) and before the provider call; a failure fails the
@@ -490,7 +506,6 @@ export function createVm(input: {
             : undefined,
         memoryMb: input.memoryMb,
         imageSize: input.imageSize,
-        afterResponse: input.afterResponse,
         envs: materials?.envs,
         edgeRules: materials?.edgeRules,
         ...(network ? { network: { id: network.providerNetworkId } } : {}),
@@ -1435,6 +1450,11 @@ function preflightResumeIfSuspended(
     const getStatus = providers.getStatus;
     const resume = providers.resume;
     if (!getStatus || !resume) return false;
+    // Our row is the source of truth for a machine we paused. A row that says
+    // running gets no provider read: a guest exec wakes a machine Freestyle
+    // idled on its own, and the status cron records that state within its
+    // cadence. Only a row we paused, or one still creating, asks the provider.
+    if (vm.status === "running") return false;
 
     const status = yield* getStatus(vm.provider, providerVmId).pipe(
       Effect.timeoutFail({

--- a/web/tests/vm-freestyle-provider.test.ts
+++ b/web/tests/vm-freestyle-provider.test.ts
@@ -12,7 +12,6 @@ import {
   freestyleRouteAddressesFromMetadata,
   freestyleDaemonHealthyCommand,
   freestyleDesktopHealCommand,
-  freestyleEdgeProbeCommand,
   freestyleEdgeRules,
   freestyleFirewallRules,
   freestylePortAddress,
@@ -294,14 +293,6 @@ describe("Freestyle platform contract", () => {
     expect(() => freestyleEdgeRules([{ ...EDGE_RULE, domain: "x; rm -rf /" }])).toThrow(ProviderError);
   });
 
-  test("edge probe is one bounded guest loop against the rule's host, with no token in it", () => {
-    const command = freestyleEdgeProbeCommand("coderouter.dev");
-    expect(command).toBe(
-      "for i in $(seq 1 30); do curl -fsS -o /dev/null --max-time 5 -H 'authorization: Bearer cmux-vm-edge-placeholder' https://coderouter.dev/api/coderouter/vm-usage/self && exit 0; sleep 2; done; exit 1",
-    );
-    expect(command).not.toContain("crt_");
-    expect(() => freestyleEdgeProbeCommand("bad host")).toThrow(ProviderError);
-  });
 
   test("exec timeouts clamp to the per-exec cap; killed execs read as 124", () => {
     expect(normalizeFreestyleExecTimeout(undefined)).toBe(30_000);

--- a/web/tests/vm-freestyle-provider.test.ts
+++ b/web/tests/vm-freestyle-provider.test.ts
@@ -311,7 +311,7 @@ describe("Freestyle platform contract", () => {
 });
 
 describe("FreestyleProvider create with edge rules", () => {
-  test("passes the rule inline, writes placeholder env only, probes, and returns the machine", async () => {
+  test("passes the rule inline, writes placeholder env only, runs no probe, and returns the machine", async () => {
     const fake = fakeFreestyle({ probeExit: 0 });
     const handle = await providerWith(fake).create({
       image: "sh-devbox",
@@ -336,7 +336,7 @@ describe("FreestyleProvider create with edge rules", () => {
         content: renderFreestyleModelPlaneEnvFile(PLACEHOLDER_ENVS)!,
       },
     ]);
-    expect(fake.execs.some((command) => command.includes("https://coderouter.dev/api/coderouter/vm-usage/self"))).toBe(true);
+    expect(fake.execs.some((command) => command.includes("/api/coderouter/vm-usage/self"))).toBe(false);
     expect(fake.deletes).toEqual([]);
   });
 
@@ -365,16 +365,6 @@ describe("FreestyleProvider create with edge rules", () => {
     expect(fake.writes).toEqual([]);
   });
 
-  test("rolls the machine back when the edge probe never succeeds", async () => {
-    const fake = fakeFreestyle({ probeExit: 1 });
-    const failure = await providerWith(fake)
-      .create({ image: "sh-devbox", envs: PLACEHOLDER_ENVS, edgeRules: [EDGE_RULE] })
-      .catch((err: unknown) => err);
-    expect(failure).toBeInstanceOf(ProviderError);
-    expect((failure as ProviderError).message).toContain("edge rule for coderouter.dev");
-    expect((failure as ProviderError).message).toContain("inactive");
-    expect(fake.deletes).toEqual([VM_ID]);
-  });
 
   test("refuses to create when an env value is a route token", async () => {
     const fake = fakeFreestyle({ probeExit: 0 });
@@ -389,7 +379,7 @@ describe("FreestyleProvider create with edge rules", () => {
     expect(fake.deletes).toEqual([VM_ID]);
   });
 
-  test("restore passes the rule inline, writes the new env, probes, and rolls back on failure", async () => {
+  test("restore passes the rule inline and writes the new env", async () => {
     const ok = fakeFreestyle({ probeExit: 0 });
     const restored = await providerWith(ok).restore("snap-1", { envs: PLACEHOLDER_ENVS, edgeRules: [EDGE_RULE] });
     expect(restored.image).toBe("snap-1");
@@ -397,12 +387,6 @@ describe("FreestyleProvider create with edge rules", () => {
     expect(ok.writes.map((write) => write.path)).toEqual(["/root/.config/cmux/model-plane.env"]);
     expect(JSON.stringify(ok.writes)).not.toContain("crt_");
     expect(ok.deletes).toEqual([]);
-
-    const bad = fakeFreestyle({ probeExit: 1 });
-    await expect(
-      providerWith(bad).restore("snap-1", { envs: PLACEHOLDER_ENVS, edgeRules: [EDGE_RULE] }),
-    ).rejects.toThrow("inactive");
-    expect(bad.deletes).toEqual([VM_ID]);
   });
 });
 

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -138,7 +138,7 @@ describe("VM Effect workflows", () => {
       userId: "user-workflow-exec-resume",
       billingTeamId: "team-workflow-exec-resume",
       providerVmId: "provider-vm-exec-resume",
-      status: "running",
+      status: "paused",
     });
     const usageEvents: RecordedUsageEvent[] = [];
     const observedStatuses: ObservedStatusUpdate[] = [];
@@ -311,7 +311,7 @@ describe("VM Effect workflows", () => {
 
     expect(error).toBe(originalError);
     expect(execCalls).toBe(1);
-    expect(statusCalls).toBe(1);
+    expect(statusCalls).toBe(0);
     expect(resumeCalls).toBe(0);
     expect(usageEvents).toHaveLength(0);
   });
@@ -321,7 +321,7 @@ describe("VM Effect workflows", () => {
       id: "00000000-0000-4000-8000-000000000103",
       userId: "user-workflow-exec-resume-fails",
       providerVmId: "provider-vm-exec-resume-fails",
-      status: "running",
+      status: "paused",
     });
     const repo = testWorkflowRepo({ vm });
     const resumeError = providerOperationError("resume", "provider resume unavailable");
@@ -367,7 +367,7 @@ describe("VM Effect workflows", () => {
       id: "00000000-0000-4000-8000-000000000112",
       userId: "user-workflow-exec-mark-false",
       providerVmId: "provider-vm-exec-mark-false",
-      status: "running",
+      status: "paused",
     });
     const repo = testWorkflowRepo({
       vm,
@@ -1138,7 +1138,7 @@ describe("VM Effect workflows", () => {
 
     expect(error).toBe(originalError);
     expect(execCalls).toBe(1);
-    expect(statusCalls).toBe(1);
+    expect(statusCalls).toBe(0);
     expect(resumeCalls).toBe(0);
     expect(usageEvents).toHaveLength(0);
   });
@@ -1664,8 +1664,6 @@ describe("VM Effect workflows", () => {
     let providerCreateCalls = 0;
     let providerMemoryMb: number | undefined;
     let providerImageSize: { name: string; cpu: number; memoryMb: number; storageMb: number } | null = null;
-    let providerAfterResponse: ((work: () => Promise<void>) => void) | null = null;
-    const afterResponse = (work: () => Promise<void>) => { void work(); };
     let usageEventAttempts = 0;
     const repo: VmRepositoryShape = {
       listUserVms: () => Effect.succeed([]),
@@ -1709,7 +1707,6 @@ describe("VM Effect workflows", () => {
           providerCreateCalls += 1;
           providerMemoryMb = options.memoryMb;
           providerImageSize = options.imageSize ?? null;
-          providerAfterResponse = options.afterResponse ?? null;
           return {
             provider: "freestyle" as const,
             providerVmId: "provider-vm-usage-events",
@@ -1742,7 +1739,6 @@ describe("VM Effect workflows", () => {
         imageVersion: "test-version",
         memoryMb: 3072,
         imageSize: { name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384 },
-        afterResponse,
         idempotencyKey: "usage-events",
       }).pipe(Effect.provide(layer)),
     );
@@ -1752,8 +1748,6 @@ describe("VM Effect workflows", () => {
     expect(providerMemoryMb).toBe(3072);
     // A sized image reaches the driver as the shape to boot at, never to resize to.
     expect(providerImageSize).toEqual({ name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384 });
-    // The route's after-response scheduler reaches the driver, so the edge probe never blocks the request.
-    expect(providerAfterResponse).toBe(afterResponse);
     expect(usageEventAttempts).toBe(2);
   });
 

--- a/web/tests/vm-workflows.test.ts
+++ b/web/tests/vm-workflows.test.ts
@@ -187,8 +187,8 @@ describe("VM Effect workflows", () => {
     expect(observedStatuses).toEqual([
       { id: vm.id, providerVmId: "provider-vm-exec-resume", status: "running" },
     ]);
-    expect(usageEvents).toHaveLength(1);
-    expect(usageEvents[0]).toMatchObject({
+    expect(usageEvents).toHaveLength(2); // the paused row's resume is accounted, then the exec
+    expect(usageEvents.find((event) => event.eventType === "vm.exec")).toMatchObject({
       eventType: "vm.exec",
       vmId: vm.id,
       metadata: { commandLength: "echo preflight".length, exitCode: 7 },
@@ -1143,7 +1143,7 @@ describe("VM Effect workflows", () => {
     expect(usageEvents).toHaveLength(0);
   });
 
-  test("exec preflight getStatus failure still attempts exec once", async () => {
+  test("exec on a row that says running makes no status call and runs once", async () => {
     const vm = testCloudVmRow({
       id: "00000000-0000-4000-8000-000000000109",
       userId: "user-workflow-exec-status-fails",
@@ -1185,7 +1185,7 @@ describe("VM Effect workflows", () => {
 
     expect(result).toEqual({ exitCode: 0, stdout: "ok", stderr: "" });
     expect(execCalls).toBe(1);
-    expect(statusCalls).toBe(1);
+    expect(statusCalls).toBe(0);
     expect(resumeCalls).toBe(0);
     expect(usageEvents).toHaveLength(1);
   });
@@ -1259,7 +1259,7 @@ describe("VM Effect workflows", () => {
       userId: "user-workflow-attach-resume",
       billingTeamId: "team-workflow-attach-resume",
       providerVmId: "provider-vm-attach-resume",
-      status: "running",
+      status: "paused",
     });
     const usageEvents: RecordedUsageEvent[] = [];
     const leases: RecordedLease[] = [];
@@ -1305,8 +1305,8 @@ describe("VM Effect workflows", () => {
       { id: vm.id, providerVmId: "provider-vm-attach-resume", status: "running" },
     ]);
     expect(leases).toHaveLength(1);
-    expect(usageEvents).toHaveLength(1);
-    expect(usageEvents[0]).toMatchObject({
+    expect(usageEvents).toHaveLength(2); // the paused row's resume is accounted, then the attach
+    expect(usageEvents.find((event) => event.eventType === "vm.attach")).toMatchObject({
       eventType: "vm.attach",
       vmId: vm.id,
       metadata: { transport: "websocket", requireDaemon: true, daemonAvailable: false },
@@ -1319,7 +1319,7 @@ describe("VM Effect workflows", () => {
       userId: "user-workflow-attach-mark-fails",
       billingTeamId: "team-workflow-attach-mark-fails",
       providerVmId: "provider-vm-attach-mark-fails",
-      status: "running",
+      status: "paused",
     });
     const usageEvents: RecordedUsageEvent[] = [];
     const leases: RecordedLease[] = [];
@@ -1385,7 +1385,7 @@ describe("VM Effect workflows", () => {
       userId: "user-workflow-attach-mark-false",
       billingTeamId: "team-workflow-attach-mark-false",
       providerVmId: "provider-vm-attach-mark-false",
-      status: "running",
+      status: "paused",
     });
     const usageEvents: RecordedUsageEvent[] = [];
     const leases: RecordedLease[] = [];
@@ -1469,8 +1469,8 @@ describe("VM Effect workflows", () => {
       getStatus: () =>
         Effect.sync(() => {
           statusCalls += 1;
-          // Running at preflight, paused when the mint failure is investigated.
-          return statusCalls === 1 ? ("running" as const) : ("paused" as const);
+          // No preflight read for a running row; the failure path finds it paused.
+          return "paused" as const;
         }),
       resume: () =>
         Effect.sync(() => {
@@ -1489,7 +1489,7 @@ describe("VM Effect workflows", () => {
 
     expect(result).toEqual(endpoint);
     expect(attachCalls).toBe(2);
-    expect(statusCalls).toBe(2);
+    expect(statusCalls).toBe(1);
     expect(resumeCalls).toBe(1);
     expect(observedStatuses).toEqual([
       { id: vm.id, providerVmId: "provider-vm-attach-race", status: "running" },


### PR DESCRIPTION
Every Freestyle call on the create and attach paths, and whether it stays, from first principles: a machine exists when Freestyle says so, everything else is state we own, verification, or a trust handshake.

Removed here:

- **Status read before every attach, exec, ssh** (`vms.get`, 33 to 120 ms). When our row says running there is no read. Spike: an exec on a paused Freestyle machine succeeds in 53 ms (Freestyle wakes it) and `start` is 14 ms, so a machine idled out of band still works, and the status cron records its state on its cadence. Rows we paused, or still creating, keep the read and the resume accounting.
- **First-machine VPC read and members-rule heal** (`vpc.get` + `firewall.rules.list`, 150 ms each cold). Create is now create-first; the read runs only on a slug conflict. The heal moves to the status reconcile cron (`ensureNetwork(..., { heal: true })`), once per owner network per run.
- **Coderouter edge probe** and its after-response plumbing. The rule is written inline by `vms.create`; the probe only verified Freestyle's own activation.

Still on the path and necessary: `vms.create` (firewall, VPC, TLS rules inline) and, once per account, `vpc.create`. Still on the path and not necessary, next PR: the model-plane env file write. Spiked today: a TLS rule for a fixed alias domain (`coderouter.cmux.internal`) with our API host as destination answers identically to the direct host, so the guest env can be one static file baked into the snapshot.

Blame for the calls removed: status preflight https://github.com/manaflow-ai/cmux/pull/7388 (Lawrence), VPC read and heal `c8ec44d672` (Jacob), edge probe https://github.com/manaflow-ai/cmux/pull/11622 (Lawrence).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Drops three Freestyle calls from the create/attach paths so requests no longer wait on reads or guest probes that don't affect correctness.

- Skips the provider status read before attach, exec, and ssh when our row says running; paused or still-creating rows keep the read, and the status cron records provider state.
- Creates the first machine's VPC up front and reads it back only on a slug conflict; the members-rule heal moved to the status reconcile cron.
- Removes the guest-side edge probe and its after-response plumbing; `vms.create` still writes the edge rule inline.
- Updates tests to expect no status read for running rows and no edge probe.

<sup>Written for commit fa06e430d88e4488ff3c0d23d68a9922fcb3daef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

