### PR TITLE
Keep client identity cache responsive during file lock waits

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -3089,6 +3089,29 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn contended_client_state_file_does_not_block_cached_daemon_reads() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = ClientIdentityStore::load_or_create(temp.path()).unwrap();
+        let state_path = temp.path().join(CLIENT_STATE_FILE);
+        let lock_path = sibling_lock_path(&state_path).unwrap();
+        let path_lock = OwnerFileLock::acquire(&lock_path).unwrap();
+
+        let lookup = store.daemon_key("unknown");
+        tokio::pin!(lookup);
+        assert!(
+            futures_util::poll!(lookup.as_mut()).is_pending(),
+            "daemon lookup unexpectedly completed while the state file was locked"
+        );
+
+        tokio::time::timeout(Duration::from_millis(100), store.known_daemons())
+            .await
+            .expect("cached daemon reads waited for an unrelated owner-file lock");
+
+        drop(path_lock);
+        assert_eq!(lookup.await.unwrap(), None);
+    }
+
+    #[tokio::test]
     async fn failed_known_daemon_forget_keeps_live_trust() {
         let temp = tempfile::tempdir().unwrap();
         let store = ClientIdentityStore::load_or_create(temp.path()).unwrap();

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -177,7 +177,7 @@ pub enum KnownDaemonAuth {
 pub struct ClientIdentityStore {
     state_dir: PathBuf,
     identity: StaticIdentity,
-    state: Mutex<PersistedClientState>,
+    state: StdMutex<ClientStateCache>,
 }
 
 impl std::fmt::Debug for ClientIdentityStore {
@@ -203,7 +203,11 @@ impl ClientIdentityStore {
         if routes_changed {
             atomic_json(&path, &state)?;
         }
-        Ok(Arc::new(Self { state_dir, identity, state: Mutex::new(state) }))
+        Ok(Arc::new(Self {
+            state_dir,
+            identity,
+            state: StdMutex::new(ClientStateCache { persisted: state, generation: 0 }),
+        }))
     }
 
     pub fn identity(&self) -> StaticIdentity {
@@ -211,7 +215,15 @@ impl ClientIdentityStore {
     }
 
     pub async fn known_daemons(&self) -> Vec<KnownDaemon> {
-        let mut daemons = self.state.lock().await.daemons.values().cloned().collect::<Vec<_>>();
+        let mut daemons = self
+            .state
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .persisted
+            .daemons
+            .values()
+            .cloned()
+            .collect::<Vec<_>>();
         daemons.sort_by(|left, right| left.name.cmp(&right.name));
         daemons
     }
@@ -254,8 +266,7 @@ impl ClientIdentityStore {
         let route_hints = credential_free_route_hints(route_hints)?;
         let fingerprint = public_key_fingerprint(&public_key);
         let now = unix_time()?;
-        let mut state = self.state.lock().await;
-        let (_path_lock, mut candidate, _) = self.reload_client_state_locked(&mut state).await?;
+        let (transaction, mut candidate) = self.reload_client_state().await?;
         if let Some(existing) = candidate.daemons.get_mut(&fingerprint) {
             if decode_key(&existing.public_key)? != public_key {
                 return Err(IdentityError::Invalid("known daemon fingerprint collision".into()));
@@ -274,7 +285,7 @@ impl ClientIdentityStore {
                 existing.route_hints = route_hints;
             }
             let record = existing.clone();
-            self.commit_client_state_locked(&mut state, candidate)?;
+            self.commit_client_state(transaction, candidate)?;
             return Ok(record);
         }
         let record = KnownDaemon {
@@ -287,7 +298,7 @@ impl ClientIdentityStore {
             last_used_at_unix: now,
         };
         candidate.daemons.insert(fingerprint, record.clone());
-        self.commit_client_state_locked(&mut state, candidate)?;
+        self.commit_client_state(transaction, candidate)?;
         Ok(record)
     }
 
@@ -298,12 +309,11 @@ impl ClientIdentityStore {
     ) -> Result<Option<KnownDaemon>, IdentityError> {
         let route = credential_free_route_hint(route)?;
         let now = unix_time()?;
-        let mut state = self.state.lock().await;
-        let (_path_lock, mut candidate, routes_changed) =
-            self.reload_client_state_locked(&mut state).await?;
+        let (transaction, mut candidate) = self.reload_client_state().await?;
+        let routes_changed = transaction.routes_changed;
         let Some(existing) = candidate.daemons.get_mut(fingerprint) else {
             if routes_changed {
-                self.commit_client_state_locked(&mut state, candidate)?;
+                self.commit_client_state(transaction, candidate)?;
             }
             return Ok(None);
         };
@@ -312,73 +322,130 @@ impl ClientIdentityStore {
             existing.route_hints.push(route);
         }
         let record = existing.clone();
-        self.commit_client_state_locked(&mut state, candidate)?;
+        self.commit_client_state(transaction, candidate)?;
         Ok(Some(record))
     }
 
     pub async fn daemon_key(&self, fingerprint: &str) -> Result<Option<[u8; 32]>, IdentityError> {
-        let mut state = self.state.lock().await;
-        let (_path_lock, candidate, routes_changed) =
-            self.reload_client_state_locked(&mut state).await?;
+        let (transaction, candidate) = self.reload_client_state().await?;
+        let routes_changed = transaction.routes_changed;
         let key = candidate
             .daemons
             .get(fingerprint)
             .map(|daemon| decode_key(&daemon.public_key))
             .transpose()?;
         if routes_changed {
-            self.commit_client_state_locked(&mut state, candidate)?;
+            self.commit_client_state(transaction, candidate)?;
         }
         Ok(key)
     }
 
     pub async fn forget_daemon(&self, fingerprint: &str) -> Result<bool, IdentityError> {
-        let mut state = self.state.lock().await;
-        let (_path_lock, mut candidate, routes_changed) =
-            self.reload_client_state_locked(&mut state).await?;
+        let (transaction, mut candidate) = self.reload_client_state().await?;
+        let routes_changed = transaction.routes_changed;
         let removed = candidate.daemons.remove(fingerprint).is_some();
         if removed || routes_changed {
-            self.commit_client_state_locked(&mut state, candidate)?;
+            self.commit_client_state(transaction, candidate)?;
         }
         Ok(removed)
     }
 
-    async fn reload_client_state_locked(
+    async fn reload_client_state(
         &self,
-        state: &mut PersistedClientState,
-    ) -> Result<(OwnerFileLock, PersistedClientState, bool), IdentityError> {
+    ) -> Result<(ClientStateTransaction, PersistedClientState), IdentityError> {
         let path = self.state_dir.join(CLIENT_STATE_FILE);
         let lock_path = sibling_lock_path(&path).map_err(IdentityError::Io)?;
-        let path_lock = OwnerFileLock::acquire_async(lock_path).await.map_err(IdentityError::Io)?;
-        let (disk_state, routes_changed) =
-            load_client_state(&path)?.unwrap_or_else(|| (state.clone(), false));
-        *state = disk_state.clone();
-        Ok((path_lock, disk_state, routes_changed))
-    }
-
-    fn commit_client_state_locked(
-        &self,
-        state: &mut PersistedClientState,
-        candidate: PersistedClientState,
-    ) -> Result<(), IdentityError> {
-        match self.persist_client_locked(&candidate) {
-            Ok(()) => {
-                *state = candidate;
-                Ok(())
+        loop {
+            let (generation, fallback) = {
+                let cache = self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+                (cache.generation, cache.persisted.clone())
+            };
+            let path_lock =
+                OwnerFileLock::acquire_async(lock_path.clone()).await.map_err(IdentityError::Io)?;
+            let loaded = load_client_state(&path)?;
+            let mut cache = self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if cache.generation != generation {
+                // A transaction completed while this operation waited for the
+                // owner-file lock. Reload under a new lease so the disk state
+                // and cache generation describe the same point in history.
+                continue;
             }
-            Err(error @ IdentityError::Committed(_)) => {
-                *state = candidate;
-                Err(error)
-            }
-            Err(error) => Err(error),
+            let (candidate, routes_changed) = loaded.unwrap_or((fallback, false));
+            cache.replace(candidate.clone())?;
+            let generation = cache.generation;
+            drop(cache);
+            return Ok((
+                ClientStateTransaction { _path_lock: path_lock, routes_changed, generation },
+                candidate,
+            ));
         }
     }
 
-    fn persist_client_locked(&self, state: &PersistedClientState) -> Result<(), IdentityError> {
+    fn commit_client_state(
+        &self,
+        transaction: ClientStateTransaction,
+        candidate: PersistedClientState,
+    ) -> Result<(), IdentityError> {
+        {
+            let cache = self.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            if cache.generation != transaction.generation {
+                return Err(IdentityError::Persistence(
+                    "client identity cache changed while its owner-file lock was held".into(),
+                ));
+            }
+        }
+        let result = match self.persist_client_state(&candidate) {
+            Ok(()) => {
+                self.state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .replace(candidate)?;
+                Ok(())
+            }
+            Err(error @ IdentityError::Committed(_)) => {
+                self.state
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner)
+                    .replace(candidate)?;
+                Err(error)
+            }
+            Err(error) => Err(error),
+        };
+        // Keep the cross-process lease through both the durable write and the
+        // matching cache publication.
+        drop(transaction);
+        result
+    }
+
+    fn persist_client_state(&self, state: &PersistedClientState) -> Result<(), IdentityError> {
         atomic_json(&self.state_dir.join(CLIENT_STATE_FILE), state)
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+struct ClientStateCache {
+    persisted: PersistedClientState,
+    generation: u64,
+}
+
+impl ClientStateCache {
+    fn replace(&mut self, persisted: PersistedClientState) -> Result<(), IdentityError> {
+        if self.persisted != persisted {
+            self.generation = self.generation.checked_add(1).ok_or_else(|| {
+                IdentityError::Invalid("client state generation exhausted".into())
+            })?;
+            self.persisted = persisted;
+        }
+        Ok(())
+    }
+}
+
+struct ClientStateTransaction {
+    _path_lock: OwnerFileLock,
+    routes_changed: bool,
+    generation: u64,
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq)]
 struct PersistedClientState {
     version: u32,
     #[serde(default)]
@@ -3754,9 +3821,9 @@ mod tests {
             .await
             .unwrap();
         {
-            let mut state = store.state.lock().await;
-            state.daemons.get_mut(&known.fingerprint).unwrap().last_used_at_unix = 1;
-            store.persist_client_locked(&state).unwrap();
+            let mut state = store.state.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+            state.persisted.daemons.get_mut(&known.fingerprint).unwrap().last_used_at_unix = 1;
+            store.persist_client_state(&state.persisted).unwrap();
         }
 
         let refreshed = store


### PR DESCRIPTION
The client identity store now keeps its in-memory cache lock separate from owner-file waits and disk I/O. A cache generation check retries a transaction when another local update completes during the file-lock wait. The owner-file lease still covers the disk transaction and matching cache publication.

The first commit adds the regression test. It failed on the old code because a cached read timed out behind a contended owner-file lock. The second commit fixes the lock scope.

Tests:
- Full `cmux-remote` package suite on Linux, 516 unit tests plus integration tests
- Focused Clippy for `cmux-remote`
- Hosted Linux and macOS focused verification: https://github.com/manaflow-ai/cmux/actions/runs/33718767854
- `rustfmt --check` and `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the client identity store so cached reads don't block while another process holds the owner-file lock. The cache lock is no longer held across file-lock waits and disk I/O; a generation check retries the reload when a local update lands during the wait, and a commit that races a newer update returns an error instead of overwriting it.

**Bug Fixes**
- The owner-file lease still covers the disk write and matching cache publication, preserving cross-process consistency.
- Adds a regression test that failed on the old code because a cached read timed out behind a contended owner-file lock.

<sup>Written for commit f75f08fcf8c1a549478933745c7da7f263e5c1fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved responsiveness when reading client state while another process is using the state file.
  * Improved reliability for concurrent state updates, reducing the risk of stale data overwriting newer changes.
  * Ensured successfully saved state is immediately reflected in subsequent reads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->