### PR TITLE
fix(relay): retry owner persistence failures

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -931,7 +931,7 @@ async fn relay_session(
                         }
                         if reconcile_owner_user_id_and_persist(
                             config,
-                            hello.owner_user_id.clone(),
+                            hello.owner_user_id,
                             config_path,
                             state.managed,
                         )

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1325,8 +1325,8 @@ mod tests {
 
 #[cfg(test)]
 mod owner_identity_tests {
-    use super::reconcile_owner_user_id;
-    use crate::config::Config;
+    use super::{reconcile_owner_user_id, reconcile_owner_user_id_and_persist};
+    use crate::config::{Config, load_config, save_config};
 
     #[test]
     fn reconnect_without_owner_clears_previous_owner() {
@@ -1338,6 +1338,27 @@ mod owner_identity_tests {
         reconcile_owner_user_id(&mut config, None);
 
         assert_eq!(config.owner_user_id, None);
+    }
+
+    #[test]
+    fn ownerless_reconnect_persists_before_restart() {
+        let path = std::env::temp_dir().join(format!(
+            "chatmux-relay-owner-reconnect-{}.json",
+            std::process::id()
+        ));
+        let mut config = Config {
+            device_id: "device".to_owned(),
+            token: "token".to_owned(),
+            owner_user_id: Some("previous-owner".to_owned()),
+            ..Config::default()
+        };
+        save_config(&path, &config).expect("initial config saves");
+
+        reconcile_owner_user_id_and_persist(&mut config, None, &path, false);
+
+        let reloaded = load_config(&path).expect("persisted config loads");
+        assert_eq!(reloaded.owner_user_id, None);
+        std::fs::remove_file(path).ok();
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -931,7 +931,7 @@ async fn relay_session(
                         }
                         if reconcile_owner_user_id_and_persist(
                             config,
-                            hello.owner_user_id,
+                            hello.owner_user_id.clone(),
                             config_path,
                             state.managed,
                         )

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1372,11 +1372,44 @@ mod owner_identity_tests {
         };
         save_config(&path, &config).expect("initial config saves");
 
-        reconcile_owner_user_id_and_persist(&mut config, None, &path, false);
+        let _ = reconcile_owner_user_id_and_persist(&mut config, None, &path, false);
 
         let reloaded = load_config(&path).expect("persisted config loads");
         assert_eq!(reloaded.owner_user_id, None);
         std::fs::remove_file(path).ok();
+    }
+
+    #[test]
+    fn ownerless_reconnect_retries_after_persist_failure() {
+        let unique = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("system clock is after the Unix epoch")
+            .as_nanos();
+        let root = std::env::temp_dir().join(format!(
+            "chatmux-relay-owner-reconnect-retry-{}-{unique}",
+            std::process::id()
+        ));
+        let persisted_path = root.join("config.json");
+        let blocked_parent = root.join("blocked");
+        let failed_path = blocked_parent.join("config.json");
+        std::fs::create_dir_all(&root).expect("test directory creates");
+
+        let mut config = Config {
+            device_id: "device".to_owned(),
+            token: "token".to_owned(),
+            owner_user_id: Some("previous-owner".to_owned()),
+            ..Config::default()
+        };
+        save_config(&persisted_path, &config).expect("initial config saves");
+        std::fs::write(&blocked_parent, b"not a directory").expect("blocker file writes");
+
+        let _ = reconcile_owner_user_id_and_persist(&mut config, None, &failed_path, false);
+        assert_eq!(config.owner_user_id.as_deref(), Some("previous-owner"));
+        let _ = reconcile_owner_user_id_and_persist(&mut config, None, &persisted_path, false);
+
+        let reloaded = load_config(&persisted_path).expect("persisted config loads");
+        assert_eq!(reloaded.owner_user_id, None);
+        std::fs::remove_dir_all(root).ok();
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -105,6 +105,19 @@ fn reconcile_owner_user_id(config: &mut Config, owner_user_id: Option<String>) {
     config.owner_user_id = owner_user_id;
 }
 
+fn reconcile_owner_user_id_and_persist(
+    config: &mut Config,
+    owner_user_id: Option<String>,
+    config_path: &Path,
+    managed: bool,
+) {
+    let changed = config.owner_user_id != owner_user_id;
+    reconcile_owner_user_id(config, owner_user_id);
+    if changed && !managed {
+        save(config, config_path);
+    }
+}
+
 pub(crate) struct OutboundFrame {
     pub(crate) text: String,
     pub(crate) live: Option<Arc<AtomicBool>>,
@@ -896,7 +909,12 @@ async fn relay_session(
                             config.pending_trust = Some(local_trust.as_str().to_owned());
                             save(config, config_path);
                         }
-                        reconcile_owner_user_id(config, hello.owner_user_id);
+                        reconcile_owner_user_id_and_persist(
+                            config,
+                            hello.owner_user_id,
+                            config_path,
+                            state.managed,
+                        );
                         if state.managed {
                             match hello
                                 .managed_session_token

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -98,6 +98,13 @@ struct AuthSnapshot {
     owner: Option<String>,
 }
 
+/// Replace the persisted owner with the identity from the latest hello.
+/// An omitted owner is an explicit absence, so retaining a prior value would
+/// carry authority across reconnects.
+fn reconcile_owner_user_id(config: &mut Config, owner_user_id: Option<String>) {
+    config.owner_user_id = owner_user_id;
+}
+
 pub(crate) struct OutboundFrame {
     pub(crate) text: String,
     pub(crate) live: Option<Arc<AtomicBool>>,
@@ -889,9 +896,7 @@ async fn relay_session(
                             config.pending_trust = Some(local_trust.as_str().to_owned());
                             save(config, config_path);
                         }
-                        if let Some(owner) = hello.owner_user_id {
-                            config.owner_user_id = Some(owner);
-                        }
+                        reconcile_owner_user_id(config, hello.owner_user_id);
                         if state.managed {
                             match hello
                                 .managed_session_token

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -105,17 +105,33 @@ fn reconcile_owner_user_id(config: &mut Config, owner_user_id: Option<String>) {
     config.owner_user_id = owner_user_id;
 }
 
+/// Reconcile the hello owner and persist unmanaged changes before publishing
+/// the new authority snapshot. A failed write restores the previous owner so
+/// the next reconnect retries the durable update.
 fn reconcile_owner_user_id_and_persist(
     config: &mut Config,
     owner_user_id: Option<String>,
     config_path: &Path,
     managed: bool,
-) {
+) -> std::io::Result<()> {
     let changed = config.owner_user_id != owner_user_id;
-    reconcile_owner_user_id(config, owner_user_id);
-    if changed && !managed {
-        save(config, config_path);
+    if !changed {
+        return Ok(());
     }
+    if managed {
+        reconcile_owner_user_id(config, owner_user_id);
+        return Ok(());
+    }
+
+    let previous_owner = config.owner_user_id.clone();
+    reconcile_owner_user_id(config, owner_user_id);
+    if let Err(error) = save(config, config_path) {
+        // Keep the old value so the next ownerless hello retries the durable
+        // write instead of treating the in-memory clear as already persisted.
+        config.owner_user_id = previous_owner;
+        return Err(error);
+    }
+    Ok(())
 }
 
 pub(crate) struct OutboundFrame {
@@ -533,8 +549,12 @@ pub async fn stay_online(
     }
 }
 
-fn save(config: &Config, config_path: &Path) {
-    if let Err(error) = save_config(config_path, config) {
+fn save(config: &Config, config_path: &Path) -> std::io::Result<()> {
+    save_config(config_path, config)
+}
+
+fn save_best_effort(config: &Config, config_path: &Path) {
+    if let Err(error) = save(config, config_path) {
         eprintln!("Could not save the relay config: {error}");
     }
 }
@@ -907,14 +927,20 @@ async fn relay_session(
                             && (configured != local_trust || local_trust == Trust::Autonomous)
                         {
                             config.pending_trust = Some(local_trust.as_str().to_owned());
-                            save(config, config_path);
+                            save_best_effort(config, config_path);
                         }
-                        reconcile_owner_user_id_and_persist(
+                        if reconcile_owner_user_id_and_persist(
                             config,
                             hello.owner_user_id,
                             config_path,
                             state.managed,
-                        );
+                        )
+                        .is_err()
+                        {
+                            break Err(RelayError::transient(
+                                "Relay owner state could not be saved; check relay config permissions while reconnecting.",
+                            ));
+                        }
                         if state.managed {
                             match hello
                                 .managed_session_token
@@ -980,7 +1006,7 @@ async fn relay_session(
                         } else if !state.managed {
                             config.trust = Some(local_trust.as_str().to_owned());
                             config.pending_trust = None;
-                            save(config, config_path);
+                            save_best_effort(config, config_path);
                         } else {
                             config.trust = Some(hello.trust.clone());
                         }
@@ -1031,7 +1057,7 @@ async fn relay_session(
                             config.pending_trust = Some(DEFAULT_RELAY_TRUST.as_str().to_owned());
                             clear_invalid_yolo_confirmation(config);
                             if !state.managed {
-                                save(config, config_path);
+                                save_best_effort(config, config_path);
                             }
                             let frame = set_trust_frame(DEFAULT_RELAY_TRUST.as_str()).to_string();
                             let _ = send_socket_text(
@@ -1054,7 +1080,7 @@ async fn relay_session(
                             config.yolo_confirmed_at = None;
                         }
                         if !state.managed {
-                            save(config, config_path);
+                            save_best_effort(config, config_path);
                         }
                         auth.lock().expect("auth lock").trust = ack.as_str().to_owned();
                         workspace.set_local_observe(ack == Trust::Observe);
@@ -1348,10 +1374,8 @@ mod owner_identity_tests {
 
     #[test]
     fn reconnect_without_owner_clears_previous_owner() {
-        let mut config = Config {
-            owner_user_id: Some("previous-owner".to_owned()),
-            ..Config::default()
-        };
+        let mut config =
+            Config { owner_user_id: Some("previous-owner".to_owned()), ..Config::default() };
 
         reconcile_owner_user_id(&mut config, None);
 
@@ -1360,10 +1384,8 @@ mod owner_identity_tests {
 
     #[test]
     fn ownerless_reconnect_persists_before_restart() {
-        let path = std::env::temp_dir().join(format!(
-            "chatmux-relay-owner-reconnect-{}.json",
-            std::process::id()
-        ));
+        let path = std::env::temp_dir()
+            .join(format!("chatmux-relay-owner-reconnect-{}.json", std::process::id()));
         let mut config = Config {
             device_id: "device".to_owned(),
             token: "token".to_owned(),
@@ -1385,10 +1407,8 @@ mod owner_identity_tests {
             .duration_since(std::time::UNIX_EPOCH)
             .expect("system clock is after the Unix epoch")
             .as_nanos();
-        let root = std::env::temp_dir().join(format!(
-            "chatmux-relay-owner-reconnect-retry-{}-{unique}",
-            std::process::id()
-        ));
+        let root = std::env::temp_dir()
+            .join(format!("chatmux-relay-owner-reconnect-retry-{}-{unique}", std::process::id()));
         let persisted_path = root.join("config.json");
         let blocked_parent = root.join("blocked");
         let failed_path = blocked_parent.join("config.json");

--- a/cmux-tui/crates/chatmux-relay/src/session.rs
+++ b/cmux-tui/crates/chatmux-relay/src/session.rs
@@ -1319,6 +1319,24 @@ mod tests {
 }
 
 #[cfg(test)]
+mod owner_identity_tests {
+    use super::reconcile_owner_user_id;
+    use crate::config::Config;
+
+    #[test]
+    fn reconnect_without_owner_clears_previous_owner() {
+        let mut config = Config {
+            owner_user_id: Some("previous-owner".to_owned()),
+            ..Config::default()
+        };
+
+        reconcile_owner_user_id(&mut config, None);
+
+        assert_eq!(config.owner_user_id, None);
+    }
+}
+
+#[cfg(test)]
 mod liveness_tests {
     use super::{
         PRE_HELLO_READ_DEADLINE, READ_LIVENESS_GRACE, SUSPEND_CLOCK_JUMP, clock_jumped,


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11558.

When hello_accepted omits ownerUserId, clear stale owner authority and persist the change for unmanaged relays. If persistence fails, retain the prior in-memory owner and reconnect so the next hello retries the durable write.

Regression tests cover in-memory clearing, persistence across restart, and retry after a failed save. Hosted cmux-tui verification is required; no local Rust tests were run.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
When a reconnect `hello` omits `ownerUserId`, the relay now clears the stale owner instead of keeping it. Unmanaged relays persist the cleared owner; managed relays update only in-memory state. If persistence fails, the previous owner is restored and a transient error is returned so the next reconnect retries the save.

Regression tests cover clearing, restart persistence, managed handling, and retry after a failed save.

<sup>Written for commit 94a731f6a47a3b2e037eb27c82e8392f7121933c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved relay session ownership handling during reconnects.
  - Stale owner information is cleared when a connection no longer identifies an owner.
  - Ownership changes are retained more reliably, including after temporary persistence failures.
  - Session state now reports transient save failures so they can be retried instead of being silently overlooked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->