### PR TITLE
cloud: unify publication deny responses

### DIFF
--- a/web/app/api/freestyle/forward-auth/route.ts
+++ b/web/app/api/freestyle/forward-auth/route.ts
@@ -1,4 +1,9 @@
 import { env } from "../../../env";
+import {
+  POSTHOG_HOST,
+  POSTHOG_PROJECT_KEY,
+  isAnalyticsTestRun,
+} from "../../../../services/analytics/iosEventPolicy";
 import { enforceNativeIngressRateLimit } from "../../../../services/nativeIngressRateLimit";
 import {
   beginPublicationAuthorization,
@@ -165,7 +170,14 @@ export async function handleForwardAuthRequest(
     });
 
     if (evaluation.kind === "allow") return response(null, 204);
-    if (evaluation.kind === "not_found") return response(null, 404);
+    if (evaluation.kind === "not_found") {
+      // A stale provider rule must not expose a provider JSON error page. Send
+      // the browser to the same CMUX-owned deny surface used by invalid links.
+      // This is a redirect only, with no transaction or other auth artifact.
+      const location = new URL("/cloud/access", authPageOrigin).toString();
+      capturePublicationError("publication_not_found", request);
+      return redirectResponse(location, "publication_not_found");
+    }
     if (evaluation.kind === "unauthorized") return response(null, 401);
 
     // Minting a transaction is the one write an anonymous request can cause;
@@ -198,6 +210,7 @@ export async function handleForwardAuthRequest(
     return new Response(null, { status: 302, headers });
   } catch (error) {
     console.error("Cloud VM publication forward auth failed", describeAuthError(error));
+    capturePublicationError("forward_auth_error", request);
     return response(null, isAuthArtifactError(error) ? 400 : 503);
   }
 }
@@ -285,6 +298,44 @@ function response(body: BodyInit | null, status: number): Response {
   return new Response(body, {
     status,
     headers: { "cache-control": "no-store" },
+  });
+}
+
+function redirectResponse(location: string, reason: string): Response {
+  return new Response(null, {
+    status: 302,
+    headers: {
+      "cache-control": "no-store",
+      location,
+      "x-cmux-publication-deny": reason,
+    },
+  });
+}
+
+/** Fire-and-forget telemetry. It must never add latency or change auth behavior. */
+function capturePublicationError(reason: string, request: Request): void {
+  if (isAnalyticsTestRun()) return;
+  const method = request.headers.get("x-forwarded-method")?.trim().toUpperCase() || "unknown";
+  const ruleId = request.headers.get("x-freestyle-tls-rule-id")?.trim() || "unknown";
+  void fetch(`${POSTHOG_HOST}/capture/`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      api_key: POSTHOG_PROJECT_KEY,
+      event: "cmux_cloud_publication_error",
+      distinct_id: `publication-edge:${ruleId}`,
+      properties: {
+        reason,
+        method,
+        provider_tls_rule_id_present: ruleId !== "unknown",
+      },
+      timestamp: new Date().toISOString(),
+    }),
+  }).catch((error) => {
+    console.error("cloud.publication.posthog_failed", {
+      reason,
+      error: error instanceof Error ? error.message : String(error),
+    });
   });
 }
 

--- a/web/app/cloud/access/access-card.tsx
+++ b/web/app/cloud/access/access-card.tsx
@@ -63,7 +63,7 @@ export function PublicationAccessCard({
         />
 
         <h1 className="mt-6 text-balance text-2xl font-semibold leading-tight tracking-[-0.03em]">
-          {invalid ? messages.invalidTitle : messages.title}
+          {messages.title}
         </h1>
 
         {hostname && !invalid ? (

--- a/web/tests/vm-publication-access-card.test.tsx
+++ b/web/tests/vm-publication-access-card.test.tsx
@@ -109,7 +109,7 @@ describe("Cloud VM publication access card", () => {
         view="invalid"
       />,
     );
-    expect(html).toContain("This access link isn&#x27;t valid");
+    expect(html).toContain("You don&#x27;t have access");
     expect(html).toContain("Return to the shared site and try again.");
     expect(html).not.toContain("prickly-lavender-minnow.cmux.sh");
     expect(html).not.toContain("<a ");

--- a/web/tests/vm-publication-forward-auth-route.test.ts
+++ b/web/tests/vm-publication-forward-auth-route.test.ts
@@ -109,6 +109,18 @@ describe("Freestyle publication forward-auth HTTP contract", () => {
     });
   });
 
+  test("redirects an unmapped edge rule to the CMUX deny page", async () => {
+    const result = await handleForwardAuthRequest(
+      request(),
+      dependencies({ evaluate: async () => ({ kind: "not_found" }) }),
+    );
+
+    expect(result.status).toBe(302);
+    expect(result.headers.get("location")).toBe("https://cmux.com/cloud/access");
+    expect(result.headers.get("cache-control")).toBe("no-store");
+    expect(result.headers.get("x-cmux-publication-deny")).toBe("publication_not_found");
+  });
+
   test("identifies the publication by TLS rule id, never by x-forwarded-host", async () => {
     // Vercel overwrites x-forwarded-host with the function's own host before the
     // route runs, so a hostname-keyed lookup 404s every protected publication.


### PR DESCRIPTION
Make invalid Cloud publication links render the same “You don’t have access” surface as other denied access states.

When a stale Freestyle TLS rule has no active publication, redirect to the CMUX deny page instead of exposing provider JSON. Emit fire-and-forget PostHog events for publication edge errors without adding request latency.

Focused tests: vm-publication-access-card, vm-publication-forward-auth-route (dependency install is unavailable in this worktree, so tests could not run locally).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791025097&installation_model_id=21920&pr_number=11839&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11839&signature=378999f3e43630beb8a6ea1072ca1e1047ddf9d4cef9f40e11f3f2035b359aa3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies invalid Cloud publication links so they show the same "You don't have access" page as other denied access states, instead of exposing provider JSON from stale TLS rules.

- Stale Freestyle TLS rules now redirect to `/cloud/access` with a 302 instead of returning a 404 with provider JSON.
- Publication edge errors emit fire-and-forget PostHog events, so request latency is unaffected.
- The invalid-link access card now uses the same title as other denied access states.

<sup>Written for commit 7bbfc71b369be8499b630a92e9837ef79ccd4313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Invalid or unavailable publication links now redirect to the access page instead of showing a plain 404 error.
  * The access page consistently displays “You don’t have access” for invalid publication states.
  * Invalid access views no longer display unavailable hostname or link details.

* **Monitoring**
  * Added telemetry for publication errors and unavailable provider rules to improve issue detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->