### PR TITLE
fix(cloud): resolve forward-auth publications by TLS rule id, not x-forwarded-host

### DIFF
--- a/web/app/api/freestyle/forward-auth/route.ts
+++ b/web/app/api/freestyle/forward-auth/route.ts
@@ -7,9 +7,11 @@ import {
   isRedirectableMethod,
   PUBLICATION_SESSION_TTL_MS,
   PUBLICATION_TRANSACTION_TTL_MS,
+  resolvePublicationForRequest,
   runPublicationAuth,
   type PublicationRequestEvaluation,
 } from "../../../../services/vm-publications/auth";
+import type { CloudVmPublicationTarget } from "../../../../services/vm-publications/repository";
 import {
   PUBLICATION_CALLBACK_PATH,
   PUBLICATION_SESSION_COOKIE,
@@ -19,7 +21,6 @@ import {
   parsePublicationTransactionCookie,
   publicationCookie,
   publicationCookieHeader,
-  publicationHostnameFromHeader,
   publicationSecretMatches,
   safePublicationReturnPath,
 } from "../../../../services/vm-publications/security";
@@ -30,6 +31,9 @@ const MAX_FORWARDED_URI_BYTES = 2_048;
 export type ForwardAuthHandlerDependencies = {
   readonly serviceSecret: string | undefined;
   readonly authPageOrigin: string | undefined;
+  /** The publication behind the edge's TLS rule id; the callback exchange is bound to its hostname. */
+  readonly resolve: (input: Parameters<typeof resolvePublicationForRequest>[0]) =>
+    Promise<CloudVmPublicationTarget | null>;
   readonly evaluate: (input: Parameters<typeof evaluatePublicationRequest>[0]) =>
     Promise<PublicationRequestEvaluation>;
   /** Runs only when a sign-in transaction is about to be minted; a Response short-circuits. */
@@ -54,6 +58,7 @@ const liveDependencies: ForwardAuthHandlerDependencies = {
   serviceSecret: env.CMUX_VM_PUBLICATION_FORWARD_AUTH_SECRET,
   authPageOrigin: normalizePublicationAuthOrigin(env.CMUX_VM_PUBLICATION_AUTH_ORIGIN) ??
     undefined,
+  resolve: (input) => runPublicationAuth(resolvePublicationForRequest(input)),
   evaluate: (input) => runPublicationAuth(evaluatePublicationRequest(input)),
   rateLimit: (input) => enforcePublicationSignInRateLimit({
     ...input,
@@ -90,6 +95,11 @@ export async function enforcePublicationSignInRateLimit(input: {
  * Freestyle's shared forward-auth target. It never authenticates from caller-
  * supplied forwarding headers: the write-only service credential is required
  * before any publication lookup or auth artifact is touched.
+ *
+ * The publication is identified by `x-freestyle-tls-rule-id` alone. Vercel
+ * replaces `x-forwarded-host` with the function's own host (cmux.com) before
+ * the route runs, so the value Freestyle sends never arrives; every hostname
+ * this route acts on is read from the resolved publication row instead.
  */
 export async function GET(request: Request): Promise<Response> {
   return handleForwardAuthRequest(request, liveDependencies);
@@ -118,9 +128,6 @@ export async function handleForwardAuthRequest(
     return response(null, 503);
   }
 
-  const hostname = publicationHostnameFromHeader(
-    request.headers.get("x-forwarded-host"),
-  );
   const providerTlsRuleId = request.headers
     .get("x-freestyle-tls-rule-id")
     ?.trim() ?? "";
@@ -129,7 +136,6 @@ export async function handleForwardAuthRequest(
     request.headers.get("x-forwarded-uri"),
   );
   if (
-    !hostname ||
     !TLS_RULE_ID_PATTERN.test(providerTlsRuleId) ||
     !method ||
     !forwardedUri
@@ -140,15 +146,16 @@ export async function handleForwardAuthRequest(
   try {
     if (forwardedUri.pathname === PUBLICATION_CALLBACK_PATH) {
       if (!isRedirectableMethod(method)) return response(null, 400);
+      const target = await dependencies.resolve({ providerTlsRuleId });
+      if (!target) return response(null, 404);
       return await callbackResponse(request, {
-        hostname,
+        hostname: target.publication.hostname,
         code: forwardedUri.searchParams.get("code") ?? "",
         state: forwardedUri.searchParams.get("state") ?? "",
       }, dependencies);
     }
 
     const evaluation = await dependencies.evaluate({
-      hostname,
       providerTlsRuleId,
       method,
       sessionToken: publicationCookie(
@@ -163,7 +170,10 @@ export async function handleForwardAuthRequest(
 
     // Minting a transaction is the one write an anonymous request can cause;
     // gate it before touching the database.
-    const limited = await dependencies.rateLimit?.({ request, hostname });
+    const limited = await dependencies.rateLimit?.({
+      request,
+      hostname: evaluation.target.publication.hostname,
+    });
     if (limited) return limited;
     const decision = await dependencies.begin({
       target: evaluation.target,

--- a/web/services/vm-publications/auth.ts
+++ b/web/services/vm-publications/auth.ts
@@ -142,7 +142,6 @@ export type PublicationRequestEvaluation =
  * limit it: every unauthenticated navigation would otherwise cost a write.
  */
 export function evaluatePublicationRequest(input: {
-  readonly hostname: string;
   readonly providerTlsRuleId: string;
   readonly method: string;
   readonly sessionToken: string | null;
@@ -151,10 +150,7 @@ export function evaluatePublicationRequest(input: {
   return Effect.gen(function* () {
     const repository = yield* CloudVmPublicationRepository;
     const viewerResolver = yield* PublicationViewerResolver;
-    const target = yield* repository.findActivePublicationForRequest({
-      hostname: input.hostname,
-      providerTlsRuleId: input.providerTlsRuleId,
-    });
+    const target = yield* resolvePublicationForRequest(input);
     if (!target) return { kind: "not_found" } as const satisfies PublicationRequestEvaluation;
 
     if (target.publication.accessMode === "public") {
@@ -167,7 +163,7 @@ export function evaluatePublicationRequest(input: {
       const principal = yield* repository.findValidSession({
         tokenHash: hashPublicationToken(input.sessionToken),
         publicationId: target.publication.id,
-        hostname: input.hostname,
+        hostname: target.publication.hostname,
         now: input.now ?? new Date(),
       });
       if (principal) {
@@ -194,9 +190,25 @@ export function evaluatePublicationRequest(input: {
   });
 }
 
+/**
+ * The publication a Freestyle forward-auth call is about, or null when no
+ * active, reachable publication owns that TLS rule. Both the policy check and
+ * the callback exchange start here so every hostname the route acts on comes
+ * from the publication row, never from a forwarding header.
+ */
+export function resolvePublicationForRequest(input: {
+  readonly providerTlsRuleId: string;
+}) {
+  return Effect.gen(function* () {
+    const repository = yield* CloudVmPublicationRepository;
+    return yield* repository.findActivePublicationForRequest({
+      providerTlsRuleId: input.providerTlsRuleId,
+    });
+  });
+}
+
 /** Evaluate and, when sign-in is required, mint the transaction in one step. */
 export function authorizePublicationRequest(input: {
-  readonly hostname: string;
   readonly providerTlsRuleId: string;
   readonly method: string;
   readonly returnPath: string;

--- a/web/services/vm-publications/repository.ts
+++ b/web/services/vm-publications/repository.ts
@@ -373,8 +373,14 @@ export type CloudVmPublicationRepositoryShape = {
     readonly CloudVmPublicationAccountDeletionTarget[],
     PublicationDatabaseError
   >;
+  /**
+   * Resolve the publication behind a Freestyle forward-auth call from the TLS
+   * rule id alone. The rule id is the one edge-controlled identifier that
+   * survives the hop into Vercel: the platform overwrites `x-forwarded-host`
+   * with the function's own host before the route runs, so the hostname is
+   * read back from the row instead of the request.
+   */
   readonly findActivePublicationForRequest: (input: {
-    readonly hostname: string;
     readonly providerTlsRuleId: string;
   }) => Effect.Effect<
     CloudVmPublicationTarget | null,
@@ -1873,10 +1879,6 @@ export const CloudVmPublicationRepositoryLive = Layer.succeed(
           .innerJoin(cloudVms, eq(cloudVmPublications.vmId, cloudVms.id))
           .where(
             and(
-              eq(
-                cloudVmPublications.hostname,
-                normalizedHostname(input.hostname),
-              ),
               eq(
                 cloudVmPublications.providerTlsRuleId,
                 input.providerTlsRuleId,

--- a/web/tests/vm-publication-auth.test.ts
+++ b/web/tests/vm-publication-auth.test.ts
@@ -48,7 +48,6 @@ describe("Cloud VM publication auth exchange", () => {
 
     const authorize = (method: string) => run(
       authorizePublicationRequest({
-        hostname: publication.hostname,
         providerTlsRuleId: "tls-rule-1",
         method,
         returnPath: "/editor?file=one",
@@ -99,7 +98,6 @@ describe("Cloud VM publication auth exchange", () => {
     });
     const evaluation = await run(
       evaluatePublicationRequest({
-        hostname: publication.hostname,
         providerTlsRuleId: "tls-rule-1",
         method: "GET",
         sessionToken: null,
@@ -127,7 +125,6 @@ describe("Cloud VM publication auth exchange", () => {
     });
     const allowed = await run(
       authorizePublicationRequest({
-        hostname: publication.hostname,
         providerTlsRuleId: "tls-rule-1",
         method: "GET",
         returnPath: "/",
@@ -160,7 +157,6 @@ describe("Cloud VM publication auth exchange", () => {
     });
     const revoked = await run(
       authorizePublicationRequest({
-        hostname: publication.hostname,
         providerTlsRuleId: "tls-rule-1",
         method: "GET",
         returnPath: "/",

--- a/web/tests/vm-publication-forward-auth-route.test.ts
+++ b/web/tests/vm-publication-forward-auth-route.test.ts
@@ -16,6 +16,8 @@ const serviceSecret = "publication-forward-auth-test-secret";
 const target = {
   publication: { id: "publication-1", hostname: "preview.example.com" },
 } as unknown as Parameters<ForwardAuthHandlerDependencies["begin"]>[0]["target"];
+// What Vercel actually hands the function: its own host, not the publication's.
+const vercelForwardedHost = "cmux.com";
 
 function request(
   overrides: Record<string, string> = {},
@@ -24,7 +26,7 @@ function request(
     headers: {
       authorization: `Bearer ${serviceSecret}`,
       "x-forwarded-proto": "https",
-      "x-forwarded-host": "preview.example.com",
+      "x-forwarded-host": vercelForwardedHost,
       "x-forwarded-method": "GET",
       "x-forwarded-uri": "/editor?file=readme",
       "x-freestyle-tls-rule-id": "tls-rule-1",
@@ -39,6 +41,7 @@ function dependencies(
   return {
     serviceSecret,
     authPageOrigin: "https://cmux.com",
+    resolve: async () => target,
     evaluate: async () => ({ kind: "allow" }),
     begin: async () => {
       throw new Error("unexpected transaction");
@@ -69,8 +72,8 @@ describe("Freestyle publication forward-auth HTTP contract", () => {
   test("requires complete trusted HTTPS request metadata", async () => {
     const malformedHeaders: readonly Record<string, string>[] = [
       { "x-forwarded-proto": "http" },
-      { "x-forwarded-host": "localhost" },
       { "x-freestyle-tls-rule-id": "rule/id" },
+      { "x-freestyle-tls-rule-id": "" },
       { "x-forwarded-uri": "https://attacker.example/" },
     ];
     for (const headers of malformedHeaders) {
@@ -100,11 +103,40 @@ describe("Freestyle publication forward-auth HTTP contract", () => {
 
     expect(result.status).toBe(204);
     expect(captured).toEqual({
-      hostname: "preview.example.com",
       providerTlsRuleId: "tls-rule-1",
       method: "HEAD",
       sessionToken: session,
     });
+  });
+
+  test("identifies the publication by TLS rule id, never by x-forwarded-host", async () => {
+    // Vercel overwrites x-forwarded-host with the function's own host before the
+    // route runs, so a hostname-keyed lookup 404s every protected publication.
+    // The route must not read that header at all: any value, or none, is fine.
+    for (const forwardedHost of [vercelForwardedHost, "!!!not a host!!!", undefined]) {
+      const headers: Record<string, string> = forwardedHost === undefined
+        ? {}
+        : { "x-forwarded-host": forwardedHost };
+      const req = request(headers);
+      if (forwardedHost === undefined) req.headers.delete("x-forwarded-host");
+      const limited: string[] = [];
+      const result = await handleForwardAuthRequest(
+        req,
+        dependencies({
+          evaluate: async () => ({ kind: "sign_in_required", target }),
+          rateLimit: async ({ hostname }) => {
+            limited.push(hostname);
+            return null;
+          },
+          begin: async () => ({
+            location: "https://cmux.com/cloud/access?transaction=one&state=two",
+            transactionCookie: "",
+          }),
+        }),
+      );
+      expect(result.status).toBe(302);
+      expect(limited).toEqual(["preview.example.com"]);
+    }
   });
 
   test("relays a cross-origin authorization redirect with a protected transaction cookie", async () => {
@@ -314,6 +346,7 @@ describe("Freestyle publication forward-auth HTTP contract", () => {
 
     expect(result.status).toBe(302);
     expect(result.headers.get("location")).toBe("/editor");
+    // Bound to the resolved publication's hostname, not to x-forwarded-host.
     expect(captured).toEqual({
       hostname: "preview.example.com",
       code,
@@ -326,6 +359,29 @@ describe("Freestyle publication forward-auth HTTP contract", () => {
     expect(cookies[0]).toContain(`${PUBLICATION_SESSION_COOKIE}=${session}`);
     expect(cookies[1]).toContain(`${PUBLICATION_TRANSACTION_COOKIE}=;`);
     expect(cookies[1]).toContain("Max-Age=0");
+  });
+
+  test("refuses the callback when no active publication owns the TLS rule", async () => {
+    let completed = false;
+    const result = await handleForwardAuthRequest(
+      request({
+        cookie: `${PUBLICATION_TRANSACTION_COOKIE}=${publicationTransactionCookieValue(
+          randomPublicationToken(),
+          randomPublicationToken(),
+        )}`,
+        "x-forwarded-uri": "/_cmux/auth/callback?code=abc&state=def",
+      }),
+      dependencies({
+        resolve: async () => null,
+        complete: async () => {
+          completed = true;
+          return { kind: "invalid" };
+        },
+      }),
+    );
+
+    expect(result.status).toBe(404);
+    expect(completed).toBe(false);
   });
 
   test("fails closed when policy infrastructure fails", async () => {

--- a/web/tests/vm-publications-db-behavior.test.ts
+++ b/web/tests/vm-publications-db-behavior.test.ts
@@ -294,7 +294,6 @@ describe("Cloud VM publication persistence", () => {
 
       const resolved = await runRepository(
         repo.findActivePublicationForRequest({
-          hostname: "OWNERSHIP.PREVIEW.EXAMPLE.TEST",
           providerTlsRuleId: "tls-rule-ownership",
         }),
       );
@@ -302,7 +301,6 @@ describe("Cloud VM publication persistence", () => {
       expect(
         await runRepository(
           repo.findActivePublicationForRequest({
-            hostname: target.publication.hostname,
             providerTlsRuleId: "tls-rule-not-this-publication",
           }),
         ),


### PR DESCRIPTION
Every protected Cloud VM publication returns 404 from `/api/freestyle/forward-auth` in production while public ones work.

**Cause.** Freestyle's edge sends the publication hostname in `x-forwarded-host`, but Vercel overwrites that header with the function's own host (`cmux.com`) before the route runs. `findActivePublicationForRequest` then queried `hostname = 'cmux.com'` and matched nothing. Locally there is no proxy, so a byte-exact replay of the prod row returns the expected 302.

**Evidence (prod).** The exact join query returns the `authtest.cmux.swerdlow.dev` row via psql on the same Aurora endpoint and IAM role the app uses. A forward-auth request with a valid bearer and rule id but no `x-forwarded-host` returns 404 rather than the 400 the parser gives for a missing host; an unparseable `x-forwarded-host` also returns 404. Both prove the header is replaced with a valid host that is not the publication's.

**Fix.** The route identifies the publication by `x-freestyle-tls-rule-id` alone (`cloud_vm_publications_provider_rule_unique` makes it unique) and reads every hostname it acts on from the resolved publication row: session lookup, transaction binding, callback exchange, and the sign-in rate-limit key. The callback path resolves the same way and 404s when no active publication owns the rule. `x-forwarded-host` is no longer read.

Principled: the rule id is the one edge-controlled identifier that survives the Vercel hop, and the hostname is now sourced from our own row instead of a header the platform rewrites.

Tests: `bun test tests/vm-publication-forward-auth-route.test.ts tests/vm-publication-auth.test.ts tests/vm-publication-security.test.ts` (25 pass). New route tests cover Vercel's own host, an unparseable host, and a missing header all resolving via the rule id, plus a 404 callback when no publication owns the rule.

Reported by Ben with live repro on `authtest.cmux.swerdlow.dev` and `musical-beige-quokka.cmux.sh`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes protected Cloud VM publications returning 404 from `/api/freestyle/forward-auth` in production. The route previously identified the publication by `x-forwarded-host`, but Vercel replaces that header with the function's own host before the route runs; it now resolves by `x-freestyle-tls-rule-id` alone and sources the hostname from the publication row.

**Bug Fixes**
- The callback exchange now resolves the same way and returns 404 when no active publication owns the TLS rule.
- Removed the hostname parameter from `findActivePublicationForRequest`, `evaluatePublicationRequest`, and `authorizePublicationRequest`; session lookup and the rate-limit key use the resolved publication's hostname.
- Added route tests covering Vercel's own host, an unparseable host, and a missing header, all resolving via the rule id.

<sup>Written for commit cba1204a087ee7aae6f42e12ee5f59895a188bd7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

