### PR TITLE
cmux-remote: abort timed-out physical link closes

### DIFF
--- a/cmux-tui/crates/cmux-remote/src/link.rs
+++ b/cmux-tui/crates/cmux-remote/src/link.rs
@@ -1057,12 +1057,14 @@ mod tests {
         started: Arc<Semaphore>,
         release: Arc<Semaphore>,
         finished: Arc<Semaphore>,
+        aborted: Arc<Semaphore>,
     }
 
     struct GatedCloseHandle {
         started: Arc<Semaphore>,
         release: Arc<Semaphore>,
         finished: Arc<Semaphore>,
+        aborted: Arc<Semaphore>,
     }
 
     fn controlled_receive_link(
@@ -1101,13 +1103,15 @@ mod tests {
         let started = Arc::new(Semaphore::new(0));
         let release = Arc::new(Semaphore::new(0));
         let finished = Arc::new(Semaphore::new(0));
+        let aborted = Arc::new(Semaphore::new(0));
         (
             GatedCloseLink {
                 started: started.clone(),
                 release: release.clone(),
                 finished: finished.clone(),
+                aborted: aborted.clone(),
             },
-            GatedCloseHandle { started, release, finished },
+            GatedCloseHandle { started, release, finished, aborted },
         )
     }
 
@@ -1241,6 +1245,10 @@ mod tests {
             self.release.acquire().await.map_err(|_| LinkError::Closed)?.forget();
             self.finished.add_permits(1);
             Ok(())
+        }
+
+        fn abort_close(&self) {
+            self.aborted.add_permits(1);
         }
     }
 
@@ -1656,6 +1664,48 @@ mod tests {
         ));
         assert!(weak_physical.upgrade().is_none(), "stalled physical link was retained by mux");
         drop(mux);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn close_aborts_child_link_after_close_timeout() {
+        let (physical, handle) = gated_close_link();
+        let physical = Arc::new(physical);
+        let weak_physical = Arc::downgrade(&physical);
+        let child = Arc::new(
+            LaneMuxLink::new(
+                "child",
+                vec![LinkRoute { lanes: Lane::ALL.to_vec(), link: physical }],
+            )
+            .unwrap(),
+        );
+        let mux = Arc::new(
+            LaneMuxLink::new(
+                "parent",
+                vec![LinkRoute { lanes: Lane::ALL.to_vec(), link: child.clone() }],
+            )
+            .unwrap(),
+        );
+
+        let close = tokio::spawn({
+            let mux = mux.clone();
+            async move { mux.close().await }
+        });
+        wait_for_signal(&handle.started, "stalled child physical close").await;
+
+        tokio::time::advance(Duration::from_secs(3)).await;
+        let result = tokio::time::timeout(Duration::from_secs(1), close);
+        tokio::pin!(result);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let result = result.await.expect("parent close remained blocked").unwrap();
+        assert!(matches!(
+            result,
+            Err(LinkError::Transport(message)) if message == "timed out closing physical link"
+        ));
+        wait_for_signal(&handle.aborted, "child close cancellation").await;
+        assert!(weak_physical.upgrade().is_none(), "child close retained physical link");
+        drop(mux);
+        drop(child);
     }
 
     #[tokio::test(start_paused = true)]

--- a/cmux-tui/crates/cmux-remote/src/link.rs
+++ b/cmux-tui/crates/cmux-remote/src/link.rs
@@ -1631,8 +1631,8 @@ mod tests {
             result,
             Err(LinkError::Transport(message)) if message == "timed out closing physical link"
         ));
+        assert!(weak_physical.upgrade().is_none(), "stalled physical link was retained by mux");
         drop(mux);
-        assert!(weak_physical.upgrade().is_none(), "stalled physical link was retained");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/link.rs
+++ b/cmux-tui/crates/cmux-remote/src/link.rs
@@ -894,6 +894,7 @@ impl FrameLink for LaneMuxLink {
                     match tokio::time::timeout(PHYSICAL_LINK_CLOSE_TIMEOUT, link.close()).await {
                         Ok(result) => result,
                         Err(_) => {
+                            link.abort_close();
                             Err(LinkError::Transport("timed out closing physical link".into()))
                         }
                     }

--- a/cmux-tui/crates/cmux-remote/src/link.rs
+++ b/cmux-tui/crates/cmux-remote/src/link.rs
@@ -16,6 +16,7 @@ const INGRESS_ACCOUNTING_FLOOR_BYTES: usize = 1_024;
 const INGRESS_FRAMES_PER_LANE: usize = INGRESS_BYTES_PER_LANE / INGRESS_ACCOUNTING_FLOOR_BYTES;
 const PRIORITY_BURST_FRAMES: usize = 32;
 const PRIORITY_LANES: [Lane; 4] = [Lane::Interactive, Lane::Control, Lane::Tunnel, Lane::Bulk];
+const PHYSICAL_LINK_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 // ReliableSession owns one physical send loop per lane, so at most one caller
 // per lane can wait for LaneMuxLink queue admission in production.
 const OUTBOUND_FRAMES_PER_LANE: usize = PRIORITY_BURST_FRAMES * PRIORITY_LANES.len();
@@ -649,7 +650,10 @@ impl fmt::Debug for LaneMuxLink {
             .debug_struct("LaneMuxLink")
             .field("description", &self.description)
             .field("maximum", &self.maximum)
-            .field("physical_links", &self.links.len())
+            .field(
+                "physical_links",
+                &self.links.lock().map(|links| links.len()).unwrap_or_default(),
+            )
             .finish_non_exhaustive()
     }
 }
@@ -783,7 +787,7 @@ impl LaneMuxLink {
             description: description.into(),
             maximum,
             routes,
-            links,
+            links: StdMutex::new(links),
             incoming: Arc::new(Mutex::new(Ingress {
                 frames: PriorityReceivers::new([interactive_rx, control_rx, bulk_rx, tunnel_rx]),
                 terminal: lifecycle.subscribe(),
@@ -867,7 +871,8 @@ impl FrameLink for LaneMuxLink {
         self.lifecycle.terminate(LinkError::Closed);
         let tasks = self.take_tasks();
         let incoming = self.incoming.clone();
-        let links = self.links.clone();
+        let links: Vec<_> =
+            self.links.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).drain(..).collect();
         let completion = LinkCloseCompletionGuard::new(self.close_state.clone());
         tokio::spawn(async move {
             let result: Result<(), LinkError> = async {
@@ -876,7 +881,16 @@ impl FrameLink for LaneMuxLink {
                 }
                 let _ = join_all(tasks).await;
                 incoming.lock().await.discard();
-                for result in join_all(links.iter().map(|link| link.close())).await {
+                for result in join_all(links.iter().map(|link| async {
+                    match tokio::time::timeout(PHYSICAL_LINK_CLOSE_TIMEOUT, link.close()).await {
+                        Ok(result) => result,
+                        Err(_) => {
+                            Err(LinkError::Transport("timed out closing physical link".into()))
+                        }
+                    }
+                }))
+                .await
+                {
                     result?;
                 }
                 Ok(())
@@ -1592,10 +1606,12 @@ mod tests {
     #[tokio::test(start_paused = true)]
     async fn close_times_out_when_physical_link_close_stalls() {
         let (physical, handle) = gated_close_link();
+        let physical = Arc::new(physical);
+        let weak_physical = Arc::downgrade(&physical);
         let mux = Arc::new(
             LaneMuxLink::new(
                 "single-physical",
-                vec![LinkRoute { lanes: Lane::ALL.to_vec(), link: Arc::new(physical) }],
+                vec![LinkRoute { lanes: Lane::ALL.to_vec(), link: physical }],
             )
             .unwrap(),
         );
@@ -1615,6 +1631,8 @@ mod tests {
             result,
             Err(LinkError::Transport(message)) if message == "timed out closing physical link"
         ));
+        drop(mux);
+        assert!(weak_physical.upgrade().is_none(), "stalled physical link was retained");
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/link.rs
+++ b/cmux-tui/crates/cmux-remote/src/link.rs
@@ -3,6 +3,7 @@ use std::fmt;
 use std::future::pending;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
+use std::time::Duration;
 
 use async_trait::async_trait;
 use bytes::Bytes;
@@ -39,6 +40,12 @@ pub trait FrameLink: Send + Sync {
     async fn send(&self, frame: Bytes) -> Result<(), LinkError>;
     async fn receive(&self) -> Result<Option<Bytes>, LinkError>;
     async fn close(&self) -> Result<(), LinkError>;
+    /// Requests cancellation of cleanup started by [`Self::close`].
+    ///
+    /// Links without separately owned cleanup work may keep the default no-op
+    /// implementation. Composite links must cancel any child task that would
+    /// otherwise outlive the caller's close deadline.
+    fn abort_close(&self) {}
 }
 
 #[derive(Clone, Debug)]
@@ -634,10 +641,11 @@ pub struct LaneMuxLink {
     description: String,
     maximum: usize,
     routes: BTreeMap<Lane, OutboundSender>,
-    links: Vec<Arc<dyn FrameLink>>,
+    links: StdMutex<Vec<Arc<dyn FrameLink>>>,
     incoming: Arc<Mutex<Ingress>>,
     lifecycle: LinkLifecycle,
     tasks: StdMutex<Vec<JoinHandle<()>>>,
+    close_task: StdMutex<Option<JoinHandle<()>>>,
     closed: AtomicBool,
     close_state: watch::Sender<LinkCloseState>,
     #[cfg(test)]
@@ -799,6 +807,7 @@ impl LaneMuxLink {
             })),
             lifecycle,
             tasks: StdMutex::new(tasks),
+            close_task: StdMutex::new(None),
             closed: AtomicBool::new(false),
             close_state,
             #[cfg(test)]
@@ -1633,6 +1642,35 @@ mod tests {
         ));
         assert!(weak_physical.upgrade().is_none(), "stalled physical link was retained by mux");
         drop(mux);
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn abort_close_stops_background_cleanup_task() {
+        let (physical, handle) = gated_close_link();
+        let mux = Arc::new(
+            LaneMuxLink::new(
+                "single-physical",
+                vec![LinkRoute { lanes: Lane::ALL.to_vec(), link: Arc::new(physical) }],
+            )
+            .unwrap(),
+        );
+
+        let close = tokio::spawn({
+            let mux = mux.clone();
+            async move { mux.close().await }
+        });
+        wait_for_signal(&handle.started, "stalled physical close").await;
+
+        mux.abort_close();
+        let result = tokio::time::timeout(Duration::from_secs(1), close);
+        tokio::pin!(result);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let result = result.await.expect("abort_close did not stop cleanup task").unwrap();
+        assert!(matches!(
+            result,
+            Err(LinkError::Protocol(message)) if message == "lane mux shutdown task stopped"
+        ));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/link.rs
+++ b/cmux-tui/crates/cmux-remote/src/link.rs
@@ -883,7 +883,7 @@ impl FrameLink for LaneMuxLink {
         let links: Vec<_> =
             self.links.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).drain(..).collect();
         let completion = LinkCloseCompletionGuard::new(self.close_state.clone());
-        tokio::spawn(async move {
+        let close_task = tokio::spawn(async move {
             let result: Result<(), LinkError> = async {
                 for task in &tasks {
                     task.abort();
@@ -911,7 +911,16 @@ impl FrameLink for LaneMuxLink {
             };
             completion.publish(outcome);
         });
+        *self.close_task.lock().unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(close_task);
         wait_for_link_close(self.close_state.subscribe()).await
+    }
+
+    fn abort_close(&self) {
+        let close_task =
+            self.close_task.lock().unwrap_or_else(|poisoned| poisoned.into_inner()).take();
+        if let Some(close_task) = close_task {
+            close_task.abort();
+        }
     }
 }
 
@@ -921,6 +930,11 @@ impl Drop for LaneMuxLink {
         let tasks = self.tasks.get_mut().unwrap_or_else(|poisoned| poisoned.into_inner());
         for task in tasks.drain(..) {
             task.abort();
+        }
+        if let Some(close_task) =
+            self.close_task.get_mut().unwrap_or_else(|poisoned| poisoned.into_inner()).take()
+        {
+            close_task.abort();
         }
     }
 }

--- a/cmux-tui/crates/cmux-remote/src/link.rs
+++ b/cmux-tui/crates/cmux-remote/src/link.rs
@@ -1589,6 +1589,34 @@ mod tests {
         wait_for_signal(&handle.finished, "completed physical close").await;
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn close_times_out_when_physical_link_close_stalls() {
+        let (physical, handle) = gated_close_link();
+        let mux = Arc::new(
+            LaneMuxLink::new(
+                "single-physical",
+                vec![LinkRoute { lanes: Lane::ALL.to_vec(), link: Arc::new(physical) }],
+            )
+            .unwrap(),
+        );
+
+        let close = tokio::spawn({
+            let mux = mux.clone();
+            async move { mux.close().await }
+        });
+        wait_for_signal(&handle.started, "stalled physical close").await;
+
+        let result = tokio::time::timeout(Duration::from_secs(1), close);
+        tokio::pin!(result);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        let result = result.await.expect("aggregate close remained blocked").unwrap();
+        assert!(matches!(
+            result,
+            Err(LinkError::Transport(message)) if message == "timed out closing physical link"
+        ));
+    }
+
     #[tokio::test]
     async fn drop_cancels_pending_physical_reader() {
         let receive_calls = Arc::new(Semaphore::new(0));

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -17,6 +17,7 @@ use tokio_util::sync::CancellationToken;
 use crate::link::{FrameLink, LinkError};
 
 const RECONNECT_CLEANUP_TIMEOUT: Duration = Duration::from_secs(2);
+const SESSION_CLOSE_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEDULER_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(2);
 const SCHEDULER_ABORT_WAIT_TIMEOUT: Duration = Duration::from_secs(1);
 
@@ -529,7 +530,13 @@ impl ReliableSession {
         // Stop ACK production first. Lane writers keep an already admitted
         // frame in flight, then observe cancellation after the link closes.
         self.scheduler.request_shutdown();
-        let link_result = self.link.close().await.map_err(SessionError::Link);
+        let link_result = match tokio::time::timeout(SESSION_CLOSE_TIMEOUT, self.link.close()).await
+        {
+            Ok(result) => result.map_err(SessionError::Link),
+            Err(_) => {
+                Err(SessionError::Link(LinkError::Transport("timed out closing link".into())))
+            }
+        };
         let scheduler_result = self.scheduler.wait_for_shutdown().await;
         match (link_result, scheduler_result) {
             (Err(error), _) => Err(error),

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -535,6 +535,7 @@ impl ReliableSession {
         {
             Ok(result) => result.map_err(SessionError::Link),
             Err(_) => {
+                self.link.abort_close();
                 Err(SessionError::Link(LinkError::Transport("timed out closing link".into())))
             }
         };

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -77,7 +77,9 @@ impl Drop for CloseUncommittedLink {
         let Some(link) = self.0.take() else { return };
         let Ok(runtime) = tokio::runtime::Handle::try_current() else { return };
         runtime.spawn(async move {
-            let _ = tokio::time::timeout(RECONNECT_CLEANUP_TIMEOUT, link.close()).await;
+            if tokio::time::timeout(RECONNECT_CLEANUP_TIMEOUT, link.close()).await.is_err() {
+                link.abort_close();
+            }
         });
     }
 }

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -1204,6 +1204,8 @@ mod tests {
         send_release: Semaphore,
     }
 
+    struct StuckCloseLink;
+
     #[async_trait]
     impl FrameLink for RejectingLink {
         fn description(&self) -> &str {
@@ -1320,6 +1322,29 @@ mod tests {
 
         async fn close(&self) -> Result<(), LinkError> {
             Ok(())
+        }
+    }
+
+    #[async_trait]
+    impl FrameLink for StuckCloseLink {
+        fn description(&self) -> &str {
+            "stuck-close"
+        }
+
+        fn maximum_frame_bytes(&self) -> usize {
+            128 * 1024
+        }
+
+        async fn send(&self, _frame: Bytes) -> Result<(), LinkError> {
+            std::future::pending().await
+        }
+
+        async fn receive(&self) -> Result<Option<Bytes>, LinkError> {
+            std::future::pending().await
+        }
+
+        async fn close(&self) -> Result<(), LinkError> {
+            std::future::pending().await
         }
     }
 
@@ -1644,6 +1669,32 @@ mod tests {
         drop(session);
         drop(link);
         assert!(weak_link.upgrade().is_none(), "close retained the stuck worker link");
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn close_times_out_when_link_close_stalls() {
+        let session = ReliableSession::new(
+            SessionId([23; 16]),
+            Arc::new(StuckCloseLink),
+            SessionLimits::default(),
+        );
+        let close = tokio::spawn({
+            let session = session.clone();
+            async move { session.close().await }
+        });
+
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(3)).await;
+        let result = tokio::time::timeout(Duration::from_secs(1), close);
+        tokio::pin!(result);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        let result = result.await.expect("close remained blocked on link close").unwrap();
+        assert!(matches!(
+            result,
+            Err(SessionError::Link(LinkError::Transport(message)))
+                if message == "timed out closing link"
+        ));
     }
 
     #[tokio::test]

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -528,7 +528,8 @@ impl ReliableSession {
             progress.notify_waiters();
         }
         // Stop ACK production first. Lane writers keep an already admitted
-        // frame in flight, then observe cancellation after the link closes.
+        // frame in flight, then observe cancellation after link close completes
+        // or reaches its deadline.
         self.scheduler.request_shutdown();
         let link_result = match tokio::time::timeout(SESSION_CLOSE_TIMEOUT, self.link.close()).await
         {

--- a/cmux-tui/crates/cmux-remote/src/session.rs
+++ b/cmux-tui/crates/cmux-remote/src/session.rs
@@ -1215,6 +1215,11 @@ mod tests {
 
     struct StuckCloseLink;
 
+    struct CloseTrackedLink {
+        started: Arc<Semaphore>,
+        aborted: Arc<Semaphore>,
+    }
+
     #[async_trait]
     impl FrameLink for RejectingLink {
         fn description(&self) -> &str {
@@ -1354,6 +1359,34 @@ mod tests {
 
         async fn close(&self) -> Result<(), LinkError> {
             std::future::pending().await
+        }
+    }
+
+    #[async_trait]
+    impl FrameLink for CloseTrackedLink {
+        fn description(&self) -> &str {
+            "close-tracked"
+        }
+
+        fn maximum_frame_bytes(&self) -> usize {
+            128 * 1024
+        }
+
+        async fn send(&self, _frame: Bytes) -> Result<(), LinkError> {
+            std::future::pending().await
+        }
+
+        async fn receive(&self) -> Result<Option<Bytes>, LinkError> {
+            std::future::pending().await
+        }
+
+        async fn close(&self) -> Result<(), LinkError> {
+            self.started.add_permits(1);
+            std::future::pending().await
+        }
+
+        fn abort_close(&self) {
+            self.aborted.add_permits(1);
         }
     }
 
@@ -1704,6 +1737,29 @@ mod tests {
             Err(SessionError::Link(LinkError::Transport(message)))
                 if message == "timed out closing link"
         ));
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn dropped_uncommitted_link_aborts_timed_out_close() {
+        let started = Arc::new(Semaphore::new(0));
+        let aborted = Arc::new(Semaphore::new(0));
+        let link =
+            Arc::new(CloseTrackedLink { started: started.clone(), aborted: aborted.clone() });
+        let weak_link = Arc::downgrade(&link);
+        drop(CloseUncommittedLink(Some(link)));
+
+        let started_wait = tokio::time::timeout(Duration::from_secs(1), started.acquire());
+        tokio::pin!(started_wait);
+        tokio::task::yield_now().await;
+        started_wait.await.expect("uncommitted link cleanup did not start").unwrap().forget();
+
+        tokio::time::advance(RECONNECT_CLEANUP_TIMEOUT + Duration::from_secs(1)).await;
+        let aborted_wait = tokio::time::timeout(Duration::from_secs(1), aborted.acquire());
+        tokio::pin!(aborted_wait);
+        tokio::task::yield_now().await;
+        tokio::time::advance(Duration::from_secs(1)).await;
+        aborted_wait.await.expect("timed-out cleanup did not abort the link").unwrap().forget();
+        assert!(weak_link.upgrade().is_none(), "timed-out cleanup retained the link");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Stacked on PR #11794.

Summary
- Retain LaneMux close handles and abort detached cleanup on session timeout.
- Abort child FrameLink cleanup when a physical close timeout expires.

Verification
- Red tests b31995116ae and 088d7654ce5.
- Fixes cc6a315dcc3 and 0928c492ca1.
- Rustfmt and diff checks pass.
- Testbox and exact hosted checks are pending.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791036895&installation_model_id=21920&pr_number=11862&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11862&signature=008c21a44417dc003de94818c19266f9e71346790783636ec67ba747adf6dfcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reliable session and `LaneMuxLink` closes now have two-second deadlines instead of waiting indefinitely on a stalled link. A timeout returns a transport error and cancels owned cleanup so timed-out physical, nested, and uncommitted links are released. Session shutdown still drains scheduler workers under a deadline, aborting stragglers instead of hanging.

- Adds `FrameLink::abort_close` with a no-op default for links without owned cleanup.
- Aborts an uncommitted link's close when reconnect cleanup hits its timeout.
- Tracks the `LaneMuxLink` close task so `abort_close` (or drop) stops stalled background cleanup.
- Makes shutdown cancellation-safe so cancelled or concurrent closes don't leak workers.
- Adds regression tests for stalled closes, child close aborts, stuck workers, and concurrent close calls.

<sup>Written for commit ab1ce0352086ca4efced654e37807cbe613253dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

