### PR TITLE
Bound machine connector action waits

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/machine_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_runtime.rs
@@ -454,6 +454,7 @@ struct MachineConnectionHubInner {
     changed: Condvar,
     closed: AtomicBool,
     warm_limit: usize,
+    connect_attempt_deadline: Duration,
     use_counter: AtomicU64,
     /// The machine whose session is on screen. Its warm connection is never
     /// evicted, whatever its LRU age: evicting it would kill the session the
@@ -465,6 +466,7 @@ struct MachineConnectionHubInner {
 struct MachineConnectionSlot {
     connector: MachineConnectFn,
     state: MachineConnectionState,
+    timed_out_worker: Option<std::thread::JoinHandle<()>>,
     /// Monotonic use stamp for least-recently-used eviction of Ready slots.
     last_used: u64,
 }
@@ -487,6 +489,14 @@ impl MachineConnectionHub {
         connectors: impl IntoIterator<Item = (MachineKey, MachineConnectFn)>,
         warm_limit: usize,
     ) -> Self {
+        Self::with_warm_limit_and_deadline(connectors, warm_limit, CONNECT_ATTEMPT_DEADLINE)
+    }
+
+    fn with_warm_limit_and_deadline(
+        connectors: impl IntoIterator<Item = (MachineKey, MachineConnectFn)>,
+        warm_limit: usize,
+        connect_attempt_deadline: Duration,
+    ) -> Self {
         let slots = connectors
             .into_iter()
             .map(|(key, connector)| {
@@ -495,6 +505,7 @@ impl MachineConnectionHub {
                     MachineConnectionSlot {
                         connector,
                         state: MachineConnectionState::Disconnected,
+                        timed_out_worker: None,
                         last_used: 0,
                     },
                 )
@@ -509,6 +520,7 @@ impl MachineConnectionHub {
                 // second most recently used connection and must never be
                 // evicted while it is still presented.
                 warm_limit: warm_limit.max(2),
+                connect_attempt_deadline,
                 use_counter: AtomicU64::new(0),
                 presented: Mutex::new(None),
             }),
@@ -596,6 +608,7 @@ impl MachineConnectionHub {
                     MachineConnectionSlot {
                         connector,
                         state: MachineConnectionState::Disconnected,
+                        timed_out_worker: None,
                         last_used: 0,
                     },
                 );
@@ -678,6 +691,17 @@ impl MachineConnectionHub {
                     return Err(anyhow::anyhow!(error.clone()));
                 }
                 MachineConnectionState::Disconnected | MachineConnectionState::Failed(_) => {
+                    if let Some(worker) = slot.timed_out_worker.take() {
+                        if worker.is_finished() {
+                            let _ = worker.join();
+                        } else {
+                            slot.timed_out_worker = Some(worker);
+                            return Err(anyhow::anyhow!(
+                                "machine connection timed out after {} seconds; the previous attempt is still stopping",
+                                self.inner.connect_attempt_deadline.as_secs_f64()
+                            ));
+                        }
+                    }
                     let connector = Arc::clone(&slot.connector);
                     slot.state = MachineConnectionState::Connecting;
                     drop(slots);
@@ -687,14 +711,30 @@ impl MachineConnectionHub {
                     // The worker owns no hub state, so a late result is safely
                     // discarded after timeout or cancellation.
                     let (result_tx, result_rx) = mpsc::sync_channel(1);
-                    std::thread::spawn(move || {
-                        let _ = result_tx.send(connector());
-                    });
-                    let result = match result_rx.recv_timeout(CONNECT_ATTEMPT_DEADLINE) {
+                    let worker = match std::thread::Builder::new()
+                        .name("machine-connector".to_string())
+                        .spawn(move || {
+                            let _ = result_tx.send(connector());
+                        }) {
+                        Ok(worker) => worker,
+                        Err(error) => {
+                            let mut slots = self.inner.slots.lock().map_err(|_| {
+                                anyhow::anyhow!(crate::localization::catalog()
+                                    .sidebar
+                                    .machine_catalog_updates_failed)
+                            })?;
+                            if let Some(slot) = slots.get_mut(&key) {
+                                slot.state = MachineConnectionState::Failed(error.to_string());
+                            }
+                            self.inner.changed.notify_all();
+                            return Err(error.into());
+                        }
+                    };
+                    let result = match result_rx.recv_timeout(self.inner.connect_attempt_deadline) {
                         Ok(result) => result,
                         Err(mpsc::RecvTimeoutError::Timeout) => Err(anyhow::anyhow!(
                             "machine connection timed out after {} seconds",
-                            CONNECT_ATTEMPT_DEADLINE.as_secs()
+                            self.inner.connect_attempt_deadline.as_secs_f64()
                         )),
                         Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!(
                             "machine connection worker stopped"
@@ -710,6 +750,11 @@ impl MachineConnectionHub {
                             crate::localization::catalog().sidebar.client_machine_unavailable
                         ));
                     };
+                    if worker.is_finished() {
+                        let _ = worker.join();
+                    } else {
+                        slot.timed_out_worker = Some(worker);
+                    }
                     if self.inner.closed.load(Ordering::Acquire) {
                         slot.state = MachineConnectionState::Disconnected;
                         self.inner.changed.notify_all();
@@ -1053,6 +1098,30 @@ mod tests {
             runtime.entry(first).map(|entry| &entry.target),
             Some(MachineTargetConfig::Unix { socket }) if socket == &PathBuf::from("/tmp/current.sock")
         ));
+    }
+
+    #[test]
+    fn timed_out_connector_is_not_restarted_while_previous_attempt_is_running() {
+        let calls = Arc::new(AtomicU64::new(0));
+        let calls_for_connector = Arc::clone(&calls);
+        let connector: MachineConnectFn = Arc::new(move || {
+            calls_for_connector.fetch_add(1, Ordering::Relaxed);
+            std::thread::sleep(Duration::from_millis(100));
+            Err(anyhow::anyhow!("blocked"))
+        });
+        let key = MachineKey(7);
+        let hub = MachineConnectionHub::with_warm_limit_and_deadline(
+            [(key, connector)],
+            2,
+            Duration::from_millis(10),
+        );
+
+        assert!(hub.connect(key).is_err());
+        assert!(hub.connect(key).is_err());
+        assert_eq!(calls.load(Ordering::Relaxed), 1);
+        std::thread::sleep(Duration::from_millis(120));
+        assert!(hub.connect(key).is_err());
+        assert_eq!(calls.load(Ordering::Relaxed), 2);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/machine_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/machine_runtime.rs
@@ -4,7 +4,8 @@ use std::collections::{HashMap, HashSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Condvar, Mutex};
+use std::sync::{Arc, Condvar, Mutex, mpsc};
+use std::time::Duration;
 
 use crate::config::{MachineConfig, MachineCreationSourceConfig, MachineTargetConfig};
 use crate::machine::{
@@ -436,6 +437,9 @@ pub(crate) struct MachineConnectionHub {
 /// the bound, so switching between the last N machines is instant while
 /// memory and remote relays stay bounded.
 const DEFAULT_WARM_CONNECTION_LIMIT: usize = 5;
+/// A connector can perform network I/O outside this process' control. Do not
+/// let a machine action worker wait for an unbounded provider timeout.
+const CONNECT_ATTEMPT_DEADLINE: Duration = Duration::from_secs(30);
 
 fn warm_connection_limit_from_env() -> usize {
     std::env::var("CMUX_TUI_WARM_MACHINES")
@@ -677,7 +681,25 @@ impl MachineConnectionHub {
                     let connector = Arc::clone(&slot.connector);
                     slot.state = MachineConnectionState::Connecting;
                     drop(slots);
-                    let result = connector();
+                    // Connectors are synchronous by contract, but provider
+                    // network calls can block for minutes. Run the attempt on
+                    // a disposable worker and bound the action worker's wait.
+                    // The worker owns no hub state, so a late result is safely
+                    // discarded after timeout or cancellation.
+                    let (result_tx, result_rx) = mpsc::sync_channel(1);
+                    std::thread::spawn(move || {
+                        let _ = result_tx.send(connector());
+                    });
+                    let result = match result_rx.recv_timeout(CONNECT_ATTEMPT_DEADLINE) {
+                        Ok(result) => result,
+                        Err(mpsc::RecvTimeoutError::Timeout) => Err(anyhow::anyhow!(
+                            "machine connection timed out after {} seconds",
+                            CONNECT_ATTEMPT_DEADLINE.as_secs()
+                        )),
+                        Err(mpsc::RecvTimeoutError::Disconnected) => Err(anyhow::anyhow!(
+                            "machine connection worker stopped"
+                        )),
+                    };
                     let mut slots = self.inner.slots.lock().map_err(|_| {
                         anyhow::anyhow!(
                             crate::localization::catalog().sidebar.machine_catalog_updates_failed


### PR DESCRIPTION
Machine connector actions previously called synchronous provider connectors on the action worker, so a network stall could block for minutes. This runs each connector on a disposable worker and bounds the action worker wait to 30 seconds; late results are discarded and surfaced as a normal failed connection state.

Verification: git diff --check passed. Cargo checks were not run locally because repository policy routes Rust builds to Blacksmith Testbox; local cargo fmt was refused by the low-disk guard (64.3 GiB, 250 GiB floor).

Residual risk: a provider connector that ignores cancellation can continue in its disposable worker after the deadline, but it cannot block the action worker or mutate hub state.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded machine connector action waits so a stalled provider network call can no longer block the action worker for minutes.

- Connectors run on a disposable worker with a 30-second deadline; late results are discarded and surfaced as a normal failed connection state.
- A provider connector that ignores cancellation can keep running in its worker after the deadline, but it can't block the action worker or mutate hub state.
- A new connect is refused while a timed-out previous attempt is still stopping.

<sup>Written for commit 971fe91129c11138ad41580dfe44c5e9688a5343. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Machine connection attempts now run with a 30-second deadline by default, preventing stalled connections from blocking the application.
  * Timed-out connection attempts are tracked until completion, preventing duplicate connection attempts while an earlier attempt is still running.
  * Connection results are handled without blocking the main action worker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->