### PR TITLE
ci(cmux-tui): run lint once per verification

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -151,6 +151,62 @@ jobs:
           npm run build
           npm test
 
+  lint:
+    name: lint
+    needs: validate-inputs
+    runs-on: blacksmith-4vcpu-ubuntu-2404
+    timeout-minutes: 40
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Install Linux build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang libclang-dev pkg-config
+
+      - name: Install zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: cargo fmt
+        id: rustfmt-check
+        working-directory: cmux-tui
+        run: cargo fmt --check
+
+      - name: Prepare hosted rustfmt patch
+        if: ${{ failure() && steps.rustfmt-check.outcome == 'failure' }}
+        working-directory: cmux-tui
+        run: |
+          cargo fmt
+          git diff --binary -- . > "$RUNNER_TEMP/rustfmt.patch"
+          test -s "$RUNNER_TEMP/rustfmt.patch"
+
+      - name: Upload hosted rustfmt patch
+        if: ${{ failure() && steps.rustfmt-check.outcome == 'failure' }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rustfmt-${{ github.sha }}
+          path: ${{ runner.temp }}/rustfmt.patch
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: cargo clippy
+        working-directory: cmux-tui
+        run: cargo clippy --workspace --all-targets --locked -- -D warnings
+
   valgrind-leak-check-shard:
     name: valgrind-leak-check (startup)
     needs: validate-inputs
@@ -400,34 +456,6 @@ jobs:
 
       - name: Test isolated TUI test-runner policy
         run: python3 .github/scripts/test_run_cmux_tui_core_tests_isolated.py
-
-      - name: cargo fmt
-        id: rustfmt-check
-        working-directory: cmux-tui
-        run: cargo fmt --check
-
-      - name: Prepare hosted rustfmt patch
-        if: ${{ failure() && steps.rustfmt-check.outcome == 'failure' }}
-        working-directory: cmux-tui
-        run: |
-          cargo fmt
-          git diff --binary -- . > "$RUNNER_TEMP/rustfmt.patch"
-          test -s "$RUNNER_TEMP/rustfmt.patch"
-
-      - name: Upload hosted rustfmt patch
-        if: ${{ failure() && steps.rustfmt-check.outcome == 'failure' }}
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: rustfmt-${{ runner.os }}-${{ github.sha }}
-          path: ${{ runner.temp }}/rustfmt.patch
-          if-no-files-found: error
-          retention-days: 1
-
-      # Lint in every hosted mode. When this ran only in full mode, warnings
-      # accumulated on main unnoticed because the full lane was rarely used.
-      - name: cargo clippy
-        working-directory: cmux-tui
-        run: cargo clippy --workspace --all-targets --locked -- -D warnings
 
       - name: focused Linux journal process-fence test
         if: inputs.mode == 'focused' && runner.os == 'Linux'
@@ -780,6 +808,7 @@ jobs:
     if: always()
     needs:
       - validate-inputs
+      - lint
       - msrv-check
       - web-frontend
       - valgrind-leak-check
@@ -793,6 +822,7 @@ jobs:
     env:
       MODE: ${{ inputs.mode }}
       VALIDATE_RESULT: ${{ needs.validate-inputs.result }}
+      LINT_RESULT: ${{ needs.lint.result }}
       MSRV_RESULT: ${{ needs.msrv-check.result }}
       WEB_RESULT: ${{ needs.web-frontend.result }}
       VALGRIND_RESULT: ${{ needs.valgrind-leak-check.result }}
@@ -815,6 +845,7 @@ jobs:
           }
 
           require_success "input validation" "$VALIDATE_RESULT"
+          require_success "lint" "$LINT_RESULT"
           require_success "Rust MSRV check" "$MSRV_RESULT"
           require_success "Rust tests" "$TEST_RESULT"
           if [[ "$MODE" == "full" ]]; then

--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -152,10 +152,18 @@ jobs:
           npm test
 
   lint:
-    name: lint
+    name: lint (${{ matrix.os }})
     needs: validate-inputs
-    runs-on: blacksmith-4vcpu-ubuntu-2404
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos
+            runner: blacksmith-6vcpu-macos-15
+          - os: linux
+            runner: blacksmith-4vcpu-ubuntu-2404
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -171,6 +179,7 @@ jobs:
         run: git submodule update --init --depth 1 ghostty
 
       - name: Install Linux build dependencies
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
           sudo apt-get install -y clang libclang-dev pkg-config
@@ -198,7 +207,7 @@ jobs:
         if: ${{ failure() && steps.rustfmt-check.outcome == 'failure' }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: rustfmt-${{ github.sha }}
+          name: rustfmt-${{ matrix.os }}-${{ github.sha }}
           path: ${{ runner.temp }}/rustfmt.patch
           if-no-files-found: error
           retention-days: 1

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -119,6 +119,18 @@ def test_lint_is_one_required_job_and_os_matrix_only_runs_behavior_tests() -> No
     gate_commands = "\n".join(str(step.get("run", "")) for step in gate["steps"])
 
     assert lint["needs"] == "validate-inputs"
+    assert lint["name"] == "lint (${{ matrix.os }})"
+    assert lint["strategy"]["fail-fast"] is False
+    assert lint["strategy"]["matrix"]["include"] == [
+        {
+            "os": "macos",
+            "runner": "blacksmith-6vcpu-macos-15",
+        },
+        {
+            "os": "linux",
+            "runner": "blacksmith-4vcpu-ubuntu-2404",
+        },
+    ]
     assert "cargo fmt --check" in lint_commands
     assert "cargo clippy --workspace --all-targets --locked -- -D warnings" in lint_commands
     assert "cargo fmt --check" not in test_commands
@@ -126,3 +138,31 @@ def test_lint_is_one_required_job_and_os_matrix_only_runs_behavior_tests() -> No
     assert "lint" in gate["needs"]
     assert gate["env"]["LINT_RESULT"] == "${{ needs.lint.result }}"
     assert 'require_success "lint" "$LINT_RESULT"' in gate_commands
+
+
+def test_lint_matrix_runs_clippy_with_each_host_cfg() -> None:
+    """Model the matrix expansion and runner guards that control lint coverage."""
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    lint = workflow["jobs"]["lint"]
+    steps = lint["steps"]
+    matrix = lint["strategy"]["matrix"]["include"]
+
+    assert {entry["os"] for entry in matrix} == {"linux", "macos"}
+    for entry in matrix:
+        runner_os = "Linux" if entry["os"] == "linux" else "macOS"
+        linux_dependency_steps = [
+            step
+            for step in steps
+            if step.get("name") == "Install Linux build dependencies"
+        ]
+        assert len(linux_dependency_steps) == 1
+        assert linux_dependency_steps[0]["if"] == "runner.os == 'Linux'"
+        if runner_os == "Linux":
+            assert entry["runner"].endswith("ubuntu-2404")
+        else:
+            assert entry["runner"].endswith("macos-15")
+
+        clippy_steps = [step for step in steps if step.get("name") == "cargo clippy"]
+        assert len(clippy_steps) == 1
+        assert clippy_steps[0]["working-directory"] == "cmux-tui"
+        assert "cargo clippy --workspace --all-targets --locked -- -D warnings" in clippy_steps[0]["run"]

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -106,3 +106,23 @@ def test_tui_status_names_remain_stable() -> None:
         workflow["jobs"]["hosted-verification"]["name"]
         == "${{ inputs.mode == 'full' && 'hosted verification' || 'focused hosted verification' }}"
     )
+
+
+def test_lint_is_one_required_job_and_os_matrix_only_runs_behavior_tests() -> None:
+    workflow = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    lint = workflow["jobs"]["lint"]
+    test = workflow["jobs"]["test"]
+    gate = workflow["jobs"]["hosted-verification"]
+
+    lint_commands = "\n".join(str(step.get("run", "")) for step in lint["steps"])
+    test_commands = "\n".join(str(step.get("run", "")) for step in test["steps"])
+    gate_commands = "\n".join(str(step.get("run", "")) for step in gate["steps"])
+
+    assert lint["needs"] == "validate-inputs"
+    assert "cargo fmt --check" in lint_commands
+    assert "cargo clippy --workspace --all-targets --locked -- -D warnings" in lint_commands
+    assert "cargo fmt --check" not in test_commands
+    assert "cargo clippy --workspace --all-targets --locked -- -D warnings" not in test_commands
+    assert "lint" in gate["needs"]
+    assert gate["env"]["LINT_RESULT"] == "${{ needs.lint.result }}"
+    assert 'require_success "lint" "$LINT_RESULT"' in gate_commands


### PR DESCRIPTION
## Summary
- move cargo fmt and clippy out of the macOS/Linux behavior matrix into one required Linux lint job
- keep exact checkout and rustfmt patch upload in the single lint lane
- require lint in the hosted verification gate

This removes duplicate platform-independent work and lets OS behavior tests start without waiting for clippy.

## Verification
- `actionlint .github/workflows/cmux-tui.yml`
- `python3 -m pytest -q tests/test_tui_focused_filter_guard.py`
- `python3 -m pytest -q tests/test_tui_publish_workflow_security.py`

PR #11823 changes the adjacent Valgrind block and may need a conflict-free rebase if merged first.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves `cargo fmt` and `cargo clippy` out of the macOS/Linux behavior-test matrix into a dedicated `lint` job that runs on both Linux and macOS, so OS behavior tests no longer wait for Clippy. Hosted verification now fails if lint fails, and workflow tests cover the lint placement, per-host matrix, and gate enforcement.

- Preserves exact-commit checkout validation and uploads a one-day rustfmt patch when formatting fails.
- The adjacent Valgrind block may need a conflict-free rebase if PR #11823 merges first.

<sup>Written for commit 1a5e488f1a9d9493c1d77557574f13832d26635d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added dedicated macOS and Linux linting stages for formatting and code quality checks.
  * Separated lint checks from platform-specific behavior tests.
  * Hosted verification now requires successful completion of linting.
  * Formatting failures can produce downloadable, OS-specific patch artifacts.

* **Tests**
  * Added coverage for lint job configuration, platform matrix behavior, dependency guards, Clippy settings, and required verification gates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->