### PR TITLE
relay: redact remote path refusal details

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -1413,6 +1413,14 @@ mod tests {
         let refusal = next_frame(&mut critical, &mut watch, "refusal").await;
         assert_eq!(refusal["type"], "fs_watch_error");
         assert_eq!(refusal["code"], "path_forbidden");
+        assert_eq!(
+            refusal["message"],
+            "path is forbidden by the workspace policy"
+        );
+        assert!(
+            !refusal.to_string().contains(&root.to_string_lossy().to_string()),
+            "watch refusal must not disclose the local workspace path"
+        );
         // Session cap: the 17th watch refuses watch_limit.
         for index in 0..WATCH_MAX_SESSIONS {
             registry.open(open_frame(&format!("w{index}"), &root), None);

--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -202,12 +202,18 @@ fn watch_error_frame(
     code: wire::WorkspaceErrorCode,
     message: Option<&str>,
 ) -> String {
+    let message = match code {
+        wire::WorkspaceErrorCode::PathForbidden => {
+            Some("path is forbidden by the workspace policy".to_owned())
+        }
+        _ => message.map(str::to_owned),
+    };
     serde_json::to_string(&wire::RelayFsWatchError {
         version: WORKSPACE_FRAME_VERSION,
         r#type: wire::TagFsWatchError::FsWatchError,
         watch_id: watch_id.to_owned(),
         code,
-        message: message.map(str::to_owned),
+        message,
     })
     .unwrap_or_else(|_| String::new())
 }

--- a/cmux-tui/crates/chatmux-relay/src/workspace.rs
+++ b/cmux-tui/crates/chatmux-relay/src/workspace.rs
@@ -2499,13 +2499,22 @@ fn ok_frame(request_id: &str, body: wire::WorkspaceResultBody) -> String {
 }
 
 fn error_frame(request_id: &str, refusal: &Refusal) -> String {
+    // Path checks may include host paths for local diagnostics. Never expose
+    // those details to a remote client, which could learn HOME or configured
+    // allowed roots from a refusal.
+    let message = match refusal.code {
+        wire::WorkspaceErrorCode::PathForbidden => {
+            Some("path is forbidden by the workspace policy".to_owned())
+        }
+        _ => Some(refusal.message.clone()),
+    };
     let frame = wire::RelayWorkspaceResultError {
         version: WORKSPACE_FRAME_VERSION,
         r#type: wire::TagWorkspaceResult::WorkspaceResult,
         request_id: request_id.to_owned(),
         ok: wire::ConstFalse,
         code: refusal.code,
-        message: Some(refusal.message.clone()),
+        message,
         current_sha256: refusal.current_sha256.clone(),
     };
     serde_json::to_string(&frame).unwrap_or_else(|_| String::new())
@@ -3566,5 +3575,19 @@ mod tests {
         assert_eq!(clamp_i64(0, MIN_TIMEOUT_MS, MAX_TIMEOUT_MS), MIN_TIMEOUT_MS);
         assert_eq!(clamp_i64(999_999, MIN_TIMEOUT_MS, MAX_TIMEOUT_MS), MAX_TIMEOUT_MS);
         let _ = root;
+    }
+
+    #[test]
+    fn path_forbidden_errors_do_not_serialize_host_paths() {
+        let home = home_dir().display().to_string();
+        let allowed = format!("{home}/private-project");
+        let refusal = Refusal::path_forbidden(format!(
+            "path {allowed}/secret.txt is outside this machine's allowed roots"
+        ));
+        let frame = error_frame("req-path", &refusal);
+        assert!(!frame.contains(&home));
+        assert!(!frame.contains(&allowed));
+        assert_eq!(serde_json::from_str::<Value>(&frame).unwrap()["message"],
+            "path is forbidden by the workspace policy");
     }
 }


### PR DESCRIPTION
Remote workspace clients received absolute host paths in path_forbidden messages. Keep detailed Refusal messages for local diagnostics, but serialize a fixed policy message for path_forbidden errors. Add a behavior test proving HOME and allowed roots are absent from the JSON frame.

Tests: cargo fmt --check blocked by local cmuxterm-hq disk guard (229 GiB free, 250 GiB floor).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a path disclosure issue where remote workspace clients received absolute host paths in `path_forbidden` error frames, potentially revealing HOME or configured allowed roots. Watch and workspace result frames now serialize a fixed policy message; local diagnostics keep the detailed refusal. Tests verify HOME and allowed roots are absent from both frame types.

<sup>Written for commit 604ddcc5c23ec09a92099303d992d2eed978f352. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

