### PR TITLE
fix(cloud): pass the create progress handler to the base-open launcher

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8634,13 +8634,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                     imageKinds: page?.limits?.imageKinds ?? [],
                     submit: { [weak self] request in
                         guard let self else { return false }
-                        return MachineCreateCoordinator.shared.start(request) { [weak self] arguments, completion in
+                        return MachineCreateCoordinator.shared.start(request) { [weak self] arguments, progress, completion in
                             guard let self else { return false }
                             return self.launchCloudVMBaseOpen(
                                 workspace: workspace,
                                 socketPath: socketPath,
                                 preferredWindow: launchWindow,
                                 arguments: arguments,
+                                onProgress: progress,
                                 onCompletion: { result in
                                     completion(result)
                                     onCompletion?(result)
@@ -8683,6 +8684,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         socketPath: String,
         preferredWindow: NSWindow?,
         arguments: [String],
+        onProgress: (@MainActor (String) -> Void)? = nil,
         onCompletion: ((CloudVMActionLauncher.Completion) -> Void)?
     ) -> Bool {
         if let loadingPanel = workspace.panels.values.first(where: { $0.panelType == .cloudVMLoading }) as? CloudVMLoadingPanel {
@@ -8697,6 +8699,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 "CMUX_CLOUD_ATTACH_RETRY_LIMIT": "12",
                 "CMUX_CLOUD_ATTACH_RETRY_DELAY_SECONDS": "2",
             ],
+            onOutput: onProgress,
             onCompletion: { completion in
                 if !completion.succeeded,
                    let loadingPanel = workspace.panels.values.first(where: { $0.panelType == .cloudVMLoading }) as? CloudVMLoadingPanel {


### PR DESCRIPTION
main has not compiled since https://github.com/manaflow-ai/cmux/pull/11773 merged. It gave `MachineCreateCoordinator.Launch` a third parameter, the progress handler that feeds the CLI's `Created Cloud VM <id>` line back into the pending row, and updated the coordinator and its tests, but left the only production call site (`AppDelegate.launchCloudVMBaseOpen` submit closure) on the two-parameter closure. `xcodebuild -scheme cmux` fails with "contextual closure type ... expects 3 arguments, but 2 were used".

This threads the handler through `launchCloudVMBaseOpen` into `CloudVMActionLauncher.start(onOutput:)`, which already existed for exactly this, so a background base-open create learns its machine id while the CLI is still running instead of only at exit.

Verified by a tagged fleet build of the app target (the failure was in `SwiftCompile AppDelegate.swift`). No test is added: the miss was a call-site arity break that the compiler catches, and the coordinator's progress behavior is already covered in `MachineCreateCoordinatorTests`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the build failure on `main` from a recent change that added a progress handler parameter to `MachineCreateCoordinator.Launch` but missed the production call site. Now `launchCloudVMBaseOpen` passes the handler through to the launcher's `onOutput` hook, so the background create can report its machine id while the CLI is running. No test added: the compiler catches the arity break and coordinator progress is already covered.

<sup>Written for commit 225fec7ff63eb12bafa0de287607328a77355fb2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

