### PR TITLE
fix(cmux-tui-core): use iterator cloned adapter

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/src/browser.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/browser.rs
@@ -1614,7 +1614,8 @@ fn release_abandoned_pointer_presses(
                 }
             }
         })
-        .map(|(button, _)| button.clone())
+        .map(|(button, _)| button)
+        .cloned()
         .collect::<Vec<_>>();
     for button in expired {
         let Some(press) = failures.active_pointer_presses.remove(&button) else {


### PR DESCRIPTION
## Summary
Use Iterator::cloned() in browser pointer cleanup to express the borrowed-key cloning directly and satisfy Clippy map_clone. Runtime behavior and ordering are unchanged.

## Testing
- `git diff --check`
- Hosted focused cmux-tui workflow will run `abandoned_pointer_release_timeout_gets_one_bounded_retry`.

## Review Trigger
Please review iterator ownership, ordering, and pointer-release behavior.

## Checklist
- [x] Current main base: e7223a53905fcc6f2f2cfd4f7ea8a92f812ad4bd
- [x] No source-shape tests added
- [x] No runtime behavior change intended
- [ ] Canonical review
- [ ] Hosted focused workflow

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791071031&installation_model_id=21920&pr_number=11883&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11883&signature=c4edff9293b54260f54c9f522002c3393ebda0c315b67effd3f15b484b77c709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates browser pointer cleanup to use Rust’s `Iterator::cloned` adapter when collecting expired buttons. This satisfies Clippy’s `map_clone` lint without changing pointer-release behavior or ordering.

<sup>Written for commit 8e299856976ce94ccc4eed7fa26e9c1d68802a88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

