### PR TITLE
cloud: compact access screen with the app icon

### DIFF
--- a/web/app/cloud/access/access-card.tsx
+++ b/web/app/cloud/access/access-card.tsx
@@ -1,14 +1,15 @@
+import Image from "next/image";
+
 export type PublicationAccessView =
   | "signed-out"
   | "signed-in"
   | "invalid";
 
 export type PublicationAccessMessages = {
-  readonly eyebrow: string;
   readonly title: string;
-  readonly signedOutBody: string;
   readonly signIn: string;
   readonly signedInAs: string;
+  readonly switchAccount: string;
   readonly invalidTitle: string;
   readonly invalidBody: string;
   readonly footer: string;
@@ -19,12 +20,14 @@ type PublicationAccessCardProps = {
   readonly hostname?: string | null;
   readonly identity?: string | null;
   readonly signInHref?: string | null;
+  readonly switchAccountHref?: string | null;
   readonly messages: PublicationAccessMessages;
   readonly locale: string;
 };
 
 /**
- * One deliberately small surface for every protected-domain access state.
+ * One deliberately small surface for every protected-domain access state:
+ * the app icon, one sentence, the hostname, and at most one action.
  * Authentication data is resolved by the server page; this component only
  * renders product-owned copy and opaque action targets.
  */
@@ -33,6 +36,7 @@ export function PublicationAccessCard({
   hostname,
   identity,
   signInHref,
+  switchAccountHref,
   messages,
   locale,
 }: PublicationAccessCardProps) {
@@ -41,92 +45,93 @@ export function PublicationAccessCard({
 
   return (
     <main
-      className="relative flex min-h-screen items-center justify-center overflow-hidden bg-[#f7f7f5] px-5 py-12 text-[#171717]"
+      className="relative flex min-h-screen flex-col items-center justify-center bg-[#fafafa] px-6 pb-20 pt-12 text-[#171717]"
       dir={direction}
     >
-      <div
-        aria-hidden="true"
-        className="pointer-events-none absolute inset-0 opacity-[0.32]"
-        style={{
-          backgroundImage:
-            "linear-gradient(to right, #deded9 1px, transparent 1px), linear-gradient(to bottom, #deded9 1px, transparent 1px)",
-          backgroundSize: "32px 32px",
-          maskImage:
-            "radial-gradient(circle at center, black 0%, transparent 72%)",
-        }}
-      />
-
       <section
-        className="relative w-full max-w-[460px] border border-black/[0.12] bg-white px-6 py-7 shadow-[0_18px_55px_rgba(0,0,0,0.08)] sm:px-8 sm:py-8"
+        className="flex w-full max-w-[400px] flex-col items-center text-center"
         data-publication-access={view}
         lang={locale}
       >
-        <div className="flex items-center justify-between gap-4 border-b border-black/[0.08] pb-5">
-          <p className="font-mono text-xs font-medium tracking-[0.14em] text-[#676762]">
-            {messages.eyebrow}
+        <Image
+          alt=""
+          className={invalid ? "opacity-50 grayscale" : undefined}
+          height={64}
+          priority
+          src="/logo.png"
+          width={64}
+        />
+
+        <h1 className="mt-6 text-balance text-2xl font-semibold leading-tight tracking-[-0.03em]">
+          {invalid ? messages.invalidTitle : messages.title}
+        </h1>
+
+        {hostname && !invalid ? (
+          <p
+            className="mt-2 max-w-full truncate font-mono text-[13px] text-[#737373]"
+            title={hostname}
+          >
+            {hostname}
           </p>
-          <AccessGlyph invalid={invalid} />
-        </div>
+        ) : null}
 
-        <div className="pt-7">
-          <h1 className="text-[28px] font-medium leading-[1.15] tracking-[-0.035em]">
-            {invalid ? messages.invalidTitle : messages.title}
-          </h1>
+        {invalid ? (
+          <p className="mt-2 text-sm leading-6 text-[#555550]">
+            {messages.invalidBody}
+          </p>
+        ) : null}
 
-          {hostname && !invalid ? (
-            <p className="mt-3 w-fit max-w-full truncate border border-black/[0.09] bg-[#f7f7f5] px-2.5 py-1.5 font-mono text-xs text-[#555550]">
-              {hostname}
-            </p>
-          ) : null}
+        {view === "signed-in" && identity ? (
+          <IdentityPill
+            identity={identity}
+            label={messages.signedInAs.replace("{identity}", () => identity)}
+          />
+        ) : null}
 
-          <div className="mt-5 text-sm leading-6 text-[#62625d]">
-            {view === "signed-out" ? <p>{messages.signedOutBody}</p> : null}
-            {view === "signed-in" && identity ? (
-              <p className="font-medium text-[#30302d]">
-                {messages.signedInAs.replace("{identity}", () => identity)}
-              </p>
-            ) : null}
-            {view === "invalid" ? <p>{messages.invalidBody}</p> : null}
-          </div>
+        {view === "signed-in" && switchAccountHref ? (
+          <a
+            className="mt-3 text-[13px] text-[#0073d9] underline-offset-4 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#0073d9]"
+            href={switchAccountHref}
+          >
+            {messages.switchAccount}
+          </a>
+        ) : null}
 
-          {view === "signed-out" && signInHref ? (
-            <a
-              className="mt-7 inline-flex min-h-11 w-full items-center justify-center bg-[#171717] px-4 py-2.5 text-sm font-medium text-white transition-colors hover:bg-[#30302d] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#171717]"
-              href={signInHref}
-            >
-              {messages.signIn}
-            </a>
-          ) : null}
-
-        </div>
-
-        <p className="mt-7 border-t border-black/[0.08] pt-5 text-xs text-[#8a8a84]">
-          {messages.footer}
-        </p>
+        {view === "signed-out" && signInHref ? (
+          <a
+            className="mt-7 inline-flex min-h-10 items-center justify-center rounded-full bg-[#171717] px-6 text-sm font-medium text-white transition-colors hover:bg-[#30302d] focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#171717]"
+            href={signInHref}
+          >
+            {messages.signIn}
+          </a>
+        ) : null}
       </section>
+
+      <p className="absolute inset-x-0 bottom-7 px-6 text-center text-xs text-[#8a8a84]">
+        {messages.footer}
+      </p>
     </main>
   );
 }
 
-function AccessGlyph({ invalid }: { readonly invalid: boolean }) {
+function IdentityPill({
+  identity,
+  label,
+}: {
+  readonly identity: string;
+  readonly label: string;
+}) {
+  const initial = [...identity.trim()][0]?.toUpperCase() ?? "";
   return (
-    <span
-      aria-hidden="true"
-      className="grid size-9 shrink-0 place-items-center border border-black/[0.1] bg-[#f7f7f5] text-[#3c3c38]"
-    >
-      {invalid ? (
-        <svg fill="none" height="17" viewBox="0 0 20 20" width="17">
-          <path d="M10 6.25v4.25" stroke="currentColor" strokeLinecap="round" strokeWidth="1.5" />
-          <path d="M10 13.75h.008" stroke="currentColor" strokeLinecap="round" strokeWidth="1.8" />
-          <path d="M8.49 2.66 1.96 14.1A1.75 1.75 0 0 0 3.48 16.7h13.04a1.75 1.75 0 0 0 1.52-2.6L11.51 2.66a1.74 1.74 0 0 0-3.02 0Z" stroke="currentColor" strokeLinejoin="round" strokeWidth="1.4" />
-        </svg>
-      ) : (
-        <svg fill="none" height="17" viewBox="0 0 20 20" width="17">
-          <rect height="9" rx="1.5" stroke="currentColor" strokeWidth="1.4" width="13" x="3.5" y="8" />
-          <path d="M6.5 8V6a3.5 3.5 0 1 1 7 0v2" stroke="currentColor" strokeLinecap="round" strokeWidth="1.4" />
-          <path d="M10 11.25v2.5" stroke="currentColor" strokeLinecap="round" strokeWidth="1.4" />
-        </svg>
-      )}
-    </span>
+    <p className="mt-5 inline-flex max-w-full items-center gap-2 rounded-full border border-[#e5e5e5] bg-white py-1 pe-3 ps-1 text-[13px] text-[#30302d]">
+      <span
+        aria-hidden="true"
+        className="grid size-6 shrink-0 place-items-center rounded-full text-[11px] font-semibold text-white"
+        style={{ backgroundImage: "linear-gradient(135deg, #3cc3ff, #5b5cf6)" }}
+      >
+        {initial}
+      </span>
+      <span className="truncate">{label}</span>
+    </p>
   );
 }

--- a/web/app/cloud/access/page.tsx
+++ b/web/app/cloud/access/page.tsx
@@ -40,11 +40,12 @@ export default async function CloudPublicationAccessPage({
   if (demo) {
     return (
       <PublicationAccessCard
-        hostname="preview.example.com"
+        hostname="prickly-lavender-minnow.cmux.sh"
         identity={demo === "signed-in" ? "viewer@example.com" : null}
         locale={localized.locale}
         messages={localized.messages}
         signInHref="#"
+        switchAccountHref="#"
         view={demo}
       />
     );
@@ -109,9 +110,23 @@ export default async function CloudPublicationAccessPage({
       identity={resolution.user.identity}
       locale={localized.locale}
       messages={localized.messages}
+      switchAccountHref={publicationSwitchAccountHref(transaction, state)}
       view="signed-in"
     />
   );
+}
+
+/**
+ * Sign out, then straight into sign-in, and back to this same transaction.
+ * The sign-out route only honours this exact same-origin shape.
+ */
+function publicationSwitchAccountHref(transaction: string, state: string): string {
+  const switchAccount = new URL("/handler/sign-out-and-sign-in", "https://cmux.com");
+  switchAccount.searchParams.set(
+    "after_auth_return_to",
+    publicationSignInHref(transaction, state),
+  );
+  return `${switchAccount.pathname}${switchAccount.search}`;
 }
 
 function publicationSignInHref(transaction: string, state: string): string {

--- a/web/app/handler/sign-out-and-sign-in/route.ts
+++ b/web/app/handler/sign-out-and-sign-in/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { env } from "../../env";
 import { stackServerApp } from "../../lib/stack";
 import { requestOrigin } from "../../lib/request-origin";
-
+import { isPublicationToken } from "../../../services/vm-publications/security";
 
 type SignOutAndSignInDependencies = {
   projectId: string | undefined;
@@ -35,6 +35,32 @@ function validatedNativeSignInTarget(request: NextRequest): string | null {
   if (afterAuth.searchParams.has("after_auth_return_to")) return null;
 
   return `${target.pathname}${target.search}${target.hash}`;
+}
+
+function onlySearchParams(url: URL, allowed: readonly string[]): boolean {
+  const keys = [...url.searchParams.keys()].sort();
+  return keys.length === allowed.length && keys.every((key, index) => key === allowed[index]);
+}
+
+// A signed-in viewer refused by a protected Cloud VM domain can switch
+// accounts: sign out, straight into sign-in, and back to the same access
+// transaction. Every hop is same-origin and the transaction is opaque.
+function validatedPublicationSignInTarget(request: NextRequest): string | null {
+  const target = sameOriginURL(request.nextUrl.searchParams.get("after_auth_return_to"), request);
+  if (!target || target.pathname !== "/handler/sign-in") return null;
+  if (!onlySearchParams(target, ["after_auth_return_to"])) return null;
+
+  const afterAuth = sameOriginURL(target.searchParams.get("after_auth_return_to"), request);
+  if (!afterAuth || afterAuth.pathname !== "/handler/after-sign-in") return null;
+  if (!onlySearchParams(afterAuth, ["after_auth_return_to"])) return null;
+
+  const access = sameOriginURL(afterAuth.searchParams.get("after_auth_return_to"), request);
+  if (!access || access.pathname !== "/cloud/access") return null;
+  if (!onlySearchParams(access, ["state", "transaction"])) return null;
+  if (!isPublicationToken(access.searchParams.get("transaction"))) return null;
+  if (!isPublicationToken(access.searchParams.get("state"))) return null;
+
+  return `${target.pathname}${target.search}`;
 }
 
 function canStartSignOut(request: NextRequest): boolean {
@@ -114,7 +140,7 @@ function isNextRedirectError(error: unknown): boolean {
 
 export function makeSignOutAndSignInHandler(dependencies: SignOutAndSignInDependencies) {
   return async function GET(request: NextRequest) {
-    const target = validatedNativeSignInTarget(request);
+    const target = validatedNativeSignInTarget(request) ?? validatedPublicationSignInTarget(request);
     if (!target || !canStartSignOut(request)) return NextResponse.redirect(new URL("/", requestOrigin(request)));
 
     const response = NextResponse.redirect(new URL(target, requestOrigin(request)));

--- a/web/messages/ar.json
+++ b/web/messages/ar.json
@@ -61,11 +61,10 @@
     "backToSignIn": "العودة إلى تسجيل الدخول"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "سحابة cmux",
     "title": "ليس لديك حق الوصول",
-    "signedOutBody": "سجّل الدخول إلى cmux لعرض هذا الموقع.",
     "signIn": "تسجيل الدخول إلى cmux",
     "signedInAs": "تم تسجيل الدخول باسم {identity}",
+    "switchAccount": "تبديل الحساب",
     "invalidTitle": "رابط الوصول هذا غير صالح",
     "invalidBody": "ارجع إلى الموقع وحاول مرة أخرى.",
     "footer": "تتم إدارة الوصول بواسطة cmux."

--- a/web/messages/bs.json
+++ b/web/messages/bs.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Nazad na prijavu"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux oblak",
     "title": "Nemate pristup",
-    "signedOutBody": "Prijavite se na cmux da biste vidjeli ovu stranicu.",
     "signIn": "Prijavite se na cmux",
     "signedInAs": "Prijavljeni ste kao {identity}",
+    "switchAccount": "Promijeni nalog",
     "invalidTitle": "Ovaj link za pristup nije važeći",
     "invalidBody": "Vratite se na stranicu i pokušajte ponovo.",
     "footer": "Pristupom upravlja cmux."

--- a/web/messages/da.json
+++ b/web/messages/da.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Tilbage til login"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux cloud",
     "title": "Du har ikke adgang",
-    "signedOutBody": "Log ind på cmux for at se dette websted.",
     "signIn": "Log ind på cmux",
     "signedInAs": "Logget ind som {identity}",
+    "switchAccount": "Skift konto",
     "invalidTitle": "Dette adgangslink er ugyldigt",
     "invalidBody": "Gå tilbage til webstedet, og prøv igen.",
     "footer": "Adgang administreres af cmux."

--- a/web/messages/de.json
+++ b/web/messages/de.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Zur Anmeldung"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux cloud",
     "title": "Du hast keinen Zugriff",
-    "signedOutBody": "Melde dich bei cmux an, um diese Website anzusehen.",
     "signIn": "Bei cmux anmelden",
     "signedInAs": "Angemeldet als {identity}",
+    "switchAccount": "Konto wechseln",
     "invalidTitle": "Dieser Zugriffslink ist ungültig",
     "invalidBody": "Kehre zur Website zurück und versuche es erneut.",
     "footer": "Der Zugriff wird von cmux verwaltet."

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -123,11 +123,10 @@
     "backToSignIn": "Back to sign in"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux cloud",
     "title": "You don't have access",
-    "signedOutBody": "Sign in to cmux to view this site.",
     "signIn": "Sign in to cmux",
     "signedInAs": "Signed in as {identity}",
+    "switchAccount": "Switch account",
     "invalidTitle": "This access link isn't valid",
     "invalidBody": "Return to the site and try again.",
     "footer": "Access is managed by cmux."

--- a/web/messages/es.json
+++ b/web/messages/es.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Volver a iniciar sesión"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "nube de cmux",
     "title": "No tienes acceso",
-    "signedOutBody": "Inicia sesión en cmux para ver este sitio.",
     "signIn": "Iniciar sesión en cmux",
     "signedInAs": "Sesión iniciada como {identity}",
+    "switchAccount": "Cambiar de cuenta",
     "invalidTitle": "Este enlace de acceso no es válido",
     "invalidBody": "Vuelve al sitio e inténtalo de nuevo.",
     "footer": "cmux administra el acceso."

--- a/web/messages/fr.json
+++ b/web/messages/fr.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Retour à la connexion"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cloud cmux",
     "title": "Vous n’avez pas accès",
-    "signedOutBody": "Connectez-vous à cmux pour voir ce site.",
     "signIn": "Se connecter à cmux",
     "signedInAs": "Connecté en tant que {identity}",
+    "switchAccount": "Changer de compte",
     "invalidTitle": "Ce lien d’accès n’est pas valide",
     "invalidBody": "Retournez sur le site et réessayez.",
     "footer": "L’accès est géré par cmux."

--- a/web/messages/it.json
+++ b/web/messages/it.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Torna all'accesso"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cloud cmux",
     "title": "Non hai accesso",
-    "signedOutBody": "Accedi a cmux per visualizzare questo sito.",
     "signIn": "Accedi a cmux",
     "signedInAs": "Accesso effettuato come {identity}",
+    "switchAccount": "Cambia account",
     "invalidTitle": "Questo link di accesso non è valido",
     "invalidBody": "Torna al sito e riprova.",
     "footer": "L’accesso è gestito da cmux."

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -123,11 +123,10 @@
     "backToSignIn": "サインインに戻る"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux クラウド",
     "title": "アクセス権がありません",
-    "signedOutBody": "このサイトを表示するには cmux にサインインしてください。",
     "signIn": "cmux にサインイン",
     "signedInAs": "{identity} としてサインイン中",
+    "switchAccount": "アカウントを切り替える",
     "invalidTitle": "このアクセスリンクは無効です",
     "invalidBody": "サイトに戻って、もう一度お試しください。",
     "footer": "アクセスは cmux によって管理されています。"

--- a/web/messages/km.json
+++ b/web/messages/km.json
@@ -61,11 +61,10 @@
     "backToSignIn": "ត្រឡប់ទៅការចូល"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "ពពក cmux",
     "title": "អ្នកមិនមានសិទ្ធិចូលប្រើទេ",
-    "signedOutBody": "ចូលគណនី cmux ដើម្បីមើលគេហទំព័រនេះ។",
     "signIn": "ចូលគណនី cmux",
     "signedInAs": "បានចូលជា {identity}",
+    "switchAccount": "ប្ដូរគណនី",
     "invalidTitle": "តំណចូលប្រើនេះមិនត្រឹមត្រូវទេ",
     "invalidBody": "ត្រឡប់ទៅគេហទំព័រ ហើយព្យាយាមម្តងទៀត។",
     "footer": "សិទ្ធិចូលប្រើត្រូវបានគ្រប់គ្រងដោយ cmux។"

--- a/web/messages/ko.json
+++ b/web/messages/ko.json
@@ -61,11 +61,10 @@
     "backToSignIn": "로그인으로 돌아가기"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux 클라우드",
     "title": "액세스 권한이 없습니다",
-    "signedOutBody": "이 사이트를 보려면 cmux에 로그인하세요.",
     "signIn": "cmux에 로그인",
     "signedInAs": "{identity}(으)로 로그인됨",
+    "switchAccount": "계정 전환",
     "invalidTitle": "이 액세스 링크는 유효하지 않습니다",
     "invalidBody": "사이트로 돌아가 다시 시도하세요.",
     "footer": "액세스는 cmux에서 관리합니다."

--- a/web/messages/no.json
+++ b/web/messages/no.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Tilbake til innlogging"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux-sky",
     "title": "Du har ikke tilgang",
-    "signedOutBody": "Logg på cmux for å se dette nettstedet.",
     "signIn": "Logg på cmux",
     "signedInAs": "Logget på som {identity}",
+    "switchAccount": "Bytt konto",
     "invalidTitle": "Denne tilgangslenken er ugyldig",
     "invalidBody": "Gå tilbake til nettstedet og prøv på nytt.",
     "footer": "Tilgang administreres av cmux."

--- a/web/messages/pl.json
+++ b/web/messages/pl.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Wróć do logowania"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "chmura cmux",
     "title": "Nie masz dostępu",
-    "signedOutBody": "Zaloguj się do cmux, aby wyświetlić tę witrynę.",
     "signIn": "Zaloguj się do cmux",
     "signedInAs": "Zalogowano jako {identity}",
+    "switchAccount": "Zmień konto",
     "invalidTitle": "Ten link dostępu jest nieprawidłowy",
     "invalidBody": "Wróć do witryny i spróbuj ponownie.",
     "footer": "Dostępem zarządza cmux."

--- a/web/messages/pt-BR.json
+++ b/web/messages/pt-BR.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Voltar para o login"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "nuvem cmux",
     "title": "Você não tem acesso",
-    "signedOutBody": "Entre no cmux para ver este site.",
     "signIn": "Entrar no cmux",
     "signedInAs": "Conectado como {identity}",
+    "switchAccount": "Trocar de conta",
     "invalidTitle": "Este link de acesso não é válido",
     "invalidBody": "Volte ao site e tente novamente.",
     "footer": "O acesso é gerenciado pelo cmux."

--- a/web/messages/ru.json
+++ b/web/messages/ru.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Вернуться ко входу"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "облако cmux",
     "title": "У вас нет доступа",
-    "signedOutBody": "Войдите в cmux, чтобы просмотреть этот сайт.",
     "signIn": "Войти в cmux",
     "signedInAs": "Вы вошли как {identity}",
+    "switchAccount": "Сменить аккаунт",
     "invalidTitle": "Эта ссылка для доступа недействительна",
     "invalidBody": "Вернитесь на сайт и повторите попытку.",
     "footer": "Доступом управляет cmux."

--- a/web/messages/th.json
+++ b/web/messages/th.json
@@ -61,11 +61,10 @@
     "backToSignIn": "กลับไปที่การลงชื่อเข้าใช้"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "คลาวด์ cmux",
     "title": "คุณไม่มีสิทธิ์เข้าถึง",
-    "signedOutBody": "ลงชื่อเข้าใช้ cmux เพื่อดูเว็บไซต์นี้",
     "signIn": "ลงชื่อเข้าใช้ cmux",
     "signedInAs": "ลงชื่อเข้าใช้เป็น {identity}",
+    "switchAccount": "สลับบัญชี",
     "invalidTitle": "ลิงก์เข้าถึงนี้ไม่ถูกต้อง",
     "invalidBody": "กลับไปยังเว็บไซต์แล้วลองอีกครั้ง",
     "footer": "cmux เป็นผู้จัดการสิทธิ์เข้าถึง"

--- a/web/messages/tr.json
+++ b/web/messages/tr.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Girişe dön"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux bulut",
     "title": "Erişim izniniz yok",
-    "signedOutBody": "Bu siteyi görüntülemek için cmux'ta oturum açın.",
     "signIn": "cmux'ta oturum aç",
     "signedInAs": "{identity} olarak oturum açıldı",
+    "switchAccount": "Hesap değiştir",
     "invalidTitle": "Bu erişim bağlantısı geçerli değil",
     "invalidBody": "Siteye dönüp tekrar deneyin.",
     "footer": "Erişim cmux tarafından yönetilir."

--- a/web/messages/uk.json
+++ b/web/messages/uk.json
@@ -61,11 +61,10 @@
     "backToSignIn": "Повернутися до входу"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "хмара cmux",
     "title": "У вас немає доступу",
-    "signedOutBody": "Увійдіть у cmux, щоб переглянути цей сайт.",
     "signIn": "Увійти в cmux",
     "signedInAs": "Ви ввійшли як {identity}",
+    "switchAccount": "Змінити обліковий запис",
     "invalidTitle": "Це посилання для доступу недійсне",
     "invalidBody": "Поверніться на сайт і повторіть спробу.",
     "footer": "Доступом керує cmux."

--- a/web/messages/zh-CN.json
+++ b/web/messages/zh-CN.json
@@ -61,11 +61,10 @@
     "backToSignIn": "返回登录"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux 云",
     "title": "你没有访问权限",
-    "signedOutBody": "登录 cmux 以查看此网站。",
     "signIn": "登录 cmux",
     "signedInAs": "已以 {identity} 的身份登录",
+    "switchAccount": "切换账号",
     "invalidTitle": "此访问链接无效",
     "invalidBody": "返回网站，然后重试。",
     "footer": "访问权限由 cmux 管理。"

--- a/web/messages/zh-TW.json
+++ b/web/messages/zh-TW.json
@@ -61,11 +61,10 @@
     "backToSignIn": "返回登入"
   },
   "cloudPublicationAccess": {
-    "eyebrow": "cmux 雲端",
     "title": "你沒有存取權限",
-    "signedOutBody": "登入 cmux 以檢視此網站。",
     "signIn": "登入 cmux",
     "signedInAs": "已以 {identity} 的身分登入",
+    "switchAccount": "切換帳號",
     "invalidTitle": "此存取連結無效",
     "invalidBody": "返回網站，然後再試一次。",
     "footer": "存取權限由 cmux 管理。"

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -526,6 +526,50 @@ describe("sign out and sign back in", () => {
     expect(response.headers.get("location")).toBe("https://cmux.test/");
   });
 
+  const publicationTransaction = "tx_0123456789abcdefghijklmnopqrstuvwxyz";
+  const publicationState = "st_ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+
+  function publicationSignIn(access: string): string {
+    const afterSignIn = `/handler/after-sign-in?after_auth_return_to=${encodeURIComponent(access)}`;
+    return `/handler/sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;
+  }
+
+  test("signs out and redirects into sign-in for a protected Cloud VM domain transaction", async () => {
+    const access = `/cloud/access?transaction=${publicationTransaction}&state=${publicationState}`;
+    const signIn = publicationSignIn(access);
+
+    const response = await GET(switchRequest(signIn));
+
+    expect(signOut).toHaveBeenCalledWith({ redirectUrl: `https://cmux.test${signIn}` });
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe(`https://cmux.test${signIn}`);
+    expect(response.headers.get("set-cookie")).toContain("stack-access=;");
+  });
+
+  test("rejects Cloud VM access targets that are not exactly an opaque transaction", async () => {
+    const malformed = [
+      `/cloud/access?transaction=short&state=${publicationState}`,
+      `/cloud/access?transaction=${publicationTransaction}`,
+      `/cloud/access?transaction=${publicationTransaction}&state=${publicationState}&next=%2Fdocs`,
+      `/cloud/other?transaction=${publicationTransaction}&state=${publicationState}`,
+      `https://evil.test/cloud/access?transaction=${publicationTransaction}&state=${publicationState}`,
+    ];
+
+    for (const access of malformed) {
+      const response = await GET(switchRequest(publicationSignIn(access)));
+      expect(signOut).not.toHaveBeenCalled();
+      expect(response.status).toBe(307);
+      expect(response.headers.get("location")).toBe("https://cmux.test/");
+    }
+
+    const extraSignInParam = `/handler/sign-in?after_auth_return_to=${encodeURIComponent(
+      `/handler/after-sign-in?after_auth_return_to=${encodeURIComponent(`/cloud/access?transaction=${publicationTransaction}&state=${publicationState}`)}`,
+    )}&prompt=none`;
+    const response = await GET(switchRequest(extraSignInParam));
+    expect(signOut).not.toHaveBeenCalled();
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+  });
+
   test("rejects cross-site attempts to force sign-out", async () => {
     const afterSignIn = "/handler/after-sign-in?native_app_return_to=cmux%3A%2F%2Fauth-callback%3Fcmux_auth_state%3Dstate-123";
     const nativeSignIn = `/handler/native-sign-in?after_auth_return_to=${encodeURIComponent(afterSignIn)}`;

--- a/web/tests/vm-publication-access-card.test.tsx
+++ b/web/tests/vm-publication-access-card.test.tsx
@@ -7,21 +7,20 @@ import {
 } from "../app/cloud/access/access-card";
 
 const messages: PublicationAccessMessages = {
-  eyebrow: "cmux cloud",
   title: "You don't have access",
-  signedOutBody: "Sign in to cmux to view this site.",
   signIn: "Sign in to cmux",
   signedInAs: "Signed in as {identity}",
+  switchAccount: "Switch account",
   invalidTitle: "This access link isn't valid",
   invalidBody: "Return to the shared site and try again.",
   footer: "Access is managed by cmux.",
 };
 
 describe("Cloud VM publication access card", () => {
-  test("shows the sign-in action without leaking an account identity", () => {
+  test("shows the icon, the hostname, and the sign-in action without leaking an account identity", () => {
     const html = renderToStaticMarkup(
       <PublicationAccessCard
-        hostname="preview.example.com"
+        hostname="prickly-lavender-minnow.cmux.sh"
         locale="en"
         messages={messages}
         signInHref="/handler/sign-in?return=opaque"
@@ -31,32 +30,54 @@ describe("Cloud VM publication access card", () => {
 
     expect(html).toContain('data-publication-access="signed-out"');
     expect(html).toContain("You don&#x27;t have access");
-    expect(html).toContain("Sign in to cmux to view this site.");
+    expect(html).toContain("prickly-lavender-minnow.cmux.sh");
     expect(html).toContain('href="/handler/sign-in?return=opaque"');
+    expect(html).toContain("Sign in to cmux");
+    expect(html).toContain("Access is managed by cmux.");
+    expect(html).toMatch(/<img[^>]*logo\.png/);
     expect(html).not.toContain("Signed in as");
+    expect(html).not.toContain("Switch account");
   });
 
-  test("shows the signed-in identity without an access action", () => {
+  test("shows the signed-in identity with only an account switch", () => {
     const html = renderToStaticMarkup(
       <PublicationAccessCard
-        hostname="preview.example.com"
+        hostname="prickly-lavender-minnow.cmux.sh"
         identity="viewer@example.com"
         locale="en"
         messages={messages}
+        switchAccountHref="/handler/sign-out-and-sign-in?after_auth_return_to=opaque"
         view="signed-in"
       />,
     );
 
     expect(html).toContain('data-publication-access="signed-in"');
     expect(html).toContain("Signed in as viewer@example.com");
+    expect(html).toContain('href="/handler/sign-out-and-sign-in?after_auth_return_to=opaque"');
+    expect(html).toContain("Switch account");
+    expect(html).not.toContain("Sign in to cmux<");
     expect(html).not.toContain("<form");
     expect(html).not.toContain("Request access");
+  });
+
+  test("omits the account switch when no target is provided", () => {
+    const html = renderToStaticMarkup(
+      <PublicationAccessCard
+        hostname="prickly-lavender-minnow.cmux.sh"
+        identity="viewer@example.com"
+        locale="en"
+        messages={messages}
+        view="signed-in"
+      />,
+    );
+    expect(html).toContain("Signed in as viewer@example.com");
+    expect(html).not.toContain("Switch account");
   });
 
   test("renders an identity containing replacement patterns literally", () => {
     const html = renderToStaticMarkup(
       <PublicationAccessCard
-        hostname="preview.example.com"
+        hostname="prickly-lavender-minnow.cmux.sh"
         identity="$& $' $1 $$ viewer"
         locale="en"
         messages={messages}
@@ -76,5 +97,21 @@ describe("Cloud VM publication access card", () => {
     );
     expect(html).toContain('dir="rtl"');
     expect(html).toContain('data-publication-access="invalid"');
+  });
+
+  test("keeps the invalid state free of any hostname or action", () => {
+    const html = renderToStaticMarkup(
+      <PublicationAccessCard
+        hostname="prickly-lavender-minnow.cmux.sh"
+        locale="en"
+        messages={messages}
+        signInHref="/handler/sign-in?return=opaque"
+        view="invalid"
+      />,
+    );
+    expect(html).toContain("This access link isn&#x27;t valid");
+    expect(html).toContain("Return to the shared site and try again.");
+    expect(html).not.toContain("prickly-lavender-minnow.cmux.sh");
+    expect(html).not.toContain("<a ");
   });
 });

--- a/web/tests/vm-publication-access-localization.test.ts
+++ b/web/tests/vm-publication-access-localization.test.ts
@@ -50,7 +50,7 @@ type AccessMessageKey = keyof typeof englishMessages.cloudPublicationAccess;
 
 const englishAccess = englishMessages.cloudPublicationAccess;
 const accessKeys = Object.keys(englishAccess).sort() as AccessMessageKey[];
-const signInCopyKeys = ["title", "signedOutBody", "signIn"] as const;
+const signInCopyKeys = ["title", "signIn", "switchAccount"] as const;
 
 function placeholders(value: string): string[] {
   return [...value.matchAll(/\{[^{}]+\}/g)]


### PR DESCRIPTION
## What

Redesigns the protected Cloud VM domain access page (`/cloud/access`) that the Freestyle edge sends browsers to when a published site is not public. The page is now the cmux app icon, one sentence, the hostname, and one action. Nothing else.

| Before (#11692) | After |
| --- | --- |
| "cmux cloud" mono eyebrow, lock glyph, bordered card on a grid backdrop | The app icon (`/logo.png`), no eyebrow, no card |
| Title + "Sign in to cmux to view this site." | Title only; the button says the rest |
| Square black full-width button | Black pill that fits its label |
| Footer inside the card | Footer at the bottom edge of the page |
| Signed-in state: identity line, no action | Identity pill with an initial, plus **Switch account** |

### Screenshots

Taken from `next dev` with the page's development-only `?demo=` states, 2x.

| Signed out | Signed in, not allowed |
| --- | --- |
| ![signed out](https://raw.githubusercontent.com/theswerd/cmux/24d45358341593585f395986c0550e89f555c4df/cloud-access-compact/signed-out-desktop.png) | ![signed in](https://raw.githubusercontent.com/theswerd/cmux/24d45358341593585f395986c0550e89f555c4df/cloud-access-compact/signed-in-desktop.png) |

| Invalid or expired link | Phone (390 × 844) |
| --- | --- |
| ![invalid](https://raw.githubusercontent.com/theswerd/cmux/24d45358341593585f395986c0550e89f555c4df/cloud-access-compact/invalid-desktop.png) | <img src="https://raw.githubusercontent.com/theswerd/cmux/24d45358341593585f395986c0550e89f555c4df/cloud-access-compact/signed-out-phone.png" width="300"> |

| Japanese | Arabic (RTL) |
| --- | --- |
| ![ja](https://raw.githubusercontent.com/theswerd/cmux/24d45358341593585f395986c0550e89f555c4df/cloud-access-compact/signed-out-ja-desktop.png) | ![ar](https://raw.githubusercontent.com/theswerd/cmux/24d45358341593585f395986c0550e89f555c4df/cloud-access-compact/signed-in-ar-desktop.png) |

## Switch account

A viewer who is signed in to the wrong cmux account had no way forward. The signed-in state now links to `/handler/sign-out-and-sign-in`, which signs out, goes straight into sign-in, and returns to the same access transaction.

That route previously accepted only the native-app sign-in shape. It now also accepts exactly this same-origin shape and nothing looser:

```
/handler/sign-in?after_auth_return_to=
  /handler/after-sign-in?after_auth_return_to=
    /cloud/access?transaction=<token>&state=<token>
```

Each hop must be same-origin, carry only the listed query parameters, and both tokens must pass `isPublicationToken`. Anything else still redirects to `/`, and the existing `sec-fetch-site` check still applies. Tests cover the accepted shape and five malformed variants (short token, missing state, extra parameter, wrong path, cross-origin) plus an extra parameter on the sign-in hop.

## Localization audit

- `cloudPublicationAccess.eyebrow` and `cloudPublicationAccess.signedOutBody` removed from all 20 catalogs. Nothing else referenced them (grepped web, Sources, plans).
- `cloudPublicationAccess.switchAccount` added to all 20 catalogs with native translations (ja アカウントを切り替える, de Konto wechseln, ar تبديل الحساب, …). `de` stays informal, consistent with the rest of that catalog.
- `vm-publication-access-localization.test.ts` asserts every locale has exactly the English key set with matching placeholders, and that title, sign-in, and switch-account copy are translated. Updated its key list.
- Rendered and checked `ja` and `ar` (screenshots above); Arabic keeps `dir="rtl"` and the identity pill mirrors correctly.

## Verification

- `bun test` on `vm-publication-access-card`, `vm-publication-access-localization`, `after-sign-in-route`: 67 pass, 0 fail.
- `bun run typecheck` and `eslint` on the changed files: clean.
- Screenshots above are the real page from `next dev`.

Not in this PR: a dark variant using `brand/app-icon-dark.png`. The page is light-only, as it was.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QRgeJamB8kV7PH5iCdbLQU


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compacts the protected Cloud VM domain access screen: the old eyebrow, lock glyph, bordered card, and explanatory body are gone, replaced by the app icon, one sentence, the hostname, and one action. Signed-in viewers who are refused access now get an identity pill plus a "Switch account" link instead of a dead end.

- `/handler/sign-out-and-sign-in` now accepts exactly one same-origin shape: `/cloud/access?transaction=<token>&state=<token>`; both tokens must pass `isPublicationToken`, and anything else still redirects to `/`.
- `cloudPublicationAccess.eyebrow` and `signedOutBody` are removed, `switchAccount` added in all 20 catalogs.

<sup>Written for commit f7982497c2ea104dad4aa9dd9031d933d18a748e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated publication access screens with a simpler layout, application logo, and clearer signed-in and invalid-state messaging.
  * Added an account-switch option for signed-in users when available.
  * Improved sign-out and sign-in flows for protected publication access.
  * Expanded localized account-switch labels across supported languages.

* **Bug Fixes**
  * Invalid access details now prevent misleading hostnames and links from appearing.
  * Safer redirect handling rejects malformed publication access targets.

* **Tests**
  * Added coverage for account switching, invalid states, redirect validation, and localized messaging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->