### PR TITLE
fix(cmux-tui): restore rustfmt import order

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_protocol.rs
@@ -795,7 +795,7 @@ impl FrameDecoder {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{mpsc, Arc, Mutex};
+    use std::sync::{Arc, Mutex, mpsc};
 
     /// Test-only stand-in for a direct pipe reader. The bounded queue models
     /// the byte pump, while the mutex is the single parser owner.


### PR DESCRIPTION
## Summary
- restore rustfmt-required ordering for the `std::sync` test import

## Verification
- `rustfmt --check --config-path rustfmt.toml --edition 2024 crates/cmux-tui-core/src/terminal_host_protocol.rs`
- `git diff --check`

Formatting-only change. No behavior changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the rustfmt-required ordering for the `std::sync` test import in `cmux-tui-core`. Formatting-only change; no behavior changes.

<sup>Written for commit f4f0e7df2c564a639268e040a8ed3d63c69f9ffe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

