### PR TITLE
Fix Korean IME committing the first jamo after an input-source switch

### DIFF
--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -202,11 +202,15 @@ extension GhosttyNSView {
         return isSingleHangulCompatibilityJamo(accumulatedText[0])
     }
 
+    /// True for Apple's bundled Korean input sources (2-Set, 3-Set, ...). Third-party
+    /// Korean input methods manage their own composition and are left alone.
     private func isAppleKoreanInputMethodSource(_ inputSourceId: String?) -> Bool {
         guard let inputSourceId else { return false }
         return inputSourceId.hasPrefix("com.apple.inputmethod.Korean")
     }
 
+    /// True when `text` is exactly one Hangul compatibility jamo (U+3131-U+318E),
+    /// the shape a 2-Set keystroke has before it joins a syllable.
     private func isSingleHangulCompatibilityJamo(_ text: String) -> Bool {
         let scalars = text.unicodeScalars
         guard scalars.count == 1, let scalar = scalars.first else { return false }
@@ -231,20 +235,6 @@ extension GhosttyNSView {
     }
 
 #if DEBUG
-    func shouldReinterpretLoneJamoCommitForTesting(
-        markedTextBefore: Bool,
-        markedTextAfter: Bool,
-        accumulatedText: [String],
-        inputSourceId: String?
-    ) -> Bool {
-        shouldReinterpretLoneJamoCommit(
-            markedTextBefore: markedTextBefore,
-            markedTextAfter: markedTextAfter,
-            accumulatedText: accumulatedText,
-            inputSourceId: inputSourceId
-        )
-    }
-
     func shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
         markedTextBefore: String,
         markedSelectionBefore: NSRange,

--- a/Sources/GhosttyNSView+IMEComposition.swift
+++ b/Sources/GhosttyNSView+IMEComposition.swift
@@ -183,6 +183,36 @@ extension GhosttyNSView {
             .subtracting([.numericPad, .function, .capsLock])
     }
 
+    /// Apple's Korean input method can hand its very first keystroke after an
+    /// input-source switch straight to `insertText` as a lone compatibility jamo
+    /// instead of opening a composition, so "분리" reaches the terminal as
+    /// "ㅂㅜㄴ리". Re-interpreting that one event lets the now-initialized input
+    /// method compose it normally. Only that exact signature qualifies: the key
+    /// started with no marked text, the IME left none behind, and the whole
+    /// result is a single Hangul compatibility jamo under Apple's Korean IME.
+    func shouldReinterpretLoneJamoCommit(
+        markedTextBefore: Bool,
+        markedTextAfter: Bool,
+        accumulatedText: [String],
+        inputSourceId: String?
+    ) -> Bool {
+        guard !markedTextBefore, !markedTextAfter else { return false }
+        guard accumulatedText.count == 1 else { return false }
+        guard isAppleKoreanInputMethodSource(inputSourceId) else { return false }
+        return isSingleHangulCompatibilityJamo(accumulatedText[0])
+    }
+
+    private func isAppleKoreanInputMethodSource(_ inputSourceId: String?) -> Bool {
+        guard let inputSourceId else { return false }
+        return inputSourceId.hasPrefix("com.apple.inputmethod.Korean")
+    }
+
+    private func isSingleHangulCompatibilityJamo(_ text: String) -> Bool {
+        let scalars = text.unicodeScalars
+        guard scalars.count == 1, let scalar = scalars.first else { return false }
+        return (0x3131...0x318E).contains(scalar.value)
+    }
+
     func shouldBufferBopomofoInsertedPreedit(_ text: String, inputSourceId: String? = nil) -> Bool {
         guard !text.isEmpty else { return false }
         guard isBopomofoInputSource(inputSourceId ?? KeyboardLayout.id) else { return false }
@@ -201,6 +231,20 @@ extension GhosttyNSView {
     }
 
 #if DEBUG
+    func shouldReinterpretLoneJamoCommitForTesting(
+        markedTextBefore: Bool,
+        markedTextAfter: Bool,
+        accumulatedText: [String],
+        inputSourceId: String?
+    ) -> Bool {
+        shouldReinterpretLoneJamoCommit(
+            markedTextBefore: markedTextBefore,
+            markedTextAfter: markedTextAfter,
+            accumulatedText: accumulatedText,
+            inputSourceId: inputSourceId
+        )
+    }
+
     func shouldSuppressGhosttyKeyForwardingAfterIMEHandlingForTesting(
         markedTextBefore: String,
         markedSelectionBefore: NSRange,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6724,6 +6724,32 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
 #endif
 
+        // Apple's Korean input method can commit the first keystroke after an
+        // input-source switch as a lone jamo instead of composing it ("분리"
+        // arrives as "ㅂㅜㄴ리"). Run that one event through interpretation again
+        // so the now-initialized input method opens the composition.
+        if keyboardIdBefore == KeyboardLayout.id,
+           shouldReinterpretLoneJamoCommit(
+               markedTextBefore: markedTextBefore,
+               markedTextAfter: markedText.length > 0,
+               accumulatedText: keyTextAccumulator ?? [],
+               inputSourceId: keyboardIdBefore
+           ) {
+            keyTextAccumulator = []
+#if DEBUG
+            cmuxDebugLog("ime.reinterpretLoneJamoCommit keyCode=\(event.keyCode)")
+            if let debugTextInputEventHandler = Self.debugTextInputEventHandler {
+                if !debugTextInputEventHandler(self, textInputEvent) {
+                    interpretKeyEvents([textInputEvent])
+                }
+            } else {
+                interpretKeyEvents([textInputEvent])
+            }
+#else
+            interpretKeyEvents([textInputEvent])
+#endif
+        }
+
         // If the keyboard layout changed, an input method grabbed the event.
         // Sync preedit and return without sending the key to Ghostty.
         if !markedTextBefore, let kbBefore = keyboardIdBefore, kbBefore != KeyboardLayout.id {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6495,6 +6495,24 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
     }
 
+    /// Hands a key event to AppKit text input (IME, dead keys, key bindings).
+    /// DEBUG builds let `debugTextInputEventHandler` intercept the event first so
+    /// tests can script IME behavior; when it declines, the event falls through
+    /// to `interpretKeyEvents`.
+    private func runTextInputInterpretation(for event: NSEvent) {
+#if DEBUG
+        if let debugTextInputEventHandler = Self.debugTextInputEventHandler {
+            if !debugTextInputEventHandler(self, event) {
+                interpretKeyEvents([event])
+            }
+        } else {
+            interpretKeyEvents([event])
+        }
+#else
+        interpretKeyEvents([event])
+#endif
+    }
+
     override func keyDown(with event: NSEvent) {
         if routeInputDuringClipboardRead(event) { return }
         let cancelledDeferredAdmission = terminalSurface?.didReceiveExplicitInput() == true
@@ -6703,18 +6721,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         let interpretTimingStart = CmuxTypingTiming.start()
         let interpretPhaseStart = ProcessInfo.processInfo.systemUptime
 #endif
-#if DEBUG
-        if let debugTextInputEventHandler = Self.debugTextInputEventHandler {
-            let handled = debugTextInputEventHandler(self, textInputEvent)
-            if !handled {
-                interpretKeyEvents([textInputEvent])
-            }
-        } else {
-            interpretKeyEvents([textInputEvent])
-        }
-#else
-        interpretKeyEvents([textInputEvent])
-#endif
+        runTextInputInterpretation(for: textInputEvent)
 #if DEBUG
         interpretMs = (ProcessInfo.processInfo.systemUptime - interpretPhaseStart) * 1000.0
         CmuxTypingTiming.logDuration(
@@ -6738,16 +6745,8 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             keyTextAccumulator = []
 #if DEBUG
             cmuxDebugLog("ime.reinterpretLoneJamoCommit keyCode=\(event.keyCode)")
-            if let debugTextInputEventHandler = Self.debugTextInputEventHandler {
-                if !debugTextInputEventHandler(self, textInputEvent) {
-                    interpretKeyEvents([textInputEvent])
-                }
-            } else {
-                interpretKeyEvents([textInputEvent])
-            }
-#else
-            interpretKeyEvents([textInputEvent])
 #endif
+            runTextInputInterpretation(for: textInputEvent)
         }
 
         // If the keyboard layout changed, an input method grabbed the event.

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -2344,12 +2344,14 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
 /// single event lets the now-initialized input method compose it normally.
 @MainActor
 final class KoreanIMEFirstKeyAfterInputSourceSwitchRegressionTests: XCTestCase {
+    /// A hosted terminal view inside a key window, ready to receive `keyDown`.
     private struct Harness {
         let window: NSWindow
         let view: GhosttyNSView
         let surface: TerminalSurface
     }
 
+    /// Builds a `TerminalSurface`, hosts it in a key window, and returns its `GhosttyNSView`.
     private func makeHarness() -> Harness? {
         _ = NSApplication.shared
 
@@ -2393,6 +2395,8 @@ final class KoreanIMEFirstKeyAfterInputSourceSwitchRegressionTests: XCTestCase {
         return Harness(window: window, view: view, surface: surface)
     }
 
+    /// Synthesizes an unmodified `keyDown` whose characters are what the Korean IME
+    /// would report for `keyCode`.
     private func makeJamoEvent(window: NSWindow, characters: String, keyCode: UInt16) -> NSEvent? {
         NSEvent.keyEvent(
             with: .keyDown,
@@ -2408,6 +2412,7 @@ final class KoreanIMEFirstKeyAfterInputSourceSwitchRegressionTests: XCTestCase {
         )
     }
 
+    /// Clears the debug seams installed by a test and hides its window.
     private func tearDown(_ harness: Harness) {
         GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
         KeyboardLayout.debugInputSourceIdOverride = nil

--- a/cmuxTests/CJKIMEInputTests.swift
+++ b/cmuxTests/CJKIMEInputTests.swift
@@ -2335,3 +2335,244 @@ final class GhosttyOptionDeleteRegressionTests: XCTestCase {
         XCTAssertNil(pressEvent.text, "Delete should be encoded as a key event, not forwarded as DEL text")
     }
 }
+
+// MARK: - Korean IME first key after an input-source switch
+
+/// Apple's Korean input method can commit the very first keystroke after an
+/// input-source switch as a lone compatibility jamo instead of opening a
+/// composition, so "분리" reaches the terminal as "ㅂㅜㄴ리". Re-interpreting that
+/// single event lets the now-initialized input method compose it normally.
+@MainActor
+final class KoreanIMEFirstKeyAfterInputSourceSwitchRegressionTests: XCTestCase {
+    private struct Harness {
+        let window: NSWindow
+        let view: GhosttyNSView
+        let surface: TerminalSurface
+    }
+
+    private func makeHarness() -> Harness? {
+        _ = NSApplication.shared
+
+        let surface = TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            workingDirectory: nil
+        )
+        let hostedView = surface.hostedView
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return nil
+        }
+
+        hostedView.frame = contentView.bounds
+        hostedView.autoresizingMask = [.width, .height]
+        contentView.addSubview(hostedView)
+
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        contentView.layoutSubtreeIfNeeded()
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(true)
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        guard let view = findGhosttyNSView(in: hostedView) else {
+            XCTFail("Expected hosted GhosttyNSView")
+            return nil
+        }
+
+        window.makeFirstResponder(view)
+        return Harness(window: window, view: view, surface: surface)
+    }
+
+    private func makeJamoEvent(window: NSWindow, characters: String, keyCode: UInt16) -> NSEvent? {
+        NSEvent.keyEvent(
+            with: .keyDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            characters: characters,
+            charactersIgnoringModifiers: characters,
+            isARepeat: false,
+            keyCode: keyCode
+        )
+    }
+
+    private func tearDown(_ harness: Harness) {
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = nil
+        KeyboardLayout.debugInputSourceIdOverride = nil
+        cjkIMEInterpretKeyEventsHook = nil
+        harness.window.orderOut(nil)
+    }
+
+    /// First key after switching to the Korean IME: the input method commits "ㅂ"
+    /// raw on the first interpretation and only composes on the second one.
+    func testLoneJamoCommitOnFirstKeyIsReinterpretedAsComposition() {
+        guard let harness = makeHarness() else { return }
+        defer { tearDown(harness) }
+        let view = harness.view
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.Korean.2SetKorean"
+        installCJKIMEInterpretKeyEventsSwizzle()
+
+        var interpretCalls = 0
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === view else { return false }
+            interpretCalls += 1
+            if interpretCalls == 1 {
+                // Uninitialized Korean IME: commits the jamo instead of composing.
+                candidateView.insertText("ㅂ", replacementRange: NSRange(location: NSNotFound, length: 0))
+            } else {
+                // Initialized Korean IME: opens a composition.
+                candidateView.setMarkedText(
+                    "ㅂ",
+                    selectedRange: NSRange(location: 0, length: 1),
+                    replacementRange: NSRange(location: NSNotFound, length: 0)
+                )
+            }
+            return true
+        }
+
+        var forwardedTexts: [String] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 12 else { return }
+            if let text = keyEvent.text {
+                forwardedTexts.append(String(cString: text))
+            }
+        }
+
+        guard let event = makeJamoEvent(window: harness.window, characters: "ㅂ", keyCode: 12) else {
+            XCTFail("Failed to create Hangul jamo event")
+            return
+        }
+
+        view.keyDown(with: event)
+
+        XCTAssertEqual(
+            interpretCalls, 2,
+            "A lone jamo committed by the first interpretation must be re-interpreted once"
+        )
+        XCTAssertEqual(
+            forwardedTexts, [],
+            "The raw first-key jamo must not reach the terminal; got \(forwardedTexts)"
+        )
+        XCTAssertTrue(view.hasMarkedText(), "The re-interpreted key should open a Hangul composition")
+    }
+
+    /// Healthy path: the IME composes on the first interpretation, so nothing is retried.
+    func testCompositionOnFirstKeyIsNotReinterpreted() {
+        guard let harness = makeHarness() else { return }
+        defer { tearDown(harness) }
+        let view = harness.view
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.Korean.2SetKorean"
+        installCJKIMEInterpretKeyEventsSwizzle()
+
+        var interpretCalls = 0
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === view else { return false }
+            interpretCalls += 1
+            candidateView.setMarkedText(
+                "ㅂ",
+                selectedRange: NSRange(location: 0, length: 1),
+                replacementRange: NSRange(location: NSNotFound, length: 0)
+            )
+            return true
+        }
+
+        guard let event = makeJamoEvent(window: harness.window, characters: "ㅂ", keyCode: 12) else {
+            XCTFail("Failed to create Hangul jamo event")
+            return
+        }
+
+        view.keyDown(with: event)
+
+        XCTAssertEqual(interpretCalls, 1, "A composing first key must be interpreted exactly once")
+        XCTAssertTrue(view.hasMarkedText())
+    }
+
+    /// Non-jamo text committed under the Korean IME (digits, punctuation) is normal
+    /// committed input and must be forwarded once without a retry.
+    func testNonJamoCommitUnderKoreanIMEIsForwardedOnce() {
+        guard let harness = makeHarness() else { return }
+        defer { tearDown(harness) }
+        let view = harness.view
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.inputmethod.Korean.2SetKorean"
+        installCJKIMEInterpretKeyEventsSwizzle()
+
+        var interpretCalls = 0
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === view else { return false }
+            interpretCalls += 1
+            candidateView.insertText("1", replacementRange: NSRange(location: NSNotFound, length: 0))
+            return true
+        }
+
+        var forwardedTexts: [String] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 18 else { return }
+            if let text = keyEvent.text {
+                forwardedTexts.append(String(cString: text))
+            }
+        }
+
+        guard let event = makeJamoEvent(window: harness.window, characters: "1", keyCode: 18) else {
+            XCTFail("Failed to create digit event")
+            return
+        }
+
+        view.keyDown(with: event)
+
+        XCTAssertEqual(interpretCalls, 1, "Committed non-jamo text must not trigger a retry")
+        XCTAssertEqual(forwardedTexts, ["1"])
+        XCTAssertFalse(view.hasMarkedText())
+    }
+
+    /// A lone jamo committed under a plain keyboard layout is not the Korean IME
+    /// first-key defect and must be forwarded as-is.
+    func testLoneJamoCommitUnderKeyboardLayoutIsNotReinterpreted() {
+        guard let harness = makeHarness() else { return }
+        defer { tearDown(harness) }
+        let view = harness.view
+
+        KeyboardLayout.debugInputSourceIdOverride = "com.apple.keylayout.ABC"
+        installCJKIMEInterpretKeyEventsSwizzle()
+
+        var interpretCalls = 0
+        cjkIMEInterpretKeyEventsHook = { candidateView, _ in
+            guard candidateView === view else { return false }
+            interpretCalls += 1
+            candidateView.insertText("ㅂ", replacementRange: NSRange(location: NSNotFound, length: 0))
+            return true
+        }
+
+        var forwardedTexts: [String] = []
+        GhosttyNSView.debugGhosttySurfaceKeyEventObserver = { keyEvent in
+            guard keyEvent.action == GHOSTTY_ACTION_PRESS, keyEvent.keycode == 12 else { return }
+            if let text = keyEvent.text {
+                forwardedTexts.append(String(cString: text))
+            }
+        }
+
+        guard let event = makeJamoEvent(window: harness.window, characters: "ㅂ", keyCode: 12) else {
+            XCTFail("Failed to create Hangul jamo event")
+            return
+        }
+
+        view.keyDown(with: event)
+
+        XCTAssertEqual(interpretCalls, 1)
+        XCTAssertEqual(forwardedTexts, ["ㅂ"])
+    }
+}


### PR DESCRIPTION
## Summary

- **What changed?** After `interpretKeyEvents`, `keyDown` now re-interprets the same event once when Apple's Korean input method committed a **lone Hangul compatibility jamo** on a key that started with no marked text and left none behind. The retry is gated to that exact signature (`shouldReinterpretLoneJamoCommit` in `GhosttyNSView+IMEComposition.swift`): no marked text before/after, exactly one committed string that is a single U+3131–U+318E scalar, and a `com.apple.inputmethod.Korean*` source. Composing keys, committed digits/punctuation and plain keyboard layouts are untouched.
- **Why?** Right after switching to the Korean IME (e.g. Ctrl+Space), the very first keystroke is handed to `insertText` as a raw jamo instead of opening a composition. cmux forwarded that committed jamo, so typing `분리` produced `ㅂㅜㄴ리`: the leading `ㅂ` was already committed, `ㅜ` and `ㄴ` could no longer form a syllable with it, and only `리` composed normally. Re-running the one event through interpretation lets the now-initialized input method open the composition, and the word arrives as `분리`.

This is the remaining first-key case of the jamo-leak family from #2519 / #2529 (which covered keys typed *while* a composition is active).

### Reproduction (standalone AppKit `NSTextInputClient`, same pipeline as cmux/Ghostty)

Switch to `com.apple.inputmethod.Korean.2SetKorean`, then type `q n s f l` (분리) 300 ms later. First `interpretKeyEvents` call commits instead of composing; everything after that cascades:

```
keyDown code=12 chars=ㅂ markedBefore='' markedAfter='' acc=["ㅂ"] -> COMMIT(ㅂ)      <- defect
keyDown code=45 chars=ㅜ markedBefore='' markedAfter='ㅜ'         -> composition
keyDown code=1  chars=ㄴ markedBefore='ㅜ' markedAfter='ㄴ' acc=["ㅜ"] -> COMMIT(ㅜ)  (ㅜ+ㄴ cannot form a syllable)
keyDown code=3  chars=ㄹ markedBefore='ㄴ' markedAfter='ㄹ' acc=["ㄴ"] -> COMMIT(ㄴ)
keyDown code=37 chars=ㅣ markedBefore='ㄹ' markedAfter='리'        -> composition
RESULT: terminal='ㅂㅜㄴ' marked='리'
```

Same run with the one-shot re-interpretation applied:

```
[M6] lone jamo commit on first key -> re-interpreting the same event
keyDown code=12 chars=ㅂ markedBefore='' markedAfter='ㅂ' acc=[] -> SUPPRESSED(composition)
RESULT: terminal='분' marked='리'
```

macOS 15.7.9 (24G830), Apple 2-Set Korean, reported against cmux 0.64.22 (does not reproduce in standalone Ghostty 1.3.1 for the reporter).

## Testing

- Two-commit layout per `CLAUDE.md`: commit 1 adds `KoreanIMEFirstKeyAfterInputSourceSwitchRegressionTests` (4 tests in `cmuxTests/CJKIMEInputTests.swift`, already-wired file, no pbxproj change) and should fail on CI; commit 2 adds the fix and should turn it green.
  - lone jamo commit on first key → re-interpreted once, nothing forwarded, composition open
  - composition on first key → interpreted exactly once (no retry)
  - committed `1` under Korean IME → forwarded once (no retry)
  - lone jamo under `com.apple.keylayout.ABC` → forwarded as-is (no retry)
- Manually verified the defect and the fix with a standalone AppKit `NSTextInputClient` harness driving the real Korean IME (logs above).
- **Not built with Xcode locally** (this machine only has Command Line Tools): changed files were syntax-checked with `swiftc -parse`; please rely on CI for the XCTest run.

## Demo Video

N/A (no UI change; terminal input only).

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (standalone IME harness; XCTest via CI)
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed (changelog is release-managed)
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EjwUvcw3KNKYJhUsYttd2e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11806"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791007785&installation_model_id=21920&pr_number=11806&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11806&signature=453d3a345cd7af6fd6f57781532da5c3a2ff50d7d9dce1e8d9019969fbeec7ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Korean IME committing the first keystroke after an input-source switch as a raw jamo instead of opening a composition. The event is now re-interpreted once so words like 분리 arrive correctly instead of as ㅂㅜㄴ리.

**Details**
- Retry fires only when no marked text exists before or after the key and the IME committed exactly one Hangul compatibility jamo (U+3131–U+318E) under an Apple Korean input source.
- Initial interpretation and the retry share one text-input dispatch path.
- Composing keys, committed digits/punctuation, and plain keyboard layouts are unaffected.
- Adds regression tests covering the retry, the normal composition path, non-jamo commits, and non-Korean layouts.

<sup>Written for commit 2f0b567aa8e3a1dd446f96ab616fcf6ed58946e4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Korean input handling after switching input sources.
  * Korean characters now begin composition correctly instead of being sent as separate compatibility jamo characters.
  * Preserved expected behavior for non-Korean layouts, already-composing input, and regular committed text.

* **Tests**
  * Added regression coverage for Korean input-method behavior after keyboard layout changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->