### PR TITLE
CI: remove duplicate Valgrind sentinel run

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -152,17 +152,13 @@ jobs:
           npm test
 
   valgrind-leak-check-shard:
-    name: valgrind-leak-check (${{ matrix.shard }})
+    name: valgrind-leak-check (startup)
     needs: validate-inputs
     if: inputs.mode == 'full'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     # Full behavior stays in the normal macOS and Linux suites. Valgrind owns
     # the bounded startup parsers and terminal replay state only.
     timeout-minutes: 40
-    strategy:
-      fail-fast: false
-      matrix:
-        shard: [startup]
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -195,7 +191,7 @@ jobs:
           # SIMD codegen stays within what valgrind's instruction emulation
           # supports (see crates/ghostty-vt-sys/build.rs).
           CMUX_GHOSTTY_VT_ZIG_CPU: baseline
-          VALGRIND_SHARD: ${{ matrix.shard }}
+          VALGRIND_SHARD: startup
         run: |
           mkdir -p target
           # Cargo target selectors keep this startup shard from compiling the

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -255,6 +255,29 @@ jobs:
           )
           PY
 
+      - name: Require startup terminal replay sentinel
+        if: matrix.shard == 'startup'
+        working-directory: cmux-tui
+        run: |
+          matches=0
+          while IFS= read -r bin; do
+            [ -n "$bin" ] || continue
+            case "$(basename "$bin")" in
+              terminal-*)
+                if ! "$bin" --list \
+                  | grep -Fqx 'pending_wrap_replay_preserves_cursor_with_origin_mode: test'; then
+                  echo "::error::terminal replay test binary does not contain the exact startup sentinel" >&2
+                  exit 1
+                fi
+                matches=$((matches + 1))
+                ;;
+            esac
+          done < target/valgrind-test-binaries.txt
+          if [[ "$matches" -ne 1 ]]; then
+            echo "::error::expected one terminal integration test binary, found $matches" >&2
+            exit 1
+          fi
+
       - name: Run test binaries under valgrind
         working-directory: cmux-tui
         run: |

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -255,32 +255,6 @@ jobs:
           )
           PY
 
-      - name: Verify baseline terminal replay behavior
-        if: matrix.shard == 'startup'
-        working-directory: cmux-tui
-        run: |
-          matches=0
-          while IFS= read -r bin; do
-            [ -n "$bin" ] || continue
-            case "$(basename "$bin")" in
-              terminal-*)
-                if ! "$bin" --list \
-                  | grep -Fqx 'pending_wrap_replay_preserves_cursor_with_origin_mode: test'; then
-                  echo "::error::terminal replay test binary does not contain the exact baseline test" >&2
-                  exit 1
-                fi
-                "$bin" pending_wrap_replay_preserves_cursor_with_origin_mode \
-                  --exact \
-                  --test-threads=1
-                matches=$((matches + 1))
-                ;;
-            esac
-          done < target/valgrind-test-binaries.txt
-          if [[ "$matches" -ne 1 ]]; then
-            echo "::error::expected one terminal integration test binary, found $matches" >&2
-            exit 1
-          fi
-
       - name: Run test binaries under valgrind
         working-directory: cmux-tui
         run: |

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -255,8 +255,7 @@ jobs:
           )
           PY
 
-      - name: Require startup terminal replay sentinel
-        if: matrix.shard == 'startup'
+      - name: Verify baseline terminal replay behavior
         working-directory: cmux-tui
         run: |
           matches=0
@@ -266,7 +265,7 @@ jobs:
               terminal-*)
                 if ! "$bin" --list \
                   | grep -Fqx 'pending_wrap_replay_preserves_cursor_with_origin_mode: test'; then
-                  echo "::error::terminal replay test binary does not contain the exact startup sentinel" >&2
+                  echo "::error::terminal replay test binary does not contain the exact baseline test" >&2
                   exit 1
                 fi
                 "$bin" pending_wrap_replay_preserves_cursor_with_origin_mode \
@@ -319,6 +318,9 @@ jobs:
           fi
 
           valgrind_args=(--track-origins=yes)
+          require_exact_test \
+            "$terminal_bin" \
+            pending_wrap_replay_preserves_cursor_with_origin_mode
           run_valgrind \
             "$terminal_bin" \
             pending_wrap_replay_preserves_cursor_with_origin_mode \

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -269,6 +269,9 @@ jobs:
                   echo "::error::terminal replay test binary does not contain the exact startup sentinel" >&2
                   exit 1
                 fi
+                "$bin" pending_wrap_replay_preserves_cursor_with_origin_mode \
+                  --exact \
+                  --test-threads=1
                 matches=$((matches + 1))
                 ;;
             esac
@@ -316,9 +319,6 @@ jobs:
           fi
 
           valgrind_args=(--track-origins=yes)
-          require_exact_test \
-            "$terminal_bin" \
-            pending_wrap_replay_preserves_cursor_with_origin_mode
           run_valgrind \
             "$terminal_bin" \
             pending_wrap_replay_preserves_cursor_with_origin_mode \

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -136,6 +136,8 @@ def test_valgrind_runner_keeps_binary_and_test_safety_guards() -> None:
     assert "name: Require startup terminal replay sentinel" in job
     assert "if: matrix.shard == 'startup'" in job
     assert "pending_wrap_replay_preserves_cursor_with_origin_mode: test" in job
+    assert '"$bin" pending_wrap_replay_preserves_cursor_with_origin_mode \\\n' in job
+    assert job.count("pending_wrap_replay_preserves_cursor_with_origin_mode") == 3
     assert 're.fullmatch(r"(?:cmux_tui|terminal)-[0-9a-f]+", name)' in job
     assert 'if not seen:\n              raise SystemExit("cargo did not report any test binaries")' in job
     assert 'if not selected:\n              raise SystemExit(f"Valgrind shard {shard} selected no test binaries")' in job

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -105,7 +105,7 @@ def valgrind_build_step() -> str:
     marker = "      - name: Build test binaries\n"
     assert marker in job
     return job.split(marker, 1)[1].split(
-        "      - name: Require startup terminal replay sentinel", 1
+        "      - name: Verify baseline terminal replay behavior", 1
     )[0]
 
 
@@ -133,11 +133,14 @@ def test_valgrind_build_selects_only_startup_cargo_targets() -> None:
 def test_valgrind_runner_keeps_binary_and_test_safety_guards() -> None:
     job = workflow_job(workflow("cmux-tui.yml"), "valgrind-leak-check-shard")
 
-    assert "name: Require startup terminal replay sentinel" in job
-    assert "if: matrix.shard == 'startup'" in job
+    assert "name: Verify baseline terminal replay behavior" in job
+    baseline_step = job.split(
+        "      - name: Verify baseline terminal replay behavior", 1
+    )[1].split("      - name: Run test binaries under valgrind", 1)[0]
+    assert "if: matrix.shard == 'startup'" not in baseline_step
     assert "pending_wrap_replay_preserves_cursor_with_origin_mode: test" in job
     assert '"$bin" pending_wrap_replay_preserves_cursor_with_origin_mode \\\n' in job
-    assert job.count("pending_wrap_replay_preserves_cursor_with_origin_mode") == 3
+    assert job.count("pending_wrap_replay_preserves_cursor_with_origin_mode") == 4
     assert 're.fullmatch(r"(?:cmux_tui|terminal)-[0-9a-f]+", name)' in job
     assert 'if not seen:\n              raise SystemExit("cargo did not report any test binaries")' in job
     assert 'if not selected:\n              raise SystemExit(f"Valgrind shard {shard} selected no test binaries")' in job

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -105,7 +105,7 @@ def valgrind_build_step() -> str:
     marker = "      - name: Build test binaries\n"
     assert marker in job
     return job.split(marker, 1)[1].split(
-        "      - name: Run test binaries under valgrind", 1
+        "      - name: Require startup terminal replay sentinel", 1
     )[0]
 
 
@@ -133,7 +133,9 @@ def test_valgrind_build_selects_only_startup_cargo_targets() -> None:
 def test_valgrind_runner_keeps_binary_and_test_safety_guards() -> None:
     job = workflow_job(workflow("cmux-tui.yml"), "valgrind-leak-check-shard")
 
-    assert "Verify baseline terminal replay behavior" not in job
+    assert "name: Require startup terminal replay sentinel" in job
+    assert "if: matrix.shard == 'startup'" in job
+    assert "pending_wrap_replay_preserves_cursor_with_origin_mode: test" in job
     assert 're.fullmatch(r"(?:cmux_tui|terminal)-[0-9a-f]+", name)' in job
     assert 'if not seen:\n              raise SystemExit("cargo did not report any test binaries")' in job
     assert 'if not selected:\n              raise SystemExit(f"Valgrind shard {shard} selected no test binaries")' in job

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -133,6 +133,8 @@ def test_valgrind_build_selects_only_startup_cargo_targets() -> None:
 def test_valgrind_runner_keeps_binary_and_test_safety_guards() -> None:
     job = workflow_job(workflow("cmux-tui.yml"), "valgrind-leak-check-shard")
 
+    assert "matrix.shard" not in job
+    assert "VALGRIND_SHARD: startup" in job
     assert "name: Verify baseline terminal replay behavior" in job
     baseline_step = job.split(
         "      - name: Verify baseline terminal replay behavior", 1

--- a/tests/test_tui_publish_workflow_security.py
+++ b/tests/test_tui_publish_workflow_security.py
@@ -105,7 +105,7 @@ def valgrind_build_step() -> str:
     marker = "      - name: Build test binaries\n"
     assert marker in job
     return job.split(marker, 1)[1].split(
-        "      - name: Verify baseline terminal replay behavior", 1
+        "      - name: Run test binaries under valgrind", 1
     )[0]
 
 
@@ -133,6 +133,7 @@ def test_valgrind_build_selects_only_startup_cargo_targets() -> None:
 def test_valgrind_runner_keeps_binary_and_test_safety_guards() -> None:
     job = workflow_job(workflow("cmux-tui.yml"), "valgrind-leak-check-shard")
 
+    assert "Verify baseline terminal replay behavior" not in job
     assert 're.fullmatch(r"(?:cmux_tui|terminal)-[0-9a-f]+", name)' in job
     assert 'if not seen:\n              raise SystemExit("cargo did not report any test binaries")' in job
     assert 'if not selected:\n              raise SystemExit(f"Valgrind shard {shard} selected no test binaries")' in job


### PR DESCRIPTION
## Summary
- remove the plain terminal replay sentinel execution from the Valgrind shard
- keep the exact sentinel presence check and execution under Valgrind
- update the workflow guard to prevent the duplicate step from returning

## Testing
- `python3 tests/test_tui_publish_workflow_security.py -v`
- `python3 tests/test_tui_focused_filter_guard.py`
- YAML parse with PyYAML
- `actionlint .github/workflows/cmux-tui.yml`
- `git diff --check`

## Context
- Audited from exact `main` commit `4e30be837d1685f641e65a78f9437c2a6b0c23a3`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the duplicate terminal replay sentinel execution from Valgrind CI by collapsing the singleton shard matrix, so the replay guard runs exactly once under Valgrind.

- Drops the plain terminal replay sentinel step; the sentinel now runs only under Valgrind.
- Collapses `valgrind-leak-check-shard` from a one-item matrix into a single startup job.
- Extends the workflow security test to fail if a duplicate sentinel step is reintroduced.

<sup>Written for commit 1fb6980cf4e6fc554fbe51ee09b4a4c76f867009. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated validation for baseline terminal replay behavior in Valgrind workflows.
  * Added checks to ensure the replay verification runs across all configured shards.
  * Strengthened safeguards confirming the expected test binary is invoked with the required arguments and appears the correct number of times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->