### PR TITLE
Fix cloud machine-create progress and protocol regressions

### DIFF
--- a/Sources/Cloud/MachineCreateCoordinator.swift
+++ b/Sources/Cloud/MachineCreateCoordinator.swift
@@ -60,6 +60,7 @@ final class MachineCreateCoordinator {
     /// observer token without going through an isolated accessor.
     @ObservationIgnored private var launches: [UUID: Launch] = [:]
     @ObservationIgnored private var progressOutput: [UUID: String] = [:]
+    @ObservationIgnored private var attemptGeneration: [UUID: UInt64] = [:]
     @ObservationIgnored private let notifier: @MainActor (MachineCreateNotice) -> Void
     @ObservationIgnored private let now: () -> Date
     @ObservationIgnored private let notificationCenter: NotificationCenter
@@ -107,13 +108,15 @@ final class MachineCreateCoordinator {
         operations.append(operation)
         launches[operation.id] = launch
         progressOutput[operation.id] = ""
+        attemptGeneration[operation.id] = 1
         postDidChange(finished: nil)
-        guard launch(request.arguments, progressHandler(for: operation.id), completionHandler(for: operation.id)) else {
+        guard launch(request.arguments, progressHandler(for: operation.id, generation: 1), completionHandler(for: operation.id, generation: 1)) else {
             if let index = operations.firstIndex(where: { $0.id == operation.id }) {
                 operations.remove(at: index)
             }
             launches.removeValue(forKey: operation.id)
             progressOutput.removeValue(forKey: operation.id)
+            attemptGeneration.removeValue(forKey: operation.id)
             postDidChange(finished: nil)
             return false
         }
@@ -131,14 +134,18 @@ final class MachineCreateCoordinator {
               let launch = launches[id] else { return false }
         operations[index].phase = .running
         operations[index].createdMachineID = nil
+        let generation = (attemptGeneration[id] ?? 0) &+ 1
+        attemptGeneration[id] = generation
         progressOutput[id] = ""
         postDidChange(finished: nil)
-        guard launch(operations[index].request.arguments, progressHandler(for: id), completionHandler(for: id)) else {
+        guard launch(operations[index].request.arguments, progressHandler(for: id, generation: generation), completionHandler(for: id, generation: generation)) else {
             if let failedIndex = operations.firstIndex(where: { $0.id == id }) {
                 operations[failedIndex].phase = .failed(output: String(
                     localized: "machines.new.error.launch",
                     defaultValue: "cmux could not start the create command. Sign in and try again."
                 ))
+                progressOutput.removeValue(forKey: id)
+                attemptGeneration[id] = (attemptGeneration[id] ?? generation) &+ 1
                 postDidChange(finished: nil)
             }
             return false
@@ -153,6 +160,7 @@ final class MachineCreateCoordinator {
         operations.remove(at: index)
         launches.removeValue(forKey: id)
         progressOutput.removeValue(forKey: id)
+        attemptGeneration.removeValue(forKey: id)
         postDidChange(finished: nil)
     }
 
@@ -162,33 +170,21 @@ final class MachineCreateCoordinator {
         operations.removeAll()
         launches.removeAll()
         progressOutput.removeAll()
+        attemptGeneration.removeAll()
         postDidChange(finished: nil)
     }
 
-    /// Recognizes the CLI's "Created Cloud VM <id>" line in `output`. The
-    /// format is the CLI's own localized string, so the match follows the
-    /// user's language instead of a hard-coded English prefix.
+    /// Recognizes only the CLI's strict stdout protocol line.
     nonisolated static func createdMachineID(fromOutput output: String) -> String? {
-        // The stable marker is emitted before opening starts and is the
-        // authoritative correlation key. Parse it before localized display
-        // text, so partial progress can identify the machine in every locale.
-        for token in output.split(whereSeparator: \.isWhitespace) {
-            let token = String(token)
-            guard token.hasPrefix("machine=") else { continue }
-            let id = String(token.dropFirst("machine=".count))
-            if !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) {
-                return id
-            }
-        }
-        let format = String(localized: "cli.vm.create.createdCloudVM", defaultValue: "Created Cloud VM %@")
-        let parts = format.components(separatedBy: "%@")
-        guard parts.count == 2 else { return nil }
-        let prefix = parts[0], suffix = parts[1]
         for rawLine in output.split(whereSeparator: \.isNewline) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard line.hasPrefix(prefix), line.hasSuffix(suffix), line.count > prefix.count + suffix.count else { continue }
-            let id = String(line.dropFirst(prefix.count).dropLast(suffix.count)).trimmingCharacters(in: .whitespaces)
-            if !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) { return id }
+            guard line.hasPrefix("OK machine=") else { continue }
+            let payload = line.dropFirst("OK machine=".count)
+            let id = payload.split(maxSplits: 1, whereSeparator: \.isWhitespace).first.map(String.init) ?? ""
+            guard !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) else { continue }
+            let suffix = payload.dropFirst(id.count)
+            guard suffix.isEmpty || suffix.first?.isWhitespace == true else { continue }
+            return id
         }
         return nil
     }
@@ -218,16 +214,22 @@ final class MachineCreateCoordinator {
         return "\(reason)\n\(safe)"
     }
 
-    private func completionHandler(for id: UUID) -> @MainActor (CloudVMActionLauncher.Completion) -> Void {
+    private func completionHandler(for id: UUID, generation: UInt64) -> @MainActor (CloudVMActionLauncher.Completion) -> Void {
         { [weak self] completion in
-            self?.finish(id: id, completion: completion)
+            guard let self, self.attemptGeneration[id] == generation else { return }
+            self.finish(id: id, completion: completion)
         }
     }
 
-    private func progressHandler(for id: UUID) -> @MainActor (String) -> Void {
+    private func progressHandler(for id: UUID, generation: UInt64) -> @MainActor (String) -> Void {
         { [weak self] chunk in
-            guard let self, let index = self.operations.firstIndex(where: { $0.id == id }) else { return }
-            self.progressOutput[id, default: ""].append(chunk)
+            guard let self,
+                  self.attemptGeneration[id] == generation,
+                  let index = self.operations.firstIndex(where: { $0.id == id }) else { return }
+            var bounded = Data((self.progressOutput[id, default: ""] + chunk).utf8)
+            bounded = Data(bounded.suffix(32 * 1024))
+            while !bounded.isEmpty && String(data: bounded, encoding: .utf8) == nil { bounded.removeFirst() }
+            self.progressOutput[id] = String(data: bounded, encoding: .utf8) ?? ""
             if let machineID = Self.createdMachineID(fromOutput: self.progressOutput[id] ?? "") {
                 guard self.operations[index].createdMachineID != machineID else { return }
                 self.operations[index].createdMachineID = machineID
@@ -240,12 +242,12 @@ final class MachineCreateCoordinator {
         // Dropped by a sign-out (or dismissed after a retry was refused): the
         // account this belonged to is gone, so there is nobody to tell.
         guard let index = operations.firstIndex(where: { $0.id == id }) else { return }
+        progressOutput.removeValue(forKey: id)
+        attemptGeneration[id] = (attemptGeneration[id] ?? 0) &+ 1
         var operation = operations[index]
         let output = completion.output.trimmingCharacters(in: .whitespacesAndNewlines)
-        // The CLI's `machine=` token is the authoritative created-machine
-        // signal; the localized "Created Cloud VM" line is the fallback for
-        // older bundled CLIs.
-        let createdMachineID = completion.machineId ?? Self.createdMachineID(fromOutput: output)
+        // The launcher's machine id comes only from the strict stdout protocol.
+        let createdMachineID = completion.machineId
         if let createdMachineID {
             operation.createdMachineID = createdMachineID
             operations[index].createdMachineID = createdMachineID
@@ -255,12 +257,14 @@ final class MachineCreateCoordinator {
             outcome = .created(machineID: createdMachineID, workspaceID: completion.workspaceId)
             operations.remove(at: index)
             launches.removeValue(forKey: id)
+            attemptGeneration.removeValue(forKey: id)
         } else if !operation.request.isBaseSetup, let machineID = createdMachineID {
             // Base setup is idempotent (`vm base open` reopens the same slot),
             // so only `vm new` can leave a machine behind that must not be re-created.
             outcome = .createdButOpenFailed(machineID: machineID, output: Self.displayableFailureOutput(output))
             operations.remove(at: index)
             launches.removeValue(forKey: id)
+            attemptGeneration.removeValue(forKey: id)
         } else {
             let failure = Self.displayableFailureOutput(output)
             outcome = .failed(output: failure)

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -108,16 +108,15 @@ final class CloudVMActionLauncher {
         let errorPipe = Pipe()
         process.standardOutput = outputPipe
         process.standardError = errorPipe
+        let outputDelivery = onOutput.map { MainActorOutputCoalescer(handler: $0) }
         let outputCollector = ProcessOutputCollector(stdout: outputPipe, stderr: errorPipe) { chunk in
-            guard let chunk = String(data: chunk, encoding: .utf8), !chunk.isEmpty else { return }
-            Task { @MainActor in
-                onOutput?(chunk)
-            }
+            outputDelivery?.enqueue(chunk)
         }
         outputCollector.start()
         let launchWindow = preferredWindow
         process.terminationHandler = { terminatedProcess in
-            let output = outputCollector.finish()
+            let result = outputCollector.finishResult()
+            let output = result.output
             let processIdentifier = terminatedProcess.processIdentifier
             let terminationStatus = terminatedProcess.terminationStatus
             Task { @MainActor in
@@ -128,7 +127,7 @@ final class CloudVMActionLauncher {
                         terminationStatus: terminationStatus,
                         output: output,
                         workspaceId: Self.createdWorkspaceId(from: output),
-                        machineId: Self.createdMachineId(from: output)
+                        machineId: Self.createdMachineId(from: result.stdout)
                     )
                 )
                 if terminationStatus == 0, presentOutputOnSuccess, !Self.shared.isShuttingDown, !suppressPresentation {
@@ -205,14 +204,16 @@ final class CloudVMActionLauncher {
 
     /// `cmux vm new` prints `OK machine=<id>` the moment the machine exists,
     /// before it tries to open it, so a failed open still reports the machine.
-    private static func createdMachineId(from output: String) -> String? {
-        for token in output.split(whereSeparator: \.isWhitespace) {
-            let string = String(token)
-            guard string.hasPrefix("machine=") else { continue }
-            let id = String(string.dropFirst("machine=".count))
-            if !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) {
-                return id
-            }
+    nonisolated static func createdMachineId(from stdout: String) -> String? {
+        for rawLine in stdout.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix("OK machine=") else { continue }
+            let payload = line.dropFirst("OK machine=".count)
+            let id = payload.split(maxSplits: 1, whereSeparator: \.isWhitespace).first.map(String.init) ?? ""
+            guard !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) else { continue }
+            let suffix = payload.dropFirst(id.count)
+            guard suffix.isEmpty || suffix.first?.isWhitespace == true else { continue }
+            return id
         }
         return nil
     }
@@ -376,6 +377,37 @@ final class CloudVMActionLauncher {
     }
 }
 
+/// Delivers bounded stdout progress through one consumer task. `AsyncStream`
+/// owns synchronization and drops the oldest chunks when its finite buffer is
+/// full, so pipe callbacks never create an unbounded MainActor task fanout.
+private final class MainActorOutputCoalescer: @unchecked Sendable {
+    private let continuation: AsyncStream<Data>.Continuation
+
+    init(handler: @escaping @MainActor (String) -> Void) {
+        let pair = AsyncStream<Data>.makeStream(bufferingPolicy: .bufferingNewest(128))
+        continuation = pair.continuation
+        Task {
+            for await data in pair.stream {
+                var safeData = data
+                while !safeData.isEmpty && String(data: safeData, encoding: .utf8) == nil { safeData.removeLast() }
+                while let first = safeData.first, (first & 0xC0) == 0x80 { safeData.removeFirst() }
+                guard let text = String(data: safeData, encoding: .utf8), !text.isEmpty else { continue }
+                await MainActor.run { handler(text) }
+            }
+        }
+    }
+
+    func enqueue(_ data: Data) {
+        guard !data.isEmpty else { return }
+        continuation.yield(data)
+    }
+}
+
+struct ProcessOutputResult: Sendable, Equatable {
+    let output: String
+    let stdout: String
+}
+
 final class ProcessOutputCollector: @unchecked Sendable {
     private enum Stream {
         case stdout
@@ -423,9 +455,13 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     @discardableResult
     func finish() -> String {
+        finishResult().output
+    }
+
+    func finishResult() -> ProcessOutputResult {
         lock.lock()
         guard !isFinished else {
-            let output = formattedOutputLocked()
+            let output = formattedResultLocked()
             lock.unlock()
             return output
         }
@@ -440,7 +476,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
         try? stderrHandle.close()
 
         lock.lock()
-        let output = formattedOutputLocked()
+        let output = formattedResultLocked()
         lock.unlock()
         return output
     }
@@ -462,7 +498,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     private func append(_ data: Data, to stream: Stream) {
         guard !data.isEmpty else { return }
-        onOutput?(data)
+        if case .stdout = stream { onOutput?(data) }
         lock.lock()
         defer { lock.unlock() }
 
@@ -475,24 +511,29 @@ final class ProcessOutputCollector: @unchecked Sendable {
     }
 
     private func appendBounded(_ data: Data, to buffer: inout Data) {
-        guard data.count < byteLimit else {
+        if data.count >= byteLimit {
             buffer = Data(data.suffix(byteLimit))
+            while !buffer.isEmpty && String(data: buffer, encoding: .utf8) == nil { buffer.removeFirst() }
             return
         }
-
         let overflow = buffer.count + data.count - byteLimit
         if overflow > 0 {
-            buffer.removeSubrange(0..<overflow)
+            buffer.removeSubrange(0..<min(overflow, buffer.count))
         }
         buffer.append(data)
+        while !buffer.isEmpty && String(data: buffer, encoding: .utf8) == nil { buffer.removeLast() }
+        while let first = buffer.first, (first & 0xC0) == 0x80 { buffer.removeFirst() }
     }
 
-    private func formattedOutputLocked() -> String {
+    private func formattedResultLocked() -> ProcessOutputResult {
         let output = String(data: stdout, encoding: .utf8) ?? ""
         let error = String(data: stderr, encoding: .utf8) ?? ""
-        return [output, error]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n\n")
+        return ProcessOutputResult(
+            output: [output, error]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n\n"),
+            stdout: output
+        )
     }
 }

--- a/Sources/Surfaces/SurfaceSocketCommands.swift
+++ b/Sources/Surfaces/SurfaceSocketCommands.swift
@@ -192,6 +192,7 @@ extension TerminalController {
         let destination = Self.surfaceDestination(surfaceResolvedParams(params), workspaceID: workspaceID)
         return v2VmCall(id: id, timeoutSeconds: 180) {
             let catalog = await SurfaceCatalog.shared
+            var didRegisterOptimistically = false
             if await catalog.resources[resource] == nil {
                 // Ports are discovered by probing the machine; a port the person names may
                 // not have been seen yet. Register it now and open it — a port pane is an
@@ -209,17 +210,23 @@ extension TerminalController {
                     port: port,
                     url: nil
                 ))
-                Task { @MainActor in
-                    if let provider = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: vmId) {
-                        await provider.refresh(force: true)
-                    }
-                }
+                didRegisterOptimistically = true
             }
             let opened = try await catalog.project(resource, into: destination, focus: focus, reuseExisting: false)
             var payload = Self.surfaceProjectPayload(opened.projection, reused: opened.reused)
             let url = await catalog.resources[resource]?.url ?? ""
             payload["url"] = url
             payload["open_url"] = url
+            // Refresh after projection. A concurrent refresh can replace the
+            // optimistic resource before project() resolves it as a known
+            // resource, producing a spurious unknownResource error.
+            if didRegisterOptimistically {
+                Task { @MainActor in
+                    if let provider = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: vmId) {
+                        await provider.refresh(force: true)
+                    }
+                }
+            }
             return payload
         }
     }

--- a/cmuxTests/MachineCreateCoordinatorTests.swift
+++ b/cmuxTests/MachineCreateCoordinatorTests.swift
@@ -185,7 +185,7 @@ struct MachineCreateCoordinatorTests {
         coordinator.start(Self.newMachineRequest(), launch: launches.launch)
         let workspaceID = UUID()
 
-        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\nOK workspace=\(workspaceID.uuidString) transport=cmux-remote\n", workspaceID: workspaceID)
+        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\nOK machine=calm-petrel\nOK workspace=\(workspaceID.uuidString) transport=cmux-remote\n", workspaceID: workspaceID, machineID: "calm-petrel")
 
         #expect(coordinator.operations.isEmpty, "the fleet row takes over")
         #expect(changes.finished.count == 1)
@@ -200,7 +200,7 @@ struct MachineCreateCoordinatorTests {
     @Test func successKeepsTheTypedLabelInTheNotification() {
         let (coordinator, launches, notices, _, _) = makeCoordinator()
         coordinator.start(Self.newMachineRequest(name: "build box"), launch: launches.launch)
-        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\n")
+        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\nOK machine=calm-petrel\n", machineID: "calm-petrel")
         #expect(notices.notices.first?.title == "build box is ready")
         #expect(notices.notices.first?.workspaceID == nil)
     }
@@ -242,7 +242,7 @@ struct MachineCreateCoordinatorTests {
         #expect(launches.arguments[1] == launches.arguments[0])
         #expect(coordinator.operation(id: id)?.isRunning == true)
 
-        launches.complete(status: 0, output: "Created Cloud VM noble-wren\n")
+        launches.complete(status: 0, output: "Created Cloud VM noble-wren\nOK machine=noble-wren\n", machineID: "noble-wren")
         #expect(coordinator.operations.isEmpty)
         #expect(notices.notices.count == 2)
     }
@@ -280,6 +280,20 @@ struct MachineCreateCoordinatorTests {
         #expect(coordinator.operation(id: id)?.failureOutput?.contains("Sign in") == true)
     }
 
+    @Test func lateProgressFromAnEarlierAttemptCannotOverwriteRetry() {
+        let (coordinator, launches, _, _, _) = makeCoordinator()
+        coordinator.start(Self.newMachineRequest(), launch: launches.launch)
+        let id = coordinator.operations[0].id
+        let firstProgress = launches.progressHandlers[0]
+        launches.complete(status: 1, output: "Error: first attempt")
+        #expect(coordinator.retry(id))
+        let secondProgress = launches.progressHandlers[1]
+        firstProgress("OK machine=stale-machine\n")
+        #expect(coordinator.operation(id: id)?.createdMachineID == nil)
+        secondProgress("OK machine=current-machine\n")
+        #expect(coordinator.operation(id: id)?.createdMachineID == "current-machine")
+    }
+
     // MARK: Created but opening failed
 
     @Test func createdButOpenFailedDropsTheRowAndNeverRetriesTheCreate() {
@@ -308,19 +322,14 @@ struct MachineCreateCoordinatorTests {
         #expect(notice?.body == "attach failed (HTTP 502)\nOpen it from the Machines list.", "the reason, not the CLI's progress line, leads the body")
     }
 
-    /// An older bundled CLI without the `machine=` token still classifies via
-    /// the localized "Created Cloud VM" line.
-    @Test func createdButOpenFailedFallsBackToTheLocalizedCreatedLine() {
+    @Test func localizedCreatedLineWithoutProtocolMarkerDoesNotClaimAMachine() {
         let (coordinator, launches, _, changes, _) = makeCoordinator()
         coordinator.start(Self.newMachineRequest(), launch: launches.launch)
         let id = coordinator.operations[0].id
         launches.complete(status: 1, output: "Created Cloud VM calm-petrel\nError: attach failed (HTTP 502)")
-        #expect(coordinator.operations.isEmpty)
-        #expect(!coordinator.retry(id))
-        #expect(changes.finished.first?.outcome == .createdButOpenFailed(
-            machineID: "calm-petrel",
-            output: "Error: attach failed (HTTP 502)"
-        ))
+        #expect(coordinator.operations.count == 1)
+        #expect(coordinator.retry(id))
+        #expect(changes.finished.first?.outcome == .failed(output: "Created Cloud VM calm-petrel\nError: attach failed (HTTP 502)"))
     }
 
     /// Transcripts that trip the app's redaction never reach the row, the
@@ -352,10 +361,12 @@ struct MachineCreateCoordinatorTests {
         #expect(launches.arguments.count == 2)
     }
 
-    @Test func createdMachineIDIsParsedFromTheCLIsCreatedLine() {
+    @Test func createdMachineIDRequiresTheStrictProtocolLine() {
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "OK machine=calm-petrel") == "calm-petrel")
-        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Created Cloud VM calm-petrel\nError: noProvider(calm-petrel)") == "calm-petrel")
-        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "  Created Cloud VM noble_wren2  ") == "noble_wren2")
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Created Cloud VM calm-petrel\nError: noProvider(calm-petrel)") == nil)
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "  OK machine=noble_wren2 transport=cmux-remote  ") == "noble_wren2")
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Error: machine=calm-petrel") == nil)
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "OK machine=bad.id") == nil)
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Error: Creating Cloud VM (HTTP 502)") == nil)
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Created Cloud VM") == nil)
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "") == nil)

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -28,4 +28,23 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         XCTAssertEqual(output, "")
     }
+
+    func testProcessOutputCollectorKeepsUtf8BoundariesAndSeparatesStdout() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr)
+        collector.start()
+        let prefix = String(repeating: "x", count: 32 * 1024) + "😀"
+        try? stdout.fileHandleForWriting.write(contentsOf: Data(prefix.utf8))
+        try? stderr.fileHandleForWriting.write(contentsOf: Data("OK machine=stderr-id\n".utf8))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        let result = collector.finishResult()
+
+        XCTAssertLessThanOrEqual(result.stdout.utf8.count, 32 * 1024)
+        XCTAssertNotNil(String(data: Data(result.stdout.utf8), encoding: .utf8))
+        XCTAssertNil(MachineCreateCoordinator.createdMachineID(fromOutput: result.stdout))
+        XCTAssertTrue(result.output.contains("OK machine=stderr-id"))
+    }
 }


### PR DESCRIPTION
Fixes regressions found after #11773.

- Bound and clean up progress transcripts on every finish, retry refusal, dismiss, and auth cancellation.
- Ignore stale callbacks from prior attempts and coalesce MainActor output delivery.
- Parse machine IDs only from strict stdout `OK machine=<id>` lines.
- Preserve UTF-8 boundaries when truncating process output.
- Move port refresh after optimistic projection to avoid unknown-resource races.

Tests cover retry callback generations, strict protocol parsing, and bounded UTF-8 output.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes regressions from #11773 in cloud machine creation by hardening progress handling and protocol parsing, and by avoiding a port refresh race.

**Progress handling**
- Bounds progress transcripts to 32 KB and clears them on finish, retry refusal, dismiss, and auth cancellation.
- Uses a generation counter so stale callbacks from prior attempts can't overwrite a retry; cancelled attempts keep their generation so their cleanup still runs.
- Coalesces MainActor output delivery and forwards only stdout.

**Protocol and port refresh**
- Machine IDs are parsed only from strict stdout `OK machine=<id>` lines; the localized "Created Cloud VM" fallback is removed.
- Truncation preserves UTF-8 boundaries so output decodes cleanly.
- Port refresh moves after optimistic projection to prevent an unknown-resource race.

Tests cover retry callback generations, strict protocol parsing, and bounded UTF-8 output.

<sup>Written for commit 46bd27e9f942b4e3e15b2741979243ebe0476074. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved machine creation reliability across retries and sign-outs by preventing stale progress or completion updates.
  * Machine creation now confirms success only from valid CLI success output, reducing false-positive results.
  * Improved handling of large or partial command output, including non-ASCII text.
  * Fixed port opening for newly discovered ports to avoid intermittent unknown-resource errors.
* **Reliability**
  * Improved separation and processing of command output to provide more consistent machine creation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->