### PR TITLE
fix(cmux-tui): clear two current clippy lints

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/http.rs
+++ b/cmux-tui/crates/cmux-remote/src/http.rs
@@ -779,7 +779,7 @@ mod tests {
         let mut file = OpenOptions::new().read(true).open(&path).unwrap();
         let metadata = file.metadata().unwrap();
         validate_workspace_http_token_metadata(&metadata).unwrap();
-        fs::OpenOptions::new()
+        OpenOptions::new()
             .append(true)
             .open(&path)
             .unwrap()

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -24819,7 +24819,7 @@ mod tests {
     #[test]
     fn crossterm_reader_propagates_poll_errors_without_reading() {
         let mut read_calls = 0;
-        let error = std::io::Error::new(std::io::ErrorKind::Other, "poll failed");
+        let error = std::io::Error::other("poll failed");
         let mut poll_calls = 0;
 
         let result = super::read_crossterm_event(


### PR DESCRIPTION
## Summary

- use `Error::other` in the crossterm poll-error test
- use the imported `OpenOptions` in the bounded HTTP-token growth test

These are mechanical lint-only changes. Existing tests already cover both behavior paths, so no new source-shape test is needed.

Base: `33b34b22b732e89716a511bec56d3886740c486b`
Head: `2ac2eb21a05`

Workspace Clippy, rustfmt, and tests will run on Blacksmith after the Actions rate limit resets.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates two tests to clear current Clippy lints without changing production behavior.

- Uses `std::io::Error::other` when constructing the poll error.
- Uses the imported `OpenOptions` type in the HTTP-token growth test.

<sup>Written for commit 2ac2eb21a058012f065a1759f77d1f1f166e9ec9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11853?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

