### PR TITLE
fix: fail closed on same-TTY process attribution

### DIFF
--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -264,9 +264,18 @@ final class CmuxTopProcessSnapshot: @unchecked Sendable {
     /// controlling TTY of the terminal it was launched from, so a detached REPL or dev
     /// server would otherwise be summed into the surface's memory.
     /// See https://github.com/manaflow-ai/cmux/issues/11004.
+    ///
+    /// - Parameters:
+    ///   - ttyPIDs: every PID sharing the surface's TTY device.
+    ///   - surfaceID: the surface being annotated, when it has an identifier.
+    ///   - cmuxOwnedPIDs: the window's app processes and their descendants, used as launch
+    ///     evidence for a process whose parent sits off the TTY.
+    ///   - provenPIDs: PIDs already proven through the cmux-scoped process tree.
+    /// - Returns: the proven set, the unattributed set, and the reason for each PID.
     func ttyOwnership(
         ttyPIDs: Set<Int>,
         surfaceID: UUID?,
+        cmuxOwnedPIDs: Set<Int>,
         provenPIDs: Set<Int> = []
     ) -> CmuxTopTTYOwnership {
         var ownershipProcesses: [Int: CmuxTopTTYOwnershipProcess] = [:]
@@ -280,7 +289,7 @@ final class CmuxTopProcessSnapshot: @unchecked Sendable {
                 cmuxSurfaceID: process.cmuxSurfaceID
             )
         }
-        return CmuxTopTTYOwnershipResolver.resolve(
+        return CmuxTopTTYOwnershipResolver(cmuxOwnedPIDs: cmuxOwnedPIDs).resolve(
             candidates: ttyPIDs,
             processes: ownershipProcesses,
             surfaceID: surfaceID,

--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -257,6 +257,37 @@ final class CmuxTopProcessSnapshot: @unchecked Sendable {
         Set(pidsByCMUXSurfaceID[surfaceID] ?? [])
     }
 
+    /// Splits a surface's TTY population into processes cmux can prove it owns and
+    /// processes that merely share the TTY device.
+    ///
+    /// Sharing a TTY is not ownership: a process reparented to launchd keeps the
+    /// controlling TTY of the terminal it was launched from, so a detached REPL or dev
+    /// server would otherwise be summed into the surface's memory.
+    /// See https://github.com/manaflow-ai/cmux/issues/11004.
+    func ttyOwnership(
+        ttyPIDs: Set<Int>,
+        surfaceID: UUID?,
+        provenPIDs: Set<Int> = []
+    ) -> CmuxTopTTYOwnership {
+        var ownershipProcesses: [Int: CmuxTopTTYOwnershipProcess] = [:]
+        ownershipProcesses.reserveCapacity(ttyPIDs.count)
+        for pid in ttyPIDs {
+            guard let process = processesByPID[pid] else { continue }
+            ownershipProcesses[pid] = CmuxTopTTYOwnershipProcess(
+                pid: process.pid,
+                parentPID: process.parentPID,
+                processGroupID: process.processGroupID,
+                cmuxSurfaceID: process.cmuxSurfaceID
+            )
+        }
+        return CmuxTopTTYOwnershipResolver.resolve(
+            candidates: ttyPIDs,
+            processes: ownershipProcesses,
+            surfaceID: surfaceID,
+            provenPIDs: provenPIDs
+        )
+    }
+
     func pids(forProcessGroupID processGroupID: Int) -> Set<Int> {
         Set(pidsByProcessGroupID[processGroupID] ?? [])
     }

--- a/Sources/CmuxTopTTYOwnership.swift
+++ b/Sources/CmuxTopTTYOwnership.swift
@@ -15,8 +15,8 @@ enum CmuxTopTTYOwnershipReason: String, Sendable, CaseIterable {
     /// The process was already proven through the surface's cmux-scoped process tree.
     case surfaceProcessTree = "surface-process-tree"
 
-    /// The process entered this TTY from outside it — its parent is alive and off the TTY,
-    /// which is how the shell cmux forked for the surface looks.
+    /// The process was launched onto this TTY by a cmux-owned process off the TTY, which
+    /// is how the shell cmux forks for a surface looks.
     case ttySessionRoot = "tty-session-root"
 
     /// The process descends from a proven owner on this TTY.
@@ -33,11 +33,17 @@ enum CmuxTopTTYOwnershipReason: String, Sendable, CaseIterable {
 
 /// The minimum a process has to expose for TTY ownership to be decidable.
 struct CmuxTopTTYOwnershipProcess: Sendable, Equatable {
+    /// The process identifier.
     let pid: Int
+    /// The parent process identifier. `1` means launchd, i.e. the process was reparented
+    /// and its parent link no longer says who started it.
     let parentPID: Int
+    /// The process group identifier, when the snapshot could read one.
     let processGroupID: Int?
+    /// The cmux surface named by the process's `CMUX_*` environment scope, when present.
     let cmuxSurfaceID: UUID?
 
+    /// Creates the process facts used to decide TTY ownership.
     init(pid: Int, parentPID: Int, processGroupID: Int?, cmuxSurfaceID: UUID?) {
         self.pid = pid
         self.parentPID = parentPID
@@ -69,8 +75,26 @@ struct CmuxTopTTYOwnership: Sendable {
     }
 }
 
-enum CmuxTopTTYOwnershipResolver {
+/// Decides which processes on a surface's TTY the surface actually owns.
+///
+/// Attribution fails closed: a PID is charged to the surface only when the snapshot
+/// carries positive evidence for it, so an unrelated detached workload that merely
+/// inherited the TTY is reported rather than summed into cmux's memory.
+struct CmuxTopTTYOwnershipResolver {
+    /// PIDs known to belong to cmux — the window's app processes and their descendants.
+    /// A process launched onto the TTY by one of these is a surface root; without this
+    /// evidence an off-TTY parent proves nothing.
+    private let cmuxOwnedPIDs: Set<Int>
+
+    /// Creates a resolver that trusts `cmuxOwnedPIDs` as launch evidence.
+    init(cmuxOwnedPIDs: Set<Int>) {
+        self.cmuxOwnedPIDs = cmuxOwnedPIDs
+    }
+
     /// Splits `candidates` into proven owners of `surfaceID` and same-TTY collisions.
+    ///
+    /// Runs in time linear in the candidate count: parent and process-group indexes are
+    /// built once, then each newly proven PID is visited exactly once from a work queue.
     ///
     /// - Parameters:
     ///   - candidates: every PID sharing the surface's TTY device.
@@ -78,7 +102,8 @@ enum CmuxTopTTYOwnershipResolver {
     ///   - surfaceID: the surface being annotated, when it has an identifier.
     ///   - provenPIDs: PIDs already proven by a stronger path, such as the expanded
     ///     cmux-scoped process tree for this surface.
-    static func resolve(
+    /// - Returns: the proven set, the unattributed set, and the reason for each PID.
+    func resolve(
         candidates: Set<Int>,
         processes: [Int: CmuxTopTTYOwnershipProcess],
         surfaceID: UUID?,
@@ -88,14 +113,29 @@ enum CmuxTopTTYOwnershipResolver {
         let livePIDs = candidates.filter { $0 > 0 }
         guard !livePIDs.isEmpty else { return ownership }
 
+        // Built once so propagation never rescans the candidate set.
+        var childrenByParentPID: [Int: [Int]] = [:]
+        var membersByProcessGroupID: [Int: [Int]] = [:]
+        for pid in livePIDs {
+            guard let process = processes[pid] else { continue }
+            if process.parentPID > 1 {
+                childrenByParentPID[process.parentPID, default: []].append(pid)
+            }
+            if let processGroupID = process.processGroupID, processGroupID != pid {
+                membersByProcessGroupID[processGroupID, default: []].append(pid)
+            }
+        }
+
         var proven: Set<Int> = []
+        var queue: [Int] = []
 
         func prove(_ pid: Int, _ reason: CmuxTopTTYOwnershipReason) {
             guard proven.insert(pid).inserted else { return }
             ownership.reasonByPID[pid] = reason
+            queue.append(pid)
         }
 
-        for pid in livePIDs.sorted() {
+        for pid in livePIDs {
             guard let process = processes[pid] else { continue }
 
             if let surfaceID, process.cmuxSurfaceID == surfaceID {
@@ -106,33 +146,23 @@ enum CmuxTopTTYOwnershipResolver {
                 prove(pid, .surfaceProcessTree)
                 continue
             }
-            // PID 1 is launchd. A process it owns was reparented, so its parent link no
-            // longer says anything about who started it.
-            if process.parentPID > 1 && !livePIDs.contains(process.parentPID) {
+            // An off-TTY parent only proves ownership when that parent is cmux's. PID 1 is
+            // launchd, and an arbitrary third-party parent says nothing about this surface.
+            if process.parentPID > 1,
+               !livePIDs.contains(process.parentPID),
+               cmuxOwnedPIDs.contains(process.parentPID) {
                 prove(pid, .ttySessionRoot)
             }
         }
 
         // Ownership is transitive: a child of a proven owner is proven, and so is a member
-        // of a process group whose leader is proven. Both need a fixpoint because a chain
-        // can be proven in any order.
-        var changed = true
-        while changed {
-            changed = false
-            for pid in livePIDs.sorted() where !proven.contains(pid) {
-                guard let process = processes[pid] else { continue }
-
-                if proven.contains(process.parentPID) {
-                    prove(pid, .ttyDescendant)
-                    changed = true
-                    continue
-                }
-                if let processGroupID = process.processGroupID,
-                   processGroupID != pid,
-                   proven.contains(processGroupID) {
-                    prove(pid, .ttyProcessGroup)
-                    changed = true
-                }
+        // of a process group whose leader is proven. Each proven PID is expanded once.
+        while let pid = queue.popLast() {
+            for child in childrenByParentPID[pid] ?? [] {
+                prove(child, .ttyDescendant)
+            }
+            for member in membersByProcessGroupID[pid] ?? [] {
+                prove(member, .ttyProcessGroup)
             }
         }
 

--- a/Sources/CmuxTopTTYOwnership.swift
+++ b/Sources/CmuxTopTTYOwnership.swift
@@ -1,0 +1,146 @@
+import Foundation
+
+/// Why a process that shares a surface's TTY device was, or was not, attributed to it.
+///
+/// A terminal's TTY is not proof of ownership. A process reparented to launchd keeps the
+/// controlling TTY of the terminal it was launched from, so the TTY population always has
+/// to be split into processes cmux can prove it owns and processes that merely collide on
+/// the device. See https://github.com/manaflow-ai/cmux/issues/11004.
+enum CmuxTopTTYOwnershipReason: String, Sendable, CaseIterable {
+    /// The process carries an explicit `CMUX_*` scope naming this surface. Strongest
+    /// evidence, and the one that survives reparenting: hook monitors and browser roots
+    /// are intentionally launchd-parented but stay attributed through it.
+    case cmuxProcessScope = "cmux-process-scope"
+
+    /// The process was already proven through the surface's cmux-scoped process tree.
+    case surfaceProcessTree = "surface-process-tree"
+
+    /// The process entered this TTY from outside it — its parent is alive and off the TTY,
+    /// which is how the shell cmux forked for the surface looks.
+    case ttySessionRoot = "tty-session-root"
+
+    /// The process descends from a proven owner on this TTY.
+    case ttyDescendant = "tty-descendant"
+
+    /// The process belongs to a process group whose leader is a proven owner, which is how
+    /// a backgrounded job of the surface's shell looks after its parent goes away.
+    case ttyProcessGroup = "tty-process-group"
+
+    /// The process only shares the TTY device. No descendant, process-group, or cmux-scope
+    /// evidence links it to the surface, so its memory is not cmux's to claim.
+    case ttyCollision = "tty-collision"
+}
+
+/// The minimum a process has to expose for TTY ownership to be decidable.
+struct CmuxTopTTYOwnershipProcess: Sendable, Equatable {
+    let pid: Int
+    let parentPID: Int
+    let processGroupID: Int?
+    let cmuxSurfaceID: UUID?
+
+    init(pid: Int, parentPID: Int, processGroupID: Int?, cmuxSurfaceID: UUID?) {
+        self.pid = pid
+        self.parentPID = parentPID
+        self.processGroupID = processGroupID
+        self.cmuxSurfaceID = cmuxSurfaceID
+    }
+}
+
+/// The result of splitting one TTY's process population by ownership evidence.
+struct CmuxTopTTYOwnership: Sendable {
+    /// Processes cmux can prove belong to the surface. Safe to use as attribution roots.
+    var provenPIDs: Set<Int> = []
+
+    /// Processes that share the TTY device with no ownership evidence. Reported separately
+    /// so a detached REPL or dev server is visible without being charged to the surface.
+    var unattributedPIDs: Set<Int> = []
+
+    /// Per-PID reason, for diagnostics and the Task Manager.
+    var reasonByPID: [Int: CmuxTopTTYOwnershipReason] = [:]
+
+    /// String-keyed reasons for the JSON payloads, which cannot carry `Int` keys.
+    func reasonPayload() -> [String: String] {
+        var payload: [String: String] = [:]
+        payload.reserveCapacity(reasonByPID.count)
+        for (pid, reason) in reasonByPID {
+            payload[String(pid)] = reason.rawValue
+        }
+        return payload
+    }
+}
+
+enum CmuxTopTTYOwnershipResolver {
+    /// Splits `candidates` into proven owners of `surfaceID` and same-TTY collisions.
+    ///
+    /// - Parameters:
+    ///   - candidates: every PID sharing the surface's TTY device.
+    ///   - processes: process facts for those PIDs. A PID missing here cannot be proven.
+    ///   - surfaceID: the surface being annotated, when it has an identifier.
+    ///   - provenPIDs: PIDs already proven by a stronger path, such as the expanded
+    ///     cmux-scoped process tree for this surface.
+    static func resolve(
+        candidates: Set<Int>,
+        processes: [Int: CmuxTopTTYOwnershipProcess],
+        surfaceID: UUID?,
+        provenPIDs: Set<Int> = []
+    ) -> CmuxTopTTYOwnership {
+        var ownership = CmuxTopTTYOwnership()
+        let livePIDs = candidates.filter { $0 > 0 }
+        guard !livePIDs.isEmpty else { return ownership }
+
+        var proven: Set<Int> = []
+
+        func prove(_ pid: Int, _ reason: CmuxTopTTYOwnershipReason) {
+            guard proven.insert(pid).inserted else { return }
+            ownership.reasonByPID[pid] = reason
+        }
+
+        for pid in livePIDs.sorted() {
+            guard let process = processes[pid] else { continue }
+
+            if let surfaceID, process.cmuxSurfaceID == surfaceID {
+                prove(pid, .cmuxProcessScope)
+                continue
+            }
+            if provenPIDs.contains(pid) {
+                prove(pid, .surfaceProcessTree)
+                continue
+            }
+            // PID 1 is launchd. A process it owns was reparented, so its parent link no
+            // longer says anything about who started it.
+            if process.parentPID > 1 && !livePIDs.contains(process.parentPID) {
+                prove(pid, .ttySessionRoot)
+            }
+        }
+
+        // Ownership is transitive: a child of a proven owner is proven, and so is a member
+        // of a process group whose leader is proven. Both need a fixpoint because a chain
+        // can be proven in any order.
+        var changed = true
+        while changed {
+            changed = false
+            for pid in livePIDs.sorted() where !proven.contains(pid) {
+                guard let process = processes[pid] else { continue }
+
+                if proven.contains(process.parentPID) {
+                    prove(pid, .ttyDescendant)
+                    changed = true
+                    continue
+                }
+                if let processGroupID = process.processGroupID,
+                   processGroupID != pid,
+                   proven.contains(processGroupID) {
+                    prove(pid, .ttyProcessGroup)
+                    changed = true
+                }
+            }
+        }
+
+        ownership.provenPIDs = proven
+        for pid in livePIDs where !proven.contains(pid) {
+            ownership.unattributedPIDs.insert(pid)
+            ownership.reasonByPID[pid] = .ttyCollision
+        }
+        return ownership
+    }
+}

--- a/Sources/TerminalControllerTopSupport.swift
+++ b/Sources/TerminalControllerTopSupport.swift
@@ -170,8 +170,9 @@ extension TerminalController {
     ) -> Set<Int> {
         var rootPIDs: Set<Int> = []
         var surfacePIDs: Set<Int> = []
+        let surfaceID = v2TopUUID(surface["id"])
 
-        if let surfaceID = v2TopUUID(surface["id"]) {
+        if let surfaceID {
             let cmuxPIDs = processSnapshot.pids(forCMUXSurfaceID: surfaceID)
             surface["cmux_process_pids"] = cmuxPIDs.sorted()
             rootPIDs.formUnion(cmuxPIDs)
@@ -180,13 +181,27 @@ extension TerminalController {
             surface["cmux_process_pids"] = []
         }
 
+        // Sharing the surface's TTY is not ownership. A process reparented to launchd
+        // keeps the terminal's controlling TTY, so promoting the whole TTY population to
+        // roots charges a detached REPL or dev server to cmux. Attribute only what the
+        // snapshot can prove, and report the rest separately. (#11004)
+        var unattributedRootPIDs: Set<Int> = []
         if let ttyName = surface["tty"] as? String {
-            let ttyPIDs = processSnapshot.pids(forTTYName: ttyName)
-            surface["tty_process_pids"] = ttyPIDs.sorted()
-            rootPIDs.formUnion(ttyPIDs)
-            surfacePIDs.formUnion(processSnapshot.expandedPIDs(rootPIDs: ttyPIDs))
+            let ownership = processSnapshot.ttyOwnership(
+                ttyPIDs: processSnapshot.pids(forTTYName: ttyName),
+                surfaceID: surfaceID,
+                provenPIDs: surfacePIDs
+            )
+            surface["tty_process_pids"] = ownership.provenPIDs.sorted()
+            surface["unattributed_tty_process_pids"] = ownership.unattributedPIDs.sorted()
+            surface["tty_ownership_reasons"] = ownership.reasonPayload()
+            rootPIDs.formUnion(ownership.provenPIDs)
+            surfacePIDs.formUnion(processSnapshot.expandedPIDs(rootPIDs: ownership.provenPIDs))
+            unattributedRootPIDs = ownership.unattributedPIDs
         } else {
             surface["tty_process_pids"] = []
+            surface["unattributed_tty_process_pids"] = []
+            surface["tty_ownership_reasons"] = [String: String]()
         }
 
         var webviews = surface["webviews"] as? [[String: Any]] ?? []
@@ -205,10 +220,20 @@ extension TerminalController {
         }
         surface["webviews"] = webviews
 
+        // Resolved once the webview roots are in, so a launchd-parented WebKit process is
+        // never mistaken for an unattributed TTY collision.
+        let unattributedPIDs = processSnapshot
+            .expandedPIDs(rootPIDs: unattributedRootPIDs)
+            .subtracting(surfacePIDs)
+
         surface["root_pids"] = rootPIDs.sorted()
         surface["top_level_pids"] = processSnapshot.topLevelPIDs(for: surfacePIDs).sorted()
         surface["foreground_pgids"] = processSnapshot.foregroundProcessGroupIDs(for: surfacePIDs).sorted()
         surface["resources"] = processSnapshot.summaryPayload(for: surfacePIDs, rootPIDs: rootPIDs)
+        surface["unattributed_resources"] = processSnapshot.summaryPayload(
+            for: unattributedPIDs,
+            rootPIDs: unattributedRootPIDs
+        )
         surface["processes"] = includeProcesses ? processSnapshot.processTreePayload(for: surfacePIDs, rootPIDs: rootPIDs) : []
         return surfacePIDs
     }

--- a/Sources/TerminalControllerTopSupport.swift
+++ b/Sources/TerminalControllerTopSupport.swift
@@ -59,6 +59,9 @@ extension TerminalController {
         for index in windows.indices {
             var workspaces = windows[index]["workspaces"] as? [[String: Any]] ?? []
             let appProcessPIDs = Set(v2TopIntArray(windows[index]["app_process_pids"]))
+            // Launch evidence for TTY ownership: a process the app forked onto a surface
+            // TTY is the surface's, an arbitrary off-TTY parent proves nothing. (#11004)
+            let cmuxOwnedPIDs = processSnapshot.expandedPIDs(rootPIDs: appProcessPIDs)
             var windowPIDs = appProcessPIDs
             var windowTopLevelPIDs: Set<Int> = []
             var windowForegroundProcessGroupIDs: Set<Int> = []
@@ -68,6 +71,7 @@ extension TerminalController {
                         &workspaces[workspaceIndex],
                         processSnapshot: processSnapshot,
                         browserPIDOccurrences: browserPIDOccurrences,
+                        cmuxOwnedPIDs: cmuxOwnedPIDs,
                         includeProcesses: includeProcesses
                     )
                 )
@@ -92,6 +96,7 @@ extension TerminalController {
         _ workspace: inout [String: Any],
         processSnapshot: CmuxTopProcessSnapshot,
         browserPIDOccurrences: [Int: Int],
+        cmuxOwnedPIDs: Set<Int>,
         includeProcesses: Bool
     ) -> Set<Int> {
         var workspacePIDs: Set<Int> = []
@@ -105,6 +110,7 @@ extension TerminalController {
                     &panes[paneIndex],
                     processSnapshot: processSnapshot,
                     browserPIDOccurrences: browserPIDOccurrences,
+                    cmuxOwnedPIDs: cmuxOwnedPIDs,
                     includeProcesses: includeProcesses
                 )
             )
@@ -137,6 +143,7 @@ extension TerminalController {
         _ pane: inout [String: Any],
         processSnapshot: CmuxTopProcessSnapshot,
         browserPIDOccurrences: [Int: Int],
+        cmuxOwnedPIDs: Set<Int>,
         includeProcesses: Bool
     ) -> Set<Int> {
         var panePIDs: Set<Int> = []
@@ -149,6 +156,7 @@ extension TerminalController {
                     &surfaces[surfaceIndex],
                     processSnapshot: processSnapshot,
                     browserPIDOccurrences: browserPIDOccurrences,
+                    cmuxOwnedPIDs: cmuxOwnedPIDs,
                     includeProcesses: includeProcesses
                 )
             )
@@ -166,6 +174,7 @@ extension TerminalController {
         _ surface: inout [String: Any],
         processSnapshot: CmuxTopProcessSnapshot,
         browserPIDOccurrences: [Int: Int],
+        cmuxOwnedPIDs: Set<Int>,
         includeProcesses: Bool
     ) -> Set<Int> {
         var rootPIDs: Set<Int> = []
@@ -190,6 +199,7 @@ extension TerminalController {
             let ownership = processSnapshot.ttyOwnership(
                 ttyPIDs: processSnapshot.pids(forTTYName: ttyName),
                 surfaceID: surfaceID,
+                cmuxOwnedPIDs: cmuxOwnedPIDs,
                 provenPIDs: surfacePIDs
             )
             surface["tty_process_pids"] = ownership.provenPIDs.sorted()

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -940,7 +940,6 @@
 		CFF12E0000000000000000A3 /* CmuxTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CFF12E0000000000000000A2 /* CmuxTestSupport */; };
 		A2977C204AD69CF268D38EE3 /* CmuxTestWindowReleaseGuard.m in Sources */ = {isa = PBXBuildFile; fileRef = EA9B442F20273D64D2BA1FC5 /* CmuxTestWindowReleaseGuard.m */; };
 		906900000000000000000002 /* CmuxTopMemoryAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906900000000000000000001 /* CmuxTopMemoryAttributionTests.swift */; };
-		A11004000000000000000002 /* CmuxTopTTYCollisionAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11004000000000000000001 /* CmuxTopTTYCollisionAttributionTests.swift */; };
 		906901000000000000000008 /* CmuxTopMemoryDiagnosticGroupAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906901000000000000000007 /* CmuxTopMemoryDiagnosticGroupAccumulator.swift */; };
 		C7A510000000000000000002 /* CmuxTopMemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */; };
 		B35750000000000000000004 /* CmuxTopProcessArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000003 /* CmuxTopProcessArguments.swift */; };
@@ -957,6 +956,8 @@
 		C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */; };
 		C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */; };
 		C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */; };
+		A11004000000000000000002 /* CmuxTopTTYCollisionAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11004000000000000000001 /* CmuxTopTTYCollisionAttributionTests.swift */; };
+		A11004000000000000000004 /* CmuxTopTTYOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11004000000000000000003 /* CmuxTopTTYOwnership.swift */; };
 		3B2BDBC03043E0C3CC4A308E /* CmuxTuiSnapshotParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = C28D6AEDE6B00F5C633ED2A8 /* CmuxTuiSnapshotParser.swift */; };
 		C11323210000000000000001 /* CmuxTuiSurfaceProvider+ManualMirror.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11323220000000000000001 /* CmuxTuiSurfaceProvider+ManualMirror.swift */; };
 		036359ABDB1F58B489D378A4 /* CmuxTuiSurfaceProviders.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63F5BDFB110A8A96C9CA0A75 /* CmuxTuiSurfaceProviders.swift */; };
@@ -4038,7 +4039,6 @@
 		F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA9B442F20273D64D2BA1FC5 /* CmuxTestWindowReleaseGuard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CmuxTestWindowReleaseGuard.m; sourceTree = "<group>"; };
 		906900000000000000000001 /* CmuxTopMemoryAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryAttributionTests.swift; sourceTree = "<group>"; };
-		A11004000000000000000001 /* CmuxTopTTYCollisionAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopTTYCollisionAttributionTests.swift; sourceTree = "<group>"; };
 		906901000000000000000007 /* CmuxTopMemoryDiagnosticGroupAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryDiagnosticGroupAccumulator.swift; sourceTree = "<group>"; };
 		C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryDiagnostics.swift; sourceTree = "<group>"; };
 		B35750000000000000000003 /* CmuxTopProcessArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessArguments.swift; sourceTree = "<group>"; };
@@ -4055,6 +4055,8 @@
 		C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCache.swift; sourceTree = "<group>"; };
 		C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCacheTests.swift; sourceTree = "<group>"; };
 		C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeTests.swift; sourceTree = "<group>"; };
+		A11004000000000000000001 /* CmuxTopTTYCollisionAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopTTYCollisionAttributionTests.swift; sourceTree = "<group>"; };
+		A11004000000000000000003 /* CmuxTopTTYOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopTTYOwnership.swift; sourceTree = "<group>"; };
 		C28D6AEDE6B00F5C633ED2A8 /* CmuxTuiSnapshotParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CmuxTuiSnapshotParser.swift; sourceTree = "<group>"; };
 		C11323220000000000000001 /* CmuxTuiSurfaceProvider+ManualMirror.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CmuxTuiSurfaceProvider+ManualMirror.swift"; sourceTree = "<group>"; };
 		63F5BDFB110A8A96C9CA0A75 /* CmuxTuiSurfaceProviders.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CmuxTuiSurfaceProviders.swift; sourceTree = "<group>"; };
@@ -7571,6 +7573,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D1FF00010000000000000001 /* TerminalController+MobileWorkspaceChanges.swift */,
 				C7A505000000000000000001 /* TerminalControllerTopSupport.swift */,
 				C7A501000000000000000001 /* CmuxTopSnapshot.swift */,
+				A11004000000000000000003 /* CmuxTopTTYOwnership.swift */,
 				C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */,
 				906901000000000000000007 /* CmuxTopMemoryDiagnosticGroupAccumulator.swift */,
 				906901000000000000000001 /* CmuxTopProcessAttribution.swift */,
@@ -10420,6 +10423,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C7A512000000000000000002 /* CmuxTopProcessSnapshotCache.swift in Sources */,
 				C7A501000000000000000002 /* CmuxTopSnapshot.swift in Sources */,
 				C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */,
+				A11004000000000000000004 /* CmuxTopTTYOwnership.swift in Sources */,
 				3B2BDBC03043E0C3CC4A308E /* CmuxTuiSnapshotParser.swift in Sources */,
 				C11323210000000000000001 /* CmuxTuiSurfaceProvider+ManualMirror.swift in Sources */,
 				036359ABDB1F58B489D378A4 /* CmuxTuiSurfaceProviders.swift in Sources */,
@@ -12384,11 +12388,11 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
 				A2977C204AD69CF268D38EE3 /* CmuxTestWindowReleaseGuard.m in Sources */,
 					906900000000000000000002 /* CmuxTopMemoryAttributionTests.swift in Sources */,
-					A11004000000000000000002 /* CmuxTopTTYCollisionAttributionTests.swift in Sources */,
 					C7A50C000000000000000003 /* CmuxTopProcessArgumentsTests.swift in Sources */,
 					C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,
 					C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */,
 					C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */,
+					A11004000000000000000002 /* CmuxTopTTYCollisionAttributionTests.swift in Sources */,
 				2C636EB7DCD3184EE9E94E31 /* CmuxTuiSurfaceProviderTests.swift in Sources */,
 				D7C0DE00000000000000A103 /* CmuxWebViewContextMenuLinkCaptureTests.swift in Sources */,
 				D0B1000CA1B2C3D4E5F60001 /* CmuxWebViewDragRoutingTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -940,6 +940,7 @@
 		CFF12E0000000000000000A3 /* CmuxTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CFF12E0000000000000000A2 /* CmuxTestSupport */; };
 		A2977C204AD69CF268D38EE3 /* CmuxTestWindowReleaseGuard.m in Sources */ = {isa = PBXBuildFile; fileRef = EA9B442F20273D64D2BA1FC5 /* CmuxTestWindowReleaseGuard.m */; };
 		906900000000000000000002 /* CmuxTopMemoryAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906900000000000000000001 /* CmuxTopMemoryAttributionTests.swift */; };
+		A11004000000000000000002 /* CmuxTopTTYCollisionAttributionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11004000000000000000001 /* CmuxTopTTYCollisionAttributionTests.swift */; };
 		906901000000000000000008 /* CmuxTopMemoryDiagnosticGroupAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 906901000000000000000007 /* CmuxTopMemoryDiagnosticGroupAccumulator.swift */; };
 		C7A510000000000000000002 /* CmuxTopMemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */; };
 		B35750000000000000000004 /* CmuxTopProcessArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000003 /* CmuxTopProcessArguments.swift */; };
@@ -4037,6 +4038,7 @@
 		F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA9B442F20273D64D2BA1FC5 /* CmuxTestWindowReleaseGuard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CmuxTestWindowReleaseGuard.m; sourceTree = "<group>"; };
 		906900000000000000000001 /* CmuxTopMemoryAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryAttributionTests.swift; sourceTree = "<group>"; };
+		A11004000000000000000001 /* CmuxTopTTYCollisionAttributionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopTTYCollisionAttributionTests.swift; sourceTree = "<group>"; };
 		906901000000000000000007 /* CmuxTopMemoryDiagnosticGroupAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryDiagnosticGroupAccumulator.swift; sourceTree = "<group>"; };
 		C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryDiagnostics.swift; sourceTree = "<group>"; };
 		B35750000000000000000003 /* CmuxTopProcessArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessArguments.swift; sourceTree = "<group>"; };
@@ -9249,6 +9251,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */,
 				C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */,
 				906900000000000000000001 /* CmuxTopMemoryAttributionTests.swift */,
+				A11004000000000000000001 /* CmuxTopTTYCollisionAttributionTests.swift */,
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
 				C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */,
 				906900000000000000000003 /* CMUXCLIMemoryAttributionTests.swift */,
@@ -12381,6 +12384,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
 				A2977C204AD69CF268D38EE3 /* CmuxTestWindowReleaseGuard.m in Sources */,
 					906900000000000000000002 /* CmuxTopMemoryAttributionTests.swift in Sources */,
+					A11004000000000000000002 /* CmuxTopTTYCollisionAttributionTests.swift in Sources */,
 					C7A50C000000000000000003 /* CmuxTopProcessArgumentsTests.swift in Sources */,
 					C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,
 					C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */,

--- a/cmuxTests/CmuxTopTTYCollisionAttributionTests.swift
+++ b/cmuxTests/CmuxTopTTYCollisionAttributionTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// A process that is no longer a descendant of cmux (reparented to PID 1) keeps the
+/// controlling TTY of the terminal it was launched from. Surface attribution must not
+/// promote that process to a surface root just because it shares the TTY device, or a
+/// detached REPL/dev server shows up as cmux memory.
+///
+/// https://github.com/manaflow-ai/cmux/issues/11004
+@Suite(.serialized)
+struct CmuxTopTTYCollisionAttributionTests {
+    private let workspaceID = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000001")!
+    private let surfaceID = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000002")!
+
+    private let appPID = 3000
+    private let shellPID = 4001
+    private let shellChildPID = 4002
+    private let detachedPID = 4003
+    private let hookMonitorPID = 4004
+    private let backgroundJobPID = 4005
+
+    private let shellBytes: Int64 = 64 * 1024 * 1024
+    private let shellChildBytes: Int64 = 32 * 1024 * 1024
+    private let detachedBytes: Int64 = 1_900 * 1024 * 1024
+    private let hookMonitorBytes: Int64 = 16 * 1024 * 1024
+    private let backgroundJobBytes: Int64 = 8 * 1024 * 1024
+
+    @MainActor
+    @Test func detachedSameTTYProcessIsNotCountedAsSurfaceMemory() throws {
+        var windows = annotatedWindows()
+        let surface = try #require(firstSurface(in: &windows))
+        let resources = try #require(surface["resources"] as? [String: Any])
+
+        let attributedPIDs = intArray(resources["pids"])
+        #expect(!attributedPIDs.contains(detachedPID))
+        #expect(attributedPIDs == [shellPID, shellChildPID, hookMonitorPID, backgroundJobPID].sorted())
+
+        let expectedBytes = shellBytes + shellChildBytes + hookMonitorBytes + backgroundJobBytes
+        #expect(int64(resources["resident_bytes"]) == expectedBytes)
+    }
+
+    @MainActor
+    @Test func detachedSameTTYProcessIsReportedAsUnattributed() throws {
+        var windows = annotatedWindows()
+        let surface = try #require(firstSurface(in: &windows))
+
+        #expect(intArray(surface["unattributed_tty_process_pids"]) == [detachedPID])
+
+        let unattributed = try #require(surface["unattributed_resources"] as? [String: Any])
+        #expect(int64(unattributed["resident_bytes"]) == detachedBytes)
+    }
+
+    @MainActor
+    @Test func provenTTYOwnersCarryTheirAttributionReason() throws {
+        var windows = annotatedWindows()
+        let surface = try #require(firstSurface(in: &windows))
+        let reasons = try #require(surface["tty_ownership_reasons"] as? [String: String])
+
+        #expect(reasons[String(shellPID)] == "tty-session-root")
+        #expect(reasons[String(shellChildPID)] == "tty-descendant")
+        #expect(reasons[String(hookMonitorPID)] == "cmux-process-scope")
+        #expect(reasons[String(backgroundJobPID)] == "tty-process-group")
+        #expect(reasons[String(detachedPID)] == "tty-collision")
+    }
+
+    /// A reparented helper that still names this surface through `CMUX_*` scope stays
+    /// attributed; explicit scope outranks the PPID-1 exclusion.
+    @MainActor
+    @Test func reparentedScopedHelperStaysAttributed() throws {
+        var windows = annotatedWindows()
+        let surface = try #require(firstSurface(in: &windows))
+
+        #expect(intArray(surface["tty_process_pids"]).contains(hookMonitorPID))
+        #expect(!intArray(surface["unattributed_tty_process_pids"]).contains(hookMonitorPID))
+    }
+
+    // MARK: - Fixture
+
+    private var ttyName: String { "/dev/null" }
+
+    private var ttyDevice: Int64? {
+        CmuxTopProcessSnapshot.deviceIdentifier(forTTYName: ttyName)
+    }
+
+    private func snapshot() -> CmuxTopProcessSnapshot {
+        let device = ttyDevice
+        return CmuxTopProcessSnapshot(
+            processes: [
+                // The shell cmux forked for this surface: its parent is the app, which is
+                // not on this TTY, so it is the process that entered the TTY from outside.
+                process(
+                    pid: shellPID,
+                    parentPID: appPID,
+                    name: "zsh",
+                    ttyDevice: device,
+                    processGroupID: shellPID,
+                    terminalProcessGroupID: shellPID,
+                    residentBytes: shellBytes
+                ),
+                process(
+                    pid: shellChildPID,
+                    parentPID: shellPID,
+                    name: "node",
+                    ttyDevice: device,
+                    processGroupID: shellChildPID,
+                    terminalProcessGroupID: shellPID,
+                    residentBytes: shellChildBytes
+                ),
+                // Detached REPL/dev server: reparented to launchd, no cmux scope, its own
+                // process group. Only the TTY device links it to the surface.
+                process(
+                    pid: detachedPID,
+                    parentPID: 1,
+                    name: "python3",
+                    ttyDevice: device,
+                    processGroupID: detachedPID,
+                    terminalProcessGroupID: shellPID,
+                    residentBytes: detachedBytes
+                ),
+                // Intentionally reparented cmux hook monitor, positively scoped.
+                process(
+                    pid: hookMonitorPID,
+                    parentPID: 1,
+                    name: "cmux",
+                    ttyDevice: device,
+                    cmuxWorkspaceID: workspaceID,
+                    cmuxSurfaceID: surfaceID,
+                    cmuxAttributionReason: "cmux-hook-arguments",
+                    processGroupID: hookMonitorPID,
+                    terminalProcessGroupID: shellPID,
+                    residentBytes: hookMonitorBytes
+                ),
+                // Background job whose process-group leader is the proven shell.
+                process(
+                    pid: backgroundJobPID,
+                    parentPID: 1,
+                    name: "rg",
+                    ttyDevice: device,
+                    processGroupID: shellPID,
+                    terminalProcessGroupID: shellPID,
+                    residentBytes: backgroundJobBytes
+                )
+            ],
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: true
+        )
+    }
+
+    private func annotatedWindows() -> [[String: Any]] {
+        var windows: [[String: Any]] = [[
+            "kind": "window",
+            "id": UUID().uuidString,
+            "index": 0,
+            "key": true,
+            "visible": true,
+            "app_process_pids": [],
+            "workspaces": [[
+                "kind": "workspace",
+                "id": workspaceID.uuidString,
+                "index": 0,
+                "title": "tty collision fixture",
+                "selected": true,
+                "pinned": false,
+                "tags": [],
+                "panes": [[
+                    "kind": "pane",
+                    "id": UUID().uuidString,
+                    "index": 0,
+                    "surfaces": [[
+                        "kind": "surface",
+                        "id": surfaceID.uuidString,
+                        "index": 0,
+                        "type": "terminal",
+                        "title": "detached repl owner",
+                        "tty": ttyName,
+                        "webviews": []
+                    ] as [String: Any]]
+                ] as [String: Any]]
+            ] as [String: Any]]
+        ]]
+
+        _ = TerminalController.shared.v2AnnotateTopWindows(
+            &windows,
+            processSnapshot: snapshot(),
+            browserPIDOccurrences: [:],
+            includeProcesses: true
+        )
+        return windows
+    }
+
+    private func firstSurface(in windows: inout [[String: Any]]) -> [String: Any]? {
+        guard let workspaces = windows.first?["workspaces"] as? [[String: Any]],
+              let panes = workspaces.first?["panes"] as? [[String: Any]],
+              let surfaces = panes.first?["surfaces"] as? [[String: Any]] else {
+            return nil
+        }
+        return surfaces.first
+    }
+
+    private func process(
+        pid: Int,
+        parentPID: Int,
+        name: String,
+        ttyDevice: Int64?,
+        cmuxWorkspaceID: UUID? = nil,
+        cmuxSurfaceID: UUID? = nil,
+        cmuxAttributionReason: String? = nil,
+        processGroupID: Int?,
+        terminalProcessGroupID: Int?,
+        residentBytes: Int64
+    ) -> CmuxTopProcessInfo {
+        CmuxTopProcessInfo(
+            pid: pid,
+            parentPID: parentPID,
+            name: name,
+            path: "/usr/bin/\(name)",
+            ttyDevice: ttyDevice,
+            cmuxWorkspaceID: cmuxWorkspaceID,
+            cmuxSurfaceID: cmuxSurfaceID,
+            cmuxAttributionReason: cmuxAttributionReason,
+            processGroupID: processGroupID,
+            terminalProcessGroupID: terminalProcessGroupID,
+            cpuPercent: 0,
+            residentBytes: residentBytes,
+            virtualBytes: residentBytes,
+            threadCount: 1
+        )
+    }
+
+    private func intArray(_ raw: Any?) -> [Int] {
+        (raw as? [Int])?.sorted() ?? []
+    }
+
+    private func int64(_ raw: Any?) -> Int64? {
+        if let value = raw as? Int64 { return value }
+        if let value = raw as? Int { return Int64(value) }
+        if let value = raw as? NSNumber { return value.int64Value }
+        return nil
+    }
+}

--- a/cmuxTests/CmuxTopTTYCollisionAttributionTests.swift
+++ b/cmuxTests/CmuxTopTTYCollisionAttributionTests.swift
@@ -19,22 +19,24 @@ struct CmuxTopTTYCollisionAttributionTests {
     private let surfaceID = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000002")!
 
     private let appPID = 3000
+    private let foreignParentPID = 9000
     private let shellPID = 4001
     private let shellChildPID = 4002
     private let detachedPID = 4003
     private let hookMonitorPID = 4004
     private let backgroundJobPID = 4005
+    private let strayPID = 4006
 
     private let shellBytes: Int64 = 64 * 1024 * 1024
     private let shellChildBytes: Int64 = 32 * 1024 * 1024
     private let detachedBytes: Int64 = 1_900 * 1024 * 1024
     private let hookMonitorBytes: Int64 = 16 * 1024 * 1024
     private let backgroundJobBytes: Int64 = 8 * 1024 * 1024
+    private let strayBytes: Int64 = 512 * 1024 * 1024
 
     @MainActor
     @Test func detachedSameTTYProcessIsNotCountedAsSurfaceMemory() throws {
-        var windows = annotatedWindows()
-        let surface = try #require(firstSurface(in: &windows))
+        let surface = try #require(firstAnnotatedSurface())
         let resources = try #require(surface["resources"] as? [String: Any])
 
         let attributedPIDs = intArray(resources["pids"])
@@ -46,20 +48,28 @@ struct CmuxTopTTYCollisionAttributionTests {
     }
 
     @MainActor
-    @Test func detachedSameTTYProcessIsReportedAsUnattributed() throws {
-        var windows = annotatedWindows()
-        let surface = try #require(firstSurface(in: &windows))
+    @Test func collisionsAreReportedAsUnattributed() throws {
+        let surface = try #require(firstAnnotatedSurface())
 
-        #expect(intArray(surface["unattributed_tty_process_pids"]) == [detachedPID])
+        #expect(intArray(surface["unattributed_tty_process_pids"]) == [detachedPID, strayPID].sorted())
 
         let unattributed = try #require(surface["unattributed_resources"] as? [String: Any])
-        #expect(int64(unattributed["resident_bytes"]) == detachedBytes)
+        #expect(int64(unattributed["resident_bytes"]) == detachedBytes + strayBytes)
+    }
+
+    /// An off-TTY parent is only launch evidence when that parent is cmux's. Attribution
+    /// fails closed for a same-TTY process parented by an unrelated live process.
+    @MainActor
+    @Test func sameTTYProcessWithForeignOffTTYParentIsACollision() throws {
+        let surface = try #require(firstAnnotatedSurface())
+
+        #expect(!intArray(surface["tty_process_pids"]).contains(strayPID))
+        #expect(intArray(surface["unattributed_tty_process_pids"]).contains(strayPID))
     }
 
     @MainActor
     @Test func provenTTYOwnersCarryTheirAttributionReason() throws {
-        var windows = annotatedWindows()
-        let surface = try #require(firstSurface(in: &windows))
+        let surface = try #require(firstAnnotatedSurface())
         let reasons = try #require(surface["tty_ownership_reasons"] as? [String: String])
 
         #expect(reasons[String(shellPID)] == "tty-session-root")
@@ -67,14 +77,14 @@ struct CmuxTopTTYCollisionAttributionTests {
         #expect(reasons[String(hookMonitorPID)] == "cmux-process-scope")
         #expect(reasons[String(backgroundJobPID)] == "tty-process-group")
         #expect(reasons[String(detachedPID)] == "tty-collision")
+        #expect(reasons[String(strayPID)] == "tty-collision")
     }
 
     /// A reparented helper that still names this surface through `CMUX_*` scope stays
     /// attributed; explicit scope outranks the PPID-1 exclusion.
     @MainActor
     @Test func reparentedScopedHelperStaysAttributed() throws {
-        var windows = annotatedWindows()
-        let surface = try #require(firstSurface(in: &windows))
+        let surface = try #require(firstAnnotatedSurface())
 
         #expect(intArray(surface["tty_process_pids"]).contains(hookMonitorPID))
         #expect(!intArray(surface["unattributed_tty_process_pids"]).contains(hookMonitorPID))
@@ -82,18 +92,40 @@ struct CmuxTopTTYCollisionAttributionTests {
 
     // MARK: - Fixture
 
+    /// A real device so `deviceIdentifier(forTTYName:)` can `stat` it.
     private var ttyName: String { "/dev/null" }
 
+    /// The device identifier the snapshot indexes TTY membership by.
     private var ttyDevice: Int64? {
         CmuxTopProcessSnapshot.deviceIdentifier(forTTYName: ttyName)
     }
 
+    /// Six processes on one surface TTY, covering every ownership reason.
     private func snapshot() -> CmuxTopProcessSnapshot {
         let device = ttyDevice
         return CmuxTopProcessSnapshot(
             processes: [
-                // The shell cmux forked for this surface: its parent is the app, which is
-                // not on this TTY, so it is the process that entered the TTY from outside.
+                // The cmux app process that forked the surface's shell. Off the TTY.
+                process(
+                    pid: appPID,
+                    parentPID: 1,
+                    name: "cmux",
+                    ttyDevice: nil,
+                    processGroupID: appPID,
+                    terminalProcessGroupID: nil,
+                    residentBytes: 128 * 1024 * 1024
+                ),
+                // An unrelated live process that also has a child on this TTY.
+                process(
+                    pid: foreignParentPID,
+                    parentPID: 1,
+                    name: "orbstack",
+                    ttyDevice: nil,
+                    processGroupID: foreignParentPID,
+                    terminalProcessGroupID: nil,
+                    residentBytes: 64 * 1024 * 1024
+                ),
+                // The shell cmux forked for this surface.
                 process(
                     pid: shellPID,
                     parentPID: appPID,
@@ -145,6 +177,16 @@ struct CmuxTopTTYCollisionAttributionTests {
                     processGroupID: shellPID,
                     terminalProcessGroupID: shellPID,
                     residentBytes: backgroundJobBytes
+                ),
+                // Live off-TTY parent, but the parent is not cmux's: no launch evidence.
+                process(
+                    pid: strayPID,
+                    parentPID: foreignParentPID,
+                    name: "dockerd",
+                    ttyDevice: device,
+                    processGroupID: strayPID,
+                    terminalProcessGroupID: shellPID,
+                    residentBytes: strayBytes
                 )
             ],
             sampledAt: Date(timeIntervalSince1970: 0),
@@ -152,14 +194,16 @@ struct CmuxTopTTYCollisionAttributionTests {
         )
     }
 
-    private func annotatedWindows() -> [[String: Any]] {
+    /// Runs the real annotation path and returns the fixture's only surface.
+    @MainActor
+    private func firstAnnotatedSurface() -> [String: Any]? {
         var windows: [[String: Any]] = [[
             "kind": "window",
             "id": UUID().uuidString,
             "index": 0,
             "key": true,
             "visible": true,
-            "app_process_pids": [],
+            "app_process_pids": [appPID],
             "workspaces": [[
                 "kind": "workspace",
                 "id": workspaceID.uuidString,
@@ -191,10 +235,7 @@ struct CmuxTopTTYCollisionAttributionTests {
             browserPIDOccurrences: [:],
             includeProcesses: true
         )
-        return windows
-    }
 
-    private func firstSurface(in windows: inout [[String: Any]]) -> [String: Any]? {
         guard let workspaces = windows.first?["workspaces"] as? [[String: Any]],
               let panes = workspaces.first?["panes"] as? [[String: Any]],
               let surfaces = panes.first?["surfaces"] as? [[String: Any]] else {
@@ -203,6 +244,7 @@ struct CmuxTopTTYCollisionAttributionTests {
         return surfaces.first
     }
 
+    /// Builds one snapshot process with only the fields this suite varies.
     private func process(
         pid: Int,
         parentPID: Int,
@@ -233,10 +275,12 @@ struct CmuxTopTTYCollisionAttributionTests {
         )
     }
 
+    /// Reads a sorted PID array out of a JSON payload field.
     private func intArray(_ raw: Any?) -> [Int] {
         (raw as? [Int])?.sorted() ?? []
     }
 
+    /// Reads a byte count out of a JSON payload field, whatever numeric box it arrives in.
     private func int64(_ raw: Any?) -> Int64? {
         if let value = raw as? Int64 { return value }
         if let value = raw as? Int { return Int64(value) }


### PR DESCRIPTION
Rebases the unique TTY ownership fix for issue #11004 onto current main c4f600d78a4.

- require cmux ownership evidence before charging same-TTY processes
- resolve descendants and process groups in linear time
- add detached PPID-1 collision behavior coverage

Preserves the red/fix commits from the original branch.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes same-TTY process attribution so detached processes that share a surface's TTY are no longer counted as cmux memory (#11004). Attribution now fails closed: only PIDs with positive ownership evidence are charged to the surface, and collisions are reported separately.

- Treats explicit `CMUX_*` surface scope, surface process tree membership, TTY session roots launched by cmux-owned off-TTY parents, descendants, and process-group leaders as proof of ownership.
- Resolves descendant and process-group chains in linear time from prebuilt parent and process-group indexes.
- Adds `unattributed_tty_process_pids`, `unattributed_resources`, and `tty_ownership_reasons` to surface payloads so detached memory stays visible without inflating cmux totals.
- Keeps reparented hook monitors attributed through explicit `CMUX_*` scope.
- Adds test coverage for detached PPID-1 processes, foreign off-TTY parents, and backgrounded jobs.

<sup>Written for commit b28d7239ee1dc5941f5b3f98df861b6d18e8c00d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved process and memory attribution for terminal surfaces that share a TTY with unrelated processes.
  * Prevented detached or independently launched processes from being incorrectly charged to a cmux surface.
  * Preserved attribution for cmux-owned descendants, process-group members, and explicitly associated helper processes.
  * Added clearer reporting for processes that cannot be confidently attributed, including collision reasons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->