### PR TITLE
fix: remove unnecessary PathBuf qualification

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/terminal_host_runtime.rs
@@ -9310,7 +9310,7 @@ mod unix {
                 assert_eq!(snapshot, Some("/spawn".into()));
                 assert_eq!(
                     crate::platform::snapshot_cwd_to_local_path(snapshot.as_deref().unwrap(), None),
-                    Some(std::path::PathBuf::from("/spawn"))
+                    Some(PathBuf::from("/spawn"))
                 );
             }
         }

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -76,7 +76,7 @@ pub(super) fn is_remote_invocation(args: &[String]) -> bool {
         match args[index].as_str() {
             "--" => return false,
             "--socket" | "--session" | "--machine" => {
-                if !args.get(index + 1).is_some_and(|value| !value.starts_with("--")) {
+                if args.get(index + 1).is_none_or(|value| value.starts_with("--")) {
                     return false;
                 }
                 index += 2;


### PR DESCRIPTION
Clippy 1.95 reports two mechanical cleanups in cmux-tui.

- Reuse the imported `PathBuf` in the terminal host runtime test.
- Express the remote invocation option-value check with `is_none_or`, preserving the existing behavior.

Verification on Blacksmith Testbox with Rust 1.95.0:
- `cargo +1.95.0 clippy --locked --all-targets -- -D warnings`
- `cargo +1.95.0 test -p cmux-tui --locked remote_invocation -- --nocapture` (2 passed)

Canonical local autoreview reports no actionable findings.