### PR TITLE
Cloud tree: index open resources and classify detached lifecycle

### DIFF
--- a/Sources/Cloud/CloudTreeNode.swift
+++ b/Sources/Cloud/CloudTreeNode.swift
@@ -219,7 +219,7 @@ struct CloudTreeTerminalRow: Equatable {
     /// A live terminal no daemon tab shows: out of every workspace's layout, so it
     /// is a Terminals-group row only, drawn greyed with a "detached" mark. Its verbs
     /// are a terminal's — a click re-attaches it in a pane, Kill Terminal ends it.
-    var isDetached: Bool = false
+    var isDetached: Bool { resource.isDetachedTerminal }
 }
 
 /// A browser row (this Mac's browser panes, or a cloud machine's browsers).
@@ -270,9 +270,15 @@ enum CloudTreeNodeBuilder {
         localWorkspaces: [CloudTreeLocalWorkspace],
         includeLocalMachine: Bool = CloudTreeNodeBuilder.includesLocalMachine
     ) -> [CloudTreeNode] {
+        let openResourceIDs = Set(snapshot.projections.map(\.resource))
         var nodes: [CloudTreeNode] = []
         if includeLocalMachine, let local = snapshot.machines.first(where: { $0.id.isLocal }) {
-            nodes.append(localMachineNode(info: local, snapshot: snapshot, localWorkspaces: localWorkspaces))
+            nodes.append(localMachineNode(
+                info: local,
+                snapshot: snapshot,
+                localWorkspaces: localWorkspaces,
+                openResourceIDs: openResourceIDs
+            ))
         }
         // Creates the person just started go first: they are what the person is
         // waiting on, and a failed one must not hide below a long fleet. A
@@ -290,7 +296,12 @@ enum CloudTreeNodeBuilder {
             nodes.append(CloudTreeNode(
                 id: nodeID(machine: .cloud(machine.id)),
                 kind: .machine(machine, info),
-                children: cloudChildren(machine: .cloud(machine.id), info: info, snapshot: snapshot)
+                children: cloudChildren(
+                    machine: .cloud(machine.id),
+                    info: info,
+                    snapshot: snapshot,
+                    openResourceIDs: openResourceIDs
+                )
             ))
         }
         // Machines the catalog knows but the fleet list has not returned yet (or
@@ -309,7 +320,12 @@ enum CloudTreeNodeBuilder {
             nodes.append(CloudTreeNode(
                 id: nodeID(machine: info.id),
                 kind: .machine(placeholderSnapshot, info),
-                children: cloudChildren(machine: info.id, info: info, snapshot: snapshot)
+                children: cloudChildren(
+                    machine: info.id,
+                    info: info,
+                    snapshot: snapshot,
+                    openResourceIDs: openResourceIDs
+                )
             ))
         }
         return nodes
@@ -363,7 +379,8 @@ enum CloudTreeNodeBuilder {
     private static func localMachineNode(
         info: SurfaceMachineInfo,
         snapshot: SurfaceCatalogSnapshot,
-        localWorkspaces: [CloudTreeLocalWorkspace]
+        localWorkspaces: [CloudTreeLocalWorkspace],
+        openResourceIDs: Set<SurfaceResourceID>
     ) -> CloudTreeNode {
         let resources = snapshot.resources(on: .local)
         let terminals = resources.filter { $0.kind == .terminal }
@@ -401,11 +418,15 @@ enum CloudTreeNodeBuilder {
                     terminalCount: projected.count,
                     isSelected: workspace.isSelected
                 )),
-                children: projected.map { terminalNode($0, snapshot: snapshot) },
+                children: projected.map {
+                    terminalNode($0, snapshot: snapshot, openResourceIDs: openResourceIDs)
+                },
                 dragGroup: SurfaceResourceGroup(title: title, resources: (projected + projectedBrowsers).map(\.id))
             )
         }
-        children.append(contentsOf: unplaced.map { terminalNode($0, snapshot: snapshot) })
+        children.append(contentsOf: unplaced.map {
+            terminalNode($0, snapshot: snapshot, openResourceIDs: openResourceIDs)
+        })
         if children.isEmpty {
             children.append(placeholder(.local, text: String(localized: "cloudTree.placeholder.noLocalTerminals", defaultValue: "No terminals open"), style: .dimmed))
         }
@@ -418,7 +439,7 @@ enum CloudTreeNodeBuilder {
                         id: nodeID(resource: browser.id),
                         kind: .browser(CloudTreeBrowserRow(
                             resource: browser,
-                            isOpen: snapshot.isOpen(browser.id),
+                            isOpen: openResourceIDs.contains(browser.id),
                             workspaceTitle: workspaceOf(browser.id).flatMap { titles[$0] }
                         ))
                     )
@@ -446,7 +467,12 @@ enum CloudTreeNodeBuilder {
         return CmuxInternalHostnames.directPortURL(privateAddress: address, port: port)
     }
 
-    private static func cloudChildren(machine: SurfaceMachineID, info: SurfaceMachineInfo?, snapshot: SurfaceCatalogSnapshot) -> [CloudTreeNode] {
+    private static func cloudChildren(
+        machine: SurfaceMachineID,
+        info: SurfaceMachineInfo?,
+        snapshot: SurfaceCatalogSnapshot,
+        openResourceIDs: Set<SurfaceResourceID>
+    ) -> [CloudTreeNode] {
         // The catalog has not registered this machine yet: nothing to expand.
         guard let info else { return [] }
         var children: [CloudTreeNode] = []
@@ -468,7 +494,14 @@ enum CloudTreeNodeBuilder {
             // always its own row (never folded into a lone workspace), so its
             // "+" — the New Workspace verb — is one click away on a fresh
             // machine with a single workspace as much as on a busy one.
-            children.append(workspacesGroupNode(machine: machine, info: info, resources: resources, displays: displays, snapshot: snapshot))
+            children.append(workspacesGroupNode(
+                machine: machine,
+                info: info,
+                resources: resources,
+                displays: displays,
+                snapshot: snapshot,
+                openResourceIDs: openResourceIDs
+            ))
         }
         // Ports: one row per listening port, titled as the URL a person would
         // paste (`http://<private-ip>:<port>`) when the machine has a private
@@ -509,7 +542,12 @@ enum CloudTreeNodeBuilder {
         // is there on an empty machine too.
         switch info.linkState {
         case .connected, .notApplicable:
-            children.append(terminalsGroupNode(machine: machine, terminals: terminals, snapshot: snapshot))
+            children.append(terminalsGroupNode(
+                machine: machine,
+                terminals: terminals,
+                snapshot: snapshot,
+                openResourceIDs: openResourceIDs
+            ))
         case .asleep, .connecting, .error, .unavailable:
             break
         }
@@ -526,7 +564,8 @@ enum CloudTreeNodeBuilder {
         info: SurfaceMachineInfo,
         resources: [SurfaceResource],
         displays: [SurfaceResource],
-        snapshot: SurfaceCatalogSnapshot
+        snapshot: SurfaceCatalogSnapshot,
+        openResourceIDs: Set<SurfaceResourceID>
     ) -> CloudTreeNode {
         // One pass over the catalog for every workspace's members and one over the
         // projections for the open marks; each row is then dictionary reads.
@@ -551,11 +590,16 @@ enum CloudTreeNodeBuilder {
                 id: nodeID(workspace: workspace.id, machine: machine),
                 kind: .workspace(machine: machine, workspace, terminalCount: members.terminals.count, openIn: openInLocal),
                 children: members.terminals.map {
-                    terminalNode($0, snapshot: snapshot, id: nodeID(resource: $0.id, inRemoteWorkspace: workspace.id))
+                    terminalNode(
+                        $0,
+                        snapshot: snapshot,
+                        id: nodeID(resource: $0.id, inRemoteWorkspace: workspace.id),
+                        openResourceIDs: openResourceIDs
+                    )
                 } + members.browsers.map {
                     CloudTreeNode(
                         id: nodeID(resource: $0.id, inRemoteWorkspace: workspace.id),
-                        kind: .browser(CloudTreeBrowserRow(resource: $0, isOpen: snapshot.isOpen($0.id), workspaceTitle: nil))
+                        kind: .browser(CloudTreeBrowserRow(resource: $0, isOpen: openResourceIDs.contains($0.id), workspaceTitle: nil))
                     )
                 } + shownDisplays.map {
                     CloudTreeNode(id: nodeID(resource: $0.id, inRemoteWorkspace: workspace.id), kind: .display($0, openIn: openInLocal))
@@ -583,9 +627,19 @@ enum CloudTreeNodeBuilder {
     /// one row per identity whatever workspaces show it (badge = daemon tabs), a
     /// zero-view one greyed as detached. Always present under a connected machine
     /// — its "+" is New Terminal — with a placeholder child when there is none yet.
-    private static func terminalsGroupNode(machine: SurfaceMachineID, terminals: [SurfaceResource], snapshot: SurfaceCatalogSnapshot) -> CloudTreeNode {
+    private static func terminalsGroupNode(
+        machine: SurfaceMachineID,
+        terminals: [SurfaceResource],
+        snapshot: SurfaceCatalogSnapshot,
+        openResourceIDs: Set<SurfaceResourceID>
+    ) -> CloudTreeNode {
         var rows = terminals.map {
-            terminalNode($0, snapshot: snapshot, viewBadge: $0.remoteViews?.count, isDetached: $0.isDetachedTerminal)
+            terminalNode(
+                $0,
+                snapshot: snapshot,
+                viewBadge: $0.remoteViews?.count,
+                openResourceIDs: openResourceIDs
+            )
         }
         if rows.isEmpty {
             rows.append(CloudTreeNode(
@@ -608,11 +662,11 @@ enum CloudTreeNodeBuilder {
         snapshot: SurfaceCatalogSnapshot,
         id: String? = nil,
         viewBadge: Int? = nil,
-        isDetached: Bool = false
+        openResourceIDs: Set<SurfaceResourceID>
     ) -> CloudTreeNode {
         CloudTreeNode(
             id: id ?? nodeID(resource: resource.id),
-            kind: .terminal(CloudTreeTerminalRow(resource: resource, isOpen: snapshot.isOpen(resource.id), viewBadge: viewBadge, isDetached: isDetached))
+            kind: .terminal(CloudTreeTerminalRow(resource: resource, isOpen: openResourceIDs.contains(resource.id), viewBadge: viewBadge))
         )
     }
 

--- a/Sources/Surfaces/SurfaceCatalogModel.swift
+++ b/Sources/Surfaces/SurfaceCatalogModel.swift
@@ -143,7 +143,9 @@ struct SurfaceResource: Identifiable, Hashable, Codable, Sendable {
     /// and is out of every workspace's layout, so it lists only in the machine's
     /// Terminals group, greyed as "detached"; a click re-attaches it in a pane and
     /// only its kill verb ends it.
-    var isDetachedTerminal: Bool { kind == .terminal && remoteViews?.isEmpty == true }
+    var isDetachedTerminal: Bool {
+        kind == .terminal && lifecycle == .running && remoteViews?.isEmpty == true
+    }
 
     /// The daemon workspaces holding at least one view, first-view order, deduped.
     /// Falls back to `remoteWorkspace` for providers that report a single workspace.

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -75,6 +75,55 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         ))
     }
 
+    @Test("An exited zero-view terminal is not marked detached")
+    func exitedZeroViewTerminalIsNotDetached() throws {
+        let main = workspace("ws_main", "main", index: 0, focused: true)
+        var exited = terminal("term_exited", title: "finished", in: [])
+        exited.lifecycle = .exited
+        let snapshot = SurfaceCatalogSnapshot(
+            machines: [info(workspaces: [main])],
+            resources: [exited],
+            projections: []
+        )
+
+        let tree = rows(snapshot)
+        guard case .terminal(let row) = try #require(tree.first(where: {
+            $0.id == "resource:brave-otter/terminal/term_exited"
+        })?.kind) else {
+            Issue.record("expected the exited terminal in the Terminals group")
+            return
+        }
+        #expect(!row.isDetached, "an exited resource is not a live detached terminal")
+    }
+
+    @Test("An active projection marks terminal rows as open")
+    func activeProjectionMarksTerminalRowsOpen() throws {
+        let main = workspace("ws_main", "main", index: 0, focused: true)
+        let viewed = terminal("term_viewed", in: [main])
+        let snapshot = SurfaceCatalogSnapshot(
+            machines: [info(workspaces: [main])],
+            resources: [viewed],
+            projections: [SurfaceProjection(
+                resource: viewed.id,
+                workspaceID: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+                panelID: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!
+            )]
+        )
+
+        let tree = rows(snapshot)
+        guard case .terminal(let poolRow) = try #require(tree.first(where: {
+            $0.id == "resource:brave-otter/terminal/term_viewed"
+        })?.kind),
+              case .terminal(let layoutRow) = try #require(tree.first(where: {
+                  $0.id == "machine:brave-otter/ws/ws_main/resource:brave-otter/terminal/term_viewed"
+              })?.kind) else {
+            Issue.record("expected both terminal rows")
+            return
+        }
+        #expect(poolRow.isOpen)
+        #expect(layoutRow.isOpen)
+    }
+
     @Test("A machine with a single workspace keeps its Workspaces group row and the group's +")
     func singleWorkspaceKeepsItsGroupRow() throws {
         let main = workspace("ws_main", "main", index: 0, focused: true)


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11805.

This stacked fix addresses two review findings without changing CLI or docs semantics:

- Red commit `75ea7e48aee` adds behavior coverage for active projection open rows and exited zero-view terminals.
- Fix commit `8ca8aac10ff` builds one `Set<SurfaceResourceID>` per tree rebuild, replacing per-terminal projection scans, and marks only running zero-view terminals as detached.

Verification: `git diff --check` passes. The same source compiled successfully in the tagged cloud reload before stacking. Rust and Swift tests remain for hosted lanes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791036905&installation_model_id=21920&pr_number=11863&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11863&signature=c4ca730127f398fb9b43b08bcce866b87c479daa7fe37424647e02a7bdacfb4c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cloud tree now indexes projected resource IDs once per rebuild instead of scanning projections for every terminal row. Previously, all zero-view terminals were marked detached; now only running zero-view terminals are, so exited terminals remain ordinary terminal rows while active projections consistently mark rows open.

- Adds regression coverage for open terminal rows and exited zero-view terminals.

<sup>Written for commit 8ca8aac10ff929311081e005a9a5cbcc63b023da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

