### PR TITLE
fix(relay): sanitize untrusted diagnostic output

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/display.rs
+++ b/cmux-tui/crates/chatmux-relay/src/display.rs
@@ -9,7 +9,7 @@ pub(crate) const DIAGNOSTIC_FIELD_MAX_BYTES: usize = 256;
 /// by UTF-8 bytes and ends with an ellipsis when text was omitted. Protocol
 /// validation stays at the wire boundary; this function changes display only.
 pub(crate) fn terminal_text(value: &str) -> String {
-    value.to_owned()
+    terminal_text_with_limit(value, DIAGNOSTIC_FIELD_MAX_BYTES)
 }
 
 fn terminal_text_with_limit(value: &str, max_bytes: usize) -> String {
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn terminal_text_is_byte_bounded_without_splitting_unicode() {
         assert_eq!(terminal_text_with_limit("éééé", 7), "éé…");
-        assert_eq!(terminal_text_with_limit("\x1bAAAA", 8), "\\u{1B}…");
+        assert_eq!(terminal_text_with_limit("\x1bAAAA", 9), "\\u{1B}…");
         assert!(terminal_text(&"界".repeat(200)).len() <= DIAGNOSTIC_FIELD_MAX_BYTES);
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/display.rs
+++ b/cmux-tui/crates/chatmux-relay/src/display.rs
@@ -45,7 +45,10 @@ fn escape_character(character: char) -> String {
         '\r' => "\\r".to_owned(),
         '\t' => "\\t".to_owned(),
         '\u{2028}' | '\u{2029}' => unicode_escape(character),
-        '\u{061c}' | '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}'
+        '\u{061c}'
+        | '\u{200e}'
+        | '\u{200f}'
+        | '\u{202a}'..='\u{202e}'
         | '\u{2066}'..='\u{2069}' => unicode_escape(character),
         character if character.is_control() => unicode_escape(character),
         character => character.to_string(),

--- a/cmux-tui/crates/chatmux-relay/src/display.rs
+++ b/cmux-tui/crates/chatmux-relay/src/display.rs
@@ -1,0 +1,89 @@
+use std::fmt::Write;
+
+/// Maximum UTF-8 byte length of one untrusted field in terminal diagnostics.
+pub(crate) const DIAGNOSTIC_FIELD_MAX_BYTES: usize = 256;
+
+/// Make an untrusted protocol field safe for one terminal output line.
+///
+/// Control characters are rendered as visible escapes. The result is bounded
+/// by UTF-8 bytes and ends with an ellipsis when text was omitted. Protocol
+/// validation stays at the wire boundary; this function changes display only.
+pub(crate) fn terminal_text(value: &str) -> String {
+    value.to_owned()
+}
+
+fn terminal_text_with_limit(value: &str, max_bytes: usize) -> String {
+    let mut output = String::with_capacity(value.len().min(max_bytes));
+    let mut truncated = false;
+
+    for character in value.chars() {
+        let escaped = escape_character(character);
+        if output.len() + escaped.len() > max_bytes {
+            truncated = true;
+            break;
+        }
+        output.push_str(&escaped);
+    }
+
+    if truncated {
+        const ELLIPSIS: &str = "…";
+        while output.len() + ELLIPSIS.len() > max_bytes {
+            let Some((index, _)) = output.char_indices().next_back() else { break };
+            output.truncate(index);
+        }
+        if ELLIPSIS.len() <= max_bytes {
+            output.push_str(ELLIPSIS);
+        }
+    }
+
+    output
+}
+
+fn escape_character(character: char) -> String {
+    match character {
+        '\n' => "\\n".to_owned(),
+        '\r' => "\\r".to_owned(),
+        '\t' => "\\t".to_owned(),
+        '\u{2028}' | '\u{2029}' => unicode_escape(character),
+        '\u{061c}' | '\u{200e}' | '\u{200f}' | '\u{202a}'..='\u{202e}'
+        | '\u{2066}'..='\u{2069}' => unicode_escape(character),
+        character if character.is_control() => unicode_escape(character),
+        character => character.to_string(),
+    }
+}
+
+fn unicode_escape(character: char) -> String {
+    let mut escaped = String::new();
+    write!(&mut escaped, "\\u{{{:X}}}", character as u32).expect("write to String");
+    escaped
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn terminal_text_escapes_terminal_controls_and_preserves_unicode() {
+        let input = "safe 日本語 🐈\x1b]0;owned\x07\rforged\nline\u{009b}31m";
+
+        assert_eq!(
+            terminal_text(input),
+            "safe 日本語 🐈\\u{1B}]0;owned\\u{7}\\rforged\\nline\\u{9B}31m"
+        );
+    }
+
+    #[test]
+    fn terminal_text_escapes_visual_line_and_direction_controls() {
+        assert_eq!(
+            terminal_text("left\u{2028}right\u{202e}hidden"),
+            "left\\u{2028}right\\u{202E}hidden"
+        );
+    }
+
+    #[test]
+    fn terminal_text_is_byte_bounded_without_splitting_unicode() {
+        assert_eq!(terminal_text_with_limit("éééé", 7), "éé…");
+        assert_eq!(terminal_text_with_limit("\x1bAAAA", 8), "\\u{1B}…");
+        assert!(terminal_text(&"界".repeat(200)).len() <= DIAGNOSTIC_FIELD_MAX_BYTES);
+    }
+}

--- a/cmux-tui/crates/chatmux-relay/src/display.rs
+++ b/cmux-tui/crates/chatmux-relay/src/display.rs
@@ -14,6 +14,7 @@ pub(crate) fn terminal_text(value: &str) -> String {
 
 fn terminal_text_with_limit(value: &str, max_bytes: usize) -> String {
     let mut output = String::with_capacity(value.len().min(max_bytes));
+    let mut units = Vec::new();
     let mut truncated = false;
 
     for character in value.chars() {
@@ -23,13 +24,14 @@ fn terminal_text_with_limit(value: &str, max_bytes: usize) -> String {
             break;
         }
         output.push_str(&escaped);
+        units.push(escaped);
     }
 
     if truncated {
         const ELLIPSIS: &str = "…";
         while output.len() + ELLIPSIS.len() > max_bytes {
-            let Some((index, _)) = output.char_indices().next_back() else { break };
-            output.truncate(index);
+            let Some(unit) = units.pop() else { break };
+            output.truncate(output.len() - unit.len());
         }
         if ELLIPSIS.len() <= max_bytes {
             output.push_str(ELLIPSIS);
@@ -87,6 +89,7 @@ mod tests {
     fn terminal_text_is_byte_bounded_without_splitting_unicode() {
         assert_eq!(terminal_text_with_limit("éééé", 7), "éé…");
         assert_eq!(terminal_text_with_limit("\x1bAAAA", 9), "\\u{1B}…");
+        assert_eq!(terminal_text_with_limit("AAAA\x1b", 8), "AAAA…");
         assert!(terminal_text(&"界".repeat(200)).len() <= DIAGNOSTIC_FIELD_MAX_BYTES);
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/lib.rs
+++ b/cmux-tui/crates/chatmux-relay/src/lib.rs
@@ -9,6 +9,7 @@ pub mod autostart;
 pub mod cli;
 pub mod config;
 pub mod control;
+mod display;
 pub mod enrollment;
 pub mod error;
 pub mod fingerprint;

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1113,9 +1113,7 @@ async fn relay_session(
                                 let code =
                                     result.get("code").and_then(Value::as_str).unwrap_or("failed");
                                 let shown_code = terminal_text(code);
-                                println!(
-                                    "Refused {shown_verb} ({shown_code}) for {shown_actor}."
-                                );
+                                println!("Refused {shown_verb} ({shown_code}) for {shown_actor}.");
                             }
                             let size = serde_json::to_string(&result)
                                 .map(|text| text.len() as u64)

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -36,6 +36,7 @@ use crate::actions::{
     ActionContext, MAX_BLOCKING_FILE_ACTIONS, perform_action, process_env_snapshot, scrubbed_env,
 };
 use crate::config::{Config, save_config};
+use crate::display::terminal_text;
 use crate::error::RelayError;
 use crate::pairing::websocket_url;
 use crate::pty::FrameContext;
@@ -918,9 +919,12 @@ async fn relay_session(
                         } else {
                             local_trust.as_str().to_owned()
                         };
+                        let display_name = terminal_text(&display_name);
+                        let shown_trust = terminal_text(&shown_trust);
+                        let shown_scope = terminal_text(&hello.scope);
                         println!(
-                            "Connected as {display_name} (protocol v{}, trust {shown_trust}, scope {}).",
-                            hello.relay_protocol_version, hello.scope,
+                            "Connected as {display_name} (protocol v{}, trust {shown_trust}, scope {shown_scope}).",
+                            hello.relay_protocol_version,
                         );
                         if state.first_connect {
                             state.first_connect = false;
@@ -980,9 +984,10 @@ async fn relay_session(
                     }
                     ServerFrame::UpgradeRequired { min_version, message } => {
                         let advertised = advertised_protocol();
+                        let message = terminal_text(&message);
                         break Err(RelayError::fatal(format!(
                             "This cmux-relay speaks relay protocol v{advertised}, but the server \
-                             requires v{min_version} or newer.\n{message}\n\nUpgrade:\n  npx \
+                             requires v{min_version} or newer. Server message: {message}\n\nUpgrade:\n  npx \
                              cmux-relay@latest        # npx fetches the latest release each run\n  \
                              npm i -g cmux-relay@latest   # if you installed it globally"
                         )));
@@ -1096,15 +1101,21 @@ async fn relay_session(
                                 result = perform_action(&raw, &action) => result,
                             };
                             let ok = result.get("ok").and_then(Value::as_bool).unwrap_or(false);
+                            let shown_verb = terminal_text(&verb);
+                            let shown_actor = terminal_text(&actor);
                             if ok {
+                                let shown_action = terminal_text(&action_id);
                                 println!(
-                                    "Ran {verb} for {actor} (action {}).",
-                                    action_id.chars().take(8).collect::<String>()
+                                    "Ran {shown_verb} for {shown_actor} (action {}).",
+                                    shown_action.chars().take(8).collect::<String>()
                                 );
                             } else {
                                 let code =
                                     result.get("code").and_then(Value::as_str).unwrap_or("failed");
-                                println!("Refused {verb} ({code}) for {actor}.");
+                                let shown_code = terminal_text(code);
+                                println!(
+                                    "Refused {shown_verb} ({shown_code}) for {shown_actor}."
+                                );
                             }
                             let size = serde_json::to_string(&result)
                                 .map(|text| text.len() as u64)
@@ -1131,7 +1142,11 @@ async fn relay_session(
                             let session = raw.get("session").and_then(Value::as_str).unwrap_or("?");
                             let actor =
                                 raw.get("actorId").and_then(Value::as_str).unwrap_or("chatmux");
-                            println!("Terminal attach to session \"{session}\" for {actor}.");
+                            let shown_session = terminal_text(session);
+                            let shown_actor = terminal_text(actor);
+                            println!(
+                                "Terminal attach to session \"{shown_session}\" for {shown_actor}."
+                            );
                         }
                         #[cfg(unix)]
                         {
@@ -1228,8 +1243,11 @@ async fn relay_session(
                                  cmux-relay --pair"
                             )));
                         }
-                        let suffix = message.map(|text| format!(" — {text}")).unwrap_or_default();
-                        eprintln!("Server error: {code}{suffix}");
+                        let shown_code = terminal_text(&code);
+                        let suffix = message
+                            .map(|text| format!(" — {}", terminal_text(&text)))
+                            .unwrap_or_default();
+                        eprintln!("Server error: {shown_code}{suffix}");
                     }
                     ServerFrame::Unknown { frame_type } => {
                         if unknown_types.insert(frame_type.clone()) {
@@ -1239,8 +1257,9 @@ async fn relay_session(
                             {
                                 unknown_types.remove(&evicted);
                             }
+                            let shown_type = terminal_text(&frame_type);
                             eprintln!(
-                                "Ignoring unknown server frame type \"{frame_type}\" (a newer server?)."
+                                "Ignoring unknown server frame type \"{shown_type}\" (a newer server?)."
                             );
                         }
                     }


### PR DESCRIPTION
Relay server fields were interpolated directly into terminal diagnostics, allowing ANSI/OSC and line injection.

Add one display-boundary sanitizer that escapes C0/C1 controls, line separators, and bidi controls, preserves Unicode, and bounds each field to 256 UTF-8 bytes. Apply it to hello, upgrade, action, PTY, error, and unknown-frame diagnostics. Protocol parsing and validation remain unchanged.

Tests cover ESC, BEL, CR, LF, C1, valid Unicode, bidi/line separators, and truncation.

Commits intentionally separate regression tests from the fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes untrusted relay fields before terminal diagnostics, replacing raw output that could inject ANSI/OSC, control characters, lines, or bidi text with escaped display text. Diagnostics preserve Unicode and cap each sanitized field at 256 UTF-8 bytes, truncating with an ellipsis without splitting an escape sequence.

- Covers hello, upgrade, action, PTY, error, and unknown-frame diagnostics.
- Leaves protocol parsing and validation unchanged.
- Tests cover terminal controls, Unicode, bidi and line separators, and byte-bounded truncation.

<sup>Written for commit 2dddb443506a1b7644cf3961763718e02f717ebb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved terminal output safety by preventing untrusted messages and identifiers from injecting control sequences.
  - Special characters now appear as visible escaped text instead of altering terminal behavior.
  - Long diagnostic messages are limited in length and truncated safely without splitting characters.
  - Unknown or malformed server responses are displayed safely for clearer, more reliable troubleshooting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->