### PR TITLE
Fix stale workspace-group rows left alignment

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -35213,9 +35213,9 @@ export default CMUXSessionRestore;
                         pid: pid,
                         launchCommand: resumeLaunchCommand,
                         agentLifecycle: .unknown,
+                        hookEventName: persistedHookEventName,
                         runtimeStatus: suppressVisibleMutations ? nil : .running,
                         updateRuntimeStatus: !suppressVisibleMutations,
-                        hookEventName: persistedHookEventName,
                         supersedesSameProcessSession: def.name == "omp"
                     )) ?? []
                     acceptedSessionStart = true

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11399,7 +11399,8 @@ struct VerticalTabsSidebar: View, Equatable {
         )
         let memberWorkspaceIdsByGroupId = SidebarWorkspaceRenderItem.memberWorkspaceIdsByGroupId(
             tabs: tabs,
-            groupsById: workspaceGroupById
+            groupsById: workspaceGroupById,
+            effectiveMembership: workspaceGroupIdByWorkspaceId
         )
         let workspaceGroupMenuSnapshot = WorkspaceGroupMenuSnapshot(
             items: workspaceGroups.map { WorkspaceGroupMenuSnapshot.Item(id: $0.id, name: $0.name) }
@@ -11407,7 +11408,8 @@ struct VerticalTabsSidebar: View, Equatable {
         let workspaceRenderItems = SidebarWorkspaceRenderItem.renderItems(
             tabs: tabs,
             groupsById: workspaceGroupById,
-            orderedGroups: workspaceGroups
+            orderedGroups: workspaceGroups,
+            effectiveMembership: workspaceGroupIdByWorkspaceId
         )
         let numberedWorkspaceIndexById = SidebarWorkspaceRenderItem.numberedWorkspaceIndexById(
             from: workspaceRenderItems

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11379,7 +11379,6 @@ struct VerticalTabsSidebar: View, Equatable {
             workspacesById: workspaceById,
             liveWorkspaceIds: Set(tabIds)
         )
-        let workspaceGroupIdByWorkspaceId = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0.groupId) })
         let orderedSelectedTabs = tabs.filter { selectedTabIds.contains($0.id) }
         let selectedContextTargetIds = orderedSelectedTabs.map(\.id)
         let selectedRemoteContextMenuTargets = orderedSelectedTabs.filter {
@@ -11394,7 +11393,14 @@ struct VerticalTabsSidebar: View, Equatable {
             selectedRemoteContextMenuTargets.allSatisfy { $0.remoteConnectionState == .disconnected }
         let workspaceGroups = isPresented ? tabManager.workspaceGroups : []
         let workspaceGroupById = Dictionary(uniqueKeysWithValues: workspaceGroups.map { ($0.id, $0) })
-        let memberWorkspaceIdsByGroupId = SidebarWorkspaceRenderItem.memberWorkspaceIdsByGroupId(tabs: tabs)
+        let workspaceGroupIdByWorkspaceId = SidebarWorkspaceRenderItem.effectiveGroupIdByWorkspaceId(
+            tabs: tabs,
+            groupsById: workspaceGroupById
+        )
+        let memberWorkspaceIdsByGroupId = SidebarWorkspaceRenderItem.memberWorkspaceIdsByGroupId(
+            tabs: tabs,
+            groupsById: workspaceGroupById
+        )
         let workspaceGroupMenuSnapshot = WorkspaceGroupMenuSnapshot(
             items: workspaceGroups.map { WorkspaceGroupMenuSnapshot.Item(id: $0.id, name: $0.name) }
         )
@@ -14618,7 +14624,7 @@ struct VerticalTabsSidebar: View, Equatable {
         }()
         let result = SidebarWorkspaceRowInput(
             workspaceId: tab.id,
-            groupId: tab.groupId,
+            groupId: renderContext.workspaceGroupIdByWorkspaceId[tab.id] ?? nil,
             index: index,
             workspaceCount: renderContext.workspaceCount,
             workspace: workspaceSnapshot,

--- a/Sources/SidebarWorkspaceRenderItem.swift
+++ b/Sources/SidebarWorkspaceRenderItem.swift
@@ -38,6 +38,10 @@ enum SidebarWorkspaceRenderItem {
         orderedGroups: [WorkspaceGroup]? = nil
     ) -> [SidebarWorkspaceRenderItem] {
         guard !tabs.isEmpty || !groupsById.isEmpty else { return [] }
+        let effectiveMembershipByWorkspaceId = effectiveGroupIdByWorkspaceId(
+            tabs: tabs,
+            groupsById: groupsById
+        )
         var items: [SidebarWorkspaceRenderItem] = []
         items.reserveCapacity(tabs.count + groupsById.count)
         var lastEmittedGroupId: UUID? = nil
@@ -45,7 +49,11 @@ enum SidebarWorkspaceRenderItem {
         var collapsedByGroupId: [UUID: Bool] = [:]
         var skipChildrenUntilNextGroup = false
         for tab in tabs {
-            let groupId = tab.groupId
+            // Render and row configuration must agree on whether this tab is
+            // actually grouped. A stale group id (or a group whose live anchor
+            // disappeared) is a root row, even if it sits between members of a
+            // valid group in the persisted tab order.
+            let groupId = effectiveMembershipByWorkspaceId[tab.id] ?? nil
             if groupId != lastEmittedGroupId {
                 lastEmittedGroupId = groupId
                 skipChildrenUntilNextGroup = false
@@ -64,7 +72,7 @@ enum SidebarWorkspaceRenderItem {
                 }
             }
             // Anchor workspaces are represented exclusively by the group header.
-            if let groupId, let group = groupsById[groupId], group.anchorWorkspaceId == tab.id {
+            if let groupId, let group = groupsById[groupId], group.liveAnchorWorkspaceId == tab.id {
                 continue
             }
             if groupId == nil || !skipChildrenUntilNextGroup {
@@ -79,9 +87,14 @@ enum SidebarWorkspaceRenderItem {
         // them) but remain renderable until an explicit mutation removes them.
         let ordered = orderedGroups
             ?? groupsById.values.sorted { $0.id.uuidString < $1.id.uuidString }
-        let memberGroupIds = Set(tabs.compactMap(\.groupId))
+        let memberGroupIds = Set(effectiveMembershipByWorkspaceId.values.compactMap { $0 })
         let tabsById = Dictionary(uniqueKeysWithValues: tabs.map { ($0.id, $0) })
-        let emptyGroups = ordered.filter { !memberGroupIds.contains($0.id) }
+        // Only durable empty groups belong in the header-only projection. A
+        // nonempty group whose anchor went stale is intentionally absent from
+        // the render tree; treating it as empty would create a ghost header.
+        let emptyGroups = ordered.filter {
+            $0.isEmpty && !memberGroupIds.contains($0.id)
+        }
         guard !emptyGroups.isEmpty else { return items }
 
         var emptyBeforeGroup: [UUID: [WorkspaceGroup]] = [:]
@@ -140,7 +153,7 @@ enum SidebarWorkspaceRenderItem {
                     guard let workspace = tabsById[workspaceId] else {
                         return false
                     }
-                    if let groupId = workspace.groupId,
+                    if let groupId = effectiveMembershipByWorkspaceId[workspace.id] ?? nil,
                        let group = groupsById[groupId] {
                         return !group.isPinned
                     }
@@ -190,9 +203,62 @@ enum SidebarWorkspaceRenderItem {
     }
 
     static func memberWorkspaceIdsByGroupId(tabs: [Workspace]) -> [UUID: [UUID]] {
+        memberWorkspaceIdsByGroupId(tabs: tabs, groupsById: nil)
+    }
+
+    /// Returns the group membership that is safe for sidebar rendering.
+    ///
+    /// A workspace may carry a stale group id after a restore or an
+    /// in-flight anchor promotion. Only groups with a live anchor (or an
+    /// explicitly empty durable anchor) are renderable; all other references
+    /// become root-level rows. A live anchor also wins when its workspace's
+    /// copied `groupId` is temporarily nil, keeping the header and member rows
+    /// on one authoritative group run.
+    static func effectiveGroupIdByWorkspaceId(
+        tabs: [Workspace],
+        groupsById: [UUID: WorkspaceGroup]
+    ) -> [UUID: UUID?] {
+        let liveWorkspaceIds = Set(tabs.map(\.id))
+        let renderableGroupIds = Set(groupsById.values.compactMap { group in
+            if group.isEmpty { return group.id }
+            guard let liveAnchorId = group.liveAnchorWorkspaceId,
+                  liveWorkspaceIds.contains(liveAnchorId) else {
+                return nil
+            }
+            return group.id
+        })
+        let groupIdByLiveAnchor = groupsById.values
+            .filter { renderableGroupIds.contains($0.id) }
+            .sorted { $0.id.uuidString < $1.id.uuidString }
+            .reduce(into: [UUID: UUID]()) { result, group in
+                guard let liveAnchorId = group.liveAnchorWorkspaceId,
+                      result[liveAnchorId] == nil else { return }
+                result[liveAnchorId] = group.id
+            }
+        return Dictionary(uniqueKeysWithValues: tabs.map { tab in
+            let effectiveGroupId = groupIdByLiveAnchor[tab.id]
+                ?? tab.groupId.flatMap { renderableGroupIds.contains($0) ? $0 : nil }
+            return (tab.id, effectiveGroupId)
+        })
+    }
+
+    /// Builds the member index using effective, renderable group membership.
+    static func memberWorkspaceIdsByGroupId(
+        tabs: [Workspace],
+        groupsById: [UUID: WorkspaceGroup]?
+    ) -> [UUID: [UUID]] {
         var result: [UUID: [UUID]] = [:]
+        let effectiveMembership = groupsById.map {
+            effectiveGroupIdByWorkspaceId(tabs: tabs, groupsById: $0)
+        }
         for tab in tabs {
-            if let groupId = tab.groupId {
+            let groupId: UUID?
+            if let effectiveMembership {
+                groupId = effectiveMembership[tab.id] ?? nil
+            } else {
+                groupId = tab.groupId
+            }
+            if let groupId {
                 result[groupId, default: []].append(tab.id)
             }
         }

--- a/Sources/SidebarWorkspaceRenderItem.swift
+++ b/Sources/SidebarWorkspaceRenderItem.swift
@@ -35,13 +35,12 @@ enum SidebarWorkspaceRenderItem {
     static func renderItems(
         tabs: [Workspace],
         groupsById: [UUID: WorkspaceGroup],
-        orderedGroups: [WorkspaceGroup]? = nil
+        orderedGroups: [WorkspaceGroup]? = nil,
+        effectiveMembership: [UUID: UUID?]? = nil
     ) -> [SidebarWorkspaceRenderItem] {
         guard !tabs.isEmpty || !groupsById.isEmpty else { return [] }
-        let effectiveMembershipByWorkspaceId = effectiveGroupIdByWorkspaceId(
-            tabs: tabs,
-            groupsById: groupsById
-        )
+        let effectiveMembershipByWorkspaceId = effectiveMembership
+            ?? effectiveGroupIdByWorkspaceId(tabs: tabs, groupsById: groupsById)
         var items: [SidebarWorkspaceRenderItem] = []
         items.reserveCapacity(tabs.count + groupsById.count)
         var lastEmittedGroupId: UUID? = nil
@@ -245,16 +244,16 @@ enum SidebarWorkspaceRenderItem {
     /// Builds the member index using effective, renderable group membership.
     static func memberWorkspaceIdsByGroupId(
         tabs: [Workspace],
-        groupsById: [UUID: WorkspaceGroup]?
+        groupsById: [UUID: WorkspaceGroup]?,
+        effectiveMembership: [UUID: UUID?]? = nil
     ) -> [UUID: [UUID]] {
         var result: [UUID: [UUID]] = [:]
-        let effectiveMembership = groupsById.map {
-            effectiveGroupIdByWorkspaceId(tabs: tabs, groupsById: $0)
-        }
+        let effectiveMembershipByWorkspaceId = effectiveMembership
+            ?? groupsById.map { effectiveGroupIdByWorkspaceId(tabs: tabs, groupsById: $0) }
         for tab in tabs {
             let groupId: UUID?
-            if let effectiveMembership {
-                groupId = effectiveMembership[tab.id] ?? nil
+            if let effectiveMembershipByWorkspaceId {
+                groupId = effectiveMembershipByWorkspaceId[tab.id] ?? nil
             } else {
                 groupId = tab.groupId
             }

--- a/cmuxTests/WorkspaceGroupTests.swift
+++ b/cmuxTests/WorkspaceGroupTests.swift
@@ -227,6 +227,89 @@ struct WorkspaceGroupTests {
         ])
     }
 
+    @Test func staleGroupReferenceInsideGroupRunRendersAsRootRow() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+        let groupId = try #require(manager.createWorkspaceGroup(
+            name: String(repeating: "A very long workspace group title ", count: 4),
+            childWorkspaceIds: Array(originalIds.dropFirst())
+        ))
+        let group = try #require(manager.workspaceGroups.first { $0.id == groupId })
+        let staleMember = try #require(manager.tabs.first {
+            $0.groupId == groupId && $0.id != group.anchorWorkspaceId
+        })
+        let staleGroupId = UUID()
+        staleMember.groupId = staleGroupId
+
+        let groupsById = Dictionary(uniqueKeysWithValues: manager.workspaceGroups.map { ($0.id, $0) })
+        let effectiveMembership = SidebarWorkspaceRenderItem.effectiveGroupIdByWorkspaceId(
+            tabs: manager.tabs,
+            groupsById: groupsById
+        )
+        let memberWorkspaceIdsByGroupId = SidebarWorkspaceRenderItem.memberWorkspaceIdsByGroupId(
+            tabs: manager.tabs,
+            groupsById: groupsById
+        )
+        let renderItems = SidebarWorkspaceRenderItem.renderItems(
+            tabs: manager.tabs,
+            groupsById: groupsById
+        )
+
+        // The row is physically between grouped members in tab order, but its
+        // stale reference must not inherit the member indent. The render-item
+        // projection and row-input projection therefore agree on root-level
+        // membership, which keeps long titles left-aligned with other roots.
+        #expect(effectiveMembership[staleMember.id] == nil)
+        #expect(!memberWorkspaceIdsByGroupId[groupId, default: []].contains(staleMember.id))
+        #expect(renderItems.contains { item in
+            if case .workspace(let workspaceId) = item {
+                return workspaceId == staleMember.id
+            }
+            return false
+        })
+        #expect(!renderItems.contains { item in
+            if case .groupHeader(let renderedGroupId, _) = item {
+                return renderedGroupId == staleGroupId
+            }
+            return false
+        })
+    }
+
+    @Test func nonemptyGroupWithMissingAnchorDoesNotBecomeGhostEmptyHeader() throws {
+        let manager = makeTabManager()
+        manager.addWorkspace(autoWelcomeIfNeeded: false)
+        let originalIds = manager.tabs.map(\.id)
+        let groupId = try #require(manager.createWorkspaceGroup(
+            name: "Stale anchor",
+            childWorkspaceIds: [originalIds[1]]
+        ))
+        guard let groupIndex = manager.workspaceGroups.firstIndex(where: { $0.id == groupId }) else {
+            Issue.record("created group disappeared")
+            return
+        }
+        manager.workspaceGroups[groupIndex].anchorWorkspaceId = UUID()
+
+        let groupsById = Dictionary(uniqueKeysWithValues: manager.workspaceGroups.map { ($0.id, $0) })
+        let items = SidebarWorkspaceRenderItem.renderItems(
+            tabs: manager.tabs,
+            groupsById: groupsById
+        )
+
+        #expect(!items.contains { item in
+            if case .groupHeader(let renderedGroupId, _) = item {
+                return renderedGroupId == groupId
+            }
+            return false
+        })
+        #expect(items.compactMap { item -> UUID? in
+            guard case .workspace(let workspaceId) = item else { return nil }
+            return workspaceId
+        } == manager.tabs.map(\.id))
+    }
+
     @Test func groupHeaderEdgeDropUsesTopLevelIndicatorScope() throws {
         let manager = makeTabManager()
         manager.addWorkspace(autoWelcomeIfNeeded: false)


### PR DESCRIPTION
## Summary
- normalize stale or unknown workspace-group membership before sidebar rendering
- keep row input, group member snapshots, and render items on one membership projection
- add regressions for stale references and missing anchors

## Verification
- `git diff --check` ✅
- `python3 scripts/check-package-resolved-policy.py` ✅
- compile-only `xcodebuild` blocked: missing local `GhosttyKit.xcframework` binary artifact
- `scripts/lint-pbxproj-test-wiring.sh` reports pre-existing unrelated omission: `ClaudeHookSessionStorePersistenceTests.swift`
- local tests not run per repository workflow; run hosted test workflow once GhosttyKit/build prerequisites are available

Preserves the existing `CLI/cmux.swift` change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11881"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791068867&installation_model_id=21920&pr_number=11881&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11881&signature=b9845b817aaaf277832e1fce7425a1f4e696dbc02a4e04f6aaa6e6b4b47a8ea6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale workspace-group rows left alignment by normalizing workspace-group membership before sidebar rendering.

Previously, a tab with a stale or unknown group id could inherit member indentation or produce a ghost header. Now such tabs render as root-level rows, and nonempty groups with a missing anchor are omitted instead of appearing as empty headers. The row input, group member snapshots, and render items all use the same effective membership projection. Adds regression tests for both cases.

<sup>Written for commit 4e7eae8bad344014e1fa70ba5b1d68dc77a1f67c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11881?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Workspaces with stale or missing group references now appear as root-level items instead of incorrectly nested rows.
  - Prevented empty group headers from appearing when their anchor workspace is unavailable.
  - Preserved correct workspace ordering in these edge cases.
  - Improved sidebar grouping behavior when group membership is unavailable or no longer renderable.

- **Tests**
  - Added coverage for stale group references, missing group anchors, and workspace ordering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->