### PR TITLE
fix: normalize Windows file URL namespaces

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -19255,11 +19255,14 @@ impl App {
                     self.terminal_tab_size_hint(self.active_pane()),
                 )
             }
-            FileCommand::OpenBrowser(path) => self.session.new_browser_tab(
-                file_url(&path),
-                self.active_pane(),
-                self.browser_tab_size_hint(self.active_pane()),
-            ),
+            FileCommand::OpenBrowser(path) => {
+                let url = file_url(&path).map_err(|error| anyhow::anyhow!(error))?;
+                self.session.new_browser_tab(
+                    url,
+                    self.active_pane(),
+                    self.browser_tab_size_hint(self.active_pane()),
+                )
+            }
         };
         match result {
             Ok(()) => self

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -19255,14 +19255,14 @@ impl App {
                     self.terminal_tab_size_hint(self.active_pane()),
                 )
             }
-            FileCommand::OpenBrowser(path) => {
-                let url = file_url(&path).map_err(|error| anyhow::anyhow!(error))?;
-                self.session.new_browser_tab(
+            FileCommand::OpenBrowser(path) => match file_url(&path) {
+                Ok(url) => self.session.new_browser_tab(
                     url,
                     self.active_pane(),
                     self.browser_tab_size_hint(self.active_pane()),
-                )
-            }
+                ),
+                Err(error) => Err(anyhow::anyhow!(error)),
+            },
         };
         match result {
             Ok(()) => self

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -369,7 +369,7 @@ pub fn file_url(path: &Path) -> Result<String, FileUrlError> {
     if let Some(authority) = prefix {
         url.push_str(&encode_uri_component(authority));
         url.push('/');
-    } else {
+    } else if !path.starts_with('/') {
         url.push('/');
     }
     url.push_str(&encode_uri_path(&path));

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -402,20 +402,38 @@ fn encode_uri_component(text: &str) -> String {
 #[cfg(windows)]
 fn windows_file_url_parts(text: &str) -> Result<(Option<&str>, String), FileUrlError> {
     let mut text = text;
-    if let Some(stripped) = text.strip_prefix(r"\\?\") {
+    if let Some(stripped) = strip_ascii_prefix(text, r"\\?\") {
         text = stripped;
-        if let Some(unc) = text.strip_prefix(r"UNC\") {
+        if let Some(unc) =
+            strip_ascii_prefix(text, r"UNC\").or_else(|| strip_ascii_prefix(text, "UNC/"))
+        {
             text = unc;
             return Ok(split_unc_path(text));
         }
+        if !is_windows_drive_path(text) {
+            return Err(FileUrlError::UnsupportedWindowsNamespace);
+        }
     }
-    if text.starts_with(r"\\.\") {
+    if strip_ascii_prefix(text, r"\\.\").is_some() {
         return Err(FileUrlError::UnsupportedWindowsNamespace);
     }
     if let Some(unc) = text.strip_prefix(r"\\") {
         return Ok(split_unc_path(unc));
     }
     Ok((None, text.replace('\\', "/")))
+}
+
+#[cfg(windows)]
+fn strip_ascii_prefix<'a>(text: &'a str, prefix: &str) -> Option<&'a str> {
+    text.get(..prefix.len())
+        .filter(|head| head.eq_ignore_ascii_case(prefix))
+        .map(|_| &text[prefix.len()..])
+}
+
+#[cfg(windows)]
+fn is_windows_drive_path(text: &str) -> bool {
+    let bytes = text.as_bytes();
+    bytes.get(1) == Some(&b':') && bytes.first().is_some_and(u8::is_ascii_alphabetic)
 }
 
 #[cfg(windows)]

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -479,4 +479,10 @@ mod tests {
     fn creates_percent_encoded_file_url() {
         assert_eq!(file_url(Path::new("/tmp/a file#1.md")), "file:///tmp/a%20file%231.md");
     }
+
+    #[cfg(windows)]
+    #[test]
+    fn creates_windows_drive_file_url() {
+        assert_eq!(file_url(Path::new(r"C:\a\b")), "file:///C:/a/b");
+    }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -343,11 +343,22 @@ pub fn shell_single_quote(value: &str) -> String {
 pub fn file_url(path: &Path) -> String {
     let text = path.to_string_lossy();
     let mut url = String::from("file://");
+    #[cfg(windows)]
+    let windows_drive_path = text.as_bytes().first().is_some_and(|b| b.is_ascii_alphabetic())
+        && text.as_bytes().get(1) == Some(&b':');
+    #[cfg(not(windows))]
+    let windows_drive_path = false;
+    if windows_drive_path {
+        url.push('/');
+    }
     for byte in text.bytes() {
         match byte {
             b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
                 url.push(char::from(byte));
             }
+            #[cfg(windows)]
+            b'\\' => url.push('/'),
+            b':' if windows_drive_path => url.push(':'),
             _ => url.push_str(&format!("%{byte:02X}")),
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -3,6 +3,7 @@ mod navigation;
 
 use std::path::{Path, PathBuf};
 use std::time::{Duration, Instant};
+use std::{error::Error, fmt};
 
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 
@@ -340,29 +341,94 @@ pub fn shell_single_quote(value: &str) -> String {
     format!("'{}'", value.replace('\'', "'\\''"))
 }
 
-pub fn file_url(path: &Path) -> String {
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum FileUrlError {
+    UnsupportedWindowsNamespace,
+}
+
+impl fmt::Display for FileUrlError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::UnsupportedWindowsNamespace => {
+                formatter.write_str("unsupported Windows device path namespace")
+            }
+        }
+    }
+}
+
+impl Error for FileUrlError {}
+
+pub fn file_url(path: &Path) -> Result<String, FileUrlError> {
     let text = path.to_string_lossy();
+    let (prefix, path) = windows_file_url_parts(&text)?;
     let mut url = String::from("file://");
-    #[cfg(windows)]
-    let windows_drive_path = text.as_bytes().first().is_some_and(|b| b.is_ascii_alphabetic())
-        && text.as_bytes().get(1) == Some(&b':');
-    #[cfg(not(windows))]
-    let windows_drive_path = false;
-    if windows_drive_path {
+    if let Some(authority) = prefix {
+        url.push_str(&encode_uri_component(authority));
+        url.push('/');
+    } else {
         url.push('/');
     }
+    url.push_str(&encode_uri_path(path));
+    Ok(url)
+}
+
+fn encode_uri_path(text: &str) -> String {
+    let mut encoded = String::new();
     for byte in text.bytes() {
         match byte {
             b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
-                url.push(char::from(byte));
+                encoded.push(char::from(byte));
             }
-            #[cfg(windows)]
-            b'\\' => url.push('/'),
-            b':' if windows_drive_path => url.push(':'),
-            _ => url.push_str(&format!("%{byte:02X}")),
+            b':' if text.as_bytes().get(1) == Some(&b':') => encoded.push(':'),
+            _ => encoded.push_str(&format!("%{byte:02X}")),
         }
     }
-    url
+    encoded
+}
+
+fn encode_uri_component(text: &str) -> String {
+    let mut encoded = String::new();
+    for byte in text.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                encoded.push(char::from(byte));
+            }
+            _ => encoded.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    encoded
+}
+
+#[cfg(windows)]
+fn windows_file_url_parts(text: &str) -> Result<(Option<&str>, String), FileUrlError> {
+    let mut text = text;
+    if let Some(stripped) = text.strip_prefix(r"\\?\") {
+        text = stripped;
+        if let Some(unc) = text.strip_prefix(r"UNC\") {
+            text = unc;
+            return Ok(split_unc_path(text));
+        }
+    }
+    if text.starts_with(r"\\.\") {
+        return Err(FileUrlError::UnsupportedWindowsNamespace);
+    }
+    if let Some(unc) = text.strip_prefix(r"\\") {
+        return Ok(split_unc_path(unc));
+    }
+    Ok((None, text.replace('\\', "/")))
+}
+
+#[cfg(windows)]
+fn split_unc_path(path: &str) -> (Option<&str>, String) {
+    match path.find(['\\', '/']) {
+        Some(index) => (Some(&path[..index]), path[index + 1..].replace('\\', "/")),
+        None => (Some(path), String::new()),
+    }
+}
+
+#[cfg(not(windows))]
+fn windows_file_url_parts(text: &str) -> Result<(Option<&str>, String), FileUrlError> {
+    Ok((None, text.to_string()))
 }
 
 #[cfg(test)]
@@ -488,12 +554,29 @@ mod tests {
 
     #[test]
     fn creates_percent_encoded_file_url() {
-        assert_eq!(file_url(Path::new("/tmp/a file#1.md")), "file:///tmp/a%20file%231.md");
+        assert_eq!(file_url(Path::new("/tmp/a file#1.md")).unwrap(), "file:///tmp/a%20file%231.md");
     }
 
     #[cfg(windows)]
     #[test]
-    fn creates_windows_drive_file_url() {
-        assert_eq!(file_url(Path::new(r"C:\a\b")), "file:///C:/a/b");
+    fn creates_windows_file_urls() {
+        let cases = [
+            (r"C:\a\b", "file:///C:/a/b"),
+            (r"\\server\share\a.html", "file://server/share/a.html"),
+            (r"\\?\C:\long\a.html", "file:///C:/long/a.html"),
+            (r"\\?\UNC\server\share\a.html", "file://server/share/a.html"),
+        ];
+        for (path, expected) in cases {
+            assert_eq!(file_url(Path::new(path)).unwrap(), expected);
+        }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn rejects_windows_device_paths() {
+        assert_eq!(
+            file_url(Path::new(r"\\.\PIPE\cmux")),
+            Err(FileUrlError::UnsupportedWindowsNamespace)
+        );
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -343,6 +343,10 @@ pub fn shell_single_quote(value: &str) -> String {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
 pub enum FileUrlError {
+    #[cfg_attr(
+        not(windows),
+        expect(dead_code, reason = "constructed only by Windows path validation")
+    )]
     UnsupportedWindowsNamespace,
 }
 

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -565,6 +565,7 @@ mod tests {
             (r"\\server\share\a.html", "file://server/share/a.html"),
             (r"\\?\C:\long\a.html", "file:///C:/long/a.html"),
             (r"\\?\UNC\server\share\a.html", "file://server/share/a.html"),
+            (r"\\?\unc\server\share\a.html", "file://server/share/a.html"),
         ];
         for (path, expected) in cases {
             assert_eq!(file_url(Path::new(path)).unwrap(), expected);
@@ -576,6 +577,10 @@ mod tests {
     fn rejects_windows_device_paths() {
         assert_eq!(
             file_url(Path::new(r"\\.\PIPE\cmux")),
+            Err(FileUrlError::UnsupportedWindowsNamespace)
+        );
+        assert_eq!(
+            file_url(Path::new(r"\\?\Volume{1234}\page.html")),
             Err(FileUrlError::UnsupportedWindowsNamespace)
         );
     }

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -368,7 +368,7 @@ pub fn file_url(path: &Path) -> Result<String, FileUrlError> {
     } else {
         url.push('/');
     }
-    url.push_str(&encode_uri_path(path));
+    url.push_str(&encode_uri_path(&path));
     Ok(url)
 }
 

--- a/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
@@ -956,6 +956,7 @@ struct ParsedTerminalProbe {
     pending_input: Vec<u8>,
 }
 
+#[cfg(unix)]
 fn write_terminal_probe_queries(stdout: &mut impl Write, query_window_pixels: bool) {
     if query_window_pixels {
         let _ = write!(stdout, "\x1b[14t");
@@ -963,6 +964,9 @@ fn write_terminal_probe_queries(stdout: &mut impl Write, query_window_pixels: bo
     let _ = write!(stdout, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c");
     let _ = stdout.flush();
 }
+
+#[cfg(not(unix))]
+fn write_terminal_probe_queries(_stdout: &mut impl Write, _query_window_pixels: bool) {}
 
 /// Probe terminal capabilities in one exchange and return any user input read
 /// alongside the replies. The final DA1 request acts as an ordering marker:

--- a/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/graphics.rs
@@ -956,6 +956,14 @@ struct ParsedTerminalProbe {
     pending_input: Vec<u8>,
 }
 
+fn write_terminal_probe_queries(stdout: &mut impl Write, query_window_pixels: bool) {
+    if query_window_pixels {
+        let _ = write!(stdout, "\x1b[14t");
+    }
+    let _ = write!(stdout, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c");
+    let _ = stdout.flush();
+}
+
 /// Probe terminal capabilities in one exchange and return any user input read
 /// alongside the replies. The final DA1 request acts as an ordering marker:
 /// any preceding Kitty reply advertises support, while its absence does not
@@ -967,11 +975,7 @@ pub fn probe_terminal(known_cell_pixels: Option<(u16, u16)>) -> StartupTerminalP
         ioctl_pixels.is_none() && terminal_size.is_some_and(|(cols, rows)| cols > 0 && rows > 0);
 
     let mut stdout = std::io::stdout();
-    if query_window_pixels {
-        let _ = write!(stdout, "\x1b[14t");
-    }
-    let _ = write!(stdout, "\x1b_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\x1b\\\x1b[c");
-    let _ = stdout.flush();
+    write_terminal_probe_queries(&mut stdout, query_window_pixels);
 
     let bytes = read_stdin_until(TERMINAL_PROBE_TIMEOUT, terminal_probe_complete);
     let parsed = parse_terminal_probe(&bytes);
@@ -1275,6 +1279,16 @@ mod tests {
     #[test]
     fn missing_initial_metrics_use_synthetic_fallback() {
         assert_eq!(resolve_cell_pixels(None, None), FALLBACK_CELL_PIXELS);
+    }
+
+    #[cfg(not(unix))]
+    #[test]
+    fn terminal_probe_does_not_write_queries_without_a_reply_reader() {
+        let mut output = Vec::new();
+
+        write_terminal_probe_queries(&mut output, true);
+
+        assert!(output.is_empty(), "unread terminal queries were written: {output:?}");
     }
 
     #[test]

--- a/cmux-tui/crates/ghostty-vt-sys/build.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build.rs
@@ -1,3 +1,5 @@
+mod build_support;
+
 use std::env;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -25,6 +27,7 @@ fn main() {
     println!("cargo:rerun-if-env-changed=CMUX_GHOSTTY_SRC");
     println!("cargo:rerun-if-env-changed=ZIG");
     println!("cargo:rerun-if-env-changed=CMUX_GHOSTTY_VT_ZIG_CPU");
+    emit_cargo_path_directive("rerun-if-changed", &manifest_dir.join("build_support.rs"));
     emit_cargo_path_directive("rerun-if-changed", &ghostty_dir.join("include"));
     // Keep the generated binding fingerprint tied to the public terminal API.
     // Hosted build caches can otherwise restore bindings from an older
@@ -50,10 +53,8 @@ fn main() {
         .arg("-Demit-lib-vt=true")
         .arg("-Demit-xcframework=false")
         .arg("-Doptimize=ReleaseFast");
-    if target != host
-        && let Some(zig_target) = zig_target_for_rust_target(&target)
-    {
-        command.arg(format!("-Dtarget={zig_target}"));
+    if let Some(zig_target_arg) = build_support::zig_target_arg(&target, &host) {
+        command.arg(zig_target_arg);
     }
     // Valgrind's instruction emulation doesn't cover every CPU-native SIMD
     // extension zig's default target detection can select (e.g. some AVX-512
@@ -133,22 +134,4 @@ fn strip_windows_verbatim(path: PathBuf) -> PathBuf {
         }
     }
     path
-}
-
-fn zig_target_for_rust_target(target: &str) -> Option<&'static str> {
-    match target {
-        "x86_64-pc-windows-gnu" => Some("x86_64-windows-gnu"),
-        "x86_64-pc-windows-msvc" => Some("x86_64-windows-msvc"),
-        "aarch64-pc-windows-msvc" => Some("aarch64-windows-msvc"),
-        // Cross-compiling libghostty-vt for the release distribution targets
-        // (npm/PyPI `cmux` binaries). zig cross-compiles these cleanly and
-        // pairs with cargo-zigbuild for the Rust link step.
-        "x86_64-apple-darwin" => Some("x86_64-macos"),
-        "aarch64-apple-darwin" => Some("aarch64-macos"),
-        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
-        "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
-        "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
-        "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
-        _ => None,
-    }
 }

--- a/cmux-tui/crates/ghostty-vt-sys/build_support.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build_support.rs
@@ -46,16 +46,8 @@ mod tests {
     #[test]
     fn cross_targets_keep_their_explicit_zig_abi() {
         let cases = [
-            (
-                "x86_64-pc-windows-gnu",
-                "aarch64-unknown-linux-gnu",
-                "-Dtarget=x86_64-windows-gnu",
-            ),
-            (
-                "x86_64-pc-windows-msvc",
-                "aarch64-unknown-linux-gnu",
-                "-Dtarget=x86_64-windows-msvc",
-            ),
+            ("x86_64-pc-windows-gnu", "aarch64-unknown-linux-gnu", "-Dtarget=x86_64-windows-gnu"),
+            ("x86_64-pc-windows-msvc", "aarch64-unknown-linux-gnu", "-Dtarget=x86_64-windows-msvc"),
             (
                 "aarch64-pc-windows-msvc",
                 "x86_64-unknown-linux-gnu",
@@ -63,16 +55,8 @@ mod tests {
             ),
             ("x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "-Dtarget=x86_64-macos"),
             ("aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "-Dtarget=aarch64-macos"),
-            (
-                "x86_64-unknown-linux-gnu",
-                "aarch64-unknown-linux-gnu",
-                "-Dtarget=x86_64-linux-gnu",
-            ),
-            (
-                "aarch64-unknown-linux-gnu",
-                "x86_64-unknown-linux-gnu",
-                "-Dtarget=aarch64-linux-gnu",
-            ),
+            ("x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu", "-Dtarget=x86_64-linux-gnu"),
+            ("aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu", "-Dtarget=aarch64-linux-gnu"),
             (
                 "x86_64-unknown-linux-musl",
                 "aarch64-unknown-linux-gnu",

--- a/cmux-tui/crates/ghostty-vt-sys/build_support.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build_support.rs
@@ -42,4 +42,51 @@ mod tests {
     fn native_non_windows_builds_keep_zigs_native_target() {
         assert_eq!(zig_target_arg("aarch64-apple-darwin", "aarch64-apple-darwin"), None);
     }
+
+    #[test]
+    fn cross_targets_keep_their_explicit_zig_abi() {
+        let cases = [
+            (
+                "x86_64-pc-windows-gnu",
+                "aarch64-unknown-linux-gnu",
+                "-Dtarget=x86_64-windows-gnu",
+            ),
+            (
+                "x86_64-pc-windows-msvc",
+                "aarch64-unknown-linux-gnu",
+                "-Dtarget=x86_64-windows-msvc",
+            ),
+            (
+                "aarch64-pc-windows-msvc",
+                "x86_64-unknown-linux-gnu",
+                "-Dtarget=aarch64-windows-msvc",
+            ),
+            ("x86_64-apple-darwin", "aarch64-unknown-linux-gnu", "-Dtarget=x86_64-macos"),
+            ("aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "-Dtarget=aarch64-macos"),
+            (
+                "x86_64-unknown-linux-gnu",
+                "aarch64-unknown-linux-gnu",
+                "-Dtarget=x86_64-linux-gnu",
+            ),
+            (
+                "aarch64-unknown-linux-gnu",
+                "x86_64-unknown-linux-gnu",
+                "-Dtarget=aarch64-linux-gnu",
+            ),
+            (
+                "x86_64-unknown-linux-musl",
+                "aarch64-unknown-linux-gnu",
+                "-Dtarget=x86_64-linux-musl",
+            ),
+            (
+                "aarch64-unknown-linux-musl",
+                "x86_64-unknown-linux-gnu",
+                "-Dtarget=aarch64-linux-musl",
+            ),
+        ];
+
+        for (target, host, expected) in cases {
+            assert_eq!(zig_target_arg(target, host).as_deref(), Some(expected), "{target}");
+        }
+    }
 }

--- a/cmux-tui/crates/ghostty-vt-sys/build_support.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build_support.rs
@@ -1,0 +1,42 @@
+pub fn zig_target_arg(target: &str, host: &str) -> Option<String> {
+    if target == host {
+        return None;
+    }
+    zig_target_for_rust_target(target).map(|zig_target| format!("-Dtarget={zig_target}"))
+}
+
+fn zig_target_for_rust_target(target: &str) -> Option<&'static str> {
+    match target {
+        "x86_64-pc-windows-gnu" => Some("x86_64-windows-gnu"),
+        "x86_64-pc-windows-msvc" => Some("x86_64-windows-msvc"),
+        "aarch64-pc-windows-msvc" => Some("aarch64-windows-msvc"),
+        // Cross-compiling libghostty-vt for the release distribution targets
+        // (npm/PyPI `cmux` binaries). Zig cross-compiles these cleanly and
+        // pairs with cargo-zigbuild for the Rust link step.
+        "x86_64-apple-darwin" => Some("x86_64-macos"),
+        "aarch64-apple-darwin" => Some("aarch64-macos"),
+        "x86_64-unknown-linux-gnu" => Some("x86_64-linux-gnu"),
+        "aarch64-unknown-linux-gnu" => Some("aarch64-linux-gnu"),
+        "x86_64-unknown-linux-musl" => Some("x86_64-linux-musl"),
+        "aarch64-unknown-linux-musl" => Some("aarch64-linux-musl"),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn native_windows_gnu_keeps_the_explicit_gnu_abi() {
+        assert_eq!(
+            zig_target_arg("x86_64-pc-windows-gnu", "x86_64-pc-windows-gnu").as_deref(),
+            Some("-Dtarget=x86_64-windows-gnu")
+        );
+    }
+
+    #[test]
+    fn native_non_windows_builds_keep_zigs_native_target() {
+        assert_eq!(zig_target_arg("aarch64-apple-darwin", "aarch64-apple-darwin"), None);
+    }
+}

--- a/cmux-tui/crates/ghostty-vt-sys/build_support.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/build_support.rs
@@ -1,5 +1,8 @@
 pub fn zig_target_arg(target: &str, host: &str) -> Option<String> {
-    if target == host {
+    // Preserve Zig's native target selection for existing native builds. The
+    // GNU Windows host is the exception: Zig otherwise defaults to MSVC and
+    // requires a Windows SDK even when the Rust toolchain is MinGW-only.
+    if target == host && !target.ends_with("-windows-gnu") {
         return None;
     }
     zig_target_for_rust_target(target).map(|zig_target| format!("-Dtarget={zig_target}"))

--- a/cmux-tui/crates/ghostty-vt-sys/src/lib.rs
+++ b/cmux-tui/crates/ghostty-vt-sys/src/lib.rs
@@ -10,6 +10,10 @@
 #![allow(unsafe_op_in_unsafe_fn)]
 #![allow(clippy::all)]
 
+#[cfg(test)]
+#[path = "../build_support.rs"]
+mod build_support;
+
 include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
 /// Reimplementation of the `ghostty_mode_new` static inline helper from


### PR DESCRIPTION
Fixes the canonical P2 found in PR #11851.

- normalize drive, UNC, and extended-drive Windows paths to canonical file URLs
- normalize extended UNC paths
- reject unsupported device namespaces with an explicit error
- add table behavior coverage for all cases

Based on #11851 head 487f1de387f4303bf5db58f19f91368be17cf743 and current main.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11884"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791071070&installation_model_id=21920&pr_number=11884&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11884&signature=a259d49999333692d19e5c07c8817624f9cb3cfbcc131e4bb6442e1178a96609"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalizes Windows file URLs so drive, UNC, extended-drive, and extended-UNC paths produce canonical `file://` URLs, rejects unsupported device namespaces with an explicit error, and preserves Unix file URL roots. `file_url` now returns a `Result`, so callers must handle the new error case. Also stops terminal probes from writing queries on non-Unix platforms and restores native Windows GNU builds by passing the explicit GNU Zig target.

<sup>Written for commit 7346ee73e08d60797a68d93885896d496e111a77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved opening local files in the browser on Windows, including drive and network paths.
  - Unsupported Windows device paths now report an error instead of opening an invalid browser tab.
  - Improved terminal compatibility on non-Unix platforms by preventing unsupported terminal queries.

- **Improvements**
  - Enhanced cross-platform behavior for browser-based file previews and terminal initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->