### PR TITLE
chore(cmux-tui): apply chatmux relay rustfmt drift

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/watch.rs
+++ b/cmux-tui/crates/chatmux-relay/src/watch.rs
@@ -1413,10 +1413,7 @@ mod tests {
         let refusal = next_frame(&mut critical, &mut watch, "refusal").await;
         assert_eq!(refusal["type"], "fs_watch_error");
         assert_eq!(refusal["code"], "path_forbidden");
-        assert_eq!(
-            refusal["message"],
-            "path is forbidden by the workspace policy"
-        );
+        assert_eq!(refusal["message"], "path is forbidden by the workspace policy");
         assert!(
             !refusal.to_string().contains(&root.to_string_lossy().to_string()),
             "watch refusal must not disclose the local workspace path"

--- a/cmux-tui/crates/chatmux-relay/src/workspace.rs
+++ b/cmux-tui/crates/chatmux-relay/src/workspace.rs
@@ -3587,7 +3587,9 @@ mod tests {
         let frame = error_frame("req-path", &refusal);
         assert!(!frame.contains(&home));
         assert!(!frame.contains(&allowed));
-        assert_eq!(serde_json::from_str::<Value>(&frame).unwrap()["message"],
-            "path is forbidden by the workspace policy");
+        assert_eq!(
+            serde_json::from_str::<Value>(&frame).unwrap()["message"],
+            "path is forbidden by the workspace policy"
+        );
     }
 }


### PR DESCRIPTION
Applies only rustfmt output to the two remaining baseline files reported by the exact #11794 run:

- cmux-tui/crates/chatmux-relay/src/watch.rs
- cmux-tui/crates/chatmux-relay/src/workspace.rs

Verification on dedicated Blacksmith Testbox:
- cargo fmt --all -- --check
- cargo check -p chatmux-relay --locked
- umask 022 cargo test -p chatmux-relay --locked (234 unit tests and 2 doc tests passed)

No behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11833"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791022406&installation_model_id=21920&pr_number=11833&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11833&signature=602126c72abfdc3f9219eb7ed43fb3facb181a52eeae9a61780e793c6d7aff0b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies rustfmt output to the two remaining `chatmux-relay` files so `cargo fmt --check` passes without changing behavior.

- Formats only test assertions in `watch.rs` and `workspace.rs`.
- Verified with `cargo fmt --all -- --check`, `cargo check -p chatmux-relay --locked`, and `cargo test -p chatmux-relay --locked`.

<sup>Written for commit 422c6082041ac77216dd0e8345df5ad130fd87f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted test assertions for improved code readability.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->