### PR TITLE
cmux-tui: fence detached-owner identity environment

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/local_owner.rs
+++ b/cmux-tui/crates/cmux-tui/src/local_owner.rs
@@ -277,6 +277,17 @@ struct SpawnedOwner {
     state: std::sync::Arc<OwnerProcessState>,
 }
 
+const DETACHED_OWNER_IDENTITY_ENV: [&str; 5] =
+    ["CMUX_SURFACE_ID", "CMUX_WORKSPACE_ID", "CMUX_TAB_ID", "CMUX_PANEL_ID", "CMUX_PANE_ID"];
+
+/// Remove terminal identity claims from the detached owner while preserving
+/// configuration and socket variables inherited from the launching client.
+fn configure_detached_owner_environment(command: &mut Command) {
+    for key in DETACHED_OWNER_IDENTITY_ENV {
+        command.env_remove(key);
+    }
+}
+
 impl SpawnedOwner {
     fn terminate(self) {
         self.state.terminate.store(true, std::sync::atomic::Ordering::Release);
@@ -304,6 +315,7 @@ fn spawn_detached_owner(spec: &OwnerSpec) -> io::Result<SpawnedOwner> {
     if let Some(term) = &spec.term {
         command.arg("--term").arg(term);
     }
+    configure_detached_owner_environment(&mut command);
     // The owner reports through the bounded client log at its state root;
     // terminal teardown must never reach it, so it gets no stdio and (on
     // Unix) its own session, free of the controlling terminal.
@@ -316,7 +328,11 @@ fn spawn_detached_owner(spec: &OwnerSpec) -> io::Result<SpawnedOwner> {
         // process-group leader, so failure is a real launch error.
         unsafe {
             command.pre_exec(|| {
-                if libc::setsid() < 0 { Err(io::Error::last_os_error()) } else { Ok(()) }
+                if libc::setsid() < 0 {
+                    Err(io::Error::last_os_error())
+                } else {
+                    Ok(())
+                }
             });
         }
     }
@@ -396,13 +412,9 @@ mod tests {
             .get_envs()
             .map(|(key, value)| (key.to_owned(), value.map(OsString::from)))
             .collect::<std::collections::HashMap<_, _>>();
-        for key in [
-            "CMUX_SURFACE_ID",
-            "CMUX_WORKSPACE_ID",
-            "CMUX_TAB_ID",
-            "CMUX_PANEL_ID",
-            "CMUX_PANE_ID",
-        ] {
+        for key in
+            ["CMUX_SURFACE_ID", "CMUX_WORKSPACE_ID", "CMUX_TAB_ID", "CMUX_PANEL_ID", "CMUX_PANE_ID"]
+        {
             assert_eq!(values.get(OsString::from(key).as_os_str()), Some(&None));
         }
         assert_eq!(

--- a/cmux-tui/crates/cmux-tui/src/local_owner.rs
+++ b/cmux-tui/crates/cmux-tui/src/local_owner.rs
@@ -370,3 +370,48 @@ fn spawn_detached_owner(spec: &OwnerSpec) -> io::Result<SpawnedOwner> {
     }
     Ok(SpawnedOwner { state })
 }
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::OsString;
+    use std::process::Command;
+
+    use super::configure_detached_owner_environment;
+
+    #[test]
+    fn detached_owner_removes_terminal_identity_but_keeps_configuration() {
+        let mut command = Command::new("cmux-tui");
+        command
+            .env("CMUX_SURFACE_ID", "surface")
+            .env("CMUX_WORKSPACE_ID", "workspace")
+            .env("CMUX_TAB_ID", "tab")
+            .env("CMUX_PANEL_ID", "panel")
+            .env("CMUX_PANE_ID", "pane")
+            .env("CMUX_TUI_CONFIG", "/tmp/mux.json")
+            .env("CMUX_MUX_CONFIG", "/tmp/legacy-mux.json");
+
+        configure_detached_owner_environment(&mut command);
+
+        let values = command
+            .get_envs()
+            .map(|(key, value)| (key.to_owned(), value.map(OsString::from)))
+            .collect::<std::collections::HashMap<_, _>>();
+        for key in [
+            "CMUX_SURFACE_ID",
+            "CMUX_WORKSPACE_ID",
+            "CMUX_TAB_ID",
+            "CMUX_PANEL_ID",
+            "CMUX_PANE_ID",
+        ] {
+            assert_eq!(values.get(OsString::from(key).as_os_str()), Some(&None));
+        }
+        assert_eq!(
+            values.get(OsString::from("CMUX_TUI_CONFIG").as_os_str()),
+            Some(&Some(OsString::from("/tmp/mux.json")))
+        );
+        assert_eq!(
+            values.get(OsString::from("CMUX_MUX_CONFIG").as_os_str()),
+            Some(&Some(OsString::from("/tmp/legacy-mux.json")))
+        );
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/local_owner.rs
+++ b/cmux-tui/crates/cmux-tui/src/local_owner.rs
@@ -328,11 +328,7 @@ fn spawn_detached_owner(spec: &OwnerSpec) -> io::Result<SpawnedOwner> {
         // process-group leader, so failure is a real launch error.
         unsafe {
             command.pre_exec(|| {
-                if libc::setsid() < 0 {
-                    Err(io::Error::last_os_error())
-                } else {
-                    Ok(())
-                }
+                if libc::setsid() < 0 { Err(io::Error::last_os_error()) } else { Ok(()) }
             });
         }
     }


### PR DESCRIPTION
Summary
- Remove inherited workspace, surface, tab, panel, and pane identity variables before detached-owner spawn.
- Preserve CMUX_TUI_CONFIG and CMUX_MUX_CONFIG.

Verification
- Red test 18c689b2987.
- Blacksmith focused test 1 passed.
- cargo fmt and diff check pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11856"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791036720&installation_model_id=21920&pr_number=11856&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11856&signature=3f0ed7a22ff90378e3f4c2b1f0263e93524de241130bcce9598abbd1cd9d9b1f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fences detached-owner spawns from inherited terminal identity environment variables so detached owners no longer claim a surface, workspace, tab, panel, or pane they don't belong to. Preserves `CMUX_TUI_CONFIG` and `CMUX_MUX_CONFIG` from the launching client, with a regression test covering the fence.

<sup>Written for commit 35b77d48067a165812d5423de31a676492e60d9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

