### PR TITLE
Stream journal segment decompression

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1465,9 +1465,7 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
             break;
         }
         anyhow::ensure!(
-            trailing[..count]
-                .iter()
-                .all(|byte| matches!(byte, b' ' | b'\n' | b'\r' | b'\t')),
+            trailing[..count].iter().all(|byte| matches!(byte, b' ' | b'\n' | b'\r' | b'\t')),
             "journal segment {segment_id} contains trailing data"
         );
     }

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -4,7 +4,7 @@ use flate2::read::GzDecoder;
 use rusqlite::Row;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::io::Read;
+use std::io::{Read, Result as IoResult};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1450,23 +1450,13 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
         "journal segment {segment_id} exceeds the uncompressed size limit"
     );
     let decoder = GzDecoder::new(compressed.as_slice());
-    // The segment header already carries a validated byte count. Reserve it
-    // once, so decompression does not repeatedly grow and copy the buffer.
-    let mut uncompressed = Vec::with_capacity(expected_bytes);
-    decoder
-        .take(u64::try_from(expected_bytes)?.saturating_add(1))
-        .read_to_end(&mut uncompressed)
-        .with_context(|| format!("decompress journal segment {segment_id}"))?;
-    anyhow::ensure!(
-        expected_bytes == uncompressed.len(),
-        "journal segment {segment_id} length is invalid"
-    );
-    anyhow::ensure!(
-        Sha256::digest(&uncompressed).as_slice() == expected_digest.as_slice(),
-        "journal segment {segment_id} digest is invalid"
-    );
-    let mut records: Vec<SessionJournalRecord> = serde_json::from_slice(&uncompressed)
+    // Decode directly from the bounded gzip stream. This avoids allocating a
+    // second buffer the size of the complete segment before JSON parsing.
+    let mut reader = DigestReader::new(decoder.take(u64::try_from(expected_bytes)?.saturating_add(1)));
+    let mut records: Vec<SessionJournalRecord> = serde_json::from_reader(&mut reader)
         .with_context(|| format!("decode journal segment {segment_id}"))?;
+    anyhow::ensure!(reader.bytes_read == expected_bytes, "journal segment {segment_id} length is invalid");
+    anyhow::ensure!(reader.digest().as_slice() == expected_digest.as_slice(), "journal segment {segment_id} digest is invalid");
     for record in &mut records {
         normalize_terminal_output(record, None)
             .with_context(|| format!("validate journal segment {segment_id}"))?;
@@ -1487,6 +1477,20 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
         );
     }
     Ok(DecodedJournalSegment { start_sequence, end_sequence, records })
+}
+
+struct DigestReader<R> { inner: R, hasher: Sha256, bytes_read: usize }
+impl<R: Read> DigestReader<R> {
+    fn new(inner: R) -> Self { Self { inner, hasher: Sha256::new(), bytes_read: 0 } }
+    fn digest(self) -> sha2::digest::Output<Sha256> { self.hasher.finalize() }
+}
+impl<R: Read> Read for DigestReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        let n = self.inner.read(buf)?;
+        self.bytes_read = self.bytes_read.saturating_add(n);
+        self.hasher.update(&buf[..n]);
+        Ok(n)
+    }
 }
 
 fn archived_records_after(

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -1452,11 +1452,33 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
     let decoder = GzDecoder::new(compressed.as_slice());
     // Decode directly from the bounded gzip stream. This avoids allocating a
     // second buffer the size of the complete segment before JSON parsing.
-    let mut reader = DigestReader::new(decoder.take(u64::try_from(expected_bytes)?.saturating_add(1)));
+    let mut reader =
+        DigestReader::new(decoder.take(u64::try_from(expected_bytes)?.saturating_add(1)));
     let mut records: Vec<SessionJournalRecord> = serde_json::from_reader(&mut reader)
         .with_context(|| format!("decode journal segment {segment_id}"))?;
-    anyhow::ensure!(reader.bytes_read == expected_bytes, "journal segment {segment_id} length is invalid");
-    anyhow::ensure!(reader.digest().as_slice() == expected_digest.as_slice(), "journal segment {segment_id} digest is invalid");
+    // Force the bounded gzip reader to reach EOF. This validates the gzip
+    // trailer even when the JSON decoder stops after the top-level value.
+    let mut trailing = [0u8; 8192];
+    loop {
+        let count = reader.read(&mut trailing)?;
+        if count == 0 {
+            break;
+        }
+        anyhow::ensure!(
+            trailing[..count]
+                .iter()
+                .all(|byte| matches!(byte, b' ' | b'\n' | b'\r' | b'\t')),
+            "journal segment {segment_id} contains trailing data"
+        );
+    }
+    anyhow::ensure!(
+        reader.bytes_read == expected_bytes,
+        "journal segment {segment_id} length is invalid"
+    );
+    anyhow::ensure!(
+        reader.digest().as_slice() == expected_digest.as_slice(),
+        "journal segment {segment_id} digest is invalid"
+    );
     for record in &mut records {
         normalize_terminal_output(record, None)
             .with_context(|| format!("validate journal segment {segment_id}"))?;
@@ -1479,10 +1501,18 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
     Ok(DecodedJournalSegment { start_sequence, end_sequence, records })
 }
 
-struct DigestReader<R> { inner: R, hasher: Sha256, bytes_read: usize }
+struct DigestReader<R> {
+    inner: R,
+    hasher: Sha256,
+    bytes_read: usize,
+}
 impl<R: Read> DigestReader<R> {
-    fn new(inner: R) -> Self { Self { inner, hasher: Sha256::new(), bytes_read: 0 } }
-    fn digest(self) -> sha2::digest::Output<Sha256> { self.hasher.finalize() }
+    fn new(inner: R) -> Self {
+        Self { inner, hasher: Sha256::new(), bytes_read: 0 }
+    }
+    fn digest(self) -> sha2::digest::Output<Sha256> {
+        self.hasher.finalize()
+    }
 }
 impl<R: Read> Read for DigestReader<R> {
     fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {

--- a/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/workspace_registry/session_journal.rs
@@ -4,7 +4,7 @@ use flate2::read::GzDecoder;
 use rusqlite::Row;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
-use std::io::{Read, Result as IoResult};
+use std::io::{BufReader, Read, Result as IoResult};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -1452,8 +1452,9 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
     let decoder = GzDecoder::new(compressed.as_slice());
     // Decode directly from the bounded gzip stream. This avoids allocating a
     // second buffer the size of the complete segment before JSON parsing.
-    let mut reader =
-        DigestReader::new(decoder.take(u64::try_from(expected_bytes)?.saturating_add(1)));
+    let mut reader = BufReader::new(DigestReader::new(
+        decoder.take(u64::try_from(expected_bytes)?.saturating_add(1)),
+    ));
     let mut records: Vec<SessionJournalRecord> = serde_json::from_reader(&mut reader)
         .with_context(|| format!("decode journal segment {segment_id}"))?;
     // Force the bounded gzip reader to reach EOF. This validates the gzip
@@ -1470,11 +1471,11 @@ fn decode_journal_segment(row: JournalSegmentRow) -> anyhow::Result<DecodedJourn
         );
     }
     anyhow::ensure!(
-        reader.bytes_read == expected_bytes,
+        reader.get_ref().bytes_read == expected_bytes,
         "journal segment {segment_id} length is invalid"
     );
     anyhow::ensure!(
-        reader.digest().as_slice() == expected_digest.as_slice(),
+        reader.into_inner().digest().as_slice() == expected_digest.as_slice(),
         "journal segment {segment_id} digest is invalid"
     );
     for record in &mut records {


### PR DESCRIPTION
Avoid buffering the full uncompressed journal segment before JSON decoding. Decode through a bounded gzip reader while hashing and counting bytes, preserving existing size and digest validation.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Streams journal segment decompression into the JSON decoder instead of buffering the full uncompressed segment, reducing peak memory while retaining size and digest validation.

- Hashes and counts decompressed bytes as records are parsed.
- Drains the stream to EOF to validate the gzip trailer and rejects trailing non-whitespace data.

<sup>Written for commit 38096d8dc91b28d4a34bfa8d7ecd4d196c1d6287. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved session journal validation to detect incomplete, corrupted, or improperly formatted data more reliably.
  - Enhanced handling of compressed journal segments by validating complete contents, trailing data, recorded lengths, and integrity checks before processing.
  - Reduced the risk of excessive resource use when processing compressed journal data, improving stability for large or malformed segments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->