### PR TITLE
fix(python): reject unary machine stats follow mode

### DIFF
--- a/cmux-tui/bindings/codegen/emit_python.py
+++ b/cmux-tui/bindings/codegen/emit_python.py
@@ -1024,6 +1024,14 @@ __all__ = [
             )
             request_name = self.models[f"commands/{wire_name}/request"].name
             conditional_stream = command.get("stream") is not None and command["stream"].get("mode_field") == "follow"
+            if conditional_stream:
+                mode_name = _snake(command["stream"]["mode_field"])
+                lines.extend(
+                    [
+                        f"        if {mode_name} is True:",
+                        f"            raise ValueError({_quote(f'{method_name}({mode_name}=True) requires {method_name}_follow()')})",
+                    ]
+                )
             arguments = []
             for name, _field in required + positional_optional + optional:
                 python_name = _snake(name)

--- a/cmux-tui/bindings/python/cmux/raw/_generated/.cmux-sdk-manifest.json
+++ b/cmux-tui/bindings/python/cmux/raw/_generated/.cmux-sdk-manifest.json
@@ -12,8 +12,8 @@
     },
     {
       "path": "client.py",
-      "sha256": "d12d59c579da0ce70337420b1bfe0d5c89ecd1d9ec70ef0cabc477b8a8fabf46",
-      "size": 39238
+      "sha256": "10dc8beba92de65ddabc38ccc6aa9342fb27d2077cc725fa9c0684aecad5c64a",
+      "size": 39356
     },
     {
       "path": "codec.py",

--- a/cmux-tui/bindings/python/cmux/raw/_generated/client.py
+++ b/cmux-tui/bindings/python/cmux/raw/_generated/client.py
@@ -145,6 +145,8 @@ class GeneratedClientMixin:
         return self._invoke_command('list-workspaces', ListWorkspacesRequest())
 
     def machine_stats(self, *, follow: Union[bool, MissingType] = MISSING) -> MachineStatsResult:
+        if follow is True:
+            raise ValueError('machine_stats(follow=True) requires machine_stats_follow()')
         return self._invoke_command('machine-stats', MachineStatsRequest(follow=MISSING))
 
     def machine_stats_follow(self, *, follow: Union[bool, MissingType] = MISSING) -> Tuple[MachineStatsResult, EventStream]:

--- a/cmux-tui/bindings/python/cmux/raw/client.py
+++ b/cmux-tui/bindings/python/cmux/raw/client.py
@@ -430,7 +430,7 @@ class CmuxClient(GeneratedClientMixin):
         stream_type = AttachStream if metadata.stream_kind == "attach" else EventStream
         return stream_type(self, command, payload)
 
-    def _open_command_stream_with_result(self, command: str, request: Any) -> tuple[Any, _Stream]:
+    def _open_command_stream_with_result(self, command: str, request: object) -> tuple[Any, _Stream]:
         stream = self._open_command_stream(command, request)
         response = stream.response or {}
         try:

--- a/cmux-tui/bindings/python/tests/test_consumer.py
+++ b/cmux-tui/bindings/python/tests/test_consumer.py
@@ -45,6 +45,14 @@ class ConsumerTests(unittest.TestCase):
         self.assertIs(request.cols, MISSING)
         self.assertIs(request.rows, MISSING)
 
+    def test_machine_stats_unary_rejects_follow_true(self) -> None:
+        client = RecordingClient()
+
+        with self.assertRaisesRegex(ValueError, "machine_stats_follow"):
+            client.machine_stats(follow=True)
+
+        self.assertEqual(client.calls, [])
+
     def test_attachment_and_delta_helpers_select_wire_modes(self) -> None:
         client = CmuxClient.__new__(CmuxClient)
         calls = []


### PR DESCRIPTION
## Summary

`machine_stats(follow=True)` previously discarded the caller's mode and sent a unary request. This stacked fix raises a clear `ValueError` and directs callers to `machine_stats_follow()`. The generator and committed Python output stay in sync. The new stream helper request annotation uses `object` instead of `Any`.

## Verification

- Regression commit `7b6e4ecde32` adds the behavior test and fails before the fix (`ValueError not raised`).
- Fix commit `d02a01b2608` makes the test pass.
- Python package tests: 110 passed.
- Python codegen check, bytecode compile, and `git diff --check`: passed.

This PR is intentionally stacked on `feat-cloud-machine-stats-event` because `main` does not yet contain the machine-stats command. The machine-stats freshness TTL remains a product/protocol decision and is not invented here.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `machine_stats(follow=True)` previously discarding the caller's mode and sending a unary request; it now raises a `ValueError` directing callers to `machine_stats_follow()`.

- The codegen now emits the guard for any conditional stream method whose mode field is `follow`.
- Adds a regression test verifying no command is sent and the error is raised.
- Changes the request parameter annotation in `_open_command_stream_with_result` from `Any` to `object`.
- This PR is stacked on `feat-cloud-machine-stats-event` because `main` doesn't have the machine-stats command yet.

<sup>Written for commit 1bf574d4978d1c8826d02e65667a060a38cb2390. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11849?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

