### PR TITLE
Fix false older-pairing marker during presence loading

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -114,7 +114,7 @@ extension MacComputerSnapshot {
     /// record and later non-online occurrences get labeled "Older pairing".
     /// An online row is never labeled: a running instance is not stale even
     /// if a fresher same-named record exists.
-    private static func markOlderDuplicates(_ snapshots: inout [MacComputerSnapshot]) {
+    static func markOlderDuplicates(_ snapshots: inout [MacComputerSnapshot]) {
         var seenNames: Set<String> = []
         for index in snapshots.indices {
             let name = snapshots[index].title

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -103,7 +103,7 @@ extension MacComputerSnapshot {
         return snapshots
     }
 
-    /// Flag rows that share a fresher row's name and are not online.
+    /// Flag rows that share a fresher row's name and are confirmed offline.
     ///
     /// A Mac that re-paired across dev builds before the shared device id
     /// (cmux PR https://github.com/manaflow-ai/cmux/pull/6772) left one stored
@@ -111,16 +111,20 @@ extension MacComputerSnapshot {
     /// not coalesce (each dials a different port), so without a marker the
     /// list reads as interchangeable duplicates. `displayPairedMacs` arrives
     /// last-seen-newest-first, so the first occurrence of a name is the live
-    /// record and later non-online occurrences get labeled "Older pairing".
-    /// An online row is never labeled: a running instance is not stale even
-    /// if a fresher same-named record exists.
+    /// record and later offline occurrences get labeled "Older pairing".
+    /// Unknown presence is left unlabeled because it is the normal startup
+    /// state while the first presence snapshot is still loading. An online row
+    /// is never labeled: a running instance is not stale even if a fresher
+    /// same-named record exists.
     static func markOlderDuplicates(_ snapshots: inout [MacComputerSnapshot]) {
         var seenNames: Set<String> = []
         for index in snapshots.indices {
             let name = snapshots[index].title
                 .trimmingCharacters(in: .whitespacesAndNewlines)
                 .lowercased()
-            if seenNames.contains(name), snapshots[index].presence != .online {
+            if seenNames.contains(name),
+               let presence = snapshots[index].presence,
+               case .offline = presence {
                 snapshots[index].isOlderDuplicate = true
             } else {
                 seenNames.insert(name)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
@@ -38,7 +38,7 @@ struct MacComputerSnapshot: Equatable, Identifiable {
     /// Stored paired-Mac ids represented by this visible row.
     let aliasIDs: [String]
     /// Whether a fresher row with the same computer name exists and this row is
-    /// not online: almost always a stale pairing record from an older dev-build
+    /// confirmed offline: almost always a stale pairing record from an older dev-build
     /// device id (pre-shared-device-id, cmux PR
     /// https://github.com/manaflow-ai/cmux/pull/6772), kept so the user can
     /// still reconnect or remove it. Labeled so several identically named

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSnapshotDuplicateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MacComputerSnapshotDuplicateTests.swift
@@ -1,0 +1,54 @@
+import CMUXMobileCore
+@testable import CmuxMobileShellUI
+import Foundation
+import Testing
+
+@Suite struct MacComputerSnapshotDuplicateTests {
+    @Test func unknownPresenceDoesNotLookLikeAnOlderPairing() {
+        var snapshots = [
+            snapshot(title: "MacBook Pro", presence: .online),
+            snapshot(title: "MacBook Pro", presence: nil),
+        ]
+
+        MacComputerSnapshot.markOlderDuplicates(&snapshots)
+
+        #expect(snapshots[1].isOlderDuplicate == false)
+    }
+
+    @Test func confirmedOfflineDuplicateIsMarkedAsOlderPairing() {
+        var snapshots = [
+            snapshot(title: "MacBook Pro", presence: .online),
+            snapshot(
+                title: "MacBook Pro",
+                presence: .offline(lastSeenAt: Date(timeIntervalSince1970: 10))
+            ),
+        ]
+
+        MacComputerSnapshot.markOlderDuplicates(&snapshots)
+
+        #expect(snapshots[1].isOlderDuplicate)
+    }
+
+    private func snapshot(
+        title: String,
+        presence: DeviceTreePresence?
+    ) -> MacComputerSnapshot {
+        MacComputerSnapshot(
+            deviceId: UUID().uuidString,
+            instanceTag: nil,
+            title: title,
+            platform: "mac",
+            colorIndex: nil,
+            customColor: nil,
+            customIcon: nil,
+            connectionStatus: nil,
+            presence: presence,
+            buildLabel: "Nightly",
+            routeDescription: nil,
+            routes: [],
+            lastSeenAt: Date(timeIntervalSince1970: 0),
+            workspaceCount: 0,
+            aliasIDs: []
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- keep unknown presence neutral while the initial presence snapshot loads
- retain the Older pairing marker for confirmed offline duplicate rows
- add regression coverage for unknown and offline presence

## Verification
- `git diff --check`
- Focused Swift package test was blocked locally because the package requires iOS-only platform dependencies; the tagged cloud macOS build was blocked by an unrelated existing `TerminalController` initializer error in the base revision.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791063500&installation_model_id=21920&pr_number=11875&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11875&signature=9f4c277307a1b8014c2d2cc651653078c7177510e3a76ae0ff323cf0c68eea70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the "Older pairing" marker so it no longer appears on duplicate rows while presence is still loading. Previously any non-online duplicate was labeled; now only confirmed offline rows are labeled, and unknown presence stays neutral during initial snapshot load. Adds regression tests for both unknown and offline presence.

<sup>Written for commit 88d09225b29c292f92fae67a68a62dc3308fee8a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Duplicate computer snapshots are now marked as older only when the computer is confirmed offline.
  * Computers with unknown presence—such as during initial status loading—are no longer incorrectly labeled as older duplicates.
  * Updated descriptions clarify the distinction between confirmed offline and unknown presence states.

* **Tests**
  * Added coverage for both unknown-presence snapshots and confirmed-offline duplicates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->