### PR TITLE
cmux-tui: close provider leases asynchronously

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -37,7 +37,6 @@ use crate::session::{RemoteSession, Session};
 
 const PROVIDER_REFRESH_QUEUE_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_QUEUE_CAPACITY: usize = 64;
-const PROVIDER_CLOSE_PENDING_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_WORKER_COUNT: usize = 4;
 
 type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
@@ -152,12 +151,8 @@ impl ProviderCloseWorker {
             Ok(()) => Ok(()),
             Err(crossbeam_channel::TrySendError::Full(close)) => {
                 if let Ok(mut pending) = self.pending.lock() {
-                    if pending.len() < PROVIDER_CLOSE_PENDING_CAPACITY {
-                        pending.insert(key, close);
-                        Ok(())
-                    } else {
-                        Err(crossbeam_channel::TrySendError::Full(close))
-                    }
+                    pending.insert(key, close);
+                    Ok(())
                 } else {
                     Err(crossbeam_channel::TrySendError::Disconnected(close))
                 }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -3018,6 +3018,7 @@ mod tests {
         let worker = Arc::new(ProviderCloseWorker::with_capacity(1).unwrap());
         let (started, started_rx) = mpsc::channel();
         let (release, release_rx) = mpsc::channel();
+        let (finished, finished_rx) = mpsc::channel();
         worker
             .schedule(
                 MachineKey(1),
@@ -3032,10 +3033,11 @@ mod tests {
             .schedule(MachineKey(2), Box::new(|| {}))
             .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
         worker
-            .schedule(MachineKey(3), Box::new(|| {}))
+            .schedule(MachineKey(3), Box::new(move || finished.send(()).unwrap()))
             .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
         assert!(worker.pending.lock().unwrap().contains_key(&MachineKey(3)));
         release.send(()).unwrap();
+        finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         drop(worker);
     }
 

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -66,14 +66,14 @@ impl ProviderCloseWorker {
             let thread = std::thread::Builder::new()
                 .name(format!("provider-close-machine-{index}"))
                 .spawn(move || {
-                while let Ok(close) = receiver.recv() {
-                    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
-                        crate::client_log::stderr_log!(
-                            "provider",
-                            "cmux-tui: provider machine close task panicked"
-                        );
+                    while let Ok(close) = receiver.recv() {
+                        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
+                            crate::client_log::stderr_log!(
+                                "provider",
+                                "cmux-tui: provider machine close task panicked"
+                            );
+                        }
                     }
-                }
                 })?;
             threads.push(thread);
         }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -158,9 +158,7 @@ struct ProviderCloseCleanup {
 impl Drop for ProviderCloseCleanup {
     fn drop(&mut self) {
         if let Ok(mut registry) = self.registry.lock()
-            && registry
-                .get(&self.key)
-                .is_some_and(|open| open.connection_id == self.connection_id)
+            && registry.get(&self.key).is_some_and(|open| open.connection_id == self.connection_id)
         {
             registry.remove(&self.key);
         }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -2476,13 +2476,13 @@ fn connect_provider_machine(
     let open = OpenConnection { client, connection_id, machine_id: machine.id };
     connections.insert(key, open.clone());
     Ok(MachineConnection {
-        session,
-        _lease: Some(Box::new(ProviderMachineConnectionLease {
-            open,
-            key,
-            registry,
-            closing: closing_connections,
-            close_worker,
+            session,
+            _lease: Some(Box::new(ProviderMachineConnectionLease {
+                open,
+                key,
+                registry: Arc::clone(&registry),
+                closing: closing_connections,
+                close_worker,
         })),
     })
 }
@@ -2797,7 +2797,9 @@ mod tests {
         let (finished, finished_rx) = mpsc::channel();
         for _ in 0..128 {
             let finished = finished.clone();
-            worker.schedule(Box::new(move || finished.send(()).unwrap())).unwrap();
+            worker
+                .schedule(Box::new(move || finished.send(()).unwrap()))
+                .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
         }
         for _ in 0..128 {
             finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
@@ -2817,7 +2819,7 @@ mod tests {
                 release_rx.recv().unwrap();
                 finished.send(()).unwrap();
             }))
-            .unwrap();
+            .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
 
         let drop_started = std::time::Instant::now();

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -36,6 +36,85 @@ use crate::machine_runtime::{
 use crate::session::{RemoteSession, Session};
 
 const PROVIDER_REFRESH_QUEUE_CAPACITY: usize = 64;
+const PROVIDER_CLOSE_QUEUE_CAPACITY: usize = 64;
+
+type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
+
+struct ProviderCloseWorker {
+    sender: Option<mpsc::SyncSender<ProviderCloseTask>>,
+    thread: Option<std::thread::JoinHandle<()>>,
+    available: Mutex<usize>,
+}
+
+struct ProviderClosePermit {
+    worker: Arc<ProviderCloseWorker>,
+}
+
+impl ProviderCloseWorker {
+    fn new() -> anyhow::Result<Self> {
+        Self::with_capacity(PROVIDER_CLOSE_QUEUE_CAPACITY)
+    }
+
+    fn with_capacity(capacity: usize) -> anyhow::Result<Self> {
+        let (sender, receiver) = mpsc::sync_channel::<ProviderCloseTask>(capacity);
+        let thread =
+            std::thread::Builder::new().name("provider-close-machine".into()).spawn(move || {
+                while let Ok(close) = receiver.recv() {
+                    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
+                        crate::client_log::stderr_log!(
+                            "provider",
+                            "cmux-tui: provider machine close task panicked"
+                        );
+                    }
+                }
+            })?;
+        Ok(Self { sender: Some(sender), thread: Some(thread), available: Mutex::new(capacity) })
+    }
+
+    fn try_reserve(self: &Arc<Self>) -> Option<ProviderClosePermit> {
+        let mut available = self.available.lock().ok()?;
+        if *available == 0 {
+            return None;
+        }
+        *available -= 1;
+        Some(ProviderClosePermit { worker: Arc::clone(self) })
+    }
+
+    fn schedule_reserved(
+        &self,
+        permit: ProviderClosePermit,
+        close: ProviderCloseTask,
+    ) -> Result<(), mpsc::TrySendError<ProviderCloseTask>> {
+        self.sender.as_ref().expect("provider close worker is active").try_send(Box::new(
+            move || {
+                close();
+                drop(permit);
+            },
+        ))
+    }
+}
+
+impl Drop for ProviderClosePermit {
+    fn drop(&mut self) {
+        if let Ok(mut available) = self.worker.available.lock() {
+            *available += 1;
+        }
+    }
+}
+
+impl Drop for ProviderCloseWorker {
+    fn drop(&mut self) {
+        self.sender.take();
+        if let Some(thread) = self.thread.take()
+            && thread.join().is_err()
+        {
+            crate::client_log::stderr_log!(
+                "provider",
+                "cmux-tui: provider machine close worker panicked"
+            );
+        }
+    }
+}
 
 #[derive(Clone)]
 struct OpenConnection {
@@ -48,6 +127,8 @@ struct ProviderMachineConnectionLease {
     open: OpenConnection,
     key: MachineKey,
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    close_worker: Arc<ProviderCloseWorker>,
+    close_permit: Option<ProviderClosePermit>,
 }
 
 impl Drop for ProviderMachineConnectionLease {
@@ -59,26 +140,30 @@ impl Drop for ProviderMachineConnectionLease {
         {
             registry.remove(&self.key);
         }
-        // Provider close is an RPC and may block on a remote provider. A lease
-        // drop runs from session teardown paths, so never make those paths
-        // synchronously wait for network I/O. Move the retained Arc and ID
-        // into a short-lived worker, preserving ownership until the RPC ends.
+        // Provider close is an RPC and may block on a remote provider. Keep
+        // session teardown non-blocking and bound both queued work and worker
+        // threads through the runtime-owned close worker.
         let client = Arc::clone(&self.open.client);
         let connection_id = self.open.connection_id.clone();
-        if let Err(error) = std::thread::Builder::new()
-            .name("provider-close-machine".into())
-            .spawn(move || {
+        let permit = self.close_permit.take().expect("provider connection owns a close permit");
+        if let Err(error) = self.close_worker.schedule_reserved(
+            permit,
+            Box::new(move || {
                 if let Err(error) = client.close_machine(connection_id) {
                     crate::client_log::stderr_log!(
                         "provider",
                         "cmux-tui: failed to close provider machine connection: {error}"
                     );
                 }
-            })
-        {
+            }),
+        ) {
+            let reason = match error {
+                mpsc::TrySendError::Full(_) => "reserved close queue capacity was unavailable",
+                mpsc::TrySendError::Disconnected(_) => "close worker disconnected",
+            };
             crate::client_log::stderr_log!(
                 "provider",
-                "cmux-tui: failed to schedule provider machine close: {error}"
+                "cmux-tui: failed to schedule provider machine close: {reason}"
             );
         }
     }
@@ -200,6 +285,7 @@ pub(crate) struct ProviderMachineRuntime {
     pending_notice_messages: HashSet<String>,
     notice: Option<String>,
     notice_identity: ProviderNoticeIdentity,
+    close_worker: Arc<ProviderCloseWorker>,
 }
 
 /// Composes a provider-owned catalog with client-local socket and SSH targets.
@@ -581,6 +667,7 @@ impl ProviderMachineRuntime {
             pending_notice_messages: HashSet::new(),
             notice: None,
             notice_identity,
+            close_worker: Arc::new(ProviderCloseWorker::new()?),
         };
         runtime.observe_snapshot_notice(
             runtime.snapshot.notice.clone(),
@@ -1146,6 +1233,7 @@ impl ProviderMachineRuntime {
         let keys = self.keys.clone();
         let connections = self.connections.clone();
         let connection_registry = self.connection_registry.clone();
+        let close_worker = self.close_worker.clone();
         let provider_connect_supported = client
             .supports_capability(protocol::EXTERNAL_MACHINE_CONNECT_CAPABILITY)
             .unwrap_or(false);
@@ -1450,6 +1538,7 @@ impl ProviderMachineRuntime {
                         &keys,
                         &connections,
                         &connection_registry,
+                        &close_worker,
                     );
                     let session_available = snapshot.selected_machine_id.is_some()
                         && connected_session.as_ref().is_some_and(|(_, machine_id)| {
@@ -1912,6 +2001,7 @@ impl ProviderMachineRuntime {
             &self.keys,
             &self.connections,
             &self.connection_registry,
+            &self.close_worker,
         );
     }
 
@@ -2246,6 +2336,7 @@ fn sync_provider_connection_hub(
     keys: &Arc<Mutex<KeyRegistry>>,
     connections: &MachineConnectionHub,
     registry: &Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    close_worker: &Arc<ProviderCloseWorker>,
 ) {
     let visible =
         snapshot.machines.iter().map(|machine| machine.id.clone()).collect::<HashSet<_>>();
@@ -2268,6 +2359,7 @@ fn sync_provider_connection_hub(
                 machine.clone(),
                 key,
                 Arc::clone(registry),
+                Arc::clone(close_worker),
             ),
         );
     }
@@ -2279,9 +2371,16 @@ fn provider_machine_connector(
     machine: protocol::MachineDescriptor,
     key: MachineKey,
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    close_worker: Arc<ProviderCloseWorker>,
 ) -> MachineConnectFn {
     Arc::new(move || {
-        connect_provider_machine(Arc::clone(&client), machine.clone(), key, Arc::clone(&registry))
+        connect_provider_machine(
+            Arc::clone(&client),
+            machine.clone(),
+            key,
+            Arc::clone(&registry),
+            Arc::clone(&close_worker),
+        )
     })
 }
 
@@ -2290,6 +2389,7 @@ fn connect_provider_machine(
     machine: protocol::MachineDescriptor,
     key: MachineKey,
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    close_worker: Arc<ProviderCloseWorker>,
 ) -> anyhow::Result<MachineConnection> {
     let provider_managed =
         matches!(machine.workspace_create, protocol::WorkspaceCreatePolicy::Provider { .. });
@@ -2298,6 +2398,13 @@ fn connect_provider_machine(
     {
         anyhow::bail!(localization::catalog().sidebar.machine_managed_authority_unsupported);
     }
+
+    // Reserve teardown capacity before the provider creates a connection.
+    // Every successful open can therefore enqueue exactly one close without
+    // blocking a session drop or losing the close request under load.
+    let close_permit = close_worker.try_reserve().ok_or_else(|| {
+        anyhow::anyhow!("provider machine close capacity is temporarily exhausted")
+    })?;
 
     let opened = client.open_machine(machine.id.clone(), provider_managed)?;
     let connection_id = opened.connection_id.clone();
@@ -2343,7 +2450,13 @@ fn connect_provider_machine(
     drop(connections);
     Ok(MachineConnection {
         session,
-        _lease: Some(Box::new(ProviderMachineConnectionLease { open, key, registry })),
+        _lease: Some(Box::new(ProviderMachineConnectionLease {
+            open,
+            key,
+            registry,
+            close_worker,
+            close_permit: Some(close_permit),
+        })),
     })
 }
 
@@ -2651,6 +2764,37 @@ mod tests {
         protocol::BearerToken::new("runtime-test-token").unwrap()
     }
 
+    #[test]
+    fn provider_close_worker_reserves_lossless_bounded_capacity() {
+        let worker = Arc::new(ProviderCloseWorker::with_capacity(2).unwrap());
+        let first_permit = worker.try_reserve().unwrap();
+        let second_permit = worker.try_reserve().unwrap();
+        assert!(worker.try_reserve().is_none());
+        let (started, wait) = mpsc::sync_channel(0);
+        let (release, released) = mpsc::sync_channel(0);
+        worker
+            .schedule_reserved(
+                first_permit,
+                Box::new(move || {
+                    started.send(()).unwrap();
+                    released.recv().unwrap();
+                }),
+            )
+            .unwrap();
+        wait.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker.schedule_reserved(second_permit, Box::new(|| {})).unwrap();
+        assert!(worker.try_reserve().is_none());
+        release.send(()).unwrap();
+        for _ in 0..100 {
+            if *worker.available.lock().unwrap() == 2 {
+                break;
+            }
+            thread::sleep(Duration::from_millis(10));
+        }
+        assert_eq!(*worker.available.lock().unwrap(), 2);
+        drop(worker);
+    }
+
     fn cache_test_connection(
         runtime: &mut ProviderMachineRuntime,
         connection_id: &str,
@@ -2673,6 +2817,8 @@ mod tests {
                 open: open.clone(),
                 key,
                 registry: runtime.connection_registry.clone(),
+                close_worker: runtime.close_worker.clone(),
+                close_permit: Some(runtime.close_worker.try_reserve().unwrap()),
             }) as Box<dyn crate::machine_runtime::MachineConnectionLease>
         });
         runtime.connections.insert_ready(

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -44,6 +44,7 @@ type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
 
 struct ProviderCloseWorker {
     sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
+    reaper_sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
     shutdown_sender: Option<crossbeam_channel::Sender<()>>,
     threads: Vec<std::thread::JoinHandle<()>>,
     pending: Arc<Mutex<HashMap<MachineKey, ProviderCloseTask>>>,
@@ -58,7 +59,28 @@ impl ProviderCloseWorker {
         let (sender, receiver) = crossbeam_channel::bounded::<ProviderCloseTask>(queue_capacity);
         let worker_count = PROVIDER_CLOSE_WORKER_COUNT.min(queue_capacity.max(1));
         let (shutdown_sender, shutdown_receiver) =
-            crossbeam_channel::bounded::<()>(worker_count.max(1));
+            crossbeam_channel::bounded::<()>(worker_count + 1);
+        let (reaper_sender, reaper_receiver) =
+            crossbeam_channel::bounded::<ProviderCloseTask>(PROVIDER_CONNECTION_ADMISSION_CAP);
+        let reaper_shutdown = shutdown_receiver.clone();
+        let reaper_thread = std::thread::Builder::new()
+            .name("provider-close-reaper".into())
+            .spawn(move || loop {
+                crossbeam_channel::select! {
+                    recv(reaper_shutdown) -> _ => {
+                        while let Ok(task) = reaper_receiver.try_recv() {
+                            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(task));
+                        }
+                        break;
+                    }
+                    recv(reaper_receiver) -> task => match task {
+                        Ok(task) => {
+                            let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(task));
+                        }
+                        Err(_) => break,
+                    }
+                }
+            })?;
         let pending = Arc::new(Mutex::new(HashMap::new()));
         let mut threads = Vec::with_capacity(worker_count);
         for index in 0..worker_count {
@@ -137,7 +159,14 @@ impl ProviderCloseWorker {
             threads.push(thread);
         }
         drop(receiver);
-        Ok(Self { sender: Some(sender), shutdown_sender: Some(shutdown_sender), threads, pending })
+        threads.push(reaper_thread);
+        Ok(Self {
+            sender: Some(sender),
+            reaper_sender: Some(reaper_sender),
+            shutdown_sender: Some(shutdown_sender),
+            threads,
+            pending,
+        })
     }
 
     fn schedule(
@@ -161,6 +190,16 @@ impl ProviderCloseWorker {
             Err(error) => Err(error),
         }
     }
+
+    fn schedule_reaper(&self, task: ProviderCloseTask) -> Result<(), ProviderCloseTask> {
+        let Some(sender) = self.reaper_sender.as_ref() else {
+            return Err(task);
+        };
+        sender.try_send(task).map_err(|error| match error {
+            crossbeam_channel::TrySendError::Full(task)
+            | crossbeam_channel::TrySendError::Disconnected(task) => task,
+        })
+    }
 }
 
 impl Drop for ProviderCloseWorker {
@@ -171,6 +210,7 @@ impl Drop for ProviderCloseWorker {
             }
         }
         self.sender.take();
+        self.reaper_sender.take();
         for thread in self.threads.drain(..) {
             // A close RPC has its own request deadline, but dropping the
             // runtime must not wait for that remote deadline. Reap a worker
@@ -296,18 +336,11 @@ impl Drop for ProviderMachineConnectionLease {
                     ("close worker disconnected", task)
                 }
             };
-            // Admission is capped, so this fallback can create at most the
-            // documented number of close reapers. It preserves the remote
-            // close obligation when the owned worker cannot accept the task.
-            if std::thread::Builder::new()
-                .name("provider-close-reaper".into())
-                .spawn(task)
-                .is_err()
-            {
-                    crate::client_log::stderr_log!(
-                        "provider",
-                        "cmux-tui: failed to start provider machine close reaper after {reason}"
-                    );
+            if self.close_worker.schedule_reaper(task).is_err() {
+                crate::client_log::stderr_log!(
+                    "provider",
+                    "cmux-tui: failed to preserve provider machine close after {reason}"
+                );
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -89,8 +89,7 @@ impl ProviderCloseWorker {
                                     .iter()
                                     .next()
                                     .map(|(key, _)| (*key, pending.remove(key).unwrap()))
-                            })
-                            else {
+                            }) else {
                                 break;
                             };
                             match sender.try_send(close) {

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -69,13 +69,31 @@ impl ProviderCloseWorker {
             let thread = std::thread::Builder::new()
                 .name(format!("provider-close-machine-{index}"))
                 .spawn(move || {
+                    let mut stopping = false;
                     loop {
-                        let close = crossbeam_channel::select! {
-                            recv(shutdown_receiver) -> _ => break,
-                            recv(receiver) -> close => match close {
+                        let close = if stopping {
+                            match receiver.try_recv() {
                                 Ok(close) => close,
-                                Err(_) => break,
-                            },
+                                Err(crossbeam_channel::TryRecvError::Empty) => {
+                                    let pending_empty = pending.lock().map_or(true, |pending| pending.is_empty());
+                                    if pending_empty {
+                                        break;
+                                    }
+                                    continue;
+                                }
+                                Err(crossbeam_channel::TryRecvError::Disconnected) => break,
+                            }
+                        } else {
+                            crossbeam_channel::select! {
+                                recv(shutdown_receiver) -> _ => {
+                                    stopping = true;
+                                    continue;
+                                }
+                                recv(receiver) -> close => match close {
+                                    Ok(close) => close,
+                                    Err(_) => break,
+                                },
+                            }
                         };
                         {
                             let close = close;

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -115,7 +115,15 @@ impl ProviderCloseWorker {
                                     stopping = true;
                                     continue;
                                 }
-                                recv(wake_receiver) -> _ => continue,
+                                recv(wake_receiver) -> _ => {
+                                    let next = pending.lock().ok().and_then(|mut pending| {
+                                        let key = pending.keys().next().copied()?;
+                                        let close = pending.remove(&key)?;
+                                        Some(close)
+                                    });
+                                    let Some(close) = next else { continue };
+                                    close
+                                }
                                 recv(receiver) -> close => match close {
                                     Ok(close) => close,
                                     Err(_) => break,

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -44,6 +44,7 @@ type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
 struct ProviderCloseWorker {
     sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
     threads: Vec<std::thread::JoinHandle<()>>,
+    pending: Arc<Mutex<HashMap<MachineKey, ProviderCloseTask>>>,
 }
 
 impl ProviderCloseWorker {
@@ -54,35 +55,81 @@ impl ProviderCloseWorker {
     fn with_capacity(queue_capacity: usize) -> anyhow::Result<Self> {
         let (sender, receiver) = crossbeam_channel::bounded::<ProviderCloseTask>(queue_capacity);
         let worker_count = PROVIDER_CLOSE_WORKER_COUNT.min(queue_capacity.max(1));
+        let pending = Arc::new(Mutex::new(HashMap::new()));
         let mut threads = Vec::with_capacity(worker_count);
         for index in 0..worker_count {
             let receiver = receiver.clone();
+            let sender = sender.clone();
+            let pending = Arc::clone(&pending);
             let thread = std::thread::Builder::new()
                 .name(format!("provider-close-machine-{index}"))
                 .spawn(move || {
-                    while let Ok(close) = receiver.recv() {
+                    loop {
+                        let close = match receiver.recv() {
+                            Ok(close) => close,
+                            Err(_) => {
+                                let mut pending = pending.lock().ok();
+                                let Some(pending) = pending.as_mut() else { break };
+                                if pending.is_empty() {
+                                    break;
+                                }
+                                let Some((&key, _)) = pending.iter().next() else { continue };
+                                pending.remove(&key).expect("pending close task disappeared")
+                            }
+                        };
                         if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
                             crate::client_log::stderr_log!(
                                 "provider",
                                 "cmux-tui: provider machine close task panicked"
                             );
                         }
+                        loop {
+                            let Some((key, close)) = pending
+                                .lock()
+                                .ok()
+                                .and_then(|mut pending| pending.iter().next().map(|(key, _)| (*key, pending.remove(key).unwrap())))
+                            else {
+                                break;
+                            };
+                            match sender.try_send(close) {
+                                Ok(()) => {}
+                                Err(crossbeam_channel::TrySendError::Full(close)) => {
+                                    if let Ok(mut pending) = pending.lock() {
+                                        pending.insert(key, close);
+                                    }
+                                    break;
+                                }
+                                Err(crossbeam_channel::TrySendError::Disconnected(_)) => break,
+                            }
+                        }
                     }
                 })?;
             threads.push(thread);
         }
         drop(receiver);
-        Ok(Self { sender: Some(sender), threads })
+        Ok(Self { sender: Some(sender), threads, pending })
     }
 
     fn schedule(
         &self,
+        key: MachineKey,
         close: ProviderCloseTask,
     ) -> Result<(), crossbeam_channel::TrySendError<ProviderCloseTask>> {
         let Some(sender) = self.sender.as_ref() else {
             return Err(crossbeam_channel::TrySendError::Disconnected(close));
         };
-        sender.try_send(close)
+        match sender.try_send(close) {
+            Ok(()) => Ok(()),
+            Err(crossbeam_channel::TrySendError::Full(close)) => {
+                if let Ok(mut pending) = self.pending.lock() {
+                    pending.insert(key, close);
+                    Ok(())
+                } else {
+                    Err(crossbeam_channel::TrySendError::Disconnected(close))
+                }
+            }
+            Err(error) => Err(error),
+        }
     }
 }
 
@@ -182,7 +229,7 @@ impl Drop for ProviderMachineConnectionLease {
             key,
             connection_id: connection_id.clone(),
         };
-        if let Err(error) = self.close_worker.schedule(Box::new(move || {
+        if let Err(error) = self.close_worker.schedule(key, Box::new(move || {
             let _cleanup = cleanup;
             if let Err(error) = client.close_machine(connection_id) {
                 crate::client_log::stderr_log!(
@@ -2513,12 +2560,22 @@ fn connect_provider_machine(
     };
     let session = Session::Remote(remote);
     let open = OpenConnection { client, connection_id, machine_id: machine.id };
-    let mut connections = registry
-        .lock()
-        .map_err(|_| anyhow::anyhow!("provider machine connection registry is poisoned"))?;
-    let mut transitions = closing_connections
-        .lock()
-        .map_err(|_| anyhow::anyhow!("provider machine closing registry is poisoned"))?;
+    let mut connections = match registry.lock() {
+        Ok(connections) => connections,
+        Err(_) => {
+            session.begin_shutdown();
+            let _ = open.client.close_machine(open.connection_id.clone());
+            anyhow::bail!(localization::catalog().sidebar.machine_provider_update_failed);
+        }
+    };
+    let mut transitions = match closing_connections.lock() {
+        Ok(transitions) => transitions,
+        Err(_) => {
+            session.begin_shutdown();
+            let _ = open.client.close_machine(open.connection_id.clone());
+            anyhow::bail!(localization::catalog().sidebar.machine_provider_update_failed);
+        }
+    };
     if !transitions.remove(&key) {
         session.begin_shutdown();
         let _ = open.client.close_machine(open.connection_id);
@@ -2848,19 +2905,19 @@ mod tests {
         let (started, started_rx) = mpsc::channel();
         let (release, release_rx) = mpsc::channel();
         worker
-            .schedule(Box::new(move || {
+            .schedule(MachineKey(1), Box::new(move || {
                 started.send(()).unwrap();
                 release_rx.recv().unwrap();
             }))
             .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         worker
-            .schedule(Box::new(|| {}))
+            .schedule(MachineKey(2), Box::new(|| {}))
             .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
-        assert!(matches!(
-            worker.schedule(Box::new(|| {})),
-            Err(crossbeam_channel::TrySendError::Full(_))
-        ));
+        worker
+            .schedule(MachineKey(3), Box::new(|| {}))
+            .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
+        assert!(worker.pending.lock().unwrap().contains_key(&MachineKey(3)));
         release.send(()).unwrap();
         drop(worker);
     }
@@ -2872,7 +2929,7 @@ mod tests {
         let (release, release_rx) = mpsc::channel();
         let (finished, finished_rx) = mpsc::channel();
         worker
-            .schedule(Box::new(move || {
+            .schedule(MachineKey(1), Box::new(move || {
                 started.send(()).unwrap();
                 release_rx.recv().unwrap();
                 finished.send(()).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -36,6 +36,7 @@ use crate::machine_runtime::{
 use crate::session::{RemoteSession, Session};
 
 const PROVIDER_REFRESH_QUEUE_CAPACITY: usize = 64;
+const PROVIDER_CLOSE_QUEUE_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_WORKER_COUNT: usize = 4;
 
 type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
@@ -47,12 +48,12 @@ struct ProviderCloseWorker {
 
 impl ProviderCloseWorker {
     fn new() -> anyhow::Result<Self> {
-        Self::with_capacity(PROVIDER_CLOSE_WORKER_COUNT)
+        Self::with_capacity(PROVIDER_CLOSE_QUEUE_CAPACITY)
     }
 
-    fn with_capacity(worker_count: usize) -> anyhow::Result<Self> {
-        let (sender, receiver) = crossbeam_channel::unbounded::<ProviderCloseTask>();
-        let worker_count = worker_count.max(1);
+    fn with_capacity(queue_capacity: usize) -> anyhow::Result<Self> {
+        let (sender, receiver) = crossbeam_channel::bounded::<ProviderCloseTask>(queue_capacity);
+        let worker_count = PROVIDER_CLOSE_WORKER_COUNT.min(queue_capacity.max(1));
         let mut threads = Vec::with_capacity(worker_count);
         for index in 0..worker_count {
             let receiver = receiver.clone();
@@ -74,9 +75,14 @@ impl ProviderCloseWorker {
         Ok(Self { sender: Some(sender), threads })
     }
 
-    fn schedule(&self, close: ProviderCloseTask) -> Result<(), ProviderCloseTask> {
-        let Some(sender) = self.sender.as_ref() else { return Err(close) };
-        sender.send(close).map_err(|error| error.0)
+    fn schedule(
+        &self,
+        close: ProviderCloseTask,
+    ) -> Result<(), crossbeam_channel::TrySendError<ProviderCloseTask>> {
+        let Some(sender) = self.sender.as_ref() else {
+            return Err(crossbeam_channel::TrySendError::Disconnected(close));
+        };
+        sender.try_send(close)
     }
 }
 
@@ -123,12 +129,33 @@ struct ProviderCloseCleanup {
 impl Drop for ProviderCloseCleanup {
     fn drop(&mut self) {
         if let Ok(mut registry) = self.registry.lock()
+            && let Ok(mut closing_keys) = self.closing.lock()
             && registry.get(&self.key).is_some_and(|open| open.connection_id == self.connection_id)
         {
             registry.remove(&self.key);
-        }
-        if let Ok(mut closing_keys) = self.closing.lock() {
             closing_keys.remove(&self.key);
+        }
+    }
+}
+
+struct ProviderConnectionReservation {
+    transitions: Arc<Mutex<HashSet<MachineKey>>>,
+    key: MachineKey,
+    active: bool,
+}
+
+impl ProviderConnectionReservation {
+    fn commit(&mut self) {
+        self.active = false;
+    }
+}
+
+impl Drop for ProviderConnectionReservation {
+    fn drop(&mut self) {
+        if self.active
+            && let Ok(mut transitions) = self.transitions.lock()
+        {
+            transitions.remove(&self.key);
         }
     }
 }
@@ -143,8 +170,11 @@ impl Drop for ProviderMachineConnectionLease {
         let key = self.key;
         let registry = Arc::clone(&self.registry);
         let closing = Arc::clone(&self.closing);
-        if let Ok(_registry_guard) = registry.lock()
+        if let Ok(registry_guard) = registry.lock()
             && let Ok(mut closing_keys) = closing.lock()
+            && registry_guard
+                .get(&key)
+                .is_some_and(|open| open.connection_id == connection_id)
         {
             closing_keys.insert(key);
         }
@@ -154,7 +184,7 @@ impl Drop for ProviderMachineConnectionLease {
             key,
             connection_id: connection_id.clone(),
         };
-        if self
+        if let Err(error) = self
             .close_worker
             .schedule(Box::new(move || {
                 let _cleanup = cleanup;
@@ -165,22 +195,15 @@ impl Drop for ProviderMachineConnectionLease {
                     );
                 }
             }))
-            .is_err()
         {
+            let reason = match error {
+                crossbeam_channel::TrySendError::Full(_) => "close queue is full",
+                crossbeam_channel::TrySendError::Disconnected(_) => "close worker disconnected",
+            };
             crate::client_log::stderr_log!(
                 "provider",
-                "cmux-tui: failed to schedule provider machine close: close worker disconnected"
+                "cmux-tui: failed to schedule provider machine close: {reason}"
             );
-            if let Ok(mut registry) = self.registry.lock()
-                && registry
-                    .get(&self.key)
-                    .is_some_and(|open| open.connection_id == self.open.connection_id)
-            {
-                registry.remove(&self.key);
-            }
-            if let Ok(mut closing_keys) = self.closing.lock() {
-                closing_keys.remove(&self.key);
-            }
         }
     }
 }
@@ -2425,22 +2448,29 @@ fn connect_provider_machine(
         anyhow::bail!(localization::catalog().sidebar.machine_managed_authority_unsupported);
     }
 
-    // Hold the registry lock through open and registration. Lease teardown
-    // marks the key as closing while holding the same lock, so reconnects
-    // cannot race the close handoff or replace an entry still being closed.
+    // Reserve this key under the registry and transition locks, then release
+    // both before the provider RPC. Lease teardown takes the same locks when
+    // marking a key closing, so reconnects cannot race the open handoff.
     let mut connections = registry
         .lock()
         .map_err(|_| anyhow::anyhow!("provider machine connection registry is poisoned"))?;
-    if closing_connections
+    let mut transitions = closing_connections
         .lock()
-        .map_err(|_| anyhow::anyhow!("provider machine closing registry is poisoned"))?
-        .contains(&key)
-    {
+        .map_err(|_| anyhow::anyhow!("provider machine closing registry is poisoned"))?;
+    if transitions.contains(&key) {
         anyhow::bail!("provider machine connection is still closing");
     }
     if connections.contains_key(&key) {
         anyhow::bail!("provider machine connection is already open");
     }
+    transitions.insert(key);
+    drop(transitions);
+    drop(connections);
+    let mut reservation = ProviderConnectionReservation {
+        transitions: Arc::clone(&closing_connections),
+        key,
+        active: true,
+    };
 
     let opened = client.open_machine(machine.id.clone(), provider_managed)?;
     let connection_id = opened.connection_id.clone();
@@ -2474,7 +2504,19 @@ fn connect_provider_machine(
     };
     let session = Session::Remote(remote);
     let open = OpenConnection { client, connection_id, machine_id: machine.id };
+    let mut connections = registry
+        .lock()
+        .map_err(|_| anyhow::anyhow!("provider machine connection registry is poisoned"))?;
+    let mut transitions = closing_connections
+        .lock()
+        .map_err(|_| anyhow::anyhow!("provider machine closing registry is poisoned"))?;
+    if !transitions.remove(&key) {
+        session.begin_shutdown();
+        let _ = open.client.close_machine(open.connection_id);
+        anyhow::bail!("provider machine connection reservation was lost");
+    }
     connections.insert(key, open.clone());
+    reservation.commit();
     Ok(MachineConnection {
         session,
         _lease: Some(Box::new(ProviderMachineConnectionLease {
@@ -2792,18 +2834,22 @@ mod tests {
     }
 
     #[test]
-    fn provider_close_worker_accepts_many_close_tasks() {
-        let worker = Arc::new(ProviderCloseWorker::with_capacity(2).unwrap());
-        let (finished, finished_rx) = mpsc::channel();
-        for _ in 0..128 {
-            let finished = finished.clone();
-            worker
-                .schedule(Box::new(move || finished.send(()).unwrap()))
-                .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
-        }
-        for _ in 0..128 {
-            finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
-        }
+    fn provider_close_worker_bounds_queue_without_blocking_schedule() {
+        let worker = Arc::new(ProviderCloseWorker::with_capacity(1).unwrap());
+        let (started, started_rx) = mpsc::channel();
+        let (release, release_rx) = mpsc::channel();
+        worker
+            .schedule(Box::new(move || {
+                started.send(()).unwrap();
+                release_rx.recv().unwrap();
+            }))
+            .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        worker
+            .schedule(Box::new(|| {}))
+            .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
+        assert!(matches!(worker.schedule(Box::new(|| {})), Err(crossbeam_channel::TrySendError::Full(_))));
+        release.send(()).unwrap();
         drop(worker);
     }
 

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -79,7 +79,9 @@ impl ProviderCloseWorker {
                         };
                         {
                             let close = close;
-                            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
+                            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close))
+                                .is_err()
+                            {
                                 crate::client_log::stderr_log!(
                                     "provider",
                                     "cmux-tui: provider machine close task panicked"

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -75,7 +75,8 @@ impl ProviderCloseWorker {
                             match receiver.try_recv() {
                                 Ok(close) => close,
                                 Err(crossbeam_channel::TryRecvError::Empty) => {
-                                    let pending_empty = pending.lock().map_or(true, |pending| pending.is_empty());
+                                    let pending_empty =
+                                        pending.lock().map_or(true, |pending| pending.is_empty());
                                     if pending_empty {
                                         break;
                                     }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -10,6 +10,7 @@ use std::time::Duration;
 
 use cmux_tui_core::{Mux, SurfaceOptions};
 use cmux_tui_machine_protocol as protocol;
+use crossbeam_channel::bounded;
 use zeroize::Zeroize;
 
 use crate::config::MachineConfig;
@@ -37,12 +38,13 @@ use crate::session::{RemoteSession, Session};
 
 const PROVIDER_REFRESH_QUEUE_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_QUEUE_CAPACITY: usize = 64;
+const PROVIDER_CLOSE_WORKER_COUNT: usize = 4;
 
 type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
 
 struct ProviderCloseWorker {
-    sender: Option<mpsc::SyncSender<ProviderCloseTask>>,
-    thread: Option<std::thread::JoinHandle<()>>,
+    sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
+    threads: Vec<std::thread::JoinHandle<()>>,
     available: Mutex<usize>,
 }
 
@@ -56,9 +58,14 @@ impl ProviderCloseWorker {
     }
 
     fn with_capacity(capacity: usize) -> anyhow::Result<Self> {
-        let (sender, receiver) = mpsc::sync_channel::<ProviderCloseTask>(capacity);
-        let thread =
-            std::thread::Builder::new().name("provider-close-machine".into()).spawn(move || {
+        let (sender, receiver) = bounded::<ProviderCloseTask>(capacity);
+        let worker_count = PROVIDER_CLOSE_WORKER_COUNT.min(capacity.max(1));
+        let mut threads = Vec::with_capacity(worker_count);
+        for index in 0..worker_count {
+            let receiver = receiver.clone();
+            let thread = std::thread::Builder::new()
+                .name(format!("provider-close-machine-{index}"))
+                .spawn(move || {
                 while let Ok(close) = receiver.recv() {
                     if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
                         crate::client_log::stderr_log!(
@@ -67,8 +74,11 @@ impl ProviderCloseWorker {
                         );
                     }
                 }
-            })?;
-        Ok(Self { sender: Some(sender), thread: Some(thread), available: Mutex::new(capacity) })
+                })?;
+            threads.push(thread);
+        }
+        drop(receiver);
+        Ok(Self { sender: Some(sender), threads, available: Mutex::new(capacity) })
     }
 
     fn try_reserve(self: &Arc<Self>) -> Option<ProviderClosePermit> {
@@ -84,7 +94,7 @@ impl ProviderCloseWorker {
         &self,
         permit: ProviderClosePermit,
         close: ProviderCloseTask,
-    ) -> Result<(), mpsc::TrySendError<ProviderCloseTask>> {
+    ) -> Result<(), crossbeam_channel::TrySendError<ProviderCloseTask>> {
         self.sender.as_ref().expect("provider close worker is active").try_send(Box::new(
             move || {
                 close();
@@ -107,7 +117,7 @@ impl Drop for ProviderClosePermit {
 impl Drop for ProviderCloseWorker {
     fn drop(&mut self) {
         self.sender.take();
-        if let Some(thread) = self.thread.take() {
+        for thread in self.threads.drain(..) {
             // A close RPC has its own request deadline, but dropping the
             // runtime must not wait for that remote deadline. Reap a worker
             // that already finished; otherwise dropping the handle detaches
@@ -167,8 +177,10 @@ impl Drop for ProviderMachineConnectionLease {
             }),
         ) {
             let reason = match error {
-                mpsc::TrySendError::Full(_) => "reserved close queue capacity was unavailable",
-                mpsc::TrySendError::Disconnected(_) => "close worker disconnected",
+                crossbeam_channel::TrySendError::Full(_) => {
+                    "reserved close queue capacity was unavailable"
+                }
+                crossbeam_channel::TrySendError::Disconnected(_) => "close worker disconnected",
             };
             crate::client_log::stderr_log!(
                 "provider",

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -148,6 +148,28 @@ struct ProviderMachineConnectionLease {
     close_permit: Option<ProviderClosePermit>,
 }
 
+struct ProviderCloseCleanup {
+    registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    closing: Arc<Mutex<HashSet<MachineKey>>>,
+    key: MachineKey,
+    connection_id: protocol::OpaqueId,
+}
+
+impl Drop for ProviderCloseCleanup {
+    fn drop(&mut self) {
+        if let Ok(mut registry) = self.registry.lock()
+            && registry
+                .get(&self.key)
+                .is_some_and(|open| open.connection_id == self.connection_id)
+        {
+            registry.remove(&self.key);
+        }
+        if let Ok(mut closing_keys) = self.closing.lock() {
+            closing_keys.remove(&self.key);
+        }
+    }
+}
+
 impl Drop for ProviderMachineConnectionLease {
     fn drop(&mut self) {
         // Provider close is an RPC and may block on a remote provider. Keep
@@ -155,32 +177,28 @@ impl Drop for ProviderMachineConnectionLease {
         // threads through the runtime-owned close worker.
         let client = Arc::clone(&self.open.client);
         let connection_id = self.open.connection_id.clone();
-        let registry_connection_id = connection_id.clone();
         let key = self.key;
         let registry = Arc::clone(&self.registry);
         let closing = Arc::clone(&self.closing);
         if let Ok(mut closing_keys) = closing.lock() {
             closing_keys.insert(key);
         }
+        let cleanup = ProviderCloseCleanup {
+            registry: Arc::clone(&registry),
+            closing: Arc::clone(&closing),
+            key,
+            connection_id: connection_id.clone(),
+        };
         let permit = self.close_permit.take().expect("provider connection owns a close permit");
         if let Err(error) = self.close_worker.schedule_reserved(
             permit,
             Box::new(move || {
+                let _cleanup = cleanup;
                 if let Err(error) = client.close_machine(connection_id) {
                     crate::client_log::stderr_log!(
                         "provider",
                         "cmux-tui: failed to close provider machine connection: {error}"
                     );
-                }
-                if let Ok(mut registry) = registry.lock()
-                    && registry
-                        .get(&key)
-                        .is_some_and(|open| open.connection_id == registry_connection_id)
-                {
-                    registry.remove(&key);
-                }
-                if let Ok(mut closing_keys) = closing.lock() {
-                    closing_keys.remove(&key);
                 }
             }),
         ) {

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -191,14 +191,28 @@ impl Drop for ProviderMachineConnectionLease {
                 );
             }
         })) {
-            let reason = match error {
-                crossbeam_channel::TrySendError::Full(_) => "close queue is full",
-                crossbeam_channel::TrySendError::Disconnected(_) => "close worker disconnected",
-            };
-            crate::client_log::stderr_log!(
-                "provider",
-                "cmux-tui: failed to schedule provider machine close: {reason}"
-            );
+            match error {
+                crossbeam_channel::TrySendError::Full(task) => {
+                    // Preserve every close when the bounded queue is full by
+                    // handing it to a detached thread without blocking Drop.
+                    if std::thread::Builder::new()
+                        .name("provider-close-overflow".into())
+                        .spawn(task)
+                        .is_err()
+                    {
+                        crate::client_log::stderr_log!(
+                            "provider",
+                            "cmux-tui: failed to spawn provider machine close overflow task"
+                        );
+                    }
+                }
+                crossbeam_channel::TrySendError::Disconnected(_) => {
+                    crate::client_log::stderr_log!(
+                        "provider",
+                        "cmux-tui: failed to schedule provider machine close: close worker disconnected"
+                    );
+                }
+            }
         }
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -87,7 +87,12 @@ impl ProviderCloseWorker {
                             let Some((key, close)) = pending
                                 .lock()
                                 .ok()
-                                .and_then(|mut pending| pending.iter().next().map(|(key, _)| (*key, pending.remove(key).unwrap())))
+                                .and_then(|mut pending| {
+                                    pending
+                                        .iter()
+                                        .next()
+                                        .map(|(key, _)| (*key, pending.remove(key).unwrap()))
+                                })
                             else {
                                 break;
                             };
@@ -229,15 +234,18 @@ impl Drop for ProviderMachineConnectionLease {
             key,
             connection_id: connection_id.clone(),
         };
-        if let Err(error) = self.close_worker.schedule(key, Box::new(move || {
-            let _cleanup = cleanup;
-            if let Err(error) = client.close_machine(connection_id) {
-                crate::client_log::stderr_log!(
-                    "provider",
-                    "cmux-tui: failed to close provider machine connection: {error}"
-                );
-            }
-        })) {
+        if let Err(error) = self.close_worker.schedule(
+            key,
+            Box::new(move || {
+                let _cleanup = cleanup;
+                if let Err(error) = client.close_machine(connection_id) {
+                    crate::client_log::stderr_log!(
+                        "provider",
+                        "cmux-tui: failed to close provider machine connection: {error}"
+                    );
+                }
+            }),
+        ) {
             match error {
                 crossbeam_channel::TrySendError::Full(task) => {
                     // Preserve every close when the bounded queue is full by
@@ -2905,10 +2913,13 @@ mod tests {
         let (started, started_rx) = mpsc::channel();
         let (release, release_rx) = mpsc::channel();
         worker
-            .schedule(MachineKey(1), Box::new(move || {
-                started.send(()).unwrap();
-                release_rx.recv().unwrap();
-            }))
+            .schedule(
+                MachineKey(1),
+                Box::new(move || {
+                    started.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                }),
+            )
             .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
         worker
@@ -2929,11 +2940,14 @@ mod tests {
         let (release, release_rx) = mpsc::channel();
         let (finished, finished_rx) = mpsc::channel();
         worker
-            .schedule(MachineKey(1), Box::new(move || {
-                started.send(()).unwrap();
-                release_rx.recv().unwrap();
-                finished.send(()).unwrap();
-            }))
+            .schedule(
+                MachineKey(1),
+                Box::new(move || {
+                    started.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    finished.send(()).unwrap();
+                }),
+            )
             .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
 

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -107,13 +107,17 @@ impl Drop for ProviderClosePermit {
 impl Drop for ProviderCloseWorker {
     fn drop(&mut self) {
         self.sender.take();
-        if let Some(thread) = self.thread.take()
-            && thread.join().is_err()
-        {
-            crate::client_log::stderr_log!(
-                "provider",
-                "cmux-tui: provider machine close worker panicked"
-            );
+        if let Some(thread) = self.thread.take() {
+            // A close RPC has its own request deadline, but dropping the
+            // runtime must not wait for that remote deadline. Reap a worker
+            // that already finished; otherwise dropping the handle detaches
+            // the bounded worker while its in-flight close completes.
+            if thread.is_finished() && thread.join().is_err() {
+                crate::client_log::stderr_log!(
+                    "provider",
+                    "cmux-tui: provider machine close worker panicked"
+                );
+            }
         }
     }
 }
@@ -135,18 +139,14 @@ struct ProviderMachineConnectionLease {
 
 impl Drop for ProviderMachineConnectionLease {
     fn drop(&mut self) {
-        if let Ok(mut registry) = self.registry.lock()
-            && registry
-                .get(&self.key)
-                .is_some_and(|open| open.connection_id == self.open.connection_id)
-        {
-            registry.remove(&self.key);
-        }
         // Provider close is an RPC and may block on a remote provider. Keep
         // session teardown non-blocking and bound both queued work and worker
         // threads through the runtime-owned close worker.
         let client = Arc::clone(&self.open.client);
         let connection_id = self.open.connection_id.clone();
+        let registry_connection_id = connection_id.clone();
+        let key = self.key;
+        let registry = Arc::clone(&self.registry);
         let permit = self.close_permit.take().expect("provider connection owns a close permit");
         if let Err(error) = self.close_worker.schedule_reserved(
             permit,
@@ -156,6 +156,13 @@ impl Drop for ProviderMachineConnectionLease {
                         "provider",
                         "cmux-tui: failed to close provider machine connection: {error}"
                     );
+                }
+                if let Ok(mut registry) = registry.lock()
+                    && registry
+                        .get(&key)
+                        .is_some_and(|open| open.connection_id == registry_connection_id)
+                {
+                    registry.remove(&key);
                 }
             }),
         ) {
@@ -167,6 +174,13 @@ impl Drop for ProviderMachineConnectionLease {
                 "provider",
                 "cmux-tui: failed to schedule provider machine close: {reason}"
             );
+            if let Ok(mut registry) = self.registry.lock()
+                && registry
+                    .get(&self.key)
+                    .is_some_and(|open| open.connection_id == self.open.connection_id)
+            {
+                registry.remove(&self.key);
+            }
         }
     }
 }
@@ -2401,6 +2415,14 @@ fn connect_provider_machine(
         anyhow::bail!(localization::catalog().sidebar.machine_managed_authority_unsupported);
     }
 
+    if registry
+        .lock()
+        .map_err(|_| anyhow::anyhow!("provider machine connection registry is poisoned"))?
+        .contains_key(&key)
+    {
+        anyhow::bail!("provider machine connection is still closing");
+    }
+
     // Reserve teardown capacity before the provider creates a connection.
     // Every successful open can therefore enqueue exactly one close without
     // blocking a session drop or losing the close request under load.
@@ -2795,6 +2817,33 @@ mod tests {
         }
         assert_eq!(*worker.available.lock().unwrap(), 2);
         drop(worker);
+    }
+
+    #[test]
+    fn provider_close_worker_drop_does_not_join_a_blocked_close() {
+        let worker = Arc::new(ProviderCloseWorker::with_capacity(1).unwrap());
+        let permit = worker.try_reserve().unwrap();
+        let (started, started_rx) = mpsc::channel();
+        let (release, release_rx) = mpsc::channel();
+        let (finished, finished_rx) = mpsc::channel();
+        worker
+            .schedule_reserved(
+                permit,
+                Box::new(move || {
+                    started.send(()).unwrap();
+                    release_rx.recv().unwrap();
+                    finished.send(()).unwrap();
+                }),
+            )
+            .unwrap();
+        started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+
+        let drop_started = std::time::Instant::now();
+        drop(worker);
+        assert!(drop_started.elapsed() < Duration::from_secs(1));
+
+        release.send(()).unwrap();
+        finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
     }
 
     fn cache_test_connection(
@@ -5791,6 +5840,7 @@ mod tests {
             default_mode: protocol::WorkspaceCreateMode::Isolated,
             modes: vec![protocol::WorkspaceCreateMode::Isolated],
         };
+        let candidate_key = key_for_id(&runtime.keys, &id("machine-2")).unwrap();
         let candidate_open =
             cache_test_connection(&mut runtime, "reject-second", "machine-2", true);
         runtime.stage_connection(Some(candidate_open), Some(rollback)).unwrap();
@@ -5807,6 +5857,19 @@ mod tests {
             runtime.open.as_ref().map(|open| open.connection_id.as_str()),
             Some("keep-first-open")
         );
+        assert!(runtime.connection_registry.lock().unwrap().contains_key(&candidate_key));
+        let mut reconnect_machine = runtime.snapshot.machines[1].clone();
+        reconnect_machine.workspace_create = protocol::WorkspaceCreatePolicy::Session;
+        let reconnect_error = connect_provider_machine(
+            runtime.client.clone(),
+            reconnect_machine,
+            candidate_key,
+            runtime.connection_registry.clone(),
+            runtime.close_worker.clone(),
+        )
+        .err()
+        .expect("reconnect must wait for the previous provider close");
+        assert!(reconnect_error.to_string().contains("still closing"));
         wait_for_close.recv_timeout(Duration::from_secs(2)).unwrap();
         runtime.refresh().expect("provider control connection remains usable");
         drop(runtime);

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -65,7 +65,7 @@ impl Drop for ProviderMachineConnectionLease {
         // into a short-lived worker, preserving ownership until the RPC ends.
         let client = Arc::clone(&self.open.client);
         let connection_id = self.open.connection_id.clone();
-        let _ = std::thread::Builder::new()
+        if let Err(error) = std::thread::Builder::new()
             .name("provider-close-machine".into())
             .spawn(move || {
                 if let Err(error) = client.close_machine(connection_id) {
@@ -74,7 +74,13 @@ impl Drop for ProviderMachineConnectionLease {
                         "cmux-tui: failed to close provider machine connection: {error}"
                     );
                 }
-            });
+            })
+        {
+            crate::client_log::stderr_log!(
+                "provider",
+                "cmux-tui: failed to schedule provider machine close: {error}"
+            );
+        }
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -84,12 +84,12 @@ impl ProviderCloseWorker {
                             );
                         }
                         loop {
-                            let Some((key, close)) = pending.lock().ok().and_then(|mut pending| {
-                                pending
-                                    .iter()
-                                    .next()
-                                    .map(|(key, _)| (*key, pending.remove(key).unwrap()))
-                            }) else {
+                            let next = pending.lock().ok().and_then(|mut pending| {
+                                let key = pending.keys().next().copied()?;
+                                let close = pending.remove(&key)?;
+                                Some((key, close))
+                            });
+                            let Some((key, close)) = next else {
                                 break;
                             };
                             match sender.try_send(close) {

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -1274,6 +1274,7 @@ impl ProviderMachineRuntime {
         let keys = self.keys.clone();
         let connections = self.connections.clone();
         let connection_registry = self.connection_registry.clone();
+        let closing_connections = self.closing_connections.clone();
         let close_worker = self.close_worker.clone();
         let provider_connect_supported = client
             .supports_capability(protocol::EXTERNAL_MACHINE_CONNECT_CAPABILITY)
@@ -2450,7 +2451,7 @@ fn connect_provider_machine(
     if closing_connections
         .lock()
         .map_err(|_| anyhow::anyhow!("provider machine closing registry is poisoned"))?
-        .contains_key(&key)
+        .contains(&key)
     {
         anyhow::bail!("provider machine connection is still closing");
     }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -154,7 +154,9 @@ impl Drop for ProviderMachineConnectionLease {
             key,
             connection_id: connection_id.clone(),
         };
-        if self.close_worker.schedule(Box::new(move || {
+        if self
+            .close_worker
+            .schedule(Box::new(move || {
                 let _cleanup = cleanup;
                 if let Err(error) = client.close_machine(connection_id) {
                     crate::client_log::stderr_log!(
@@ -2811,10 +2813,10 @@ mod tests {
         let (finished, finished_rx) = mpsc::channel();
         worker
             .schedule(Box::new(move || {
-                    started.send(()).unwrap();
-                    release_rx.recv().unwrap();
-                    finished.send(()).unwrap();
-                }))
+                started.send(()).unwrap();
+                release_rx.recv().unwrap();
+                finished.send(()).unwrap();
+            }))
             .unwrap();
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
 

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -5658,6 +5658,7 @@ mod tests {
             workspace_create: protocol::WorkspaceCreatePolicy::Session,
         });
         let server_catalog = catalog.clone();
+        let (close_received, wait_for_close) = mpsc::channel();
         let server = thread::spawn(move || {
             let (mut stream, mut reader) =
                 serve_initial_snapshot(&listener, server_catalog.clone());
@@ -5752,6 +5753,7 @@ mod tests {
                     protocol::CloseMachineResult { revision: 2 },
                 ),
             );
+            close_received.send(()).unwrap();
 
             let refresh: protocol::RequestEnvelope = read_frame(&mut reader);
             assert!(matches!(refresh.request, protocol::ProviderRequest::Snapshot(_)));
@@ -5805,6 +5807,7 @@ mod tests {
             runtime.open.as_ref().map(|open| open.connection_id.as_str()),
             Some("keep-first-open")
         );
+        wait_for_close.recv_timeout(Duration::from_secs(2)).unwrap();
         runtime.refresh().expect("provider control connection remains usable");
         drop(runtime);
         server.join().unwrap();

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -46,6 +46,7 @@ struct ProviderCloseWorker {
     sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
     reaper_sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
     shutdown_sender: Option<crossbeam_channel::Sender<()>>,
+    wake_sender: Option<crossbeam_channel::Sender<()>>,
     threads: Vec<std::thread::JoinHandle<()>>,
     pending: Arc<Mutex<HashMap<MachineKey, ProviderCloseTask>>>,
 }
@@ -60,6 +61,7 @@ impl ProviderCloseWorker {
         let worker_count = PROVIDER_CLOSE_WORKER_COUNT.min(queue_capacity.max(1));
         let (shutdown_sender, shutdown_receiver) =
             crossbeam_channel::bounded::<()>(worker_count + 1);
+        let (wake_sender, wake_receiver) = crossbeam_channel::bounded::<()>(1);
         let (reaper_sender, reaper_receiver) =
             crossbeam_channel::bounded::<ProviderCloseTask>(PROVIDER_CONNECTION_ADMISSION_CAP);
         let reaper_shutdown = shutdown_receiver.clone();
@@ -88,6 +90,7 @@ impl ProviderCloseWorker {
             let sender = sender.clone();
             let pending = Arc::clone(&pending);
             let shutdown_receiver = shutdown_receiver.clone();
+            let wake_receiver = wake_receiver.clone();
             let thread = std::thread::Builder::new()
                 .name(format!("provider-close-machine-{index}"))
                 .spawn(move || {
@@ -112,6 +115,7 @@ impl ProviderCloseWorker {
                                     stopping = true;
                                     continue;
                                 }
+                                recv(wake_receiver) -> _ => continue,
                                 recv(receiver) -> close => match close {
                                     Ok(close) => close,
                                     Err(_) => break,
@@ -164,6 +168,7 @@ impl ProviderCloseWorker {
             sender: Some(sender),
             reaper_sender: Some(reaper_sender),
             shutdown_sender: Some(shutdown_sender),
+            wake_sender: Some(wake_sender),
             threads,
             pending,
         })
@@ -182,6 +187,9 @@ impl ProviderCloseWorker {
             Err(crossbeam_channel::TrySendError::Full(close)) => {
                 if let Ok(mut pending) = self.pending.lock() {
                     pending.insert(key, close);
+                    if let Some(wake_sender) = self.wake_sender.as_ref() {
+                        let _ = wake_sender.try_send(());
+                    }
                     Ok(())
                 } else {
                     Err(crossbeam_channel::TrySendError::Disconnected(close))
@@ -211,6 +219,7 @@ impl Drop for ProviderCloseWorker {
         }
         self.sender.take();
         self.reaper_sender.take();
+        self.wake_sender.take();
         for thread in self.threads.drain(..) {
             // A close RPC has its own request deadline, but dropping the
             // runtime must not wait for that remote deadline. Reap a worker

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -38,6 +38,7 @@ use crate::session::{RemoteSession, Session};
 const PROVIDER_REFRESH_QUEUE_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_QUEUE_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_WORKER_COUNT: usize = 4;
+const PROVIDER_CONNECTION_ADMISSION_CAP: usize = 256;
 
 type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
 
@@ -198,6 +199,7 @@ struct ProviderMachineConnectionLease {
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
     closing: Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: Arc<ProviderCloseWorker>,
+    admissions: Arc<AtomicUsize>,
 }
 
 struct ProviderCloseCleanup {
@@ -205,6 +207,7 @@ struct ProviderCloseCleanup {
     closing: Arc<Mutex<HashSet<MachineKey>>>,
     key: MachineKey,
     connection_id: protocol::OpaqueId,
+    admissions: Arc<AtomicUsize>,
 }
 
 impl Drop for ProviderCloseCleanup {
@@ -216,10 +219,12 @@ impl Drop for ProviderCloseCleanup {
             registry.remove(&self.key);
             closing_keys.remove(&self.key);
         }
+        self.admissions.fetch_sub(1, Ordering::AcqRel);
     }
 }
 
 struct ProviderConnectionReservation {
+    admissions: Arc<AtomicUsize>,
     transitions: Arc<Mutex<HashSet<MachineKey>>>,
     key: MachineKey,
     active: bool,
@@ -233,12 +238,21 @@ impl ProviderConnectionReservation {
 
 impl Drop for ProviderConnectionReservation {
     fn drop(&mut self) {
-        if self.active
-            && let Ok(mut transitions) = self.transitions.lock()
-        {
-            transitions.remove(&self.key);
+        if self.active {
+            if let Ok(mut transitions) = self.transitions.lock() {
+                transitions.remove(&self.key);
+            }
+            self.admissions.fetch_sub(1, Ordering::AcqRel);
         }
     }
+}
+
+fn try_admit_provider_connection(admissions: &AtomicUsize) -> bool {
+    admissions
+        .fetch_update(Ordering::AcqRel, Ordering::Acquire, |count| {
+            (count < PROVIDER_CONNECTION_ADMISSION_CAP).then_some(count + 1)
+        })
+        .is_ok()
 }
 
 impl Drop for ProviderMachineConnectionLease {
@@ -412,6 +426,7 @@ pub(crate) struct ProviderMachineRuntime {
     notice: Option<String>,
     notice_identity: ProviderNoticeIdentity,
     close_worker: Arc<ProviderCloseWorker>,
+    connection_admissions: Arc<AtomicUsize>,
 }
 
 /// Composes a provider-owned catalog with client-local socket and SSH targets.
@@ -795,6 +810,7 @@ impl ProviderMachineRuntime {
             notice: None,
             notice_identity,
             close_worker: Arc::new(ProviderCloseWorker::new()?),
+            connection_admissions: Arc::new(AtomicUsize::new(0)),
         };
         runtime.observe_snapshot_notice(
             runtime.snapshot.notice.clone(),
@@ -1362,6 +1378,7 @@ impl ProviderMachineRuntime {
         let connection_registry = self.connection_registry.clone();
         let closing_connections = self.closing_connections.clone();
         let close_worker = self.close_worker.clone();
+        let connection_admissions = self.connection_admissions.clone();
         let provider_connect_supported = client
             .supports_capability(protocol::EXTERNAL_MACHINE_CONNECT_CAPABILITY)
             .unwrap_or(false);
@@ -1668,6 +1685,7 @@ impl ProviderMachineRuntime {
                         &connection_registry,
                         &closing_connections,
                         &close_worker,
+                        &connection_admissions,
                     );
                     let session_available = snapshot.selected_machine_id.is_some()
                         && connected_session.as_ref().is_some_and(|(_, machine_id)| {
@@ -2132,6 +2150,7 @@ impl ProviderMachineRuntime {
             &self.connection_registry,
             &self.closing_connections,
             &self.close_worker,
+            &self.connection_admissions,
         );
     }
 
@@ -2468,6 +2487,7 @@ fn sync_provider_connection_hub(
     registry: &Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
     closing_connections: &Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: &Arc<ProviderCloseWorker>,
+    connection_admissions: &Arc<AtomicUsize>,
 ) {
     let visible =
         snapshot.machines.iter().map(|machine| machine.id.clone()).collect::<HashSet<_>>();
@@ -2492,6 +2512,7 @@ fn sync_provider_connection_hub(
                 Arc::clone(registry),
                 Arc::clone(closing_connections),
                 Arc::clone(close_worker),
+                Arc::clone(connection_admissions),
             ),
         );
     }
@@ -2505,6 +2526,7 @@ fn provider_machine_connector(
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
     closing_connections: Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: Arc<ProviderCloseWorker>,
+    connection_admissions: Arc<AtomicUsize>,
 ) -> MachineConnectFn {
     Arc::new(move || {
         connect_provider_machine(
@@ -2514,6 +2536,7 @@ fn provider_machine_connector(
             Arc::clone(&registry),
             Arc::clone(&closing_connections),
             Arc::clone(&close_worker),
+            Arc::clone(&connection_admissions),
         )
     })
 }
@@ -2525,6 +2548,7 @@ fn connect_provider_machine(
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
     closing_connections: Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: Arc<ProviderCloseWorker>,
+    connection_admissions: Arc<AtomicUsize>,
 ) -> anyhow::Result<MachineConnection> {
     let provider_managed =
         matches!(machine.workspace_create, protocol::WorkspaceCreatePolicy::Provider { .. });
@@ -2549,10 +2573,14 @@ fn connect_provider_machine(
     if connections.contains_key(&key) {
         anyhow::bail!("provider machine connection is already open");
     }
+    if !try_admit_provider_connection(&connection_admissions) {
+        anyhow::bail!("provider machine connection capacity is temporarily exhausted");
+    }
     transitions.insert(key);
     drop(transitions);
     drop(connections);
     let mut reservation = ProviderConnectionReservation {
+        admissions: Arc::clone(&connection_admissions),
         transitions: Arc::clone(&closing_connections),
         key,
         active: true,
@@ -2621,6 +2649,7 @@ fn connect_provider_machine(
             registry: Arc::clone(&registry),
             closing: Arc::clone(&closing_connections),
             close_worker,
+            admissions: Arc::clone(&connection_admissions),
         })),
     })
 }
@@ -2981,6 +3010,15 @@ mod tests {
         finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
     }
 
+    #[test]
+    fn provider_connection_admission_cap_is_explicit_and_reusable() {
+        let admissions = AtomicUsize::new(PROVIDER_CONNECTION_ADMISSION_CAP);
+        assert!(!try_admit_provider_connection(&admissions));
+        admissions.fetch_sub(1, Ordering::AcqRel);
+        assert!(try_admit_provider_connection(&admissions));
+        assert_eq!(admissions.load(Ordering::Acquire), PROVIDER_CONNECTION_ADMISSION_CAP);
+    }
+
     fn cache_test_connection(
         runtime: &mut ProviderMachineRuntime,
         connection_id: &str,
@@ -2999,12 +3037,14 @@ mod tests {
         runtime.connections.register(key, connector);
         runtime.connection_registry.lock().unwrap().insert(key, open.clone());
         let lease = close_on_drop.then(|| {
+            runtime.connection_admissions.fetch_add(1, Ordering::AcqRel);
             Box::new(ProviderMachineConnectionLease {
                 open: open.clone(),
                 key,
                 registry: runtime.connection_registry.clone(),
                 closing: runtime.closing_connections.clone(),
                 close_worker: runtime.close_worker.clone(),
+                admissions: runtime.connection_admissions.clone(),
             }) as Box<dyn crate::machine_runtime::MachineConnectionLease>
         });
         runtime.connections.insert_ready(
@@ -6003,6 +6043,7 @@ mod tests {
             runtime.connection_registry.clone(),
             runtime.closing_connections.clone(),
             runtime.close_worker.clone(),
+            runtime.connection_admissions.clone(),
         )
         .err()
         .expect("reconnect must wait for the previous provider close");

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -2446,7 +2446,7 @@ fn connect_provider_machine(
     // Reserve this key under the registry and transition locks, then release
     // both before the provider RPC. Lease teardown takes the same locks when
     // marking a key closing, so reconnects cannot race the open handoff.
-    let mut connections = registry
+    let connections = registry
         .lock()
         .map_err(|_| anyhow::anyhow!("provider machine connection registry is poisoned"))?;
     let mut transitions = closing_connections
@@ -2518,7 +2518,7 @@ fn connect_provider_machine(
             open,
             key,
             registry: Arc::clone(&registry),
-            closing: closing_connections,
+            closing: Arc::clone(&closing_connections),
             close_worker,
         })),
     })

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -37,12 +37,14 @@ use crate::session::{RemoteSession, Session};
 
 const PROVIDER_REFRESH_QUEUE_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_QUEUE_CAPACITY: usize = 64;
+const PROVIDER_CLOSE_PENDING_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_WORKER_COUNT: usize = 4;
 
 type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
 
 struct ProviderCloseWorker {
     sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
+    shutdown_sender: Option<crossbeam_channel::Sender<()>>,
     threads: Vec<std::thread::JoinHandle<()>>,
     pending: Arc<Mutex<HashMap<MachineKey, ProviderCloseTask>>>,
 }
@@ -55,34 +57,40 @@ impl ProviderCloseWorker {
     fn with_capacity(queue_capacity: usize) -> anyhow::Result<Self> {
         let (sender, receiver) = crossbeam_channel::bounded::<ProviderCloseTask>(queue_capacity);
         let worker_count = PROVIDER_CLOSE_WORKER_COUNT.min(queue_capacity.max(1));
+        let (shutdown_sender, shutdown_receiver) =
+            crossbeam_channel::bounded::<()>(worker_count.max(1));
         let pending = Arc::new(Mutex::new(HashMap::new()));
         let mut threads = Vec::with_capacity(worker_count);
         for index in 0..worker_count {
             let receiver = receiver.clone();
             let sender = sender.clone();
             let pending = Arc::clone(&pending);
+            let shutdown_receiver = shutdown_receiver.clone();
             let thread = std::thread::Builder::new()
                 .name(format!("provider-close-machine-{index}"))
                 .spawn(move || {
                     loop {
-                        let close = match receiver.recv() {
-                            Ok(close) => close,
-                            Err(_) => {
-                                let mut pending = pending.lock().ok();
-                                let Some(pending) = pending.as_mut() else { break };
-                                if pending.is_empty() {
-                                    break;
-                                }
-                                let Some((&key, _)) = pending.iter().next() else { continue };
-                                pending.remove(&key).expect("pending close task disappeared")
-                            }
+                        let close = crossbeam_channel::select! {
+                            recv(shutdown_receiver) -> _ => break,
+                            recv(receiver) -> close => match close {
+                                Ok(close) => close,
+                                Err(_) => break,
+                            },
                         };
-                        if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
-                            crate::client_log::stderr_log!(
-                                "provider",
-                                "cmux-tui: provider machine close task panicked"
-                            );
+                        {
+                            let close = close;
+                            if std::panic::catch_unwind(std::panic::AssertUnwindSafe(close)).is_err() {
+                                crate::client_log::stderr_log!(
+                                    "provider",
+                                    "cmux-tui: provider machine close task panicked"
+                                );
+                            }
                         }
+                        /*
+                         * Drain deferred tasks whenever a worker frees a queue
+                         * slot. The shutdown signal above exits promptly when
+                         * the runtime is dropped.
+                         */
                         loop {
                             let next = pending.lock().ok().and_then(|mut pending| {
                                 let key = pending.keys().next().copied()?;
@@ -108,7 +116,7 @@ impl ProviderCloseWorker {
             threads.push(thread);
         }
         drop(receiver);
-        Ok(Self { sender: Some(sender), threads, pending })
+        Ok(Self { sender: Some(sender), shutdown_sender: Some(shutdown_sender), threads, pending })
     }
 
     fn schedule(
@@ -123,8 +131,12 @@ impl ProviderCloseWorker {
             Ok(()) => Ok(()),
             Err(crossbeam_channel::TrySendError::Full(close)) => {
                 if let Ok(mut pending) = self.pending.lock() {
-                    pending.insert(key, close);
-                    Ok(())
+                    if pending.len() < PROVIDER_CLOSE_PENDING_CAPACITY {
+                        pending.insert(key, close);
+                        Ok(())
+                    } else {
+                        Err(crossbeam_channel::TrySendError::Full(close))
+                    }
                 } else {
                     Err(crossbeam_channel::TrySendError::Disconnected(close))
                 }
@@ -136,6 +148,11 @@ impl ProviderCloseWorker {
 
 impl Drop for ProviderCloseWorker {
     fn drop(&mut self) {
+        if let Some(shutdown_sender) = self.shutdown_sender.take() {
+            for _ in &self.threads {
+                let _ = shutdown_sender.send(());
+            }
+        }
         self.sender.take();
         for thread in self.threads.drain(..) {
             // A close RPC has its own request deadline, but dropping the
@@ -244,18 +261,11 @@ impl Drop for ProviderMachineConnectionLease {
         ) {
             match error {
                 crossbeam_channel::TrySendError::Full(task) => {
-                    // Preserve every close when the bounded queue is full by
-                    // handing it to a detached thread without blocking Drop.
-                    if std::thread::Builder::new()
-                        .name("provider-close-overflow".into())
-                        .spawn(task)
-                        .is_err()
-                    {
-                        crate::client_log::stderr_log!(
-                            "provider",
-                            "cmux-tui: failed to spawn provider machine close overflow task"
-                        );
-                    }
+                    drop(task);
+                    crate::client_log::stderr_log!(
+                        "provider",
+                        "cmux-tui: failed to schedule provider machine close: close backlog is full"
+                    );
                 }
                 crossbeam_channel::TrySendError::Disconnected(_) => {
                     crate::client_log::stderr_log!(

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -3050,7 +3050,10 @@ mod tests {
 
     #[test]
     fn provider_connection_admission_cap_is_explicit_and_reusable() {
-        let admissions = AtomicUsize::new(PROVIDER_CONNECTION_ADMISSION_CAP);
+        let admissions = AtomicUsize::new(0);
+        for _ in 0..PROVIDER_CONNECTION_ADMISSION_CAP {
+            assert!(try_admit_provider_connection(&admissions));
+        }
         assert!(!try_admit_provider_connection(&admissions));
         admissions.fetch_sub(1, Ordering::AcqRel);
         assert!(try_admit_provider_connection(&admissions));

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -5,7 +5,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, mpsc};
+use std::sync::{Arc, Mutex, Weak, mpsc};
 use std::time::Duration;
 
 use cmux_tui_core::{Mux, SurfaceOptions};
@@ -47,7 +47,7 @@ struct ProviderCloseWorker {
 }
 
 struct ProviderClosePermit {
-    worker: Arc<ProviderCloseWorker>,
+    worker: Weak<ProviderCloseWorker>,
 }
 
 impl ProviderCloseWorker {
@@ -77,7 +77,7 @@ impl ProviderCloseWorker {
             return None;
         }
         *available -= 1;
-        Some(ProviderClosePermit { worker: Arc::clone(self) })
+        Some(ProviderClosePermit { worker: Arc::downgrade(self) })
     }
 
     fn schedule_reserved(
@@ -96,7 +96,9 @@ impl ProviderCloseWorker {
 
 impl Drop for ProviderClosePermit {
     fn drop(&mut self) {
-        if let Ok(mut available) = self.worker.available.lock() {
+        if let Some(worker) = self.worker.upgrade()
+            && let Ok(mut available) = worker.available.lock()
+        {
             *available += 1;
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -5,12 +5,11 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex, Weak, mpsc};
+use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 
 use cmux_tui_core::{Mux, SurfaceOptions};
 use cmux_tui_machine_protocol as protocol;
-use crossbeam_channel::bounded;
 use zeroize::Zeroize;
 
 use crate::config::MachineConfig;
@@ -37,7 +36,6 @@ use crate::machine_runtime::{
 use crate::session::{RemoteSession, Session};
 
 const PROVIDER_REFRESH_QUEUE_CAPACITY: usize = 64;
-const PROVIDER_CLOSE_QUEUE_CAPACITY: usize = 64;
 const PROVIDER_CLOSE_WORKER_COUNT: usize = 4;
 
 type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
@@ -45,21 +43,16 @@ type ProviderCloseTask = Box<dyn FnOnce() + Send + 'static>;
 struct ProviderCloseWorker {
     sender: Option<crossbeam_channel::Sender<ProviderCloseTask>>,
     threads: Vec<std::thread::JoinHandle<()>>,
-    available: Mutex<usize>,
-}
-
-struct ProviderClosePermit {
-    worker: Weak<ProviderCloseWorker>,
 }
 
 impl ProviderCloseWorker {
     fn new() -> anyhow::Result<Self> {
-        Self::with_capacity(PROVIDER_CLOSE_QUEUE_CAPACITY)
+        Self::with_capacity(PROVIDER_CLOSE_WORKER_COUNT)
     }
 
-    fn with_capacity(capacity: usize) -> anyhow::Result<Self> {
-        let (sender, receiver) = bounded::<ProviderCloseTask>(capacity);
-        let worker_count = PROVIDER_CLOSE_WORKER_COUNT.min(capacity.max(1));
+    fn with_capacity(worker_count: usize) -> anyhow::Result<Self> {
+        let (sender, receiver) = crossbeam_channel::unbounded::<ProviderCloseTask>();
+        let worker_count = worker_count.max(1);
         let mut threads = Vec::with_capacity(worker_count);
         for index in 0..worker_count {
             let receiver = receiver.clone();
@@ -78,39 +71,12 @@ impl ProviderCloseWorker {
             threads.push(thread);
         }
         drop(receiver);
-        Ok(Self { sender: Some(sender), threads, available: Mutex::new(capacity) })
+        Ok(Self { sender: Some(sender), threads })
     }
 
-    fn try_reserve(self: &Arc<Self>) -> Option<ProviderClosePermit> {
-        let mut available = self.available.lock().ok()?;
-        if *available == 0 {
-            return None;
-        }
-        *available -= 1;
-        Some(ProviderClosePermit { worker: Arc::downgrade(self) })
-    }
-
-    fn schedule_reserved(
-        &self,
-        permit: ProviderClosePermit,
-        close: ProviderCloseTask,
-    ) -> Result<(), crossbeam_channel::TrySendError<ProviderCloseTask>> {
-        self.sender.as_ref().expect("provider close worker is active").try_send(Box::new(
-            move || {
-                close();
-                drop(permit);
-            },
-        ))
-    }
-}
-
-impl Drop for ProviderClosePermit {
-    fn drop(&mut self) {
-        if let Some(worker) = self.worker.upgrade()
-            && let Ok(mut available) = worker.available.lock()
-        {
-            *available += 1;
-        }
+    fn schedule(&self, close: ProviderCloseTask) -> Result<(), ProviderCloseTask> {
+        let Some(sender) = self.sender.as_ref() else { return Err(close) };
+        sender.send(close).map_err(|error| error.0)
     }
 }
 
@@ -121,7 +87,7 @@ impl Drop for ProviderCloseWorker {
             // A close RPC has its own request deadline, but dropping the
             // runtime must not wait for that remote deadline. Reap a worker
             // that already finished; otherwise dropping the handle detaches
-            // the bounded worker while its in-flight close completes.
+            // the fixed worker while its in-flight close completes.
             if thread.is_finished() && thread.join().is_err() {
                 crate::client_log::stderr_log!(
                     "provider",
@@ -145,7 +111,6 @@ struct ProviderMachineConnectionLease {
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
     closing: Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: Arc<ProviderCloseWorker>,
-    close_permit: Option<ProviderClosePermit>,
 }
 
 struct ProviderCloseCleanup {
@@ -171,14 +136,16 @@ impl Drop for ProviderCloseCleanup {
 impl Drop for ProviderMachineConnectionLease {
     fn drop(&mut self) {
         // Provider close is an RPC and may block on a remote provider. Keep
-        // session teardown non-blocking and bound both queued work and worker
-        // threads through the runtime-owned close worker.
+        // session teardown non-blocking through the runtime-owned fixed worker
+        // pool, and never join a worker that has an in-flight close.
         let client = Arc::clone(&self.open.client);
         let connection_id = self.open.connection_id.clone();
         let key = self.key;
         let registry = Arc::clone(&self.registry);
         let closing = Arc::clone(&self.closing);
-        if let Ok(mut closing_keys) = closing.lock() {
+        if let Ok(_registry_guard) = registry.lock()
+            && let Ok(mut closing_keys) = closing.lock()
+        {
             closing_keys.insert(key);
         }
         let cleanup = ProviderCloseCleanup {
@@ -187,10 +154,7 @@ impl Drop for ProviderMachineConnectionLease {
             key,
             connection_id: connection_id.clone(),
         };
-        let permit = self.close_permit.take().expect("provider connection owns a close permit");
-        if let Err(error) = self.close_worker.schedule_reserved(
-            permit,
-            Box::new(move || {
+        if self.close_worker.schedule(Box::new(move || {
                 let _cleanup = cleanup;
                 if let Err(error) = client.close_machine(connection_id) {
                     crate::client_log::stderr_log!(
@@ -198,17 +162,12 @@ impl Drop for ProviderMachineConnectionLease {
                         "cmux-tui: failed to close provider machine connection: {error}"
                     );
                 }
-            }),
-        ) {
-            let reason = match error {
-                crossbeam_channel::TrySendError::Full(_) => {
-                    "reserved close queue capacity was unavailable"
-                }
-                crossbeam_channel::TrySendError::Disconnected(_) => "close worker disconnected",
-            };
+            }))
+            .is_err()
+        {
             crate::client_log::stderr_log!(
                 "provider",
-                "cmux-tui: failed to schedule provider machine close: {reason}"
+                "cmux-tui: failed to schedule provider machine close: close worker disconnected"
             );
             if let Ok(mut registry) = self.registry.lock()
                 && registry
@@ -2464,6 +2423,12 @@ fn connect_provider_machine(
         anyhow::bail!(localization::catalog().sidebar.machine_managed_authority_unsupported);
     }
 
+    // Hold the registry lock through open and registration. Lease teardown
+    // marks the key as closing while holding the same lock, so reconnects
+    // cannot race the close handoff or replace an entry still being closed.
+    let mut connections = registry
+        .lock()
+        .map_err(|_| anyhow::anyhow!("provider machine connection registry is poisoned"))?;
     if closing_connections
         .lock()
         .map_err(|_| anyhow::anyhow!("provider machine closing registry is poisoned"))?
@@ -2471,13 +2436,9 @@ fn connect_provider_machine(
     {
         anyhow::bail!("provider machine connection is still closing");
     }
-
-    // Reserve teardown capacity before the provider creates a connection.
-    // Every successful open can therefore enqueue exactly one close without
-    // blocking a session drop or losing the close request under load.
-    let close_permit = close_worker.try_reserve().ok_or_else(|| {
-        anyhow::anyhow!("provider machine close capacity is temporarily exhausted")
-    })?;
+    if connections.contains_key(&key) {
+        anyhow::bail!("provider machine connection is already open");
+    }
 
     let opened = client.open_machine(machine.id.clone(), provider_managed)?;
     let connection_id = opened.connection_id.clone();
@@ -2511,16 +2472,7 @@ fn connect_provider_machine(
     };
     let session = Session::Remote(remote);
     let open = OpenConnection { client, connection_id, machine_id: machine.id };
-    let mut connections = match registry.lock() {
-        Ok(connections) => connections,
-        Err(_) => {
-            session.begin_shutdown();
-            let _ = open.client.close_machine(open.connection_id);
-            anyhow::bail!(localization::catalog().sidebar.machine_provider_update_failed);
-        }
-    };
     connections.insert(key, open.clone());
-    drop(connections);
     Ok(MachineConnection {
         session,
         _lease: Some(Box::new(ProviderMachineConnectionLease {
@@ -2529,7 +2481,6 @@ fn connect_provider_machine(
             registry,
             closing: closing_connections,
             close_worker,
-            close_permit: Some(close_permit),
         })),
     })
 }
@@ -2839,52 +2790,31 @@ mod tests {
     }
 
     #[test]
-    fn provider_close_worker_reserves_lossless_bounded_capacity() {
+    fn provider_close_worker_accepts_many_close_tasks() {
         let worker = Arc::new(ProviderCloseWorker::with_capacity(2).unwrap());
-        let first_permit = worker.try_reserve().unwrap();
-        let second_permit = worker.try_reserve().unwrap();
-        assert!(worker.try_reserve().is_none());
-        let (started, wait) = mpsc::sync_channel(0);
-        let (release, released) = mpsc::sync_channel(0);
-        worker
-            .schedule_reserved(
-                first_permit,
-                Box::new(move || {
-                    started.send(()).unwrap();
-                    released.recv().unwrap();
-                }),
-            )
-            .unwrap();
-        wait.recv_timeout(Duration::from_secs(1)).unwrap();
-        worker.schedule_reserved(second_permit, Box::new(|| {})).unwrap();
-        assert!(worker.try_reserve().is_none());
-        release.send(()).unwrap();
-        for _ in 0..100 {
-            if *worker.available.lock().unwrap() == 2 {
-                break;
-            }
-            thread::sleep(Duration::from_millis(10));
+        let (finished, finished_rx) = mpsc::channel();
+        for _ in 0..128 {
+            let finished = finished.clone();
+            worker.schedule(Box::new(move || finished.send(()).unwrap())).unwrap();
         }
-        assert_eq!(*worker.available.lock().unwrap(), 2);
+        for _ in 0..128 {
+            finished_rx.recv_timeout(Duration::from_secs(1)).unwrap();
+        }
         drop(worker);
     }
 
     #[test]
     fn provider_close_worker_drop_does_not_join_a_blocked_close() {
         let worker = Arc::new(ProviderCloseWorker::with_capacity(1).unwrap());
-        let permit = worker.try_reserve().unwrap();
         let (started, started_rx) = mpsc::channel();
         let (release, release_rx) = mpsc::channel();
         let (finished, finished_rx) = mpsc::channel();
         worker
-            .schedule_reserved(
-                permit,
-                Box::new(move || {
+            .schedule(Box::new(move || {
                     started.send(()).unwrap();
                     release_rx.recv().unwrap();
                     finished.send(()).unwrap();
-                }),
-            )
+                }))
             .unwrap();
         started_rx.recv_timeout(Duration::from_secs(1)).unwrap();
 
@@ -2920,7 +2850,6 @@ mod tests {
                 registry: runtime.connection_registry.clone(),
                 closing: runtime.closing_connections.clone(),
                 close_worker: runtime.close_worker.clone(),
-                close_permit: Some(runtime.close_worker.try_reserve().unwrap()),
             }) as Box<dyn crate::machine_runtime::MachineConnectionLease>
         });
         runtime.connections.insert_ready(

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -4,7 +4,7 @@ use std::collections::{BTreeMap, HashMap, HashSet};
 #[cfg(test)]
 use std::path::Path;
 use std::path::PathBuf;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::{Arc, Mutex, mpsc};
 use std::time::Duration;
 

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -143,6 +143,7 @@ struct ProviderMachineConnectionLease {
     open: OpenConnection,
     key: MachineKey,
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    closing: Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: Arc<ProviderCloseWorker>,
     close_permit: Option<ProviderClosePermit>,
 }
@@ -155,8 +156,12 @@ impl Drop for ProviderMachineConnectionLease {
         let client = Arc::clone(&self.open.client);
         let connection_id = self.open.connection_id.clone();
         let registry_connection_id = connection_id.clone();
-        let key = self.key;
+        let key = self.key.clone();
         let registry = Arc::clone(&self.registry);
+        let closing = Arc::clone(&self.closing);
+        if let Ok(mut closing_keys) = closing.lock() {
+            closing_keys.insert(key.clone());
+        }
         let permit = self.close_permit.take().expect("provider connection owns a close permit");
         if let Err(error) = self.close_worker.schedule_reserved(
             permit,
@@ -173,6 +178,9 @@ impl Drop for ProviderMachineConnectionLease {
                         .is_some_and(|open| open.connection_id == registry_connection_id)
                 {
                     registry.remove(&key);
+                }
+                if let Ok(mut closing_keys) = closing.lock() {
+                    closing_keys.remove(&key);
                 }
             }),
         ) {
@@ -192,6 +200,9 @@ impl Drop for ProviderMachineConnectionLease {
                     .is_some_and(|open| open.connection_id == self.open.connection_id)
             {
                 registry.remove(&self.key);
+            }
+            if let Ok(mut closing_keys) = self.closing.lock() {
+                closing_keys.remove(&self.key);
             }
         }
     }
@@ -306,6 +317,7 @@ pub(crate) struct ProviderMachineRuntime {
     open: Option<OpenConnection>,
     connections: MachineConnectionHub,
     connection_registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    closing_connections: Arc<Mutex<HashSet<MachineKey>>>,
     pending: Option<PendingConnection>,
     pending_external_connect: Option<PendingExternalConnect>,
     accepted_selection: Option<AcceptedSelectionIntent>,
@@ -688,6 +700,7 @@ impl ProviderMachineRuntime {
                 MachineConnectFn,
             )>()),
             connection_registry: Arc::new(Mutex::new(HashMap::new())),
+            closing_connections: Arc::new(Mutex::new(HashSet::new())),
             pending: None,
             pending_external_connect: None,
             accepted_selection: None,
@@ -1566,6 +1579,7 @@ impl ProviderMachineRuntime {
                         &keys,
                         &connections,
                         &connection_registry,
+                        &closing_connections,
                         &close_worker,
                     );
                     let session_available = snapshot.selected_machine_id.is_some()
@@ -2029,6 +2043,7 @@ impl ProviderMachineRuntime {
             &self.keys,
             &self.connections,
             &self.connection_registry,
+            &self.closing_connections,
             &self.close_worker,
         );
     }
@@ -2364,6 +2379,7 @@ fn sync_provider_connection_hub(
     keys: &Arc<Mutex<KeyRegistry>>,
     connections: &MachineConnectionHub,
     registry: &Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    closing_connections: &Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: &Arc<ProviderCloseWorker>,
 ) {
     let visible =
@@ -2387,6 +2403,7 @@ fn sync_provider_connection_hub(
                 machine.clone(),
                 key,
                 Arc::clone(registry),
+                Arc::clone(closing_connections),
                 Arc::clone(close_worker),
             ),
         );
@@ -2399,6 +2416,7 @@ fn provider_machine_connector(
     machine: protocol::MachineDescriptor,
     key: MachineKey,
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    closing_connections: Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: Arc<ProviderCloseWorker>,
 ) -> MachineConnectFn {
     Arc::new(move || {
@@ -2407,6 +2425,7 @@ fn provider_machine_connector(
             machine.clone(),
             key,
             Arc::clone(&registry),
+            Arc::clone(&closing_connections),
             Arc::clone(&close_worker),
         )
     })
@@ -2417,6 +2436,7 @@ fn connect_provider_machine(
     machine: protocol::MachineDescriptor,
     key: MachineKey,
     registry: Arc<Mutex<HashMap<MachineKey, OpenConnection>>>,
+    closing_connections: Arc<Mutex<HashSet<MachineKey>>>,
     close_worker: Arc<ProviderCloseWorker>,
 ) -> anyhow::Result<MachineConnection> {
     let provider_managed =
@@ -2427,9 +2447,9 @@ fn connect_provider_machine(
         anyhow::bail!(localization::catalog().sidebar.machine_managed_authority_unsupported);
     }
 
-    if registry
+    if closing_connections
         .lock()
-        .map_err(|_| anyhow::anyhow!("provider machine connection registry is poisoned"))?
+        .map_err(|_| anyhow::anyhow!("provider machine closing registry is poisoned"))?
         .contains_key(&key)
     {
         anyhow::bail!("provider machine connection is still closing");
@@ -2490,6 +2510,7 @@ fn connect_provider_machine(
             open,
             key,
             registry,
+            closing: closing_connections,
             close_worker,
             close_permit: Some(close_permit),
         })),
@@ -2880,6 +2901,7 @@ mod tests {
                 open: open.clone(),
                 key,
                 registry: runtime.connection_registry.clone(),
+                closing: runtime.closing_connections.clone(),
                 close_worker: runtime.close_worker.clone(),
                 close_permit: Some(runtime.close_worker.try_reserve().unwrap()),
             }) as Box<dyn crate::machine_runtime::MachineConnectionLease>
@@ -5870,6 +5892,7 @@ mod tests {
             Some("keep-first-open")
         );
         assert!(runtime.connection_registry.lock().unwrap().contains_key(&candidate_key));
+        assert!(runtime.closing_connections.lock().unwrap().contains(&candidate_key));
         let mut reconnect_machine = runtime.snapshot.machines[1].clone();
         reconnect_machine.workspace_create = protocol::WorkspaceCreatePolicy::Session;
         let reconnect_error = connect_provider_machine(
@@ -5877,6 +5900,7 @@ mod tests {
             reconnect_machine,
             candidate_key,
             runtime.connection_registry.clone(),
+            runtime.closing_connections.clone(),
             runtime.close_worker.clone(),
         )
         .err()

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -172,9 +172,7 @@ impl Drop for ProviderMachineConnectionLease {
         let closing = Arc::clone(&self.closing);
         if let Ok(registry_guard) = registry.lock()
             && let Ok(mut closing_keys) = closing.lock()
-            && registry_guard
-                .get(&key)
-                .is_some_and(|open| open.connection_id == connection_id)
+            && registry_guard.get(&key).is_some_and(|open| open.connection_id == connection_id)
         {
             closing_keys.insert(key);
         }
@@ -184,18 +182,15 @@ impl Drop for ProviderMachineConnectionLease {
             key,
             connection_id: connection_id.clone(),
         };
-        if let Err(error) = self
-            .close_worker
-            .schedule(Box::new(move || {
-                let _cleanup = cleanup;
-                if let Err(error) = client.close_machine(connection_id) {
-                    crate::client_log::stderr_log!(
-                        "provider",
-                        "cmux-tui: failed to close provider machine connection: {error}"
-                    );
-                }
-            }))
-        {
+        if let Err(error) = self.close_worker.schedule(Box::new(move || {
+            let _cleanup = cleanup;
+            if let Err(error) = client.close_machine(connection_id) {
+                crate::client_log::stderr_log!(
+                    "provider",
+                    "cmux-tui: failed to close provider machine connection: {error}"
+                );
+            }
+        })) {
             let reason = match error {
                 crossbeam_channel::TrySendError::Full(_) => "close queue is full",
                 crossbeam_channel::TrySendError::Disconnected(_) => "close worker disconnected",
@@ -2848,7 +2843,10 @@ mod tests {
         worker
             .schedule(Box::new(|| {}))
             .unwrap_or_else(|_| panic!("close worker unexpectedly disconnected"));
-        assert!(matches!(worker.schedule(Box::new(|| {})), Err(crossbeam_channel::TrySendError::Full(_))));
+        assert!(matches!(
+            worker.schedule(Box::new(|| {})),
+            Err(crossbeam_channel::TrySendError::Full(_))
+        ));
         release.send(()).unwrap();
         drop(worker);
     }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -2476,13 +2476,13 @@ fn connect_provider_machine(
     let open = OpenConnection { client, connection_id, machine_id: machine.id };
     connections.insert(key, open.clone());
     Ok(MachineConnection {
-            session,
-            _lease: Some(Box::new(ProviderMachineConnectionLease {
-                open,
-                key,
-                registry: Arc::clone(&registry),
-                closing: closing_connections,
-                close_worker,
+        session,
+        _lease: Some(Box::new(ProviderMachineConnectionLease {
+            open,
+            key,
+            registry: Arc::clone(&registry),
+            closing: closing_connections,
+            close_worker,
         })),
     })
 }

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -156,11 +156,11 @@ impl Drop for ProviderMachineConnectionLease {
         let client = Arc::clone(&self.open.client);
         let connection_id = self.open.connection_id.clone();
         let registry_connection_id = connection_id.clone();
-        let key = self.key.clone();
+        let key = self.key;
         let registry = Arc::clone(&self.registry);
         let closing = Arc::clone(&self.closing);
         if let Ok(mut closing_keys) = closing.lock() {
-            closing_keys.insert(key.clone());
+            closing_keys.insert(key);
         }
         let permit = self.close_permit.take().expect("provider connection owns a close permit");
         if let Err(error) = self.close_worker.schedule_reserved(

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -5658,7 +5658,6 @@ mod tests {
             workspace_create: protocol::WorkspaceCreatePolicy::Session,
         });
         let server_catalog = catalog.clone();
-        let (close_received, wait_for_close) = mpsc::channel();
         let server = thread::spawn(move || {
             let (mut stream, mut reader) =
                 serve_initial_snapshot(&listener, server_catalog.clone());
@@ -5736,6 +5735,7 @@ mod tests {
             workspace_create: protocol::WorkspaceCreatePolicy::Session,
         });
         let server_catalog = catalog.clone();
+        let (close_received, wait_for_close) = mpsc::channel();
         let server = thread::spawn(move || {
             let (mut stream, mut reader) =
                 serve_initial_snapshot(&listener, server_catalog.clone());

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -59,7 +59,22 @@ impl Drop for ProviderMachineConnectionLease {
         {
             registry.remove(&self.key);
         }
-        let _ = self.open.client.close_machine(self.open.connection_id.clone());
+        // Provider close is an RPC and may block on a remote provider. A lease
+        // drop runs from session teardown paths, so never make those paths
+        // synchronously wait for network I/O. Move the retained Arc and ID
+        // into a short-lived worker, preserving ownership until the RPC ends.
+        let client = Arc::clone(&self.open.client);
+        let connection_id = self.open.connection_id.clone();
+        let _ = std::thread::Builder::new()
+            .name("provider-close-machine".into())
+            .spawn(move || {
+                if let Err(error) = client.close_machine(connection_id) {
+                    crate::client_log::stderr_log!(
+                        "provider",
+                        "cmux-tui: failed to close provider machine connection: {error}"
+                    );
+                }
+            });
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -84,15 +84,12 @@ impl ProviderCloseWorker {
                             );
                         }
                         loop {
-                            let Some((key, close)) = pending
-                                .lock()
-                                .ok()
-                                .and_then(|mut pending| {
-                                    pending
-                                        .iter()
-                                        .next()
-                                        .map(|(key, _)| (*key, pending.remove(key).unwrap()))
-                                })
+                            let Some((key, close)) = pending.lock().ok().and_then(|mut pending| {
+                                pending
+                                    .iter()
+                                    .next()
+                                    .map(|(key, _)| (*key, pending.remove(key).unwrap()))
+                            })
                             else {
                                 break;
                             };

--- a/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_provider_runtime.rs
@@ -276,6 +276,7 @@ impl Drop for ProviderMachineConnectionLease {
             closing: Arc::clone(&closing),
             key,
             connection_id: connection_id.clone(),
+            admissions: Arc::clone(&self.admissions),
         };
         if let Err(error) = self.close_worker.schedule(
             key,
@@ -289,20 +290,24 @@ impl Drop for ProviderMachineConnectionLease {
                 }
             }),
         ) {
-            match error {
-                crossbeam_channel::TrySendError::Full(task) => {
-                    drop(task);
+            let (reason, task) = match error {
+                crossbeam_channel::TrySendError::Full(task) => ("close backlog is full", task),
+                crossbeam_channel::TrySendError::Disconnected(task) => {
+                    ("close worker disconnected", task)
+                }
+            };
+            // Admission is capped, so this fallback can create at most the
+            // documented number of close reapers. It preserves the remote
+            // close obligation when the owned worker cannot accept the task.
+            if std::thread::Builder::new()
+                .name("provider-close-reaper".into())
+                .spawn(task)
+                .is_err()
+            {
                     crate::client_log::stderr_log!(
                         "provider",
-                        "cmux-tui: failed to schedule provider machine close: close backlog is full"
+                        "cmux-tui: failed to start provider machine close reaper after {reason}"
                     );
-                }
-                crossbeam_channel::TrySendError::Disconnected(_) => {
-                    crate::client_log::stderr_log!(
-                        "provider",
-                        "cmux-tui: failed to schedule provider machine close: close worker disconnected"
-                    );
-                }
             }
         }
     }


### PR DESCRIPTION
Provider machine lease Drop previously performed close_machine synchronously, blocking session teardown on provider RPC latency. Move the retained client and connection ID into a dedicated worker thread, and log failures for observability. Ownership remains held until the RPC completes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Provider machine lease teardown previously called `close_machine` synchronously; it now schedules closes on a runtime-owned worker pool so session shutdown stays responsive despite provider RPC latency. Reconnects to a machine are rejected until the earlier close finishes.

- Four workers process a bounded queue of 64 closes; when the queue saturates, closes are retained and drained later, coalesced by machine key.
- If the worker pool cannot accept a close, a fallback reaper thread runs it so the remote close still happens.
- Shutdown drains pending work without joining workers blocked on in-flight RPCs; scheduling, RPC, and task-panic failures are logged.
- Provider connection admissions are capped at 256 concurrent opens; excess attempts fail with a temporary capacity error.

<sup>Written for commit a2be7aa9b0ef3c2d6fe59153b42d399f72be2a31. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Provider machine connections now close asynchronously during session teardown, improving responsiveness.
  * Cleanup remains bounded when multiple machines close at the same time.
  * Reconnecting to a machine waits for any earlier close operation to finish, helping prevent connection conflicts.
  * Cleanup failures no longer block session teardown, and closed machines are removed from active connections.
  * Session shutdown remains responsive even when individual machine close operations take longer than expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->