### PR TITLE
Fix baseline Swift test compilation

### DIFF
--- a/cmuxTests/MachineCreateCoordinatorTests.swift
+++ b/cmuxTests/MachineCreateCoordinatorTests.swift
@@ -175,7 +175,7 @@ struct MachineCreateCoordinatorTests {
             id: "calm-petrel", provider: "freestyle", image: "image", isDesktop: false,
             activity: .ready, createdAt: nil, label: nil
         )
-        #expect(coordinator.operations.first?.isSuperseded(by: [machine], catalogMachines: []))
+        #expect(coordinator.operations.first?.isSuperseded(by: [machine], catalogMachines: []) == true)
     }
 
     // MARK: Success
@@ -475,14 +475,14 @@ struct MachinesPanelPendingCreateTests {
         // A pending operation without its emitted machine id cannot safely be
         // matched by a label or timestamp, especially with concurrent creates.
         let uncorrelated = MachineCreateOperation(
-            id: UUID(), request: Self.newMachineRequest(name: "troll"), startedAt: started
+            id: UUID(), request: MachineCreateCoordinatorTests.newMachineRequest(name: "troll"), startedAt: started
         )
         #expect(rows(machines: [created], pending: [uncorrelated]).first?.hasPrefix("pending-machine:") == true)
 
         // Two concurrent unnamed creates must not both disappear when one
         // newly observed machine has no matching authoritative id.
         let uncorrelatedOther = MachineCreateOperation(
-            id: UUID(), request: Self.newMachineRequest(name: nil), startedAt: started
+            id: UUID(), request: MachineCreateCoordinatorTests.newMachineRequest(name: nil), startedAt: started
         )
         let concurrentRows = rows(machines: [anonymous], pending: [uncorrelated, uncorrelatedOther])
         #expect(concurrentRows.filter { $0.hasPrefix("pending-machine:") }.count == 2)


### PR DESCRIPTION
Fixes three baseline compile errors in MachineCreateCoordinatorTests.swift.

- Make optional supersession assertion explicit.
- Qualify shared request helper from panel tests.

Behavior is unchanged; this restores test compilation on current main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes three baseline compile errors in `MachineCreateCoordinatorTests.swift` so the test target builds again on current `main`. Behavior is unchanged.

- Makes the optional supersession assertion explicit with `== true`.
- Qualifies the shared `newMachineRequest` helper from `MachineCreateCoordinatorTests` in panel tests.

<sup>Written for commit 1bdcd333c9df4812909b60267f261162a9e36466. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

