### PR TITLE
cmux-tui: cache projection rows and preserve selection state

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -16881,6 +16881,7 @@ impl App {
         self.tree.set_active_tab(workspace_index, screen_index, pane_id, tab_index);
         self.sidebar_workspace_selection =
             workspace_index.min(self.tree.workspaces().len().saturating_sub(1));
+        self.bump_sidebar_generation();
         self.pane_focus_history.record(pane_id);
         self.reported_focus = Some(crate::session::ClientFocus { pane: pane_id, tab: tab_index });
     }
@@ -18369,6 +18370,7 @@ impl App {
                     }
                     self.sidebar_workspace_selection = index;
                     self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
+                    self.bump_sidebar_generation();
                 }
             }
             WorkspaceRailTarget::Recoverable(id) => {
@@ -20755,6 +20757,7 @@ impl App {
                     self.sidebar_workspace_selection = self.tree.active_workspace;
                     self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
                     self.workspace_rail_follow_selection = true;
+                    self.bump_sidebar_generation();
                 } else if !self.sync_sidebar_files_to_focus(true) {
                     self.sidebar_files.refresh();
                 }
@@ -20784,6 +20787,7 @@ impl App {
                 self.sidebar_workspace_selection = self.tree.active_workspace;
                 self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
                 self.workspace_rail_follow_selection = true;
+                self.bump_sidebar_generation();
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10355,7 +10355,7 @@ impl App {
         crate::sidebar_projection::rows(
             spec,
             &self.tree,
-            &agents,
+            agents,
             self.sidebar_workspace_selection,
             collapsed,
         )

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13190,24 +13190,30 @@ impl App {
         else {
             return;
         };
-        let Some(pane_id) = self
+        let Some((pane_id, tab_count)) = self
             .tree
             .workspaces()
             .get(workspace_index)
             .and_then(|workspace| workspace.screens.get(screen_index))
             .and_then(|screen| screen.panes.get(pane_index))
-            .map(|pane| pane.id)
+            .map(|pane| (pane.id, pane.tabs.len()))
         else {
             return;
         };
+        // Validate the complete target before changing any focus state. The
+        // location map can outlive a topology update, including a stale tab
+        // index, so the fallible setters must not run on a partial target.
+        if tab_index >= tab_count {
+            return;
+        }
         let previous_focus = self.active_focus_state();
-        self.tree.active_workspace = workspace_index;
         if !self.tree.set_active_screen(workspace_index, screen_index)
             || !self.tree.set_active_pane(workspace_index, screen_index, pane_id)
             || !self.tree.set_active_tab(workspace_index, screen_index, pane_id, tab_index)
         {
             return;
         }
+        self.tree.active_workspace = workspace_index;
         if previous_focus != self.active_focus_state() {
             self.bump_sidebar_generation();
         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44259,6 +44259,56 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_refresh_when_focus_changes_without_active_surface() {
+        let mux =
+            Mux::new("projection-focus-without-surface-refresh-test", SurfaceOptions::default());
+        let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let first_pane = mux.with_state(|state| state.pane_of(surface.id).unwrap());
+        mux.split(first_pane, SplitDir::Right, Some((40, 24))).unwrap();
+        let second_pane = Session::Local(mux.clone()).tree().active_screen().unwrap().active_pane;
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == second_pane
+                )
+        }));
+
+        for workspace in app.tree.workspaces_mut() {
+            for screen in &mut workspace.screens {
+                for pane in &mut screen.panes {
+                    pane.tabs.clear();
+                }
+            }
+        }
+        app.activate_projection_target(crate::sidebar_projection::ProjectionTarget::Pane {
+            workspace: 0,
+            screen: 0,
+            pane: first_pane,
+        })
+        .unwrap();
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == first_pane
+                )
+        }));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn projection_rows_scope_agent_revision_to_agent_views() {
         let (mux, surface) = test_mux("projection-agent-revision-scope-test", None);
         mux.report_agent(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -43999,10 +43999,7 @@ mod tests {
                 matches!(
                     hit,
                     super::Hit::ProjectionRow {
-                        target: crate::sidebar_projection::ProjectionTarget::Workspace {
-                            index: 0,
-                            ..
-                        },
+                        target: ProjectionTarget::Workspace { index: 0, .. },
                         ..
                     }
                 )
@@ -44028,10 +44025,7 @@ mod tests {
         let mut app = test_app(Session::Local(mux.clone()));
         app.replace_tree(app.session.tree());
 
-        let target = crate::sidebar_projection::ProjectionTarget::Workspace {
-            index: 0,
-            id: app.tree.workspaces()[0].id,
-        };
+        let target = ProjectionTarget::Workspace { index: 0, id: app.tree.workspaces()[0].id };
         app.tree.workspaces_mut().swap(0, 1);
         app.activate_projection_target(target).unwrap();
 
@@ -44046,11 +44040,9 @@ mod tests {
         }
     }
 
-    fn target_id(
-        target: crate::sidebar_projection::ProjectionTarget,
-    ) -> cmux_tui_core::WorkspaceId {
+    fn target_id(target: ProjectionTarget) -> cmux_tui_core::WorkspaceId {
         match target {
-            crate::sidebar_projection::ProjectionTarget::Workspace { id, .. } => id,
+            ProjectionTarget::Workspace { id, .. } => id,
             _ => unreachable!("workspace target expected"),
         }
     }
@@ -44165,10 +44157,7 @@ mod tests {
         assert!(app.projection_rows(0).iter().any(|row| {
             row.resource == SidebarResourceKind::Workspaces
                 && row.active
-                && matches!(
-                    row.target,
-                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 1, .. }
-                )
+                && matches!(row.target, ProjectionTarget::Workspace { index: 1, .. })
         }));
 
         app.select_workspace_for_client(Some(0), None);
@@ -44176,10 +44165,7 @@ mod tests {
         assert!(app.projection_rows(0).iter().any(|row| {
             row.resource == SidebarResourceKind::Workspaces
                 && row.active
-                && matches!(
-                    row.target,
-                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
-                )
+                && matches!(row.target, ProjectionTarget::Workspace { index: 0, .. })
         }));
 
         for surface in [first, second] {
@@ -44204,7 +44190,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                    ProjectionTarget::Pane { pane, .. }
                         if pane == second_pane
                 )
         }));
@@ -44216,7 +44202,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                    ProjectionTarget::Pane { pane, .. }
                         if pane == first_pane
                 )
         }));
@@ -44244,7 +44230,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                    ProjectionTarget::Surface { surface, .. }
                         if surface == second.id
                 )
         }));
@@ -44256,7 +44242,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                    ProjectionTarget::Surface { surface, .. }
                         if surface == first.id
                 )
         }));
@@ -44268,7 +44254,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                    ProjectionTarget::Surface { surface, .. }
                         if surface == second.id
                 )
         }));
@@ -44295,7 +44281,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                    ProjectionTarget::Pane { pane, .. }
                         if pane == second_screen_pane
                 )
         }));
@@ -44314,7 +44300,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                    ProjectionTarget::Pane { pane, .. }
                         if pane == first_screen_pane
                 )
         }));
@@ -44340,7 +44326,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                    ProjectionTarget::Pane { pane, .. }
                         if pane == second_pane
                 )
         }));
@@ -44352,7 +44338,7 @@ mod tests {
                 }
             }
         }
-        app.activate_projection_target(crate::sidebar_projection::ProjectionTarget::Pane {
+        app.activate_projection_target(ProjectionTarget::Pane {
             workspace: 0,
             screen: 0,
             pane: first_pane,
@@ -44364,7 +44350,7 @@ mod tests {
                 && row.active
                 && matches!(
                     row.target,
-                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                    ProjectionTarget::Pane { pane, .. }
                         if pane == first_pane
                 )
         }));
@@ -44385,10 +44371,7 @@ mod tests {
         assert!(app.projection_rows(0).iter().any(|row| {
             row.resource == SidebarResourceKind::Workspaces
                 && row.active
-                && matches!(
-                    row.target,
-                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
-                )
+                && matches!(row.target, ProjectionTarget::Workspace { index: 0, .. })
         }));
 
         // Simulate a stale completion. The workspace index is still valid, but
@@ -44402,10 +44385,7 @@ mod tests {
         assert!(app.projection_rows(0).iter().any(|row| {
             row.resource == SidebarResourceKind::Workspaces
                 && row.active
-                && matches!(
-                    row.target,
-                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
-                )
+                && matches!(row.target, ProjectionTarget::Workspace { index: 0, .. })
         }));
 
         mux.close_surface(first.id).unwrap();
@@ -44787,7 +44767,7 @@ mod tests {
                 matches!(
                     hit,
                     super::Hit::ProjectionRow {
-                        target: crate::sidebar_projection::ProjectionTarget::Surface {
+                        target: ProjectionTarget::Surface {
                             surface: hit_surface,
                             ..
                         },
@@ -44826,7 +44806,7 @@ mod tests {
         assert!(!app.hits.iter().any(|(_, hit)| matches!(
             hit,
             super::Hit::ProjectionRow {
-                target: crate::sidebar_projection::ProjectionTarget::Surface {
+                target: ProjectionTarget::Surface {
                     surface: hit_surface,
                     ..
                 },

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10544,10 +10544,14 @@ impl App {
         if !self.prepare_pty_input_before_mutation() {
             return Ok(());
         }
+        let previous_surface = self.tree.active_surface();
         if !self.tree.select_surface(target.surface) {
             return Ok(());
         }
         self.follow_sidebar_workspace(target.workspace);
+        if previous_surface != Some(target.surface) {
+            self.bump_sidebar_generation();
+        }
         self.pane_focus_history.record(target.pane);
         self.claim_active_terminal_geometry(true);
         Ok(())
@@ -10570,14 +10574,16 @@ impl App {
         if index >= self.tree.workspaces().len() || !self.prepare_pty_input_before_mutation() {
             return;
         }
+        let changed = self.tree.active_workspace != index;
         self.follow_sidebar_workspace(index);
         self.tree.active_workspace = index;
-        self.bump_sidebar_generation();
+        if changed {
+            self.bump_sidebar_generation();
+        }
         self.select_workspace_for_client(Some(index), None);
     }
 
     fn activate_projection_target(&mut self, target: ProjectionTarget) -> anyhow::Result<()> {
-        self.bump_sidebar_generation();
         match target {
             ProjectionTarget::Workspace { id, .. } => {
                 // The hit map can outlive a tree snapshot while a remote
@@ -10594,10 +10600,23 @@ impl App {
                 if !self.prepare_pty_input_before_mutation() {
                     return Ok(());
                 }
+                let previous = (
+                    self.tree.active_workspace,
+                    self.tree.active_workspace().map(|workspace| workspace.active_screen),
+                    self.tree.active_screen().map(|screen| screen.active_pane),
+                );
                 self.follow_sidebar_workspace(workspace);
                 self.tree.active_workspace = workspace;
                 self.tree.set_active_screen(workspace, screen);
                 self.tree.set_active_pane(workspace, screen, pane);
+                let current = (
+                    self.tree.active_workspace,
+                    self.tree.active_workspace().map(|workspace| workspace.active_screen),
+                    self.tree.active_screen().map(|screen| screen.active_pane),
+                );
+                if previous != current {
+                    self.bump_sidebar_generation();
+                }
                 self.pane_focus_history.record(pane);
                 self.claim_active_terminal_geometry(true);
             }
@@ -13171,12 +13190,16 @@ impl App {
         else {
             return;
         };
+        let changed = self.tree.active_surface() != Some(surface);
         self.tree.active_workspace = workspace_index;
         if !self.tree.set_active_screen(workspace_index, screen_index)
             || !self.tree.set_active_pane(workspace_index, screen_index, pane_id)
             || !self.tree.set_active_tab(workspace_index, screen_index, pane_id, tab_index)
         {
             return;
+        }
+        if changed {
+            self.bump_sidebar_generation();
         }
         self.pane_focus_history.record(pane_id);
         self.claim_active_terminal_geometry(true);
@@ -22158,9 +22181,16 @@ impl App {
             let workspace_index = self.tree.active_workspace;
             let screen_index =
                 self.tree.active_workspace().map(|workspace| workspace.active_screen);
+            let changed = self
+                .tree
+                .active_screen()
+                .is_some_and(|screen| screen.active_pane != pane);
             let focused = screen_index
                 .is_some_and(|screen| self.tree.set_active_pane(workspace_index, screen, pane));
             if focused {
+                if changed {
+                    self.bump_sidebar_generation();
+                }
                 self.pane_focus_history.record(pane);
                 self.claim_active_terminal_geometry(true);
             }
@@ -22174,6 +22204,7 @@ impl App {
         delta: Option<isize>,
     ) {
         let pane = pane.or_else(|| self.active_pane());
+<<<<<<< HEAD
         if let Some(pane_id) = pane {
             let target = self.tree.pane(pane_id).and_then(|pane| {
                 if pane.tabs.is_empty() {
@@ -22187,7 +22218,11 @@ impl App {
                 })
             });
             if let Some(target) = target {
+                let changed = self.tree.pane(pane_id).is_some_and(|pane| pane.active_tab != target);
                 self.tree.set_pane_active_tab(pane_id, target);
+                if changed {
+                    self.bump_sidebar_generation();
+                }
             }
         }
         self.claim_active_terminal_geometry(true);
@@ -22208,7 +22243,14 @@ impl App {
         });
         if let Some(target) = target {
             let workspace_index = self.tree.active_workspace;
+            let changed = self
+                .tree
+                .active_workspace()
+                .is_some_and(|workspace| workspace.active_screen != target);
             selected = self.tree.set_active_screen(workspace_index, target);
+            if changed {
+                self.bump_sidebar_generation();
+            }
         }
         if selected && let Some(active) = self.active_pane() {
             self.pane_focus_history.record(active);
@@ -22220,14 +22262,23 @@ impl App {
         let mut selected = false;
         if !self.tree.workspaces().is_empty() {
             if let Some(index) = index.filter(|index| *index < self.tree.workspaces().len()) {
+                let changed = self.tree.active_workspace != index;
                 self.tree.active_workspace = index;
                 selected = true;
+                if changed {
+                    self.bump_sidebar_generation();
+                }
             } else if let Some(delta) = delta {
+                let previous = self.tree.active_workspace;
                 self.tree.active_workspace = ((self.tree.active_workspace as isize + delta)
                     .rem_euclid(self.tree.workspaces().len() as isize))
                     as usize;
                 selected = true;
+                if self.tree.active_workspace != previous {
+                    self.bump_sidebar_generation();
+                }
             }
+        }
         }
         if selected && let Some(active) = self.active_pane() {
             self.pane_focus_history.record(active);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10364,7 +10364,8 @@ impl App {
         let revision = ProjectionRevision {
             tree_workspace: self.tree.workspace_revision,
             tree_pane: self.tree.pane_revision,
-            agents: spec.includes(SidebarResourceKind::Agents)
+            agents: spec
+                .includes(SidebarResourceKind::Agents)
                 .then_some(self.projection_agents_generation),
             selected_workspace: (!spec.includes(SidebarResourceKind::Workspaces))
                 .then_some(self.sidebar_workspace_selection)

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7178,6 +7178,13 @@ pub struct App {
     config_reload_applications: usize,
     pub chrome: ChromeTheme,
     pub tree: TreeView,
+    /// Cached active-agent snapshot used by projection rows. Agent records
+    /// are unchanged across most redraws, so avoid rebuilding the full list
+    /// until a topology or agent event advances this generation.
+    projection_agents: Option<(u64, Vec<AgentInfo>)>,
+    projection_agents_generation: u64,
+    #[cfg(test)]
+    projection_agents_builds: usize,
     tab_locations: HashMap<SurfaceId, [usize; 4]>,
     pub render_states: HashMap<SurfaceId, RenderState>,
     pub(crate) chrome_row_scratch: ReusableRowBuffer,
@@ -9480,6 +9487,10 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         config_reload_applications: 0,
         chrome,
         tree: TreeView::default(),
+        projection_agents: None,
+        projection_agents_generation: 0,
+        #[cfg(test)]
+        projection_agents_builds: 0,
         tab_locations: HashMap::new(),
         render_states: HashMap::new(),
         chrome_row_scratch: ReusableRowBuffer::default(),
@@ -10297,7 +10308,38 @@ impl App {
         self.focus == FocusTarget::ProjectionRail(index)
     }
 
-    pub(crate) fn projection_rows(&self, index: usize) -> Vec<ProjectionRow> {
+    pub(crate) fn projection_rows(&mut self, index: usize) -> Vec<ProjectionRow> {
+        let Some(includes_agents) = self
+            .config
+            .sidebar
+            .views
+            .get(index)
+            .map(|spec| spec.includes(SidebarResourceKind::Agents))
+        else {
+            return Vec::new();
+        };
+        if includes_agents {
+            let generation = self.projection_agents_generation;
+            let cache_stale = self
+                .projection_agents
+                .as_ref()
+                .is_none_or(|(cached_generation, _)| *cached_generation != generation);
+            if cache_stale {
+                // Finished reports are historical records, not active agents.
+                // Otherwise detached "surface..." rows remain forever after exit.
+                let agents = self
+                    .session
+                    .agents()
+                    .into_iter()
+                    .filter(|agent| !matches!(agent.state.as_str(), "done" | "unknown"))
+                    .collect::<Vec<_>>();
+                self.projection_agents = Some((generation, agents));
+                #[cfg(test)]
+                {
+                    self.projection_agents_builds += 1;
+                }
+            }
+        }
         let Some(spec) = self.config.sidebar.views.get(index) else { return Vec::new() };
         let empty_collapsed = HashSet::new();
         let collapsed = self
@@ -10305,17 +10347,11 @@ impl App {
             .get(&spec.id)
             .map(|state| &state.collapsed)
             .unwrap_or(&empty_collapsed);
-        let agents = if spec.includes(SidebarResourceKind::Agents) {
-            // Finished reports are historical records, not active agents.
-            // Otherwise detached "surface..." rows remain forever after exit.
-            self.session
-                .agents()
-                .into_iter()
-                .filter(|agent| !matches!(agent.state.as_str(), "done" | "unknown"))
-                .collect::<Vec<_>>()
-        } else {
-            Vec::new()
-        };
+        let agents = self
+            .projection_agents
+            .as_ref()
+            .filter(|_| includes_agents)
+            .map_or(&[][..], |(_, agents)| agents.as_slice());
         crate::sidebar_projection::rows(
             spec,
             &self.tree,
@@ -11964,6 +12000,7 @@ impl App {
             self.browser_input.forget_surface(surface);
         }
         self.tree = tree;
+        self.invalidate_projection_agents();
         // The readout belongs to the previous daemon; the replacement's own
         // value arrives from its background refresh.
         self.machine_usage = None;
@@ -13219,7 +13256,14 @@ impl App {
         changed
     }
 
+    fn invalidate_projection_agents(&mut self) {
+        self.projection_agents_generation = self.projection_agents_generation.wrapping_add(1);
+        self.projection_agents = None;
+    }
+
     fn replace_tree(&mut self, mut tree: TreeView) {
+        let topology_changed = self.tree.workspace_revision != tree.workspace_revision
+            || self.tree.pane_revision != tree.pane_revision;
         let previous_active = self.active_pane();
         let selected_workspace = self
             .tree
@@ -13273,6 +13317,9 @@ impl App {
         self.viewport_states.retain(|screen, _| live_screens.contains(screen));
         self.pane_focus_history.sync_membership(&tree);
         self.tree = tree;
+        if topology_changed {
+            self.invalidate_projection_agents();
+        }
         self.sidebar_workspace_selection = selected_workspace
             .and_then(|selected| {
                 self.tree.workspaces().iter().position(|workspace| workspace.id == selected)
@@ -13389,6 +13436,7 @@ impl App {
     /// topology refresh arrives. The backend projection still owns parent
     /// pane, screen, and workspace collapse.
     fn remove_surface_from_cached_tree(&mut self, surface: SurfaceId) {
+        self.invalidate_projection_agents();
         self.tree.invalidate_location_index();
         let Some([workspace_index, screen_index, pane_index, tab_index]) =
             self.tab_locations.get(&surface).copied()
@@ -15549,6 +15597,10 @@ impl App {
                 } else {
                     Ok(RenderAction::Paint)
                 }
+            }
+            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
+                self.invalidate_projection_agents();
+                Ok(RenderAction::Draw)
             }
             AppEvent::Mux(MuxEvent::PairingRequested(challenge)) => {
                 let duplicate = self
@@ -43984,6 +44036,34 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_reuse_agent_snapshot_until_invalidated() {
+        let (mux, _surface) = test_mux("projection-agent-snapshot-cache-test", None);
+        let mut app = test_app(Session::Local(mux));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "workspace-agents".into(),
+            levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Agents],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+
+        let first = app.projection_rows(0);
+        let second = app.projection_rows(0);
+        assert_eq!(first, second);
+        assert_eq!(app.projection_agents_builds, 1);
+
+        app.invalidate_projection_agents();
+        let third = app.projection_rows(0);
+        assert_eq!(third, first);
+        assert_eq!(app.projection_agents_builds, 2);
+    }
+
+    #[test]
     fn tabs_column_context_menu_renames_the_exact_clicked_tab() {
         let (mux, first) = test_mux("tabs-column-rename-test", None);
         let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
@@ -46097,6 +46177,9 @@ mod tests {
             config_reload_applications: 0,
             chrome: ChromeTheme::dark(),
             tree: TreeView::default(),
+            projection_agents: None,
+            projection_agents_generation: 0,
+            projection_agents_builds: 0,
             tab_locations: HashMap::new(),
             render_states: HashMap::<u64, RenderState>::new(),
             chrome_row_scratch: crate::ui::ReusableRowBuffer::default(),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -25182,7 +25182,7 @@ mod tests {
         swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
         workspace_creation_selection,
     };
-    use crate::sidebar_projection::ProjectionRowsCache;
+    use crate::sidebar_projection::{ProjectionRowsCache, ProjectionTarget};
     use cmux_tui_core::{FrontendFocusTarget, FrontendJournalEvent};
     use crossbeam_channel::Receiver;
     use serde_json::Value;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -13514,6 +13514,8 @@ impl App {
     /// topology refresh arrives. The backend projection still owns parent
     /// pane, screen, and workspace collapse.
     fn remove_surface_from_cached_tree(&mut self, surface: SurfaceId) {
+        self.projection_rows_cache.invalidate();
+        self.bump_sidebar_generation();
         self.invalidate_projection_agents();
         self.tree.invalidate_location_index();
         let Some([workspace_index, screen_index, pane_index, tab_index]) =

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44340,6 +44340,7 @@ mod tests {
 
         // A failed focus request must not leave a partial workspace mutation
         // behind, or the cached active row can become stale.
+        assert_eq!(app.tree.active_workspace, 0);
         assert!(app.projection_rows(0).iter().any(|row| {
             row.resource == SidebarResourceKind::Workspaces
                 && row.active

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10315,7 +10315,9 @@ impl App {
         self.focus == FocusTarget::ProjectionRail(index)
     }
 
-    pub(crate) fn projection_rows(&mut self, index: usize) -> Vec<ProjectionRow> {
+    /// Return a projection's rows, reusing the cached immutable snapshot when
+    /// its tree and presentation revisions have not changed.
+    pub(crate) fn projection_rows(&mut self, index: usize) -> Arc<[ProjectionRow]> {
         let Some(includes_agents) = self
             .config
             .sidebar
@@ -10323,7 +10325,7 @@ impl App {
             .get(index)
             .map(|spec| spec.includes(SidebarResourceKind::Agents))
         else {
-            return Vec::new();
+            return Arc::from([]);
         };
         if includes_agents {
             let generation = self.projection_agents_generation;
@@ -10347,7 +10349,7 @@ impl App {
                 }
             }
         }
-        let Some(spec) = self.config.sidebar.views.get(index) else { return Vec::new() };
+        let Some(spec) = self.config.sidebar.views.get(index) else { return Arc::from([]) };
         let empty_collapsed = HashSet::new();
         let collapsed = self
             .projection_rails

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7186,6 +7186,8 @@ pub struct App {
     projection_agents_generation: u64,
     #[cfg(test)]
     projection_agents_builds: usize,
+    #[cfg(test)]
+    projection_collapsed_clones: usize,
     tab_locations: HashMap<SurfaceId, [usize; 4]>,
     pub render_states: HashMap<SurfaceId, RenderState>,
     pub(crate) chrome_row_scratch: ReusableRowBuffer,
@@ -9494,6 +9496,8 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         projection_agents_generation: 0,
         #[cfg(test)]
         projection_agents_builds: 0,
+        #[cfg(test)]
+        projection_collapsed_clones: 0,
         tab_locations: HashMap::new(),
         render_states: HashMap::new(),
         chrome_row_scratch: ReusableRowBuffer::default(),
@@ -10349,11 +10353,15 @@ impl App {
         }
         let Some(spec) = self.config.sidebar.views.get(index) else { return Arc::from([]) };
         let empty_collapsed = HashSet::new();
-        let collapsed = self
-            .projection_rails
-            .get(&spec.id)
-            .map(|state| state.collapsed.clone())
-            .unwrap_or(empty_collapsed);
+        let collapsed = if let Some(state) = self.projection_rails.get(&spec.id) {
+            #[cfg(test)]
+            {
+                self.projection_collapsed_clones += 1;
+            }
+            state.collapsed.clone()
+        } else {
+            empty_collapsed
+        };
         let agents = self
             .projection_agents
             .as_ref()
@@ -44558,11 +44566,15 @@ mod tests {
         }];
         app.config.sidebar.views_explicit = true;
         app.replace_tree(app.session.tree());
+        app.projection_rail_state_mut(0)
+            .collapsed
+            .insert(crate::sidebar_projection::ProjectionBranch::Workspace(1));
 
         let first = app.projection_rows(0);
         let second = app.projection_rows(0);
         assert_eq!(first, second);
         assert_eq!(app.projection_agents_builds, 1);
+        assert_eq!(app.projection_collapsed_clones, 1);
 
         app.handle(AppEvent::Mux(MuxEvent::AgentChanged {
             surface: 0,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44057,7 +44057,14 @@ mod tests {
         assert_eq!(first, second);
         assert_eq!(app.projection_agents_builds, 1);
 
-        app.invalidate_projection_agents();
+        app.handle(AppEvent::Mux(MuxEvent::AgentChanged {
+            surface: 0,
+            state: "working".into(),
+            source: "hook".into(),
+            session: None,
+            updated_at_ms: 1,
+        }))
+        .unwrap();
         let third = app.projection_rows(0);
         assert_eq!(third, first);
         assert_eq!(app.projection_agents_builds, 2);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10352,16 +10352,6 @@ impl App {
             }
         }
         let Some(spec) = self.config.sidebar.views.get(index) else { return Arc::from([]) };
-        let empty_collapsed = HashSet::new();
-        let collapsed = if let Some(state) = self.projection_rails.get(&spec.id) {
-            #[cfg(test)]
-            {
-                self.projection_collapsed_clones += 1;
-            }
-            state.collapsed.clone()
-        } else {
-            empty_collapsed
-        };
         let agents = self
             .projection_agents
             .as_ref()
@@ -10382,6 +10372,19 @@ impl App {
             },
             sidebar: self.sidebar_generation,
             rail: rail_generation,
+        };
+        if let Some(rows) = self.projection_rows_cache.get(&spec.id, &revision) {
+            return rows;
+        }
+        let empty_collapsed = HashSet::new();
+        let collapsed = if let Some(state) = self.projection_rails.get(&spec.id) {
+            #[cfg(test)]
+            {
+                self.projection_collapsed_clones += 1;
+            }
+            state.collapsed.clone()
+        } else {
+            empty_collapsed
         };
         let tree = &self.tree;
         let selected_workspace = self.sidebar_workspace_selection;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -35584,6 +35584,37 @@ mod tests {
     }
 
     #[test]
+    fn cached_surface_exit_invalidates_projection_rows() {
+        let mux = Mux::new("cached-surface-exit-projection-test", SurfaceOptions::default());
+        let mut app = test_app(Session::Local(mux));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "tabs".into(),
+            levels: vec![SidebarResourceKind::Tabs],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        let tree = notify_tree(40, false);
+        app.replace_tree(tree);
+
+        assert!(
+            app.projection_rows(0)
+                .iter()
+                .any(|row| { matches!(row.target, ProjectionTarget::Surface { surface: 40, .. }) })
+        );
+        app.remove_surface_from_cached_tree(40);
+        assert!(
+            !app.projection_rows(0)
+                .iter()
+                .any(|row| { matches!(row.target, ProjectionTarget::Surface { surface: 40, .. }) })
+        );
+    }
+
+    #[test]
     fn stale_surface_exit_index_falls_back_to_tree_scan_and_rebuilds_locations() {
         let mux = Mux::new("stale-surface-exit-index-test", SurfaceOptions::default());
         let mut app = test_app(Session::Local(mux));

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44320,6 +44320,45 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_refresh_after_client_focus_partial_failure() {
+        let mux =
+            Mux::new("projection-client-focus-partial-failure-test", SurfaceOptions::default());
+        let first = mux.new_workspace(Some("Alpha".into()), Some((80, 24))).unwrap();
+        let second = mux.new_workspace(Some("Beta".into()), Some((80, 24))).unwrap();
+        let mut app =
+            projection_test_app(Session::Local(mux.clone()), vec![SidebarResourceKind::Workspaces]);
+        app.tree.active_workspace = 0;
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
+                )
+        }));
+
+        // Simulate a stale completion. The workspace index is still valid, but
+        // the tab index no longer exists when the client focus is applied.
+        app.tab_locations.insert(second.id, [1, 0, 0, usize::MAX]);
+        app.select_created_surface(second.id);
+
+        // A failed focus request must not leave a partial workspace mutation
+        // behind, or the cached active row can become stale.
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
+                )
+        }));
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
     fn projection_rows_scope_agent_revision_to_agent_views() {
         let (mux, surface) = test_mux("projection-agent-revision-scope-test", None);
         mux.report_agent(
@@ -44445,6 +44484,31 @@ mod tests {
         let after = app.projection_rows_cache.revision_for("agent-view").unwrap();
 
         assert_eq!(before, after);
+
+        mux.close_surface(first_surface.id).unwrap();
+        mux.close_surface(second_surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_agent_generations_prune_removed_workspaces() {
+        let (mux, first_surface) = test_mux("projection-agent-generation-prune-test", None);
+        let second_surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.replace_tree(app.session.tree());
+        let first_workspace = app.tree.workspaces()[0].id;
+        let second_workspace = app.tree.workspaces()[1].id;
+
+        app.bump_agent_generation(first_surface.id);
+        app.bump_agent_generation(second_surface.id);
+        assert_eq!(app.agent_generations.len(), 2);
+
+        let mut replacement = app.tree.clone();
+        replacement.workspaces_mut().remove(0);
+        replacement.active_workspace = 0;
+        app.replace_tree(replacement);
+
+        assert!(!app.agent_generations.contains_key(&first_workspace));
+        assert!(app.agent_generations.contains_key(&second_workspace));
 
         mux.close_surface(first_surface.id).unwrap();
         mux.close_surface(second_surface.id).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -7279,7 +7279,6 @@ pub struct App {
     pub(crate) tabs_footer_scroll: usize,
     projection_rails: HashMap<String, ProjectionRailState>,
     projection_rows_cache: ProjectionRowsCache,
-    agent_generation: u64,
     sidebar_generation: u64,
     pub(crate) machine_rail_follow_selection: bool,
     pub(crate) workspace_rail_follow_selection: bool,
@@ -9554,7 +9553,6 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         tabs_footer_scroll: 0,
         projection_rails: HashMap::new(),
         projection_rows_cache: ProjectionRowsCache::default(),
-        agent_generation: 0,
         sidebar_generation: 0,
         machine_rail_follow_selection: true,
         workspace_rail_follow_selection: true,
@@ -10486,10 +10484,6 @@ impl App {
     fn bump_projection_rows_generation(&mut self, index: usize) {
         let state = self.projection_rail_state_mut(index);
         state.rows_generation = state.rows_generation.saturating_add(1);
-    }
-
-    fn bump_agent_generation(&mut self) {
-        self.agent_generation = self.agent_generation.saturating_add(1);
     }
 
     fn invoke_sidebar_action(
@@ -13320,7 +13314,7 @@ impl App {
     }
 
     fn invalidate_projection_agents(&mut self) {
-        self.projection_agents_generation = self.projection_agents_generation.wrapping_add(1);
+        self.projection_agents_generation = self.projection_agents_generation.saturating_add(1);
         self.projection_agents = None;
     }
 
@@ -15700,10 +15694,6 @@ impl App {
                 | MuxEvent::ClientListInvalidated,
             ) => {
                 self.session.refresh_clients_background();
-                Ok(RenderAction::Draw)
-            }
-            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
-                self.bump_agent_generation();
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(_) => Ok(RenderAction::Draw),
@@ -44399,7 +44389,7 @@ mod tests {
         let workspace_before = app.projection_rows_cache.revision_for("workspace-view").unwrap();
         let agent_before = app.projection_rows_cache.revision_for("agent-view").unwrap();
 
-        app.bump_agent_generation(surface.id);
+        app.invalidate_projection_agents();
         app.projection_rows(0);
         app.projection_rows(1);
         let workspace_after = app.projection_rows_cache.revision_for("workspace-view").unwrap();
@@ -44458,62 +44448,6 @@ mod tests {
         assert_eq!(second_before, second_after);
 
         mux.close_surface(surface.id).unwrap();
-    }
-
-    #[test]
-    fn projection_rows_scope_agent_revision_to_selected_workspace() {
-        let (mux, first_surface) = test_mux("projection-agent-owner-scope-test", None);
-        let second_surface = mux.new_workspace(None, Some((80, 24))).unwrap();
-        let mut app = test_app(Session::Local(mux.clone()));
-        app.config.sidebar.columns.clear();
-        app.config.sidebar.views = vec![SidebarViewSpec {
-            id: "agent-view".into(),
-            levels: vec![SidebarResourceKind::Agents],
-            actions: Vec::new(),
-            actions_position: crate::config::ActionsPosition::Bottom,
-            width: 40,
-            max_width: 0,
-            collapse_priority: 30,
-        }];
-        app.config.sidebar.views_explicit = true;
-        app.replace_tree(app.session.tree());
-        app.sidebar_workspace_selection = 0;
-        app.projection_rows(0);
-        let before = app.projection_rows_cache.revision_for("agent-view").unwrap();
-
-        app.bump_agent_generation(second_surface.id);
-        app.projection_rows(0);
-        let after = app.projection_rows_cache.revision_for("agent-view").unwrap();
-
-        assert_eq!(before, after);
-
-        mux.close_surface(first_surface.id).unwrap();
-        mux.close_surface(second_surface.id).unwrap();
-    }
-
-    #[test]
-    fn projection_agent_generations_prune_removed_workspaces() {
-        let (mux, first_surface) = test_mux("projection-agent-generation-prune-test", None);
-        let second_surface = mux.new_workspace(None, Some((80, 24))).unwrap();
-        let mut app = test_app(Session::Local(mux.clone()));
-        app.replace_tree(app.session.tree());
-        let first_workspace = app.tree.workspaces()[0].id;
-        let second_workspace = app.tree.workspaces()[1].id;
-
-        app.bump_agent_generation(first_surface.id);
-        app.bump_agent_generation(second_surface.id);
-        assert_eq!(app.agent_generations.len(), 2);
-
-        let mut replacement = app.tree.clone();
-        replacement.workspaces_mut().remove(0);
-        replacement.active_workspace = 0;
-        app.replace_tree(replacement);
-
-        assert!(!app.agent_generations.contains_key(&first_workspace));
-        assert!(app.agent_generations.contains_key(&second_workspace));
-
-        mux.close_surface(first_surface.id).unwrap();
-        mux.close_surface(second_surface.id).unwrap();
     }
 
     #[test]
@@ -46797,7 +46731,6 @@ mod tests {
             tabs_footer_scroll: 0,
             projection_rails: HashMap::new(),
             projection_rows_cache: ProjectionRowsCache::default(),
-            agent_generation: 0,
             sidebar_generation: 0,
             machine_rail_follow_selection: true,
             workspace_rail_follow_selection: true,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10375,7 +10375,7 @@ impl App {
         };
         let tree = &self.tree;
         let selected_workspace = self.sidebar_workspace_selection;
-        self.projection_rows_cache.get_or_build(&spec.id, revision, || {
+        self.projection_rows_cache.get_or_build(&spec.id, &revision, || {
             crate::sidebar_projection::rows(spec, tree, agents, selected_workspace, &collapsed)
         })
     }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44015,6 +44015,191 @@ mod tests {
         mux.close_surface(surface.id).unwrap();
     }
 
+    fn projection_test_app(session: Session, levels: Vec<SidebarResourceKind>) -> App {
+        let mut app = test_app(session);
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "projection-active-refresh".into(),
+            levels,
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_workspace_after_client_selection() {
+        let mux = Mux::new("projection-active-workspace-refresh-test", SurfaceOptions::default());
+        let first = mux.new_workspace(Some("Alpha".into()), Some((80, 24))).unwrap();
+        let second = mux.new_workspace(Some("Beta".into()), Some((80, 24))).unwrap();
+        let mut app =
+            projection_test_app(Session::Local(mux.clone()), vec![SidebarResourceKind::Workspaces]);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 1, .. }
+                )
+        }));
+
+        app.select_workspace_for_client(Some(0), None);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Workspaces
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Workspace { index: 0, .. }
+                )
+        }));
+
+        for surface in [first, second] {
+            mux.close_surface(surface.id).unwrap();
+        }
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_pane_after_client_focus() {
+        let mux = Mux::new("projection-active-pane-refresh-test", SurfaceOptions::default());
+        let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let first_pane = mux.with_state(|state| state.pane_of(surface.id).unwrap());
+        mux.split(first_pane, SplitDir::Right, Some((40, 24))).unwrap();
+        let second_pane = Session::Local(mux.clone()).tree().active_screen().unwrap().active_pane;
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == second_pane
+                )
+        }));
+
+        app.focus_pane_after_input(first_pane);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == first_pane
+                )
+        }));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_tab_after_client_selection() {
+        let mux = Mux::new("projection-active-tab-refresh-test", SurfaceOptions::default());
+        let first = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let pane = mux.with_state(|state| state.pane_of(first.id).unwrap());
+        let second = mux.new_tab(Some(pane), None, Some((80, 24))).unwrap();
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![
+                SidebarResourceKind::Workspaces,
+                SidebarResourceKind::Panes,
+                SidebarResourceKind::Tabs,
+            ],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Tabs
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                        if surface == second.id
+                )
+        }));
+
+        app.select_tab_for_client(Some(pane), Some(0), None);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Tabs
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                        if surface == first.id
+                )
+        }));
+
+        app.select_created_surface(second.id);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Tabs
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Surface { surface, .. }
+                        if surface == second.id
+                )
+        }));
+
+        mux.close_surface(first.id).unwrap();
+        mux.close_surface(second.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_refresh_active_screen_after_client_selection() {
+        let mux = Mux::new("projection-active-screen-refresh-test", SurfaceOptions::default());
+        let surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let workspace = Session::Local(mux.clone()).tree().active_workspace().unwrap().id;
+        mux.new_screen(Some(workspace), Some((80, 24))).unwrap();
+        let second_screen_pane =
+            Session::Local(mux.clone()).tree().active_screen().unwrap().active_pane;
+        let mut app = projection_test_app(
+            Session::Local(mux.clone()),
+            vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+        );
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == second_screen_pane
+                )
+        }));
+
+        let first_screen_pane = app
+            .tree
+            .workspaces
+            .first()
+            .and_then(|workspace| workspace.screens.first())
+            .map(|screen| screen.active_pane)
+            .unwrap();
+        app.select_screen_for_client(Some(0), None);
+
+        assert!(app.projection_rows(0).iter().any(|row| {
+            row.resource == SidebarResourceKind::Panes
+                && row.active
+                && matches!(
+                    row.target,
+                    crate::sidebar_projection::ProjectionTarget::Pane { pane, .. }
+                        if pane == first_screen_pane
+                )
+        }));
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
     #[test]
     fn projection_stale_action_selection_does_not_retarget_resource_row() {
         let (mux, surface) = test_mux("projection-stale-action-selection-test", None);

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -18823,6 +18823,7 @@ impl App {
         let actions = self.sidebar_action_rows(view_index);
         {
             let state = self.projection_rail_state_mut(view_index);
+            state.reconcile_action_selection(actions.len());
             state.reconcile_selection(&rows);
         }
         let selectable_rows = rows.len().saturating_add(actions.len());
@@ -18878,7 +18879,6 @@ impl App {
                 state.selected_action = Some(next.saturating_sub(rows.len()));
             }
             state.follow_selection = true;
-            self.bump_sidebar_generation();
             return Ok(RenderAction::Draw);
         }
         if matches!(key.code, KeyCode::Char(' '))

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -87,7 +87,8 @@ use crate::session::{
 };
 use crate::sidebar_files::{FileBrowser, FileCommand, file_url, shell_single_quote};
 use crate::sidebar_projection::{
-    ProjectionBranch, ProjectionRailState, ProjectionRow, ProjectionTarget,
+    ProjectionBranch, ProjectionRailState, ProjectionRevision, ProjectionRow, ProjectionRowsCache,
+    ProjectionTarget,
 };
 use crate::ui::graphics::{
     GraphicPlacement, GraphicSourceRect, kitty_graphic_image, kitty_graphic_placement,
@@ -7277,6 +7278,9 @@ pub struct App {
     pub(crate) tabs_rail_scroll: usize,
     pub(crate) tabs_footer_scroll: usize,
     projection_rails: HashMap<String, ProjectionRailState>,
+    projection_rows_cache: ProjectionRowsCache,
+    agent_generation: u64,
+    sidebar_generation: u64,
     pub(crate) machine_rail_follow_selection: bool,
     pub(crate) workspace_rail_follow_selection: bool,
     pub(crate) tabs_rail_follow_selection: bool,
@@ -9549,6 +9553,9 @@ fn run_with_machine_updates_inner(request: RunRequest) -> anyhow::Result<RunOutc
         tabs_rail_scroll: 0,
         tabs_footer_scroll: 0,
         projection_rails: HashMap::new(),
+        projection_rows_cache: ProjectionRowsCache::default(),
+        agent_generation: 0,
+        sidebar_generation: 0,
         machine_rail_follow_selection: true,
         workspace_rail_follow_selection: true,
         tabs_rail_follow_selection: true,
@@ -10352,13 +10359,18 @@ impl App {
             .as_ref()
             .filter(|_| includes_agents)
             .map_or(&[][..], |(_, agents)| agents.as_slice());
-        crate::sidebar_projection::rows(
-            spec,
-            &self.tree,
-            agents,
-            self.sidebar_workspace_selection,
-            collapsed,
-        )
+        let revision = ProjectionRevision {
+            tree_workspace: self.tree.workspace_revision,
+            tree_pane: self.tree.pane_revision,
+            agents: self.projection_agents_generation,
+            sidebar: self.sidebar_generation,
+        };
+        let tree = &self.tree;
+        let selected_workspace = self.sidebar_workspace_selection;
+        self.projection_rows_cache.get_or_build(&spec.id, revision, || {
+            crate::sidebar_projection::rows(spec, tree, agents, selected_workspace, collapsed)
+        })
+            
     }
 
     pub(crate) fn sidebar_action_rows(&self, index: usize) -> Vec<SidebarActionRow> {
@@ -10459,6 +10471,14 @@ impl App {
         self.projection_rails.entry(id).or_default()
     }
 
+    fn bump_sidebar_generation(&mut self) {
+        self.sidebar_generation = self.sidebar_generation.saturating_add(1);
+    }
+
+    fn bump_agent_generation(&mut self) {
+        self.agent_generation = self.agent_generation.saturating_add(1);
+    }
+
     fn invoke_sidebar_action(
         &mut self,
         target: SidebarActionTarget,
@@ -10534,12 +10554,16 @@ impl App {
     }
 
     fn follow_sidebar_workspace(&mut self, index: usize) {
+        let changed = self.sidebar_workspace_selection != index;
         if self.sidebar_workspace_selection != index {
             self.tabs_rail_selection = 0;
             self.tabs_rail_scroll = 0;
         }
         self.sidebar_workspace_selection = index;
         self.workspace_rail_selection = WorkspaceRailSelection::Workspace;
+        if changed {
+            self.bump_sidebar_generation();
+        }
     }
 
     fn activate_workspace(&mut self, index: usize) {
@@ -10548,10 +10572,12 @@ impl App {
         }
         self.follow_sidebar_workspace(index);
         self.tree.active_workspace = index;
+        self.bump_sidebar_generation();
         self.select_workspace_for_client(Some(index), None);
     }
 
     fn activate_projection_target(&mut self, target: ProjectionTarget) -> anyhow::Result<()> {
+        self.bump_sidebar_generation();
         match target {
             ProjectionTarget::Workspace { id, .. } => {
                 // The hit map can outlive a tree snapshot while a remote
@@ -12004,6 +12030,7 @@ impl App {
         // The readout belongs to the previous daemon; the replacement's own
         // value arrives from its background refresh.
         self.machine_usage = None;
+        self.bump_sidebar_generation();
         self.tab_locations.clear();
         self.rebuild_tab_locations();
         self.render_states.clear();
@@ -13320,6 +13347,7 @@ impl App {
         if topology_changed {
             self.invalidate_projection_agents();
         }
+        self.bump_sidebar_generation();
         self.sidebar_workspace_selection = selected_workspace
             .and_then(|selected| {
                 self.tree.workspaces().iter().position(|workspace| workspace.id == selected)
@@ -14255,6 +14283,8 @@ impl App {
         let valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
         self.projection_rails.retain(|id, _| valid_view_ids.contains(id));
+        self.projection_rows_cache.retain_view_ids(&valid_view_ids);
+        self.bump_sidebar_generation();
         self.projection_sidebar_width_overrides.retain(|id, _| valid_view_ids.contains(id));
         if let Some(id) = focused_projection_id {
             if let Some((index, view)) =
@@ -15634,6 +15664,10 @@ impl App {
                 | MuxEvent::ClientListInvalidated,
             ) => {
                 self.session.refresh_clients_background();
+                Ok(RenderAction::Draw)
+            }
+            AppEvent::Mux(MuxEvent::AgentChanged { .. }) => {
+                self.bump_agent_generation();
                 Ok(RenderAction::Draw)
             }
             AppEvent::Mux(_) => Ok(RenderAction::Draw),
@@ -18744,7 +18778,9 @@ impl App {
                 && let Some(branch) = selected.as_ref().and_then(|row| row.branch)
                 && selected.as_ref().is_some_and(|row| row.expanded)
             {
-                self.projection_rail_state_mut(view_index).collapsed.insert(branch);
+                if self.projection_rail_state_mut(view_index).collapsed.insert(branch) {
+                    self.bump_sidebar_generation();
+                }
             } else {
                 self.focus_adjacent_rail(RailKind::Projection(view_index), -1);
             }
@@ -18755,7 +18791,9 @@ impl App {
                 && let Some(branch) = selected.as_ref().and_then(|row| row.branch)
                 && selected.as_ref().is_some_and(|row| !row.expanded)
             {
-                self.projection_rail_state_mut(view_index).collapsed.remove(&branch);
+                if self.projection_rail_state_mut(view_index).collapsed.remove(&branch) {
+                    self.bump_sidebar_generation();
+                }
             } else if !self.focus_adjacent_rail(RailKind::Projection(view_index), 1) {
                 self.focus = FocusTarget::Pane;
             }
@@ -18773,6 +18811,7 @@ impl App {
                 state.selected_action = Some(next.saturating_sub(rows.len()));
             }
             state.follow_selection = true;
+            self.bump_sidebar_generation();
             return Ok(RenderAction::Draw);
         }
         if matches!(key.code, KeyCode::Char(' '))
@@ -18782,6 +18821,7 @@ impl App {
             if !state.collapsed.remove(&branch) {
                 state.collapsed.insert(branch);
             }
+            self.bump_sidebar_generation();
             return Ok(RenderAction::Draw);
         }
         if key.code == KeyCode::Enter {
@@ -22623,12 +22663,14 @@ impl App {
                     if !state.collapsed.remove(&branch) {
                         state.collapsed.insert(branch);
                     }
+                    self.bump_sidebar_generation();
                 }
                 Hit::ProjectionRow { view, row, target } => {
                     let state = self.projection_rail_state_mut(view);
                     state.selected = row;
                     state.selected_action = None;
                     state.follow_selection = true;
+                    self.bump_sidebar_generation();
                     self.activate_projection_target(target)?;
                     self.focus = FocusTarget::Pane;
                 }
@@ -23769,12 +23811,18 @@ impl App {
             .entry(self.config.sidebar.active_profile.clone())
             .or_default();
         if visible {
-            hidden.remove(&view_id);
+            let changed = hidden.remove(&view_id);
             self.sidebar_visible = true;
+            if changed {
+                self.bump_sidebar_generation();
+            }
         } else {
-            hidden.insert(view_id);
+            let changed = hidden.insert(view_id);
             if hides_focused {
                 self.focus = FocusTarget::Pane;
+            }
+            if changed {
+                self.bump_sidebar_generation();
             }
         }
     }
@@ -23798,6 +23846,7 @@ impl App {
             })
             .collect();
         self.sidebar_visible = true;
+        self.bump_sidebar_generation();
         if let Some(focused_view) = focused_view {
             let hidden = self
                 .hidden_sidebar_views
@@ -46245,6 +46294,9 @@ mod tests {
             tabs_rail_scroll: 0,
             tabs_footer_scroll: 0,
             projection_rails: HashMap::new(),
+            projection_rows_cache: ProjectionRowsCache::default(),
+            agent_generation: 0,
+            sidebar_generation: 0,
             machine_rail_follow_selection: true,
             workspace_rail_follow_selection: true,
             tabs_rail_follow_selection: true,

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10352,25 +10352,31 @@ impl App {
         let collapsed = self
             .projection_rails
             .get(&spec.id)
-            .map(|state| &state.collapsed)
-            .unwrap_or(&empty_collapsed);
+            .map(|state| state.collapsed.clone())
+            .unwrap_or(empty_collapsed);
         let agents = self
             .projection_agents
             .as_ref()
             .filter(|_| includes_agents)
             .map_or(&[][..], |(_, agents)| agents.as_slice());
+        let rail_generation =
+            self.projection_rails.get(&spec.id).map_or(0, |state| state.rows_generation);
         let revision = ProjectionRevision {
             tree_workspace: self.tree.workspace_revision,
             tree_pane: self.tree.pane_revision,
-            agents: self.projection_agents_generation,
+            agents: spec.includes(SidebarResourceKind::Agents)
+                .then_some(self.projection_agents_generation),
+            selected_workspace: (!spec.includes(SidebarResourceKind::Workspaces))
+                .then_some(self.sidebar_workspace_selection)
+                .unwrap_or(0),
             sidebar: self.sidebar_generation,
+            rail: rail_generation,
         };
         let tree = &self.tree;
         let selected_workspace = self.sidebar_workspace_selection;
         self.projection_rows_cache.get_or_build(&spec.id, revision, || {
-            crate::sidebar_projection::rows(spec, tree, agents, selected_workspace, collapsed)
+            crate::sidebar_projection::rows(spec, tree, agents, selected_workspace, &collapsed)
         })
-            
     }
 
     pub(crate) fn sidebar_action_rows(&self, index: usize) -> Vec<SidebarActionRow> {
@@ -10473,6 +10479,11 @@ impl App {
 
     fn bump_sidebar_generation(&mut self) {
         self.sidebar_generation = self.sidebar_generation.saturating_add(1);
+    }
+
+    fn bump_projection_rows_generation(&mut self, index: usize) {
+        let state = self.projection_rail_state_mut(index);
+        state.rows_generation = state.rows_generation.saturating_add(1);
     }
 
     fn bump_agent_generation(&mut self) {
@@ -18804,7 +18815,7 @@ impl App {
                 && selected.as_ref().is_some_and(|row| row.expanded)
             {
                 if self.projection_rail_state_mut(view_index).collapsed.insert(branch) {
-                    self.bump_sidebar_generation();
+                    self.bump_projection_rows_generation(view_index);
                 }
             } else {
                 self.focus_adjacent_rail(RailKind::Projection(view_index), -1);
@@ -18817,7 +18828,7 @@ impl App {
                 && selected.as_ref().is_some_and(|row| !row.expanded)
             {
                 if self.projection_rail_state_mut(view_index).collapsed.remove(&branch) {
-                    self.bump_sidebar_generation();
+                    self.bump_projection_rows_generation(view_index);
                 }
             } else if !self.focus_adjacent_rail(RailKind::Projection(view_index), 1) {
                 self.focus = FocusTarget::Pane;
@@ -18846,7 +18857,7 @@ impl App {
             if !state.collapsed.remove(&branch) {
                 state.collapsed.insert(branch);
             }
-            self.bump_sidebar_generation();
+            self.bump_projection_rows_generation(view_index);
             return Ok(RenderAction::Draw);
         }
         if key.code == KeyCode::Enter {
@@ -22181,10 +22192,8 @@ impl App {
             let workspace_index = self.tree.active_workspace;
             let screen_index =
                 self.tree.active_workspace().map(|workspace| workspace.active_screen);
-            let changed = self
-                .tree
-                .active_screen()
-                .is_some_and(|screen| screen.active_pane != pane);
+            let changed =
+                self.tree.active_screen().is_some_and(|screen| screen.active_pane != pane);
             let focused = screen_index
                 .is_some_and(|screen| self.tree.set_active_pane(workspace_index, screen, pane));
             if focused {
@@ -22204,7 +22213,6 @@ impl App {
         delta: Option<isize>,
     ) {
         let pane = pane.or_else(|| self.active_pane());
-<<<<<<< HEAD
         if let Some(pane_id) = pane {
             let target = self.tree.pane(pane_id).and_then(|pane| {
                 if pane.tabs.is_empty() {
@@ -22278,7 +22286,6 @@ impl App {
                     self.bump_sidebar_generation();
                 }
             }
-        }
         }
         if selected && let Some(active) = self.active_pane() {
             self.pane_focus_history.record(active);
@@ -22718,7 +22725,7 @@ impl App {
                     if !state.collapsed.remove(&branch) {
                         state.collapsed.insert(branch);
                     }
-                    self.bump_sidebar_generation();
+                    self.bump_projection_rows_generation(view);
                 }
                 Hit::ProjectionRow { view, row, target } => {
                     let state = self.projection_rail_state_mut(view);
@@ -44344,7 +44351,8 @@ mod tests {
         let first_after = app.projection_rows_cache.revision_for("first-view").unwrap();
         let second_after = app.projection_rows_cache.revision_for("second-view").unwrap();
 
-        assert_ne!(first_before, first_after);
+        assert_ne!(first_before.rail, first_after.rail);
+        assert_eq!(first_before.sidebar, first_after.sidebar);
         assert_eq!(second_before, second_after);
 
         mux.close_surface(surface.id).unwrap();

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -23810,20 +23810,16 @@ impl App {
             .hidden_sidebar_views
             .entry(self.config.sidebar.active_profile.clone())
             .or_default();
+        let changed = if visible { hidden.remove(&view_id) } else { hidden.insert(view_id) };
         if visible {
-            let changed = hidden.remove(&view_id);
             self.sidebar_visible = true;
-            if changed {
-                self.bump_sidebar_generation();
-            }
         } else {
-            let changed = hidden.insert(view_id);
             if hides_focused {
                 self.focus = FocusTarget::Pane;
             }
-            if changed {
-                self.bump_sidebar_generation();
-            }
+        }
+        if changed {
+            self.bump_sidebar_generation();
         }
     }
 

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10367,9 +10367,11 @@ impl App {
             agents: spec
                 .includes(SidebarResourceKind::Agents)
                 .then_some(self.projection_agents_generation),
-            selected_workspace: (!spec.includes(SidebarResourceKind::Workspaces))
-                .then_some(self.sidebar_workspace_selection)
-                .unwrap_or(0),
+            selected_workspace: if !spec.includes(SidebarResourceKind::Workspaces) {
+                self.sidebar_workspace_selection
+            } else {
+                0
+            },
             sidebar: self.sidebar_generation,
             rail: rail_generation,
         };

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -18823,10 +18823,6 @@ impl App {
         let actions = self.sidebar_action_rows(view_index);
         {
             let state = self.projection_rail_state_mut(view_index);
-            state.selected_action = state
-                .selected_action
-                .map(|index| index.min(actions.len().saturating_sub(1)))
-                .filter(|_| !actions.is_empty());
             state.reconcile_selection(&rows);
         }
         let selectable_rows = rows.len().saturating_add(actions.len());

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44251,7 +44251,7 @@ mod tests {
 
         let first_screen_pane = app
             .tree
-            .workspaces
+            .workspaces()
             .first()
             .and_then(|workspace| workspace.screens.first())
             .map(|screen| screen.active_pane)
@@ -44442,7 +44442,7 @@ mod tests {
         app.projection_rows(1);
         let first_before = app.projection_rows_cache.revision_for("first-view").unwrap();
         let second_before = app.projection_rows_cache.revision_for("second-view").unwrap();
-        let workspace_id = app.tree.workspaces.first().unwrap().id;
+        let workspace_id = app.tree.workspaces().first().unwrap().id;
 
         app.projection_rail_state_mut(0)
             .collapsed

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -46709,6 +46709,7 @@ mod tests {
             projection_agents: None,
             projection_agents_generation: 0,
             projection_agents_builds: 0,
+            projection_collapsed_clones: 0,
             tab_locations: HashMap::new(),
             render_states: HashMap::<u64, RenderState>::new(),
             chrome_row_scratch: crate::ui::ReusableRowBuffer::default(),

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -25083,6 +25083,7 @@ mod tests {
         swept_viewport_size_leases, thumb_geometry, with_panic_stdout_lock,
         workspace_creation_selection,
     };
+    use crate::sidebar_projection::ProjectionRowsCache;
     use cmux_tui_core::{FrontendFocusTarget, FrontendJournalEvent};
     use crossbeam_channel::Receiver;
     use serde_json::Value;

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -18854,8 +18854,10 @@ impl App {
             let state = self.projection_rail_state_mut(view_index);
             if next < rows.len() {
                 state.selected = next;
+                state.selected_target = rows.get(next).map(|row| row.target);
                 state.selected_action = None;
             } else {
+                state.selected_target = None;
                 state.selected_action = Some(next.saturating_sub(rows.len()));
             }
             state.follow_selection = true;
@@ -22742,6 +22744,7 @@ impl App {
                 Hit::ProjectionRow { view, row, target } => {
                     let state = self.projection_rail_state_mut(view);
                     state.selected = row;
+                    state.selected_target = Some(target);
                     state.selected_action = None;
                     state.follow_selection = true;
                     self.bump_sidebar_generation();
@@ -22765,6 +22768,7 @@ impl App {
                                 .position(|candidate| candidate.target == action)
                                 .unwrap_or_default();
                             let state = self.projection_rail_state_mut(view);
+                            state.selected_target = None;
                             state.selected_action = Some(action_index);
                             state.follow_selection = true;
                         }

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -14283,7 +14283,7 @@ impl App {
         let valid_view_ids =
             self.config.sidebar.views.iter().map(|view| view.id.clone()).collect::<HashSet<_>>();
         self.projection_rails.retain(|id, _| valid_view_ids.contains(id));
-        self.projection_rows_cache.retain_view_ids(&valid_view_ids);
+        self.projection_rows_cache.invalidate();
         self.bump_sidebar_generation();
         self.projection_sidebar_width_overrides.retain(|id, _| valid_view_ids.contains(id));
         if let Some(id) = focused_projection_id {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -18808,6 +18808,14 @@ impl App {
         }
         let rows = self.projection_rows(view_index);
         let actions = self.sidebar_action_rows(view_index);
+        {
+            let state = self.projection_rail_state_mut(view_index);
+            state.selected_action = state
+                .selected_action
+                .map(|index| index.min(actions.len().saturating_sub(1)))
+                .filter(|_| !actions.is_empty());
+            state.reconcile_selection(&rows);
+        }
         let selectable_rows = rows.len().saturating_add(actions.len());
         let current = self
             .config

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -44252,6 +44252,105 @@ mod tests {
     }
 
     #[test]
+    fn projection_rows_scope_agent_revision_to_agent_views() {
+        let (mux, surface) = test_mux("projection-agent-revision-scope-test", None);
+        mux.report_agent(
+            surface.id,
+            AgentState::Working,
+            AgentSource::Hook,
+            Some("agent-session".into()),
+        )
+        .unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![
+            SidebarViewSpec {
+                id: "workspace-view".into(),
+                levels: vec![SidebarResourceKind::Workspaces],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+            SidebarViewSpec {
+                id: "agent-view".into(),
+                levels: vec![SidebarResourceKind::Agents],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+        ];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let workspace_before = app.projection_rows_cache.revision_for("workspace-view").unwrap();
+        let agent_before = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        app.bump_agent_generation();
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let workspace_after = app.projection_rows_cache.revision_for("workspace-view").unwrap();
+        let agent_after = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        assert_eq!(workspace_before, workspace_after);
+        assert_ne!(agent_before, agent_after);
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_scope_collapse_revision_to_its_rail() {
+        let (mux, surface) = test_mux("projection-sidebar-revision-scope-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![
+            SidebarViewSpec {
+                id: "first-view".into(),
+                levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+            SidebarViewSpec {
+                id: "second-view".into(),
+                levels: vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Panes],
+                actions: Vec::new(),
+                actions_position: crate::config::ActionsPosition::Bottom,
+                width: 40,
+                max_width: 0,
+                collapse_priority: 30,
+            },
+        ];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let first_before = app.projection_rows_cache.revision_for("first-view").unwrap();
+        let second_before = app.projection_rows_cache.revision_for("second-view").unwrap();
+        let workspace_id = app.tree.workspaces.first().unwrap().id;
+
+        app.projection_rail_state_mut(0)
+            .collapsed
+            .insert(crate::sidebar_projection::ProjectionBranch::Workspace(workspace_id));
+        app.bump_projection_rows_generation(0);
+        app.projection_rows(0);
+        app.projection_rows(1);
+        let first_after = app.projection_rows_cache.revision_for("first-view").unwrap();
+        let second_after = app.projection_rows_cache.revision_for("second-view").unwrap();
+
+        assert_ne!(first_before, first_after);
+        assert_eq!(second_before, second_after);
+
+        mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
     fn projection_stale_action_selection_does_not_retarget_resource_row() {
         let (mux, surface) = test_mux("projection-stale-action-selection-test", None);
         mux.report_agent(

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -10555,12 +10555,12 @@ impl App {
         if !self.prepare_pty_input_before_mutation() {
             return Ok(());
         }
-        let previous_surface = self.tree.active_surface();
+        let previous_focus = self.active_focus_state();
         if !self.tree.select_surface(target.surface) {
             return Ok(());
         }
         self.follow_sidebar_workspace(target.workspace);
-        if previous_surface != Some(target.surface) {
+        if previous_focus != self.active_focus_state() {
             self.bump_sidebar_generation();
         }
         self.pane_focus_history.record(target.pane);
@@ -13201,7 +13201,7 @@ impl App {
         else {
             return;
         };
-        let changed = self.tree.active_surface() != Some(surface);
+        let previous_focus = self.active_focus_state();
         self.tree.active_workspace = workspace_index;
         if !self.tree.set_active_screen(workspace_index, screen_index)
             || !self.tree.set_active_pane(workspace_index, screen_index, pane_id)
@@ -13209,7 +13209,7 @@ impl App {
         {
             return;
         }
-        if changed {
+        if previous_focus != self.active_focus_state() {
             self.bump_sidebar_generation();
         }
         self.pane_focus_history.record(pane_id);
@@ -16890,6 +16890,17 @@ impl App {
 
     fn active_surface(&self) -> Option<SurfaceId> {
         self.tree.active_surface()
+    }
+
+    fn active_focus_state(&self) -> Option<(usize, usize, PaneId, Option<usize>)> {
+        let workspace_index = self.tree.active_workspace;
+        let workspace = self.tree.active_workspace()?;
+        let screen_index = workspace.active_screen;
+        let screen = workspace.screens.get(screen_index)?;
+        let pane_id = screen.active_pane;
+        let pane = screen.panes.iter().find(|pane| pane.id == pane_id)?;
+        let active_tab = pane.tabs.get(pane.active_tab).map(|_| pane.active_tab);
+        Some((workspace_index, screen_index, pane_id, active_tab))
     }
 
     /// Adopt this client's own remembered focus from the mux (or the
@@ -44347,7 +44358,7 @@ mod tests {
         let workspace_before = app.projection_rows_cache.revision_for("workspace-view").unwrap();
         let agent_before = app.projection_rows_cache.revision_for("agent-view").unwrap();
 
-        app.bump_agent_generation();
+        app.bump_agent_generation(surface.id);
         app.projection_rows(0);
         app.projection_rows(1);
         let workspace_after = app.projection_rows_cache.revision_for("workspace-view").unwrap();
@@ -44406,6 +44417,37 @@ mod tests {
         assert_eq!(second_before, second_after);
 
         mux.close_surface(surface.id).unwrap();
+    }
+
+    #[test]
+    fn projection_rows_scope_agent_revision_to_selected_workspace() {
+        let (mux, first_surface) = test_mux("projection-agent-owner-scope-test", None);
+        let second_surface = mux.new_workspace(None, Some((80, 24))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.config.sidebar.columns.clear();
+        app.config.sidebar.views = vec![SidebarViewSpec {
+            id: "agent-view".into(),
+            levels: vec![SidebarResourceKind::Agents],
+            actions: Vec::new(),
+            actions_position: crate::config::ActionsPosition::Bottom,
+            width: 40,
+            max_width: 0,
+            collapse_priority: 30,
+        }];
+        app.config.sidebar.views_explicit = true;
+        app.replace_tree(app.session.tree());
+        app.sidebar_workspace_selection = 0;
+        app.projection_rows(0);
+        let before = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        app.bump_agent_generation(second_surface.id);
+        app.projection_rows(0);
+        let after = app.projection_rows_cache.revision_for("agent-view").unwrap();
+
+        assert_eq!(before, after);
+
+        mux.close_surface(first_surface.id).unwrap();
+        mux.close_surface(second_surface.id).unwrap();
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -94,6 +94,10 @@ pub(crate) struct ProjectionRowsCache {
 }
 
 impl ProjectionRowsCache {
+    pub(crate) fn invalidate(&mut self) {
+        self.entries.clear();
+    }
+
     pub(crate) fn get_or_build(
         &mut self,
         view_id: &str,
@@ -109,10 +113,6 @@ impl ProjectionRowsCache {
         self.entries
             .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
         rows
-    }
-
-    pub(crate) fn retain_view_ids(&mut self, view_ids: &HashSet<String>) {
-        self.entries.retain(|view_id, _| view_ids.contains(view_id));
     }
 }
 

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -72,6 +72,50 @@ impl Default for ProjectionRailState {
     }
 }
 
+/// Revisions that determine whether a projection row list is still valid.
+/// Tree and agent revisions come from the session snapshots, while the
+/// sidebar revision covers presentation state such as selection and collapse.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct ProjectionRevision {
+    pub tree_workspace: u64,
+    pub tree_pane: Option<u64>,
+    pub agents: u64,
+    pub sidebar: u64,
+}
+
+struct CachedProjectionRows {
+    revision: ProjectionRevision,
+    rows: Vec<ProjectionRow>,
+}
+
+#[derive(Default)]
+pub(crate) struct ProjectionRowsCache {
+    entries: HashMap<String, CachedProjectionRows>,
+}
+
+impl ProjectionRowsCache {
+    pub(crate) fn get_or_build(
+        &mut self,
+        view_id: &str,
+        revision: ProjectionRevision,
+        build: impl FnOnce() -> Vec<ProjectionRow>,
+    ) -> Vec<ProjectionRow> {
+        if let Some(cached) = self.entries.get(view_id)
+            && cached.revision == revision
+        {
+            return cached.rows.clone();
+        }
+        let rows = build();
+        self.entries
+            .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
+        rows
+    }
+
+    pub(crate) fn retain_view_ids(&mut self, view_ids: &HashSet<String>) {
+        self.entries.retain(|view_id, _| view_ids.contains(view_id));
+    }
+}
+
 #[derive(Clone, Copy)]
 struct ProjectionContext {
     workspace: usize,

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -430,4 +430,38 @@ mod tests {
         let rows = rows(&spec(vec![SidebarResourceKind::Agents]), &tree(), &[], 0, &HashSet::new());
         assert!(rows.is_empty());
     }
+
+    #[test]
+    fn projection_cache_reuses_rows_until_revision_changes() {
+        let tree = tree();
+        let view = spec(vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Tabs]);
+        let collapsed = HashSet::new();
+        let revision = ProjectionRevision {
+            tree_workspace: tree.workspace_revision,
+            tree_pane: tree.pane_revision,
+            agents: 3,
+            sidebar: 7,
+        };
+        let mut cache = ProjectionRowsCache::default();
+        let mut builds = 0;
+        let first = cache.get_or_build("tabs", revision, || {
+            builds += 1;
+            rows(&view, &tree, &[], 0, &collapsed)
+        });
+        let second = cache.get_or_build("tabs", revision, || {
+            builds += 1;
+            rows(&view, &tree, &[], 0, &collapsed)
+        });
+
+        assert_eq!(first, second);
+        assert_eq!(builds, 1);
+
+        let changed = ProjectionRevision { sidebar: 8, ..revision };
+        let third = cache.get_or_build("tabs", changed, || {
+            builds += 1;
+            rows(&view, &tree, &[], 0, &collapsed)
+        });
+        assert_eq!(third, first);
+        assert_eq!(builds, 2);
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -1,6 +1,7 @@
 //! Pure projection of mux resources into configurable native sidebar trees.
 
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use cmux_tui_core::{PaneId, SurfaceId, WorkspaceId};
 
@@ -94,7 +95,7 @@ pub(crate) struct ProjectionRevision {
 
 struct CachedProjectionRows {
     revision: ProjectionRevision,
-    rows: Vec<ProjectionRow>,
+    rows: Arc<[ProjectionRow]>,
 }
 
 #[derive(Default)]
@@ -103,24 +104,38 @@ pub(crate) struct ProjectionRowsCache {
 }
 
 impl ProjectionRowsCache {
+    /// Remove all rows so the next lookup rebuilds every view.
     pub(crate) fn invalidate(&mut self) {
         self.entries.clear();
     }
 
+    /// Return rows for a matching view and revision without cloning row data.
+    pub(crate) fn get(
+        &self,
+        view_id: &str,
+        revision: &ProjectionRevision,
+    ) -> Option<Arc<[ProjectionRow]>> {
+        let cached = self.entries.get(view_id)?;
+        (cached.revision == *revision).then(|| Arc::clone(&cached.rows))
+    }
+
+    /// Reuse rows for a matching revision, or build and cache a new list.
     pub(crate) fn get_or_build(
         &mut self,
         view_id: &str,
-        revision: ProjectionRevision,
+        revision: &ProjectionRevision,
         build: impl FnOnce() -> Vec<ProjectionRow>,
-    ) -> Vec<ProjectionRow> {
-        if let Some(cached) = self.entries.get(view_id)
-            && cached.revision == revision
-        {
-            return cached.rows.clone();
+    ) -> Arc<[ProjectionRow]> {
+        if let Some(rows) = self.get(view_id, revision) {
+            return rows;
         }
         let rows = build();
+        let rows = Arc::<[ProjectionRow]>::from(rows);
         self.entries
-            .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
+            .insert(
+                view_id.to_string(),
+                CachedProjectionRows { revision: *revision, rows: Arc::clone(&rows) },
+            );
         rows
     }
 
@@ -338,6 +353,7 @@ fn append_level(
 mod tests {
     use super::*;
     use cmux_tui_core::{Node, SurfaceKind};
+    use std::sync::Arc;
 
     use crate::session::tree::{PaneView, ScreenView, TabView, WorkspaceView};
 
@@ -504,24 +520,74 @@ mod tests {
         };
         let mut cache = ProjectionRowsCache::default();
         let mut builds = 0;
-        let first = cache.get_or_build("tabs", revision, || {
+        let first = cache.get_or_build("tabs", &revision, || {
             builds += 1;
             rows(&view, &tree, &[], 0, &collapsed)
         });
-        let second = cache.get_or_build("tabs", revision, || {
+        let second = cache.get_or_build("tabs", &revision, || {
             builds += 1;
             rows(&view, &tree, &[], 0, &collapsed)
         });
 
         assert_eq!(first, second);
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(cache.get("tabs", &revision).is_some_and(|rows| Arc::ptr_eq(&rows, &first)));
         assert_eq!(builds, 1);
 
         let changed = ProjectionRevision { sidebar: 8, ..revision };
-        let third = cache.get_or_build("tabs", changed, || {
+        let third = cache.get_or_build("tabs", &changed, || {
             builds += 1;
             rows(&view, &tree, &[], 0, &collapsed)
         });
         assert_eq!(third, first);
+        assert!(!Arc::ptr_eq(&third, &first));
         assert_eq!(builds, 2);
+    }
+
+    #[test]
+    fn projection_cache_invalidate_forces_a_rebuild() {
+        let revision = ProjectionRevision {
+            tree_workspace: 1,
+            tree_pane: Some(2),
+            agents: None,
+            selected_workspace: 0,
+            sidebar: 3,
+            rail: 4,
+        };
+        let mut cache = ProjectionRowsCache::default();
+        let mut builds = 0;
+        let first = cache.get_or_build("view", &revision, || {
+            builds += 1;
+            vec![ProjectionRow {
+                resource: SidebarResourceKind::Workspaces,
+                depth: 0,
+                name: "first".into(),
+                subtitle: String::new(),
+                agent_state: None,
+                active: false,
+                branch: None,
+                expanded: false,
+                target: ProjectionTarget::Workspace { index: 0, id: 1 },
+            }]
+        });
+        cache.invalidate();
+        let second = cache.get_or_build("view", &revision, || {
+            builds += 1;
+            vec![ProjectionRow {
+                resource: SidebarResourceKind::Workspaces,
+                depth: 0,
+                name: "second".into(),
+                subtitle: String::new(),
+                agent_state: None,
+                active: false,
+                branch: None,
+                expanded: false,
+                target: ProjectionTarget::Workspace { index: 0, id: 1 },
+            }]
+        });
+
+        assert_eq!(builds, 2);
+        assert_eq!(second[0].name, "second");
+        assert!(!Arc::ptr_eq(&first, &second));
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -131,11 +131,10 @@ impl ProjectionRowsCache {
         }
         let rows = build();
         let rows = Arc::<[ProjectionRow]>::from(rows);
-        self.entries
-            .insert(
-                view_id.to_string(),
-                CachedProjectionRows { revision: *revision, rows: Arc::clone(&rows) },
-            );
+        self.entries.insert(
+            view_id.to_string(),
+            CachedProjectionRows { revision: *revision, rows: Arc::clone(&rows) },
+        );
         rows
     }
 

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -57,6 +57,8 @@ pub(crate) struct ProjectionRailState {
     pub footer_scroll: usize,
     pub follow_selection: bool,
     pub collapsed: HashSet<ProjectionBranch>,
+    /// Revision for row-affecting presentation state in this rail.
+    pub rows_generation: u64,
 }
 
 impl Default for ProjectionRailState {
@@ -68,6 +70,7 @@ impl Default for ProjectionRailState {
             footer_scroll: 0,
             follow_selection: true,
             collapsed: HashSet::new(),
+            rows_generation: 0,
         }
     }
 }
@@ -79,8 +82,14 @@ impl Default for ProjectionRailState {
 pub(crate) struct ProjectionRevision {
     pub tree_workspace: u64,
     pub tree_pane: Option<u64>,
-    pub agents: u64,
+    /// Agent changes affect only views that include the Agents resource.
+    pub agents: Option<u64>,
+    /// Workspace selection affects flat views that need a workspace context.
+    pub selected_workspace: usize,
+    /// Selection and focus changes that affect every projection view.
     pub sidebar: u64,
+    /// Collapse changes are scoped to the projection rail being rendered.
+    pub rail: u64,
 }
 
 struct CachedProjectionRows {
@@ -488,8 +497,10 @@ mod tests {
         let revision = ProjectionRevision {
             tree_workspace: tree.workspace_revision,
             tree_pane: tree.pane_revision,
-            agents: 3,
+            agents: Some(3),
+            selected_workspace: 0,
             sidebar: 7,
+            rail: 0,
         };
         let mut cache = ProjectionRowsCache::default();
         let mut builds = 0;

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -114,6 +114,11 @@ impl ProjectionRowsCache {
             .insert(view_id.to_string(), CachedProjectionRows { revision, rows: rows.clone() });
         rows
     }
+
+    #[cfg(test)]
+    pub(crate) fn revision_for(&self, view_id: &str) -> Option<ProjectionRevision> {
+        self.entries.get(view_id).map(|entry| entry.revision)
+    }
 }
 
 #[derive(Clone, Copy)]

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -91,6 +91,17 @@ impl Default for ProjectionRailState {
 }
 
 impl ProjectionRailState {
+    /// Keep action selection valid when the current view changes its actions.
+    /// An unavailable action remains in action mode until navigation chooses a
+    /// new item, so input cannot fall through to a resource row.
+    pub(crate) fn reconcile_action_selection(&mut self, action_count: usize) {
+        if let Some(index) = self.selected_action
+            && let Some(last) = action_count.checked_sub(1)
+        {
+            self.selected_action = Some(index.min(last));
+        }
+    }
+
     /// Keep resource selection attached to its target when rows reorder.
     pub(crate) fn reconcile_selection(&mut self, rows: &[ProjectionRow]) {
         if self.selected_action.is_some() {

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -202,9 +202,7 @@ pub(crate) fn rows(
     let agent_order = if spec.includes(SidebarResourceKind::Agents) {
         let mut order = agents
             .iter()
-            .map(|agent| {
-                (agent.surface, (agent_attention(&agent.state), agent.updated_at_ms))
-            })
+            .map(|agent| (agent.surface, (agent_attention(&agent.state), agent.updated_at_ms)))
             .collect::<HashMap<_, _>>();
         let mut indexed = tree
             .workspaces()
@@ -686,9 +684,7 @@ mod tests {
         state.reconcile_selection(&initial);
 
         let mut moved_tree = tree.clone();
-        moved_tree.workspaces_mut()[0].screens[0].panes[0]
-            .tabs
-            .insert(0, tab(7, "moved before"));
+        moved_tree.workspaces_mut()[0].screens[0].panes[0].tabs.insert(0, tab(7, "moved before"));
         let reordered = rows(
             &spec,
             &moved_tree,

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -96,15 +96,14 @@ impl ProjectionRailState {
         if self.selected_action.is_some() {
             return;
         }
-        if let Some(target) = self.selected_target {
-            if let Some(index) = rows
+        if let Some(target) = self.selected_target
+            && let Some(index) = rows
                 .iter()
                 .position(|row| row.target == target)
                 .or_else(|| rows.iter().position(|row| row.target.same_resource(target)))
-            {
-                self.selected = index;
-                return;
-            }
+        {
+            self.selected = index;
+            return;
         }
         self.selected = self.selected.min(rows.len().saturating_sub(1));
         self.selected_target = rows.get(self.selected).map(|row| row.target);

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -212,16 +212,12 @@ pub(crate) fn rows(
             .flat_map(|pane| pane.tabs.iter())
             .enumerate()
             .filter_map(|(index, tab)| {
-                order
-                    .remove(&tab.surface)
-                    .map(|(attention, updated_at_ms)| {
-                        (u8::MAX - attention, u64::MAX - updated_at_ms, index, tab.surface)
-                    })
+                order.remove(&tab.surface).map(|(attention, updated_at_ms)| {
+                    (u8::MAX - attention, u64::MAX - updated_at_ms, index, tab.surface)
+                })
             })
             .collect::<Vec<_>>();
-        indexed.sort_unstable_by_key(|&(attention, recency, index, _)| {
-            (attention, recency, index)
-        });
+        indexed.sort_unstable_by_key(|&(attention, recency, index, _)| (attention, recency, index));
         indexed.into_iter().map(|(_, _, _, surface)| surface).collect::<Vec<_>>()
     } else {
         Vec::new()
@@ -625,13 +621,8 @@ mod tests {
                 updated_at_ms: 30,
             },
         ];
-        let rows = rows(
-            &spec(vec![SidebarResourceKind::Agents]),
-            &tree,
-            &agents,
-            0,
-            &HashSet::new(),
-        );
+        let rows =
+            rows(&spec(vec![SidebarResourceKind::Agents]), &tree, &agents, 0, &HashSet::new());
 
         assert_eq!(
             rows.iter().map(|row| row.target).collect::<Vec<_>>(),

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -202,7 +202,9 @@ pub(crate) fn rows(
     let agent_order = if spec.includes(SidebarResourceKind::Agents) {
         let mut order = agents
             .iter()
-            .map(|agent| (agent.surface, agent_attention(&agent.state), agent.updated_at_ms))
+            .map(|agent| {
+                (agent.surface, (agent_attention(&agent.state), agent.updated_at_ms))
+            })
             .collect::<HashMap<_, _>>();
         let mut indexed = tree
             .workspaces()
@@ -597,7 +599,7 @@ mod tests {
     #[test]
     fn agent_view_orders_blocked_before_working_then_by_recency() {
         let mut tree = tree();
-        tree.workspaces[0].screens[0].panes[0].tabs.push(tab(6, "new blocked"));
+        tree.workspaces_mut()[0].screens[0].panes[0].tabs.push(tab(6, "new blocked"));
         let agents = vec![
             AgentInfo {
                 surface: 4,
@@ -658,7 +660,7 @@ mod tests {
     #[test]
     fn projection_selection_follows_target_when_agent_rows_reorder() {
         let mut tree = tree();
-        tree.workspaces[0].screens[0].panes[0].tabs.push(tab(6, "new blocked"));
+        tree.workspaces_mut()[0].screens[0].panes[0].tabs.push(tab(6, "new blocked"));
         let agents = |states: [(&str, u64); 3]| {
             [4, 5, 6]
                 .into_iter()
@@ -684,7 +686,9 @@ mod tests {
         state.reconcile_selection(&initial);
 
         let mut moved_tree = tree.clone();
-        moved_tree.workspaces[0].screens[0].panes[0].tabs.insert(0, tab(7, "moved before"));
+        moved_tree.workspaces_mut()[0].screens[0].panes[0]
+            .tabs
+            .insert(0, tab(7, "moved before"));
         let reordered = rows(
             &spec,
             &moved_tree,

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -324,7 +324,7 @@ fn append_level(
         }
         SidebarResourceKind::Tabs | SidebarResourceKind::Agents => {
             let agent_only = resource == SidebarResourceKind::Agents;
-            let mut agent_entries = HashMap::<SurfaceId, ProjectionRow>::new();
+            let mut agent_entries = Vec::<(SurfaceId, ProjectionRow)>::new();
             let workspace_index = context.map_or(selected_workspace, |context| context.workspace);
             let Some(workspace) = tree.workspaces().get(workspace_index) else { return };
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
@@ -385,17 +385,23 @@ fn append_level(
                             },
                         };
                         if agent_only {
-                            agent_entries.insert(tab.surface, row);
+                            agent_entries.push((tab.surface, row));
                         } else {
                             output.push(row);
                         }
                     }
                 }
             }
-            for surface in agent_order {
-                if let Some(row) = agent_entries.remove(surface) {
-                    output.push(row);
-                }
+            if agent_only {
+                let order_index = agent_order
+                    .iter()
+                    .enumerate()
+                    .map(|(index, surface)| (*surface, index))
+                    .collect::<HashMap<_, _>>();
+                agent_entries.sort_by_key(|(surface, _)| {
+                    order_index.get(surface).copied().unwrap_or(usize::MAX)
+                });
+                output.extend(agent_entries.into_iter().map(|(_, row)| row));
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -222,6 +222,11 @@ pub(crate) fn rows(
     } else {
         Vec::new()
     };
+    let agent_order_index = agent_order
+        .iter()
+        .enumerate()
+        .map(|(index, surface)| (*surface, index))
+        .collect::<HashMap<_, _>>();
     append_level(
         &mut rows,
         &spec.levels,
@@ -229,7 +234,7 @@ pub(crate) fn rows(
         None,
         tree,
         &agents_by_surface,
-        &agent_order,
+        &agent_order_index,
         selected_workspace.min(tree.workspaces().len().saturating_sub(1)),
         collapsed,
     );
@@ -255,7 +260,7 @@ fn append_level(
     context: Option<ProjectionContext>,
     tree: &TreeView,
     agents: &HashMap<SurfaceId, &AgentInfo>,
-    agent_order: &[SurfaceId],
+    agent_order_index: &HashMap<SurfaceId, usize>,
     selected_workspace: usize,
     collapsed: &HashSet<ProjectionBranch>,
 ) {
@@ -293,7 +298,7 @@ fn append_level(
                         }),
                         tree,
                         agents,
-                        agent_order,
+                        agent_order_index,
                         selected_workspace,
                         collapsed,
                     );
@@ -345,7 +350,7 @@ fn append_level(
                             }),
                             tree,
                             agents,
-                            agent_order,
+                            agent_order_index,
                             selected_workspace,
                             collapsed,
                         );
@@ -424,13 +429,8 @@ fn append_level(
                 }
             }
             if agent_only {
-                let order_index = agent_order
-                    .iter()
-                    .enumerate()
-                    .map(|(index, surface)| (*surface, index))
-                    .collect::<HashMap<_, _>>();
                 agent_entries.sort_by_key(|(surface, _)| {
-                    order_index.get(surface).copied().unwrap_or(usize::MAX)
+                    agent_order_index.get(surface).copied().unwrap_or(usize::MAX)
                 });
                 output.extend(agent_entries.into_iter().map(|(_, row)| row));
             }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -505,6 +505,72 @@ mod tests {
     }
 
     #[test]
+    fn agent_view_orders_blocked_before_working_then_by_recency() {
+        let mut tree = tree();
+        tree.workspaces[0].screens[0].panes[0].tabs.push(tab(6, "new blocked"));
+        let agents = vec![
+            AgentInfo {
+                surface: 4,
+                state: "working".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 20,
+            },
+            AgentInfo {
+                surface: 5,
+                state: "blocked".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 1,
+            },
+            AgentInfo {
+                surface: 6,
+                state: "blocked".into(),
+                source: "hook".into(),
+                session: None,
+                updated_at_ms: 30,
+            },
+        ];
+        let rows = rows(
+            &spec(vec![SidebarResourceKind::Agents]),
+            &tree,
+            &agents,
+            0,
+            &HashSet::new(),
+        );
+
+        assert_eq!(
+            rows.iter().map(|row| row.target).collect::<Vec<_>>(),
+            vec![
+                ProjectionTarget::Surface {
+                    workspace: 0,
+                    screen: 0,
+                    pane: 3,
+                    index: 2,
+                    surface: 6,
+                    agent: true,
+                },
+                ProjectionTarget::Surface {
+                    workspace: 0,
+                    screen: 0,
+                    pane: 3,
+                    index: 1,
+                    surface: 5,
+                    agent: true,
+                },
+                ProjectionTarget::Surface {
+                    workspace: 0,
+                    screen: 0,
+                    pane: 3,
+                    index: 0,
+                    surface: 4,
+                    agent: true,
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn projection_cache_reuses_rows_until_revision_changes() {
         let tree = tree();
         let view = spec(vec![SidebarResourceKind::Workspaces, SidebarResourceKind::Tabs]);

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -694,7 +694,7 @@ mod tests {
         );
         state.reconcile_selection(&reordered);
         assert_eq!(state.selected, 2);
-        assert_eq!(reordered[state.selected].target, initial[1].target);
+        assert!(reordered[state.selected].target.same_resource(initial[1].target));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -164,6 +164,33 @@ pub(crate) fn rows(
     let mut rows = Vec::with_capacity(tree.workspaces().len());
     let agents_by_surface: HashMap<SurfaceId, &AgentInfo> =
         agents.iter().map(|agent| (agent.surface, agent)).collect();
+    let agent_order = if spec.includes(SidebarResourceKind::Agents) {
+        let mut order = agents
+            .iter()
+            .map(|agent| (agent.surface, agent_attention(&agent.state), agent.updated_at_ms))
+            .collect::<HashMap<_, _>>();
+        let mut indexed = tree
+            .workspaces()
+            .iter()
+            .flat_map(|workspace| workspace.screens.iter())
+            .flat_map(|screen| screen.panes.iter())
+            .flat_map(|pane| pane.tabs.iter())
+            .enumerate()
+            .filter_map(|(index, tab)| {
+                order
+                    .remove(&tab.surface)
+                    .map(|(attention, updated_at_ms)| {
+                        (u8::MAX - attention, u64::MAX - updated_at_ms, index, tab.surface)
+                    })
+            })
+            .collect::<Vec<_>>();
+        indexed.sort_unstable_by_key(|&(attention, recency, index, _)| {
+            (attention, recency, index)
+        });
+        indexed.into_iter().map(|(_, _, _, surface)| surface).collect::<Vec<_>>()
+    } else {
+        Vec::new()
+    };
     append_level(
         &mut rows,
         &spec.levels,
@@ -171,10 +198,22 @@ pub(crate) fn rows(
         None,
         tree,
         &agents_by_surface,
+        &agent_order,
         selected_workspace.min(tree.workspaces().len().saturating_sub(1)),
         collapsed,
     );
     rows
+}
+
+/// Return the herdr-style attention rank used by agent rows. Higher values
+/// sort first, while the original tree order breaks ties.
+fn agent_attention(state: &str) -> u8 {
+    match state {
+        "blocked" => 4,
+        "idle" => 3,
+        "working" => 2,
+        _ => 0,
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -185,6 +224,7 @@ fn append_level(
     context: Option<ProjectionContext>,
     tree: &TreeView,
     agents: &HashMap<SurfaceId, &AgentInfo>,
+    agent_order: &[SurfaceId],
     selected_workspace: usize,
     collapsed: &HashSet<ProjectionBranch>,
 ) {
@@ -222,6 +262,7 @@ fn append_level(
                         }),
                         tree,
                         agents,
+                        agent_order,
                         selected_workspace,
                         collapsed,
                     );
@@ -273,6 +314,7 @@ fn append_level(
                             }),
                             tree,
                             agents,
+                            agent_order,
                             selected_workspace,
                             collapsed,
                         );
@@ -282,6 +324,7 @@ fn append_level(
         }
         SidebarResourceKind::Tabs | SidebarResourceKind::Agents => {
             let agent_only = resource == SidebarResourceKind::Agents;
+            let mut agent_entries = HashMap::<SurfaceId, ProjectionRow>::new();
             let workspace_index = context.map_or(selected_workspace, |context| context.workspace);
             let Some(workspace) = tree.workspaces().get(workspace_index) else { return };
             for (screen_index, screen) in workspace.screens.iter().enumerate() {
@@ -318,7 +361,7 @@ fn append_level(
                         } else {
                             pane.short_id.clone()
                         };
-                        output.push(ProjectionRow {
+                        let row = ProjectionRow {
                             resource,
                             depth: depth as u16,
                             name,
@@ -340,8 +383,18 @@ fn append_level(
                                 surface: tab.surface,
                                 agent: agent_only,
                             },
-                        });
+                        };
+                        if agent_only {
+                            agent_entries.insert(tab.surface, row);
+                        } else {
+                            output.push(row);
+                        }
                     }
+                }
+            }
+            for surface in agent_order {
+                if let Some(row) = agent_entries.remove(surface) {
+                    output.push(row);
                 }
             }
         }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_projection.rs
@@ -35,6 +35,17 @@ pub(crate) enum ProjectionTarget {
     },
 }
 
+impl ProjectionTarget {
+    fn same_resource(self, other: Self) -> bool {
+        match (self, other) {
+            (Self::Workspace { id: lhs, .. }, Self::Workspace { id: rhs, .. }) => lhs == rhs,
+            (Self::Pane { pane: lhs, .. }, Self::Pane { pane: rhs, .. }) => lhs == rhs,
+            (Self::Surface { surface: lhs, .. }, Self::Surface { surface: rhs, .. }) => lhs == rhs,
+            _ => false,
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ProjectionRow {
     pub resource: SidebarResourceKind,
@@ -53,6 +64,8 @@ pub(crate) struct ProjectionRailState {
     /// Selected resource-row index. Action selection is tracked separately so
     /// live resource insertions cannot retarget a pinned action.
     pub selected: usize,
+    /// Stable identity for the selected resource row across live reordering.
+    pub selected_target: Option<ProjectionTarget>,
     pub selected_action: Option<usize>,
     pub scroll: usize,
     pub footer_scroll: usize,
@@ -66,6 +79,7 @@ impl Default for ProjectionRailState {
     fn default() -> Self {
         Self {
             selected: 0,
+            selected_target: None,
             selected_action: None,
             scroll: 0,
             footer_scroll: 0,
@@ -73,6 +87,27 @@ impl Default for ProjectionRailState {
             collapsed: HashSet::new(),
             rows_generation: 0,
         }
+    }
+}
+
+impl ProjectionRailState {
+    /// Keep resource selection attached to its target when rows reorder.
+    pub(crate) fn reconcile_selection(&mut self, rows: &[ProjectionRow]) {
+        if self.selected_action.is_some() {
+            return;
+        }
+        if let Some(target) = self.selected_target {
+            if let Some(index) = rows
+                .iter()
+                .position(|row| row.target == target)
+                .or_else(|| rows.iter().position(|row| row.target.same_resource(target)))
+            {
+                self.selected = index;
+                return;
+            }
+        }
+        self.selected = self.selected.min(rows.len().saturating_sub(1));
+        self.selected_target = rows.get(self.selected).map(|row| row.target);
     }
 }
 
@@ -627,6 +662,48 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn projection_selection_follows_target_when_agent_rows_reorder() {
+        let mut tree = tree();
+        tree.workspaces[0].screens[0].panes[0].tabs.push(tab(6, "new blocked"));
+        let agents = |states: [(&str, u64); 3]| {
+            [4, 5, 6]
+                .into_iter()
+                .zip(states)
+                .map(|(surface, (state, updated_at_ms))| AgentInfo {
+                    surface,
+                    state: state.into(),
+                    source: "hook".into(),
+                    session: None,
+                    updated_at_ms,
+                })
+                .collect::<Vec<_>>()
+        };
+        let spec = spec(vec![SidebarResourceKind::Agents]);
+        let initial = rows(
+            &spec,
+            &tree,
+            &agents([("working", 30), ("working", 20), ("working", 10)]),
+            0,
+            &HashSet::new(),
+        );
+        let mut state = ProjectionRailState { selected: 1, ..Default::default() };
+        state.reconcile_selection(&initial);
+
+        let mut moved_tree = tree.clone();
+        moved_tree.workspaces[0].screens[0].panes[0].tabs.insert(0, tab(7, "moved before"));
+        let reordered = rows(
+            &spec,
+            &moved_tree,
+            &agents([("blocked", 1), ("working", 20), ("blocked", 40)]),
+            0,
+            &HashSet::new(),
+        );
+        state.reconcile_selection(&reordered);
+        assert_eq!(state.selected, 2);
+        assert_eq!(reordered[state.selected].target, initial[1].target);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -339,6 +339,7 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
     let selectable_rows = rows.len().saturating_add(actions.len());
     let (selected, viewport) = {
         let state = app.projection_rail_state_mut(view_index);
+        state.reconcile_action_selection(actions.len());
         state.reconcile_selection(&rows);
         let selected = state
             .selected_action

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -339,11 +339,11 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
     let selectable_rows = rows.len().saturating_add(actions.len());
     let (selected, viewport) = {
         let state = app.projection_rail_state_mut(view_index);
-        state.selected = state.selected.min(rows.len().saturating_sub(1));
         state.selected_action = state
             .selected_action
             .map(|index| index.min(actions.len().saturating_sub(1)))
             .filter(|_| !actions.is_empty());
+        state.reconcile_selection(&rows);
         let selected = state
             .selected_action
             .map(|index| rows.len().saturating_add(index))

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -339,10 +339,6 @@ pub fn draw_projection(app: &mut App, frame: &mut Frame, view_index: usize) {
     let selectable_rows = rows.len().saturating_add(actions.len());
     let (selected, viewport) = {
         let state = app.projection_rail_state_mut(view_index);
-        state.selected_action = state
-            .selected_action
-            .map(|index| index.min(actions.len().saturating_sub(1)))
-            .filter(|_| !actions.is_empty());
         state.reconcile_selection(&rows);
         let selected = state
             .selected_action


### PR DESCRIPTION
Summary
- Fold the agent snapshot and projection-row caches onto current main.
- Preserve stable resource identity and monotonic generation invalidation.
- Validate all selection setters before mutating active workspace state.

Verification
- Red test e1e7025d19.
- Fix 8dbca64383.
- Projection cache tests 3 passed.
- Stale-selection test 1 passed.
- Clippy and fmt pass on Blacksmith.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Caches projection rows and active-agent snapshots in `cmux-tui` so unchanged redraws reuse immutable rows without missing topology, focus, selection, collapse, or agent updates. Agent rows now sort by attention and recency, rail selection follows a stable target identity across reordering, and stale surface selections are rejected atomically instead of partially mutating the active workspace.

**Implementation**

- Uses monotonic revisions scoped per view and per projection rail so invalidation only rebuilds affected rows.
- Rebuilds active-agent data only after topology or agent events, excluding completed and unknown agents.
- Preserves selection by target identity rather than row index, keeps action mode pinned when a view's actions change, and rejects stale surface targets before mutating state.
- Adds regression coverage for cache reuse, scoped invalidation, agent ordering, active-row refreshes, action-mode preservation, and stale selection failures.

<sup>Written for commit 87316ccede3890768706e71a5c7b62bec435bc59. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

