### PR TITLE
fix(cmux-tui): make workspace clippy green and lint in every hosted lane

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -428,8 +428,9 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # Lint in every hosted mode. When this ran only in full mode, warnings
+      # accumulated on main unnoticed because the full lane was rarely used.
       - name: cargo clippy
-        if: inputs.mode == 'full'
         working-directory: cmux-tui
         run: cargo clippy --workspace --all-targets --locked -- -D warnings
 

--- a/cmux-tui/crates/chatmux-relay/src/actions.rs
+++ b/cmux-tui/crates/chatmux-relay/src/actions.rs
@@ -1442,17 +1442,6 @@ async fn run_spec(
     RunOutcome::Done { exit_code: exited.unwrap_or(0), output: text.into_owned() }
 }
 
-#[cfg(unix)]
-fn signal_process_group_id<F>(pid: Option<u32>, kill: bool, send: F) -> bool
-where
-    F: FnOnce(libc::pid_t, libc::c_int) -> libc::c_int,
-{
-    let Some(pid) = pid else { return false };
-    let signal = if kill { libc::SIGKILL } else { libc::SIGTERM };
-    let group = -(pid as i32);
-    send(group, signal) == 0
-}
-
 #[cfg(windows)]
 struct WindowsJob {
     handle: std::os::windows::io::OwnedHandle,
@@ -2124,19 +2113,6 @@ mod tests {
         std::fs::create_dir_all(&dir).unwrap();
         // realpath so canonical checks match (macOS /tmp -> /private/tmp).
         std::fs::canonicalize(&dir).unwrap()
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn process_group_failure_does_not_fallback_to_numeric_pid() {
-        let mut targets = Vec::new();
-        let signalled = signal_process_group_id(Some(4_321), false, |target, _| {
-            targets.push(target);
-            -1
-        });
-
-        assert!(!signalled);
-        assert_eq!(targets, vec![-4_321]);
     }
 
     #[cfg(windows)]

--- a/cmux-tui/crates/chatmux-relay/src/enrollment.rs
+++ b/cmux-tui/crates/chatmux-relay/src/enrollment.rs
@@ -437,7 +437,7 @@ mod tests {
         let path = fixture(&enrollment(), 0o600, "oversized");
         let current_len = std::fs::metadata(&path).unwrap().len() as usize;
         let padding = vec![b' '; MAX_ENROLLMENT_BYTES + 1 - current_len];
-        let mut file = std::fs::OpenOptions::new().append(true).open(&path).unwrap();
+        let mut file = OpenOptions::new().append(true).open(&path).unwrap();
         file.write_all(&padding).unwrap();
 
         let error = load_managed_enrollment_file(&path, NOW).expect_err("oversized enrollment");

--- a/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_checkpoint.rs
@@ -883,7 +883,7 @@ mod tests {
             terminal_output: None,
         };
         assert!(restore_preview(&checkpoint, &[record.clone(), record.clone()], 4).is_err());
-        assert!(restore_preview(&checkpoint, &[record.clone()], 5).is_err());
+        assert!(restore_preview(&checkpoint, std::slice::from_ref(&record), 5).is_err());
         let mut gapped = record;
         gapped.sequence = 5;
         assert!(restore_preview(&checkpoint, &[gapped], 5).is_err());
@@ -976,7 +976,8 @@ mod tests {
         };
 
         for cursor in [None, Some(Value::Null)] {
-            let preview = restore_preview(&checkpoint(cursor), &[record.clone()], 4).unwrap();
+            let preview =
+                restore_preview(&checkpoint(cursor), std::slice::from_ref(&record), 4).unwrap();
             assert_eq!(preview["fully_reducible"], false);
         }
     }

--- a/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/journal_ingress.rs
@@ -1291,9 +1291,9 @@ mod tests {
     fn retry_wait_releases_mux_before_waiting() {
         let mux = Mux::new("journal-retry-wait-drop", crate::SurfaceOptions::default());
         let journal = mux.shared_journal_handle();
-        let (released_tx, released_rx) = std::sync::mpsc::sync_channel(1);
-        let (proceed_tx, proceed_rx) = std::sync::mpsc::sync_channel(1);
-        let (done_tx, done_rx) = std::sync::mpsc::sync_channel(1);
+        let (released_tx, released_rx) = sync_channel(1);
+        let (proceed_tx, proceed_rx) = sync_channel(1);
+        let (done_tx, done_rx) = sync_channel(1);
         let waiter_mux = Arc::clone(&mux);
         let waiter = std::thread::spawn(move || {
             wait_for_journal_retry_after_release(waiter_mux, Duration::from_secs(60), || {

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -19275,7 +19275,7 @@ mod tests {
         let expected = expected_panes_by_screen(&duplicate_panes);
         assert_eq!(expected.get(&first_screen).map(|panes| panes.len()), Some(4));
         assert_eq!(expected.get(&second_screen).map(|panes| panes.len()), Some(1));
-        assert!(expected.get(&restore_screen_id(999)).is_none());
+        assert!(!expected.contains_key(&restore_screen_id(999)));
 
         let mut mismatched = topology;
         mismatched.panes[3].screen_id = second_screen.clone();

--- a/cmux-tui/crates/cmux-tui-core/src/mux.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/mux.rs
@@ -16665,7 +16665,7 @@ fn restore_resource_state(
     for screen in &topology.screens {
         let expected_panes =
             panes_by_screen.get(&screen.public_id).unwrap_or(&empty_expected_panes);
-        crate::workspace_registry::validate_registry_screen_projection(screen, &expected_panes)?;
+        crate::workspace_registry::validate_registry_screen_projection(screen, expected_panes)?;
         let id = screen_slots[&screen.public_id];
         let root =
             restore_layout_node(&screen.layout, &pane_slots, &mut split_slots, &mut allocate)?;

--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -4366,10 +4366,10 @@ impl Surface {
     }
 
     #[cfg(test)]
-    pub(crate) fn install_terminal_reaper_that_finishes_for_test(
+    fn install_terminal_reaper_that_finishes_for_test(
         self: &Arc<Self>,
-        started: std::sync::mpsc::SyncSender<()>,
-        proceed: std::sync::mpsc::Receiver<()>,
+        started: SyncSender<()>,
+        proceed: Receiver<()>,
     ) -> Arc<ReaderCompletion> {
         let pty = self.as_pty().expect("test reaper requires a PTY surface");
         pty.reaper_completion.reset();
@@ -6295,7 +6295,7 @@ struct StartupChild {
 }
 
 #[cfg(test)]
-impl cmux_pty::ChildKiller for StartupChild {
+impl ChildKiller for StartupChild {
     fn kill(&mut self) -> std::io::Result<()> {
         self.state.kill_count.fetch_add(1, Ordering::Relaxed);
         Ok(())

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -144,6 +144,18 @@ impl TerminalExit {
     }
 }
 
+/// Wait for the native child hidden behind cmux-pty without collapsing Unix
+/// signal/core information into its display-only fallback status.
+///
+/// cmux-pty's Unix backend returns `std::process::Child`, so failure to downcast
+/// is an alternate backend and becomes an explicit unknown outcome.
+#[cfg(test)]
+pub(crate) fn wait_for_native_child_status(
+    child: &mut (dyn cmux_pty::Child + Send + Sync),
+) -> TerminalExit {
+    wait_for_native_child_status_with_reap_result(child).0
+}
+
 /// Wait for a PTY child and report whether the wait reaped it successfully.
 ///
 /// Callers that retain an owning guard can use the boolean to avoid issuing a
@@ -795,7 +807,7 @@ impl FrameDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{mpsc, Arc, Mutex};
+    use std::sync::{Arc, Mutex, mpsc};
 
     /// Test-only stand-in for a direct pipe reader. The bounded queue models
     /// the byte pump, while the mutex is the single parser owner.
@@ -1104,7 +1116,7 @@ mod tests {
             let mut command = cmux_pty::PtyCommand::new("/bin/sh");
             command.args(["-c", script]);
             let mut spawned = pty.spawn(command).unwrap();
-            wait_for_native_child_status_with_reap_result(spawned.child.as_mut()).0.outcome
+            wait_for_native_child_status(spawned.child.as_mut()).outcome
         }
 
         assert_eq!(run("exit 17"), TerminalExitOutcome::Exit { code: 17 });

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -6421,9 +6421,7 @@ const VIEWPORT_ANIMATION_SYNC_OPERATION_BUDGET: usize = PTY_OPERATION_QUEUE_CAPA
 
 #[cfg(test)]
 thread_local! {
-    static PANE_AREA_PROJECTION_WORK: std::cell::Cell<usize> = const {
-        std::cell::Cell::new(0)
-    };
+    static PANE_AREA_PROJECTION_WORK: Cell<usize> = const { Cell::new(0) };
 }
 
 #[cfg(test)]
@@ -25112,7 +25110,7 @@ mod tests {
 
     #[test]
     fn host_input_runtime_shutdown_joins_reader_before_returning() {
-        let mut runtime = HostInputRuntime::new();
+        let runtime = HostInputRuntime::new();
         let ingress = runtime.ingress.clone();
         let (events_tx, events_rx) = crossbeam_channel::bounded(1);
         events_tx.send(AppEvent::HostInputReady).unwrap();
@@ -25139,7 +25137,7 @@ mod tests {
 
     #[test]
     fn host_input_runtime_shutdown_serializes_concurrent_callers() {
-        let mut runtime = HostInputRuntime::new();
+        let runtime = HostInputRuntime::new();
         let ingress = runtime.ingress.clone();
         let (closed_tx, closed_rx) = std::sync::mpsc::sync_channel(1);
         let (release_tx, release_rx) = std::sync::mpsc::sync_channel(1);
@@ -25161,7 +25159,7 @@ mod tests {
         });
         closed_rx.recv().unwrap();
 
-        let second_shutdown = shutdown.clone();
+        let second_shutdown = shutdown;
         let (second_done_tx, second_done_rx) = std::sync::mpsc::sync_channel(1);
         let second = std::thread::spawn(move || {
             second_shutdown.shutdown();
@@ -32894,7 +32892,7 @@ mod tests {
     #[test]
     fn graphics_changed_rect_bound_stays_within_linear_comparison_budget() {
         let mux = Mux::new("graphics-diff-complexity-test", SurfaceOptions::default());
-        let mut app = test_app(Session::Local(mux));
+        let app = test_app(Session::Local(mux));
         let count = 512usize;
         let previous = (0..count)
             .map(|index| GraphicIdentity {
@@ -34933,7 +34931,7 @@ mod tests {
             surface_filter: None,
             cancellation: cancellation.clone(),
         };
-        let forwarder_recovery_generation = recovery_generation.clone();
+        let forwarder_recovery_generation = recovery_generation;
         let forwarder = std::thread::spawn(move || {
             forward_mux_events(
                 event_source,

--- a/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
+++ b/cmux-tui/crates/cmux-tui/src/plugin_manager.rs
@@ -498,6 +498,7 @@ fn validate_git_source(source: &str) -> anyhow::Result<()> {
     Ok(())
 }
 
+#[cfg(test)]
 fn is_sensitive_env_name(name: &str) -> bool {
     let name = name.to_ascii_uppercase();
     name.contains("TOKEN")
@@ -1068,12 +1069,12 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn plugin_build_command_terminates_after_timeout() {
-        let mut command = std::process::Command::new("sh");
+        let mut command = Command::new("sh");
         command.args(["-c", "while :; do :; done"]);
-        let started = std::time::Instant::now();
-        let error = run_plugin_build_command(&mut command, std::time::Duration::from_millis(20))
+        let started = Instant::now();
+        let error = run_plugin_build_command(&mut command, Duration::from_millis(20))
             .expect_err("a busy build must time out");
-        assert!(started.elapsed() < std::time::Duration::from_secs(2));
+        assert!(started.elapsed() < Duration::from_secs(2));
         assert!(error.to_string().contains("timed out"));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -1087,14 +1087,17 @@ impl PendingRemoteRequests {
         progressed
     }
 
+    #[cfg(test)]
     fn is_empty(&self) -> bool {
         self.requests.is_empty()
     }
 
+    #[cfg(test)]
     fn len(&self) -> usize {
         self.requests.len()
     }
 
+    #[cfg(test)]
     fn values(&self) -> impl Iterator<Item = &PendingRemoteRequest> {
         self.requests.values()
     }

--- a/cmux-tui/crates/cmux-tui/src/session/tree.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/tree.rs
@@ -183,6 +183,7 @@ pub struct TabNotificationView {
 }
 
 impl TreeView {
+    #[cfg(test)]
     pub(crate) fn from_parts(
         workspaces: Vec<WorkspaceView>,
         workspace_revision: u64,
@@ -349,11 +350,7 @@ impl TreeView {
         true
     }
 
-    pub fn active_workspace_mut(&mut self) -> Option<&mut WorkspaceView> {
-        self.invalidate_location_index();
-        self.workspaces.get_mut(self.active_workspace)
-    }
-
+    #[cfg(test)]
     pub fn active_workspace_mut_screen(&mut self) -> Option<&mut ScreenView> {
         self.invalidate_location_index();
         let workspace = self.workspaces.get_mut(self.active_workspace)?;
@@ -376,6 +373,7 @@ impl TreeView {
             .filter(|pane| pane.id == id)
     }
 
+    #[cfg(test)]
     pub fn pane_mut(&mut self, id: PaneId) -> Option<&mut PaneView> {
         self.invalidate_location_index();
         self.workspaces
@@ -398,6 +396,7 @@ impl TreeView {
             .filter(|tab| tab.surface == id)
     }
 
+    #[cfg(test)]
     pub(crate) fn update_surface_title(&mut self, id: SurfaceId, title: &str) -> bool {
         let (workspace_index, screen_index, pane_index, tab_index) = match self.surface_location(id)
         {
@@ -418,15 +417,12 @@ impl TreeView {
         [workspace_index, screen_index, pane_index, tab_index]: [usize; 4],
         title: &str,
     ) -> Option<bool> {
-        let Some(tab) = self
+        let tab = self
             .workspaces
             .get_mut(workspace_index)
             .and_then(|workspace| workspace.screens.get_mut(screen_index))
             .and_then(|screen| screen.panes.get_mut(pane_index))
-            .and_then(|pane| pane.tabs.get_mut(tab_index))
-        else {
-            return None;
-        };
+            .and_then(|pane| pane.tabs.get_mut(tab_index))?;
         if tab.surface != id {
             return None;
         }
@@ -833,8 +829,7 @@ fn parse_pane(value: &Value) -> Option<PaneView> {
                     .collect()
             })
             .unwrap_or_default(),
-        active_tab: active_tab
-            .unwrap_or_else(|| if active_tab_is_declared { usize::MAX } else { 0 }),
+        active_tab: active_tab.unwrap_or(if active_tab_is_declared { usize::MAX } else { 0 }),
     })
 }
 
@@ -967,8 +962,8 @@ pub(super) fn parse_tree_with_capabilities(
                     }
                 }
             }
-            view.active_screen = active_screen
-                .unwrap_or_else(|| if active_screen_is_invalid { usize::MAX } else { 0 });
+            view.active_screen =
+                active_screen.unwrap_or(if active_screen_is_invalid { usize::MAX } else { 0 });
         }
         tree.workspaces.push(view);
     }

--- a/cmux-tui/crates/cmux-tui/src/ui/input.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/input.rs
@@ -535,7 +535,7 @@ mod tests {
 
     #[test]
     fn visible_cursor_uses_terminal_cell_width() {
-        let mut input = text_input("界a");
+        let input = text_input("界a");
 
         let (shown, cursor) = input.visible_text_and_cursor(4);
 
@@ -567,7 +567,7 @@ mod tests {
 
     #[test]
     fn visible_cursor_counts_halfwidth_sound_marks_as_terminal_cells() {
-        let mut input = text_input("ｶﾞa");
+        let input = text_input("ｶﾞa");
 
         let (shown, cursor) = input.visible_text_and_cursor(4);
 

--- a/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/terminal_grid.rs
@@ -872,9 +872,11 @@ mod tests {
                 columns,
                 "Ghostty width {width:?} must remain authoritative"
             );
-            let expected_diff_option = forced
-                .then(|| CellDiffOption::ForcedWidth(NonZeroU16::new(columns).unwrap()))
-                .unwrap_or(CellDiffOption::None);
+            let expected_diff_option = if forced {
+                CellDiffOption::ForcedWidth(NonZeroU16::new(columns).unwrap())
+            } else {
+                CellDiffOption::None
+            };
             assert_eq!(target.diff_option, expected_diff_option);
         }
     }


### PR DESCRIPTION
`cargo clippy --workspace --all-targets --locked -- -D warnings` fails on current main with eleven pre-existing warnings, and the check that would catch them runs only in the hosted full lane, which nobody can pass right now because its Windows smoke is red (https://github.com/manaflow-ai/cmux/issues/11793). So lint drift on main went unnoticed.

This PR:

- carries the three commits from https://github.com/manaflow-ai/cmux/pull/11763 (which already contains https://github.com/manaflow-ai/cmux/pull/11758) with their original authorship: test cleanups, import simplifications, an equivalent map assertion, slice references, removal of an unused process-group helper and its test, unused `mut`s, and an unused `TreeView` method;
- marks `wait_for_native_child_status` test-only, the one warning those commits no longer cover because main moved;
- runs `cargo clippy` in every hosted mode, not only `full`, so the focused lane everyone uses catches lint drift.

Trade-off stated: clippy adds a few minutes to each focused test job. The alternative, a PR-triggered clippy job, needs the Rust toolchain plus the Zig ghostty-vt build on every PR and is left as a follow-up.

Verification on the fleet builder against this exact tree: `cargo fmt --check` clean, `cargo clippy --workspace --all-targets --locked -- -D warnings` finishes with no errors. Local codex review of 11763's diff was clean. 11758 and 11763 become redundant once this merges.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the workspace clippy warnings on main and runs clippy in every hosted mode so lint drift no longer goes unnoticed.

**Notes**
- Marked `wait_for_native_child_status`, several `TreeView` methods, and `PendingRemoteRequests` accessors as test-only, and removed the unused `active_workspace_mut` method.
- Removed an unused process-group helper and its test.
- Clippy adds a few minutes to each focused test job.

<sup>Written for commit 60bba981dc20ea3bfc1a7708c4b0762c9e9d59d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

