### PR TITLE
cmux-tui: simplify PTY error mapping

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/pty_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/pty_input.rs
@@ -76,8 +76,7 @@ pub(crate) fn mark_operation_known_not_delivered(error: anyhow::Error) -> anyhow
 fn underlying_operation_error(error: &anyhow::Error) -> &anyhow::Error {
     error
         .downcast_ref::<KnownNotDeliveredOperationError>()
-        .map(|marked| &marked.error)
-        .unwrap_or(error)
+        .map_or(error, |marked| &marked.error)
 }
 
 pub struct PtyInputEvent {

--- a/cmux-tui/crates/cmux-tui/src/pty_input.rs
+++ b/cmux-tui/crates/cmux-tui/src/pty_input.rs
@@ -74,9 +74,7 @@ pub(crate) fn mark_operation_known_not_delivered(error: anyhow::Error) -> anyhow
 }
 
 fn underlying_operation_error(error: &anyhow::Error) -> &anyhow::Error {
-    error
-        .downcast_ref::<KnownNotDeliveredOperationError>()
-        .map_or(error, |marked| &marked.error)
+    error.downcast_ref::<KnownNotDeliveredOperationError>().map_or(error, |marked| &marked.error)
 }
 
 pub struct PtyInputEvent {


### PR DESCRIPTION
Summary
- Replace equivalent map/unwrap_or nesting with Option::map_or in pty_input.rs.
- Preserve all existing PTY failure behavior.

Verification
- 47 pty_input tests pass on Blacksmith.
- cargo fmt and diff checks pass.
- Canonical review clean at 0.99.
- Full Clippy is blocked only by baseline lints fixed in PR #11853.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the equivalent `Option::map`/`unwrap_or` chain in PTY error mapping with `Option::map_or`. It still returns the marked underlying error when available and the original error otherwise, so PTY failure behavior is unchanged.

<sup>Written for commit ccdad661df9f206764d6fc80e70a95267c02ab3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified internal error-handling logic without changing user-visible behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->