### PR TITLE
perf(cmux-tui): avoid front-shifting layout nodes

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/layout.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/layout.rs
@@ -1,7 +1,7 @@
 //! Pure layout math shared by frontends: a screen's split tree plus a
 //! rectangle produce pane rects that tile the area exactly.
 
-use std::collections::{BTreeMap, HashSet};
+use std::collections::{BTreeMap, HashSet, VecDeque};
 
 use crate::{Node, PaneId, SplitDir, SplitId, ViewportColumn};
 
@@ -523,7 +523,7 @@ pub(crate) fn zellij_default_pane_layout_with_ids(
             for column in panes[first_column_len..].chunks(4) {
                 columns.push(equal_split(column, SplitDir::Down, next_split_id));
             }
-            Some(equal_nodes(columns, SplitDir::Right, next_split_id))
+            Some(equal_nodes(columns.into(), SplitDir::Right, next_split_id))
         }
     }
 }
@@ -550,15 +550,15 @@ fn equal_split(
 }
 
 fn equal_nodes(
-    mut nodes: Vec<Node>,
+    mut nodes: VecDeque<Node>,
     dir: SplitDir,
     next_split_id: &mut impl FnMut() -> SplitId,
 ) -> Node {
     debug_assert!(!nodes.is_empty());
     if nodes.len() == 1 {
-        return nodes.pop().unwrap();
+        return nodes.pop_front().expect("equal_nodes has one node");
     }
-    let first = nodes.remove(0);
+    let first = nodes.pop_front().expect("equal_nodes has at least two nodes");
     let ratio = 1.0 / (nodes.len() + 1) as f32;
     Node::Split {
         id: next_split_id(),


### PR DESCRIPTION
Summary
- Replace recursive Vec::remove(0) with VecDeque::pop_front in layout equality.
- Preserve public APIs and pane order.

Verification
- Existing layout order tests remain in place.
- Rustfmt and diff checks pass.
- Blacksmith Rust tests are pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11860"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791036866&installation_model_id=21920&pr_number=11860&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11860&signature=1456d1ac0f4d5f1c9db45d10292e856e2d52bdd0331c3ae8af58a0169d0ea752"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up layout construction in `cmux-tui` by replacing front-shifting `Vec::remove(0)` calls with `VecDeque::pop_front()`, so building equal-split trees is now O(1) per node instead of O(n). Public APIs and pane ordering are unchanged.

<sup>Written for commit 49001c3c5df7765e1116f39ed86fb1f0b985cd34. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved the internal layout tree construction process without changing user-visible layout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->