### PR TITLE
Fix blank Stack Auth team invitation page

### DIFF
--- a/web/app/handler/[...stack]/page.tsx
+++ b/web/app/handler/[...stack]/page.tsx
@@ -22,39 +22,41 @@ export default async function StackHandlerPage(
     headers(),
   ]);
 
-  if (
+  const isCoderouterSignIn =
     coderouterHost(requestHeaders.get("host")) &&
     stack.length === 1 &&
-    stack[0] === "sign-in"
-  ) {
+    stack[0] === "sign-in";
+
+  const handlerContent = isCoderouterSignIn ? (
     // The shared cmux Google connector requests Drive, Gmail, and Calendar
     // scopes for optional integrations. Those scopes are inappropriate for
     // coderouter authentication, so coderouter deliberately offers
     // passwordless email only.
-    return (
-      <main className="flex min-h-screen items-center justify-center bg-[#faf9f6] px-6 text-[#25231f]">
-        <section className="w-full max-w-sm border border-[#ded9cf] bg-white p-7 shadow-[4px_4px_0_#eee8dc]">
-          <p className="mb-2 font-mono text-xs lowercase tracking-[0.16em] text-[#9a5b22]">
-            coderouter
-          </p>
-          <h1 className="mb-2 text-xl font-medium">sign in</h1>
-          <p className="mb-6 text-sm leading-6 text-[#6f6a61]">
-            use your cmux account email. we’ll send a one-time code.
-          </p>
-          <MagicLinkSignIn />
-        </section>
-      </main>
-    );
-  }
-
-  const stackHandler = (
+    <main className="flex min-h-screen items-center justify-center bg-[#faf9f6] px-6 text-[#25231f]">
+      <section className="w-full max-w-sm border border-[#ded9cf] bg-white p-7 shadow-[4px_4px_0_#eee8dc]">
+        <p className="mb-2 font-mono text-xs lowercase tracking-[0.16em] text-[#9a5b22]">
+          coderouter
+        </p>
+        <h1 className="mb-2 text-xl font-medium">sign in</h1>
+        <p className="mb-6 text-sm leading-6 text-[#6f6a61]">
+          use your cmux account email. we’ll send a one-time code.
+        </p>
+        <MagicLinkSignIn />
+      </section>
+    </main>
+  ) : (
     <StackHandler fullPage app={stackServerApp} params={props.params} />
   );
 
   // Stack handler pages use client hooks for session and query state. Keep the
-  // whole handler behind one boundary so every current and future auth path
-  // can opt into client rendering without a missing-boundary error.
-  return <Suspense fallback={<StackHandlerLoading />}>{stackHandler}</Suspense>;
+  // complete handler, including custom host variants, behind one boundary so
+  // every current and future auth path can opt into client rendering without
+  // a missing-boundary error.
+  return (
+    <Suspense fallback={<StackHandlerLoading />}>
+      {handlerContent}
+    </Suspense>
+  );
 }
 
 function StackHandlerLoading() {

--- a/web/app/handler/[...stack]/page.tsx
+++ b/web/app/handler/[...stack]/page.tsx
@@ -51,14 +51,24 @@ export default async function StackHandlerPage(
     <StackHandler fullPage app={stackServerApp} params={props.params} />
   );
 
-  // Stack's email-verification page calls useUser() while rendering its
-  // client component. Next requires that CSR bailout to have a boundary on
-  // this route, otherwise a real verification link returns HTTP 500.
-  if (stack[0] === "email-verification") {
-    return <Suspense fallback={null}>{stackHandler}</Suspense>;
-  }
+  // Stack handler pages use client hooks for session and query state. Keep the
+  // whole handler behind one boundary so every current and future auth path
+  // can opt into client rendering without a missing-boundary error.
+  return <Suspense fallback={<StackHandlerLoading />}>{stackHandler}</Suspense>;
+}
 
-  return stackHandler;
+function StackHandlerLoading() {
+  return (
+    <main
+      aria-busy="true"
+      className="flex min-h-screen items-center justify-center"
+    >
+      <div
+        aria-hidden="true"
+        className="h-5 w-5 animate-spin rounded-full border-2 border-current border-t-transparent"
+      />
+    </main>
+  );
 }
 
 function coderouterHost(host: string | null): boolean {

--- a/web/tests/email-verification-handler-page.test.tsx
+++ b/web/tests/email-verification-handler-page.test.tsx
@@ -49,4 +49,12 @@ describe("Stack handler page", () => {
 
     expect(renderToStaticMarkup(page)).toContain('aria-busy="true"');
   });
+
+  test("keeps an unlisted future handler path behind the same boundary", async () => {
+    const page = await StackHandlerPage({
+      params: Promise.resolve({ stack: ["future-handler"] }),
+    });
+
+    expect(renderToStaticMarkup(page)).toContain('aria-busy="true"');
+  });
 });

--- a/web/tests/email-verification-handler-page.test.tsx
+++ b/web/tests/email-verification-handler-page.test.tsx
@@ -41,4 +41,12 @@ describe("email verification handler page", () => {
 
     expect(renderToStaticMarkup(page)).toBe("");
   });
+
+  test("renders a loading state when any Stack handler path suspends", async () => {
+    const page = await StackHandlerPage({
+      params: Promise.resolve({ stack: ["team-invitation"] }),
+    });
+
+    expect(renderToStaticMarkup(page)).toContain('aria-busy="true"');
+  });
 });

--- a/web/tests/email-verification-handler-page.test.tsx
+++ b/web/tests/email-verification-handler-page.test.tsx
@@ -33,13 +33,13 @@ const { default: StackHandlerPage } = await import(
   "../app/handler/[...stack]/page"
 );
 
-describe("email verification handler page", () => {
-  test("contains Stack's client-side session suspension", async () => {
+describe("Stack handler page", () => {
+  test("renders a loading state while Stack's client component suspends", async () => {
     const page = await StackHandlerPage({
       params: Promise.resolve({ stack: ["email-verification"] }),
     });
 
-    expect(renderToStaticMarkup(page)).toBe("");
+    expect(renderToStaticMarkup(page)).toContain('aria-busy="true"');
   });
 
   test("renders a loading state when any Stack handler path suspends", async () => {


### PR DESCRIPTION
## Summary

- Wrap the complete Stack Auth handler catch-all in one Suspense boundary.
- Render an accessible loading state while Stack Auth hydrates client-only session and invitation state.
- Keep `connection()` on the route so invitation codes remain request-scoped and are not prerendered or cached.

## Root cause

Stack Auth's team invitation component calls `useUser()` and suspends during server rendering. The route had a boundary only for email verification, so team invitations could produce an empty response. One route-level boundary covers current and future Stack handler paths.

## Security

This changes rendering only. Stack Auth still performs authentication and invitation authorization. The route remains dynamic through `connection()`, and no secret or invitation validation moves to the client.

## Verification

- `bun test web/tests/email-verification-handler-page.test.tsx`
- `bun run typecheck` from `web/`
- `bun run lint -- app/handler tests/email-verification-handler-page.test.tsx` from `web/`
- `bun run build` from `web/` with local development environment
- Production browser check for `/handler/team-invitation?code=foo`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11821"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791010675&installation_model_id=21920&pr_number=11821&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11821&signature=f4928cbe2a09cb62132e2b6f78d4e8cc46867b932851575098c780d85845156b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blank Stack Auth team invitation pages by putting the whole Stack handler, including the coderouter sign-in variant, behind one Suspense boundary with an accessible loading state. Previously only email verification had a boundary, so team invitations returned an empty response when Stack's client component suspended.

- Covers all current and future Stack handler paths with a single route-level boundary.
- Keeps the route dynamic via `connection()` so invitation codes remain request-scoped.
- Adds tests for the team-invitation and future-handler paths and updates the email-verification test to assert the loading state.

<sup>Written for commit 889984445be410418ff6e95260f8dbc1414d87f9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved loading behavior across authentication pages by consistently displaying a loading state while content is being prepared.
  * Loading indicators now appear for both email verification and other authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->