### PR TITLE
fix(cmux-remote): reap session workers on close

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -687,6 +687,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-tungstenite",
+ "tokio-util",
  "tower",
  "tower-http",
  "url",

--- a/cmux-tui/crates/cmux-remote/Cargo.toml
+++ b/cmux-tui/crates/cmux-remote/Cargo.toml
@@ -41,6 +41,7 @@ socket2 = { workspace = true, optional = true }
 snow.workspace = true
 subtle.workspace = true
 tokio.workspace = true
+tokio-util.workspace = true
 tokio-tungstenite.workspace = true
 tower.workspace = true
 tower-http.workspace = true

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -11,7 +11,7 @@ use cmux_remote_protocol::{
     WireFrame,
 };
 use tokio::sync::{Notify, mpsc, oneshot};
-use tokio::task::JoinHandle;
+use tokio::task::{AbortHandle, JoinHandle};
 use tokio_util::sync::CancellationToken;
 
 use crate::link::{FrameLink, LinkError};
@@ -758,6 +758,7 @@ struct ScheduledSenderInner {
     limits: SessionLimits,
     cancel: CancellationToken,
     tasks: Mutex<Option<Vec<JoinHandle<()>>>>,
+    task_abort_handles: Mutex<Vec<AbortHandle>>,
     shutdown_join: Mutex<Option<JoinHandle<()>>>,
     join_started: AtomicBool,
     shutdown_complete: CancellationToken,
@@ -775,6 +776,16 @@ impl Drop for ScheduledSenderInner {
             for task in tasks {
                 task.abort();
             }
+        }
+        let abort_handles = match self.task_abort_handles.lock() {
+            Ok(mut abort_handles) => std::mem::take(&mut *abort_handles),
+            Err(poisoned) => {
+                let mut abort_handles = poisoned.into_inner();
+                std::mem::take(&mut *abort_handles)
+            }
+        };
+        for abort_handle in abort_handles {
+            abort_handle.abort();
         }
         let join = match self.shutdown_join.lock() {
             Ok(mut join) => join.take(),
@@ -806,6 +817,7 @@ impl ScheduledSender {
             limits,
             cancel: CancellationToken::new(),
             tasks: Mutex::new(Some(Vec::with_capacity(8))),
+            task_abort_handles: Mutex::new(Vec::with_capacity(8)),
             shutdown_join: Mutex::new(None),
             join_started: AtomicBool::new(false),
             shutdown_complete: CancellationToken::new(),
@@ -846,9 +858,11 @@ impl ScheduledSender {
                 inner.active_tasks.fetch_sub(1, Ordering::AcqRel);
             }
         });
+        let abort_handle = task.abort_handle();
         let mut tasks = self.inner.tasks.lock().unwrap();
         if let Some(tasks) = tasks.as_mut() {
             tasks.push(task);
+            self.inner.task_abort_handles.lock().unwrap().push(abort_handle);
         } else {
             task.abort();
         }
@@ -1513,6 +1527,52 @@ mod tests {
             .expect("later close waited forever after cancelled shutdown")
             .unwrap();
         assert_eq!(send.await.unwrap().unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn dropping_cancelled_close_aborts_joined_workers() {
+        let link = Arc::new(CloseJoinGateLink {
+            send_entered: Semaphore::new(0),
+            send_release: Semaphore::new(0),
+        });
+        let weak_link = Arc::downgrade(&link);
+        let session =
+            ReliableSession::new(SessionId([21; 16]), link.clone(), SessionLimits::default());
+        let send = tokio::spawn({
+            let session = session.clone();
+            async move {
+                session
+                    .send(Lane::Bulk, 1, Bytes::from_static(b"in flight"), FrameFlags::empty())
+                    .await
+            }
+        });
+        link.send_entered.acquire().await.unwrap().forget();
+
+        let first_close = tokio::spawn({
+            let session = session.clone();
+            async move { session.close().await }
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !session.scheduler.inner.join_started.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first close did not begin scheduler shutdown");
+        first_close.abort();
+        let _ = first_close.await;
+        send.abort();
+        let _ = send.await;
+        drop(session);
+        drop(link);
+
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while weak_link.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("cancelled close retained a worker and its link");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -152,7 +152,7 @@ impl ReliableSession {
             let (sender, receiver) = mpsc::channel(1);
             scheduler.spawn_tracked(run_ack_sender(
                 shared.clone(),
-                scheduler.clone(),
+                Arc::downgrade(&scheduler.inner),
                 generation,
                 lane,
                 receiver,
@@ -554,7 +554,7 @@ fn encode_ack(shared: &SharedState, generation: u64, lane: Lane) -> Result<Bytes
 
 async fn run_ack_sender(
     shared: Arc<SharedState>,
-    scheduler: ScheduledSender,
+    scheduler: Weak<ScheduledSenderInner>,
     generation: u64,
     lane: Lane,
     mut requested: mpsc::Receiver<()>,
@@ -570,7 +570,7 @@ async fn run_ack_sender(
         }
         while requested.try_recv().is_ok() {}
         let Ok(encoded) = encode_ack(&shared, generation, lane) else { return };
-        if scheduler.send(lane, encoded).await.is_err() {
+        if ScheduledSender::send_from_weak(&scheduler, lane, encoded).await.is_err() {
             return;
         }
     }
@@ -763,6 +763,17 @@ struct ScheduledSenderInner {
     active_tasks: AtomicUsize,
 }
 
+impl Drop for ScheduledSenderInner {
+    fn drop(&mut self) {
+        self.cancel.cancel();
+        if let Some(tasks) = self.tasks.get_mut().as_mut() {
+            for task in tasks {
+                task.abort();
+            }
+        }
+    }
+}
+
 impl ScheduledSender {
     fn spawn(link: Arc<dyn FrameLink>, limits: SessionLimits) -> Self {
         let (interactive_tx, interactive_rx) = mpsc::channel(limits.queued_frames_per_lane);
@@ -815,16 +826,63 @@ impl ScheduledSender {
         F: Future<Output = ()> + Send + 'static,
     {
         self.inner.active_tasks.fetch_add(1, Ordering::AcqRel);
-        let inner = self.inner.clone();
+        let inner = Arc::downgrade(&self.inner);
         let task = tokio::spawn(async move {
             future.await;
-            inner.active_tasks.fetch_sub(1, Ordering::AcqRel);
+            if let Some(inner) = inner.upgrade() {
+                inner.active_tasks.fetch_sub(1, Ordering::AcqRel);
+            }
         });
         let mut tasks = self.inner.tasks.lock().unwrap();
         if let Some(tasks) = tasks.as_mut() {
             tasks.push(task);
         } else {
             task.abort();
+        }
+    }
+
+    async fn send_from_weak(
+        scheduler: &Weak<ScheduledSenderInner>,
+        lane: Lane,
+        frame: Bytes,
+    ) -> Result<(), ScheduleError> {
+        let Some(inner) = scheduler.upgrade() else {
+            return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
+        };
+        let queues = inner.queues.clone();
+        let budgets = inner.budgets.clone();
+        let limits = inner.limits;
+        let cancel = inner.cancel.clone();
+        drop(inner);
+
+        if cancel.is_cancelled() {
+            return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
+        }
+        let budget = &budgets[lane_index(lane)];
+        budget
+            .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
+                current
+                    .checked_add(frame.len())
+                    .filter(|next| *next <= limits.queued_bytes_per_lane)
+            })
+            .map_err(|_| ScheduleError::Unscheduled(SessionError::QueueFull(lane)))?;
+        let bytes = frame.len();
+        let (completion, result) = oneshot::channel();
+        let queued = tokio::select! {
+            _ = cancel.cancelled() => {
+                budget.fetch_sub(bytes, Ordering::AcqRel);
+                return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
+            }
+            result = queues.get(lane).send(ScheduledFrame { lane, frame, completion }) => result,
+        };
+        if queued.is_err() {
+            budget.fetch_sub(bytes, Ordering::AcqRel);
+            return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
+        }
+        match result.await {
+            Ok(Ok(())) => Ok(()),
+            Ok(Err(message)) => Err(ScheduleError::Ambiguous(SessionError::LinkMessage(message))),
+            Err(_) => Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed)),
         }
     }
 
@@ -1298,6 +1356,24 @@ mod tests {
         })
         .await
         .expect("concurrent close calls missed scheduler completion");
+    }
+
+    #[tokio::test]
+    async fn dropping_session_aborts_worker_tasks_without_close() {
+        let link = Arc::new(GatedRecordingLink::new());
+        let weak_link = Arc::downgrade(&link);
+        let session =
+            ReliableSession::new(SessionId([18; 16]), link.clone(), SessionLimits::default());
+
+        drop(session);
+        drop(link);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while weak_link.upgrade().is_some() {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("session workers retained the link after session drop");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -17,6 +17,7 @@ use tokio_util::sync::CancellationToken;
 use crate::link::{FrameLink, LinkError};
 
 const RECONNECT_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const SCHEDULER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 
 #[derive(Debug, Clone, Copy)]
 pub struct SessionLimits {
@@ -528,8 +529,12 @@ impl ReliableSession {
         // frame in flight, then observe cancellation after the link closes.
         self.scheduler.request_shutdown();
         let link_result = self.link.close().await.map_err(SessionError::Link);
-        self.scheduler.wait_for_shutdown().await;
-        link_result
+        let scheduler_result = self.scheduler.wait_for_shutdown().await;
+        match (link_result, scheduler_result) {
+            (Err(error), _) => Err(error),
+            (Ok(()), Err(())) => Err(SessionError::SchedulerClosed),
+            (Ok(()), Ok(())) => Ok(()),
+        }
     }
 }
 
@@ -761,6 +766,7 @@ struct ScheduledSenderInner {
     task_abort_handles: Mutex<Vec<AbortHandle>>,
     shutdown_join: Mutex<Option<JoinHandle<()>>>,
     join_started: AtomicBool,
+    shutdown_forced: Arc<AtomicBool>,
     shutdown_complete: CancellationToken,
     active_tasks: AtomicUsize,
 }
@@ -820,6 +826,7 @@ impl ScheduledSender {
             task_abort_handles: Mutex::new(Vec::with_capacity(8)),
             shutdown_join: Mutex::new(None),
             join_started: AtomicBool::new(false),
+            shutdown_forced: Arc::new(AtomicBool::new(false)),
             shutdown_complete: CancellationToken::new(),
             active_tasks: AtomicUsize::new(0),
         });
@@ -921,7 +928,7 @@ impl ScheduledSender {
         self.inner.cancel.cancel();
     }
 
-    async fn wait_for_shutdown(&self) {
+    async fn wait_for_shutdown(&self) -> Result<(), ()> {
         self.request_shutdown();
         if self
             .inner
@@ -931,15 +938,28 @@ impl ScheduledSender {
         {
             let tasks = self.inner.tasks.lock().unwrap().take().unwrap_or_default();
             let shutdown_complete = self.inner.shutdown_complete.clone();
+            let abort_handles = self.inner.task_abort_handles.lock().unwrap().clone();
+            let shutdown_forced = self.inner.shutdown_forced.clone();
             let join = tokio::spawn(async move {
-                for task in tasks {
-                    let _ = task.await;
+                let timed_out = tokio::time::timeout(SCHEDULER_SHUTDOWN_TIMEOUT, async {
+                    for task in tasks {
+                        let _ = task.await;
+                    }
+                })
+                .await
+                .is_err();
+                if timed_out {
+                    shutdown_forced.store(true, Ordering::Release);
+                    for abort_handle in abort_handles {
+                        abort_handle.abort();
+                    }
                 }
                 shutdown_complete.cancel();
             });
             self.inner.shutdown_join.lock().unwrap().replace(join);
         }
         self.inner.shutdown_complete.cancelled().await;
+        if self.inner.shutdown_forced.load(Ordering::Acquire) { Err(()) } else { Ok(()) }
     }
 
     async fn send(&self, lane: Lane, frame: Bytes) -> Result<(), ScheduleError> {
@@ -1573,6 +1593,34 @@ mod tests {
         })
         .await
         .expect("cancelled close retained a worker and its link");
+    }
+
+    #[tokio::test]
+    async fn close_aborts_a_worker_stuck_in_link_send() {
+        let link = Arc::new(CloseJoinGateLink {
+            send_entered: Semaphore::new(0),
+            send_release: Semaphore::new(0),
+        });
+        let weak_link = Arc::downgrade(&link);
+        let session =
+            ReliableSession::new(SessionId([22; 16]), link.clone(), SessionLimits::default());
+        let send = tokio::spawn({
+            let session = session.clone();
+            async move {
+                session.send(Lane::Bulk, 1, Bytes::from_static(b"stuck"), FrameFlags::empty()).await
+            }
+        });
+        link.send_entered.acquire().await.unwrap().forget();
+
+        let close = tokio::time::timeout(Duration::from_secs(4), session.close())
+            .await
+            .expect("close exceeded the bounded scheduler shutdown timeout");
+        assert!(matches!(close, Err(SessionError::SchedulerClosed)));
+        send.abort();
+        let _ = send.await;
+        drop(session);
+        drop(link);
+        assert!(weak_link.upgrade().is_none(), "close retained the stuck worker link");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -930,21 +930,26 @@ impl ScheduledSender {
             .map_err(|_| ScheduleError::Unscheduled(SessionError::QueueFull(lane)))?;
         let bytes = frame.len();
         let (completion, result) = oneshot::channel();
-        if self
-            .inner
-            .queues
-            .get(lane)
-            .send(ScheduledFrame { lane, frame, completion })
-            .await
-            .is_err()
-        {
+        let queued = tokio::select! {
+            _ = self.inner.cancel.cancelled() => {
+                budget.fetch_sub(bytes, Ordering::AcqRel);
+                return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
+            }
+            result = self.inner.queues.get(lane).send(ScheduledFrame { lane, frame, completion }) => result,
+        };
+        if queued.is_err() {
             budget.fetch_sub(bytes, Ordering::AcqRel);
             return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
         }
-        match result.await {
+        tokio::select! {
+            _ = self.inner.cancel.cancelled() => {
+                Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed))
+            }
+            result = result => match result {
             Ok(Ok(())) => Ok(()),
             Ok(Err(message)) => Err(ScheduleError::Ambiguous(SessionError::LinkMessage(message))),
             Err(_) => Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed)),
+            }
         }
     }
 }

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
 use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::{Arc, Mutex, Weak};
 use std::time::Duration;
 
 use bytes::Bytes;
@@ -766,7 +766,11 @@ struct ScheduledSenderInner {
 impl Drop for ScheduledSenderInner {
     fn drop(&mut self) {
         self.cancel.cancel();
-        if let Some(tasks) = self.tasks.get_mut().as_mut() {
+        let tasks = match self.tasks.get_mut() {
+            Ok(tasks) => tasks,
+            Err(poisoned) => poisoned.into_inner(),
+        };
+        if let Some(tasks) = tasks {
             for task in tasks {
                 task.abort();
             }

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -758,6 +758,7 @@ struct ScheduledSenderInner {
     limits: SessionLimits,
     cancel: CancellationToken,
     tasks: Mutex<Option<Vec<JoinHandle<()>>>>,
+    shutdown_join: Mutex<Option<JoinHandle<()>>>,
     join_started: AtomicBool,
     shutdown_complete: CancellationToken,
     active_tasks: AtomicUsize,
@@ -774,6 +775,13 @@ impl Drop for ScheduledSenderInner {
             for task in tasks {
                 task.abort();
             }
+        }
+        let join = match self.shutdown_join.lock() {
+            Ok(mut join) => join.take(),
+            Err(poisoned) => poisoned.into_inner().take(),
+        };
+        if let Some(join) = join {
+            join.abort();
         }
     }
 }
@@ -798,6 +806,7 @@ impl ScheduledSender {
             limits,
             cancel: CancellationToken::new(),
             tasks: Mutex::new(Some(Vec::with_capacity(8))),
+            shutdown_join: Mutex::new(None),
             join_started: AtomicBool::new(false),
             shutdown_complete: CancellationToken::new(),
             active_tasks: AtomicUsize::new(0),
@@ -907,13 +916,16 @@ impl ScheduledSender {
             .is_ok()
         {
             let tasks = self.inner.tasks.lock().unwrap().take().unwrap_or_default();
-            for task in tasks {
-                let _ = task.await;
-            }
-            self.inner.shutdown_complete.cancel();
-        } else {
-            self.inner.shutdown_complete.cancelled().await;
+            let shutdown_complete = self.inner.shutdown_complete.clone();
+            let join = tokio::spawn(async move {
+                for task in tasks {
+                    let _ = task.await;
+                }
+                shutdown_complete.cancel();
+            });
+            self.inner.shutdown_join.lock().unwrap().replace(join);
         }
+        self.inner.shutdown_complete.cancelled().await;
     }
 
     async fn send(&self, lane: Lane, frame: Bytes) -> Result<(), ScheduleError> {
@@ -1140,6 +1152,11 @@ mod tests {
         close_barrier: Barrier,
     }
 
+    struct CloseJoinGateLink {
+        send_entered: Semaphore,
+        send_release: Semaphore,
+    }
+
     #[async_trait]
     impl FrameLink for RejectingLink {
         fn description(&self) -> &str {
@@ -1230,6 +1247,31 @@ mod tests {
 
         async fn close(&self) -> Result<(), LinkError> {
             self.close_barrier.wait().await;
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl FrameLink for CloseJoinGateLink {
+        fn description(&self) -> &str {
+            "close-join-gate"
+        }
+
+        fn maximum_frame_bytes(&self) -> usize {
+            128 * 1024
+        }
+
+        async fn send(&self, _frame: Bytes) -> Result<(), LinkError> {
+            self.send_entered.add_permits(1);
+            self.send_release.acquire().await.unwrap().forget();
+            Ok(())
+        }
+
+        async fn receive(&self) -> Result<Option<Bytes>, LinkError> {
+            std::future::pending().await
+        }
+
+        async fn close(&self) -> Result<(), LinkError> {
             Ok(())
         }
     }
@@ -1431,6 +1473,46 @@ mod tests {
         link.release.add_permits(1);
         let _ = first.await;
         let _ = second.await;
+    }
+
+    #[tokio::test]
+    async fn cancelled_close_does_not_poison_later_shutdown_waiters() {
+        let link = Arc::new(CloseJoinGateLink {
+            send_entered: Semaphore::new(0),
+            send_release: Semaphore::new(0),
+        });
+        let session =
+            ReliableSession::new(SessionId([20; 16]), link.clone(), SessionLimits::default());
+        let send = tokio::spawn({
+            let session = session.clone();
+            async move {
+                session
+                    .send(Lane::Bulk, 1, Bytes::from_static(b"in flight"), FrameFlags::empty())
+                    .await
+            }
+        });
+        link.send_entered.acquire().await.unwrap().forget();
+
+        let first_close = tokio::spawn({
+            let session = session.clone();
+            async move { session.close().await }
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while !session.scheduler.inner.join_started.load(Ordering::Acquire) {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("first close did not begin scheduler shutdown");
+        first_close.abort();
+        let _ = first_close.await;
+
+        link.send_release.add_permits(1);
+        tokio::time::timeout(Duration::from_secs(1), session.close())
+            .await
+            .expect("later close waited forever after cancelled shutdown")
+            .unwrap();
+        assert_eq!(send.await.unwrap().unwrap(), 1);
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -941,15 +941,10 @@ impl ScheduledSender {
             budget.fetch_sub(bytes, Ordering::AcqRel);
             return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
         }
-        tokio::select! {
-            _ = self.inner.cancel.cancelled() => {
-                Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed))
-            }
-            result = result => match result {
+        match result.await {
             Ok(Ok(())) => Ok(()),
             Ok(Err(message)) => Err(ScheduleError::Ambiguous(SessionError::LinkMessage(message))),
             Err(_) => Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed)),
-            }
         }
     }
 }
@@ -967,11 +962,13 @@ async fn run_lane_sender(
         let scheduled = tokio::select! {
             biased;
             _ = cancel.cancelled() => {
+                receiver.close();
                 fail_pending(&mut receiver, &budgets, "scheduler closed");
                 return;
             }
             changed = failed_rx.changed() => {
                 if changed.is_ok() && *failed_rx.borrow() {
+                    receiver.close();
                     fail_pending(&mut receiver, &budgets, "physical link failed");
                     return;
                 }

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -1,5 +1,6 @@
 use std::collections::{BTreeMap, VecDeque};
 use std::fmt;
+use std::future::Future;
 use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
@@ -9,7 +10,9 @@ use cmux_remote_protocol::{
     FrameDecodeError, FrameFlags, Lane, MAX_FRAME_PAYLOAD, MAX_WIRE_FRAME_BYTES, SessionId,
     WireFrame,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::link::{FrameLink, LinkError};
 
@@ -147,12 +150,13 @@ impl ReliableSession {
         let scheduler = ScheduledSender::spawn(link.clone(), shared.limits);
         let ack_senders = Lane::ALL.map(|lane| {
             let (sender, receiver) = mpsc::channel(1);
-            tokio::spawn(run_ack_sender(
+            scheduler.spawn_tracked(run_ack_sender(
                 shared.clone(),
                 scheduler.clone(),
                 generation,
                 lane,
                 receiver,
+                scheduler.cancel_token(),
             ));
             sender
         });
@@ -520,7 +524,12 @@ impl ReliableSession {
         for progress in &self.shared.outbound_progress {
             progress.notify_waiters();
         }
-        self.link.close().await.map_err(SessionError::Link)
+        // Stop ACK production first. Lane writers keep an already admitted
+        // frame in flight, then observe cancellation after the link closes.
+        self.scheduler.request_shutdown();
+        let link_result = self.link.close().await.map_err(SessionError::Link);
+        self.scheduler.wait_for_shutdown().await;
+        link_result
     }
 }
 
@@ -549,8 +558,16 @@ async fn run_ack_sender(
     generation: u64,
     lane: Lane,
     mut requested: mpsc::Receiver<()>,
+    cancel: CancellationToken,
 ) {
-    while requested.recv().await.is_some() {
+    loop {
+        let request = tokio::select! {
+            _ = cancel.cancelled() => return,
+            requested = requested.recv() => requested,
+        };
+        if request.is_none() {
+            return;
+        }
         while requested.try_recv().is_ok() {}
         let Ok(encoded) = encode_ack(&shared, generation, lane) else { return };
         if scheduler.send(lane, encoded).await.is_err() {
@@ -732,9 +749,19 @@ struct DeliveryEntry {
 
 #[derive(Clone)]
 struct ScheduledSender {
+    inner: Arc<ScheduledSenderInner>,
+}
+
+struct ScheduledSenderInner {
     queues: Arc<QueueSenders>,
     budgets: Arc<[AtomicUsize; 4]>,
     limits: SessionLimits,
+    cancel: CancellationToken,
+    tasks: Mutex<Option<Vec<JoinHandle<()>>>>,
+    join_started: AtomicBool,
+    finished: AtomicBool,
+    done: Notify,
+    active_tasks: AtomicUsize,
 }
 
 impl ScheduledSender {
@@ -751,6 +778,18 @@ impl ScheduledSender {
         });
         let budgets = Arc::new(std::array::from_fn(|_| AtomicUsize::new(0)));
         let (failed_tx, failed_rx) = tokio::sync::watch::channel(false);
+        let inner = Arc::new(ScheduledSenderInner {
+            queues,
+            budgets,
+            limits,
+            cancel: CancellationToken::new(),
+            tasks: Mutex::new(Some(Vec::with_capacity(8))),
+            join_started: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            done: Notify::new(),
+            active_tasks: AtomicUsize::new(0),
+        });
+        let scheduler = Self { inner };
         // Each lane owns an independent physical send loop. LaneMuxLink can
         // therefore progress dedicated carriers concurrently; a FrameLink
         // backed by one writer may still serialize inside its implementation.
@@ -760,30 +799,87 @@ impl ScheduledSender {
             (Lane::Bulk, bulk_rx),
             (Lane::Tunnel, tunnel_rx),
         ] {
-            tokio::spawn(run_lane_sender(
+            scheduler.spawn_tracked(run_lane_sender(
                 link.clone(),
                 lane,
                 receiver,
-                budgets.clone(),
+                scheduler.inner.budgets.clone(),
                 failed_tx.clone(),
                 failed_rx.clone(),
+                scheduler.cancel_token(),
             ));
         }
-        Self { queues, budgets, limits }
+        scheduler
+    }
+
+    fn spawn_tracked<F>(&self, future: F)
+    where
+        F: Future<Output = ()> + Send + 'static,
+    {
+        self.inner.active_tasks.fetch_add(1, Ordering::AcqRel);
+        let inner = self.inner.clone();
+        let task = tokio::spawn(async move {
+            future.await;
+            inner.active_tasks.fetch_sub(1, Ordering::AcqRel);
+        });
+        let mut tasks = self.inner.tasks.lock().unwrap();
+        if let Some(tasks) = tasks.as_mut() {
+            tasks.push(task);
+        } else {
+            task.abort();
+        }
+    }
+
+    fn cancel_token(&self) -> CancellationToken {
+        self.inner.cancel.clone()
+    }
+
+    fn request_shutdown(&self) {
+        self.inner.cancel.cancel();
+    }
+
+    async fn wait_for_shutdown(&self) {
+        self.request_shutdown();
+        let notified = self.inner.done.notified();
+        if self
+            .inner
+            .join_started
+            .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
+            .is_ok()
+        {
+            let tasks = self.inner.tasks.lock().unwrap().take().unwrap_or_default();
+            for task in tasks {
+                let _ = task.await;
+            }
+            self.inner.finished.store(true, Ordering::Release);
+            self.inner.done.notify_waiters();
+        } else if !self.inner.finished.load(Ordering::Acquire) {
+            notified.await;
+        }
     }
 
     async fn send(&self, lane: Lane, frame: Bytes) -> Result<(), ScheduleError> {
-        let budget = &self.budgets[lane_index(lane)];
+        if self.inner.cancel.is_cancelled() {
+            return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
+        }
+        let budget = &self.inner.budgets[lane_index(lane)];
         budget
             .fetch_update(Ordering::AcqRel, Ordering::Acquire, |current| {
                 current
                     .checked_add(frame.len())
-                    .filter(|next| *next <= self.limits.queued_bytes_per_lane)
+                    .filter(|next| *next <= self.inner.limits.queued_bytes_per_lane)
             })
             .map_err(|_| ScheduleError::Unscheduled(SessionError::QueueFull(lane)))?;
         let bytes = frame.len();
         let (completion, result) = oneshot::channel();
-        if self.queues.get(lane).send(ScheduledFrame { lane, frame, completion }).await.is_err() {
+        if self
+            .inner
+            .queues
+            .get(lane)
+            .send(ScheduledFrame { lane, frame, completion })
+            .await
+            .is_err()
+        {
             budget.fetch_sub(bytes, Ordering::AcqRel);
             return Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed));
         }
@@ -802,10 +898,15 @@ async fn run_lane_sender(
     budgets: Arc<[AtomicUsize; 4]>,
     failed_tx: tokio::sync::watch::Sender<bool>,
     mut failed_rx: tokio::sync::watch::Receiver<bool>,
+    cancel: CancellationToken,
 ) {
     loop {
         let scheduled = tokio::select! {
             biased;
+            _ = cancel.cancelled() => {
+                fail_pending(&mut receiver, &budgets, "scheduler closed");
+                return;
+            }
             changed = failed_rx.changed() => {
                 if changed.is_ok() && *failed_rx.borrow() {
                     fail_pending(&mut receiver, &budgets, "physical link failed");
@@ -1122,6 +1223,29 @@ mod tests {
         first.await.unwrap().unwrap();
         let sent = link.sent.lock().await.clone();
         assert_eq!(sent, [Lane::Interactive, Lane::Bulk]);
+    }
+
+    #[tokio::test]
+    async fn close_waits_for_lane_and_ack_tasks_without_dropping_in_flight_frame() {
+        let link = Arc::new(GatedRecordingLink::new());
+        let weak_link = Arc::downgrade(&link);
+        let session =
+            ReliableSession::new(SessionId([14; 16]), link.clone(), SessionLimits::default());
+        let send = tokio::spawn({
+            let session = session.clone();
+            async move {
+                session
+                    .send(Lane::Bulk, 1, Bytes::from_static(b"in flight"), FrameFlags::empty())
+                    .await
+            }
+        });
+        link.entered.acquire().await.unwrap().forget();
+
+        session.close().await.unwrap();
+        assert_eq!(send.await.unwrap().unwrap(), 1);
+        drop(session);
+        drop(link);
+        assert!(weak_link.upgrade().is_none(), "session tasks retained the link after close");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -140,7 +140,7 @@ impl ReliableSession {
             limits,
             transition: Arc::new(tokio::sync::RwLock::new(())),
             lane_sends: std::array::from_fn(|_| tokio::sync::Mutex::new(())),
-            outbound_progress: std::array::from_fn(|_| tokio::sync::Notify::new()),
+            outbound_progress: std::array::from_fn(|_| Notify::new()),
             state: Mutex::new(ReliabilityState::new()),
         });
         Self::from_parts(shared, link, 0)
@@ -581,7 +581,7 @@ struct SharedState {
     limits: SessionLimits,
     transition: Arc<tokio::sync::RwLock<()>>,
     lane_sends: [tokio::sync::Mutex<()>; 4],
-    outbound_progress: [tokio::sync::Notify; 4],
+    outbound_progress: [Notify; 4],
     state: Mutex<ReliabilityState>,
 }
 

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -10,7 +10,7 @@ use cmux_remote_protocol::{
     FrameDecodeError, FrameFlags, Lane, MAX_FRAME_PAYLOAD, MAX_WIRE_FRAME_BYTES, SessionId,
     WireFrame,
 };
-use tokio::sync::{mpsc, oneshot};
+use tokio::sync::{Notify, mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -18,6 +18,7 @@ use crate::link::{FrameLink, LinkError};
 
 const RECONNECT_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEDULER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
+const SCHEDULER_ABORT_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
 
 #[derive(Debug, Clone, Copy)]
 pub struct SessionLimits {
@@ -936,13 +937,13 @@ impl ScheduledSender {
             .compare_exchange(false, true, Ordering::AcqRel, Ordering::Acquire)
             .is_ok()
         {
-            let tasks = self.inner.tasks.lock().unwrap().take().unwrap_or_default();
+            let mut tasks = self.inner.tasks.lock().unwrap().take().unwrap_or_default();
             let shutdown_complete = self.inner.shutdown_complete.clone();
             let abort_handles = self.inner.task_abort_handles.lock().unwrap().clone();
             let shutdown_forced = self.inner.shutdown_forced.clone();
             let join = tokio::spawn(async move {
                 let timed_out = tokio::time::timeout(SCHEDULER_SHUTDOWN_TIMEOUT, async {
-                    for task in tasks {
+                    for task in &mut tasks {
                         let _ = task.await;
                     }
                 })
@@ -953,6 +954,12 @@ impl ScheduledSender {
                     for abort_handle in abort_handles {
                         abort_handle.abort();
                     }
+                    let _ = tokio::time::timeout(SCHEDULER_ABORT_WAIT_TIMEOUT, async {
+                        for task in tasks {
+                            let _ = task.await;
+                        }
+                    })
+                    .await;
                 }
                 shutdown_complete.cancel();
             });

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -10,7 +10,7 @@ use cmux_remote_protocol::{
     FrameDecodeError, FrameFlags, Lane, MAX_FRAME_PAYLOAD, MAX_WIRE_FRAME_BYTES, SessionId,
     WireFrame,
 };
-use tokio::sync::{Notify, mpsc, oneshot};
+use tokio::sync::{mpsc, oneshot};
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
@@ -759,8 +759,7 @@ struct ScheduledSenderInner {
     cancel: CancellationToken,
     tasks: Mutex<Option<Vec<JoinHandle<()>>>>,
     join_started: AtomicBool,
-    finished: AtomicBool,
-    done: Notify,
+    shutdown_complete: CancellationToken,
     active_tasks: AtomicUsize,
 }
 
@@ -785,8 +784,7 @@ impl ScheduledSender {
             cancel: CancellationToken::new(),
             tasks: Mutex::new(Some(Vec::with_capacity(8))),
             join_started: AtomicBool::new(false),
-            finished: AtomicBool::new(false),
-            done: Notify::new(),
+            shutdown_complete: CancellationToken::new(),
             active_tasks: AtomicUsize::new(0),
         });
         let scheduler = Self { inner };
@@ -840,7 +838,6 @@ impl ScheduledSender {
 
     async fn wait_for_shutdown(&self) {
         self.request_shutdown();
-        let notified = self.inner.done.notified();
         if self
             .inner
             .join_started
@@ -851,10 +848,9 @@ impl ScheduledSender {
             for task in tasks {
                 let _ = task.await;
             }
-            self.inner.finished.store(true, Ordering::Release);
-            self.inner.done.notify_waiters();
-        } else if !self.inner.finished.load(Ordering::Acquire) {
-            notified.await;
+            self.inner.shutdown_complete.cancel();
+        } else {
+            self.inner.shutdown_complete.cancelled().await;
         }
     }
 

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -1383,6 +1383,57 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shutdown_rejects_send_waiting_for_queue_without_orphaning_completion() {
+        let link = Arc::new(GatedRecordingLink::new());
+        let mut limits = SessionLimits::default();
+        limits.queued_frames_per_lane = 1;
+        let session = ReliableSession::new(SessionId([19; 16]), link.clone(), limits);
+
+        let first = tokio::spawn({
+            let session = session.clone();
+            async move {
+                session.send(Lane::Bulk, 1, Bytes::from_static(b"first"), FrameFlags::empty()).await
+            }
+        });
+        link.entered.acquire().await.unwrap().forget();
+
+        let second = tokio::spawn({
+            let session = session.clone();
+            async move {
+                session
+                    .send(Lane::Bulk, 2, Bytes::from_static(b"second"), FrameFlags::empty())
+                    .await
+            }
+        });
+        tokio::time::timeout(Duration::from_secs(1), async {
+            while session.scheduler.inner.budgets[lane_index(Lane::Bulk)].load(Ordering::Acquire)
+                == 0
+            {
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("second frame was not admitted to the bounded lane queue");
+
+        let third = tokio::spawn({
+            let session = session.clone();
+            async move {
+                session.send(Lane::Bulk, 3, Bytes::from_static(b"third"), FrameFlags::empty()).await
+            }
+        });
+        session.scheduler.request_shutdown();
+        let third_result = tokio::time::timeout(Duration::from_secs(1), third)
+            .await
+            .expect("send waiting for queue did not observe shutdown")
+            .unwrap();
+        assert!(matches!(third_result, Err(SessionError::SchedulerClosed)));
+
+        link.release.add_permits(1);
+        let _ = first.await;
+        let _ = second.await;
+    }
+
+    #[tokio::test]
     async fn committed_frame_is_delivered_when_its_ack_write_fails() {
         let session_id = SessionId([15; 16]);
         let frame = WireFrame {

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -1052,7 +1052,7 @@ mod tests {
     use std::sync::atomic::AtomicBool;
 
     use async_trait::async_trait;
-    use tokio::sync::{Mutex as AsyncMutex, Semaphore, oneshot};
+    use tokio::sync::{Barrier, Mutex as AsyncMutex, Semaphore, oneshot};
 
     use super::*;
     use crate::link::{LaneMuxLink, LinkRoute, test_support};
@@ -1074,6 +1074,10 @@ mod tests {
     struct GatedAckLink {
         incoming: AsyncMutex<mpsc::UnboundedReceiver<Bytes>>,
         send_entered: Semaphore,
+    }
+
+    struct ConcurrentCloseLink {
+        close_barrier: Barrier,
     }
 
     #[async_trait]
@@ -1142,6 +1146,30 @@ mod tests {
         }
 
         async fn close(&self) -> Result<(), LinkError> {
+            Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl FrameLink for ConcurrentCloseLink {
+        fn description(&self) -> &str {
+            "concurrent-close"
+        }
+
+        fn maximum_frame_bytes(&self) -> usize {
+            128 * 1024
+        }
+
+        async fn send(&self, _frame: Bytes) -> Result<(), LinkError> {
+            std::future::pending().await
+        }
+
+        async fn receive(&self) -> Result<Option<Bytes>, LinkError> {
+            std::future::pending().await
+        }
+
+        async fn close(&self) -> Result<(), LinkError> {
+            self.close_barrier.wait().await;
             Ok(())
         }
     }
@@ -1246,6 +1274,34 @@ mod tests {
         drop(session);
         drop(link);
         assert!(weak_link.upgrade().is_none(), "session tasks retained the link after close");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 8)]
+    async fn concurrent_close_calls_all_observe_worker_shutdown() {
+        const CLOSE_CALLS: usize = 64;
+        const ROUNDS: usize = 256;
+
+        tokio::time::timeout(Duration::from_secs(10), async {
+            for round in 0..ROUNDS {
+                let link =
+                    Arc::new(ConcurrentCloseLink { close_barrier: Barrier::new(CLOSE_CALLS) });
+                let session = ReliableSession::new(
+                    SessionId([(round % 256) as u8; 16]),
+                    link,
+                    SessionLimits::default(),
+                );
+                let mut closes = Vec::with_capacity(CLOSE_CALLS);
+                for _ in 0..CLOSE_CALLS {
+                    let session = session.clone();
+                    closes.push(tokio::spawn(async move { session.close().await }));
+                }
+                for close in closes {
+                    close.await.unwrap().unwrap();
+                }
+            }
+        })
+        .await
+        .expect("concurrent close calls missed scheduler completion");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -956,6 +956,12 @@ impl ScheduledSender {
                     }
                     let _ = tokio::time::timeout(SCHEDULER_ABORT_WAIT_TIMEOUT, async {
                         for task in tasks {
+                            // Tasks awaited before the shutdown deadline have
+                            // already consumed their JoinHandle completion.
+                            // Tokio panics if such a handle is polled again.
+                            if task.is_finished() {
+                                continue;
+                            }
                             let _ = task.await;
                         }
                     })
@@ -1471,22 +1477,32 @@ mod tests {
         let mut limits = SessionLimits::default();
         limits.queued_frames_per_lane = 1;
         let session = ReliableSession::new(SessionId([19; 16]), link.clone(), limits);
+        fn encode(sequence: u64, payload: &'static [u8]) -> Bytes {
+            Bytes::from(
+                WireFrame {
+                    session: SessionId([19; 16]),
+                    generation: 0,
+                    lane: Lane::Bulk,
+                    flags: FrameFlags::RELIABLE,
+                    sequence,
+                    acknowledgement: 0,
+                    stream: 1,
+                    payload: payload.to_vec(),
+                }
+                .encode()
+                .unwrap(),
+            )
+        }
 
         let first = tokio::spawn({
-            let session = session.clone();
-            async move {
-                session.send(Lane::Bulk, 1, Bytes::from_static(b"first"), FrameFlags::empty()).await
-            }
+            let scheduler = session.scheduler.clone();
+            async move { scheduler.send(Lane::Bulk, encode(1, b"first")).await }
         });
         link.entered.acquire().await.unwrap().forget();
 
         let second = tokio::spawn({
-            let session = session.clone();
-            async move {
-                session
-                    .send(Lane::Bulk, 2, Bytes::from_static(b"second"), FrameFlags::empty())
-                    .await
-            }
+            let scheduler = session.scheduler.clone();
+            async move { scheduler.send(Lane::Bulk, encode(2, b"second")).await }
         });
         tokio::time::timeout(Duration::from_secs(1), async {
             while session.scheduler.inner.budgets[lane_index(Lane::Bulk)].load(Ordering::Acquire)
@@ -1499,17 +1515,18 @@ mod tests {
         .expect("second frame was not admitted to the bounded lane queue");
 
         let third = tokio::spawn({
-            let session = session.clone();
-            async move {
-                session.send(Lane::Bulk, 3, Bytes::from_static(b"third"), FrameFlags::empty()).await
-            }
+            let scheduler = session.scheduler.clone();
+            async move { scheduler.send(Lane::Bulk, encode(3, b"third")).await }
         });
         session.scheduler.request_shutdown();
         let third_result = tokio::time::timeout(Duration::from_secs(1), third)
             .await
             .expect("send waiting for queue did not observe shutdown")
             .unwrap();
-        assert!(matches!(third_result, Err(SessionError::SchedulerClosed)));
+        assert!(matches!(
+            third_result,
+            Err(ScheduleError::Ambiguous(SessionError::SchedulerClosed))
+        ));
 
         link.release.add_permits(1);
         let _ = first.await;

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -1474,8 +1474,7 @@ mod tests {
     #[tokio::test]
     async fn shutdown_rejects_send_waiting_for_queue_without_orphaning_completion() {
         let link = Arc::new(GatedRecordingLink::new());
-        let mut limits = SessionLimits::default();
-        limits.queued_frames_per_lane = 1;
+        let limits = SessionLimits { queued_frames_per_lane: 1, ..SessionLimits::default() };
         let session = ReliableSession::new(SessionId([19; 16]), link.clone(), limits);
         fn encode(sequence: u64, payload: &'static [u8]) -> Bytes {
             Bytes::from(


### PR DESCRIPTION
ReliableSession now owns its ACK and lane sender tasks through the scheduler lifecycle. close cancels ACK production, closes the link to release in-flight writes, then joins every worker.

Adds a behavior test proving an in-flight frame completes and worker-held link references are released.

Hosted verification: https://github.com/manaflow-ai/cmux/actions/runs/33718677568

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
`ReliableSession` now reaps its ACK and lane sender workers instead of only closing the link. Shutdown fences new sends, allows already-admitted frames to finish, and returns `SchedulerClosed` when a worker remains stuck past the bounded timeout; dropping the session aborts workers and releases the link.

- Concurrent close calls share shutdown completion, and cancelling one waiter does not block later shutdowns.
- Queued frames and sends waiting for queue admission fail with `SchedulerClosed`.
- Adds coverage for in-flight completion, queue fencing, concurrent and cancelled closes, drop cleanup, and stuck link sends.
- Adds `tokio-util` for cancellation.

<sup>Written for commit bec8a90e6e3e9c972568aaa8c9106e81bbca9c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session shutdown reliability by ensuring in-flight messages finish before the connection closes.
  - Connections are now consistently released after shutdown, including when multiple close requests occur simultaneously.
  - New sends are rejected cleanly once session shutdown begins.
  - Pending outbound messages are handled during shutdown, reducing interrupted communication.
  - Concurrent shutdown requests now wait for background session activity to finish.
  - Background session activity is now cleaned up when a session is discarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->