### PR TITLE
iOS: reconnecting never exits the user's workspace or invalidates their current task

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceListRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceListRecovery.swift
@@ -123,10 +123,10 @@ extension MobileShellComposite {
             return
         }
         // Failed dials run their own cleanup with the default non-preserving
-        // teardown, dropping the secondary subscriptions preserved above (the
-        // foreground id is already nil, so that filter keeps only the
-        // anonymous key). Rebuild them so a failed foreground redial cannot
-        // strand healthy secondary Macs.
+        // teardown, cancelling the secondary subscriptions preserved above
+        // (their last-known rows stay, downgraded to unavailable). Rebuild the
+        // subscriptions so a failed foreground redial cannot strand healthy
+        // secondary Macs on stale rows.
         await refreshSecondaryMacWorkspaces()
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -10596,8 +10596,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectionAttemptGeneration = UUID()
         // Capture the tagged foreground key BEFORE the identity clears below:
         // `foregroundMacKey` derives from `activeMacInstanceTag`, which
-        // `clearActiveConnectionContext()` nils, and the offline retention
-        // filter must keep the exact tagged entry.
+        // `clearActiveConnectionContext()` nils, and the offline status
+        // downgrade must hit the exact tagged entry.
         let offlineForegroundKey = foregroundMacKey
         focusedHandoffPreparedGenerations.removeAll()
         cancelRemoteOperationTasks()
@@ -10619,35 +10619,32 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         replaceRemoteClient(with: nil)
         foregroundMacDeviceID = nil
         if !preservingOtherMacWorkspaceState {
-            // Cancel the live secondary subscriptions (slice 3) and keep only the
-            // now-offline foreground Mac's last-known workspaces for the offline
-            // view; the derived list recomputes to just the offline Mac's rows.
-            // The demonstration Mac's entry is also retained: it has no
-            // subscription or transport, so unlike a real secondary nothing
-            // re-establishes it, and dropping it here made every failed dial
-            // of an unreachable real Mac erase the demo workspaces. Demo state
-            // is invariant to real-connection teardown by design.
+            // Cancel the live secondary subscriptions (slice 3). Their rows STAY:
+            // teardown is a transport event, and transport events never remove
+            // user-visible workspace state. Rows are removed only by authoritative
+            // events (a healthy list reconcile, unpair/hide, sign-out, team
+            // change). Removing them here popped the mounted workspace detail the
+            // moment a reconnect began: dropping secondary entries flips multi-Mac
+            // row-id scoping (re-keying the selection and every pushed navigation
+            // route), and a failed first dial re-entered this teardown with
+            // `foregroundMacDeviceID` already nil, so a retention filter keyed on
+            // the anonymous sentinel wiped the whole list. The demonstration
+            // Mac's entry survives with the rest; demo state is invariant to
+            // real-connection teardown by design.
             teardownSecondaryMacSubscriptions()
-            workspacesByMac = workspacesByMac.filter {
-                $0.key == offlineForegroundKey
-                    || $0.key == Self.demonstrationPairingKey
-            }
         }
-        // The retained foreground entry still carries its last-known
-        // `status: .connected`; `macConnectionStatuses` (the Computers screen's
-        // per-Mac dots) derives from these per-Mac states, so without this the
-        // just-disconnected Mac would keep showing a green connected dot. Downgrade
-        // it to `.unavailable` to match the global connection state.
-        let offlineDeviceID = offlineForegroundKey.canonicalMacDeviceID
+        // Retained entries still carry their last-known `status: .connected`;
+        // `macConnectionStatuses` (the Computers screen's per-Mac dots) derives
+        // from these per-Mac states, so without this the just-disconnected Macs
+        // would keep showing a green connected dot. Downgrade the foreground
+        // entry — and every entry whose secondary subscription was torn down
+        // above — to `.unavailable` to match the global connection state.
         let keysToDowngrade = workspacesByMac.keys.filter { key in
             // The demonstration entry keeps its connected presentation: it is
             // served locally and its liveness is unrelated to the torn-down
             // real connection.
             guard key != Self.demonstrationPairingKey else { return false }
-            return key == offlineForegroundKey
-                || (!preservingOtherMacWorkspaceState
-                    && offlineForegroundKey != .anonymousForeground
-                    && key.canonicalMacDeviceID == offlineDeviceID)
+            return key == offlineForegroundKey || !preservingOtherMacWorkspaceState
         }
         var updatedWorkspacesByMac = workspacesByMac
         for key in keysToDowngrade {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ConnectionTeardownWorkspaceRetentionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ConnectionTeardownWorkspaceRetentionTests.swift
@@ -1,0 +1,138 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+/// Connection teardown is a transport event: it must never remove user-visible
+/// workspace rows, retarget the selection, or change derived row identity.
+/// Rows are removed only by authoritative events (a healthy workspace list,
+/// unpair/hide, sign-out, team change).
+///
+/// These pin the reconnect regression where a recovery redial tore down the
+/// connection context once (dropping every secondary Mac's rows, which flips
+/// multi-Mac row-id scoping and re-keys the pushed navigation route), and a
+/// failed first dial tore it down again with the foreground identity already
+/// nil — so the retention filter keyed on the anonymous sentinel, wiped
+/// `workspacesByMac` entirely, nilled the selection, and popped the mounted
+/// workspace detail the moment reconnecting began.
+@MainActor
+struct ConnectionTeardownWorkspaceRetentionTests {
+    private static let foregroundKey = MacPairingKey(
+        macDeviceID: "mac-fg",
+        instanceTag: "default"
+    )
+    private static let secondaryKey = MacPairingKey(
+        macDeviceID: "mac-2nd",
+        instanceTag: "default"
+    )
+
+    private func makeTwoMacStore() -> MobileShellComposite {
+        let store = MobileShellComposite(
+            isSignedIn: true,
+            connectionState: .connected,
+            presence: IdlePresence(),
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            teamIDProvider: { "team-1" },
+            reachability: AlwaysOnlineReachability(),
+            pendingDismissQueue: PendingNotificationDismissQueue(
+                defaults: UserDefaults(
+                    suiteName: "teardown-retention-\(UUID().uuidString)"
+                )!
+            )
+        )
+        var foregroundWorkspace = MobileWorkspacePreview(
+            id: "ws-fg",
+            macDeviceID: "mac-fg",
+            name: "Foreground Workspace",
+            terminals: []
+        )
+        foregroundWorkspace.macInstanceTag = "default"
+        var secondaryWorkspace = MobileWorkspacePreview(
+            id: "ws-2nd",
+            macDeviceID: "mac-2nd",
+            name: "Secondary Workspace",
+            terminals: []
+        )
+        secondaryWorkspace.macInstanceTag = "default"
+        store.foregroundMacDeviceID = "mac-fg"
+        store.activeMacInstanceTag = "default"
+        store.macConnectionStatus = .connected
+        store.workspacesByMac = [
+            Self.foregroundKey: MacWorkspaceState(
+                macDeviceID: "mac-fg",
+                instanceTag: "default",
+                displayName: "Foreground Mac",
+                workspaces: [foregroundWorkspace],
+                status: .connected
+            ),
+            Self.secondaryKey: MacWorkspaceState(
+                macDeviceID: "mac-2nd",
+                instanceTag: "default",
+                displayName: "Secondary Mac",
+                workspaces: [secondaryWorkspace],
+                status: .connected
+            ),
+        ]
+        return store
+    }
+
+    /// Models the recovery sequence exactly: redial teardown with the
+    /// foreground identity still set, then a failed-dial teardown after that
+    /// identity was nilled by the first.
+    private func runRecoveryTeardownTwice(on store: MobileShellComposite) {
+        store.connectionState = .disconnected
+        store.macConnectionStatus = .unavailable
+        store.clearRemoteConnectionContext()
+        store.clearRemoteConnectionContext()
+    }
+
+    @Test func teardownRetainsEveryMacsRowsAndForegroundSelection() {
+        let store = makeTwoMacStore()
+        let initialRowIDs = Set(store.workspaces.map(\.id))
+        #expect(initialRowIDs.count == 2)
+        let selected = store.workspaces.first { $0.macDeviceID == "mac-fg" }
+        #expect(selected != nil)
+        store.selectedWorkspaceID = selected?.id
+
+        store.connectionState = .disconnected
+        store.macConnectionStatus = .unavailable
+        store.clearRemoteConnectionContext()
+
+        #expect(store.workspacesByMac[Self.foregroundKey] != nil)
+        #expect(store.workspacesByMac[Self.secondaryKey] != nil)
+        #expect(store.workspacesByMac.values.allSatisfy { $0.status == .unavailable })
+        #expect(store.selectedWorkspaceID == selected?.id)
+        #expect(Set(store.workspaces.map(\.id)) == initialRowIDs)
+
+        store.clearRemoteConnectionContext()
+
+        #expect(store.workspacesByMac[Self.foregroundKey] != nil)
+        #expect(store.workspacesByMac[Self.secondaryKey] != nil)
+        #expect(store.selectedWorkspaceID == selected?.id)
+        #expect(Set(store.workspaces.map(\.id)) == initialRowIDs)
+    }
+
+    @Test func teardownKeepsSelectionOnSecondaryMacRow() {
+        let store = makeTwoMacStore()
+        let selected = store.workspaces.first { $0.macDeviceID == "mac-2nd" }
+        #expect(selected != nil)
+        store.selectedWorkspaceID = selected?.id
+
+        runRecoveryTeardownTwice(on: store)
+
+        #expect(store.workspacesByMac[Self.secondaryKey] != nil)
+        #expect(store.selectedWorkspaceID == selected?.id)
+        #expect(store.workspaces.contains { $0.id == selected?.id })
+    }
+
+    @Test func preservingTeardownStillDowngradesOnlyTheForegroundEntry() {
+        let store = makeTwoMacStore()
+
+        store.connectionState = .disconnected
+        store.macConnectionStatus = .unavailable
+        store.clearRemoteConnectionContext(preservingOtherMacWorkspaceState: true)
+
+        #expect(store.workspacesByMac[Self.foregroundKey]?.status == .unavailable)
+        #expect(store.workspacesByMac[Self.secondaryKey]?.status == .connected)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -242,6 +242,15 @@ struct WorkspaceShellView: View {
         return store.workspaceListConnectionStatus
     }
 
+    /// Whether the workspace list reflects a healthy connection. Compact
+    /// navigation pops a mounted detail only when it does: a reconnecting or
+    /// disconnected state must never exit the user's current workspace, so
+    /// list holes and cleared selections during a degraded connection keep the
+    /// pushed route mounted on its last-known snapshot.
+    private var workspaceListIsAuthoritative: Bool {
+        listConnectionStatus == .connected
+    }
+
     private var canCreateWorkspaceOnForegroundConnection: Bool {
         store.connectionState == .connected
     }
@@ -702,7 +711,8 @@ struct WorkspaceShellView: View {
             compactNavigationPath = compactNavigationPolicy.pathForSelectionChange(
                 currentPath: compactNavigationPath,
                 selectedWorkspaceID: selectedWorkspaceID,
-                visibleWorkspaceIDs: Set(store.workspaces.map(\.id))
+                visibleWorkspaceIDs: Set(store.workspaces.map(\.id)),
+                listIsAuthoritative: workspaceListIsAuthoritative
             )
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }
@@ -720,7 +730,8 @@ struct WorkspaceShellView: View {
             compactNavigationPath = compactNavigationPolicy.pathForVisibleWorkspaceIDsChange(
                 currentPath: compactNavigationPath,
                 visibleWorkspaceIDs: Set(workspaceIDs),
-                selectedWorkspaceID: store.selectedWorkspaceID
+                selectedWorkspaceID: store.selectedWorkspaceID,
+                listIsAuthoritative: workspaceListIsAuthoritative
             )
             autoOpenSelectedWorkspaceForSoakIfNeeded()
         }

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/WorkspaceShellCompactNavigationPolicy.swift
@@ -14,6 +14,11 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// - Parameters:
     ///   - currentPath: The current navigation path.
     ///   - selectedWorkspaceID: The newly selected workspace, or `nil` to clear.
+    ///   - listIsAuthoritative: Whether the workspace list reflects a healthy
+    ///     connection. A cleared selection pops to the root only when it does;
+    ///     while reconnecting or disconnected the mounted detail stays, because
+    ///     a connection-state change must never exit the user's current
+    ///     workspace.
     /// - Returns: The path to apply. Stays empty when the user is at the root,
     ///   clears when the authoritative selection clears, and retargets when the
     ///   store selects a different workspace. Transient workspace-list omissions
@@ -21,13 +26,14 @@ public struct WorkspaceShellCompactNavigationPolicy {
     public func pathForSelectionChange<ID: Hashable>(
         currentPath: [ID],
         selectedWorkspaceID: ID?,
-        visibleWorkspaceIDs: Set<ID> = []
+        visibleWorkspaceIDs: Set<ID> = [],
+        listIsAuthoritative: Bool = true
     ) -> [ID] {
         guard !currentPath.isEmpty else {
             return currentPath
         }
         guard let selectedWorkspaceID else {
-            return []
+            return listIsAuthoritative ? [] : currentPath
         }
         guard currentPath.last != selectedWorkspaceID else {
             return currentPath
@@ -80,10 +86,16 @@ public struct WorkspaceShellCompactNavigationPolicy {
     /// terminal arrives. If the authoritative selection has moved away, pop or
     /// remap to the selected visible workspace so deleted workspaces do not stay
     /// mounted from a stale route snapshot.
+    /// - Parameter listIsAuthoritative: Whether the workspace list reflects a
+    ///   healthy connection. Routes are dropped only when it does; a list hole
+    ///   opened by a reconnecting or disconnected state keeps the mounted
+    ///   detail, which renders its last-known snapshot until the next healthy
+    ///   list restores the row or confirms the deletion.
     public func pathForVisibleWorkspaceIDsChange<ID: Hashable>(
         currentPath: [ID],
         visibleWorkspaceIDs: Set<ID>,
-        selectedWorkspaceID: ID?
+        selectedWorkspaceID: ID?,
+        listIsAuthoritative: Bool = true
     ) -> [ID] {
         guard let currentDetailID = currentPath.last else {
             return currentPath
@@ -97,6 +109,9 @@ public struct WorkspaceShellCompactNavigationPolicy {
         if let selectedWorkspaceID,
            visibleWorkspaceIDs.contains(selectedWorkspaceID) {
             return [selectedWorkspaceID]
+        }
+        guard listIsAuthoritative else {
+            return currentPath
         }
         return currentPath.filter { visibleWorkspaceIDs.contains($0) }
     }

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/WorkspaceShellCompactNavigationPolicyTests.swift
@@ -148,4 +148,49 @@ import Testing
 
         #expect(path.isEmpty)
     }
+
+    @Test func clearedSelectionKeepsDetailWhileListIsNotAuthoritative() {
+        let detailID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let path = policy.pathForSelectionChange(
+            currentPath: [detailID],
+            selectedWorkspaceID: nil,
+            listIsAuthoritative: false
+        )
+
+        #expect(path == [detailID])
+    }
+
+    @Test func clearedSelectionStillPopsWhenListIsAuthoritative() {
+        let path = policy.pathForSelectionChange(
+            currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
+            selectedWorkspaceID: nil,
+            listIsAuthoritative: true
+        )
+
+        #expect(path.isEmpty)
+    }
+
+    @Test func listHoleKeepsDetailWhileListIsNotAuthoritative() {
+        let detailID = MobileWorkspacePreview.ID(rawValue: "workspace-a")
+        let path = policy.pathForVisibleWorkspaceIDsChange(
+            currentPath: [detailID],
+            visibleWorkspaceIDs: [],
+            selectedWorkspaceID: nil,
+            listIsAuthoritative: false
+        )
+
+        #expect(path == [detailID])
+    }
+
+    @Test func retargetsToVisibleSelectionEvenWhileListIsNotAuthoritative() {
+        let selectedID = MobileWorkspacePreview.ID(rawValue: "workspace-b")
+        let path = policy.pathForVisibleWorkspaceIDsChange(
+            currentPath: [MobileWorkspacePreview.ID(rawValue: "workspace-a")],
+            visibleWorkspaceIDs: [selectedID],
+            selectedWorkspaceID: selectedID,
+            listIsAuthoritative: false
+        )
+
+        #expect(path == [selectedID])
+    }
 }


### PR DESCRIPTION
Supersedes https://github.com/manaflow-ai/cmux/pull/11091 (same fix, rebuilt onto current main; the old branch fell 622 commits behind and conflicts with the demonstration-mode changes from https://github.com/manaflow-ai/cmux/pull/11289).

On iPhone, the moment an in-foreground or background-to-foreground reconnect began, the mounted workspace detail popped back to the list, and sometimes the whole workspace list reset. Reproduced today on the 09-02 INTERNAL build: the irx journal shows constant teardown/redial churn (rate-limited dials with 60s Retry-After, `host-shutdown` reaps, `explicit-redial` closes), and every one of those teardowns ran `clearRemoteConnectionContext`, which removed `workspacesByMac` rows.

Two cascades, pinned by the red test commit:

1. Redial teardown dropped every secondary Mac's entry. Going from N Macs to 1 flips multi-Mac row-id scoping, so every derived row id changes raw value, the selection remaps, and the pushed navigation route is destroyed (the mounted detail pops). It happens again in reverse when the reconnect completes.
2. A failed first dial re-enters the teardown with `foregroundMacDeviceID` already nil, so the retention filter keyed on the anonymous sentinel and wiped the entire list.

Fix: teardown is a transport event and never removes rows. Retained entries only downgrade to `.unavailable` (idempotent), so the Computers dots stay truthful; the post-reconnect secondary refresh re-syncs them. Row removal stays exclusively with authoritative events: healthy list reconcile, unpair/hide, sign-out, team change. The demonstration Mac's entry keeps its connected presentation per #11289.

Defense-in-depth at the navigation layer: `WorkspaceShellCompactNavigationPolicy` takes `listIsAuthoritative` (the view passes `listConnectionStatus == .connected`). While reconnecting or disconnected, a cleared selection or a list hole keeps the mounted detail on its last-known snapshot; pops still happen normally once a healthy list confirms a deletion. Retarget-to-visible-selection stays allowed.

Commit 1 adds the failing tests only (CI red), commit 2 the fix (CI green): `ConnectionTeardownWorkspaceRetentionTests` (CmuxMobileShell) and 4 new `WorkspaceShellCompactNavigationPolicyTests` cases (CmuxMobileWorkspace).

HIG (Feedback): status changes should keep people informed "without making them leave their current context".

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791056282&installation_model_id=21920&pr_number=11873&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11873&signature=cd0886dbde68e2f2ecf30efaa0d121a344ec57fa3136215d66993c11863822ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS reconnect so starting a reconnect no longer pops the mounted workspace detail back to the list or wipes the workspace list.

**Bug Fixes**
- Connection teardown now keeps all workspace rows and only downgrades their status to `.unavailable`, so the Computers dots stay truthful and the post-reconnect refresh re-syncs them.
- Rows are removed only by authoritative events: healthy list reconcile, unpair/hide, sign-out, team change.
- Compact navigation now keeps the mounted detail while the list is reconnecting or disconnected; pops still happen once a healthy list confirms a deletion.
- Adds regression tests for both the teardown retention and the navigation policy.

<sup>Written for commit fc309b5b46ed920553626fb152892d21ef1c67b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Workspace rows now remain visible when a Mac connection is interrupted or reconnects.
  - Previously selected workspaces and their navigation routes are preserved during temporary connection issues.
  - Workspaces affected by teardown are shown as unavailable rather than removed.
  - Secondary Mac workspaces retain their connected status when only the foreground connection is downgraded.
  - Detail views remain mounted while workspace data is temporarily unavailable, preventing unexpected navigation back to the root.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->