### PR TITLE
refactor(cmux-tui): share stack row allocation

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/layout.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/layout.rs
@@ -704,47 +704,40 @@ fn walk_viewport_stack(
     owner: ViewportColumn,
     out: &mut ViewportLayoutResult,
 ) {
-    let expanded_index = panes.iter().position(|pane| *pane == expanded).unwrap_or(panes.len() - 1);
-    let visible_headers = usize::from(area.height.saturating_sub(1)).min(panes.len() - 1);
-    let available_before = expanded_index;
-    let available_after = panes.len() - expanded_index - 1;
-    let mut headers_before = 0;
-    let mut headers_after = 0;
-    while headers_before + headers_after < visible_headers {
-        let can_take_before = headers_before < available_before;
-        let can_take_after = headers_after < available_after;
-        if can_take_before && (!can_take_after || headers_before <= headers_after) {
-            headers_before += 1;
-        } else if can_take_after {
-            headers_after += 1;
-        } else {
-            break;
-        }
-    }
-    let expanded_height = area.height.saturating_sub((headers_before + headers_after) as u16);
-
     let mut y = area.y;
-    for (index, pane) in panes.iter().copied().enumerate() {
-        let height = if index == expanded_index {
-            expanded_height
-        } else if index >= expanded_index - headers_before && index < expanded_index
-            || index > expanded_index && index <= expanded_index + headers_after
-        {
-            1
-        } else {
-            0
-        };
+    walk_stack_rows(panes, expanded, area.height, |_, pane, height, is_expanded| {
         record_viewport_pane(out, owner, pane, VirtualRect { y, height, ..area });
-        if height == 1 && index != expanded_index {
+        if height == 1 && !is_expanded {
             out.stacked_headers.insert(pane);
         }
         y = y.saturating_add(height);
-    }
+    });
 }
 
 fn walk_stack(panes: &[PaneId], expanded: PaneId, area: Rect, out: &mut LayoutResult) {
+    let mut y = area.y;
+    walk_stack_rows(panes, expanded, area.height, |_, pane, height, is_expanded| {
+        out.panes.push((pane, Rect { y, height, ..area }));
+        if height == 1 && !is_expanded {
+            out.stacked_headers.insert(pane);
+        }
+        y = y.saturating_add(height);
+    });
+}
+
+/// Visit each pane in a stack with its allocated row height.
+///
+/// Keeping row allocation in one traversal ensures normal and viewport
+/// layouts expose the same expanded pane and header ordering.
+fn walk_stack_rows(
+    panes: &[PaneId],
+    expanded: PaneId,
+    area_height: u16,
+    mut visit: impl FnMut(usize, PaneId, u16, bool),
+) {
+    debug_assert!(!panes.is_empty());
     let expanded_index = panes.iter().position(|pane| *pane == expanded).unwrap_or(panes.len() - 1);
-    let visible_headers = usize::from(area.height.saturating_sub(1)).min(panes.len() - 1);
+    let visible_headers = usize::from(area_height.saturating_sub(1)).min(panes.len() - 1);
     let available_before = expanded_index;
     let available_after = panes.len() - expanded_index - 1;
     let mut headers_before = 0;
@@ -760,9 +753,7 @@ fn walk_stack(panes: &[PaneId], expanded: PaneId, area: Rect, out: &mut LayoutRe
             break;
         }
     }
-    let expanded_height = area.height.saturating_sub((headers_before + headers_after) as u16);
-
-    let mut y = area.y;
+    let expanded_height = area_height.saturating_sub((headers_before + headers_after) as u16);
     for (index, pane) in panes.iter().copied().enumerate() {
         let height = if index == expanded_index {
             expanded_height
@@ -773,11 +764,7 @@ fn walk_stack(panes: &[PaneId], expanded: PaneId, area: Rect, out: &mut LayoutRe
         } else {
             0
         };
-        out.panes.push((pane, Rect { y, height, ..area }));
-        if height == 1 && index != expanded_index {
-            out.stacked_headers.insert(pane);
-        }
-        y = y.saturating_add(height);
+        visit(index, pane, height, index == expanded_index);
     }
 }
 


### PR DESCRIPTION
Summary:
- centralize stack row height and header allocation for tiled and viewport layouts
- preserve expanded-pane ordering and public layout APIs

Verification:
- rustfmt --edition 2024 --check cmux-tui/crates/cmux-tui-core/src/layout.rs
- git diff --check
- cargo tests require Blacksmith Testbox per repository policy

The helper follows Ratatui immediate-rendering guidance by keeping frame geometry decisions in one deterministic traversal.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes stack row height and header allocation for tiled and viewport layouts in `cmux-tui` so both paths share the same ordering and expanded-pane behavior.

- Extracts the row allocation logic into a shared `walk_stack_rows` helper.
- Preserves existing expanded-pane ordering and public layout APIs.

<sup>Written for commit 8729fe96d84250e72e38b7e5155f335a4cad9b98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11867?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified stacked layout calculations to improve consistency when arranging panes and collapsed stack headers.
  * Preserved existing layout behavior while reducing duplicated processing behind the scenes.
  * No visible interface changes are included in this update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->