### PR TITLE
Fix stale cmux-tui projection workspace targets

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43633,6 +43633,36 @@ mod tests {
     }
 
     #[test]
+    fn projection_workspace_target_follows_id_after_tree_reorder() {
+        let mux = Mux::new("projection-workspace-target-reorder-test", SurfaceOptions::default());
+        let first = mux.new_workspace(Some("Alpha".into()), Some((80, 24))).unwrap();
+        let second = mux.new_workspace(Some("Beta".into()), Some((80, 24))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.replace_tree(app.session.tree());
+
+        let target = crate::sidebar_projection::ProjectionTarget::Workspace {
+            index: 0,
+            id: app.tree.workspaces()[0].id,
+        };
+        app.tree.workspaces_mut().swap(0, 1);
+        app.activate_projection_target(target).unwrap();
+
+        assert_eq!(app.tree.active_workspace, 1);
+        assert_eq!(app.tree.active_workspace().map(|workspace| workspace.id), Some(target_id(target)));
+
+        for surface in [first.id, second.id] {
+            mux.close_surface(surface).unwrap();
+        }
+    }
+
+    fn target_id(target: crate::sidebar_projection::ProjectionTarget) -> cmux_tui_core::WorkspaceId {
+        match target {
+            crate::sidebar_projection::ProjectionTarget::Workspace { id, .. } => id,
+            _ => unreachable!("workspace target expected"),
+        }
+    }
+
+    #[test]
     fn empty_projection_uses_its_leaf_resource_label() {
         let mux = Mux::new("projection-empty-leaf-label-test", SurfaceOptions::default());
         let mut app = test_app(Session::Local(mux));

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10432,7 +10432,15 @@ impl App {
 
     fn activate_projection_target(&mut self, target: ProjectionTarget) -> anyhow::Result<()> {
         match target {
-            ProjectionTarget::Workspace { index, .. } => {
+            ProjectionTarget::Workspace { id, .. } => {
+                // The hit map can outlive a tree snapshot while a remote
+                // reorder is queued. Resolve the stable workspace identity
+                // again instead of applying a stale row index.
+                let Some(index) =
+                    self.tree.workspaces().iter().position(|workspace| workspace.id == id)
+                else {
+                    return Ok(());
+                };
                 self.activate_workspace(index);
             }
             ProjectionTarget::Pane { workspace, screen, pane } => {
@@ -43648,14 +43656,19 @@ mod tests {
         app.activate_projection_target(target).unwrap();
 
         assert_eq!(app.tree.active_workspace, 1);
-        assert_eq!(app.tree.active_workspace().map(|workspace| workspace.id), Some(target_id(target)));
+        assert_eq!(
+            app.tree.active_workspace().map(|workspace| workspace.id),
+            Some(target_id(target))
+        );
 
         for surface in [first.id, second.id] {
             mux.close_surface(surface).unwrap();
         }
     }
 
-    fn target_id(target: crate::sidebar_projection::ProjectionTarget) -> cmux_tui_core::WorkspaceId {
+    fn target_id(
+        target: crate::sidebar_projection::ProjectionTarget,
+    ) -> cmux_tui_core::WorkspaceId {
         match target {
             crate::sidebar_projection::ProjectionTarget::Workspace { id, .. } => id,
             _ => unreachable!("workspace target expected"),


### PR DESCRIPTION
Summary:

- Resolve projection workspace clicks by stable workspace ID after tree reorders.
- Ignore a target when its workspace no longer exists.
- Preserve first-match behavior for malformed duplicate IDs.

Tests:

- Blacksmith test-only commit failed the new reorder assertion as expected.
- Blacksmith fixed-head focused test passed.
- Blacksmith Clippy passed with the existing `clippy::nonminimal-bool` lint allowed.
- Blacksmith rustfmt check passed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale cmux-tui projection workspace targets so clicking a workspace in the sidebar activates the correct workspace after a tree reorder.

Previously, projection targets were resolved by row index, which could point at the wrong workspace after a reorder or at a workspace that no longer existed. Now targets are resolved by stable workspace ID, and targets whose workspace is gone are ignored.

**Tests**
- Adds a regression test that swaps workspaces before activation and asserts the correct workspace is activated.
- Removes the `clippy::nonminimal-bool` lint allow in the test path since it's no longer needed.

<sup>Written for commit c079dcbeefbde49dfebd40785b2d0c8f84446c3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

