### PR TITLE
chore(cmux-tui): apply rustfmt drift fixes

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/surface.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/surface.rs
@@ -5472,18 +5472,20 @@ impl Surface {
         } else {
             platform::local_terminal_pwd_to_local_path
         };
-        let terminal_cwd = if hosted { None } else {
+        let terminal_cwd = if hosted {
+            None
+        } else {
             self.pwd()
                 .as_deref()
                 .and_then(terminal_pwd_to_local_path)
                 .map(|path| path.to_string_lossy().into_owned())
         };
         terminal_cwd.or_else(|| {
-                self.spawn_cwd()
-                    .as_deref()
-                    .and_then(platform::spawn_cwd_to_local_path)
-                    .map(|path| path.to_string_lossy().into_owned())
-            })
+            self.spawn_cwd()
+                .as_deref()
+                .and_then(platform::spawn_cwd_to_local_path)
+                .map(|path| path.to_string_lossy().into_owned())
+        })
     }
 
     #[cfg(test)]

--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -5470,7 +5470,12 @@ mod unix {
                     colors: colors.clone(),
                     pid: host.pid,
                     command: host.command.clone(),
-                    cwd: snapshot_cwd(&term, host.cwd.as_deref(), &host.owner_token, selected_version),
+                    cwd: snapshot_cwd(
+                        &term,
+                        host.cwd.as_deref(),
+                        &host.owner_token,
+                        selected_version,
+                    ),
                 },
                 colors,
                 snapshot_sequence,
@@ -9273,14 +9278,26 @@ mod unix {
                 crate::platform::SNAPSHOT_SPAWN_CWD_PREFIX,
                 encode_hex(owner_token.as_bytes())
             );
-            assert_eq!(snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION), Some(marker.clone()));
+            assert_eq!(
+                snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION),
+                Some(marker.clone())
+            );
 
             term.vt_write(b"\x1b]7;file:///live\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION), Some(marker.clone()));
+            assert_eq!(
+                snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION),
+                Some(marker.clone())
+            );
 
             term.vt_write(b"\x1b]7;\x1b\\");
-            assert_eq!(snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION), Some(marker));
-            assert_eq!(snapshot_cwd(&term, Some("file:///spawn"), &owner_token, PROTOCOL_VERSION), None);
+            assert_eq!(
+                snapshot_cwd(&term, Some("/spawn"), &owner_token, PROTOCOL_VERSION),
+                Some(marker)
+            );
+            assert_eq!(
+                snapshot_cwd(&term, Some("file:///spawn"), &owner_token, PROTOCOL_VERSION),
+                None
+            );
         }
 
         #[test]


### PR DESCRIPTION
Apply the existing rustfmt output to the two files reported by cargo fmt --check on main.

Changed only:
- cmux-tui/crates/cmux-tui-core/src/surface.rs
- cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs

Validation on a dedicated Blacksmith Testbox:
- cargo fmt --all -- --check
- cargo check -p cmux-tui-core --locked
- cargo test -p cmux-tui-core --locked (1210 passed, 11 pre-existing failures, 5 ignored)

The test failures are unrelated existing failures in mux, platform, resource_api, and workspace_registry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies rustfmt formatting to `surface.rs` and `terminal_host_runtime.rs` in `cmux-tui-core` so `cargo fmt --check` passes on main. No behavior changes.

- `cargo fmt --all -- --check` and `cargo check -p cmux-tui-core --locked` pass.
- `cargo test -p cmux-tui-core --locked` passes with 11 pre-existing failures unrelated to this change.

<sup>Written for commit 753f02046c97021974caf55fe2085948a5d902f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

