### PR TITLE
perf(cmux-tui): cache projection agent snapshots

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/http.rs
+++ b/cmux-tui/crates/cmux-remote/src/http.rs
@@ -779,7 +779,7 @@ mod tests {
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
         let metadata = file.metadata().unwrap();
         validate_workspace_http_token_metadata(&metadata).unwrap();
-        fs::OpenOptions::new()
+        OpenOptions::new()
             .append(true)
             .open(&path)
             .unwrap()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10308,7 +10308,7 @@ impl App {
         crate::sidebar_projection::rows(
             spec,
             &self.tree,
-            &agents,
+            agents,
             self.sidebar_workspace_selection,
             collapsed,
         )

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24871,7 +24871,7 @@ mod tests {
     #[test]
     fn crossterm_reader_propagates_poll_errors_without_reading() {
         let mut read_calls = 0;
-        let error = std::io::Error::new(std::io::ErrorKind::Other, "poll failed");
+        let error = std::io::Error::other("poll failed");
         let mut poll_calls = 0;
 
         let result = super::read_crossterm_event(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44034,7 +44034,14 @@ mod tests {
         assert_eq!(first, second);
         assert_eq!(app.projection_agents_builds, 1);
 
-        app.invalidate_projection_agents();
+        app.handle(AppEvent::Mux(MuxEvent::AgentChanged {
+            surface: 0,
+            state: "working".into(),
+            source: "hook".into(),
+            session: None,
+            updated_at_ms: 1,
+        }))
+        .unwrap();
         let third = app.projection_rows(0);
         assert_eq!(third, first);
         assert_eq!(app.projection_agents_builds, 2);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7131,6 +7131,13 @@ pub struct App {
     config_reload_applications: usize,
     pub chrome: ChromeTheme,
     pub tree: TreeView,
+    /// Cached active-agent snapshot used by projection rows. Agent records
+    /// are unchanged across most redraws, so avoid rebuilding the full list
+    /// until a topology or agent event advances this generation.
+    projection_agents: Option<(u64, Vec<AgentInfo>)>,
+    projection_agents_generation: u64,
+    #[cfg(test)]
+    projection_agents_builds: usize,
     tab_locations: HashMap<SurfaceId, [usize; 4]>,
     pub render_states: HashMap<SurfaceId, RenderState>,
     pub(crate) chrome_row_scratch: ReusableRowBuffer,
@@ -9433,6 +9440,10 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         config_reload_applications: 0,
         chrome,
         tree: TreeView::default(),
+        projection_agents: None,
+        projection_agents_generation: 0,
+        #[cfg(test)]
+        projection_agents_builds: 0,
         tab_locations: HashMap::new(),
         render_states: HashMap::new(),
         chrome_row_scratch: ReusableRowBuffer::default(),
@@ -10250,7 +10261,38 @@ impl App {
         self.focus == FocusTarget::ProjectionRail(index)
     }
 
-    pub(crate) fn projection_rows(&self, index: usize) -> Vec<ProjectionRow> {
+    pub(crate) fn projection_rows(&mut self, index: usize) -> Vec<ProjectionRow> {
+        let Some(includes_agents) = self
+            .config
+            .sidebar
+            .views
+            .get(index)
+            .map(|spec| spec.includes(SidebarResourceKind::Agents))
+        else {
+            return Vec::new();
+        };
+        if includes_agents {
+            let generation = self.projection_agents_generation;
+            let cache_stale = self
+                .projection_agents
+                .as_ref()
+                .is_none_or(|(cached_generation, _)| *cached_generation != generation);
+            if cache_stale {
+                // Finished reports are historical records, not active agents.
+                // Otherwise detached "surface..." rows remain forever after exit.
+                let agents = self
+                    .session
+                    .agents()
+                    .into_iter()
+                    .filter(|agent| !matches!(agent.state.as_str(), "done" | "unknown"))
+                    .collect::<Vec<_>>();
+                self.projection_agents = Some((generation, agents));
+                #[cfg(test)]
+                {
+                    self.projection_agents_builds += 1;
+                }
+            }
+        }
         let Some(spec) = self.config.sidebar.views.get(index) else { return Vec::new() };
         let empty_collapsed = HashSet::new();
         let collapsed = self
@@ -10258,17 +10300,11 @@ impl App {
             .get(&spec.id)
             .map(|state| &state.collapsed)
             .unwrap_or(&empty_collapsed);
-        let agents = if spec.includes(SidebarResourceKind::Agents) {
-            // Finished reports are historical records, not active agents.
-            // Otherwise detached "surface..." rows remain forever after exit.
-            self.session
-                .agents()
-                .into_iter()
-                .filter(|agent| !matches!(agent.state.as_str(), "done" | "unknown"))
-                .collect::<Vec<_>>()
-        } else {
-            Vec::new()
-        };
+        let agents = self
+            .projection_agents
+            .as_ref()
+            .filter(|_| includes_agents)
+            .map_or(&[][..], |(_, agents)| agents.as_slice());
         crate::sidebar_projection::rows(
             spec,
             &self.tree,
@@ -11917,6 +11953,7 @@ impl App {
             self.browser_input.forget_surface(surface);
         }
         self.tree = tree;
+        self.invalidate_projection_agents();
         // The readout belongs to the previous daemon; the replacement's own
         // value arrives from its background refresh.
         self.machine_usage = None;
@@ -13184,7 +13221,14 @@ impl App {
         changed
     }
 
+    fn invalidate_projection_agents(&mut self) {
+        self.projection_agents_generation = self.projection_agents_generation.wrapping_add(1);
+        self.projection_agents = None;
+    }
+
     fn replace_tree(&mut self, mut tree: TreeView) {
+        let topology_changed = self.tree.workspace_revision != tree.workspace_revision
+            || self.tree.pane_revision != tree.pane_revision;
         let previous_active = self.active_pane();
         let selected_workspace = self
             .tree
@@ -13238,6 +13282,9 @@ impl App {
         self.viewport_states.retain(|screen, _| live_screens.contains(screen));
         self.pane_focus_history.sync_membership(&tree);
         self.tree = tree;
+        if topology_changed {
+            self.invalidate_projection_agents();
+        }
         self.sidebar_workspace_selection = selected_workspace
             .and_then(|selected| {
                 self.tree.workspaces().iter().position(|workspace| workspace.id == selected)
@@ -13354,6 +13401,7 @@ impl App {
     /// topology refresh arrives. The backend projection still owns parent
     /// pane, screen, and workspace collapse.
     fn remove_surface_from_cached_tree(&mut self, surface: SurfaceId) {
+        self.invalidate_projection_agents();
         self.tree.invalidate_location_index();
         let Some([workspace_index, screen_index, pane_index, tab_index]) =
             self.tab_locations.get(&surface).copied()
@@ -15535,6 +15583,10 @@ impl App {
                 } else {
                     Ok(RenderAction::Paint)
                 }
+            }
+            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
+                self.invalidate_projection_agents();
+                Ok(RenderAction::Draw)
             }
             AppEvent::Mux(MuxEvent::PairingRequested(challenge)) => {
                 let duplicate = self
@@ -43961,6 +44013,34 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_reuse_agent_snapshot_until_invalidated() {
+        let (mux, _surface) = test_mux("projection-agent-snapshot-cache-test", None);
+        let mut app = test_app(Session::Local(mux));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "workspace-agents".into(),
+            levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+
+        let first = app.projection_rows(0);
+        let second = app.projection_rows(0);
+        assert_eq!(first, second);
+        assert_eq!(app.projection_agents_builds, 1);
+
+        app.invalidate_projection_agents();
+        let third = app.projection_rows(0);
+        assert_eq!(third, first);
+        assert_eq!(app.projection_agents_builds, 2);
+    }
+
+    #[test]
     fn tabs_column_context_menu_renames_the_exact_clicked_tab() {
         let (mux, first) = test_mux("tabs-column-rename-test", None);
         let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
@@ -46074,6 +46154,9 @@ mod tests {
             config_reload_applications: 0,
             chrome: ChromeTheme::dark(),
             tree: TreeView::default(),
+            projection_agents: None,
+            projection_agents_generation: 0,
+            projection_agents_builds: 0,
             tab_locations: HashMap::new(),
             render_states: HashMap::<u64, RenderState>::new(),
             chrome_row_scratch: crate::ui::ReusableRowBuffer::default(),


### PR DESCRIPTION
## Summary

Cache the filtered agent snapshot used by sidebar projection rows. The cache is invalidated by agent events, topology revision changes, session replacement, and retired surfaces. This removes the repeated full agent-record fold on redraw while preserving existing row generation and filtering.

## Testing

- `rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui/src/app.rs`
- Blacksmith Testbox: `cargo test --locked -p cmux-tui projection_rows_reuse_agent_snapshot_until_invalidated`
- Blacksmith Testbox: `cargo test --locked -p cmux-tui sidebar_projection`
- `git diff --check`

Adds a regression test proving repeated projection reads reuse the snapshot and invalidation rebuilds it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches the active-agent snapshot used by sidebar projection rows so redraws no longer rebuild agent records. The cache invalidates on agent events, topology changes, session replacement, and retired surfaces; filtering and row generation are unchanged.

- Adds regression coverage for snapshot reuse and `AgentChanged` invalidation.
- Removes redundant `OpenOptions` qualification in `cmux-remote` tests.

<sup>Written for commit e87a08a714e00ae1eb7975b05dc34e3758f418d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved projection view responsiveness by reusing active-agent data when no relevant changes have occurred.
  * Automatically refreshes displayed agent information after tree updates, surface removal, or agent status changes.

* **Tests**
  * Added coverage confirming cached agent data is reused appropriately and refreshed after agent changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->