### PR TITLE
fix(cloud): finish progress coalescer lifecycle

### DIFF
--- a/Sources/Cloud/MachineCreateCoordinator.swift
+++ b/Sources/Cloud/MachineCreateCoordinator.swift
@@ -60,6 +60,7 @@ final class MachineCreateCoordinator {
     /// observer token without going through an isolated accessor.
     @ObservationIgnored private var launches: [UUID: Launch] = [:]
     @ObservationIgnored private var progressOutput: [UUID: String] = [:]
+    @ObservationIgnored private var attemptGeneration: [UUID: UInt64] = [:]
     @ObservationIgnored private let notifier: @MainActor (MachineCreateNotice) -> Void
     @ObservationIgnored private let now: () -> Date
     @ObservationIgnored private let notificationCenter: NotificationCenter
@@ -107,13 +108,15 @@ final class MachineCreateCoordinator {
         operations.append(operation)
         launches[operation.id] = launch
         progressOutput[operation.id] = ""
+        attemptGeneration[operation.id] = 1
         postDidChange(finished: nil)
-        guard launch(request.arguments, progressHandler(for: operation.id), completionHandler(for: operation.id)) else {
+        guard launch(request.arguments, progressHandler(for: operation.id, generation: 1), completionHandler(for: operation.id, generation: 1)) else {
             if let index = operations.firstIndex(where: { $0.id == operation.id }) {
                 operations.remove(at: index)
             }
             launches.removeValue(forKey: operation.id)
             progressOutput.removeValue(forKey: operation.id)
+            attemptGeneration.removeValue(forKey: operation.id)
             postDidChange(finished: nil)
             return false
         }
@@ -131,14 +134,18 @@ final class MachineCreateCoordinator {
               let launch = launches[id] else { return false }
         operations[index].phase = .running
         operations[index].createdMachineID = nil
+        let generation = (attemptGeneration[id] ?? 0) &+ 1
+        attemptGeneration[id] = generation
         progressOutput[id] = ""
         postDidChange(finished: nil)
-        guard launch(operations[index].request.arguments, progressHandler(for: id), completionHandler(for: id)) else {
+        guard launch(operations[index].request.arguments, progressHandler(for: id, generation: generation), completionHandler(for: id, generation: generation)) else {
             if let failedIndex = operations.firstIndex(where: { $0.id == id }) {
                 operations[failedIndex].phase = .failed(output: String(
                     localized: "machines.new.error.launch",
                     defaultValue: "cmux could not start the create command. Sign in and try again."
                 ))
+                progressOutput.removeValue(forKey: id)
+                attemptGeneration[id] = (attemptGeneration[id] ?? generation) &+ 1
                 postDidChange(finished: nil)
             }
             return false
@@ -153,6 +160,7 @@ final class MachineCreateCoordinator {
         operations.remove(at: index)
         launches.removeValue(forKey: id)
         progressOutput.removeValue(forKey: id)
+        attemptGeneration.removeValue(forKey: id)
         postDidChange(finished: nil)
     }
 
@@ -162,33 +170,21 @@ final class MachineCreateCoordinator {
         operations.removeAll()
         launches.removeAll()
         progressOutput.removeAll()
+        attemptGeneration.removeAll()
         postDidChange(finished: nil)
     }
 
-    /// Recognizes the CLI's "Created Cloud VM <id>" line in `output`. The
-    /// format is the CLI's own localized string, so the match follows the
-    /// user's language instead of a hard-coded English prefix.
+    /// Recognizes only the CLI's strict stdout protocol line.
     nonisolated static func createdMachineID(fromOutput output: String) -> String? {
-        // The stable marker is emitted before opening starts and is the
-        // authoritative correlation key. Parse it before localized display
-        // text, so partial progress can identify the machine in every locale.
-        for token in output.split(whereSeparator: \.isWhitespace) {
-            let token = String(token)
-            guard token.hasPrefix("machine=") else { continue }
-            let id = String(token.dropFirst("machine=".count))
-            if !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) {
-                return id
-            }
-        }
-        let format = String(localized: "cli.vm.create.createdCloudVM", defaultValue: "Created Cloud VM %@")
-        let parts = format.components(separatedBy: "%@")
-        guard parts.count == 2 else { return nil }
-        let prefix = parts[0], suffix = parts[1]
         for rawLine in output.split(whereSeparator: \.isNewline) {
             let line = rawLine.trimmingCharacters(in: .whitespaces)
-            guard line.hasPrefix(prefix), line.hasSuffix(suffix), line.count > prefix.count + suffix.count else { continue }
-            let id = String(line.dropFirst(prefix.count).dropLast(suffix.count)).trimmingCharacters(in: .whitespaces)
-            if !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) { return id }
+            guard line.hasPrefix("OK machine=") else { continue }
+            let payload = line.dropFirst("OK machine=".count)
+            let id = payload.split(maxSplits: 1, whereSeparator: \.isWhitespace).first.map(String.init) ?? ""
+            guard !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) else { continue }
+            let suffix = payload.dropFirst(id.count)
+            guard suffix.isEmpty || suffix.first?.isWhitespace == true else { continue }
+            return id
         }
         return nil
     }
@@ -218,16 +214,22 @@ final class MachineCreateCoordinator {
         return "\(reason)\n\(safe)"
     }
 
-    private func completionHandler(for id: UUID) -> @MainActor (CloudVMActionLauncher.Completion) -> Void {
+    private func completionHandler(for id: UUID, generation: UInt64) -> @MainActor (CloudVMActionLauncher.Completion) -> Void {
         { [weak self] completion in
-            self?.finish(id: id, completion: completion)
+            guard let self, self.attemptGeneration[id] == generation else { return }
+            self.finish(id: id, completion: completion)
         }
     }
 
-    private func progressHandler(for id: UUID) -> @MainActor (String) -> Void {
+    private func progressHandler(for id: UUID, generation: UInt64) -> @MainActor (String) -> Void {
         { [weak self] chunk in
-            guard let self, let index = self.operations.firstIndex(where: { $0.id == id }) else { return }
-            self.progressOutput[id, default: ""].append(chunk)
+            guard let self,
+                  self.attemptGeneration[id] == generation,
+                  let index = self.operations.firstIndex(where: { $0.id == id }) else { return }
+            var bounded = Data((self.progressOutput[id, default: ""] + chunk).utf8)
+            bounded = Data(bounded.suffix(32 * 1024))
+            while !bounded.isEmpty && String(data: bounded, encoding: .utf8) == nil { bounded.removeFirst() }
+            self.progressOutput[id] = String(data: bounded, encoding: .utf8) ?? ""
             if let machineID = Self.createdMachineID(fromOutput: self.progressOutput[id] ?? "") {
                 guard self.operations[index].createdMachineID != machineID else { return }
                 self.operations[index].createdMachineID = machineID
@@ -240,12 +242,12 @@ final class MachineCreateCoordinator {
         // Dropped by a sign-out (or dismissed after a retry was refused): the
         // account this belonged to is gone, so there is nobody to tell.
         guard let index = operations.firstIndex(where: { $0.id == id }) else { return }
+        progressOutput.removeValue(forKey: id)
+        attemptGeneration[id] = (attemptGeneration[id] ?? 0) &+ 1
         var operation = operations[index]
         let output = completion.output.trimmingCharacters(in: .whitespacesAndNewlines)
-        // The CLI's `machine=` token is the authoritative created-machine
-        // signal; the localized "Created Cloud VM" line is the fallback for
-        // older bundled CLIs.
-        let createdMachineID = completion.machineId ?? Self.createdMachineID(fromOutput: output)
+        // The launcher's machine id comes only from the strict stdout protocol.
+        let createdMachineID = completion.machineId
         if let createdMachineID {
             operation.createdMachineID = createdMachineID
             operations[index].createdMachineID = createdMachineID
@@ -255,12 +257,14 @@ final class MachineCreateCoordinator {
             outcome = .created(machineID: createdMachineID, workspaceID: completion.workspaceId)
             operations.remove(at: index)
             launches.removeValue(forKey: id)
+            attemptGeneration.removeValue(forKey: id)
         } else if !operation.request.isBaseSetup, let machineID = createdMachineID {
             // Base setup is idempotent (`vm base open` reopens the same slot),
             // so only `vm new` can leave a machine behind that must not be re-created.
             outcome = .createdButOpenFailed(machineID: machineID, output: Self.displayableFailureOutput(output))
             operations.remove(at: index)
             launches.removeValue(forKey: id)
+            attemptGeneration.removeValue(forKey: id)
         } else {
             let failure = Self.displayableFailureOutput(output)
             outcome = .failed(output: failure)

--- a/Sources/Cloud/MachineCreateCoordinator.swift
+++ b/Sources/Cloud/MachineCreateCoordinator.swift
@@ -247,7 +247,11 @@ final class MachineCreateCoordinator {
         var operation = operations[index]
         let output = completion.output.trimmingCharacters(in: .whitespacesAndNewlines)
         // The launcher's machine id comes only from the strict stdout protocol.
-        let createdMachineID = completion.machineId
+        // The launcher parses the bounded stdout transcript, while the
+        // progress handler may have seen the authoritative line before the
+        // transcript's oldest bytes were evicted. Keep that observed id as a
+        // fallback so an open failure never invites a duplicate create.
+        let createdMachineID = completion.machineId ?? operation.createdMachineID
         if let createdMachineID {
             operation.createdMachineID = createdMachineID
             operations[index].createdMachineID = createdMachineID

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -108,16 +108,15 @@ final class CloudVMActionLauncher {
         let errorPipe = Pipe()
         process.standardOutput = outputPipe
         process.standardError = errorPipe
+        let outputDelivery = onOutput.map { MainActorOutputCoalescer(handler: $0) }
         let outputCollector = ProcessOutputCollector(stdout: outputPipe, stderr: errorPipe) { chunk in
-            guard let chunk = String(data: chunk, encoding: .utf8), !chunk.isEmpty else { return }
-            Task { @MainActor in
-                onOutput?(chunk)
-            }
+            outputDelivery?.enqueue(chunk)
         }
         outputCollector.start()
         let launchWindow = preferredWindow
         process.terminationHandler = { terminatedProcess in
-            let output = outputCollector.finish()
+            let result = outputCollector.finishResult()
+            let output = result.output
             let processIdentifier = terminatedProcess.processIdentifier
             let terminationStatus = terminatedProcess.terminationStatus
             Task { @MainActor in
@@ -128,7 +127,7 @@ final class CloudVMActionLauncher {
                         terminationStatus: terminationStatus,
                         output: output,
                         workspaceId: Self.createdWorkspaceId(from: output),
-                        machineId: Self.createdMachineId(from: output)
+                        machineId: Self.createdMachineId(from: result.stdout)
                     )
                 )
                 if terminationStatus == 0, presentOutputOnSuccess, !Self.shared.isShuttingDown, !suppressPresentation {
@@ -205,14 +204,16 @@ final class CloudVMActionLauncher {
 
     /// `cmux vm new` prints `OK machine=<id>` the moment the machine exists,
     /// before it tries to open it, so a failed open still reports the machine.
-    private static func createdMachineId(from output: String) -> String? {
-        for token in output.split(whereSeparator: \.isWhitespace) {
-            let string = String(token)
-            guard string.hasPrefix("machine=") else { continue }
-            let id = String(string.dropFirst("machine=".count))
-            if !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) {
-                return id
-            }
+    nonisolated static func createdMachineId(from stdout: String) -> String? {
+        for rawLine in stdout.split(whereSeparator: \.isNewline) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            guard line.hasPrefix("OK machine=") else { continue }
+            let payload = line.dropFirst("OK machine=".count)
+            let id = payload.split(maxSplits: 1, whereSeparator: \.isWhitespace).first.map(String.init) ?? ""
+            guard !id.isEmpty, id.allSatisfy({ $0.isLetter || $0.isNumber || $0 == "-" || $0 == "_" }) else { continue }
+            let suffix = payload.dropFirst(id.count)
+            guard suffix.isEmpty || suffix.first?.isWhitespace == true else { continue }
+            return id
         }
         return nil
     }
@@ -376,6 +377,37 @@ final class CloudVMActionLauncher {
     }
 }
 
+/// Delivers bounded stdout progress through one consumer task. `AsyncStream`
+/// owns synchronization and drops the oldest chunks when its finite buffer is
+/// full, so pipe callbacks never create an unbounded MainActor task fanout.
+private final class MainActorOutputCoalescer: @unchecked Sendable {
+    private let continuation: AsyncStream<Data>.Continuation
+
+    init(handler: @escaping @MainActor (String) -> Void) {
+        let pair = AsyncStream<Data>.makeStream(bufferingPolicy: .bufferingNewest(128))
+        continuation = pair.continuation
+        Task {
+            for await data in pair.stream {
+                var safeData = data
+                while !safeData.isEmpty && String(data: safeData, encoding: .utf8) == nil { safeData.removeLast() }
+                while let first = safeData.first, (first & 0xC0) == 0x80 { safeData.removeFirst() }
+                guard let text = String(data: safeData, encoding: .utf8), !text.isEmpty else { continue }
+                await MainActor.run { handler(text) }
+            }
+        }
+    }
+
+    func enqueue(_ data: Data) {
+        guard !data.isEmpty else { return }
+        continuation.yield(data)
+    }
+}
+
+struct ProcessOutputResult: Sendable, Equatable {
+    let output: String
+    let stdout: String
+}
+
 final class ProcessOutputCollector: @unchecked Sendable {
     private enum Stream {
         case stdout
@@ -423,9 +455,13 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     @discardableResult
     func finish() -> String {
+        finishResult().output
+    }
+
+    func finishResult() -> ProcessOutputResult {
         lock.lock()
         guard !isFinished else {
-            let output = formattedOutputLocked()
+            let output = formattedResultLocked()
             lock.unlock()
             return output
         }
@@ -440,7 +476,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
         try? stderrHandle.close()
 
         lock.lock()
-        let output = formattedOutputLocked()
+        let output = formattedResultLocked()
         lock.unlock()
         return output
     }
@@ -462,7 +498,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     private func append(_ data: Data, to stream: Stream) {
         guard !data.isEmpty else { return }
-        onOutput?(data)
+        if case .stdout = stream { onOutput?(data) }
         lock.lock()
         defer { lock.unlock() }
 
@@ -475,24 +511,29 @@ final class ProcessOutputCollector: @unchecked Sendable {
     }
 
     private func appendBounded(_ data: Data, to buffer: inout Data) {
-        guard data.count < byteLimit else {
+        if data.count >= byteLimit {
             buffer = Data(data.suffix(byteLimit))
+            while !buffer.isEmpty && String(data: buffer, encoding: .utf8) == nil { buffer.removeFirst() }
             return
         }
-
         let overflow = buffer.count + data.count - byteLimit
         if overflow > 0 {
-            buffer.removeSubrange(0..<overflow)
+            buffer.removeSubrange(0..<min(overflow, buffer.count))
         }
         buffer.append(data)
+        while !buffer.isEmpty && String(data: buffer, encoding: .utf8) == nil { buffer.removeLast() }
+        while let first = buffer.first, (first & 0xC0) == 0x80 { buffer.removeFirst() }
     }
 
-    private func formattedOutputLocked() -> String {
+    private func formattedResultLocked() -> ProcessOutputResult {
         let output = String(data: stdout, encoding: .utf8) ?? ""
         let error = String(data: stderr, encoding: .utf8) ?? ""
-        return [output, error]
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-            .joined(separator: "\n\n")
+        return ProcessOutputResult(
+            output: [output, error]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .filter { !$0.isEmpty }
+                .joined(separator: "\n\n"),
+            stdout: output
+        )
     }
 }

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -575,8 +575,12 @@ final class ProcessOutputCollector: @unchecked Sendable {
             let sequence = Data(data[index..<(index + width)])
             if String(data: sequence, encoding: .utf8) != nil {
                 valid.append(sequence)
+                index += width
+            } else {
+                // Skip only the malformed leading byte. The following bytes
+                // may begin a valid sequence and must be examined again.
+                index += 1
             }
-            index += width
         }
         return (valid, Data())
     }

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -444,6 +444,8 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private var stdoutProtocolLine = Data()
     private var observedMachineID: String?
     private var isFinished = false
+    private var acceptingReads = true
+    private var activeReads = 0
 
     private let onOutput: ((Data) -> Void)?
 
@@ -455,9 +457,11 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     func start() {
         stdoutHandle.readabilityHandler = { [weak self] handle in
+            guard let self, self.beginRead() else { return }
+            defer { self.endRead() }
             switch handle.readAvailableDataOrEndOfFile() {
             case .data(let data):
-                self?.append(data, to: .stdout)
+                self.append(data, to: .stdout)
             case .wouldBlock:
                 return
             case .endOfFile:
@@ -465,9 +469,11 @@ final class ProcessOutputCollector: @unchecked Sendable {
             }
         }
         stderrHandle.readabilityHandler = { [weak self] handle in
+            guard let self, self.beginRead() else { return }
+            defer { self.endRead() }
             switch handle.readAvailableDataOrEndOfFile() {
             case .data(let data):
-                self?.append(data, to: .stderr)
+                self.append(data, to: .stderr)
             case .wouldBlock:
                 return
             case .endOfFile:
@@ -482,7 +488,11 @@ final class ProcessOutputCollector: @unchecked Sendable {
     }
 
     func finishResult() -> ProcessOutputResult {
+        stdoutHandle.readabilityHandler = nil
+        stderrHandle.readabilityHandler = nil
         lock.lock()
+        acceptingReads = false
+        while activeReads > 0 { lock.unlock(); Thread.yield(); lock.lock() }
         if isFinished {
             let output = formattedResultLocked()
             lock.unlock()
@@ -490,9 +500,6 @@ final class ProcessOutputCollector: @unchecked Sendable {
         }
         isFinished = true
         lock.unlock()
-
-        stdoutHandle.readabilityHandler = nil
-        stderrHandle.readabilityHandler = nil
         append(stdoutHandle.readDataToEndOfFileOrEmpty(), to: .stdout)
         append(stderrHandle.readDataToEndOfFileOrEmpty(), to: .stderr)
         lock.lock()
@@ -509,7 +516,11 @@ final class ProcessOutputCollector: @unchecked Sendable {
     }
 
     func cancel() {
+        stdoutHandle.readabilityHandler = nil
+        stderrHandle.readabilityHandler = nil
         lock.lock()
+        acceptingReads = false
+        while activeReads > 0 { lock.unlock(); Thread.yield(); lock.lock() }
         if isFinished {
             lock.unlock()
             return
@@ -517,8 +528,6 @@ final class ProcessOutputCollector: @unchecked Sendable {
         isFinished = true
         lock.unlock()
 
-        stdoutHandle.readabilityHandler = nil
-        stderrHandle.readabilityHandler = nil
         lock.lock()
         finishPendingUTF8Locked()
         lock.unlock()
@@ -539,6 +548,19 @@ final class ProcessOutputCollector: @unchecked Sendable {
         case .stderr:
             appendBounded(data, to: &stderr, pending: &stderrPendingUTF8)
         }
+    }
+
+    private func beginRead() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard acceptingReads else { return false }
+        activeReads += 1
+        return true
+    }
+
+    private func endRead() {
+        lock.lock()
+        activeReads -= 1
+        lock.unlock()
     }
 
     private func appendBounded(_ data: Data, to buffer: inout Data, pending: inout Data) {

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -128,7 +128,7 @@ final class CloudVMActionLauncher {
                         terminationStatus: terminationStatus,
                         output: output,
                         workspaceId: Self.createdWorkspaceId(from: output),
-                        machineId: Self.createdMachineId(from: result.stdout)
+                        machineId: result.machineId
                     )
                 )
                 if terminationStatus == 0, presentOutputOnSuccess, !Self.shared.isShuttingDown, !suppressPresentation {
@@ -426,6 +426,7 @@ final class MainActorOutputCoalescer: @unchecked Sendable {
 struct ProcessOutputResult: Sendable, Equatable {
     let output: String
     let stdout: String
+    let machineId: String?
 }
 
 final class ProcessOutputCollector: @unchecked Sendable {
@@ -440,6 +441,10 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private let byteLimit = 32 * 1024
     private var stdout = Data()
     private var stderr = Data()
+    private var stdoutPendingUTF8 = Data()
+    private var stderrPendingUTF8 = Data()
+    private var stdoutProtocolLine = Data()
+    private var observedMachineID: String?
     private var isFinished = false
 
     private let onOutput: ((Data) -> Void)?
@@ -492,10 +497,12 @@ final class ProcessOutputCollector: @unchecked Sendable {
         stderrHandle.readabilityHandler = nil
         append(stdoutHandle.readDataToEndOfFileOrEmpty(), to: .stdout)
         append(stderrHandle.readDataToEndOfFileOrEmpty(), to: .stderr)
+        finishPendingUTF8()
         try? stdoutHandle.close()
         try? stderrHandle.close()
 
         lock.lock()
+        finishProtocolObservation()
         let output = formattedResultLocked()
         lock.unlock()
         return output
@@ -512,6 +519,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
+        finishPendingUTF8()
         try? stdoutHandle.close()
         try? stderrHandle.close()
     }
@@ -524,25 +532,64 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
         switch stream {
         case .stdout:
-            appendBounded(data, to: &stdout)
+            observeMachineID(in: data)
+            appendBounded(data, to: &stdout, pending: &stdoutPendingUTF8)
         case .stderr:
-            appendBounded(data, to: &stderr)
+            appendBounded(data, to: &stderr, pending: &stderrPendingUTF8)
         }
     }
 
-    private func appendBounded(_ data: Data, to buffer: inout Data) {
-        if data.count >= byteLimit {
-            buffer = Data(data.suffix(byteLimit))
-            while !buffer.isEmpty && String(data: buffer, encoding: .utf8) == nil { buffer.removeFirst() }
-            return
+    private func appendBounded(_ data: Data, to buffer: inout Data, pending: inout Data) {
+        var combined = pending
+        combined.append(data)
+        var validCount = combined.count
+        while validCount > 0,
+              String(data: combined.prefix(validCount), encoding: .utf8) == nil {
+            validCount -= 1
         }
-        let overflow = buffer.count + data.count - byteLimit
+        pending = Data(combined.dropFirst(validCount).prefix(3))
+        buffer.append(combined.prefix(validCount))
+        let overflow = buffer.count - byteLimit
         if overflow > 0 {
             buffer.removeSubrange(0..<min(overflow, buffer.count))
         }
-        buffer.append(data)
-        while !buffer.isEmpty && String(data: buffer, encoding: .utf8) == nil { buffer.removeLast() }
         while let first = buffer.first, (first & 0xC0) == 0x80 { buffer.removeFirst() }
+    }
+
+    private func finishPendingUTF8() {
+        lock.lock()
+        defer { lock.unlock() }
+        if !stdoutPendingUTF8.isEmpty {
+            stdout.append(String(decoding: stdoutPendingUTF8, as: UTF8.self).data(using: .utf8) ?? Data())
+            stdoutPendingUTF8.removeAll(keepingCapacity: false)
+        }
+        if !stderrPendingUTF8.isEmpty {
+            stderr.append(String(decoding: stderrPendingUTF8, as: UTF8.self).data(using: .utf8) ?? Data())
+            stderrPendingUTF8.removeAll(keepingCapacity: false)
+        }
+    }
+
+    private func finishProtocolObservation() {
+        guard observedMachineID == nil,
+              let text = String(data: stdoutProtocolLine, encoding: .utf8) else { return }
+        observedMachineID = CloudVMActionLauncher.createdMachineId(from: text)
+    }
+
+    private func observeMachineID(in data: Data) {
+        guard observedMachineID == nil else { return }
+        stdoutProtocolLine.append(data)
+        if stdoutProtocolLine.count > 4096 {
+            stdoutProtocolLine.removeSubrange(0..<(stdoutProtocolLine.count - 4096))
+        }
+        while let newline = stdoutProtocolLine.firstIndex(of: 0x0A) {
+            let line = stdoutProtocolLine.prefix(upTo: newline)
+            stdoutProtocolLine.removeSubrange(...newline)
+            if let text = String(data: line, encoding: .utf8),
+               let machineID = CloudVMActionLauncher.createdMachineId(from: text) {
+                observedMachineID = machineID
+                return
+            }
+        }
     }
 
     private func formattedResultLocked() -> ProcessOutputResult {
@@ -553,7 +600,8 @@ final class ProcessOutputCollector: @unchecked Sendable {
                 .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
                 .filter { !$0.isEmpty }
                 .joined(separator: "\n\n"),
-            stdout: output
+            stdout: output,
+            machineId: observedMachineID
         )
     }
 }

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -444,9 +444,18 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private var stderrPendingUTF8 = Data()
     private var stdoutProtocolLine = Data()
     private var observedMachineID: String?
-    private var isFinished = false
     private var acceptingReads = true
     private var activeReads = 0
+
+    private enum FinishState {
+        case open
+        case finishing
+        case finished(ProcessOutputResult)
+    }
+
+    private let finishCondition = NSCondition()
+    private var finishState: FinishState = .open
+    private var suppressOutputDelivery = false
 
     private let onOutput: ((Data) -> Void)?
 
@@ -492,54 +501,78 @@ final class ProcessOutputCollector: @unchecked Sendable {
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
         stopAcceptingAndWaitForReads()
-        lock.lock()
-        if isFinished {
-            let output = formattedResultLocked()
-            lock.unlock()
-            return output
+        finishCondition.lock()
+        while true {
+            switch finishState {
+            case .open:
+                finishState = .finishing
+                finishCondition.unlock()
+                let result = finalize(drain: true)
+                finishCondition.lock()
+                finishState = .finished(result)
+                finishCondition.broadcast()
+                finishCondition.unlock()
+                return result
+            case .finishing:
+                finishCondition.wait()
+            case .finished(let result):
+                finishCondition.unlock()
+                return result
+            }
         }
-        isFinished = true
-        lock.unlock()
-        append(stdoutHandle.readDataToEndOfFileOrEmpty(), to: .stdout)
-        append(stderrHandle.readDataToEndOfFileOrEmpty(), to: .stderr)
-        lock.lock()
-        finishPendingUTF8Locked()
-        lock.unlock()
-        try? stdoutHandle.close()
-        try? stderrHandle.close()
-
-        lock.lock()
-        finishProtocolObservation()
-        let output = formattedResultLocked()
-        lock.unlock()
-        return output
     }
 
     func cancel() {
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
         stopAcceptingAndWaitForReads()
-        lock.lock()
-        if isFinished {
-            lock.unlock()
-            return
+        finishCondition.lock()
+        while true {
+            switch finishState {
+            case .open:
+                finishState = .finishing
+                finishCondition.unlock()
+                let result = finalize(drain: false)
+                finishCondition.lock()
+                finishState = .finished(result)
+                finishCondition.broadcast()
+                finishCondition.unlock()
+                return
+            case .finishing:
+                finishCondition.wait()
+            case .finished:
+                finishCondition.unlock()
+                return
+            }
         }
-        isFinished = true
+    }
+
+    private func finalize(drain: Bool) -> ProcessOutputResult {
+        lock.lock()
+        // A finish invoked from an output callback must not recursively deliver
+        // drain bytes to that callback. The callback's own bytes were committed
+        // before it was entered. Normal finalization still delivers drained
+        // bytes so live progress keeps its existing behavior.
+        suppressOutputDelivery = callbackDepthOnCurrentThread() > 0
         lock.unlock()
 
+        if drain {
+            append(stdoutHandle.readDataToEndOfFileOrEmpty(), to: .stdout)
+            append(stderrHandle.readDataToEndOfFileOrEmpty(), to: .stderr)
+        }
         lock.lock()
         finishPendingUTF8Locked()
+        finishProtocolObservation()
+        let result = formattedResultLocked()
         lock.unlock()
         try? stdoutHandle.close()
         try? stderrHandle.close()
+        return result
     }
 
     private func append(_ data: Data, to stream: Stream) {
         guard !data.isEmpty else { return }
-        onOutput?(data)
         lock.lock()
-        defer { lock.unlock() }
-
         switch stream {
         case .stdout:
             observeMachineID(in: data)
@@ -547,6 +580,32 @@ final class ProcessOutputCollector: @unchecked Sendable {
         case .stderr:
             appendBounded(data, to: &stderr, pending: &stderrPendingUTF8)
         }
+        let shouldDeliver = !suppressOutputDelivery
+        lock.unlock()
+        if shouldDeliver {
+            deliverOutput(data)
+        }
+    }
+
+    private func deliverOutput(_ data: Data) {
+        guard let onOutput else { return }
+        let key = "ProcessOutputCollector.callbackDepth.\(ObjectIdentifier(self))"
+        let threadDictionary = Thread.current.threadDictionary
+        let priorDepth = threadDictionary[key] as? Int ?? 0
+        threadDictionary[key] = priorDepth + 1
+        defer {
+            if priorDepth == 0 {
+                threadDictionary.removeObject(forKey: key)
+            } else {
+                threadDictionary[key] = priorDepth
+            }
+        }
+        onOutput(data)
+    }
+
+    private func callbackDepthOnCurrentThread() -> Int {
+        let key = "ProcessOutputCollector.callbackDepth.\(ObjectIdentifier(self))"
+        return Thread.current.threadDictionary[key] as? Int ?? 0
     }
 
     private func beginRead() -> Bool {
@@ -566,7 +625,8 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private func stopAcceptingAndWaitForReads() {
         readCondition.lock()
         acceptingReads = false
-        while activeReads > 0 { readCondition.wait() }
+        let ownReadDepth = callbackDepthOnCurrentThread()
+        while activeReads > ownReadDepth { readCondition.wait() }
         readCondition.unlock()
     }
 

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -587,9 +587,6 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private func observeMachineID(in data: Data) {
         guard observedMachineID == nil else { return }
         stdoutProtocolLine.append(data)
-        if stdoutProtocolLine.count > 4096 {
-            stdoutProtocolLine.removeSubrange(0..<(stdoutProtocolLine.count - 4096))
-        }
         while let newline = stdoutProtocolLine.firstIndex(of: 0x0A) {
             let line = stdoutProtocolLine.prefix(upTo: newline)
             stdoutProtocolLine.removeSubrange(...newline)
@@ -598,6 +595,11 @@ final class ProcessOutputCollector: @unchecked Sendable {
                 observedMachineID = machineID
                 return
             }
+        }
+        // Scan complete lines before bounding the incomplete suffix. A single
+        // pipe read can contain the protocol line and much later output.
+        if stdoutProtocolLine.count > 4096 {
+            stdoutProtocolLine.removeSubrange(0..<(stdoutProtocolLine.count - 4096))
         }
     }
 

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -638,6 +638,13 @@ final class ProcessOutputCollector: @unchecked Sendable {
         finishCondition.unlock()
 
         if shouldStartOwner {
+            // Close admission before dispatching the owner. A readability
+            // callback may already be queued on another thread, but no new
+            // callback can begin after this point. The owner still waits for
+            // callbacks admitted before this lock transition.
+            readCondition.lock()
+            acceptingReads = false
+            readCondition.unlock()
             DispatchQueue.global().async { [self] in
                 // The callback cannot wait for itself. This owner waits on a
                 // separate thread until every read callback has returned.

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -116,11 +116,11 @@ final class CloudVMActionLauncher {
         let launchWindow = preferredWindow
         process.terminationHandler = { terminatedProcess in
             let result = outputCollector.finishResult()
-            outputDelivery?.finish()
             let output = result.output
             let processIdentifier = terminatedProcess.processIdentifier
             let terminationStatus = terminatedProcess.terminationStatus
             Task { @MainActor in
+                await outputDelivery?.finishAndWait()
                 Self.shared.processes.removeValue(forKey: processIdentifier)
                 let suppressPresentation = Self.shared.authTransitionSuppressedProcessIDs.remove(processIdentifier) != nil
                 onCompletion?(
@@ -385,6 +385,8 @@ final class CloudVMActionLauncher {
 final class MainActorOutputCoalescer: @unchecked Sendable {
     private let continuation: AsyncStream<Data>.Continuation
     private let deliveryTask: Task<Void, Never>
+    private let stateLock = NSLock()
+    private var didFinish = false
 
     init(
         handler: @escaping @MainActor (String) -> Void,
@@ -412,12 +414,32 @@ final class MainActorOutputCoalescer: @unchecked Sendable {
     /// Finish the stream after the process has delivered its final output.
     /// The delivery task then drains any buffered chunks and exits.
     func finish() {
+        stateLock.lock()
+        guard !didFinish else {
+            stateLock.unlock()
+            return
+        }
+        didFinish = true
+        stateLock.unlock()
         continuation.finish()
     }
 
+    /// Finishes the stream and waits until every buffered chunk reaches the
+    /// handler. This is used before process completion is published.
+    func finishAndWait() async {
+        finish()
+        await deliveryTask.value
+    }
+
     deinit {
-        continuation.finish()
-        deliveryTask.cancel()
+        stateLock.lock()
+        let shouldCancel = !didFinish
+        didFinish = true
+        stateLock.unlock()
+        if shouldCancel {
+            continuation.finish()
+            deliveryTask.cancel()
+        }
     }
 }
 

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -116,6 +116,7 @@ final class CloudVMActionLauncher {
         let launchWindow = preferredWindow
         process.terminationHandler = { terminatedProcess in
             let result = outputCollector.finishResult()
+            outputDelivery?.finish()
             let output = result.output
             let processIdentifier = terminatedProcess.processIdentifier
             let terminationStatus = terminatedProcess.terminationStatus
@@ -166,6 +167,7 @@ final class CloudVMActionLauncher {
             return true
         } catch {
             outputCollector.cancel()
+            outputDelivery?.finish()
             if presentsFailureAlert {
                 presentStartFailure(
                     summary: String(
@@ -380,13 +382,20 @@ final class CloudVMActionLauncher {
 /// Delivers bounded stdout progress through one consumer task. `AsyncStream`
 /// owns synchronization and drops the oldest chunks when its finite buffer is
 /// full, so pipe callbacks never create an unbounded MainActor task fanout.
-private final class MainActorOutputCoalescer: @unchecked Sendable {
+final class MainActorOutputCoalescer: @unchecked Sendable {
     private let continuation: AsyncStream<Data>.Continuation
+    private let deliveryTask: Task<Void, Never>
 
-    init(handler: @escaping @MainActor (String) -> Void) {
+    init(
+        handler: @escaping @MainActor (String) -> Void,
+        onTermination: (@Sendable () -> Void)? = nil
+    ) {
         let pair = AsyncStream<Data>.makeStream(bufferingPolicy: .bufferingNewest(128))
         continuation = pair.continuation
-        Task {
+        pair.continuation.onTermination = { @Sendable _ in
+            onTermination?()
+        }
+        deliveryTask = Task {
             for await data in pair.stream {
                 var safeData = data
                 while !safeData.isEmpty && String(data: safeData, encoding: .utf8) == nil { safeData.removeLast() }
@@ -400,6 +409,17 @@ private final class MainActorOutputCoalescer: @unchecked Sendable {
     func enqueue(_ data: Data) {
         guard !data.isEmpty else { return }
         continuation.yield(data)
+    }
+
+    /// Finish the stream after the process has delivered its final output.
+    /// The delivery task then drains any buffered chunks and exits.
+    func finish() {
+        continuation.finish()
+    }
+
+    deinit {
+        continuation.finish()
+        deliveryTask.cancel()
     }
 }
 

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -514,6 +514,16 @@ final class ProcessOutputCollector: @unchecked Sendable {
                 finishCondition.unlock()
                 return result
             case .finishing:
+                if callbackDepthOnCurrentThread() > 0 {
+                    // The owner may be inside this callback's drain. Waiting
+                    // here would deadlock that owner. Return a committed
+                    // snapshot; the owner still publishes the final result.
+                    finishCondition.unlock()
+                    lock.lock()
+                    let snapshot = formattedResultLocked()
+                    lock.unlock()
+                    return snapshot
+                }
                 finishCondition.wait()
             case .finished(let result):
                 finishCondition.unlock()
@@ -539,6 +549,10 @@ final class ProcessOutputCollector: @unchecked Sendable {
                 finishCondition.unlock()
                 return
             case .finishing:
+                if callbackDepthOnCurrentThread() > 0 {
+                    finishCondition.unlock()
+                    return
+                }
                 finishCondition.wait()
             case .finished:
                 finishCondition.unlock()

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -640,6 +640,13 @@ final class ProcessOutputCollector: @unchecked Sendable {
         readCondition.lock()
         acceptingReads = false
         let ownReadDepth = callbackDepthOnCurrentThread()
+        if ownReadDepth > 0 {
+            // The callback has already committed its bytes before re-entering.
+            // Waiting for another callback on this thread could deadlock if
+            // callbacks finish each other. Finalization is serialized below.
+            readCondition.unlock()
+            return
+        }
         while activeReads > ownReadDepth { readCondition.wait() }
         readCondition.unlock()
     }

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -397,10 +397,8 @@ final class MainActorOutputCoalescer: @unchecked Sendable {
         }
         deliveryTask = Task {
             for await data in pair.stream {
-                var safeData = data
-                while !safeData.isEmpty && String(data: safeData, encoding: .utf8) == nil { safeData.removeLast() }
-                while let first = safeData.first, (first & 0xC0) == 0x80 { safeData.removeFirst() }
-                guard let text = String(data: safeData, encoding: .utf8), !text.isEmpty else { continue }
+                let text = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
+                guard !text.isEmpty else { continue }
                 await MainActor.run { handler(text) }
             }
         }

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -542,18 +542,41 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private func appendBounded(_ data: Data, to buffer: inout Data, pending: inout Data) {
         var combined = pending
         combined.append(data)
-        var validCount = combined.count
-        while validCount > 0,
-              String(data: combined.prefix(validCount), encoding: .utf8) == nil {
-            validCount -= 1
-        }
-        pending = Data(combined.dropFirst(validCount).prefix(3))
-        buffer.append(combined.prefix(validCount))
+        let decoded = decodeUTF8(combined)
+        pending = decoded.pending
+        buffer.append(decoded.valid)
         let overflow = buffer.count - byteLimit
         if overflow > 0 {
             buffer.removeSubrange(0..<min(overflow, buffer.count))
         }
         while let first = buffer.first, (first & 0xC0) == 0x80 { buffer.removeFirst() }
+    }
+
+    private func decodeUTF8(_ data: Data) -> (valid: Data, pending: Data) {
+        var valid = Data()
+        var index = 0
+        while index < data.count {
+            let byte = data[index]
+            let width: Int
+            switch byte {
+            case 0x00...0x7F: width = 1
+            case 0xC2...0xDF: width = 2
+            case 0xE0...0xEF: width = 3
+            case 0xF0...0xF4: width = 4
+            default:
+                index += 1
+                continue
+            }
+            guard index + width <= data.count else {
+                return (valid, Data(data[index...]))
+            }
+            let sequence = Data(data[index..<(index + width)])
+            if String(data: sequence, encoding: .utf8) != nil {
+                valid.append(sequence)
+            }
+            index += width
+        }
+        return (valid, Data())
     }
 
     private func finishPendingUTF8() {

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -436,6 +436,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private let stdoutHandle: FileHandle
     private let stderrHandle: FileHandle
     private let lock = NSLock()
+    private let readCondition = NSCondition()
     private let byteLimit = 32 * 1024
     private var stdout = Data()
     private var stderr = Data()
@@ -490,9 +491,8 @@ final class ProcessOutputCollector: @unchecked Sendable {
     func finishResult() -> ProcessOutputResult {
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
+        stopAcceptingAndWaitForReads()
         lock.lock()
-        acceptingReads = false
-        while activeReads > 0 { lock.unlock(); Thread.yield(); lock.lock() }
         if isFinished {
             let output = formattedResultLocked()
             lock.unlock()
@@ -518,9 +518,8 @@ final class ProcessOutputCollector: @unchecked Sendable {
     func cancel() {
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
+        stopAcceptingAndWaitForReads()
         lock.lock()
-        acceptingReads = false
-        while activeReads > 0 { lock.unlock(); Thread.yield(); lock.lock() }
         if isFinished {
             lock.unlock()
             return
@@ -551,16 +550,24 @@ final class ProcessOutputCollector: @unchecked Sendable {
     }
 
     private func beginRead() -> Bool {
-        lock.lock(); defer { lock.unlock() }
+        readCondition.lock(); defer { readCondition.unlock() }
         guard acceptingReads else { return false }
         activeReads += 1
         return true
     }
 
     private func endRead() {
-        lock.lock()
+        readCondition.lock()
         activeReads -= 1
-        lock.unlock()
+        if activeReads == 0 { readCondition.broadcast() }
+        readCondition.unlock()
+    }
+
+    private func stopAcceptingAndWaitForReads() {
+        readCondition.lock()
+        acceptingReads = false
+        while activeReads > 0 { readCondition.wait() }
+        readCondition.unlock()
     }
 
     private func appendBounded(_ data: Data, to buffer: inout Data, pending: inout Data) {

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -556,6 +556,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     private func decodeUTF8(_ data: Data) -> (valid: Data, pending: Data) {
         var valid = Data()
+        valid.reserveCapacity(data.count)
         var index = 0
         while index < data.count {
             let byte = data[index]
@@ -572,9 +573,8 @@ final class ProcessOutputCollector: @unchecked Sendable {
             guard index + width <= data.count else {
                 return (valid, Data(data[index...]))
             }
-            let sequence = Data(data[index..<(index + width)])
-            if String(data: sequence, encoding: .utf8) != nil {
-                valid.append(sequence)
+            if isValidUTF8Sequence(in: data, at: index, width: width) {
+                valid.append(contentsOf: data[index..<(index + width)])
                 index += width
             } else {
                 // Skip only the malformed leading byte. The following bytes
@@ -583,6 +583,21 @@ final class ProcessOutputCollector: @unchecked Sendable {
             }
         }
         return (valid, Data())
+    }
+
+    private func isValidUTF8Sequence(in data: Data, at index: Int, width: Int) -> Bool {
+        guard width > 1 else { return true }
+        let first = data[index]
+        let second = data[index + 1]
+        guard (second & 0xC0) == 0x80 else { return false }
+        if first == 0xE0, second < 0xA0 { return false }
+        if first == 0xED, second >= 0xA0 { return false }
+        if first == 0xF0, second < 0x90 { return false }
+        if first == 0xF4, second >= 0x90 { return false }
+        for offset in 2..<width where (data[index + offset] & 0xC0) != 0x80 {
+            return false
+        }
+        return true
     }
 
     private func finishPendingUTF8Locked() {

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -483,7 +483,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     func finishResult() -> ProcessOutputResult {
         lock.lock()
-        guard !isFinished else {
+        if isFinished {
             let output = formattedResultLocked()
             lock.unlock()
             return output
@@ -508,7 +508,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     func cancel() {
         lock.lock()
-        guard !isFinished else {
+        if isFinished {
             lock.unlock()
             return
         }

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -562,11 +562,20 @@ final class ProcessOutputCollector: @unchecked Sendable {
         if !stdoutPendingUTF8.isEmpty {
             stdout.append(String(decoding: stdoutPendingUTF8, as: UTF8.self).data(using: .utf8) ?? Data())
             stdoutPendingUTF8.removeAll(keepingCapacity: false)
+            trimToByteLimit(&stdout)
         }
         if !stderrPendingUTF8.isEmpty {
             stderr.append(String(decoding: stderrPendingUTF8, as: UTF8.self).data(using: .utf8) ?? Data())
             stderrPendingUTF8.removeAll(keepingCapacity: false)
+            trimToByteLimit(&stderr)
         }
+    }
+
+    private func trimToByteLimit(_ buffer: inout Data) {
+        let overflow = buffer.count - byteLimit
+        guard overflow > 0 else { return }
+        buffer.removeSubrange(0..<overflow)
+        while let first = buffer.first, (first & 0xC0) == 0x80 { buffer.removeFirst() }
     }
 
     private func finishProtocolObservation() {

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -526,7 +526,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
     private func append(_ data: Data, to stream: Stream) {
         guard !data.isEmpty else { return }
-        if case .stdout = stream { onOutput?(data) }
+        onOutput?(data)
         lock.lock()
         defer { lock.unlock() }
 

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -495,7 +495,9 @@ final class ProcessOutputCollector: @unchecked Sendable {
         stderrHandle.readabilityHandler = nil
         append(stdoutHandle.readDataToEndOfFileOrEmpty(), to: .stdout)
         append(stderrHandle.readDataToEndOfFileOrEmpty(), to: .stderr)
-        finishPendingUTF8()
+        lock.lock()
+        finishPendingUTF8Locked()
+        lock.unlock()
         try? stdoutHandle.close()
         try? stderrHandle.close()
 
@@ -517,7 +519,9 @@ final class ProcessOutputCollector: @unchecked Sendable {
 
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
-        finishPendingUTF8()
+        lock.lock()
+        finishPendingUTF8Locked()
+        lock.unlock()
         try? stdoutHandle.close()
         try? stderrHandle.close()
     }
@@ -577,9 +581,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
         return (valid, Data())
     }
 
-    private func finishPendingUTF8() {
-        lock.lock()
-        defer { lock.unlock() }
+    private func finishPendingUTF8Locked() {
         if !stdoutPendingUTF8.isEmpty {
             stdout.append(String(decoding: stdoutPendingUTF8, as: UTF8.self).data(using: .utf8) ?? Data())
             stdoutPendingUTF8.removeAll(keepingCapacity: false)

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -497,6 +497,11 @@ final class ProcessOutputCollector: @unchecked Sendable {
         finishResult().output
     }
 
+    /// Finishes all pipe reads and returns one cached result. A synchronous
+    /// output callback may re-enter this method. That path returns a snapshot
+    /// of bytes already committed by the callback and schedules the single
+    /// finalizer, which publishes the complete result after all callbacks
+    /// return.
     func finishResult() -> ProcessOutputResult {
         if callbackDepthOnCurrentThread() > 0 {
             stdoutHandle.readabilityHandler = nil

--- a/Sources/CloudVMActionLauncher.swift
+++ b/Sources/CloudVMActionLauncher.swift
@@ -498,6 +498,11 @@ final class ProcessOutputCollector: @unchecked Sendable {
     }
 
     func finishResult() -> ProcessOutputResult {
+        if callbackDepthOnCurrentThread() > 0 {
+            stdoutHandle.readabilityHandler = nil
+            stderrHandle.readabilityHandler = nil
+            return requestReentrantFinish(drain: true)
+        }
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
         stopAcceptingAndWaitForReads()
@@ -533,6 +538,12 @@ final class ProcessOutputCollector: @unchecked Sendable {
     }
 
     func cancel() {
+        if callbackDepthOnCurrentThread() > 0 {
+            stdoutHandle.readabilityHandler = nil
+            stderrHandle.readabilityHandler = nil
+            requestReentrantFinish(drain: false)
+            return
+        }
         stdoutHandle.readabilityHandler = nil
         stderrHandle.readabilityHandler = nil
         stopAcceptingAndWaitForReads()
@@ -582,6 +593,40 @@ final class ProcessOutputCollector: @unchecked Sendable {
         try? stdoutHandle.close()
         try? stderrHandle.close()
         return result
+    }
+
+    private func requestReentrantFinish(drain: Bool) -> ProcessOutputResult {
+        finishCondition.lock()
+        let shouldStartOwner: Bool
+        switch finishState {
+        case .open:
+            finishState = .finishing
+            shouldStartOwner = true
+        case .finishing:
+            shouldStartOwner = false
+        case .finished(let result):
+            finishCondition.unlock()
+            return result
+        }
+        finishCondition.unlock()
+
+        if shouldStartOwner {
+            DispatchQueue.global().async { [self] in
+                // The callback cannot wait for itself. This owner waits on a
+                // separate thread until every read callback has returned.
+                stopAcceptingAndWaitForReads()
+                let result = finalize(drain: drain)
+                finishCondition.lock()
+                finishState = .finished(result)
+                finishCondition.broadcast()
+                finishCondition.unlock()
+            }
+        }
+
+        lock.lock()
+        let snapshot = formattedResultLocked()
+        lock.unlock()
+        return snapshot
     }
 
     private func append(_ data: Data, to stream: Stream) {
@@ -639,15 +684,7 @@ final class ProcessOutputCollector: @unchecked Sendable {
     private func stopAcceptingAndWaitForReads() {
         readCondition.lock()
         acceptingReads = false
-        let ownReadDepth = callbackDepthOnCurrentThread()
-        if ownReadDepth > 0 {
-            // The callback has already committed its bytes before re-entering.
-            // Waiting for another callback on this thread could deadlock if
-            // callbacks finish each other. Finalization is serialized below.
-            readCondition.unlock()
-            return
-        }
-        while activeReads > ownReadDepth { readCondition.wait() }
+        while activeReads > 0 { readCondition.wait() }
         readCondition.unlock()
     }
 

--- a/Sources/Surfaces/SurfaceSocketCommands.swift
+++ b/Sources/Surfaces/SurfaceSocketCommands.swift
@@ -192,6 +192,7 @@ extension TerminalController {
         let destination = Self.surfaceDestination(surfaceResolvedParams(params), workspaceID: workspaceID)
         return v2VmCall(id: id, timeoutSeconds: 180) {
             let catalog = await SurfaceCatalog.shared
+            var didRegisterOptimistically = false
             if await catalog.resources[resource] == nil {
                 // Ports are discovered by probing the machine; a port the person names may
                 // not have been seen yet. Register it now and open it — a port pane is an
@@ -209,17 +210,23 @@ extension TerminalController {
                     port: port,
                     url: nil
                 ))
-                Task { @MainActor in
-                    if let provider = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: vmId) {
-                        await provider.refresh(force: true)
-                    }
-                }
+                didRegisterOptimistically = true
             }
             let opened = try await catalog.project(resource, into: destination, focus: focus, reuseExisting: false)
             var payload = Self.surfaceProjectPayload(opened.projection, reused: opened.reused)
             let url = await catalog.resources[resource]?.url ?? ""
             payload["url"] = url
             payload["open_url"] = url
+            // Refresh after projection. A concurrent refresh can replace the
+            // optimistic resource before project() resolves it as a known
+            // resource, producing a spurious unknownResource error.
+            if didRegisterOptimistically {
+                Task { @MainActor in
+                    if let provider = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: vmId) {
+                        await provider.refresh(force: true)
+                    }
+                }
+            }
             return payload
         }
     }

--- a/Sources/Surfaces/SurfaceSocketCommands.swift
+++ b/Sources/Surfaces/SurfaceSocketCommands.swift
@@ -212,21 +212,19 @@ extension TerminalController {
                 ))
                 didRegisterOptimistically = true
             }
-            let opened = try await catalog.project(resource, into: destination, focus: focus, reuseExisting: false)
-            var payload = Self.surfaceProjectPayload(opened.projection, reused: opened.reused)
-            let url = await catalog.resources[resource]?.url ?? ""
-            payload["url"] = url
-            payload["open_url"] = url
-            // Refresh after projection. A concurrent refresh can replace the
-            // optimistic resource before project() resolves it as a known
-            // resource, producing a spurious unknownResource error.
-            if didRegisterOptimistically {
+            defer {
+                guard didRegisterOptimistically else { return }
                 Task { @MainActor in
                     if let provider = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: vmId) {
                         await provider.refresh(force: true)
                     }
                 }
             }
+            let opened = try await catalog.project(resource, into: destination, focus: focus, reuseExisting: false)
+            var payload = Self.surfaceProjectPayload(opened.projection, reused: opened.reused)
+            let url = await catalog.resources[resource]?.url ?? ""
+            payload["url"] = url
+            payload["open_url"] = url
             return payload
         }
     }

--- a/Sources/Surfaces/SurfaceSocketCommands.swift
+++ b/Sources/Surfaces/SurfaceSocketCommands.swift
@@ -213,10 +213,11 @@ extension TerminalController {
                 didRegisterOptimistically = true
             }
             defer {
-                guard didRegisterOptimistically else { return }
-                Task { @MainActor in
-                    if let provider = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: vmId) {
-                        await provider.refresh(force: true)
+                if didRegisterOptimistically {
+                    Task { @MainActor in
+                        if let provider = CmuxTuiSurfaceProviderRegistry.shared.provider(machineID: vmId) {
+                            await provider.refresh(force: true)
+                        }
                     }
                 }
             }

--- a/cmuxTests/MachineCreateCoordinatorTests.swift
+++ b/cmuxTests/MachineCreateCoordinatorTests.swift
@@ -185,7 +185,7 @@ struct MachineCreateCoordinatorTests {
         coordinator.start(Self.newMachineRequest(), launch: launches.launch)
         let workspaceID = UUID()
 
-        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\nOK workspace=\(workspaceID.uuidString) transport=cmux-remote\n", workspaceID: workspaceID)
+        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\nOK machine=calm-petrel\nOK workspace=\(workspaceID.uuidString) transport=cmux-remote\n", workspaceID: workspaceID, machineID: "calm-petrel")
 
         #expect(coordinator.operations.isEmpty, "the fleet row takes over")
         #expect(changes.finished.count == 1)
@@ -200,7 +200,7 @@ struct MachineCreateCoordinatorTests {
     @Test func successKeepsTheTypedLabelInTheNotification() {
         let (coordinator, launches, notices, _, _) = makeCoordinator()
         coordinator.start(Self.newMachineRequest(name: "build box"), launch: launches.launch)
-        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\n")
+        launches.complete(status: 0, output: "Created Cloud VM calm-petrel\nOK machine=calm-petrel\n", machineID: "calm-petrel")
         #expect(notices.notices.first?.title == "build box is ready")
         #expect(notices.notices.first?.workspaceID == nil)
     }
@@ -242,7 +242,7 @@ struct MachineCreateCoordinatorTests {
         #expect(launches.arguments[1] == launches.arguments[0])
         #expect(coordinator.operation(id: id)?.isRunning == true)
 
-        launches.complete(status: 0, output: "Created Cloud VM noble-wren\n")
+        launches.complete(status: 0, output: "Created Cloud VM noble-wren\nOK machine=noble-wren\n", machineID: "noble-wren")
         #expect(coordinator.operations.isEmpty)
         #expect(notices.notices.count == 2)
     }
@@ -280,6 +280,20 @@ struct MachineCreateCoordinatorTests {
         #expect(coordinator.operation(id: id)?.failureOutput?.contains("Sign in") == true)
     }
 
+    @Test func lateProgressFromAnEarlierAttemptCannotOverwriteRetry() {
+        let (coordinator, launches, _, _, _) = makeCoordinator()
+        coordinator.start(Self.newMachineRequest(), launch: launches.launch)
+        let id = coordinator.operations[0].id
+        let firstProgress = launches.progressHandlers[0]
+        launches.complete(status: 1, output: "Error: first attempt")
+        #expect(coordinator.retry(id))
+        let secondProgress = launches.progressHandlers[1]
+        firstProgress("OK machine=stale-machine\n")
+        #expect(coordinator.operation(id: id)?.createdMachineID == nil)
+        secondProgress("OK machine=current-machine\n")
+        #expect(coordinator.operation(id: id)?.createdMachineID == "current-machine")
+    }
+
     // MARK: Created but opening failed
 
     @Test func createdButOpenFailedDropsTheRowAndNeverRetriesTheCreate() {
@@ -308,19 +322,14 @@ struct MachineCreateCoordinatorTests {
         #expect(notice?.body == "attach failed (HTTP 502)\nOpen it from the Machines list.", "the reason, not the CLI's progress line, leads the body")
     }
 
-    /// An older bundled CLI without the `machine=` token still classifies via
-    /// the localized "Created Cloud VM" line.
-    @Test func createdButOpenFailedFallsBackToTheLocalizedCreatedLine() {
+    @Test func localizedCreatedLineWithoutProtocolMarkerDoesNotClaimAMachine() {
         let (coordinator, launches, _, changes, _) = makeCoordinator()
         coordinator.start(Self.newMachineRequest(), launch: launches.launch)
         let id = coordinator.operations[0].id
         launches.complete(status: 1, output: "Created Cloud VM calm-petrel\nError: attach failed (HTTP 502)")
-        #expect(coordinator.operations.isEmpty)
-        #expect(!coordinator.retry(id))
-        #expect(changes.finished.first?.outcome == .createdButOpenFailed(
-            machineID: "calm-petrel",
-            output: "Error: attach failed (HTTP 502)"
-        ))
+        #expect(coordinator.operations.count == 1)
+        #expect(coordinator.retry(id))
+        #expect(changes.finished.first?.outcome == .failed(output: "Created Cloud VM calm-petrel\nError: attach failed (HTTP 502)"))
     }
 
     /// Transcripts that trip the app's redaction never reach the row, the
@@ -352,10 +361,12 @@ struct MachineCreateCoordinatorTests {
         #expect(launches.arguments.count == 2)
     }
 
-    @Test func createdMachineIDIsParsedFromTheCLIsCreatedLine() {
+    @Test func createdMachineIDRequiresTheStrictProtocolLine() {
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "OK machine=calm-petrel") == "calm-petrel")
-        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Created Cloud VM calm-petrel\nError: noProvider(calm-petrel)") == "calm-petrel")
-        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "  Created Cloud VM noble_wren2  ") == "noble_wren2")
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Created Cloud VM calm-petrel\nError: noProvider(calm-petrel)") == nil)
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "  OK machine=noble_wren2 transport=cmux-remote  ") == "noble_wren2")
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Error: machine=calm-petrel") == nil)
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "OK machine=bad.id") == nil)
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Error: Creating Cloud VM (HTTP 502)") == nil)
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "Created Cloud VM") == nil)
         #expect(MachineCreateCoordinator.createdMachineID(fromOutput: "") == nil)

--- a/cmuxTests/MachineCreateCoordinatorTests.swift
+++ b/cmuxTests/MachineCreateCoordinatorTests.swift
@@ -389,6 +389,69 @@ struct MachineCreateCoordinatorTests {
     }
 }
 
+private actor CoalescerTerminationProbe {
+    private(set) var didTerminate = false
+
+    func markTerminated() {
+        didTerminate = true
+    }
+}
+
+@MainActor
+@Suite(.serialized)
+struct MainActorOutputCoalescerTests {
+    @Test func processCompletionFinishesStreamAfterDeliveringBufferedOutput() async throws {
+        let termination = CoalescerTerminationProbe()
+        let handler = OutputHandlerProbe()
+        let coalescer = MainActorOutputCoalescer(
+            handler: { text in handler.values.append(text) },
+            onTermination: {
+                Task { await termination.markTerminated() }
+            }
+        )
+
+        coalescer.enqueue(Data("progress".utf8))
+        coalescer.finish()
+
+        try await Self.waitForTermination(termination)
+        #expect(handler.values == ["progress"])
+    }
+
+    @Test func cancellationReleasesTaskAndHandlerAfterStreamTermination() async throws {
+        let termination = CoalescerTerminationProbe()
+        weak var weakHandler: OutputHandlerProbe?
+
+        do {
+            let handler = OutputHandlerProbe()
+            weakHandler = handler
+            var coalescer: MainActorOutputCoalescer? = MainActorOutputCoalescer(
+                handler: { _ in handler.values.append("received") },
+                onTermination: {
+                    Task { await termination.markTerminated() }
+                }
+            )
+            coalescer?.enqueue(Data("cancelled".utf8))
+            coalescer = nil
+        }
+
+        try await Self.waitForTermination(termination)
+        #expect(weakHandler == nil)
+    }
+
+    private static func waitForTermination(_ probe: CoalescerTerminationProbe) async throws {
+        for _ in 0..<100 {
+            if await probe.didTerminate { return }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        Issue.record("coalescer stream did not terminate")
+    }
+
+    @MainActor
+    private final class OutputHandlerProbe {
+        var values: [String] = []
+    }
+}
+
 /// The Machines panel mirrors the coordinator: pending rows above the fleet,
 /// a completion re-reads the fleet, and a created-but-unopened machine's
 /// reason lands in the control bar.

--- a/cmuxTests/MachineCreateCoordinatorTests.swift
+++ b/cmuxTests/MachineCreateCoordinatorTests.swift
@@ -322,6 +322,24 @@ struct MachineCreateCoordinatorTests {
         #expect(notice?.body == "attach failed (HTTP 502)\nOpen it from the Machines list.", "the reason, not the CLI's progress line, leads the body")
     }
 
+    @Test func progressMachineIDSurvivesBoundedTranscriptEviction() {
+        let (coordinator, launches, _, changes, _) = makeCoordinator()
+        coordinator.start(Self.newMachineRequest(), launch: launches.launch)
+        let id = coordinator.operations[0].id
+
+        // The progress stream saw the protocol line, but the completion's
+        // bounded stdout transcript no longer contains it.
+        launches.progressHandlers[0]("OK machine=calm-petrel\n")
+        launches.complete(status: 1, output: "Error: attach failed", machineID: nil)
+
+        #expect(coordinator.operations.isEmpty)
+        #expect(changes.finished.first?.outcome == .createdButOpenFailed(
+            machineID: "calm-petrel",
+            output: "Error: attach failed"
+        ))
+        #expect(!coordinator.retry(id))
+    }
+
     @Test func localizedCreatedLineWithoutProtocolMarkerDoesNotClaimAMachine() {
         let (coordinator, launches, _, changes, _) = makeCoordinator()
         coordinator.start(Self.newMachineRequest(), launch: launches.launch)

--- a/cmuxTests/MachineCreateCoordinatorTests.swift
+++ b/cmuxTests/MachineCreateCoordinatorTests.swift
@@ -429,10 +429,26 @@ struct MainActorOutputCoalescerTests {
         )
 
         coalescer.enqueue(Data("progress".utf8))
-        coalescer.finish()
+        await coalescer.finishAndWait()
 
         try await Self.waitForTermination(termination)
         #expect(handler.values == ["progress"])
+    }
+
+    @Test func finishAndWaitDrainsBufferedChunksBeforeReturning() async {
+        let values = OutputHandlerProbe()
+        let coalescer = MainActorOutputCoalescer(
+            handler: { text in values.values.append(text) }
+        )
+        for index in 0..<32 {
+            coalescer.enqueue(Data("chunk-\(index)".utf8))
+        }
+
+        await coalescer.finishAndWait()
+
+        #expect(values.values.count == 32)
+        #expect(values.values.first == "chunk-0")
+        #expect(values.values.last == "chunk-31")
     }
 
     @Test func cancellationReleasesTaskAndHandlerAfterStreamTermination() async throws {

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -28,4 +28,23 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         XCTAssertEqual(output, "")
     }
+
+    func testProcessOutputCollectorKeepsUtf8BoundariesAndSeparatesStdout() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr)
+        collector.start()
+        let prefix = String(repeating: "x", count: 32 * 1024) + "😀"
+        try? stdout.fileHandleForWriting.write(contentsOf: Data(prefix.utf8))
+        try? stderr.fileHandleForWriting.write(contentsOf: Data("OK machine=stderr-id\n".utf8))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        let result = collector.finishResult()
+
+        XCTAssertLessThanOrEqual(result.stdout.utf8.count, 32 * 1024)
+        XCTAssertNotNil(String(data: Data(result.stdout.utf8), encoding: .utf8))
+        XCTAssertNil(MachineCreateCoordinator.createdMachineID(fromOutput: result.stdout))
+        XCTAssertTrue(result.output.contains("OK machine=stderr-id"))
+    }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -85,6 +85,21 @@ struct ProcessPipeReadCrashRegressionTests {
     }
 
     @Test
+    func testProcessOutputCollectorKeepsValidBytesAfterMalformedMultibyteSequence() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr)
+        collector.start()
+        try? stdout.fileHandleForWriting.write(contentsOf: Data([0xE2, 0x82, 0x41]))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        let result = collector.finishResult()
+
+        #expect(result.stdout == "A")
+    }
+
+    @Test
     func testProcessOutputCollectorDeliversStderrProgressToLiveConsumer() {
         let stdout = Pipe()
         let stderr = Pipe()

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -275,4 +275,36 @@ struct ProcessPipeReadCrashRegressionTests {
         #expect(result?.stdout.contains("stdout") == true)
         #expect(result?.output.contains("stderr") == true)
     }
+
+    @Test
+    func testProcessOutputCollectorReentrantFinishDrainsTailFromOtherPipe() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let callbackEntered = DispatchSemaphore(value: 0)
+        let releaseCallback = DispatchSemaphore(value: 0)
+        let callbackLock = NSLock()
+        var callbackCount = 0
+        var collector: ProcessOutputCollector!
+        collector = ProcessOutputCollector(stdout: stdout, stderr: stderr) { _ in
+            callbackLock.lock()
+            callbackCount += 1
+            let isFirst = callbackCount == 1
+            callbackLock.unlock()
+            guard isFirst else { return }
+            _ = collector.finishResult()
+            callbackEntered.signal()
+            releaseCallback.wait()
+        }
+        collector.start()
+        try? stdout.fileHandleForWriting.write(contentsOf: Data("OK machine=calm-petrel\n".utf8))
+        #expect(callbackEntered.wait(timeout: .now() + 1) == .success)
+        try? stderr.fileHandleForWriting.write(contentsOf: Data("tail from stderr\n".utf8))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+        releaseCallback.signal()
+
+        let result = collector.finishResult()
+        #expect(result.machineId == "calm-petrel")
+        #expect(result.output.contains("tail from stderr"))
+    }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -142,4 +142,82 @@ struct ProcessPipeReadCrashRegressionTests {
         try? stdout.fileHandleForWriting.close()
         try? stderr.fileHandleForWriting.close()
     }
+
+    @Test
+    func testProcessOutputCollectorConcurrentFinishersShareDrainedResult() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let drainEntered = DispatchSemaphore(value: 0)
+        let releaseDrain = DispatchSemaphore(value: 0)
+        let firstFinished = DispatchSemaphore(value: 0)
+        let secondFinished = DispatchSemaphore(value: 0)
+        let resultLock = NSLock()
+        var firstResult: ProcessOutputResult?
+        var secondResult: ProcessOutputResult?
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr) { data in
+            guard data == Data("tail\n".utf8) else { return }
+            drainEntered.signal()
+            releaseDrain.wait()
+        }
+
+        try? stdout.fileHandleForWriting.write(contentsOf: Data("tail\n".utf8))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        DispatchQueue.global().async {
+            let result = collector.finishResult()
+            resultLock.lock()
+            firstResult = result
+            resultLock.unlock()
+            firstFinished.signal()
+        }
+        #expect(drainEntered.wait(timeout: .now() + 1) == .success)
+
+        DispatchQueue.global().async {
+            let result = collector.finishResult()
+            resultLock.lock()
+            secondResult = result
+            resultLock.unlock()
+            secondFinished.signal()
+        }
+        #expect(secondFinished.wait(timeout: .now() + 0.05) == .timedOut)
+
+        releaseDrain.signal()
+        #expect(firstFinished.wait(timeout: .now() + 1) == .success)
+        #expect(secondFinished.wait(timeout: .now() + 1) == .success)
+        resultLock.lock()
+        let results = (firstResult, secondResult)
+        resultLock.unlock()
+        #expect(results.0 == results.1)
+        #expect(results.0?.stdout == "tail")
+    }
+
+    @Test
+    func testProcessOutputCollectorAllowsReentrantFinishFromOutputCallback() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let callbackFinished = DispatchSemaphore(value: 0)
+        var collector: ProcessOutputCollector!
+        var callbackResult: ProcessOutputResult?
+        let resultLock = NSLock()
+        collector = ProcessOutputCollector(stdout: stdout, stderr: stderr) { _ in
+            let result = collector.finishResult()
+            resultLock.lock()
+            callbackResult = result
+            resultLock.unlock()
+            callbackFinished.signal()
+        }
+        collector.start()
+        try? stdout.fileHandleForWriting.write(contentsOf: Data("reentrant\n".utf8))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        #expect(callbackFinished.wait(timeout: .now() + 1) == .success)
+        let result = collector.finishResult()
+        resultLock.lock()
+        let nestedResult = callbackResult
+        resultLock.unlock()
+        #expect(nestedResult == result)
+        #expect(result.stdout == "reentrant")
+    }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -1,7 +1,7 @@
 import CmuxFoundation
 import Darwin
 import Foundation
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -14,7 +14,9 @@ import XCTest
 // are covered in CmuxFoundation's FileHandleProcessPipeReadingTests, next to
 // the moved implementation. This app-side test pins the consumer behavior
 // that depends on app types.
-final class ProcessPipeReadCrashRegressionTests: XCTestCase {
+@Suite
+struct ProcessPipeReadCrashRegressionTests {
+    @Test
     func testProcessOutputCollectorTreatsBrokenReadDescriptorAsClosedPipe() {
         let stdout = Pipe()
         let stderr = Pipe()
@@ -26,9 +28,10 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         let output = collector.finish()
 
-        XCTAssertEqual(output, "")
+        #expect(output == "")
     }
 
+    @Test
     func testProcessOutputCollectorKeepsUtf8BoundariesAndSeparatesStdout() {
         let stdout = Pipe()
         let stderr = Pipe()
@@ -42,13 +45,14 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         let result = collector.finishResult()
 
-        XCTAssertLessThanOrEqual(result.stdout.utf8.count, 32 * 1024)
-        XCTAssertNotNil(String(data: Data(result.stdout.utf8), encoding: .utf8))
-        XCTAssertNil(result.machineId, "machine protocol is authoritative only on stdout")
-        XCTAssertNil(MachineCreateCoordinator.createdMachineID(fromOutput: result.stdout))
-        XCTAssertTrue(result.output.contains("OK machine=stderr-id"))
+        #expect(result.stdout.utf8.count <= 32 * 1024)
+        #expect(String(data: Data(result.stdout.utf8), encoding: .utf8) != nil)
+        #expect(result.machineId == nil, "machine protocol is authoritative only on stdout")
+        #expect(MachineCreateCoordinator.createdMachineID(fromOutput: result.stdout) == nil)
+        #expect(result.output.contains("OK machine=stderr-id"))
     }
 
+    @Test
     func testProcessOutputCollectorKeepsMachineProtocolAfterTranscriptEviction() {
         let stdout = Pipe()
         let stderr = Pipe()
@@ -61,10 +65,11 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         let result = collector.finishResult()
 
-        XCTAssertEqual(result.machineId, "calm-petrel")
-        XCTAssertLessThanOrEqual(result.stdout.utf8.count, 32 * 1024)
+        #expect(result.machineId == "calm-petrel")
+        #expect(result.stdout.utf8.count <= 32 * 1024)
     }
 
+    @Test
     func testProcessOutputCollectorSkipsMalformedBytesAndKeepsFollowingText() {
         let stdout = Pipe()
         let stderr = Pipe()
@@ -76,9 +81,10 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         let result = collector.finishResult()
 
-        XCTAssertTrue(result.stdout.contains("Error"))
+        #expect(result.stdout.contains("Error"))
     }
 
+    @Test
     func testProcessOutputCollectorDeliversStderrProgressToLiveConsumer() {
         let stdout = Pipe()
         let stderr = Pipe()
@@ -93,6 +99,6 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         _ = collector.finishResult()
 
-        XCTAssertTrue(chunks.contains("waiting for link\n"))
+        #expect(chunks.contains("waiting for link\n"))
     }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -44,6 +44,7 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         XCTAssertLessThanOrEqual(result.stdout.utf8.count, 32 * 1024)
         XCTAssertNotNil(String(data: Data(result.stdout.utf8), encoding: .utf8))
+        XCTAssertNil(result.machineId, "machine protocol is authoritative only on stdout")
         XCTAssertNil(MachineCreateCoordinator.createdMachineID(fromOutput: result.stdout))
         XCTAssertTrue(result.output.contains("OK machine=stderr-id"))
     }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -116,4 +116,30 @@ struct ProcessPipeReadCrashRegressionTests {
 
         #expect(chunks.contains("waiting for link\n"))
     }
+
+    @Test
+    func testProcessOutputCollectorWaitsForInFlightReadBeforeFinishing() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let entered = DispatchSemaphore(value: 0)
+        let release = DispatchSemaphore(value: 0)
+        let finished = DispatchSemaphore(value: 0)
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr) { _ in
+            entered.signal()
+            release.wait()
+        }
+        collector.start()
+        try? stdout.fileHandleForWriting.write(contentsOf: Data("progress\n".utf8))
+        #expect(entered.wait(timeout: .now() + 1) == .success)
+
+        DispatchQueue.global().async {
+            _ = collector.finishResult()
+            finished.signal()
+        }
+        #expect(finished.wait(timeout: .now() + 0.05) == .timedOut)
+        release.signal()
+        #expect(finished.wait(timeout: .now() + 1) == .success)
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+    }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -207,7 +207,6 @@ struct ProcessPipeReadCrashRegressionTests {
             resultLock.unlock()
             callbackFinished.signal()
         }
-        collector.start()
         try? stdout.fileHandleForWriting.write(contentsOf: Data("reentrant\n".utf8))
         try? stdout.fileHandleForWriting.close()
         try? stderr.fileHandleForWriting.close()

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -305,6 +305,7 @@ struct ProcessPipeReadCrashRegressionTests {
 
         let result = collector.finishResult()
         #expect(result.machineId == "calm-petrel")
+        #expect(result.stdout == "OK machine=calm-petrel")
         #expect(result.output.contains("tail from stderr"))
     }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -9,6 +9,24 @@ import Testing
 @testable import cmux
 #endif
 
+private final class ProcessOutputResultStore: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [ProcessOutputResult?] = [nil, nil]
+
+    func set(_ result: ProcessOutputResult, at index: Int) {
+        lock.lock()
+        values[index] = result
+        lock.unlock()
+    }
+
+    func get() -> (ProcessOutputResult?, ProcessOutputResult?) {
+        lock.lock()
+        let result = (values[0], values[1])
+        lock.unlock()
+        return result
+    }
+}
+
 // The descriptor-level read regressions (would-block on an open writer,
 // end-of-file on a closed writer, partial data preserved on a failing read)
 // are covered in CmuxFoundation's FileHandleProcessPipeReadingTests, next to
@@ -151,9 +169,7 @@ struct ProcessPipeReadCrashRegressionTests {
         let releaseDrain = DispatchSemaphore(value: 0)
         let firstFinished = DispatchSemaphore(value: 0)
         let secondFinished = DispatchSemaphore(value: 0)
-        let resultLock = NSLock()
-        var firstResult: ProcessOutputResult?
-        var secondResult: ProcessOutputResult?
+        let results = ProcessOutputResultStore()
         let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr) { data in
             guard data == Data("tail\n".utf8) else { return }
             drainEntered.signal()
@@ -166,18 +182,14 @@ struct ProcessPipeReadCrashRegressionTests {
 
         DispatchQueue.global().async {
             let result = collector.finishResult()
-            resultLock.lock()
-            firstResult = result
-            resultLock.unlock()
+            results.set(result, at: 0)
             firstFinished.signal()
         }
         #expect(drainEntered.wait(timeout: .now() + 1) == .success)
 
         DispatchQueue.global().async {
             let result = collector.finishResult()
-            resultLock.lock()
-            secondResult = result
-            resultLock.unlock()
+            results.set(result, at: 1)
             secondFinished.signal()
         }
         #expect(secondFinished.wait(timeout: .now() + 0.05) == .timedOut)
@@ -185,11 +197,9 @@ struct ProcessPipeReadCrashRegressionTests {
         releaseDrain.signal()
         #expect(firstFinished.wait(timeout: .now() + 1) == .success)
         #expect(secondFinished.wait(timeout: .now() + 1) == .success)
-        resultLock.lock()
-        let results = (firstResult, secondResult)
-        resultLock.unlock()
-        #expect(results.0 == results.1)
-        #expect(results.0?.stdout == "tail")
+        let collected = results.get()
+        #expect(collected.0 == collected.1)
+        #expect(collected.0?.stdout == "tail")
     }
 
     @Test

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -27,6 +27,29 @@ private final class ProcessOutputResultStore: @unchecked Sendable {
     }
 }
 
+private final class ConcurrentOutputCallbackCoordinator: @unchecked Sendable {
+    let entered = DispatchSemaphore(value: 0)
+    let release = DispatchSemaphore(value: 0)
+    let reentrantReturned = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var callbackCount = 0
+    var collector: ProcessOutputCollector?
+
+    func handle(_ data: Data) {
+        lock.lock()
+        callbackCount += 1
+        let index = callbackCount
+        lock.unlock()
+        if index == 1 {
+            _ = collector?.finishResult()
+            reentrantReturned.signal()
+        }
+        entered.signal()
+        release.wait()
+        _ = data
+    }
+}
+
 // The descriptor-level read regressions (would-block on an open writer,
 // end-of-file on a closed writer, partial data preserved on a failing read)
 // are covered in CmuxFoundation's FileHandleProcessPipeReadingTests, next to
@@ -228,5 +251,28 @@ struct ProcessPipeReadCrashRegressionTests {
         resultLock.unlock()
         #expect(nestedResult == result)
         #expect(result.stdout == "reentrant")
+    }
+
+    @Test
+    func testProcessOutputCollectorDefersReentrantFinishUntilConcurrentReadsReturn() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let callbacks = ConcurrentOutputCallbackCoordinator()
+        callbacks.collector = ProcessOutputCollector(stdout: stdout, stderr: stderr, onOutput: callbacks.handle)
+        callbacks.collector?.start()
+        try? stdout.fileHandleForWriting.write(contentsOf: Data("stdout\n".utf8))
+        try? stderr.fileHandleForWriting.write(contentsOf: Data("stderr\n".utf8))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        #expect(callbacks.entered.wait(timeout: .now() + 1) == .success)
+        #expect(callbacks.entered.wait(timeout: .now() + 1) == .success)
+        #expect(callbacks.reentrantReturned.wait(timeout: .now() + 1) == .success)
+        callbacks.release.signal()
+        callbacks.release.signal()
+
+        let result = callbacks.collector?.finishResult()
+        #expect(result?.stdout.contains("stdout") == true)
+        #expect(result?.output.contains("stderr") == true)
     }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -240,6 +240,7 @@ struct ProcessPipeReadCrashRegressionTests {
             resultLock.unlock()
             callbackFinished.signal()
         }
+        collector.start()
         try? stdout.fileHandleForWriting.write(contentsOf: Data("reentrant\n".utf8))
         try? stdout.fileHandleForWriting.close()
         try? stderr.fileHandleForWriting.close()

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -64,4 +64,18 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
         XCTAssertEqual(result.machineId, "calm-petrel")
         XCTAssertLessThanOrEqual(result.stdout.utf8.count, 32 * 1024)
     }
+
+    func testProcessOutputCollectorSkipsMalformedBytesAndKeepsFollowingText() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr)
+        collector.start()
+        try? stdout.fileHandleForWriting.write(contentsOf: Data([0xFF, 0x45, 0x72, 0x72, 0x6F, 0x72]))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        let result = collector.finishResult()
+
+        XCTAssertTrue(result.stdout.contains("Error"))
+    }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -48,4 +48,20 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
         XCTAssertNil(MachineCreateCoordinator.createdMachineID(fromOutput: result.stdout))
         XCTAssertTrue(result.output.contains("OK machine=stderr-id"))
     }
+
+    func testProcessOutputCollectorKeepsMachineProtocolAfterTranscriptEviction() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr)
+        collector.start()
+        let output = "OK machine=calm-petrel\n" + String(repeating: "x", count: 64 * 1024)
+        try? stdout.fileHandleForWriting.write(contentsOf: Data(output.utf8))
+        try? stdout.fileHandleForWriting.close()
+        try? stderr.fileHandleForWriting.close()
+
+        let result = collector.finishResult()
+
+        XCTAssertEqual(result.machineId, "calm-petrel")
+        XCTAssertLessThanOrEqual(result.stdout.utf8.count, 32 * 1024)
+    }
 }

--- a/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
+++ b/cmuxTests/ProcessPipeReadCrashRegressionTests.swift
@@ -78,4 +78,21 @@ final class ProcessPipeReadCrashRegressionTests: XCTestCase {
 
         XCTAssertTrue(result.stdout.contains("Error"))
     }
+
+    func testProcessOutputCollectorDeliversStderrProgressToLiveConsumer() {
+        let stdout = Pipe()
+        let stderr = Pipe()
+        var chunks: [String] = []
+        let collector = ProcessOutputCollector(stdout: stdout, stderr: stderr) { data in
+            if let chunk = String(data: data, encoding: .utf8) { chunks.append(chunk) }
+        }
+        collector.start()
+        try? stderr.fileHandleForWriting.write(contentsOf: Data("waiting for link\n".utf8))
+        try? stderr.fileHandleForWriting.close()
+        try? stdout.fileHandleForWriting.close()
+
+        _ = collector.finishResult()
+
+        XCTAssertTrue(chunks.contains("waiting for link\n"))
+    }
 }


### PR DESCRIPTION
The cloud VM launcher coalescer now has an owned delivery task and finishes its AsyncStream on process termination and launch cancellation. This releases buffered progress and output handlers instead of retaining one task per launch.

Tests cover process-completion stream draining and cancellation deallocation. The branch also carries the bounded progress transcript, retry generation, and strict stdout machine protocol fixes from #11797 so this PR is self-contained.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloud VM progress delivery now runs through one bounded, owned task instead of creating a task per output chunk. It drains buffered output before publishing process completion, cancels cleanly on launch cancellation, and covers concurrent and reentrant finalization without retaining handlers or tasks.

**Cloud VM creation**

- Bounds stdout and stderr transcripts to 32 KB while preserving valid UTF-8 across fragmented or malformed bytes.
- Recognizes machine IDs only on strict `OK machine=...` stdout lines and keeps them after transcript eviction or failed opens.
- Tags callbacks by retry generation so stale progress or completion cannot affect newer attempts.
- Keeps stderr progress live and waits for active pipe reads before closing the collector.
- Adds regression coverage for coalescer cleanup, output races, UTF-8 handling, and protocol parsing.

**Surface commands**

- Refreshes the surface catalog after optimistic port registration so newly opened ports are available immediately.

<sup>Written for commit 756f3bff65af9eda8e7075dd8011cee996f3e366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud machine creation reliability when retrying, cancelling, or restarting operations.
  - Prevented outdated operation results from affecting newer creation attempts.
  - Improved machine ID detection and preserved successful creation details despite lengthy or fragmented command output.
  - Fixed handling of non-ASCII and malformed streamed output.
  - Fixed an issue where opening a VM port could briefly produce an “unknown resource” error.
  - Improved reliability when processing large volumes of command output during machine creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->