### PR TITLE
fix(cmux-tui): keep PTY control cleanup nonblocking

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -480,11 +480,62 @@ impl Drop for SpawnedChildCleanup {
     }
 }
 
+#[derive(Default)]
+struct ChildLifecycleState {
+    exited: bool,
+    termination_started: bool,
+}
+
+/// Fences control cleanup against the wait thread's final reap. The child PID
+/// remains reserved until `wait` returns, so a late control drop cannot signal
+/// an unrelated process after PID reuse.
+struct ChildLifecycle {
+    state: Mutex<ChildLifecycleState>,
+}
+
+impl ChildLifecycle {
+    fn new() -> Arc<Self> {
+        Arc::new(Self { state: Mutex::new(ChildLifecycleState::default()) })
+    }
+
+    fn mark_exited_before_reap(&self) {
+        self.state.lock().expect("child lifecycle lock").exited = true;
+    }
+
+    fn begin_termination(&self) -> bool {
+        let mut state = self.state.lock().expect("child lifecycle lock");
+        if state.exited || state.termination_started {
+            return false;
+        }
+        state.termination_started = true;
+        true
+    }
+}
+
+fn force_kill_process_group(pid: libc::pid_t) {
+    if pid > 0 {
+        // `kill(2)` only queues the signal. It does not touch the blocking
+        // ChildKiller handle or wait for the child to exit.
+        unsafe {
+            let _ = libc::kill(-pid, libc::SIGKILL);
+        }
+    }
+}
+
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
-    killer: Mutex<Box<dyn cmux_pty::ChildKiller + Send + Sync>>,
+    lifecycle: Arc<ChildLifecycle>,
+    process_group: libc::pid_t,
+}
+
+impl Drop for MasterControl {
+    fn drop(&mut self) {
+        if self.lifecycle.begin_termination() {
+            force_kill_process_group(self.process_group);
+        }
+    }
 }
 
 impl PtyControl for MasterControl {
@@ -502,8 +553,8 @@ impl PtyControl for MasterControl {
     fn pause(&self) {}
     fn resume(&self) {}
     fn kill(&self) {
-        if let Ok(mut killer) = self.killer.lock() {
-            let _ = killer.kill();
+        if self.lifecycle.begin_termination() {
+            force_kill_process_group(self.process_group);
         }
     }
 }
@@ -602,11 +653,13 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let cmux_pty::SpawnedPty { master, child } = spawned;
     let mut child_cleanup = SpawnedChildCleanup::new(child);
     let writer = master.take_writer()?;
-    let killer = child_cleanup.child().clone_killer();
+    let pid = child_cleanup.child().process_id().unwrap_or(0) as libc::pid_t;
+    let lifecycle = ChildLifecycle::new();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
         writer: Mutex::new(writer),
-        killer: Mutex::new(killer),
+        lifecycle: Arc::clone(&lifecycle),
+        process_group: pid,
     });
     output.set_overflow_control(&control);
     // Use the same bounded post-exit grace as pipe fallback. A background
@@ -621,8 +674,20 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     // Blocking wait thread -> exit.
     let mut child = child_cleanup.take();
     let exit_completion = Arc::clone(&completion);
+    let wait_lifecycle = Arc::clone(&lifecycle);
     std::thread::spawn(move || {
+        let observed_exit = child
+            .process_id()
+            .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok());
+        if observed_exit {
+            wait_lifecycle.mark_exited_before_reap();
+        } else if wait_lifecycle.begin_termination() {
+            // The wait thread owns the only blocking child handle. If WNOWAIT
+            // is unavailable, it is also the only thread allowed to kill it.
+            let _ = child.kill();
+        }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+        wait_lifecycle.mark_exited_before_reap();
         exit_completion.child_exited(code);
     });
 
@@ -1068,7 +1133,7 @@ pub fn valid_session(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cmux_pty::{ChildKiller, MasterPty};
+    use cmux_pty::MasterPty;
     use std::os::unix::net::UnixStream;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex, mpsc};
@@ -1104,19 +1169,6 @@ mod tests {
 
         fn tty_name(&self) -> Option<std::path::PathBuf> {
             None
-        }
-    }
-
-    #[derive(Debug)]
-    struct TestChildKiller;
-
-    impl ChildKiller for TestChildKiller {
-        fn kill(&mut self) -> std::io::Result<()> {
-            Ok(())
-        }
-
-        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
-            Box::new(Self)
         }
     }
 
@@ -1340,15 +1392,24 @@ mod tests {
     }
 
     #[test]
-    fn master_control_kill_does_not_wait_for_killer_mutex() {
+    fn master_control_kill_is_nonblocking_and_eventually_reaps() {
+        let mut child = std::process::Command::new("/bin/sh");
+        child.args(["-c", "sleep 30"]);
+        unsafe {
+            child.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = child.spawn().expect("test child");
         let control = TestArc::new(MasterControl {
             master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
             writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
-            killer: TestMutex::new(
-                Box::new(TestChildKiller) as Box<dyn ChildKiller + Send + Sync>
-            ),
+            lifecycle: ChildLifecycle::new(),
+            process_group: child.id() as libc::pid_t,
         });
-        let held = control.killer.lock().expect("test killer lock");
         let (done_tx, done_rx) = mpsc::channel();
         let kill_control = TestArc::clone(&control);
         thread::spawn(move || {
@@ -1358,9 +1419,47 @@ mod tests {
 
         assert!(
             done_rx.recv_timeout(Duration::from_millis(100)).is_ok(),
-            "PTY kill must not wait for a synchronous child-killer lock"
+            "PTY kill must not wait for child cleanup"
         );
-        drop(held);
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if child.try_wait().expect("test child status").is_some() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "PTY kill must eventually terminate the child");
+            thread::sleep(Duration::from_millis(10));
+        }
+    }
+
+    #[test]
+    fn master_control_drop_eventually_reaps_child() {
+        let mut child = std::process::Command::new("/bin/sh");
+        child.args(["-c", "sleep 30"]);
+        unsafe {
+            child.pre_exec(|| {
+                if libc::setsid() == -1 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+        let mut child = child.spawn().expect("test child");
+        let control = MasterControl {
+            master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
+            writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
+            lifecycle: ChildLifecycle::new(),
+            process_group: child.id() as libc::pid_t,
+        };
+        drop(control);
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if child.try_wait().expect("test child status").is_some() {
+                break;
+            }
+            assert!(Instant::now() < deadline, "dropping PTY control must terminate the child");
+            thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1068,10 +1068,57 @@ pub fn valid_session(name: &str) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cmux_pty::{ChildKiller, MasterPty};
     use std::os::unix::net::UnixStream;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex, mpsc};
     use std::thread;
+
+    #[derive(Debug)]
+    struct TestMasterPty;
+
+    impl MasterPty for TestMasterPty {
+        fn resize(&self, _size: PtySize) -> Result<(), anyhow::Error> {
+            Ok(())
+        }
+
+        fn get_size(&self) -> Result<PtySize, anyhow::Error> {
+            Ok(PtySize::default())
+        }
+
+        fn try_clone_reader(&self) -> Result<Box<dyn std::io::Read + Send>, anyhow::Error> {
+            Ok(Box::new(std::io::empty()))
+        }
+
+        fn take_writer(&self) -> Result<Box<dyn std::io::Write + Send>, anyhow::Error> {
+            Ok(Box::new(Vec::<u8>::new()))
+        }
+
+        fn process_group_leader(&self) -> Option<libc::pid_t> {
+            None
+        }
+
+        fn as_raw_fd(&self) -> Option<std::os::unix::io::RawFd> {
+            None
+        }
+
+        fn tty_name(&self) -> Option<std::path::PathBuf> {
+            None
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestChildKiller;
+
+    impl ChildKiller for TestChildKiller {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn ChildKiller + Send + Sync> {
+            Box::new(Self)
+        }
+    }
 
     struct TestControl {
         kills: TestArc<AtomicUsize>,
@@ -1290,6 +1337,30 @@ mod tests {
 
         assert!(matches!(command_rx.recv(), Ok(PipeChildCommand::Kill)));
         assert!(command_rx.try_recv().is_err());
+    }
+
+    #[test]
+    fn master_control_kill_does_not_wait_for_killer_mutex() {
+        let control = TestArc::new(MasterControl {
+            master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
+            writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
+            killer: TestMutex::new(
+                Box::new(TestChildKiller) as Box<dyn ChildKiller + Send + Sync>
+            ),
+        });
+        let held = control.killer.lock().expect("test killer lock");
+        let (done_tx, done_rx) = mpsc::channel();
+        let kill_control = TestArc::clone(&control);
+        thread::spawn(move || {
+            kill_control.kill();
+            done_tx.send(()).expect("kill completion");
+        });
+
+        assert!(
+            done_rx.recv_timeout(Duration::from_millis(100)).is_ok(),
+            "PTY kill must not wait for a synchronous child-killer lock"
+        );
+        drop(held);
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -704,6 +704,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         // retain ownership and retry rather than releasing a PID that a late
         // control drop could mistake for this child. A requested termination
         // may use the owned blocking handle as the final fallback.
+        let mut observe_retry_delay = Duration::from_millis(10);
         loop {
             if child
                 .process_id()
@@ -716,7 +717,8 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                 let _ = child.kill();
                 break;
             }
-            std::thread::sleep(Duration::from_millis(10));
+            std::thread::sleep(observe_retry_delay);
+            observe_retry_delay = (observe_retry_delay * 2).min(Duration::from_secs(1));
         }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
         exit_completion.child_exited(code);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -726,18 +726,12 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                     break;
                 }
                 Err(error) => {
-                    if !matches!(error.raw_os_error(), Some(libc::ECHILD | libc::ESRCH)) {
-                        if observer_tx.send(PtyChildCommand::ObserveFailed).is_err() {
-                            break;
-                        }
-                        std::thread::sleep(Duration::from_millis(100));
-                        continue;
-                    }
                     failures += 1;
                     if failures >= PTY_OBSERVER_MAX_FAILURES {
                         let _ = observer_tx.send(PtyChildCommand::ObserveUnavailable);
                         break;
                     }
+                    let _ = error;
                     if observer_tx.send(PtyChildCommand::ObserveFailed).is_err() {
                         break;
                     }
@@ -760,9 +754,12 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                     wait_lifecycle.mark_reap_pending();
                 }
                 Ok(PtyChildCommand::ObserveUnavailable) => {
-                    let _ = wait_lifecycle.begin_termination();
-                    force_kill_process_group(pid, process_group);
-                    let _ = child.kill();
+                    if wait_lifecycle.begin_termination() {
+                        force_kill_process_group(pid, process_group);
+                        let _ = child.kill();
+                    } else {
+                        wait_lifecycle.mark_reap_pending();
+                    }
                     break;
                 }
                 Ok(PtyChildCommand::Kill) => {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -36,6 +36,7 @@ const THREAD_OUTPUT_BACKLOG_CAP: usize = 1024 * 1024;
 const THREAD_OUTPUT_OVERFLOW_EXIT: i64 = 75;
 const PIPE_OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(250);
 const PIPE_READ_POLL_MS: i32 = 100;
+const PTY_REAP_RETRY: Duration = Duration::from_millis(100);
 // `lifecycle_ready` was added to the cmux-tui control protocol at version 12.
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
@@ -558,6 +559,66 @@ enum PtyChildCommand {
 
 const PTY_OBSERVER_MAX_FAILURES: usize = 8;
 
+/// Own the PTY child and serialize commands with the final reap. If exit
+/// observation becomes unavailable, poll `try_wait` while still receiving
+/// kill requests. A successful poll always falls through to `wait`, so the
+/// child cannot remain an unreaped zombie merely because the observer failed.
+fn run_pty_wait_owner(
+    mut child: Box<dyn cmux_pty::Child + Send + Sync>,
+    pid: libc::pid_t,
+    process_group: libc::pid_t,
+    command_rx: mpsc::Receiver<PtyChildCommand>,
+    lifecycle: Arc<ChildLifecycle>,
+) -> i64 {
+    let mut observer_unavailable = false;
+    loop {
+        let command = if observer_unavailable {
+            match command_rx.recv_timeout(PTY_REAP_RETRY) {
+                Ok(command) => command,
+                Err(mpsc::RecvTimeoutError::Timeout) => match child.try_wait() {
+                    Ok(Some(_)) => break,
+                    Ok(None) | Err(_) => continue,
+                },
+                Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            }
+        } else {
+            match command_rx.recv() {
+                Ok(command) => command,
+                Err(_) => {
+                    if lifecycle.begin_termination() {
+                        force_kill_process_group(pid, process_group);
+                        let _ = child.kill();
+                    }
+                    break;
+                }
+            }
+        };
+
+        match command {
+            PtyChildCommand::ExitReady => break,
+            PtyChildCommand::ObserveFailed => lifecycle.mark_reap_pending(),
+            PtyChildCommand::ObserveUnavailable => {
+                if lifecycle.termination_requested() {
+                    force_kill_process_group(pid, process_group);
+                    let _ = child.kill();
+                    break;
+                }
+                lifecycle.mark_reap_pending();
+                observer_unavailable = true;
+            }
+            PtyChildCommand::Kill => {
+                force_kill_process_group(pid, process_group);
+                let _ = child.kill();
+                break;
+            }
+        }
+    }
+
+    let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+    lifecycle.mark_exited();
+    code
+}
+
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
@@ -745,44 +806,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         }
     });
     std::thread::spawn(move || {
-        // The wait owner alone may call the blocking Child methods. WNOWAIT
-        // fences normal reaping; a kill command remains available when
-        // observation fails.
-        loop {
-            match command_rx.recv() {
-                Ok(PtyChildCommand::ExitReady) => {
-                    wait_lifecycle.mark_exited();
-                    break;
-                }
-                Ok(PtyChildCommand::ObserveFailed) => {
-                    wait_lifecycle.mark_reap_pending();
-                }
-                Ok(PtyChildCommand::ObserveUnavailable) => {
-                    if wait_lifecycle.termination_requested() {
-                        force_kill_process_group(pid, process_group);
-                        let _ = child.kill();
-                    } else {
-                        wait_lifecycle.mark_reap_pending();
-                        continue;
-                    }
-                    break;
-                }
-                Ok(PtyChildCommand::Kill) => {
-                    force_kill_process_group(pid, process_group);
-                    let _ = child.kill();
-                    break;
-                }
-                Err(_) => {
-                    if wait_lifecycle.begin_termination() {
-                        force_kill_process_group(pid, process_group);
-                        let _ = child.kill();
-                    }
-                    break;
-                }
-            }
-        }
-        let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
-        wait_lifecycle.mark_exited();
+        let code = run_pty_wait_owner(child, pid, process_group, command_rx, wait_lifecycle);
         exit_completion.child_exited(code);
     });
 
@@ -1626,7 +1650,6 @@ mod tests {
         let lifecycle = ChildLifecycle::new();
         let (command_tx, command_rx) = mpsc::channel();
         command_tx.send(PtyChildCommand::ObserveUnavailable).expect("observer event");
-        drop(command_tx);
 
         let code = run_pty_wait_owner(child, 0, 0, command_rx, Arc::clone(&lifecycle));
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -700,15 +700,23 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let exit_completion = Arc::clone(&completion);
     let wait_lifecycle = Arc::clone(&lifecycle);
     std::thread::spawn(move || {
-        let observed_exit = child
-            .process_id()
-            .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok());
-        if observed_exit {
-            wait_lifecycle.mark_exited_before_reap();
-        } else if wait_lifecycle.termination_requested() {
-            // If exit observation failed after a caller requested
-            // termination, the wait owner retains the blocking fallback.
-            let _ = child.kill();
+        // Do not reap until WNOWAIT has fenced the PID. If observation fails,
+        // retain ownership and retry rather than releasing a PID that a late
+        // control drop could mistake for this child. A requested termination
+        // may use the owned blocking handle as the final fallback.
+        loop {
+            if child
+                .process_id()
+                .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok())
+            {
+                wait_lifecycle.mark_exited_before_reap();
+                break;
+            }
+            if wait_lifecycle.termination_requested() {
+                let _ = child.kill();
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(10));
         }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
         exit_completion.child_exited(code);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -37,6 +37,7 @@ const THREAD_OUTPUT_OVERFLOW_EXIT: i64 = 75;
 const PIPE_OUTPUT_DRAIN_GRACE: Duration = Duration::from_millis(250);
 const PIPE_READ_POLL_MS: i32 = 100;
 const PTY_REAP_RETRY: Duration = Duration::from_millis(100);
+const PTY_REAP_MAX_RETRY: Duration = Duration::from_secs(5);
 // `lifecycle_ready` was added to the cmux-tui control protocol at version 12.
 // This is distinct from the relay's lower-level CONTROL_MIN_PROTOCOL floor.
 const DAEMON_LIFECYCLE_PROTOCOL_MIN: u64 = 12;
@@ -568,28 +569,25 @@ fn run_pty_wait_owner(
 ) -> i64 {
     let mut observer_unavailable = false;
     let mut reap_failures = 0;
+    let mut reap_retry = PTY_REAP_RETRY;
     loop {
         let command = if observer_unavailable {
-            match command_rx.recv_timeout(PTY_REAP_RETRY) {
+            match command_rx.recv_timeout(reap_retry) {
                 Ok(command) => command,
                 Err(mpsc::RecvTimeoutError::Timeout) => match child.try_wait() {
                     Ok(Some(_)) => break,
                     Ok(None) => {
                         reap_failures = 0;
+                        reap_retry = PTY_REAP_RETRY;
                         continue;
                     }
                     Err(_) => {
                         reap_failures += 1;
-                        if reap_failures < PTY_REAP_MAX_FAILURES {
-                            continue;
+                        if reap_failures >= PTY_REAP_MAX_FAILURES {
+                            reap_failures = 0;
                         }
-                        // A broken non-blocking wait implementation cannot
-                        // establish whether the child exited. Terminate it
-                        // through the owned wait path before the definitive
-                        // wait, so a later Drop/Kill command is not stranded.
-                        force_kill_process_group(pid, process_group);
-                        let _ = child.kill();
-                        break;
+                        reap_retry = (reap_retry * 2).min(PTY_REAP_MAX_RETRY);
+                        continue;
                     }
                 },
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -758,8 +758,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                     wait_lifecycle.mark_reap_pending();
                 }
                 Ok(PtyChildCommand::ObserveUnavailable) => {
-                    if wait_lifecycle.begin_termination() || wait_lifecycle.termination_requested()
-                    {
+                    if wait_lifecycle.termination_requested() {
                         force_kill_process_group(pid, process_group);
                         let _ = child.kill();
                     } else {

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -701,24 +701,18 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let wait_lifecycle = Arc::clone(&lifecycle);
     std::thread::spawn(move || {
         // Do not reap until WNOWAIT has fenced the PID. If observation fails,
-        // retain ownership and retry rather than releasing a PID that a late
-        // control drop could mistake for this child. A requested termination
-        // may use the owned blocking handle as the final fallback.
-        let mut observe_retry_delay = Duration::from_millis(10);
-        loop {
-            if child
-                .process_id()
-                .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok())
-            {
-                wait_lifecycle.mark_exited_before_reap();
-                break;
-            }
-            if wait_lifecycle.termination_requested() {
-                let _ = child.kill();
-                break;
-            }
-            std::thread::sleep(observe_retry_delay);
-            observe_retry_delay = (observe_retry_delay * 2).min(Duration::from_secs(1));
+        // either honor an existing termination request with the owned child
+        // handle, or fence the PID before the fallback blocking wait. The
+        // latter keeps a late control drop from signaling a reused PID.
+        if child
+            .process_id()
+            .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok())
+        {
+            wait_lifecycle.mark_exited_before_reap();
+        } else if wait_lifecycle.termination_requested() {
+            let _ = child.kill();
+        } else {
+            wait_lifecycle.mark_exited_before_reap();
         }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
         exit_completion.child_exited(code);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -516,20 +516,25 @@ impl ChildLifecycle {
     }
 }
 
-fn force_kill_process_group(pid: libc::pid_t) {
-    if pid > 0 {
-        // `kill(2)` only queues the signal. It does not touch the blocking
-        // ChildKiller handle or wait for the child to exit.
-        let group_result = unsafe { libc::kill(-pid, libc::SIGKILL) };
-        if group_result != 0 {
-            // Keep the primary child from being stranded if the process
-            // group has already changed or disappeared. Descendants are
-            // best-effort in this error path; the wait owner still reaps the
-            // primary child through its owned handle.
+fn force_kill_process_group(pid: libc::pid_t, process_group: libc::pid_t) {
+    if pid <= 0 {
+        return;
+    }
+    // The child remains waitable, and therefore its PID remains reserved,
+    // until the wait owner reaps it. Validate group membership before the
+    // negative-PID signal so a stale group ID cannot target an unrelated group.
+    if process_group > 0 {
+        let current_group = unsafe { libc::getpgid(pid) };
+        if current_group == process_group {
             unsafe {
-                let _ = libc::kill(pid, libc::SIGKILL);
+                let _ = libc::kill(-process_group, libc::SIGKILL);
             }
         }
+    }
+    // Always signal the primary child independently. It may have moved out of
+    // the original group while descendants remain in that group.
+    unsafe {
+        let _ = libc::kill(pid, libc::SIGKILL);
     }
 }
 
@@ -538,13 +543,14 @@ struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
     lifecycle: Arc<ChildLifecycle>,
+    process_id: libc::pid_t,
     process_group: libc::pid_t,
 }
 
 impl Drop for MasterControl {
     fn drop(&mut self) {
         if self.lifecycle.begin_termination() {
-            force_kill_process_group(self.process_group);
+            force_kill_process_group(self.process_id, self.process_group);
         }
     }
 }
@@ -565,7 +571,7 @@ impl PtyControl for MasterControl {
     fn resume(&self) {}
     fn kill(&self) {
         if self.lifecycle.begin_termination() {
-            force_kill_process_group(self.process_group);
+            force_kill_process_group(self.process_id, self.process_group);
         }
     }
 }
@@ -676,6 +682,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         master: Mutex::new(master),
         writer: Mutex::new(writer),
         lifecycle: Arc::clone(&lifecycle),
+        process_id: pid,
         process_group,
     });
     output.set_overflow_control(&control);
@@ -1424,6 +1431,7 @@ mod tests {
             master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
             writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
             lifecycle: ChildLifecycle::new(),
+            process_id: child.id() as libc::pid_t,
             process_group: child.id() as libc::pid_t,
         });
         let (done_tx, done_rx) = mpsc::channel();
@@ -1464,6 +1472,7 @@ mod tests {
             master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
             writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
             lifecycle: ChildLifecycle::new(),
+            process_id: child.id() as libc::pid_t,
             process_group: child.id() as libc::pid_t,
         };
         drop(control);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -763,6 +763,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                         let _ = child.kill();
                     } else {
                         wait_lifecycle.mark_reap_pending();
+                        continue;
                     }
                     break;
                 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -480,39 +480,50 @@ impl Drop for SpawnedChildCleanup {
     }
 }
 
-#[derive(Default)]
-struct ChildLifecycleState {
-    exited: bool,
-    termination_started: bool,
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ChildLifecycleState {
+    Running,
+    ReapPending,
+    Exited,
 }
 
-/// Fences control cleanup against the wait thread's final reap. The child PID
-/// remains reserved until `wait` returns, so a late control drop cannot signal
-/// an unrelated process after PID reuse.
 struct ChildLifecycle {
-    state: Mutex<ChildLifecycleState>,
+    state: Mutex<(ChildLifecycleState, bool)>,
+}
+
+impl Default for ChildLifecycleState {
+    fn default() -> Self {
+        Self::Running
+    }
 }
 
 impl ChildLifecycle {
     fn new() -> Arc<Self> {
-        Arc::new(Self { state: Mutex::new(ChildLifecycleState::default()) })
+        Arc::new(Self { state: Mutex::new((ChildLifecycleState::default(), false)) })
     }
 
-    fn mark_exited_before_reap(&self) {
-        self.state.lock().expect("child lifecycle lock").exited = true;
+    fn mark_reap_pending(&self) {
+        let mut state = self.state.lock().expect("child lifecycle lock");
+        if state.0 != ChildLifecycleState::Exited {
+            state.0 = ChildLifecycleState::ReapPending;
+        }
+    }
+
+    fn mark_exited(&self) {
+        self.state.lock().expect("child lifecycle lock").0 = ChildLifecycleState::Exited;
     }
 
     fn begin_termination(&self) -> bool {
         let mut state = self.state.lock().expect("child lifecycle lock");
-        if state.exited || state.termination_started {
+        if state.0 == ChildLifecycleState::Exited || state.1 {
             return false;
         }
-        state.termination_started = true;
+        state.1 = true;
         true
     }
 
     fn termination_requested(&self) -> bool {
-        self.state.lock().expect("child lifecycle lock").termination_started
+        self.state.lock().expect("child lifecycle lock").1
     }
 }
 
@@ -708,13 +719,14 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
             .process_id()
             .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok())
         {
-            wait_lifecycle.mark_exited_before_reap();
+            wait_lifecycle.mark_exited();
         } else if wait_lifecycle.termination_requested() {
             let _ = child.kill();
         } else {
-            wait_lifecycle.mark_exited_before_reap();
+            wait_lifecycle.mark_reap_pending();
         }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
+        wait_lifecycle.mark_exited();
         exit_completion.child_exited(code);
     });
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -666,12 +666,13 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         .filter(|pid| *pid > 0)
         .map(|pid| pid as libc::pid_t)
         .ok_or_else(|| anyhow::anyhow!("PTY child did not provide a valid process ID"))?;
+    let process_group = master.process_group_leader().filter(|group| *group > 0).unwrap_or(pid);
     let lifecycle = ChildLifecycle::new();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
         writer: Mutex::new(writer),
         lifecycle: Arc::clone(&lifecycle),
-        process_group: pid,
+        process_group,
     });
     output.set_overflow_control(&control);
     // Use the same bounded post-exit grace as pipe fallback. A background

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -521,10 +521,6 @@ impl ChildLifecycle {
         state.1 = true;
         true
     }
-
-    fn termination_requested(&self) -> bool {
-        self.state.lock().expect("child lifecycle lock").1
-    }
 }
 
 fn force_kill_process_group(pid: libc::pid_t, process_group: libc::pid_t) {
@@ -549,6 +545,12 @@ fn force_kill_process_group(pid: libc::pid_t, process_group: libc::pid_t) {
     }
 }
 
+enum PtyChildCommand {
+    Kill,
+    ExitReady,
+    ObserveFailed,
+}
+
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
@@ -556,12 +558,14 @@ struct MasterControl {
     lifecycle: Arc<ChildLifecycle>,
     process_id: libc::pid_t,
     process_group: libc::pid_t,
+    command_tx: mpsc::Sender<PtyChildCommand>,
 }
 
 impl Drop for MasterControl {
     fn drop(&mut self) {
         if self.lifecycle.begin_termination() {
             force_kill_process_group(self.process_id, self.process_group);
+            let _ = self.command_tx.send(PtyChildCommand::Kill);
         }
     }
 }
@@ -583,6 +587,7 @@ impl PtyControl for MasterControl {
     fn kill(&self) {
         if self.lifecycle.begin_termination() {
             force_kill_process_group(self.process_id, self.process_group);
+            let _ = self.command_tx.send(PtyChildCommand::Kill);
         }
     }
 }
@@ -689,12 +694,14 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         .ok_or_else(|| anyhow::anyhow!("PTY child did not provide a valid process ID"))?;
     let process_group = master.process_group_leader().filter(|group| *group > 0).unwrap_or(pid);
     let lifecycle = ChildLifecycle::new();
+    let (command_tx, command_rx) = mpsc::channel();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),
         writer: Mutex::new(writer),
         lifecycle: Arc::clone(&lifecycle),
         process_id: pid,
         process_group,
+        command_tx: command_tx.clone(),
     });
     output.set_overflow_control(&control);
     // Use the same bounded post-exit grace as pipe fallback. A background
@@ -710,20 +717,45 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let mut child = child_cleanup.take();
     let exit_completion = Arc::clone(&completion);
     let wait_lifecycle = Arc::clone(&lifecycle);
+    let observer_tx = command_tx;
     std::thread::spawn(move || {
-        // Do not reap until WNOWAIT has fenced the PID. If observation fails,
-        // either honor an existing termination request with the owned child
-        // handle, or fence the PID before the fallback blocking wait. The
-        // latter keeps a late control drop from signaling a reused PID.
-        if child
-            .process_id()
-            .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok())
-        {
-            wait_lifecycle.mark_exited();
-        } else if wait_lifecycle.termination_requested() {
-            let _ = child.kill();
-        } else {
-            wait_lifecycle.mark_reap_pending();
+        loop {
+            match wait_for_child_exit_without_reaping(pid) {
+                Ok(()) => {
+                    let _ = observer_tx.send(PtyChildCommand::ExitReady);
+                    break;
+                }
+                Err(_) => {
+                    let _ = observer_tx.send(PtyChildCommand::ObserveFailed);
+                    std::thread::sleep(Duration::from_millis(100));
+                }
+            }
+        }
+    });
+    std::thread::spawn(move || {
+        // The wait owner alone may call the blocking Child methods. WNOWAIT
+        // fences normal reaping; a kill command remains available when
+        // observation fails.
+        loop {
+            match command_rx.recv() {
+                Ok(PtyChildCommand::ExitReady) => {
+                    wait_lifecycle.mark_exited();
+                    break;
+                }
+                Ok(PtyChildCommand::ObserveFailed) => {
+                    wait_lifecycle.mark_reap_pending();
+                }
+                Ok(PtyChildCommand::Kill) => {
+                    let _ = child.kill();
+                    break;
+                }
+                Err(_) => {
+                    if wait_lifecycle.begin_termination() {
+                        let _ = child.kill();
+                    }
+                    break;
+                }
+            }
         }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
         wait_lifecycle.mark_exited();
@@ -1443,12 +1475,14 @@ mod tests {
             });
         }
         let mut child = child.spawn().expect("test child");
+        let (command_tx, _command_rx) = mpsc::channel();
         let control = TestArc::new(MasterControl {
             master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
             writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
             lifecycle: ChildLifecycle::new(),
             process_id: child.id() as libc::pid_t,
             process_group: child.id() as libc::pid_t,
+            command_tx,
         });
         let (done_tx, done_rx) = mpsc::channel();
         let kill_control = TestArc::clone(&control);
@@ -1484,12 +1518,14 @@ mod tests {
             });
         }
         let mut child = child.spawn().expect("test child");
+        let (command_tx, _command_rx) = mpsc::channel();
         let control = MasterControl {
             master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
             writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
             lifecycle: ChildLifecycle::new(),
             process_id: child.id() as libc::pid_t,
             process_group: child.id() as libc::pid_t,
+            command_tx,
         };
         drop(control);
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -760,6 +760,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                 }
                 Ok(PtyChildCommand::ObserveUnavailable) => {
                     let _ = wait_lifecycle.begin_termination();
+                    force_kill_process_group(pid, process_group);
                     let _ = child.kill();
                     break;
                 }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -510,6 +510,10 @@ impl ChildLifecycle {
         state.termination_started = true;
         true
     }
+
+    fn termination_requested(&self) -> bool {
+        self.state.lock().expect("child lifecycle lock").termination_started
+    }
 }
 
 fn force_kill_process_group(pid: libc::pid_t) {
@@ -694,9 +698,9 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
             .is_some_and(|pid| wait_for_child_exit_without_reaping(pid as libc::pid_t).is_ok());
         if observed_exit {
             wait_lifecycle.mark_exited_before_reap();
-        } else if wait_lifecycle.begin_termination() {
-            // The wait thread owns the only blocking child handle. If WNOWAIT
-            // is unavailable, it is also the only thread allowed to kill it.
+        } else if wait_lifecycle.termination_requested() {
+            // If exit observation failed after a caller requested
+            // termination, the wait owner retains the blocking fallback.
             let _ = child.kill();
         }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1492,6 +1492,15 @@ mod tests {
     }
 
     #[test]
+    fn observer_error_keeps_termination_available_while_reaping() {
+        let lifecycle = ChildLifecycle::new();
+        lifecycle.mark_reap_pending();
+
+        assert!(lifecycle.begin_termination());
+        assert!(!lifecycle.begin_termination());
+    }
+
+    #[test]
     fn child_exit_observer_leaves_child_owned_for_wait() {
         let mut child = std::process::Command::new("/bin/sh")
             .args(["-c", "exit 23"])

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -559,15 +559,12 @@ struct MasterControl {
     master: Mutex<Box<dyn MasterPty + Send>>,
     writer: Mutex<Box<dyn Write + Send>>,
     lifecycle: Arc<ChildLifecycle>,
-    process_id: libc::pid_t,
-    process_group: libc::pid_t,
     command_tx: mpsc::Sender<PtyChildCommand>,
 }
 
 impl Drop for MasterControl {
     fn drop(&mut self) {
         if self.lifecycle.begin_termination() {
-            force_kill_process_group(self.process_id, self.process_group);
             let _ = self.command_tx.send(PtyChildCommand::Kill);
         }
     }
@@ -589,7 +586,6 @@ impl PtyControl for MasterControl {
     fn resume(&self) {}
     fn kill(&self) {
         if self.lifecycle.begin_termination() {
-            force_kill_process_group(self.process_id, self.process_group);
             let _ = self.command_tx.send(PtyChildCommand::Kill);
         }
     }
@@ -702,8 +698,6 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         master: Mutex::new(master),
         writer: Mutex::new(writer),
         lifecycle: Arc::clone(&lifecycle),
-        process_id: pid,
-        process_group,
         command_tx: command_tx.clone(),
     });
     output.set_overflow_control(&control);
@@ -765,11 +759,13 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                     break;
                 }
                 Ok(PtyChildCommand::Kill) => {
+                    force_kill_process_group(pid, process_group);
                     let _ = child.kill();
                     break;
                 }
                 Err(_) => {
                     if wait_lifecycle.begin_termination() {
+                        force_kill_process_group(pid, process_group);
                         let _ = child.kill();
                     }
                     break;
@@ -1494,13 +1490,17 @@ mod tests {
             });
         }
         let mut child = child.spawn().expect("test child");
-        let (command_tx, _command_rx) = mpsc::channel();
+        let pid = child.id() as libc::pid_t;
+        let (command_tx, command_rx) = mpsc::channel();
+        thread::spawn(move || {
+            if matches!(command_rx.recv(), Ok(PtyChildCommand::Kill)) {
+                force_kill_process_group(pid, pid);
+            }
+        });
         let control = TestArc::new(MasterControl {
             master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
             writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
             lifecycle: ChildLifecycle::new(),
-            process_id: child.id() as libc::pid_t,
-            process_group: child.id() as libc::pid_t,
             command_tx,
         });
         let (done_tx, done_rx) = mpsc::channel();
@@ -1537,13 +1537,17 @@ mod tests {
             });
         }
         let mut child = child.spawn().expect("test child");
-        let (command_tx, _command_rx) = mpsc::channel();
+        let pid = child.id() as libc::pid_t;
+        let (command_tx, command_rx) = mpsc::channel();
+        thread::spawn(move || {
+            if matches!(command_rx.recv(), Ok(PtyChildCommand::Kill)) {
+                force_kill_process_group(pid, pid);
+            }
+        });
         let control = MasterControl {
             master: TestMutex::new(Box::new(TestMasterPty) as Box<dyn MasterPty + Send>),
             writer: TestMutex::new(Box::new(Vec::<u8>::new()) as Box<dyn Write + Send>),
             lifecycle: ChildLifecycle::new(),
-            process_id: child.id() as libc::pid_t,
-            process_group: child.id() as libc::pid_t,
             command_tx,
         };
         drop(control);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -725,7 +725,14 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                     }
                     break;
                 }
-                Err(_) => {
+                Err(error) => {
+                    if !matches!(error.raw_os_error(), Some(libc::ECHILD | libc::ESRCH)) {
+                        if observer_tx.send(PtyChildCommand::ObserveFailed).is_err() {
+                            break;
+                        }
+                        std::thread::sleep(Duration::from_millis(100));
+                        continue;
+                    }
                     failures += 1;
                     if failures >= PTY_OBSERVER_MAX_FAILURES {
                         let _ = observer_tx.send(PtyChildCommand::ObserveUnavailable);

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -1580,6 +1580,62 @@ mod tests {
         assert!(!lifecycle.begin_termination());
     }
 
+    #[derive(Debug)]
+    struct FakeReapChild {
+        try_wait_calls: TestArc<AtomicUsize>,
+        wait_calls: TestArc<AtomicUsize>,
+    }
+
+    impl cmux_pty::ChildKiller for FakeReapChild {
+        fn kill(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+
+        fn clone_killer(&self) -> Box<dyn cmux_pty::ChildKiller + Send + Sync> {
+            Box::new(Self {
+                try_wait_calls: TestArc::clone(&self.try_wait_calls),
+                wait_calls: TestArc::clone(&self.wait_calls),
+            })
+        }
+    }
+
+    impl cmux_pty::Child for FakeReapChild {
+        fn try_wait(&mut self) -> std::io::Result<Option<cmux_pty::ExitStatus>> {
+            self.try_wait_calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(Some(cmux_pty::ExitStatus::with_exit_code(23)))
+        }
+
+        fn wait(&mut self) -> std::io::Result<cmux_pty::ExitStatus> {
+            self.wait_calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Ok(cmux_pty::ExitStatus::with_exit_code(23))
+        }
+
+        fn process_id(&self) -> Option<u32> {
+            None
+        }
+    }
+
+    #[test]
+    fn observer_unavailable_fallback_reaps_without_a_later_command() {
+        let try_wait_calls = TestArc::new(AtomicUsize::new(0));
+        let wait_calls = TestArc::new(AtomicUsize::new(0));
+        let child = Box::new(FakeReapChild {
+            try_wait_calls: TestArc::clone(&try_wait_calls),
+            wait_calls: TestArc::clone(&wait_calls),
+        }) as Box<dyn cmux_pty::Child + Send + Sync>;
+        let lifecycle = ChildLifecycle::new();
+        let (command_tx, command_rx) = mpsc::channel();
+        command_tx.send(PtyChildCommand::ObserveUnavailable).expect("observer event");
+        drop(command_tx);
+
+        let code = run_pty_wait_owner(child, 0, 0, command_rx, Arc::clone(&lifecycle));
+
+        assert_eq!(code, 23);
+        assert_eq!(try_wait_calls.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(wait_calls.load(AtomicOrdering::SeqCst), 1);
+        assert_eq!(lifecycle.state.lock().expect("lifecycle lock").0, ChildLifecycleState::Exited);
+    }
+
     #[test]
     fn child_exit_observer_leaves_child_owned_for_wait() {
         let mut child = std::process::Command::new("/bin/sh")

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -558,6 +558,7 @@ enum PtyChildCommand {
 }
 
 const PTY_OBSERVER_MAX_FAILURES: usize = 8;
+const PTY_REAP_MAX_FAILURES: usize = 8;
 
 /// Own the PTY child and serialize commands with the final reap. If exit
 /// observation becomes unavailable, poll `try_wait` while still receiving
@@ -571,13 +572,27 @@ fn run_pty_wait_owner(
     lifecycle: Arc<ChildLifecycle>,
 ) -> i64 {
     let mut observer_unavailable = false;
+    let mut reap_failures = 0;
     loop {
         let command = if observer_unavailable {
             match command_rx.recv_timeout(PTY_REAP_RETRY) {
                 Ok(command) => command,
                 Err(mpsc::RecvTimeoutError::Timeout) => match child.try_wait() {
                     Ok(Some(_)) => break,
-                    Ok(None) | Err(_) => continue,
+                    Ok(None) => {
+                        reap_failures = 0;
+                        continue;
+                    }
+                    Err(_) => {
+                        reap_failures += 1;
+                        if reap_failures < PTY_REAP_MAX_FAILURES {
+                            continue;
+                        }
+                        // A broken non-blocking wait implementation cannot
+                        // establish whether the child exited. Fall through
+                        // to the definitive wait so ownership still ends.
+                        break;
+                    }
                 },
                 Err(mpsc::RecvTimeoutError::Disconnected) => break,
             }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -549,7 +549,10 @@ enum PtyChildCommand {
     Kill,
     ExitReady,
     ObserveFailed,
+    ObserveUnavailable,
 }
+
+const PTY_OBSERVER_MAX_FAILURES: usize = 8;
 
 /// A real PTY master behind a mutex; write/resize block briefly.
 struct MasterControl {
@@ -719,14 +722,24 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let wait_lifecycle = Arc::clone(&lifecycle);
     let observer_tx = command_tx;
     std::thread::spawn(move || {
+        let mut failures = 0;
         loop {
             match wait_for_child_exit_without_reaping(pid) {
                 Ok(()) => {
-                    let _ = observer_tx.send(PtyChildCommand::ExitReady);
+                    if observer_tx.send(PtyChildCommand::ExitReady).is_err() {
+                        break;
+                    }
                     break;
                 }
                 Err(_) => {
-                    let _ = observer_tx.send(PtyChildCommand::ObserveFailed);
+                    failures += 1;
+                    if failures >= PTY_OBSERVER_MAX_FAILURES {
+                        let _ = observer_tx.send(PtyChildCommand::ObserveUnavailable);
+                        break;
+                    }
+                    if observer_tx.send(PtyChildCommand::ObserveFailed).is_err() {
+                        break;
+                    }
                     std::thread::sleep(Duration::from_millis(100));
                 }
             }
@@ -744,6 +757,11 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                 }
                 Ok(PtyChildCommand::ObserveFailed) => {
                     wait_lifecycle.mark_reap_pending();
+                }
+                Ok(PtyChildCommand::ObserveUnavailable) => {
+                    let _ = wait_lifecycle.begin_termination();
+                    let _ = child.kill();
+                    break;
                 }
                 Ok(PtyChildCommand::Kill) => {
                     let _ = child.kill();

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -481,7 +481,7 @@ impl Drop for SpawnedChildCleanup {
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ChildLifecycleState {
     Running,
     ReapPending,

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -516,8 +516,15 @@ fn force_kill_process_group(pid: libc::pid_t) {
     if pid > 0 {
         // `kill(2)` only queues the signal. It does not touch the blocking
         // ChildKiller handle or wait for the child to exit.
-        unsafe {
-            let _ = libc::kill(-pid, libc::SIGKILL);
+        let group_result = unsafe { libc::kill(-pid, libc::SIGKILL) };
+        if group_result != 0 {
+            // Keep the primary child from being stranded if the process
+            // group has already changed or disappeared. Descendants are
+            // best-effort in this error path; the wait owner still reaps the
+            // primary child through its owned handle.
+            unsafe {
+                let _ = libc::kill(pid, libc::SIGKILL);
+            }
         }
     }
 }
@@ -687,7 +694,6 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
             let _ = child.kill();
         }
         let code = child.wait().map(|status| i64::from(status.exit_code() as i32)).unwrap_or(0);
-        wait_lifecycle.mark_exited_before_reap();
         exit_completion.child_exited(code);
     });
 

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -584,8 +584,11 @@ fn run_pty_wait_owner(
                             continue;
                         }
                         // A broken non-blocking wait implementation cannot
-                        // establish whether the child exited. Fall through
-                        // to the definitive wait so ownership still ends.
+                        // establish whether the child exited. Terminate it
+                        // through the owned wait path before the definitive
+                        // wait, so a later Drop/Kill command is not stranded.
+                        force_kill_process_group(pid, process_group);
+                        let _ = child.kill();
                         break;
                     }
                 },

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -481,8 +481,9 @@ impl Drop for SpawnedChildCleanup {
     }
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 enum ChildLifecycleState {
+    #[default]
     Running,
     ReapPending,
     Exited,
@@ -490,12 +491,6 @@ enum ChildLifecycleState {
 
 struct ChildLifecycle {
     state: Mutex<(ChildLifecycleState, bool)>,
-}
-
-impl Default for ChildLifecycleState {
-    fn default() -> Self {
-        Self::Running
-    }
 }
 
 impl ChildLifecycle {
@@ -791,7 +786,7 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
         pump_pty(reader, cancel_reader, data_output, data_completion);
     });
     // Blocking wait thread -> exit.
-    let mut child = child_cleanup.take();
+    let child = child_cleanup.take();
     let exit_completion = Arc::clone(&completion);
     let wait_lifecycle = Arc::clone(&lifecycle);
     let observer_tx = command_tx;
@@ -1268,6 +1263,7 @@ pub fn valid_session(name: &str) -> bool {
 mod tests {
     use super::*;
     use cmux_pty::MasterPty;
+    use std::os::fd::RawFd;
     use std::os::unix::net::UnixStream;
     use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
     use std::sync::{Arc as TestArc, Barrier, Mutex as TestMutex, mpsc};
@@ -1285,11 +1281,11 @@ mod tests {
             Ok(PtySize::default())
         }
 
-        fn try_clone_reader(&self) -> Result<Box<dyn std::io::Read + Send>, anyhow::Error> {
+        fn try_clone_reader(&self) -> Result<Box<dyn Read + Send>, anyhow::Error> {
             Ok(Box::new(std::io::empty()))
         }
 
-        fn take_writer(&self) -> Result<Box<dyn std::io::Write + Send>, anyhow::Error> {
+        fn take_writer(&self) -> Result<Box<dyn Write + Send>, anyhow::Error> {
             Ok(Box::new(Vec::<u8>::new()))
         }
 
@@ -1297,11 +1293,11 @@ mod tests {
             None
         }
 
-        fn as_raw_fd(&self) -> Option<std::os::unix::io::RawFd> {
+        fn as_raw_fd(&self) -> Option<RawFd> {
             None
         }
 
-        fn tty_name(&self) -> Option<std::path::PathBuf> {
+        fn tty_name(&self) -> Option<PathBuf> {
             None
         }
     }

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -660,7 +660,12 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
     let cmux_pty::SpawnedPty { master, child } = spawned;
     let mut child_cleanup = SpawnedChildCleanup::new(child);
     let writer = master.take_writer()?;
-    let pid = child_cleanup.child().process_id().unwrap_or(0) as libc::pid_t;
+    let pid = child_cleanup
+        .child()
+        .process_id()
+        .filter(|pid| *pid > 0)
+        .map(|pid| pid as libc::pid_t)
+        .ok_or_else(|| anyhow::anyhow!("PTY child did not provide a valid process ID"))?;
     let lifecycle = ChildLifecycle::new();
     let control = Arc::new(MasterControl {
         master: Mutex::new(master),

--- a/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
+++ b/cmux-tui/crates/chatmux-relay/src/pty_deps.rs
@@ -521,6 +521,10 @@ impl ChildLifecycle {
         state.1 = true;
         true
     }
+
+    fn termination_requested(&self) -> bool {
+        self.state.lock().expect("child lifecycle lock").1
+    }
 }
 
 fn force_kill_process_group(pid: libc::pid_t, process_group: libc::pid_t) {
@@ -754,7 +758,8 @@ fn spawn_real_pty(spec: &SpawnSpec) -> anyhow::Result<PtyHandle> {
                     wait_lifecycle.mark_reap_pending();
                 }
                 Ok(PtyChildCommand::ObserveUnavailable) => {
-                    if wait_lifecycle.begin_termination() {
+                    if wait_lifecycle.begin_termination() || wait_lifecycle.termination_requested()
+                    {
                         force_kill_process_group(pid, process_group);
                         let _ = child.kill();
                     } else {


### PR DESCRIPTION
Main still calls the portable-pty ChildKiller from PTY control kill paths. A cancellation can drop the control on an async runtime thread while that synchronous handle path is contended.

This adds a lifecycle fence around the wait owner and uses the already-isolated PTY process group for immediate signal delivery. The wait thread remains responsible for the blocking child wait and reap. Behavior tests cover bounded kill/drop return and eventual child termination.

Regression test is the first commit; the fix is the second commit.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
PTY control kill and drop no longer use `cmux_pty`'s synchronous `ChildKiller`, so cleanup returns without blocking an async runtime thread. The wait owner handles signaling and reaping, and observer failures no longer kill a healthy PTY unless termination was requested.

**Bug Fixes**

- Tracks lifecycle state so only the first kill or drop request sends a termination command.
- Uses the PTY process-group leader when available, falls back to the child PID, and rejects PTYs without a valid PID.
- Validates group membership before signaling the group and always signals the child directly as a fallback.
- Retries observer failures with backoff; after eight failures it stops observing and polls `try_wait`. Repeated `try_wait` errors cause the wait owner to force-kill the process group and child before the final wait, so the child is reaped and queued or later kill/drop requests still terminate it.
- Tests nonblocking kill and drop, eventual reaping, and observer-error recovery.

<sup>Written for commit 347698508e911f47e0a9e1f7ee3ca980b7b93e04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved termination of managed terminal processes and related subprocesses during explicit stops and automatic cleanup.
  - Prevented shutdown operations from blocking while terminal processes exit.
  - Improved detection and cleanup of exited terminal processes, reducing lingering background processes.
  - Ensured terminal sessions are fully reaped after termination for more reliable repeated session creation and cleanup.
  - Added safeguards for consistent process-group shutdown when terminating an individual process is insufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->