### PR TITLE
perf(tui): avoid duplicate response envelope checks

### DIFF
--- a/cmux-tui/bindings/typescript/src/resource-protocol.ts
+++ b/cmux-tui/bindings/typescript/src/resource-protocol.ts
@@ -1396,12 +1396,9 @@ type DecodedResponse =
   | { readonly ok: false; readonly error: ResourceError };
 
 function decodeResponseEnvelope(value: Record<string, unknown>): DecodedResponse {
-  if (
-    value.protocol !== PROTOCOL
-    || value.type !== "response"
-    || typeof value.id !== "string"
-    || typeof value.ok !== "boolean"
-  ) {
+  // receive() validates the shared envelope, response type, and request ID
+  // before calling this response-specific decoder.
+  if (typeof value.ok !== "boolean") {
     throw new CmuxProtocolError("invalid response envelope");
   }
   if (value.ok) {

--- a/cmux-tui/bindings/typescript/test/resource-api.test.ts
+++ b/cmux-tui/bindings/typescript/test/resource-api.test.ts
@@ -247,6 +247,95 @@ async function waitForOperation(
   }
 }
 
+test("response envelopes reject malformed protocol, type, id, ok, result, and error fields", async () => {
+  const cases = [
+    {
+      name: "protocol",
+      envelope: (request: Envelope) => ({
+        protocol: "cmux.protocol/1",
+        type: "response",
+        id: request.id,
+        ok: true,
+        result: { alive: true, cursor: null },
+      }),
+      message: /invalid resource envelope/,
+    },
+    {
+      name: "type",
+      envelope: (request: Envelope) => ({
+        protocol: "cmux.protocol/2",
+        type: 2,
+        id: request.id,
+        ok: true,
+        result: { alive: true, cursor: null },
+      }),
+      message: /invalid resource envelope/,
+    },
+    {
+      name: "id",
+      envelope: (_request: Envelope) => ({
+        protocol: "cmux.protocol/2",
+        type: "response",
+        id: 2,
+        ok: true,
+        result: { alive: true, cursor: null },
+      }),
+      message: /response id must be a string/,
+    },
+    {
+      name: "ok",
+      envelope: (request: Envelope) => ({
+        protocol: "cmux.protocol/2",
+        type: "response",
+        id: request.id,
+        ok: "yes",
+        result: { alive: true, cursor: null },
+      }),
+      message: /invalid response envelope/,
+    },
+    {
+      name: "result",
+      envelope: (request: Envelope) => ({
+        protocol: "cmux.protocol/2",
+        type: "response",
+        id: request.id,
+        ok: true,
+      }),
+      message: /successful response is missing field "result"/,
+    },
+    {
+      name: "error",
+      envelope: (request: Envelope) => ({
+        protocol: "cmux.protocol/2",
+        type: "response",
+        id: request.id,
+        ok: false,
+      }),
+      message: /failed response is missing field "error"/,
+    },
+  ] as const;
+
+  for (const fixture of cases) {
+    const transport = new FakeTransport((request, current) => {
+      current.emit(fixture.envelope(request));
+    });
+    const protocol = new ResourceProtocol({
+      transport,
+      randomHex128: () => HEX_A,
+    });
+    await assert.rejects(
+      () => protocol.request(operations.sessionPing, {
+        machine: "current",
+        session: SESSION,
+      }),
+      fixture.message,
+      fixture.name,
+    );
+    assert.deepEqual(transport.closeRequestCounts, [1], fixture.name);
+    protocol.close();
+  }
+});
+
 test("journal options reject invalid combinations before transport", () => {
   const transport = new FakeTransport(() => {
     assert.fail("invalid journal options reached the transport");


### PR DESCRIPTION
## Summary
- cover malformed TypeScript resource response envelopes
- remove protocol, type, and id checks duplicated after receive() routing

## Verification
- `npm run check:generated` passes
- `npm run build` is blocked by existing Node type errors in newline-frame-buffer and tests
- hosted TypeScript SDK verification is required

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes duplicate response envelope checks in the TypeScript SDK resource protocol so malformed responses are caught without validating the same fields twice.

- `decodeResponseEnvelope` now only checks the `ok` field; `receive()` already validates protocol, type, and id.
- Adds a test covering malformed protocol, type, id, ok, result, and error fields.

<sup>Written for commit 600750af4cf4b8cc20c325da11c57937fb207aac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of malformed protocol responses, including invalid protocol versions, response types, request IDs, status values, and missing result or error data.
  - Invalid responses are now rejected consistently, with clearer validation behavior and proper transport shutdown.
  - Added coverage for malformed response scenarios to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->