### PR TITLE
cmux-remote: bound live invitation state

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -3932,6 +3932,29 @@ mod tests {
         assert_eq!(decoded.relay_access, vec![access]);
     }
 
+    #[tokio::test]
+    async fn invitation_count_is_bounded_without_evicting_live_entries() {
+        const EXPECTED_MAX_INVITATIONS: usize = 256;
+        let temp = tempfile::tempdir().unwrap();
+        let database = AuthDatabase::load_or_create(temp.path(), "daemon", false).unwrap();
+
+        for _ in 0..EXPECTED_MAX_INVITATIONS {
+            database.create_invitation(Duration::from_secs(60), Vec::new()).await.unwrap();
+        }
+
+        let error = database
+            .create_invitation(Duration::from_secs(60), Vec::new())
+            .await
+            .expect_err("live invitation cardinality limit was not enforced");
+        assert!(matches!(
+            error,
+            IdentityError::Invalid(message) if message.contains("maximum invitation count")
+        ));
+
+        let persisted = load_state(&temp.path().join("devices.json")).unwrap();
+        assert_eq!(persisted.invitations.len(), EXPECTED_MAX_INVITATIONS);
+    }
+
     #[test]
     fn invitation_rejects_duplicate_relay_bootstrap_routes() {
         let route = "relay+do://relay.example".to_string();

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -3943,8 +3943,11 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let database = AuthDatabase::load_or_create(temp.path(), "daemon", false).unwrap();
 
+        let mut invitation_ids = HashSet::with_capacity(MAX_LIVE_INVITATIONS);
         for _ in 0..MAX_LIVE_INVITATIONS {
-            database.create_invitation(Duration::from_secs(60), Vec::new()).await.unwrap();
+            let invitation =
+                database.create_invitation(Duration::from_secs(60), Vec::new()).await.unwrap();
+            invitation_ids.insert(invitation.id);
         }
 
         let error = database
@@ -3958,6 +3961,12 @@ mod tests {
 
         let persisted = load_state(&temp.path().join("devices.json")).unwrap();
         assert_eq!(persisted.invitations.len(), MAX_LIVE_INVITATIONS);
+        let persisted_ids = persisted
+            .invitations
+            .into_iter()
+            .map(|invitation| invitation.id)
+            .collect::<HashSet<_>>();
+        assert_eq!(persisted_ids, invitation_ids);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -24,6 +24,7 @@ const STATE_VERSION: u32 = 1;
 /// understand the original version-1 state.
 pub const AUTH_STATE_VERSION: u32 = 2;
 const MAX_INVITATION_TTL: Duration = Duration::from_secs(5 * 60);
+const MAX_LIVE_INVITATIONS: usize = 256;
 const APPROVAL_TIMEOUT: Duration = Duration::from_secs(5 * 60);
 const ENROLLMENT_RETRY_GRACE: Duration = Duration::from_secs(60);
 const MAX_INVITATION_RELAY_ROUTES: usize = 2;
@@ -1126,6 +1127,11 @@ impl AuthDatabase {
         let mut state = self.state.lock().await;
         state.ensure_open()?;
         state.prune_invitations(now);
+        if state.invitations.len() >= MAX_LIVE_INVITATIONS {
+            return Err(IdentityError::Invalid(format!(
+                "maximum invitation count ({MAX_LIVE_INVITATIONS}) reached"
+            )));
+        }
         state.invitations.insert(
             id,
             InvitationRecord {
@@ -3934,11 +3940,10 @@ mod tests {
 
     #[tokio::test]
     async fn invitation_count_is_bounded_without_evicting_live_entries() {
-        const EXPECTED_MAX_INVITATIONS: usize = 256;
         let temp = tempfile::tempdir().unwrap();
         let database = AuthDatabase::load_or_create(temp.path(), "daemon", false).unwrap();
 
-        for _ in 0..EXPECTED_MAX_INVITATIONS {
+        for _ in 0..MAX_LIVE_INVITATIONS {
             database.create_invitation(Duration::from_secs(60), Vec::new()).await.unwrap();
         }
 
@@ -3952,7 +3957,7 @@ mod tests {
         ));
 
         let persisted = load_state(&temp.path().join("devices.json")).unwrap();
-        assert_eq!(persisted.invitations.len(), EXPECTED_MAX_INVITATIONS);
+        assert_eq!(persisted.invitations.len(), MAX_LIVE_INVITATIONS);
     }
 
     #[test]


### PR DESCRIPTION
Summary
- Bound live invitations at 256 after pruning expired entries.
- Reject new live invitations without evicting valid records.

Verification
- Red test 590cb7b86d.
- Fix 216e280e535.
- Rustfmt and diff checks pass.
- Hosted run 33764855121 reached existing baseline Clippy errors before this test.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791036843&installation_model_id=21920&pr_number=11857&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11857&signature=fdaa33d3f15720310c5a5d89194dc32330605036f0f753797d994c2fc081af23"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caps live enrollment invitations at 256 so `cmux-remote` no longer accumulates unbounded invitation records.

- Rejects new invitations with an error once 256 live invitations remain after pruning expired entries.
- Keeps existing invitation IDs intact and does not evict valid records to make room for new ones.

<sup>Written for commit 307d738e325b547cf2b69d86d75246d762b9776f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Limited the number of simultaneously active invitations to 256.
  * New invitations are rejected once the limit is reached, while existing active invitations remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->