### PR TITLE
ci: run Cloudflare relay in full TUI verification

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -709,7 +709,7 @@ jobs:
       package_pypi: ${{ inputs.mode == 'full' }}
       include_windows: ${{ inputs.mode == 'full' }}
       target_set: ${{ inputs.mode == 'full' && 'all' || 'macos-arm64' }}
-      build_cloudflare_relay: false
+      build_cloudflare_relay: ${{ inputs.mode == 'full' }}
       verify_linux_arm64: ${{ inputs.mode == 'full' }}
       macos_runner: blacksmith-6vcpu-macos-15
       linux_runner: blacksmith-4vcpu-ubuntu-2404

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -9,6 +9,7 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[1]
 WORKFLOW = ROOT / ".github" / "workflows" / "cmux-tui.yml"
+PACKAGE_WORKFLOW = ROOT / ".github" / "workflows" / "cmux-tui-build-package.yml"
 
 FOCUSED_SENTINEL_STEPS = (
     "focused Linux journal process-fence test",
@@ -106,3 +107,35 @@ def test_tui_status_names_remain_stable() -> None:
         workflow["jobs"]["hosted-verification"]["name"]
         == "${{ inputs.mode == 'full' && 'hosted verification' || 'focused hosted verification' }}"
     )
+
+
+def _resolve_mode_boolean(value: object, mode: str) -> bool:
+    """Evaluate the small expression subset used by workflow mode inputs."""
+
+    if isinstance(value, bool):
+        return value
+    expression = str(value).strip()
+    if expression.startswith("${{") and expression.endswith("}}"):
+        expression = expression[3:-2].strip()
+    if expression == "true":
+        return True
+    if expression == "false":
+        return False
+    if expression == "inputs.mode == 'full'":
+        return mode == "full"
+    raise AssertionError(f"unsupported mode expression: {value!r}")
+
+
+def test_full_mode_runs_cloudflare_relay_and_focused_mode_skips_it() -> None:
+    caller = yaml.safe_load(WORKFLOW.read_text(encoding="utf-8"))
+    package = yaml.safe_load(PACKAGE_WORKFLOW.read_text(encoding="utf-8"))
+    caller_with = caller["jobs"]["build-artifacts"]["with"]
+    cloudflare_job = package["jobs"]["cloudflare-relay"]
+
+    # Model GitHub's mode expression and the called job's `if` condition. This
+    # catches a green full gate that silently disables relay verification.
+    assert cloudflare_job["if"] == "inputs.build_cloudflare_relay"
+    for mode, expected in (("focused", False), ("full", True)):
+        relay_input = _resolve_mode_boolean(caller_with["build_cloudflare_relay"], mode)
+        relay_runs = relay_input
+        assert relay_runs is expected

--- a/tests/test_tui_focused_filter_guard.py
+++ b/tests/test_tui_focused_filter_guard.py
@@ -109,7 +109,9 @@ def test_tui_status_names_remain_stable() -> None:
     )
 
 
-def _resolve_mode_boolean(value: object, mode: str) -> bool:
+def _resolve_mode_boolean(
+    value: object, mode: str, variables: dict[str, bool] | None = None
+) -> bool:
     """Evaluate the small expression subset used by workflow mode inputs."""
 
     if isinstance(value, bool):
@@ -123,6 +125,8 @@ def _resolve_mode_boolean(value: object, mode: str) -> bool:
         return False
     if expression == "inputs.mode == 'full'":
         return mode == "full"
+    if variables is not None and expression in variables:
+        return variables[expression]
     raise AssertionError(f"unsupported mode expression: {value!r}")
 
 
@@ -134,8 +138,11 @@ def test_full_mode_runs_cloudflare_relay_and_focused_mode_skips_it() -> None:
 
     # Model GitHub's mode expression and the called job's `if` condition. This
     # catches a green full gate that silently disables relay verification.
-    assert cloudflare_job["if"] == "inputs.build_cloudflare_relay"
     for mode, expected in (("focused", False), ("full", True)):
         relay_input = _resolve_mode_boolean(caller_with["build_cloudflare_relay"], mode)
-        relay_runs = relay_input
+        relay_runs = _resolve_mode_boolean(
+            cloudflare_job["if"],
+            mode,
+            {"inputs.build_cloudflare_relay": relay_input},
+        )
         assert relay_runs is expected


### PR DESCRIPTION
Summary
- Enable the reusable Cloudflare relay job for full cmux-tui verification.
- Keep focused mode unchanged and add dispatch-condition coverage.

Verification
- Red test 62dca571c7.
- Fix 2cdfc35f85.
- Focused guard tests: 6 passed.
- actionlint and diff checks pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791036860&installation_model_id=21920&pr_number=11859&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11859&signature=5febebdb0612f67428f2da7efc5f49bda92e96a0df28337c306ace3dadaff768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the full TUI verification gate so it actually runs the Cloudflare relay job. The relay build flag was hardcoded to `false`, so the full gate never verified the relay; it is now enabled only in full mode, and focused mode is unchanged. Adds a regression test that models GitHub's mode expression to confirm the relay runs in full mode and is skipped in focused mode.

<sup>Written for commit 42a11a77c46c7b15b87c603e146c1f8fe0a7e03a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Full workflow builds now include Cloudflare relay artifacts.
  - Focused workflow mode continues to skip Cloudflare relay artifact builds.

- **Tests**
  - Added coverage to verify Cloudflare relay build behavior in both workflow modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->