### PR TITLE
fix(cmux-tui): bound tunnel writer and flow queues

### DIFF
--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -39,7 +39,8 @@
 //! never run this listener: it starts from the managed branch only.
 
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use std::sync::Mutex;
 use std::time::Duration;
 
 use base64::engine::general_purpose::STANDARD as BASE64;

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -43,11 +43,6 @@ use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
-<<<<<<< HEAD
-use base64::engine::general_purpose::STANDARD as BASE64;
-use bytes::{Buf, BytesMut};
-=======
->>>>>>> c6878e73f05 (chore(chatmux-relay): match pinned rustfmt import order)
 use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use bytes::{Buf, BytesMut};
@@ -163,17 +158,20 @@ pub fn encode_pty_frame(bytes: &[u8]) -> Vec<u8> {
 /// length-prefixed stream that desynced once can never be trusted again, so
 /// the caller must close the connection.
 pub struct TunnelFrameDecoder {
-    buffer: Vec<u8>,
+    buffer: BytesMut,
+    storage_capacity: usize,
     failed: bool,
     max_frame_bytes: usize,
 }
 
 impl TunnelFrameDecoder {
     pub fn new(max_frame_bytes: usize) -> TunnelFrameDecoder {
+        let max_frame_bytes = max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES);
         TunnelFrameDecoder {
-            buffer: Vec::new(),
+            storage_capacity: 0,
+            buffer: BytesMut::new(),
             failed: false,
-            max_frame_bytes: max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES),
+            max_frame_bytes,
         }
     }
 
@@ -182,6 +180,7 @@ impl TunnelFrameDecoder {
             return Err("decoder_poisoned");
         }
         self.buffer.extend_from_slice(chunk);
+        self.storage_capacity = self.storage_capacity.max(self.buffer.capacity());
         let mut frames = Vec::new();
         while self.buffer.len() >= HEADER_BYTES {
             let length = u32::from_be_bytes([
@@ -202,9 +201,19 @@ impl TunnelFrameDecoder {
             if self.buffer.len() < HEADER_BYTES + length {
                 break;
             }
-            let payload = self.buffer[HEADER_BYTES..HEADER_BYTES + length].to_vec();
-            self.buffer.drain(..HEADER_BYTES + length);
+            self.buffer.advance(HEADER_BYTES);
+            let payload = self.buffer.split_to(length).to_vec();
             frames.push(TunnelFrame { kind, payload });
+        }
+        // A single read may contain many frames. Keep the retained decoder
+        // storage bounded by one maximum-size frame plus its header instead
+        // of holding the capacity of that whole read forever.
+        let retained_limit = self.max_frame_bytes + HEADER_BYTES;
+        if self.storage_capacity > retained_limit && self.buffer.len() <= retained_limit {
+            let mut compacted = BytesMut::with_capacity(retained_limit);
+            compacted.extend_from_slice(&self.buffer);
+            self.storage_capacity = compacted.capacity();
+            self.buffer = compacted;
         }
         Ok(frames)
     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1377,6 +1377,23 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn two_maximum_pty_frames_leave_the_control_byte_reserve() {
+        let rig = rig().await;
+        let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
+        let first = encode_pty_frame(&vec![1; MAX_TUNNEL_FRAME_BYTES]);
+        let second = encode_pty_frame(&vec![2; MAX_TUNNEL_FRAME_BYTES]);
+
+        assert!(connection.enqueue_frame(first, false));
+        assert!(connection.enqueue_frame(second, false));
+        assert!(!connection.finished.load(Ordering::SeqCst));
+
+        let control = encode_control_frame(&json!({ "t": "error", "code": "failed" }));
+        assert!(connection.enqueue_frame(control, true));
+        assert!(!connection.finished.load(Ordering::SeqCst));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn control_frame_survives_message_reserve_before_end() {
         let rig = rig().await;
         let (connection, mut writer_rx, _flow_rx) = test_connection(&rig);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -416,9 +416,14 @@ impl Connection {
         if self.finished.load(Ordering::SeqCst) {
             return;
         }
+        if !pause
+            && (self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
+                || self.writer_tx.capacity() <= FLOW_PAUSE_MESSAGES)
+        {
+            return;
+        }
         let changed = if pause {
-            self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
-                && !self.paused.swap(true, Ordering::SeqCst)
+            !self.paused.swap(true, Ordering::SeqCst)
         } else {
             self.paused.swap(false, Ordering::SeqCst)
         };

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -407,9 +407,6 @@ impl Connection {
     }
 
     fn publish_flow(&self, pause: bool) {
-        if self.finished.load(Ordering::SeqCst) {
-            return;
-        }
         self.flow_tx.send_if_modified(|current| {
             if *current == pause {
                 false
@@ -457,6 +454,17 @@ impl Connection {
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
+        // Stop admitting output before resuming a paused source. The writer
+        // drains only frames already admitted, so this transition cannot add
+        // new bytes to the queue during shutdown.
+        self.flow_tx.send_if_modified(|current| {
+            if *current {
+                *current = false;
+                true
+            } else {
+                false
+            }
+        });
         if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take() {
             permit.send(WriterMessage::End);
         }
@@ -649,12 +657,12 @@ fn spawn_flow_worker(
                     // Read the watch value before exiting, and deliver a
                     // required pause while the attachment remains live.
                     let pause = *flow_rx.borrow();
-                    if pause && !applied_pause {
+                    if pause != applied_pause {
                         let frame = json!({
                             "version": PTY_PROTOCOL_VERSION,
                             "type": "pty_flow",
                             "ptyId": connection.pty_id,
-                            "pause": true,
+                            "pause": pause,
                         });
                         connection.manager.handle_frame(&frame, &context).await;
                     }
@@ -1319,6 +1327,37 @@ mod tests {
             "ptyId": connection.pty_id,
         });
         rig.manager.handle_frame(&close, &connection.frame_context()).await;
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn finish_resumes_a_source_paused_before_shutdown() {
+        let rig = rig().await;
+        let (connection, _writer_rx, flow_rx) = test_connection(&rig);
+        let pty = attach_test_pty(&rig, &connection).await;
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context(), flow_rx);
+
+        connection.publish_flow(true);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pty.state.lock().unwrap().pause_calls == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pause should reach the live attachment");
+
+        connection.finish();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker drain")
+            .expect("flow worker join");
+
+        let state = pty.state.lock().unwrap();
+        assert_eq!(state.pause_calls, 1);
+        assert_eq!(state.resume_calls, 1, "shutdown must resume a paused source");
         rig.cancel.cancel();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,22 +38,27 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
+<<<<<<< HEAD
 use base64::engine::general_purpose::STANDARD as BASE64;
 use bytes::{Buf, BytesMut};
+=======
+>>>>>>> c6878e73f05 (chore(chatmux-relay): match pinned rustfmt import order)
 use base64::Engine as _;
-use serde_json::{json, Value};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use bytes::{Buf, BytesMut};
+use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
+    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -367,8 +367,13 @@ impl Connection {
                 let control = is_encoded_control_frame(&frame);
                 self.enqueue_frame(frame, control)
             }
-            // End is sent only through its reserved permit in `finish`.
-            WriterMessage::End => false,
+            // Preserve the old End-shaped call site while routing the marker
+            // through the reserved permit and the idempotent shutdown path.
+            WriterMessage::End => {
+                let was_finished = self.finished.load(Ordering::SeqCst);
+                self.finish();
+                !was_finished
+            }
         }
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -84,10 +84,28 @@ const FLOW_RESUME_BYTES: u64 = 32_768;
 /// bounded if a future manager implementation blocks unexpectedly.
 const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Admission is synchronous from the manager callback, so the writer queue
-/// uses non-blocking sends with both message and byte budgets. The byte cap
-/// leaves room for a maximum PTY frame and a follow-up control/error frame.
+/// uses non-blocking sends with both message and byte budgets. Keep part of
+/// each budget available for control/error frames after PTY data saturates.
 const WRITER_QUEUE_CAPACITY: usize = 128;
 const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
+const WRITER_CONTROL_MESSAGE_RESERVE: usize = 8;
+const WRITER_CONTROL_BYTE_RESERVE: u64 = 64 * 1024;
+
+fn writer_queue_byte_limit(control: bool) -> u64 {
+    if control {
+        WRITER_QUEUE_BYTE_CAP
+    } else {
+        WRITER_QUEUE_BYTE_CAP.saturating_sub(WRITER_CONTROL_BYTE_RESERVE)
+    }
+}
+
+fn is_encoded_control_frame(frame: &[u8]) -> bool {
+    if frame.len() < HEADER_BYTES {
+        return false;
+    }
+    let payload_len = u32::from_be_bytes([frame[0], frame[1], frame[2], frame[3]]) as usize;
+    frame[4] == FRAME_KIND_CONTROL && payload_len == frame.len() - HEADER_BYTES
+}
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -269,6 +287,9 @@ struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
     writer_tx: mpsc::Sender<WriterMessage>,
+    /// A permanently reserved channel slot for shutdown. `finish` is
+    /// synchronous, so it cannot wait for queue capacity.
+    end_permit: Mutex<Option<mpsc::OwnedPermit<WriterMessage>>>,
     /// Serializes queue admission with the End marker so no frame can be
     /// inserted after shutdown and silently be dropped by the writer.
     queue_gate: Mutex<()>,
@@ -307,16 +328,17 @@ enum FlowAction {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
+        let _ = self.enqueue_frame(encode_control_frame(frame), true);
     }
 
-    fn reserve_bytes(&self, amount: u64) -> bool {
+    fn reserve_bytes(&self, amount: u64, control: bool) -> bool {
         let mut current = self.pending_out.load(Ordering::SeqCst);
         loop {
             let Some(next) = current.checked_add(amount) else {
                 return false;
             };
-            if next > WRITER_QUEUE_BYTE_CAP {
+            let limit = writer_queue_byte_limit(control);
+            if next > limit {
                 return false;
             }
             match self.pending_out.compare_exchange(
@@ -333,6 +355,50 @@ impl Connection {
 
     fn release_bytes(&self, amount: u64) {
         self.pending_out.fetch_sub(amount, Ordering::SeqCst);
+    }
+
+    /// Preserve the existing message-shaped queue API for tests and callers
+    /// that already build `WriterMessage::Frame`. Production paths use the
+    /// explicit class-aware helper below so a control frame cannot consume
+    /// the reserved data budget.
+    fn enqueue(&self, message: WriterMessage) -> bool {
+        match message {
+            WriterMessage::Frame(frame) => {
+                let control = is_encoded_control_frame(&frame);
+                self.enqueue_frame(frame, control)
+            }
+            // End is sent only through its reserved permit in `finish`.
+            WriterMessage::End => false,
+        }
+    }
+
+    fn enqueue_frame(&self, frame: Vec<u8>, control: bool) -> bool {
+        let frame_bytes = frame.len() as u64;
+        let mut reserved = false;
+        let admitted = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            let queue_has_room =
+                control || self.writer_tx.capacity() > WRITER_CONTROL_MESSAGE_RESERVE;
+            if self.finished.load(Ordering::SeqCst)
+                || !queue_has_room
+                || !self.reserve_bytes(frame_bytes, control)
+            {
+                false
+            } else {
+                reserved = frame_bytes != 0;
+                self.writer_tx.try_send(WriterMessage::Frame(frame)).is_ok()
+            }
+        };
+        if admitted {
+            return true;
+        }
+        if reserved {
+            self.release_bytes(frame_bytes);
+        }
+        if !self.finished.load(Ordering::SeqCst) {
+            self.reject_due_to_backpressure();
+        }
+        false
     }
 
     fn publish_flow(&self, pause: bool) {
@@ -364,7 +430,10 @@ impl Connection {
                 state.desired_pause = true;
                 state.stopping = true;
                 self.finished.store(true, Ordering::SeqCst);
-                let _ = self.writer_tx.try_send(WriterMessage::End);
+                if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take()
+                {
+                    permit.send(WriterMessage::End);
+                }
                 self.done.cancel();
                 notify
             }
@@ -376,35 +445,6 @@ impl Connection {
             let _ = self.flow_tx.send(true);
         }
         self.flow_notify.notify_one();
-    }
-
-    fn enqueue(&self, message: WriterMessage) -> bool {
-        let frame_bytes = match &message {
-            WriterMessage::Frame(frame) => frame.len() as u64,
-            WriterMessage::End => 0,
-        };
-        let mut reserved = false;
-        let admitted = {
-            let _gate = self.queue_gate.lock().expect("writer queue lock");
-            if self.finished.load(Ordering::SeqCst) {
-                false
-            } else if frame_bytes != 0 && !self.reserve_bytes(frame_bytes) {
-                false
-            } else {
-                reserved = frame_bytes != 0;
-                self.writer_tx.try_send(message).is_ok()
-            }
-        };
-        if admitted {
-            return true;
-        }
-        if reserved {
-            self.release_bytes(frame_bytes);
-        }
-        if !self.finished.load(Ordering::SeqCst) {
-            self.reject_due_to_backpressure();
-        }
-        false
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -419,7 +459,10 @@ impl Connection {
             } else {
                 let mut state = self.flow_state.lock().expect("flow state lock");
                 state.stopping = true;
-                let _ = self.writer_tx.try_send(WriterMessage::End);
+                if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take()
+                {
+                    permit.send(WriterMessage::End);
+                }
                 self.done.cancel();
                 true
             }
@@ -470,7 +513,7 @@ impl Connection {
                 else {
                     return;
                 };
-                if !self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes))) {
+                if !self.enqueue_frame(encode_pty_frame(&bytes), false) {
                     return;
                 }
                 // Socket-side congestion: pause the source through the
@@ -625,11 +668,22 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
+    // Reserve one item before any producer can fill the queue. The owned
+    // permit keeps End available to the synchronous shutdown path without
+    // waiting for a stalled peer or an already-full queue.
+    let end_permit = match writer_tx.clone().try_reserve_owned() {
+        Ok(permit) => permit,
+        Err(_) => {
+            let _ = write_half.shutdown().await;
+            return;
+        }
+    };
     let (flow_tx, _flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
+        end_permit: Mutex::new(Some(end_permit)),
         queue_gate: Mutex::new(()),
         flow_tx,
         flow_state: Mutex::new(FlowState::default()),
@@ -664,12 +718,6 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
                             connection.publish_flow(false);
-                        }
-                        // `finish` may race with a full queue, so End is only
-                        // best effort. Once all admitted frames drain, stop
-                        // without waiting for another sender-side message.
-                        if connection.finished.load(Ordering::SeqCst) && writer_rx.is_empty() {
-                            break;
                         }
                     }
                     WriterMessage::End => break,
@@ -973,6 +1021,16 @@ mod tests {
         serde_json::from_slice(&frame.payload).expect("control json")
     }
 
+    #[test]
+    fn data_budget_leaves_byte_reserve_for_control_frames() {
+        assert_eq!(
+            writer_queue_byte_limit(false) + WRITER_CONTROL_BYTE_RESERVE,
+            WRITER_QUEUE_BYTE_CAP
+        );
+        assert!(writer_queue_byte_limit(false) < writer_queue_byte_limit(true));
+        assert!(WRITER_CONTROL_BYTE_RESERVE > 0);
+    }
+
     /// Wait until the fake spawn landed (open settles asynchronously).
     async fn spawned_pty(rig: &Rig) -> FakePty {
         for _ in 0..100 {
@@ -1100,11 +1158,13 @@ mod tests {
         rig: &Rig,
     ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, watch::Receiver<bool>) {
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
+        let end_permit = writer_tx.clone().try_reserve_owned().expect("reserve End slot");
         let (flow_tx, flow_rx) = watch::channel(false);
         let connection = Arc::new(Connection {
             pty_id: "test-pty".to_owned(),
             manager: Arc::clone(&rig.manager),
             writer_tx,
+            end_permit: Mutex::new(Some(end_permit)),
             queue_gate: Mutex::new(()),
             flow_tx,
             flow_state: Mutex::new(FlowState::default()),
@@ -1138,13 +1198,18 @@ mod tests {
     async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
         let rig = rig().await;
         let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
-        let frame_len = WRITER_QUEUE_BYTE_CAP as usize / 2;
+        let frame_len = (WRITER_QUEUE_BYTE_CAP - WRITER_CONTROL_BYTE_RESERVE) as usize / 2;
         assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
         assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
         assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
         assert!(connection.finished.load(Ordering::SeqCst));
-        assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
+        assert_eq!(
+            connection.pending_out.load(Ordering::SeqCst),
+            (frame_len * 2) as u64,
+            "a rejected frame must release its byte reservation"
+        );
         assert_eq!(*flow_rx.borrow(), true);
+        assert!(connection.done.is_cancelled());
         match writer_rx.recv().await.expect("first admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
             WriterMessage::End => panic!("queue order changed"),
@@ -1153,6 +1218,69 @@ mod tests {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
             WriterMessage::End => panic!("queue order changed"),
         }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn control_frame_uses_reserved_byte_budget_and_end_stays_fifo() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, _flow_rx) = test_connection(&rig);
+        let data_limit = writer_queue_byte_limit(false) as usize;
+        let frame_len = data_limit / 2;
+        assert!(connection.enqueue_frame(vec![1; frame_len], false));
+        assert!(connection.enqueue_frame(vec![2; data_limit - frame_len], false));
+        assert_eq!(connection.pending_out.load(Ordering::SeqCst), data_limit as u64);
+
+        let control = encode_control_frame(&json!({ "t": "error", "code": "failed" }));
+        let control_len = control.len() as u64;
+        assert!(connection.enqueue_frame(control, true));
+        assert_eq!(connection.pending_out.load(Ordering::SeqCst), data_limit as u64 + control_len);
+
+        connection.finish();
+        match writer_rx.recv().await.expect("first data frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
+            WriterMessage::End => panic!("End overtook queued data"),
+        }
+        match writer_rx.recv().await.expect("second data frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
+            WriterMessage::End => panic!("End overtook queued data"),
+        }
+        match writer_rx.recv().await.expect("control frame") {
+            WriterMessage::Frame(frame) => {
+                assert_eq!(frame.get(HEADER_BYTES - 1), Some(&FRAME_KIND_CONTROL));
+            }
+            WriterMessage::End => panic!("End overtook control"),
+        }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn control_frame_survives_message_reserve_before_end() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, _flow_rx) = test_connection(&rig);
+        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
+        for index in 0..data_capacity {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        }
+        let control = encode_control_frame(&json!({ "t": "error", "code": "failed" }));
+        assert!(connection.enqueue_frame(control, true));
+        connection.finish();
+
+        for index in 0..data_capacity {
+            match writer_rx.recv().await.expect("admitted data frame") {
+                WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
+                WriterMessage::End => panic!("End overtook queued data"),
+            }
+        }
+        match writer_rx.recv().await.expect("control frame") {
+            WriterMessage::Frame(frame) => {
+                assert_eq!(frame.get(HEADER_BYTES - 1), Some(&FRAME_KIND_CONTROL));
+            }
+            WriterMessage::End => panic!("End overtook control"),
+        }
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
     }
 
@@ -1201,19 +1329,21 @@ mod tests {
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
         let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
-        for index in 0..WRITER_QUEUE_CAPACITY {
+        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
+        for index in 0..data_capacity {
             assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
         }
         assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
         assert!(connection.finished.load(Ordering::SeqCst));
         assert_eq!(*flow_rx.borrow(), true);
-        for index in 0..WRITER_QUEUE_CAPACITY {
+        assert!(connection.done.is_cancelled());
+        for index in 0..data_capacity {
             match writer_rx.recv().await.expect("admitted frame") {
                 WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
                 WriterMessage::End => panic!("queue order changed"),
             }
         }
-        assert!(writer_rx.try_recv().is_err());
+        assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -54,7 +54,7 @@ use bytes::{Buf, BytesMut};
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, watch};
+use tokio::sync::{Notify, mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
@@ -80,6 +80,9 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// The flow worker is local and normally drains synchronously. Keep shutdown
+/// bounded if a future manager implementation blocks unexpectedly.
+const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// Admission is synchronous from the manager callback, so the writer queue
 /// uses non-blocking sends with both message and byte budgets. The byte cap
 /// leaves room for a maximum PTY frame and a follow-up control/error frame.
@@ -274,6 +277,11 @@ struct Connection {
     /// busy. Pause and resume are idempotent, so retaining only the newest
     /// state is the correct flow-control contract.
     flow_tx: watch::Sender<bool>,
+    /// Coalesced flow state and shutdown marker. The flow worker drains this
+    /// state before it exits, so a required pause cannot be lost to task
+    /// cancellation.
+    flow_state: Mutex<FlowState>,
+    flow_notify: Arc<Notify>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -283,6 +291,18 @@ struct Connection {
     opened_seen: AtomicBool,
     finished: AtomicBool,
     done: CancellationToken,
+}
+
+#[derive(Debug, Default)]
+struct FlowState {
+    desired_pause: bool,
+    stopping: bool,
+}
+
+enum FlowAction {
+    Apply(bool),
+    Wait,
+    Stop,
 }
 
 impl Connection {
@@ -316,15 +336,46 @@ impl Connection {
     }
 
     fn publish_flow(&self, pause: bool) {
-        let _ = self.flow_tx.send(pause);
+        let changed = {
+            let mut state = self.flow_state.lock().expect("flow state lock");
+            if state.stopping || state.desired_pause == pause {
+                false
+            } else {
+                state.desired_pause = pause;
+                true
+            }
+        };
+        if changed {
+            let _ = self.flow_tx.send(pause);
+            self.flow_notify.notify_one();
+        }
     }
 
     /// Pause the source before closing when a stalled peer exhausts admission.
     fn reject_due_to_backpressure(&self) {
-        if !self.paused.swap(true, Ordering::SeqCst) {
-            self.publish_flow(true);
+        let notify_flow = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            if self.finished.load(Ordering::SeqCst) {
+                false
+            } else {
+                self.paused.store(true, Ordering::SeqCst);
+                let mut state = self.flow_state.lock().expect("flow state lock");
+                let notify = !state.desired_pause;
+                state.desired_pause = true;
+                state.stopping = true;
+                self.finished.store(true, Ordering::SeqCst);
+                let _ = self.writer_tx.try_send(WriterMessage::End);
+                self.done.cancel();
+                notify
+            }
+        };
+        // The state transition and End marker are serialized by queue_gate.
+        // Notify after releasing it so the worker can observe the complete
+        // pause-before-stop state in one read.
+        if notify_flow {
+            let _ = self.flow_tx.send(true);
         }
-        self.finish();
+        self.flow_notify.notify_one();
     }
 
     fn enqueue(&self, message: WriterMessage) -> bool {
@@ -361,12 +412,21 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
-        let _gate = self.queue_gate.lock().expect("writer queue lock");
-        if self.finished.swap(true, Ordering::SeqCst) {
-            return;
+        let should_notify = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            if self.finished.swap(true, Ordering::SeqCst) {
+                false
+            } else {
+                let mut state = self.flow_state.lock().expect("flow state lock");
+                state.stopping = true;
+                let _ = self.writer_tx.try_send(WriterMessage::End);
+                self.done.cancel();
+                true
+            }
+        };
+        if should_notify {
+            self.flow_notify.notify_one();
         }
-        let _ = self.writer_tx.try_send(WriterMessage::End);
-        self.done.cancel();
     }
 
     fn protocol_error(&self, code: &str, message: &str) {
@@ -522,17 +582,58 @@ async fn handle_client_frame(
     }
 }
 
+fn spawn_flow_worker(
+    connection: Arc<Connection>,
+    context: FrameContext,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut applied_pause = false;
+        loop {
+            // Create the notification future before inspecting state. Tokio
+            // retains a notification permit, so a concurrent transition
+            // cannot be lost between the read and the await.
+            let notified = connection.flow_notify.notified();
+            let action = {
+                let state = connection.flow_state.lock().expect("flow state lock");
+                if state.desired_pause != applied_pause {
+                    FlowAction::Apply(state.desired_pause)
+                } else if state.stopping {
+                    FlowAction::Stop
+                } else {
+                    FlowAction::Wait
+                }
+            };
+            match action {
+                FlowAction::Apply(pause) => {
+                    let frame = json!({
+                        "version": PTY_PROTOCOL_VERSION,
+                        "type": "pty_flow",
+                        "ptyId": connection.pty_id,
+                        "pause": pause,
+                    });
+                    connection.manager.handle_frame(&frame, &context).await;
+                    applied_pause = pause;
+                }
+                FlowAction::Wait => notified.await,
+                FlowAction::Stop => break,
+            }
+        }
+    })
+}
+
 async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: CancellationToken) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
-    let (flow_tx, mut flow_rx) = watch::channel(false);
+    let (flow_tx, _flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
         queue_gate: Mutex::new(()),
         flow_tx,
+        flow_state: Mutex::new(FlowState::default()),
+        flow_notify: Arc::new(Notify::new()),
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
@@ -579,32 +680,9 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     };
 
     // Flow verbs need the async manager; drain them on their own task so a
-    // slow open never delays a pause.
-    let flow = {
-        let connection = Arc::clone(&connection);
-        let context = context.clone();
-        tokio::spawn(async move {
-            loop {
-                tokio::select! {
-                    biased;
-                    _ = connection.done.cancelled() => break,
-                    changed = flow_rx.changed() => {
-                        if changed.is_err() || connection.finished.load(Ordering::SeqCst) {
-                            break;
-                        }
-                        let pause = *flow_rx.borrow_and_update();
-                        let frame = json!({
-                            "version": PTY_PROTOCOL_VERSION,
-                            "type": "pty_flow",
-                            "ptyId": connection.pty_id,
-                            "pause": pause,
-                        });
-                        connection.manager.handle_frame(&frame, &context).await;
-                    }
-                }
-            }
-        })
-    };
+    // slow open never delays a pause. Its state is drained during shutdown
+    // before the attachment is released.
+    let mut flow = spawn_flow_worker(Arc::clone(&connection), context.clone());
 
     // Reader: strictly in arrival order, so input received while an open
     // settles lands after the attachment exists. Awaiting each frame is the
@@ -650,6 +728,13 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         }
     }
     connection.finish();
+    // Drain the flow state before releasing the attachment. In particular,
+    // backpressure shutdown must deliver pty_flow(true) while authorization
+    // still sees this connection's live attachment.
+    if tokio::time::timeout(FLOW_DRAIN_TIMEOUT, &mut flow).await.is_err() {
+        flow.abort();
+        let _ = flow.await;
+    }
     // Detach, never kill: the owed close releases only this connection's
     // attachment (transport-fenced), and the session lives on.
     if connection.open_sent.load(Ordering::SeqCst) {
@@ -660,13 +745,12 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         });
         manager.handle_frame(&close, &context).await;
     }
-    flow.abort();
     // A peer that stopped reading can wedge the final flush forever; the
     // attachment is already released above, so cap the flush and reap.
     if tokio::time::timeout(Duration::from_secs(30), &mut writer).await.is_err() {
         writer.abort();
+        let _ = writer.await;
     }
-    let _ = flow.await;
 }
 
 /// Start the loopback listener. Managed mode only — the caller's managed
@@ -730,6 +814,8 @@ mod tests {
         on_exit: Option<ExitSink>,
         written: Vec<Vec<u8>>,
         resized: Vec<(u16, u16)>,
+        pause_calls: usize,
+        resume_calls: usize,
         killed: bool,
     }
 
@@ -760,8 +846,12 @@ mod tests {
         fn resize(&self, cols: u16, rows: u16) {
             self.state.lock().unwrap().resized.push((cols, rows));
         }
-        fn pause(&self) {}
-        fn resume(&self) {}
+        fn pause(&self) {
+            self.state.lock().unwrap().pause_calls += 1;
+        }
+        fn resume(&self) {
+            self.state.lock().unwrap().resume_calls += 1;
+        }
         fn kill(&self) {
             self.state.lock().unwrap().killed = true;
         }
@@ -1017,6 +1107,8 @@ mod tests {
             writer_tx,
             queue_gate: Mutex::new(()),
             flow_tx,
+            flow_state: Mutex::new(FlowState::default()),
+            flow_notify: Arc::new(Notify::new()),
             pending_out: AtomicU64::new(0),
             paused: AtomicBool::new(false),
             open_sent: AtomicBool::new(false),
@@ -1025,6 +1117,21 @@ mod tests {
             done: CancellationToken::new(),
         });
         (connection, writer_rx, flow_rx)
+    }
+
+    async fn attach_test_pty(rig: &Rig, connection: &Arc<Connection>) -> FakePty {
+        connection.open_sent.store(true, Ordering::SeqCst);
+        let context = connection.frame_context();
+        let open = json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_open",
+            "ptyId": connection.pty_id,
+            "session": "flow-test",
+            "cols": 80,
+            "rows": 24,
+        });
+        rig.manager.handle_frame(&open, &context).await;
+        spawned_pty(rig).await
     }
 
     #[tokio::test]
@@ -1046,6 +1153,33 @@ mod tests {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
             WriterMessage::End => panic!("queue order changed"),
         }
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn backpressure_delivers_pause_before_flow_worker_stops() {
+        let rig = rig().await;
+        let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
+        let pty = attach_test_pty(&rig, &connection).await;
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
+
+        connection.reject_due_to_backpressure();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker drain")
+            .expect("flow worker join");
+
+        let state = pty.state.lock().unwrap();
+        assert_eq!(state.pause_calls, 1, "shutdown must pause the live attachment");
+        assert_eq!(state.resume_calls, 0);
+        assert!(connection.finished.load(Ordering::SeqCst));
+
+        let close = json!({
+            "version": PTY_PROTOCOL_VERSION,
+            "type": "pty_close",
+            "ptyId": connection.pty_id,
+        });
+        rig.manager.handle_frame(&close, &connection.frame_context()).await;
         rig.cancel.cancel();
     }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1033,7 +1033,6 @@ mod tests {
             WRITER_QUEUE_BYTE_CAP
         );
         assert!(writer_queue_byte_limit(false) < writer_queue_byte_limit(true));
-        assert!(WRITER_CONTROL_BYTE_RESERVE > 0);
     }
 
     /// Wait until the fake spawn landed (open settles asynchronously).
@@ -1202,7 +1201,7 @@ mod tests {
     #[tokio::test]
     async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
         let rig = rig().await;
-        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        let (connection, mut writer_rx, flow_rx) = test_connection(&rig);
         let frame_len = (WRITER_QUEUE_BYTE_CAP - WRITER_CONTROL_BYTE_RESERVE) as usize / 2;
         assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
         assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
@@ -1213,7 +1212,7 @@ mod tests {
             (frame_len * 2) as u64,
             "a rejected frame must release its byte reservation"
         );
-        assert_eq!(*flow_rx.borrow(), true);
+        assert!(*flow_rx.borrow());
         assert!(connection.done.is_cancelled());
         match writer_rx.recv().await.expect("first admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
@@ -1302,9 +1301,11 @@ mod tests {
             .expect("flow worker drain")
             .expect("flow worker join");
 
-        let state = pty.state.lock().unwrap();
-        assert_eq!(state.pause_calls, 1, "shutdown must pause the live attachment");
-        assert_eq!(state.resume_calls, 0);
+        {
+            let state = pty.state.lock().unwrap();
+            assert_eq!(state.pause_calls, 1, "shutdown must pause the live attachment");
+            assert_eq!(state.resume_calls, 0);
+        }
         assert!(connection.finished.load(Ordering::SeqCst));
 
         let close = json!({
@@ -1333,14 +1334,14 @@ mod tests {
     #[tokio::test]
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
-        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        let (connection, mut writer_rx, flow_rx) = test_connection(&rig);
         let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
         for index in 0..data_capacity {
             assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
         }
         assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
         assert!(connection.finished.load(Ordering::SeqCst));
-        assert_eq!(*flow_rx.borrow(), true);
+        assert!(*flow_rx.borrow());
         assert!(connection.done.is_cancelled());
         for index in 0..data_capacity {
             match writer_rx.recv().await.expect("admitted frame") {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1085,6 +1085,36 @@ mod tests {
     }
 
     #[test]
+    fn decoder_handles_many_frames_without_retaining_batch_storage() {
+        const MAX_FRAME_BYTES: usize = 8;
+        const FRAME_COUNT: usize = 2_048;
+
+        let mut stream = Vec::with_capacity(FRAME_COUNT * (HEADER_BYTES + 1));
+        for index in 0..FRAME_COUNT {
+            stream.extend_from_slice(&encode_tunnel_frame(
+                if index % 2 == 0 { FRAME_KIND_CONTROL } else { FRAME_KIND_PTY },
+                &[index as u8],
+            ));
+        }
+
+        let mut decoder = TunnelFrameDecoder::new(MAX_FRAME_BYTES);
+        let frames = decoder.push(&stream).expect("clean stream");
+
+        assert_eq!(frames.len(), FRAME_COUNT);
+        assert!(frames.iter().enumerate().all(|(index, frame)| {
+            frame.kind == if index % 2 == 0 { FRAME_KIND_CONTROL } else { FRAME_KIND_PTY }
+                && frame.payload == [index as u8]
+        }));
+        assert!(decoder.buffer.is_empty());
+        assert!(
+            decoder.storage_capacity <= MAX_FRAME_BYTES + HEADER_BYTES,
+            "decoder retained {} bytes for a {} byte max frame",
+            decoder.storage_capacity,
+            MAX_FRAME_BYTES
+        );
+    }
+
+    #[test]
     fn oversized_length_poisons_the_decoder() {
         let mut decoder = TunnelFrameDecoder::new(MAX_TUNNEL_FRAME_BYTES);
         let mut header = ((MAX_TUNNEL_FRAME_BYTES + 1) as u32).to_be_bytes().to_vec();

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,22 +38,22 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
-use base64::engine::general_purpose::STANDARD as BASE64;
 use base64::Engine as _;
+use base64::engine::general_purpose::STANDARD as BASE64;
 use bytes::{Buf, BytesMut};
-use serde_json::{json, Value};
+use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
+    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,22 +38,22 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::sync::Mutex;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::time::Duration;
 
-use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
 use bytes::{Buf, BytesMut};
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{Notify, mpsc, watch};
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
+    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -315,11 +315,6 @@ struct Connection {
     /// busy. Pause and resume are idempotent, so retaining only the newest
     /// state is the correct flow-control contract.
     flow_tx: watch::Sender<bool>,
-    /// Coalesced flow state and shutdown marker. The flow worker drains this
-    /// state before it exits, so a required pause cannot be lost to task
-    /// cancellation.
-    flow_state: Mutex<FlowState>,
-    flow_notify: Arc<Notify>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -329,18 +324,6 @@ struct Connection {
     opened_seen: AtomicBool,
     finished: AtomicBool,
     done: CancellationToken,
-}
-
-#[derive(Debug, Default)]
-struct FlowState {
-    desired_pause: bool,
-    stopping: bool,
-}
-
-enum FlowAction {
-    Apply(bool),
-    Wait,
-    Stop,
 }
 
 impl Connection {
@@ -424,59 +407,45 @@ impl Connection {
     }
 
     fn publish_flow(&self, pause: bool) {
-        let changed = {
-            let mut state = self.flow_state.lock().expect("flow state lock");
-            if state.stopping || state.desired_pause == pause {
+        if self.finished.load(Ordering::SeqCst) {
+            return;
+        }
+        self.flow_tx.send_if_modified(|current| {
+            if *current == pause {
                 false
             } else {
-                state.desired_pause = pause;
+                *current = pause;
                 true
             }
-        };
-        if changed {
-            let _ = self.flow_tx.send(pause);
-            self.flow_notify.notify_one();
-        }
+        });
     }
 
     /// Pause the source before closing when a stalled peer exhausts admission.
     fn reject_due_to_backpressure(&self) {
-        let notify_flow = {
-            let _gate = self.queue_gate.lock().expect("writer queue lock");
-            if self.finished.load(Ordering::SeqCst) {
-                false
-            } else {
-                // Keep the client informed before closing. Data admission
-                // leaves a message and byte reserve for this bounded control
-                // frame, and the End permit remains last in FIFO order.
-                let overflow = encode_overflow_frame();
-                let overflow_bytes = overflow.len() as u64;
-                if self.reserve_bytes(overflow_bytes, true) {
-                    if self.writer_tx.try_send(WriterMessage::Frame(overflow)).is_err() {
-                        self.release_bytes(overflow_bytes);
-                    }
-                }
-                self.paused.store(true, Ordering::SeqCst);
-                let mut state = self.flow_state.lock().expect("flow state lock");
-                let notify = !state.desired_pause;
-                state.desired_pause = true;
-                state.stopping = true;
-                self.finished.store(true, Ordering::SeqCst);
-                if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take()
-                {
-                    permit.send(WriterMessage::End);
-                }
-                self.done.cancel();
-                notify
-            }
-        };
-        // The state transition and End marker are serialized by queue_gate.
-        // Notify after releasing it so the worker can observe the complete
-        // pause-before-stop state in one read.
-        if notify_flow {
-            let _ = self.flow_tx.send(true);
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
+        if self.finished.load(Ordering::SeqCst) {
+            return;
         }
-        self.flow_notify.notify_one();
+        // Keep the client informed before closing. Data admission leaves a
+        // message and byte reserve for this bounded control frame, and the
+        // End permit remains last in FIFO order.
+        let overflow = encode_overflow_frame();
+        let overflow_bytes = overflow.len() as u64;
+        if self.reserve_bytes(overflow_bytes, true) {
+            if self.writer_tx.try_send(WriterMessage::Frame(overflow)).is_err() {
+                self.release_bytes(overflow_bytes);
+            }
+        }
+        self.paused.store(true, Ordering::SeqCst);
+        // Publish the final pause before cancellation. The flow worker reads
+        // the latest watch value when cancellation wins the race with its
+        // change notification.
+        self.flow_tx.send_replace(true);
+        self.finished.store(true, Ordering::SeqCst);
+        if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take() {
+            permit.send(WriterMessage::End);
+        }
+        self.done.cancel();
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -484,24 +453,14 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
-        let should_notify = {
-            let _gate = self.queue_gate.lock().expect("writer queue lock");
-            if self.finished.swap(true, Ordering::SeqCst) {
-                false
-            } else {
-                let mut state = self.flow_state.lock().expect("flow state lock");
-                state.stopping = true;
-                if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take()
-                {
-                    permit.send(WriterMessage::End);
-                }
-                self.done.cancel();
-                true
-            }
-        };
-        if should_notify {
-            self.flow_notify.notify_one();
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
+        if self.finished.swap(true, Ordering::SeqCst) {
+            return;
         }
+        if let Some(permit) = self.end_permit.lock().expect("tunnel end permit lock").take() {
+            permit.send(WriterMessage::End);
+        }
+        self.done.cancel();
     }
 
     fn protocol_error(&self, code: &str, message: &str) {
@@ -660,26 +619,21 @@ async fn handle_client_frame(
 fn spawn_flow_worker(
     connection: Arc<Connection>,
     context: FrameContext,
+    mut flow_rx: watch::Receiver<bool>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let mut applied_pause = false;
         loop {
-            // Create the notification future before inspecting state. Tokio
-            // retains a notification permit, so a concurrent transition
-            // cannot be lost between the read and the await.
-            let notified = connection.flow_notify.notified();
-            let action = {
-                let state = connection.flow_state.lock().expect("flow state lock");
-                if state.desired_pause != applied_pause {
-                    FlowAction::Apply(state.desired_pause)
-                } else if state.stopping {
-                    FlowAction::Stop
-                } else {
-                    FlowAction::Wait
-                }
-            };
-            match action {
-                FlowAction::Apply(pause) => {
+            tokio::select! {
+                biased;
+                changed = flow_rx.changed() => {
+                    if changed.is_err() {
+                        break;
+                    }
+                    let pause = *flow_rx.borrow_and_update();
+                    if pause == applied_pause {
+                        continue;
+                    }
                     let frame = json!({
                         "version": PTY_PROTOCOL_VERSION,
                         "type": "pty_flow",
@@ -689,8 +643,22 @@ fn spawn_flow_worker(
                     connection.manager.handle_frame(&frame, &context).await;
                     applied_pause = pause;
                 }
-                FlowAction::Wait => notified.await,
-                FlowAction::Stop => break,
+                _ = connection.done.cancelled() => {
+                    // Cancellation can race with the final pause publication.
+                    // Read the watch value before exiting, and deliver a
+                    // required pause while the attachment remains live.
+                    let pause = *flow_rx.borrow();
+                    if pause && !applied_pause {
+                        let frame = json!({
+                            "version": PTY_PROTOCOL_VERSION,
+                            "type": "pty_flow",
+                            "ptyId": connection.pty_id,
+                            "pause": true,
+                        });
+                        connection.manager.handle_frame(&frame, &context).await;
+                    }
+                    break;
+                }
             }
         }
     })
@@ -710,7 +678,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
             return;
         }
     };
-    let (flow_tx, _flow_rx) = watch::channel(false);
+    let (flow_tx, flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
@@ -718,8 +686,6 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         end_permit: Mutex::new(Some(end_permit)),
         queue_gate: Mutex::new(()),
         flow_tx,
-        flow_state: Mutex::new(FlowState::default()),
-        flow_notify: Arc::new(Notify::new()),
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
         open_sent: AtomicBool::new(false),
@@ -762,7 +728,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     // Flow verbs need the async manager; drain them on their own task so a
     // slow open never delays a pause. Its state is drained during shutdown
     // before the attachment is released.
-    let mut flow = spawn_flow_worker(Arc::clone(&connection), context.clone());
+    let mut flow = spawn_flow_worker(Arc::clone(&connection), context.clone(), flow_rx);
 
     // Reader: strictly in arrival order, so input received while an open
     // settles lands after the attachment exists. Awaiting each frame is the
@@ -1203,8 +1169,6 @@ mod tests {
             end_permit: Mutex::new(Some(end_permit)),
             queue_gate: Mutex::new(()),
             flow_tx,
-            flow_state: Mutex::new(FlowState::default()),
-            flow_notify: Arc::new(Notify::new()),
             pending_out: AtomicU64::new(0),
             paused: AtomicBool::new(false),
             open_sent: AtomicBool::new(false),
@@ -1331,9 +1295,9 @@ mod tests {
     #[tokio::test]
     async fn backpressure_delivers_pause_before_flow_worker_stops() {
         let rig = rig().await;
-        let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
+        let (connection, _writer_rx, flow_rx) = test_connection(&rig);
         let pty = attach_test_pty(&rig, &connection).await;
-        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context(), flow_rx);
 
         connection.reject_due_to_backpressure();
         tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
@@ -1374,7 +1338,7 @@ mod tests {
     #[tokio::test]
     async fn full_writer_queue_keeps_flow_resume_and_worker_completion() {
         let rig = rig().await;
-        let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
+        let (connection, _writer_rx, flow_rx) = test_connection(&rig);
         let pty = attach_test_pty(&rig, &connection).await;
         let mut frame_index = 0_usize;
         while connection.writer_tx.capacity() > WRITER_CONTROL_MESSAGE_RESERVE {
@@ -1384,7 +1348,7 @@ mod tests {
         assert!(frame_index > 0);
         assert!(connection.writer_tx.capacity() <= WRITER_CONTROL_MESSAGE_RESERVE);
 
-        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context(), flow_rx);
         connection.publish_flow(true);
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -961,6 +961,69 @@ mod tests {
         }
     }
 
+    fn test_connection(
+        rig: &Rig,
+    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, mpsc::Receiver<bool>) {
+        let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
+        let (flow_tx, flow_rx) = mpsc::channel(4);
+        let connection = Arc::new(Connection {
+            pty_id: "test-pty".to_owned(),
+            manager: Arc::clone(&rig.manager),
+            writer_tx,
+            queue_gate: Mutex::new(()),
+            flow_tx,
+            pending_out: AtomicU64::new(0),
+            paused: AtomicBool::new(false),
+            open_sent: AtomicBool::new(false),
+            opened_seen: AtomicBool::new(false),
+            finished: AtomicBool::new(false),
+            done: CancellationToken::new(),
+        });
+        (connection, writer_rx, flow_rx)
+    }
+
+    #[tokio::test]
+    async fn stalled_peer_hits_the_byte_budget_and_pauses_before_close() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        let frame_len = WRITER_QUEUE_BYTE_CAP as usize / 2;
+        assert!(connection.enqueue(WriterMessage::Frame(vec![1; frame_len])));
+        assert!(connection.enqueue(WriterMessage::Frame(vec![2; frame_len])));
+        assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
+        assert!(connection.finished.load(Ordering::SeqCst));
+        assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
+        assert_eq!(flow_rx.try_recv(), Ok(true));
+        match writer_rx.recv().await.expect("first admitted frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
+            WriterMessage::End => panic!("queue order changed"),
+        }
+        match writer_rx.recv().await.expect("second admitted frame") {
+            WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
+            WriterMessage::End => panic!("queue order changed"),
+        }
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
+    async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
+        let rig = rig().await;
+        let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
+        for index in 0..WRITER_QUEUE_CAPACITY {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        }
+        assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
+        assert!(connection.finished.load(Ordering::SeqCst));
+        assert_eq!(flow_rx.try_recv(), Ok(true));
+        for index in 0..WRITER_QUEUE_CAPACITY {
+            match writer_rx.recv().await.expect("admitted frame") {
+                WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
+                WriterMessage::End => panic!("queue order changed"),
+            }
+        }
+        assert!(writer_rx.try_recv().is_err());
+        rig.cancel.cancel();
+    }
+
     // -- live listener ------------------------------------------------------
 
     #[tokio::test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -38,21 +38,21 @@
 //! already attach terminals through the cmux CLI. Paired human machines
 //! never run this listener: it starts from the managed branch only.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use base64::Engine as _;
 use base64::engine::general_purpose::STANDARD as BASE64;
 use bytes::{Buf, BytesMut};
-use serde_json::{Value, json};
+use base64::Engine as _;
+use serde_json::{json, Value};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::mpsc;
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
+    random_hex, session_name_ok, surface_ref_ok, FrameContext, PtyManager, PTY_PROTOCOL_VERSION,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -74,6 +74,11 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// Admission is synchronous from the manager callback, so the writer queue
+/// uses non-blocking sends with both message and byte budgets. The byte cap
+/// leaves room for a maximum PTY frame and a follow-up control/error frame.
+const WRITER_QUEUE_CAPACITY: usize = 128;
+const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
 
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
@@ -123,20 +128,17 @@ pub fn encode_pty_frame(bytes: &[u8]) -> Vec<u8> {
 /// length-prefixed stream that desynced once can never be trusted again, so
 /// the caller must close the connection.
 pub struct TunnelFrameDecoder {
-    buffer: BytesMut,
-    storage_capacity: usize,
+    buffer: Vec<u8>,
     failed: bool,
     max_frame_bytes: usize,
 }
 
 impl TunnelFrameDecoder {
     pub fn new(max_frame_bytes: usize) -> TunnelFrameDecoder {
-        let max_frame_bytes = max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES);
         TunnelFrameDecoder {
-            storage_capacity: 0,
-            buffer: BytesMut::new(),
+            buffer: Vec::new(),
             failed: false,
-            max_frame_bytes,
+            max_frame_bytes: max_frame_bytes.clamp(1, MAX_TUNNEL_FRAME_BYTES),
         }
     }
 
@@ -145,7 +147,6 @@ impl TunnelFrameDecoder {
             return Err("decoder_poisoned");
         }
         self.buffer.extend_from_slice(chunk);
-        self.storage_capacity = self.storage_capacity.max(self.buffer.capacity());
         let mut frames = Vec::new();
         while self.buffer.len() >= HEADER_BYTES {
             let length = u32::from_be_bytes([
@@ -166,19 +167,9 @@ impl TunnelFrameDecoder {
             if self.buffer.len() < HEADER_BYTES + length {
                 break;
             }
-            self.buffer.advance(HEADER_BYTES);
-            let payload = self.buffer.split_to(length).to_vec();
+            let payload = self.buffer[HEADER_BYTES..HEADER_BYTES + length].to_vec();
+            self.buffer.drain(..HEADER_BYTES + length);
             frames.push(TunnelFrame { kind, payload });
-        }
-        // A single read may contain many frames. Keep the retained decoder
-        // storage bounded by one maximum-size frame plus its header instead
-        // of holding the capacity of that whole read forever.
-        let retained_limit = self.max_frame_bytes + HEADER_BYTES;
-        if self.storage_capacity > retained_limit && self.buffer.len() <= retained_limit {
-            let mut compacted = BytesMut::with_capacity(retained_limit);
-            compacted.extend_from_slice(&self.buffer);
-            self.storage_capacity = compacted.capacity();
-            self.buffer = compacted;
         }
         Ok(frames)
     }
@@ -268,9 +259,12 @@ enum WriterMessage {
 struct Connection {
     pty_id: String,
     manager: Arc<PtyManager>,
-    writer_tx: mpsc::UnboundedSender<WriterMessage>,
+    writer_tx: mpsc::Sender<WriterMessage>,
+    /// Serializes queue admission with the End marker so no frame can be
+    /// inserted after shutdown and silently be dropped by the writer.
+    queue_gate: Mutex<()>,
     /// pty_flow requests from the writer's water marks (true = pause).
-    flow_tx: mpsc::UnboundedSender<bool>,
+    flow_tx: mpsc::Sender<bool>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -284,17 +278,69 @@ struct Connection {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
+        let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
     }
 
-    fn enqueue(&self, message: WriterMessage) {
-        if self.finished.load(Ordering::SeqCst) {
-            return;
+    fn reserve_bytes(&self, amount: u64) -> bool {
+        let mut current = self.pending_out.load(Ordering::SeqCst);
+        loop {
+            let Some(next) = current.checked_add(amount) else {
+                return false;
+            };
+            if next > WRITER_QUEUE_BYTE_CAP {
+                return false;
+            }
+            match self.pending_out.compare_exchange(
+                current,
+                next,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return true,
+                Err(actual) => current = actual,
+            }
         }
-        if let WriterMessage::Frame(frame) = &message {
-            self.pending_out.fetch_add(frame.len() as u64, Ordering::SeqCst);
+    }
+
+    fn release_bytes(&self, amount: u64) {
+        self.pending_out.fetch_sub(amount, Ordering::SeqCst);
+    }
+
+    /// Pause the source before closing when a stalled peer exhausts admission.
+    fn reject_due_to_backpressure(&self) {
+        if !self.paused.swap(true, Ordering::SeqCst) {
+            let _ = self.flow_tx.try_send(true);
         }
-        let _ = self.writer_tx.send(message);
+        self.finish();
+    }
+
+    fn enqueue(&self, message: WriterMessage) -> bool {
+        let frame_bytes = match &message {
+            WriterMessage::Frame(frame) => frame.len() as u64,
+            WriterMessage::End => 0,
+        };
+        let mut reserved = false;
+        let admitted = {
+            let _gate = self.queue_gate.lock().expect("writer queue lock");
+            if self.finished.load(Ordering::SeqCst) {
+                false
+            } else if frame_bytes != 0 && !self.reserve_bytes(frame_bytes) {
+                false
+            } else {
+                reserved = frame_bytes != 0;
+                self.writer_tx.try_send(message).is_ok()
+            }
+        };
+        if admitted {
+            return true;
+        }
+        if reserved {
+            self.release_bytes(frame_bytes);
+        }
+        if !self.finished.load(Ordering::SeqCst) {
+            self.reject_due_to_backpressure();
+        }
+        false
     }
 
     /// Idempotent shutdown: flush queued frames, close the socket, and let
@@ -302,10 +348,11 @@ impl Connection {
     /// session lives on for a later re-attach, the same rule a dropped
     /// relay-socket viewer follows).
     fn finish(&self) {
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
-        let _ = self.writer_tx.send(WriterMessage::End);
+        let _ = self.writer_tx.try_send(WriterMessage::End);
         self.done.cancel();
     }
 
@@ -350,14 +397,16 @@ impl Connection {
                 else {
                     return;
                 };
-                self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes)));
+                if !self.enqueue(WriterMessage::Frame(encode_pty_frame(&bytes))) {
+                    return;
+                }
                 // Socket-side congestion: pause the source through the
                 // manager's own flow verb; the writer resumes it below the
                 // low-water mark.
                 if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
                     && !self.paused.swap(true, Ordering::SeqCst)
                 {
-                    let _ = self.flow_tx.send(true);
+                    let _ = self.flow_tx.try_send(true);
                 }
             }
             Some("pty_exit") => {
@@ -394,7 +443,6 @@ impl Connection {
             local_roots: None,
             owner_user_id: None,
             transport_id: Some(self.pty_id.clone()),
-            cancellation: self.done.clone(),
         }
     }
 }
@@ -464,12 +512,13 @@ async fn handle_client_frame(
 async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: CancellationToken) {
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
-    let (writer_tx, mut writer_rx) = mpsc::unbounded_channel::<WriterMessage>();
-    let (flow_tx, mut flow_rx) = mpsc::unbounded_channel::<bool>();
+    let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
+    let (flow_tx, mut flow_rx) = mpsc::channel::<bool>(4);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
         writer_tx,
+        queue_gate: Mutex::new(()),
         flow_tx,
         pending_out: AtomicU64::new(0),
         paused: AtomicBool::new(false),
@@ -500,7 +549,13 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                         if previous.saturating_sub(length) < FLOW_RESUME_BYTES
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
-                            let _ = connection.flow_tx.send(false);
+                            let _ = connection.flow_tx.try_send(false);
+                        }
+                        // `finish` may race with a full queue, so End is only
+                        // best effort. Once all admitted frames drain, stop
+                        // without waiting for another sender-side message.
+                        if connection.finished.load(Ordering::SeqCst) && writer_rx.is_empty() {
+                            break;
                         }
                     }
                     WriterMessage::End => break,
@@ -517,7 +572,9 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         let context = context.clone();
         tokio::spawn(async move {
             while let Some(pause) = flow_rx.recv().await {
-                if connection.finished.load(Ordering::SeqCst) {
+                // Deliver a final pause even when shutdown has started. This
+                // keeps PTY flow semantics intact for a queue-overflow close.
+                if connection.finished.load(Ordering::SeqCst) && !pause {
                     break;
                 }
                 let frame = json!({
@@ -719,7 +776,7 @@ mod tests {
             _cmux_tui: &CmuxTui,
             _session: &str,
             _socket_dir: &Path,
-            _cwd: &crate::pty::ResolvedCwd,
+            _cwd: &Path,
             _env: &HashMap<String, String>,
         ) -> Result<EnsureDaemon, String> {
             Err("no daemon in tunnel tests".to_owned())
@@ -848,36 +905,6 @@ mod tests {
         assert_eq!(frames[0].kind, FRAME_KIND_CONTROL);
         assert_eq!(frames[1].kind, FRAME_KIND_PTY);
         assert_eq!(frames[1].payload, b"echo hi\r");
-    }
-
-    #[test]
-    fn decoder_handles_many_frames_without_retaining_batch_storage() {
-        const MAX_FRAME_BYTES: usize = 8;
-        const FRAME_COUNT: usize = 2_048;
-
-        let mut stream = Vec::with_capacity(FRAME_COUNT * (HEADER_BYTES + 1));
-        for index in 0..FRAME_COUNT {
-            stream.extend_from_slice(&encode_tunnel_frame(
-                if index % 2 == 0 { FRAME_KIND_CONTROL } else { FRAME_KIND_PTY },
-                &[index as u8],
-            ));
-        }
-
-        let mut decoder = TunnelFrameDecoder::new(MAX_FRAME_BYTES);
-        let frames = decoder.push(&stream).expect("clean stream");
-
-        assert_eq!(frames.len(), FRAME_COUNT);
-        assert!(frames.iter().enumerate().all(|(index, frame)| {
-            frame.kind == if index % 2 == 0 { FRAME_KIND_CONTROL } else { FRAME_KIND_PTY }
-                && frame.payload == [index as u8]
-        }));
-        assert!(decoder.buffer.is_empty());
-        assert!(
-            decoder.storage_capacity <= MAX_FRAME_BYTES + HEADER_BYTES,
-            "decoder retained {} bytes for a {} byte max frame",
-            decoder.storage_capacity,
-            MAX_FRAME_BYTES
-        );
     }
 
     #[test]

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -328,7 +328,7 @@ enum FlowAction {
 
 impl Connection {
     fn send_control(&self, frame: &Value) {
-        let _ = self.enqueue_frame(encode_control_frame(frame), true);
+        let _ = self.enqueue(WriterMessage::Frame(encode_control_frame(frame)));
     }
 
     fn reserve_bytes(&self, amount: u64, control: bool) -> bool {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1332,6 +1332,51 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn full_writer_queue_keeps_flow_resume_and_worker_completion() {
+        let rig = rig().await;
+        let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
+        let pty = attach_test_pty(&rig, &connection).await;
+        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
+        for index in 0..data_capacity {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        }
+
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
+        connection.publish_flow(true);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pty.state.lock().unwrap().pause_calls == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("pause should reach the live attachment");
+
+        // A resume published after the queue is full must not be dropped.
+        connection.publish_flow(false);
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pty.state.lock().unwrap().resume_calls == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("resume should reach the live attachment");
+
+        connection.finish();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker completion")
+            .expect("flow worker join");
+        assert!(connection.finished.load(Ordering::SeqCst));
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
         let (connection, mut writer_rx, flow_rx) = test_connection(&rig);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -54,7 +54,7 @@ use bytes::{Buf, BytesMut};
 use serde_json::{Value, json};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::mpsc;
+use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
@@ -269,8 +269,11 @@ struct Connection {
     /// Serializes queue admission with the End marker so no frame can be
     /// inserted after shutdown and silently be dropped by the writer.
     queue_gate: Mutex<()>,
-    /// pty_flow requests from the writer's water marks (true = pause).
-    flow_tx: mpsc::Sender<bool>,
+    /// Latest pty_flow state from the writer's water marks (true = pause).
+    /// A watch channel cannot lose the current state when its consumer is
+    /// busy. Pause and resume are idempotent, so retaining only the newest
+    /// state is the correct flow-control contract.
+    flow_tx: watch::Sender<bool>,
     /// Bytes queued toward the socket and not yet written.
     pending_out: AtomicU64,
     paused: AtomicBool,
@@ -312,10 +315,14 @@ impl Connection {
         self.pending_out.fetch_sub(amount, Ordering::SeqCst);
     }
 
+    fn publish_flow(&self, pause: bool) {
+        let _ = self.flow_tx.send(pause);
+    }
+
     /// Pause the source before closing when a stalled peer exhausts admission.
     fn reject_due_to_backpressure(&self) {
         if !self.paused.swap(true, Ordering::SeqCst) {
-            let _ = self.flow_tx.try_send(true);
+            self.publish_flow(true);
         }
         self.finish();
     }
@@ -412,7 +419,7 @@ impl Connection {
                 if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
                     && !self.paused.swap(true, Ordering::SeqCst)
                 {
-                    let _ = self.flow_tx.try_send(true);
+                    self.publish_flow(true);
                 }
             }
             Some("pty_exit") => {
@@ -519,7 +526,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
     let _ = stream.set_nodelay(true);
     let (mut read_half, mut write_half) = stream.into_split();
     let (writer_tx, mut writer_rx) = mpsc::channel::<WriterMessage>(WRITER_QUEUE_CAPACITY);
-    let (flow_tx, mut flow_rx) = mpsc::channel::<bool>(4);
+    let (flow_tx, mut flow_rx) = watch::channel(false);
     let connection = Arc::new(Connection {
         pty_id: format!("tunnel-{}", random_hex(8)),
         manager: Arc::clone(&manager),
@@ -555,7 +562,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                         if previous.saturating_sub(length) < FLOW_RESUME_BYTES
                             && connection.paused.swap(false, Ordering::SeqCst)
                         {
-                            let _ = connection.flow_tx.try_send(false);
+                            connection.publish_flow(false);
                         }
                         // `finish` may race with a full queue, so End is only
                         // best effort. Once all admitted frames drain, stop
@@ -577,12 +584,8 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         let connection = Arc::clone(&connection);
         let context = context.clone();
         tokio::spawn(async move {
-            while let Some(pause) = flow_rx.recv().await {
-                // Deliver a final pause even when shutdown has started. This
-                // keeps PTY flow semantics intact for a queue-overflow close.
-                if connection.finished.load(Ordering::SeqCst) && !pause {
-                    break;
-                }
+            while flow_rx.changed().await.is_ok() {
+                let pause = *flow_rx.borrow_and_update();
                 let frame = json!({
                     "version": PTY_PROTOCOL_VERSION,
                     "type": "pty_flow",
@@ -996,9 +999,9 @@ mod tests {
 
     fn test_connection(
         rig: &Rig,
-    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, mpsc::Receiver<bool>) {
+    ) -> (Arc<Connection>, mpsc::Receiver<WriterMessage>, watch::Receiver<bool>) {
         let (writer_tx, writer_rx) = mpsc::channel(WRITER_QUEUE_CAPACITY);
-        let (flow_tx, flow_rx) = mpsc::channel(4);
+        let (flow_tx, flow_rx) = watch::channel(false);
         let connection = Arc::new(Connection {
             pty_id: "test-pty".to_owned(),
             manager: Arc::clone(&rig.manager),
@@ -1025,7 +1028,7 @@ mod tests {
         assert!(!connection.enqueue(WriterMessage::Frame(vec![3])));
         assert!(connection.finished.load(Ordering::SeqCst));
         assert!(connection.pending_out.load(Ordering::SeqCst) <= WRITER_QUEUE_BYTE_CAP);
-        assert_eq!(flow_rx.try_recv(), Ok(true));
+        assert_eq!(*flow_rx.borrow(), true);
         match writer_rx.recv().await.expect("first admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 1),
             WriterMessage::End => panic!("queue order changed"),
@@ -1038,6 +1041,20 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn flow_state_keeps_resume_after_consumer_lag() {
+        let rig = rig().await;
+        let (connection, _writer_rx, mut flow_rx) = test_connection(&rig);
+        connection.publish_flow(true);
+        connection.publish_flow(true);
+        connection.publish_flow(true);
+        connection.publish_flow(true);
+        connection.publish_flow(false);
+        assert!(flow_rx.changed().await.is_ok());
+        assert!(!*flow_rx.borrow_and_update());
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn full_writer_queue_closes_without_growing_beyond_message_budget() {
         let rig = rig().await;
         let (connection, mut writer_rx, mut flow_rx) = test_connection(&rig);
@@ -1046,7 +1063,7 @@ mod tests {
         }
         assert!(!connection.enqueue(WriterMessage::Frame(vec![0])));
         assert!(connection.finished.load(Ordering::SeqCst));
-        assert_eq!(flow_rx.try_recv(), Ok(true));
+        assert_eq!(*flow_rx.borrow(), true);
         for index in 0..WRITER_QUEUE_CAPACITY {
             match writer_rx.recv().await.expect("admitted frame") {
                 WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1302,6 +1302,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn small_frames_pause_before_message_budget_closes_connection() {
+        let rig = rig().await;
+        let (connection, _writer_rx, flow_rx) = test_connection(&rig);
+        let pty = attach_test_pty(&rig, &connection).await;
+        let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context(), flow_rx);
+        let output = json!({
+            "ptyId": connection.pty_id,
+            "type": "pty_output",
+            "dataB64": BASE64.encode([1_u8]),
+        });
+        while connection.writer_tx.capacity() > FLOW_PAUSE_MESSAGES {
+            connection.on_manager_frame(&output);
+        }
+        tokio::time::timeout(Duration::from_secs(1), async {
+            loop {
+                if pty.state.lock().unwrap().pause_calls == 1 {
+                    break;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("message water mark should pause the source");
+        assert!(!connection.finished.load(Ordering::SeqCst));
+        connection.finish();
+        tokio::time::timeout(FLOW_DRAIN_TIMEOUT, flow)
+            .await
+            .expect("flow worker drain")
+            .expect("flow worker join");
+        rig.cancel.cancel();
+    }
+
+    #[tokio::test]
     async fn control_frame_uses_reserved_byte_budget_and_end_stays_fifo() {
         let rig = rig().await;
         let (connection, mut writer_rx, _flow_rx) = test_connection(&rig);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -428,10 +428,10 @@ impl Connection {
         // End permit remains last in FIFO order.
         let overflow = encode_overflow_frame();
         let overflow_bytes = overflow.len() as u64;
-        if self.reserve_bytes(overflow_bytes, true) {
-            if self.writer_tx.try_send(WriterMessage::Frame(overflow)).is_err() {
-                self.release_bytes(overflow_bytes);
-            }
+        if self.reserve_bytes(overflow_bytes, true)
+            && self.writer_tx.try_send(WriterMessage::Frame(overflow)).is_err()
+        {
+            self.release_bytes(overflow_bytes);
         }
         self.paused.store(true, Ordering::SeqCst);
         // Publish the final pause before cancellation. The flow worker reads

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1336,10 +1336,13 @@ mod tests {
         let rig = rig().await;
         let (connection, _writer_rx, _flow_rx) = test_connection(&rig);
         let pty = attach_test_pty(&rig, &connection).await;
-        let data_capacity = WRITER_QUEUE_CAPACITY - WRITER_CONTROL_MESSAGE_RESERVE - 1;
-        for index in 0..data_capacity {
-            assert!(connection.enqueue(WriterMessage::Frame(vec![index as u8])));
+        let mut frame_index = 0_usize;
+        while connection.writer_tx.capacity() > WRITER_CONTROL_MESSAGE_RESERVE {
+            assert!(connection.enqueue(WriterMessage::Frame(vec![(frame_index % 256) as u8])));
+            frame_index += 1;
         }
+        assert!(frame_index > 0);
+        assert!(connection.writer_tx.capacity() <= WRITER_CONTROL_MESSAGE_RESERVE);
 
         let flow = spawn_flow_worker(Arc::clone(&connection), connection.frame_context());
         connection.publish_flow(true);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -107,6 +107,14 @@ fn is_encoded_control_frame(frame: &[u8]) -> bool {
     frame[4] == FRAME_KIND_CONTROL && payload_len == frame.len() - HEADER_BYTES
 }
 
+fn encode_overflow_frame() -> Vec<u8> {
+    encode_control_frame(&json!({
+        "t": "error",
+        "code": "overflow",
+        "message": "terminal output queue is full; reconnect to resume",
+    }))
+}
+
 /// Relay pty_error codes -> browser wire codes. Mirrors the Worker's
 /// browserErrorCode map (apps/backend/src/terminal/relay-pty.ts). KEEP IN
 /// SYNC; `wire_error_codes_match_the_worker_map` pins the shape here.
@@ -429,6 +437,16 @@ impl Connection {
             if self.finished.load(Ordering::SeqCst) {
                 false
             } else {
+                // Keep the client informed before closing. Data admission
+                // leaves a message and byte reserve for this bounded control
+                // frame, and the End permit remains last in FIFO order.
+                let overflow = encode_overflow_frame();
+                let overflow_bytes = overflow.len() as u64;
+                if self.reserve_bytes(overflow_bytes, true) {
+                    if self.writer_tx.try_send(WriterMessage::Frame(overflow)).is_err() {
+                        self.release_bytes(overflow_bytes);
+                    }
+                }
                 self.paused.store(true, Ordering::SeqCst);
                 let mut state = self.flow_state.lock().expect("flow state lock");
                 let notify = !state.desired_pause;
@@ -1026,6 +1044,11 @@ mod tests {
         serde_json::from_slice(&frame.payload).expect("control json")
     }
 
+    fn encoded_control_json(frame: &[u8]) -> Value {
+        assert!(is_encoded_control_frame(frame));
+        serde_json::from_slice(&frame[HEADER_BYTES..]).expect("encoded control json")
+    }
+
     #[test]
     fn data_budget_leaves_byte_reserve_for_control_frames() {
         assert_eq!(
@@ -1209,8 +1232,8 @@ mod tests {
         assert!(connection.finished.load(Ordering::SeqCst));
         assert_eq!(
             connection.pending_out.load(Ordering::SeqCst),
-            (frame_len * 2) as u64,
-            "a rejected frame must release its byte reservation"
+            (frame_len * 2) as u64 + encode_overflow_frame().len() as u64,
+            "a rejected frame must release its byte reservation while retaining the error"
         );
         assert!(*flow_rx.borrow());
         assert!(connection.done.is_cancelled());
@@ -1221,6 +1244,14 @@ mod tests {
         match writer_rx.recv().await.expect("second admitted frame") {
             WriterMessage::Frame(frame) => assert_eq!(frame[0], 2),
             WriterMessage::End => panic!("queue order changed"),
+        }
+        match writer_rx.recv().await.expect("overflow control frame") {
+            WriterMessage::Frame(frame) => {
+                let error = encoded_control_json(&frame);
+                assert_eq!(error["t"], "error");
+                assert_eq!(error["code"], "overflow");
+            }
+            WriterMessage::End => panic!("End overtook overflow error"),
         }
         assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();
@@ -1396,6 +1427,14 @@ mod tests {
                 WriterMessage::Frame(frame) => assert_eq!(frame, vec![index as u8]),
                 WriterMessage::End => panic!("queue order changed"),
             }
+        }
+        match writer_rx.recv().await.expect("overflow control frame") {
+            WriterMessage::Frame(frame) => {
+                let error = encoded_control_json(&frame);
+                assert_eq!(error["t"], "error");
+                assert_eq!(error["code"], "overflow");
+            }
+            WriterMessage::End => panic!("End overtook overflow error"),
         }
         assert!(matches!(writer_rx.recv().await, Some(WriterMessage::End)));
         rig.cancel.cancel();

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -550,6 +550,7 @@ impl Connection {
             local_roots: None,
             owner_user_id: None,
             transport_id: Some(self.pty_id.clone()),
+            cancellation: self.done.clone(),
         }
     }
 }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -1481,7 +1481,7 @@ mod tests {
     #[tokio::test]
     async fn full_writer_queue_keeps_flow_resume_and_worker_completion() {
         let rig = rig().await;
-        let (connection, _writer_rx, flow_rx) = test_connection(&rig);
+        let (connection, mut writer_rx, flow_rx) = test_connection(&rig);
         let pty = attach_test_pty(&rig, &connection).await;
         let mut frame_index = 0_usize;
         while connection.writer_tx.capacity() > WRITER_CONTROL_MESSAGE_RESERVE {
@@ -1504,7 +1504,10 @@ mod tests {
         .await
         .expect("pause should reach the live attachment");
 
-        // A resume published after the queue is full must not be dropped.
+        // Resume only after the message queue drains below its low-water mark.
+        while connection.writer_tx.capacity() < FLOW_RESUME_MESSAGES {
+            writer_rx.recv().await.expect("queued frame");
+        }
         connection.publish_flow(false);
         tokio::time::timeout(Duration::from_secs(1), async {
             loop {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -408,6 +408,19 @@ impl Connection {
     }
 
     fn publish_flow(&self, pause: bool) {
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
+        if self.finished.load(Ordering::SeqCst) {
+            return;
+        }
+        let changed = if pause {
+            self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
+                && !self.paused.swap(true, Ordering::SeqCst)
+        } else {
+            self.paused.swap(false, Ordering::SeqCst)
+        };
+        if !changed {
+            return;
+        }
         self.flow_tx.send_if_modified(|current| {
             if *current == pause {
                 false
@@ -455,6 +468,7 @@ impl Connection {
         if self.finished.swap(true, Ordering::SeqCst) {
             return;
         }
+        self.paused.store(false, Ordering::SeqCst);
         // Stop admitting output before resuming a paused source. The writer
         // drains only frames already admitted, so this transition cannot add
         // new bytes to the queue during shutdown.
@@ -519,9 +533,7 @@ impl Connection {
                 // Socket-side congestion: pause the source through the
                 // manager's own flow verb; the writer resumes it below the
                 // low-water mark.
-                if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
-                    && !self.paused.swap(true, Ordering::SeqCst)
-                {
+                if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES {
                     self.publish_flow(true);
                 }
             }
@@ -722,9 +734,7 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             connection.finish();
                             break;
                         }
-                        if previous.saturating_sub(length) < FLOW_RESUME_BYTES
-                            && connection.paused.swap(false, Ordering::SeqCst)
-                        {
+                        if previous.saturating_sub(length) < FLOW_RESUME_BYTES {
                             connection.publish_flow(false);
                         }
                     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -53,7 +53,8 @@ use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
+    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, ResolvedCwd, random_hex, session_name_ok,
+    surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -939,7 +940,7 @@ mod tests {
             _cmux_tui: &CmuxTui,
             _session: &str,
             _socket_dir: &Path,
-            _cwd: &Path,
+            _cwd: &ResolvedCwd,
             _env: &HashMap<String, String>,
         ) -> Result<EnsureDaemon, String> {
             Err("no daemon in tunnel tests".to_owned())

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -93,11 +93,7 @@ const WRITER_DATA_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES 
 const WRITER_QUEUE_BYTE_CAP: u64 = WRITER_DATA_BYTE_CAP + WRITER_CONTROL_BYTE_RESERVE;
 
 fn writer_queue_byte_limit(control: bool) -> u64 {
-    if control {
-        WRITER_QUEUE_BYTE_CAP
-    } else {
-        WRITER_DATA_BYTE_CAP
-    }
+    if control { WRITER_QUEUE_BYTE_CAP } else { WRITER_DATA_BYTE_CAP }
 }
 
 fn is_encoded_control_frame(frame: &[u8]) -> bool {

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -86,6 +86,7 @@ const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// uses non-blocking sends with both message and byte budgets. Keep part of
 /// each budget available for control/error frames after PTY data saturates.
 const WRITER_QUEUE_CAPACITY: usize = 128;
+const FLOW_RESUME_MESSAGES: usize = WRITER_QUEUE_CAPACITY - 32;
 const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
 const WRITER_CONTROL_MESSAGE_RESERVE: usize = 8;
 const WRITER_CONTROL_BYTE_RESERVE: u64 = 64 * 1024;
@@ -755,7 +756,9 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
                             connection.finish();
                             break;
                         }
-                        if previous.saturating_sub(length) < FLOW_RESUME_BYTES {
+                        if previous.saturating_sub(length) < FLOW_RESUME_BYTES
+                            && connection.writer_tx.capacity() >= FLOW_RESUME_MESSAGES
+                        {
                             connection.publish_flow(false);
                         }
                     }

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -87,15 +87,16 @@ const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
 /// each budget available for control/error frames after PTY data saturates.
 const WRITER_QUEUE_CAPACITY: usize = 128;
 const FLOW_RESUME_MESSAGES: usize = WRITER_QUEUE_CAPACITY - 32;
-const WRITER_QUEUE_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
 const WRITER_CONTROL_MESSAGE_RESERVE: usize = 8;
 const WRITER_CONTROL_BYTE_RESERVE: u64 = 64 * 1024;
+const WRITER_DATA_BYTE_CAP: u64 = (MAX_TUNNEL_FRAME_BYTES as u64 + HEADER_BYTES as u64) * 2;
+const WRITER_QUEUE_BYTE_CAP: u64 = WRITER_DATA_BYTE_CAP + WRITER_CONTROL_BYTE_RESERVE;
 
 fn writer_queue_byte_limit(control: bool) -> u64 {
     if control {
         WRITER_QUEUE_BYTE_CAP
     } else {
-        WRITER_QUEUE_BYTE_CAP.saturating_sub(WRITER_CONTROL_BYTE_RESERVE)
+        WRITER_DATA_BYTE_CAP
     }
 }
 

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -75,6 +75,10 @@ const OPEN_TIMEOUT: Duration = Duration::from_secs(10);
 /// manager's own 1 MiB output cap stays the hard boundary above this.
 const FLOW_PAUSE_BYTES: u64 = 262_144;
 const FLOW_RESUME_BYTES: u64 = 32_768;
+/// Pause before the bounded message queue consumes the slots reserved for
+/// control frames. This covers bursts of many small PTY writes whose byte
+/// total is still below the byte water mark.
+const FLOW_PAUSE_MESSAGES: usize = WRITER_CONTROL_MESSAGE_RESERVE + 16;
 /// The flow worker is local and normally drains synchronously. Keep shutdown
 /// bounded if a future manager implementation blocks unexpectedly.
 const FLOW_DRAIN_TIMEOUT: Duration = Duration::from_secs(5);
@@ -430,6 +434,26 @@ impl Connection {
         });
     }
 
+    fn maybe_pause_source(&self) {
+        let _gate = self.queue_gate.lock().expect("writer queue lock");
+        if self.finished.load(Ordering::SeqCst) {
+            return;
+        }
+        let congested = self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES
+            || self.writer_tx.capacity() <= FLOW_PAUSE_MESSAGES;
+        if !congested || self.paused.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        self.flow_tx.send_if_modified(|current| {
+            if *current {
+                false
+            } else {
+                *current = true;
+                true
+            }
+        });
+    }
+
     /// Pause the source before closing when a stalled peer exhausts admission.
     fn reject_due_to_backpressure(&self) {
         let _gate = self.queue_gate.lock().expect("writer queue lock");
@@ -532,9 +556,7 @@ impl Connection {
                 // Socket-side congestion: pause the source through the
                 // manager's own flow verb; the writer resumes it below the
                 // low-water mark.
-                if self.pending_out.load(Ordering::SeqCst) > FLOW_PAUSE_BYTES {
-                    self.publish_flow(true);
-                }
+                self.maybe_pause_source();
             }
             Some("pty_exit") => {
                 let code = frame.get("code").and_then(Value::as_i64).unwrap_or(0);

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -584,15 +584,24 @@ async fn serve_connection(stream: TcpStream, manager: Arc<PtyManager>, parent: C
         let connection = Arc::clone(&connection);
         let context = context.clone();
         tokio::spawn(async move {
-            while flow_rx.changed().await.is_ok() {
-                let pause = *flow_rx.borrow_and_update();
-                let frame = json!({
-                    "version": PTY_PROTOCOL_VERSION,
-                    "type": "pty_flow",
-                    "ptyId": connection.pty_id,
-                    "pause": pause,
-                });
-                connection.manager.handle_frame(&frame, &context).await;
+            loop {
+                tokio::select! {
+                    biased;
+                    _ = connection.done.cancelled() => break,
+                    changed = flow_rx.changed() => {
+                        if changed.is_err() || connection.finished.load(Ordering::SeqCst) {
+                            break;
+                        }
+                        let pause = *flow_rx.borrow_and_update();
+                        let frame = json!({
+                            "version": PTY_PROTOCOL_VERSION,
+                            "type": "pty_flow",
+                            "ptyId": connection.pty_id,
+                            "pause": pause,
+                        });
+                        connection.manager.handle_frame(&frame, &context).await;
+                    }
+                }
             }
         })
     };

--- a/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
+++ b/cmux-tui/crates/chatmux-relay/src/tunnel_terminal.rs
@@ -53,8 +53,7 @@ use tokio::sync::{mpsc, watch};
 use tokio_util::sync::CancellationToken;
 
 use crate::pty::{
-    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, ResolvedCwd, random_hex, session_name_ok,
-    surface_ref_ok,
+    FrameContext, PTY_PROTOCOL_VERSION, PtyManager, random_hex, session_name_ok, surface_ref_ok,
 };
 
 /// Loopback port the gateway's spliced streams dial. The chatmux Worker
@@ -950,7 +949,7 @@ mod tests {
             _cmux_tui: &CmuxTui,
             _session: &str,
             _socket_dir: &Path,
-            _cwd: &ResolvedCwd,
+            _cwd: &crate::pty::ResolvedCwd,
             _env: &HashMap<String, String>,
         ) -> Result<EnsureDaemon, String> {
             Err("no daemon in tunnel tests".to_owned())


### PR DESCRIPTION
## Summary

- replace unbounded tunnel writer messages with bounded message and byte admission
- reserve shutdown capacity, preserve FIFO output, and report overflow before close
- coalesce PTY flow state in one watch channel and deliver a final pause during cancellation

## Verification

- `rustfmt --edition 2021`
- `git diff --check`
- Hosted cmux-tui tests are required. Local Cargo/Rust execution is intentionally skipped by repository policy.

This is a current-main successor for the closed https://github.com/manaflow-ai/cmux/pull/11174. The broader https://github.com/manaflow-ai/cmux/pull/11401 remains stale and includes unrelated lifecycle changes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the unbounded tunnel writer and flow queues in `chatmux-relay` with bounded admission so a stalled peer can't grow memory without limit.

- Applies message and byte budgets with separate reserves for control frames and shutdown, pausing the source on byte water marks or message queue pressure; overflow sends an error frame to the client before closing.
- Coalesces flow state in a watch channel and serializes it with shutdown, keeping the latest pause/resume, rechecking congestion before resuming, delivering a final pause on backpressure, and resuming a paused source on byte low-water or message queue drain, including during shutdown.

<sup>Written for commit a0bcd0dd0a4b0ed7b4256e91bf56aa3b697ae9fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal session stability during high-volume output.
  * Made flow control more reliable to preserve responsiveness under load.
  * Ensured terminal pause and resume behavior is applied consistently, including during shutdown.
  * Improved feedback when output capacity is temporarily exceeded.
  * Reduced the risk of incomplete shutdowns and lost terminal output during backpressure.
  * Improved delivery of final terminal updates before a session closes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->