### PR TITLE
CLI: align cloud tree detached terminal lifecycle

### DIFF
--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -1162,7 +1162,7 @@ extension CMUXCLI {
             for group in groups {
                 lines.append("    \(group.label)")
                 for terminal in group.items {
-                    lines.append("      " + vmTreeResourceCell(terminal, openHint: "cmux surface open"))
+                    lines.append("      " + vmTreeResourceCell(terminal, openHint: vmTreeTerminalOpenHint(terminal, "cmux surface open")))
                 }
             }
             if !browsers.isEmpty {
@@ -1232,6 +1232,9 @@ extension CMUXCLI {
                 // Only pre-multi-view payloads fall back to this field. An
                 // explicit empty `remote_views` is authoritative: the terminal
                 // has no workspace layout and belongs only in Terminals.
+                // Retained exited, launching, or unavailable records are not
+                // actionable workspace children.
+                guard Self.vmTreeTerminalIsRunning(terminal) else { continue }
                 workspacePayloads = [terminal["remote_workspace"] as? [String: Any]]
             }
             for workspace in workspacePayloads {
@@ -1285,7 +1288,11 @@ extension CMUXCLI {
             let name = workspace.name.isEmpty ? workspaceId : workspace.name
             lines.append("    \(name)  \(workspaceId)\(workspace.focused ? "  *" : "")  (cmux vm open \(id)/\(workspaceId))")
             for terminal in workspace.terminals {
-                lines.append("      " + vmTreeResourceCell(terminal, openHint: "cmux vm open \(id)/\(workspaceId)", addressKey: "key"))
+                lines.append("      " + vmTreeResourceCell(
+                    terminal,
+                    openHint: vmTreeTerminalOpenHint(terminal, "cmux vm open \(id)/\(workspaceId)"),
+                    addressKey: "key"
+                ))
             }
         }
         // Ports come before displays, matching the Cloud sidebar's group order.
@@ -1339,12 +1346,12 @@ extension CMUXCLI {
                 }
             }
             for terminal in attached {
-                lines.append("    " + vmTreeResourceCell(terminal, openHint: "cmux surface open"))
+                lines.append("    " + vmTreeResourceCell(terminal, openHint: vmTreeTerminalOpenHint(terminal, "cmux surface open")))
             }
             if !detached.isEmpty {
                 lines.append("    " + String(localized: "cli.vm.tree.detached", defaultValue: "(detached — no tab on the machine shows these)"))
                 for terminal in detached {
-                    lines.append("      " + vmTreeResourceCell(terminal, openHint: "cmux surface open"))
+                    lines.append("      " + vmTreeResourceCell(terminal, openHint: vmTreeTerminalOpenHint(terminal, "cmux surface open")))
                 }
             }
         }
@@ -1365,13 +1372,29 @@ extension CMUXCLI {
         return terminal["remote_workspace"] == nil
     }
 
+    /// Legacy payloads expose `running` without a lifecycle string. Keep their
+    /// grouping semantics aligned with lifecycle-aware payloads.
+    private static func vmTreeTerminalIsRunning(_ terminal: [String: Any]) -> Bool {
+        if let lifecycle = terminal["lifecycle"] as? String {
+            return lifecycle == "running"
+        }
+        return (terminal["running"] as? Bool) == true
+    }
+
+    /// Returns an open command only for terminals that can still be projected.
+    /// Exited records remain visible for lifecycle inspection but cannot be reopened.
+    private static func vmTreeTerminalOpenHint(_ terminal: [String: Any], _ hint: String) -> String? {
+        guard (terminal["lifecycle"] as? String) != "exited" else { return nil }
+        return hint
+    }
+
     /// One resource line: lifecycle glyph, id, title, detail, agent badge, open marker,
     /// and the address to open it. `addressKey` picks the resource's `key` (cloud terminal
     /// workspace rows) or its full id (pool rows); display rows set `showFullKey` so each
     /// screen number remains visible instead of being truncated to the common prefix.
     private static func vmTreeResourceCell(
         _ terminal: [String: Any],
-        openHint: String,
+        openHint: String?,
         addressKey: String = "id",
         showFullKey: Bool = false
     ) -> String {
@@ -1397,8 +1420,10 @@ extension CMUXCLI {
         if let open = (terminal["open_surface_ids"] as? [String])?.first, !open.isEmpty {
             cell += "  " + String(format: String(localized: "cli.vm.tree.open", defaultValue: "(open: %@)"), String(open.prefix(8)))
         }
-        let address = addressKey == "key" ? "\(openHint)/\(key)" : "\(openHint) \(resourceId)"
-        cell += "  (\(address))"
+        if let openHint {
+            let address = addressKey == "key" ? "\(openHint)/\(key)" : "\(openHint) \(resourceId)"
+            cell += "  (\(address))"
+        }
         return cell
     }
 

--- a/CLI/CMUXCLI+VMTui.swift
+++ b/CLI/CMUXCLI+VMTui.swift
@@ -1384,7 +1384,12 @@ extension CMUXCLI {
     /// Returns an open command only for terminals that can still be projected.
     /// Exited records remain visible for lifecycle inspection but cannot be reopened.
     private static func vmTreeTerminalOpenHint(_ terminal: [String: Any], _ hint: String) -> String? {
-        guard (terminal["lifecycle"] as? String) != "exited" else { return nil }
+        if let lifecycle = terminal["lifecycle"] as? String {
+            return lifecycle == "exited" ? nil : hint
+        }
+        if let running = terminal["running"] as? Bool, !running {
+            return nil
+        }
         return hint
     }
 

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -493,6 +493,86 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(!row.isDetached, "an exited record with unresolved views stays an ordinary exited row")
     }
 
+    @Test("CLI keeps an exited zero-view terminal out of the detached label")
+    func cliDoesNotLabelExitedZeroViewAsDetached() throws {
+        let machine: [String: Any] = [
+            "id": machineID,
+            "status": "running",
+            "link_state": "connected",
+        ]
+        let exited: [String: Any] = [
+            "id": "\(machineID)/terminal/term_exited",
+            "key": "term_exited",
+            "kind": "terminal",
+            "lifecycle": "exited",
+            "remote_views": [[String: Any]](),
+        ]
+
+        let result = try runCLICloudTree(machine: machine, resources: [exited])
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stdout.contains("term_exited"))
+        #expect(!result.stdout.contains("detached"))
+        #expect(!result.stdout.contains("cmux surface open"))
+    }
+
+    @Test("CLI does not advertise vm open for an exited workspace terminal")
+    func cliDoesNotOfferOpenForExitedWorkspaceTerminal() throws {
+        let workspace: [String: Any] = [
+            "id": "ws_main",
+            "name": "main",
+            "index": 0,
+            "focused": true,
+        ]
+        let machine: [String: Any] = [
+            "id": machineID,
+            "status": "running",
+            "link_state": "connected",
+            "remote_workspaces": [workspace],
+        ]
+        let exited: [String: Any] = [
+            "id": "\(machineID)/terminal/term_exited",
+            "key": "term_exited",
+            "kind": "terminal",
+            "lifecycle": "exited",
+            "remote_workspace": workspace,
+            "remote_views": [["workspace": workspace]],
+        ]
+
+        let result = try runCLICloudTree(machine: machine, resources: [exited])
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stdout.contains("term_exited"))
+        #expect(!result.stdout.contains("cmux vm open \(machineID)/ws_main/term_exited"))
+    }
+
+    @Test("CLI does not group an exited legacy terminal in a workspace")
+    func cliDoesNotGroupExitedLegacyTerminalInWorkspace() throws {
+        let workspace: [String: Any] = [
+            "id": "ws_main",
+            "name": "main",
+            "index": 0,
+            "focused": true,
+        ]
+        let machine: [String: Any] = [
+            "id": machineID,
+            "status": "running",
+            "link_state": "connected",
+            "remote_workspaces": [workspace],
+        ]
+        // Older providers omit remote_views and expose only the legacy owner field.
+        let exited: [String: Any] = [
+            "id": "\(machineID)/terminal/term_exited",
+            "key": "term_exited",
+            "kind": "terminal",
+            "lifecycle": "exited",
+            "remote_workspace": workspace,
+        ]
+
+        let result = try runCLICloudTree(machine: machine, resources: [exited])
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stdout.contains("    ○ term_exited"))
+        #expect(!result.stdout.contains("      ○ term_exited"), "an exited legacy terminal stays in the pool")
+    }
+
     @Test("Sidebar keeps machine-owned terminals visible for unavailable cloud links")
     func sidebarKeepsTerminalsWhenLinkUnavailable() throws {
         let terminal = terminal("term_sleeping", in: [])

--- a/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
+++ b/cmuxTests/CloudTreeOneMachineManyWorkspacesTests.swift
@@ -573,6 +573,26 @@ struct CloudTreeOneMachineManyWorkspacesTests {
         #expect(!result.stdout.contains("      ○ term_exited"), "an exited legacy terminal stays in the pool")
     }
 
+    @Test("CLI does not offer surface open for a stopped legacy terminal")
+    func cliDoesNotOfferOpenForStoppedLegacyTerminal() throws {
+        let machine: [String: Any] = [
+            "id": machineID,
+            "status": "running",
+            "link_state": "connected",
+        ]
+        let stopped: [String: Any] = [
+            "id": "\(machineID)/terminal/term_stopped",
+            "key": "term_stopped",
+            "kind": "terminal",
+            "running": false,
+        ]
+
+        let result = try runCLICloudTree(machine: machine, resources: [stopped])
+        #expect(result.status == 0, Comment(rawValue: result.stderr))
+        #expect(result.stdout.contains("term_stopped"))
+        #expect(!result.stdout.contains("cmux surface open"))
+    }
+
     @Test("Sidebar keeps machine-owned terminals visible for unavailable cloud links")
     func sidebarKeepsTerminalsWhenLinkUnavailable() throws {
         let terminal = terminal("term_sleeping", in: [])


### PR DESCRIPTION
Keep `cmux vm tree` lifecycle semantics aligned with the cloud sidebar.

- Red commit `6f52a35d666` covers exited zero-view grouping and dead open hints.
- Fix commit `24af105cf20` excludes non-running zero-view resources from the detached group and suppresses `vm open` addresses for exited workspace terminals.

The parser normally drops exited zero-view records, but retained records can occur when tab ids no longer resolve. This keeps CLI output from advertising a dead reattach action. `git diff --check` passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns `cmux vm tree` terminal lifecycle with the cloud sidebar. Only running terminals are listed as detached, exited and stopped terminals no longer show open hints, and exited legacy terminals without `remote_views` stay in the pool instead of workspace groups.

<sup>Written for commit 5336ada3499013aec41cc79c642dc48c54f7b83d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

