### PR TITLE
fix(cmux-tui): bound private frame dump retention

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4624,6 +4624,18 @@ mod tests {
         }
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_directory_is_private_when_created() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let path = root.path().join("dumps");
+        let directory = private_dump_directory(&path).unwrap();
+
+        assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+    }
+
     #[test]
     fn disabled_frame_logging_does_not_format_hot_path_messages() {
         struct FormattingProbe(Arc<AtomicBool>);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3916,6 +3916,9 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         return Err(io::Error::last_os_error());
     }
     let stream = DirectoryStream(stream);
+    // `dup` shares the directory cursor. Reset each scan so a prior pass on
+    // this descriptor cannot hide entries that were created later.
+    unsafe { libc::rewinddir(stream.0) };
     loop {
         let entry = unsafe { libc::readdir(stream.0) };
         if entry.is_null() {
@@ -4022,6 +4025,9 @@ fn prune_dump_files_with_limits(
         return Err(io::Error::last_os_error());
     }
     let stream = DirectoryStream(stream);
+    // `dup` shares the directory cursor. Reset each scan so a prior pass on
+    // this descriptor cannot hide entries that were created later.
+    unsafe { libc::rewinddir(stream.0) };
     let mut dumps = Vec::new();
     loop {
         let entry = unsafe { libc::readdir(stream.0) };

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3805,7 +3805,7 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         {
             continue;
         }
-        let Some(name) = name.to_str().ok() else { continue };
+        let Some(name) = name.to_str() else { continue };
         let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
         let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
             continue;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3702,6 +3702,12 @@ impl Drop for RemoteSession {
                         &format!("cannot write private dump {frames_name}: {error}"),
                     );
                 }
+                if let Err(error) = prune_dump_files(&directory.output) {
+                    crate::client_log::error(
+                        "mux-dump",
+                        &format!("cannot enforce private dump retention: {error}"),
+                    );
+                }
             }
         }
     }
@@ -4059,23 +4065,35 @@ fn prune_dump_files_with_limits(
             modified,
             bytes: metadata.st_size.max(0) as u64,
         });
-    }
-    dumps.sort_by(|left, right| {
-        left.modified.cmp(&right.modified).then_with(|| left.name.cmp(&right.name))
-    });
-    let mut total_bytes = dumps.iter().map(|dump| dump.bytes).sum::<u64>();
-    while dumps.len() > maximum_files || total_bytes > maximum_bytes {
-        let dump = dumps.remove(0);
-        let name = std::ffi::CString::new(dump.name)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-        let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
-        if status != 0 {
-            let error = io::Error::last_os_error();
-            if error.raw_os_error() != Some(libc::ENOENT) {
-                return Err(error);
-            }
+        dumps.sort_by(|left, right| {
+            left.modified.cmp(&right.modified).then_with(|| left.name.cmp(&right.name))
+        });
+        if dumps.len() > maximum_files {
+            let dump = dumps.remove(0);
+            delete_dump_file(directory, &dump.name)?;
         }
+    }
+    let mut total_bytes = dumps.iter().map(|dump| dump.bytes).sum::<u64>();
+    while total_bytes > maximum_bytes {
+        let dump = dumps.remove(0);
+        delete_dump_file(directory, &dump.name)?;
         total_bytes = total_bytes.saturating_sub(dump.bytes);
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn delete_dump_file(directory: &fs::File, name: &[u8]) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let name = std::ffi::CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+    let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+    if status != 0 {
+        let error = io::Error::last_os_error();
+        if error.raw_os_error() != Some(libc::ENOENT) {
+            return Err(error);
+        }
     }
     Ok(())
 }
@@ -4145,7 +4163,7 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
 
 #[cfg(target_os = "macos")]
 fn macos_dump_acl_tag_is_safe(tag: libc::c_int) -> bool {
-    const ACL_EXTENDED_DENY: libc::c_int = 2;
+    const ACL_EXTENDED_DENY: libc::c_int = 0x0000_0200;
     tag == ACL_EXTENDED_DENY
 }
 
@@ -5273,8 +5291,8 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_dump_acl_accepts_deny_and_rejects_allow_entries() {
-        assert!(macos_dump_acl_tag_is_safe(2));
-        assert!(!macos_dump_acl_tag_is_safe(1));
+        assert!(macos_dump_acl_tag_is_safe(0x0000_0200));
+        assert!(!macos_dump_acl_tag_is_safe(0x0000_0100));
         assert!(!macos_dump_acl_tag_is_safe(99));
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3963,16 +3963,13 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
 
 #[cfg(unix)]
 fn is_private_dump_name(name: &[u8]) -> bool {
-    [
-        (&b"mirror-"[..], &b".txt"[..]),
-        (&b"frames-"[..], &b".log"[..]),
-    ]
-    .into_iter()
-    .any(|(prefix, suffix)| {
-        name.strip_prefix(prefix)
-            .and_then(|name| name.strip_suffix(suffix))
-            .is_some_and(|id| !id.is_empty() && id.iter().all(|byte| byte.is_ascii_digit()))
-    })
+    [(&b"mirror-"[..], &b".txt"[..]), (&b"frames-"[..], &b".log"[..])].into_iter().any(
+        |(prefix, suffix)| {
+            name.strip_prefix(prefix)
+                .and_then(|name| name.strip_suffix(suffix))
+                .is_some_and(|id| !id.is_empty() && id.iter().all(|byte| byte.is_ascii_digit()))
+        },
+    )
 }
 
 #[cfg(unix)]
@@ -5200,7 +5197,10 @@ mod tests {
                 libc::timespec { tv_sec: modified, tv_nsec: 0 },
                 libc::timespec { tv_sec: modified, tv_nsec: 0 },
             ];
-            assert_eq!(unsafe { libc::utimensat(libc::AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) }, 0);
+            assert_eq!(
+                unsafe { libc::utimensat(libc::AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) },
+                0
+            );
         }
 
         prune_dump_files_with_limits(&directory.output, 2, 10).unwrap();
@@ -5214,10 +5214,7 @@ mod tests {
             .filter(|entry| is_private_dump_name(entry.file_name().as_os_str().as_bytes()))
             .collect::<Vec<_>>();
         assert_eq!(retained.len(), 2);
-        let bytes = retained
-            .iter()
-            .map(|entry| entry.metadata().unwrap().len())
-            .sum::<u64>();
+        let bytes = retained.iter().map(|entry| entry.metadata().unwrap().len()).sum::<u64>();
         assert_eq!(bytes, 10);
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3681,7 +3681,13 @@ impl Drop for RemoteSession {
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::ffi::CString;
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    // Validate existing ancestors before create_dir_all follows them, then
+    // validate again after creation to catch newly created components. A
+    // writable non-sticky ancestor permits another user to replace the dump
+    // directory between path operations and redirect secret-bearing output.
+    validate_dump_ancestors(path)?;
 
     let existed = match fs::symlink_metadata(path) {
         Ok(metadata) if metadata.is_dir() => true,
@@ -3695,10 +3701,7 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         Err(error) => return Err(error),
     };
     if !existed {
-        if let Some(parent) = path
-            .parent()
-            .filter(|parent| !parent.as_os_str().is_empty())
-        {
+        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
             fs::create_dir_all(parent)?;
         }
         let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
@@ -3712,6 +3715,7 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             }
         }
     }
+    validate_dump_ancestors(path)?;
     let directory = fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
@@ -3723,57 +3727,121 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
+    reject_extended_acl(&directory)?;
     if metadata.mode() & 0o077 != 0 {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
             format!("dump directory is not private: {}", path.display()),
         ));
     }
-    reject_extended_acl(&directory)?;
     Ok(directory)
+}
+
+#[cfg(unix)]
+fn validate_dump_ancestors(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
+
+    let mut ancestor = path.parent();
+    while let Some(candidate) = ancestor {
+        if candidate.as_os_str().is_empty() {
+            break;
+        }
+        match fs::symlink_metadata(candidate) {
+            Ok(metadata) => {
+                let resolved = if metadata.file_type().is_symlink() {
+                    if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
+                        return Err(io::Error::new(
+                            io::ErrorKind::PermissionDenied,
+                            format!(
+                                "dump directory ancestor is not trusted: {}",
+                                candidate.display()
+                            ),
+                        ));
+                    }
+                    let resolved = fs::canonicalize(candidate)?;
+                    validate_dump_ancestors(&resolved)?;
+                    resolved
+                } else {
+                    candidate.to_path_buf()
+                };
+                let metadata = fs::symlink_metadata(&resolved)?;
+                if !metadata.is_dir() {
+                    return Err(io::Error::new(
+                        io::ErrorKind::InvalidInput,
+                        format!(
+                            "dump directory ancestor is not a directory: {}",
+                            candidate.display()
+                        ),
+                    ));
+                }
+                if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!("dump directory ancestor is not trusted: {}", candidate.display()),
+                    ));
+                }
+                let mode = metadata.mode();
+                let sticky = mode & 0o1000 != 0;
+                if mode & 0o022 != 0 && !sticky {
+                    return Err(io::Error::new(
+                        io::ErrorKind::PermissionDenied,
+                        format!(
+                            "dump directory ancestor is writable without private protection: {}",
+                            candidate.display()
+                        ),
+                    ));
+                }
+                let directory = fs::OpenOptions::new()
+                    .read(true)
+                    .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+                    .open(&resolved)?;
+                reject_extended_acl(&directory)?;
+            }
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        let next = candidate.parent();
+        if next == Some(candidate) {
+            break;
+        }
+        ancestor = next;
+    }
+    Ok(())
 }
 
 #[cfg(target_os = "macos")]
 fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
-    use std::ptr;
 
-    // Any extended ACL can carry non-owner grants or inheritance. Reject the
-    // directory instead of trying to interpret ACE ordering and masks.
-    let descriptor = directory.as_raw_fd();
-    let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
-    if size < 0 {
+    // `acl_get_fd_np` reads the effective macOS ACL from the opened
+    // descriptor, including inherited ACEs that are not exposed by the mode
+    // bits. Reject any extended ACL instead of attempting to interpret ACE
+    // ordering, principals, and inheritance flags here.
+    unsafe extern "C" {
+        fn acl_get_fd_np(fd: libc::c_int, acl_type: libc::c_int) -> *mut libc::c_void;
+        fn acl_free(object: *mut libc::c_void) -> libc::c_int;
+    }
+
+    const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+    let acl = unsafe { acl_get_fd_np(directory.as_raw_fd(), ACL_TYPE_EXTENDED) };
+    if acl.is_null() {
         let error = io::Error::last_os_error();
-        if matches!(error.raw_os_error(), Some(libc::ENOTSUP) | Some(libc::ENOSYS)) {
+        if matches!(
+            error.raw_os_error(),
+            Some(libc::ENOENT)
+                | Some(libc::ENOATTR)
+                | Some(libc::ENOTSUP)
+                | Some(libc::EOPNOTSUPP)
+                | Some(libc::ENOSYS)
+        ) {
             return Ok(());
         }
         return Err(error);
     }
-    if size == 0 {
-        return Ok(());
+    unsafe {
+        acl_free(acl);
     }
-    let mut names = vec![0_u8; size as usize];
-    let size = unsafe {
-        libc::flistxattr(
-            descriptor,
-            names.as_mut_ptr().cast(),
-            names.len(),
-            0,
-        )
-    };
-    if size < 0 {
-        return Err(io::Error::last_os_error());
-    }
-    if names[..size as usize]
-        .split(|byte| *byte == 0)
-        .any(|name| name == b"com.apple.acl.text")
-    {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            "dump directory has an extended ACL",
-        ));
-    }
-    Ok(())
+    Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
 }
 
 #[cfg(not(target_os = "macos"))]
@@ -3807,9 +3875,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     }
     let file = unsafe { fs::File::from_raw_fd(descriptor) };
     let metadata = file.metadata()?;
-    if !metadata.is_file()
-        || metadata.uid() != unsafe { libc::geteuid() }
-        || metadata.nlink() != 1
+    if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } || metadata.nlink() != 1
     {
         return Err(io::Error::new(
             io::ErrorKind::PermissionDenied,
@@ -4748,8 +4814,9 @@ mod tests {
     #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
         fs::write(&final_path, b"previous").unwrap();
 
         let error = write_private_dump(&directory, "mirror.txt", |_file| {
@@ -4759,19 +4826,22 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
-        assert!(fs::read_dir(root.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .all(|entry| entry.file_name() == "mirror.txt"));
+        assert!(
+            fs::read_dir(&dump_path)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| entry.file_name() == "mirror.txt")
+        );
     }
 
     #[cfg(unix)]
     #[test]
     fn private_dump_replacement_does_not_modify_hard_linked_previous_dump() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
-        let linked_path = root.path().join("mirror-backup.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
+        let linked_path = dump_path.join("mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -4786,9 +4856,10 @@ mod tests {
     #[test]
     fn private_dump_file_rejects_existing_hard_link_without_truncation() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
-        let linked_path = root.path().join("mirror-backup.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
+        let linked_path = dump_path.join("mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -4803,21 +4874,23 @@ mod tests {
     #[test]
     fn private_dump_rename_failure_preserves_previous_directory_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
-        let directory = private_dump_directory(root.path()).unwrap();
-        let final_path = root.path().join("mirror.txt");
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let final_path = dump_path.join("mirror.txt");
         fs::create_dir(&final_path).unwrap();
 
-        let error = write_private_dump(&directory, "mirror.txt", |file| {
-            file.write_all(b"replacement")
-        })
-        .unwrap_err();
+        let error =
+            write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"replacement"))
+                .unwrap_err();
 
         assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
         assert!(final_path.is_dir());
-        assert!(fs::read_dir(root.path())
-            .unwrap()
-            .filter_map(Result::ok)
-            .all(|entry| entry.file_name() == "mirror.txt"));
+        assert!(
+            fs::read_dir(&dump_path)
+                .unwrap()
+                .filter_map(Result::ok)
+                .all(|entry| entry.file_name() == "mirror.txt")
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4145,8 +4145,10 @@ fn delete_dump_file(directory: &fs::File, name: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
-// These values come from Darwin's sys/acl.h. The acl_tag_t values (1 and 2)
-// are separate from the ACL type value (0x100) and the entry selectors (0/-1).
+// These values come from Darwin's sys/acl.h. `acl_get_tag_type` returns an
+// `acl_tag_t`, whose extended allow and deny values are 1 and 2. They are
+// separate from the ACL type value (0x100) and the entry selectors (0/-1).
+// Darwin exposes this tag accessor, rather than a separate entry-type API.
 #[cfg(target_os = "macos")]
 const MACOS_ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3702,12 +3702,12 @@ impl Drop for RemoteSession {
                         &format!("cannot write private dump {frames_name}: {error}"),
                     );
                 }
-                if let Err(error) = prune_dump_files(&directory.output) {
-                    crate::client_log::error(
-                        "mux-dump",
-                        &format!("cannot enforce private dump retention: {error}"),
-                    );
-                }
+            }
+            if let Err(error) = prune_dump_files(&directory.output) {
+                crate::client_log::error(
+                    "mux-dump",
+                    &format!("cannot enforce private dump retention: {error}"),
+                );
             }
         }
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3818,7 +3818,7 @@ impl Drop for DirectoryStream {
 #[cfg(unix)]
 fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
     use std::ffi::CString;
-    use std::os::fd::AsRawFd;
+    use std::os::fd::{AsRawFd, FromRawFd};
 
     let uid = unsafe { libc::geteuid() };
     let duplicate = unsafe { libc::dup(directory.as_raw_fd()) };
@@ -3863,15 +3863,23 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         {
             continue;
         }
-        let Ok(name) = name.to_str() else { continue };
-        let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
-        let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
-            continue;
+        let descriptor = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+            )
         };
-        let process_alive = unsafe { libc::kill(pid, 0) == 0 }
-            || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
-        if process_alive {
+        if descriptor < 0 {
             continue;
+        }
+        let candidate = unsafe { fs::File::from_raw_fd(descriptor) };
+        if unsafe { libc::flock(candidate.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::EWOULDBLOCK) {
+                continue;
+            }
+            return Err(error);
         }
         let name = CString::new(name_bytes).map_err(|_| io::ErrorKind::InvalidInput)?;
         let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
@@ -3997,6 +4005,9 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     // Exclusive creation means an existing hard link or symlink is never
     // opened, and no previously existing file is truncated.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
     Ok(file)
 }
 
@@ -4936,6 +4947,25 @@ mod tests {
         let _directory = private_dump_directory(&dump_path).unwrap();
 
         assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_directory_preserves_locked_temporary_dumps() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let name = ".mirror-1.txt.tmp-99999999-1";
+        let active = private_dump_file(&directory.temporary, name).unwrap();
+        let temp_path = dump_path.join(".cmux-dump-tmp").join(name);
+
+        let next_directory = private_dump_directory(&dump_path).unwrap();
+        assert!(temp_path.exists());
+        drop(active);
+        drop(next_directory);
+
+        let _directory = private_dump_directory(&dump_path).unwrap();
+        assert!(!temp_path.exists());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5303,6 +5303,36 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_file_waits_for_directory_lock_before_creation() {
+        use std::os::fd::AsRawFd;
+        use std::sync::mpsc::channel;
+        use std::time::Duration;
+
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let temporary_path = dump_path.join(".cmux-dump-files/.cmux-dump-tmp");
+        let temp_path = temporary_path.join(".mirror-1.txt.tmp-99999999-1");
+        assert_eq!(unsafe { libc::flock(directory.temporary.as_raw_fd(), libc::LOCK_EX) }, 0);
+        let (created_tx, created_rx) = channel();
+        let worker = std::thread::spawn(move || {
+            let temporary = fs::File::open(&temporary_path).unwrap();
+            let file = private_dump_file(&temporary, ".mirror-1.txt.tmp-99999999-1").unwrap();
+            created_tx.send(()).unwrap();
+            (temporary, file)
+        });
+
+        assert!(created_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        assert!(!temp_path.exists());
+        assert_eq!(unsafe { libc::flock(directory.temporary.as_raw_fd(), libc::LOCK_UN) }, 0);
+        created_rx.recv_timeout(Duration::from_secs(2)).unwrap();
+        let (temporary, file) = worker.join().unwrap();
+        drop(file);
+        drop(temporary);
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_directory_preserves_unowned_matching_files() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4101,20 +4101,6 @@ fn prune_dump_files(directory: &fs::File) -> io::Result<()> {
 }
 
 #[cfg(unix)]
-fn private_dump_modified_time(metadata: &libc::stat) -> (u64, u32) {
-    #[cfg(any(target_os = "aix", target_os = "hurd"))]
-    let seconds = metadata.st_mtim.tv_sec;
-    #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
-    let seconds = metadata.st_mtime;
-    #[cfg(any(target_os = "aix", target_os = "hurd"))]
-    let nanoseconds = metadata.st_mtim.tv_nsec;
-    #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
-    let nanoseconds = metadata.st_mtime_nsec;
-
-    (u64::try_from(seconds).unwrap_or(0), u32::try_from(nanoseconds).unwrap_or(0))
-}
-
-#[cfg(unix)]
 fn prune_dump_files_with_limits(
     directory: &fs::File,
     maximum_files: usize,
@@ -4187,15 +4173,32 @@ fn prune_dump_files_with_limits(
                     .and_then(|metadata| metadata.modified().ok())
                     .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
                     .map(|modified| (modified.as_secs(), modified.subsec_nanos()))
-                    .unwrap_or_else(|| private_dump_modified_time(&metadata))
+                    .unwrap_or((0, 0))
             } else {
-                private_dump_modified_time(&metadata)
+                (0, 0)
             }
         } else {
             // Count a hard-linked managed entry toward retention limits, but
             // do not open it for writing or chmod it. Those operations would
             // change the file visible through the other hard-link entries.
-            private_dump_modified_time(&metadata)
+            let descriptor = unsafe {
+                libc::openat(
+                    directory.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+                )
+            };
+            if descriptor >= 0 {
+                let file = unsafe { fs::File::from_raw_fd(descriptor) };
+                file.metadata()
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok())
+                    .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|modified| (modified.as_secs(), modified.subsec_nanos()))
+                    .unwrap_or((0, 0))
+            } else {
+                (0, 0)
+            }
         };
         dumps.push(DumpFile {
             name: name_bytes.to_vec(),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3663,12 +3663,11 @@ impl Drop for RemoteSession {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
                 let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
                 let frames_name = format!("frames-{}.log", surface.id);
-                if let Ok(file) = private_dump_file(&directory, &frames_name) {
-                    let mut writer = io::BufWriter::new(file);
-                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                        let _ = writeln!(writer, "{line}");
-                    }
+                let mut frames = String::new();
+                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                    let _ = writeln!(frames, "{line}");
                 }
+                let _ = write_private_dump(&directory, &frames_name, &frames);
             }
         }
     }
@@ -3738,9 +3737,48 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
 
 #[cfg(unix)]
 fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
-    let mut file = private_dump_file(directory, name)?;
-    file.write_all(contents.as_bytes())?;
-    Ok(())
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+    let final_name = CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+    for _ in 0..16 {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
+        let mut file = match private_dump_file(directory, &temp) {
+            Ok(file) => file,
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
+        };
+        let result = (|| {
+            file.write_all(contents.as_bytes())?;
+            file.sync_all()?;
+            drop(file);
+            let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+            let status = unsafe {
+                libc::renameat(
+                    directory.as_raw_fd(),
+                    temp_name.as_ptr(),
+                    directory.as_raw_fd(),
+                    final_name.as_ptr(),
+                )
+            };
+            if status != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            Ok(())
+        })();
+        if result.is_ok() {
+            return Ok(());
+        }
+        let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return result;
+    }
+    Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"))
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4101,6 +4101,23 @@ fn prune_dump_files(directory: &fs::File) -> io::Result<()> {
 }
 
 #[cfg(unix)]
+fn private_dump_modified_time(metadata: &libc::stat) -> (u64, u32) {
+    #[cfg(any(target_os = "aix", target_os = "hurd"))]
+    let seconds = metadata.st_mtim.tv_sec;
+    #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
+    let seconds = metadata.st_mtime;
+    #[cfg(any(target_os = "aix", target_os = "hurd"))]
+    let nanoseconds = metadata.st_mtim.tv_nsec;
+    #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
+    let nanoseconds = metadata.st_mtime_nsec;
+
+    (
+        u64::try_from(seconds).unwrap_or(0),
+        u32::try_from(nanoseconds).unwrap_or(0),
+    )
+}
+
+#[cfg(unix)]
 fn prune_dump_files_with_limits(
     directory: &fs::File,
     maximum_files: usize,
@@ -4154,28 +4171,34 @@ fn prune_dump_files_with_limits(
         let metadata = unsafe { metadata.assume_init() };
         if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
             || metadata.st_uid != unsafe { libc::geteuid() }
-            || metadata.st_nlink != 1
         {
             continue;
         }
-        let descriptor = unsafe {
-            libc::openat(
-                directory.as_raw_fd(),
-                name.as_ptr(),
-                libc::O_WRONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
-            )
-        };
-        let modified = if descriptor >= 0 {
-            let file = unsafe { fs::File::from_raw_fd(descriptor) };
-            unsafe { libc::fchmod(file.as_raw_fd(), 0o600) };
-            file.metadata()
-                .ok()
-                .and_then(|metadata| metadata.modified().ok())
-                .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
-                .map(|modified| (modified.as_secs(), modified.subsec_nanos()))
-                .unwrap_or((0, 0))
+        let modified = if metadata.st_nlink == 1 {
+            let descriptor = unsafe {
+                libc::openat(
+                    directory.as_raw_fd(),
+                    name.as_ptr(),
+                    libc::O_WRONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+                )
+            };
+            if descriptor >= 0 {
+                let file = unsafe { fs::File::from_raw_fd(descriptor) };
+                unsafe { libc::fchmod(file.as_raw_fd(), 0o600) };
+                file.metadata()
+                    .ok()
+                    .and_then(|metadata| metadata.modified().ok())
+                    .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+                    .map(|modified| (modified.as_secs(), modified.subsec_nanos()))
+                    .unwrap_or_else(|| private_dump_modified_time(&metadata))
+            } else {
+                private_dump_modified_time(&metadata)
+            }
         } else {
-            (0, 0)
+            // Count a hard-linked managed entry toward retention limits, but
+            // do not open it for writing or chmod it. Those operations would
+            // change the file visible through the other hard-link entries.
+            private_dump_modified_time(&metadata)
         };
         dumps.push(DumpFile {
             name: name_bytes.to_vec(),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3783,10 +3783,11 @@ fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
         directory = unsafe { fs::File::from_raw_fd(next) };
     }
     validate_dump_directory(&directory, true)?;
-    let temporary = open_private_child_directory(&directory, ".cmux-dump-tmp")?;
+    let output = open_private_child_directory(&directory, ".cmux-dump-files")?;
+    let temporary = open_private_child_directory(&output, ".cmux-dump-tmp")?;
     prune_stale_dump_temps(&temporary)?;
-    prune_dump_files(&directory)?;
-    Ok(PrivateDumpDirectory { output: directory, temporary })
+    prune_dump_files(&output)?;
+    Ok(PrivateDumpDirectory { output, temporary })
 }
 
 #[cfg(unix)]
@@ -4298,7 +4299,6 @@ where
     })?;
     let mut file = file.expect("temporary file is present when its name is present");
     let result = write_contents(&mut file).and_then(|()| file.sync_all());
-    drop(file);
     if let Err(error) = result {
         unsafe {
             libc::unlinkat(directory.temporary.as_raw_fd(), temp_name.as_ptr(), 0);
@@ -5203,7 +5203,8 @@ mod tests {
         let dump_path = root.path().join("dumps");
         let directory = private_dump_directory(&dump_path).unwrap();
         drop(directory);
-        let stale_path = dump_path.join(".cmux-dump-tmp/.mirror-1.txt.tmp-99999999-1");
+        let stale_path =
+            dump_path.join(".cmux-dump-files/.cmux-dump-tmp/.mirror-1.txt.tmp-99999999-1");
         fs::write(&stale_path, b"partial secret").unwrap();
 
         let _directory = private_dump_directory(&dump_path).unwrap();
@@ -5226,7 +5227,7 @@ mod tests {
             ("mirror-2.txt", b"new-".as_slice(), 3_i64),
         ];
         for (name, contents, modified) in files {
-            let path = dump_path.join(name);
+            let path = dump_path.join(".cmux-dump-files").join(name);
             fs::write(&path, contents).unwrap();
             fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
             let path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
@@ -5242,10 +5243,11 @@ mod tests {
 
         prune_dump_files_with_limits(&directory.output, 2, 10).unwrap();
 
-        assert!(!dump_path.join("mirror-1.txt").exists());
-        assert!(dump_path.join("frames-1.log").exists());
-        assert!(dump_path.join("mirror-2.txt").exists());
-        let retained = fs::read_dir(&dump_path)
+        let output_path = dump_path.join(".cmux-dump-files");
+        assert!(!output_path.join("mirror-1.txt").exists());
+        assert!(output_path.join("frames-1.log").exists());
+        assert!(output_path.join("mirror-2.txt").exists());
+        let retained = fs::read_dir(&output_path)
             .unwrap()
             .filter_map(Result::ok)
             .filter(|entry| is_private_dump_name(entry.file_name().as_os_str().as_bytes()))
@@ -5263,7 +5265,7 @@ mod tests {
         let directory = private_dump_directory(&dump_path).unwrap();
         let name = ".mirror-1.txt.tmp-99999999-1";
         let active = private_dump_file(&directory.temporary, name).unwrap();
-        let temp_path = dump_path.join(".cmux-dump-tmp").join(name);
+        let temp_path = dump_path.join(".cmux-dump-files/.cmux-dump-tmp").join(name);
 
         let next_directory = private_dump_directory(&dump_path).unwrap();
         assert!(temp_path.exists());
@@ -5327,8 +5329,8 @@ mod tests {
 
         write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"secret")).unwrap();
 
-        assert_eq!(fs::read(original.join("mirror.txt")).unwrap(), b"secret");
-        assert!(!dump_path.join("mirror.txt").exists());
+        assert_eq!(fs::read(original.join(".cmux-dump-files/mirror.txt")).unwrap(), b"secret");
+        assert!(!dump_path.join(".cmux-dump-files/mirror.txt").exists());
     }
 
     #[cfg(unix)]
@@ -5337,7 +5339,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
         let directory = private_dump_directory(&dump_path).unwrap();
-        let final_path = dump_path.join("mirror.txt");
+        let final_path = dump_path.join(".cmux-dump-files/mirror.txt");
         fs::write(&final_path, b"previous").unwrap();
 
         let error = write_private_dump(&directory, "mirror.txt", |_file| {
@@ -5347,7 +5349,7 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
-        assert!(fs::read_dir(&dump_path).unwrap().filter_map(Result::ok).all(|entry| {
+        assert!(fs::read_dir(dump_path.join(".cmux-dump-files")).unwrap().filter_map(Result::ok).all(|entry| {
             entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
         }));
     }
@@ -5358,8 +5360,8 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
         let directory = private_dump_directory(&dump_path).unwrap();
-        let final_path = dump_path.join("mirror.txt");
-        let linked_path = dump_path.join("mirror-backup.txt");
+        let final_path = dump_path.join(".cmux-dump-files/mirror.txt");
+        let linked_path = dump_path.join(".cmux-dump-files/mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -5376,8 +5378,8 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
         let directory = private_dump_directory(&dump_path).unwrap();
-        let final_path = dump_path.join("mirror.txt");
-        let linked_path = dump_path.join("mirror-backup.txt");
+        let final_path = dump_path.join(".cmux-dump-files/mirror.txt");
+        let linked_path = dump_path.join(".cmux-dump-files/mirror-backup.txt");
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
@@ -5403,7 +5405,7 @@ mod tests {
 
         assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
         assert!(final_path.is_dir());
-        assert!(fs::read_dir(&dump_path).unwrap().filter_map(Result::ok).all(|entry| {
+        assert!(fs::read_dir(dump_path.join(".cmux-dump-files")).unwrap().filter_map(Result::ok).all(|entry| {
             entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
         }));
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -19,7 +19,7 @@ use cmux_tui_core::{
     MuxEventReceiver, NotificationEvent, NotificationLevel, PairingChallenge, PointerSemanticProbe,
     PointerSnapshotProbe, REMOTE_SESSION_MESSAGE_MAX_BYTES, Rgb, SurfaceId, SurfaceKind,
     TerminalPointerSnapshot,
-    platform::{restrict_directory, transport},
+    platform::transport,
     server::{
         CLEAR_HISTORY_CAPABILITY, CLEAR_HISTORY_KEY_CAPABILITY, CREATION_RECEIPTS_CAPABILITY,
         CREATION_SELECTOR_FALLBACKS_CAPABILITY, GUARDED_BROWSER_POINTER_CAPABILITY,
@@ -3643,69 +3643,101 @@ impl Drop for RemoteSession {
         let Some(dir) = self.frame_dump_dir.as_deref() else {
             return;
         };
-        let _ = fs::create_dir_all(dir);
-        // Frame mirrors contain terminal output and may include secrets. Keep
-        // the opt-in dump directory and files private even when the process
-        // runs with a permissive umask.
-        let _ = restrict_directory(dir);
-        let logs = self.frame_logs.lock().unwrap();
-        let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
-        for entry in &logs.entries {
-            entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
+        #[cfg(not(unix))]
+        {
+            // Secure descriptor-relative file creation is not available in
+            // this implementation. Do not emit secret-bearing dumps through
+            // path-based APIs on unsupported targets.
+            let _ = dir;
+            return;
         }
-        for surface in self.surfaces.lock().unwrap().values() {
-            let path = dir.join(format!("mirror-{}.txt", surface.id));
-            let _ = write_private_dump(&path, &dump_mirror(surface));
-            let frames = dir.join(format!("frames-{}.log", surface.id));
-            if let Ok(file) = private_dump_file(&frames) {
-                let mut writer = io::BufWriter::new(file);
-                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                    let _ = writeln!(writer, "{line}");
+        #[cfg(unix)]
+        {
+            let Ok(directory) = private_dump_directory(dir) else { return };
+            let logs = self.frame_logs.lock().unwrap();
+            let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
+            for entry in &logs.entries {
+                entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
+            }
+            for surface in self.surfaces.lock().unwrap().values() {
+                let mirror_name = format!("mirror-{}.txt", surface.id);
+                let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
+                let frames_name = format!("frames-{}.log", surface.id);
+                if let Ok(file) = private_dump_file(&directory, &frames_name) {
+                    let mut writer = io::BufWriter::new(file);
+                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                        let _ = writeln!(writer, "{line}");
+                    }
                 }
             }
         }
     }
 }
 
-fn private_dump_file(path: &Path) -> io::Result<fs::File> {
-    let mut options = fs::OpenOptions::new();
-    options.write(true).create(true);
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
+#[cfg(unix)]
+fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+    use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
+
+    fs::create_dir_all(path)?;
+    let directory = fs::OpenOptions::new()
+        .read(true)
+        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
+        .open(path)?;
+    let metadata = directory.metadata()?;
+    if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("dump directory is not private and user-owned: {}", path.display()),
+        ));
     }
-    #[cfg(not(unix))]
-    options.truncate(true);
-    let file = options.open(path)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::{MetadataExt, PermissionsExt};
-        let metadata = file.metadata()?;
-        // O_NOFOLLOW protects only the final path component. Verify the
-        // opened descriptor as well, so a stale or malicious dump entry
-        // cannot block on a FIFO or redirect output to a device. A link count
-        // above one indicates a hard link, which could otherwise truncate a
-        // different file when the dump is refreshed.
-        if !metadata.is_file() || metadata.nlink() != 1 {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("dump target is not a private regular file: {}", path.display()),
-            ));
-        }
-        // Truncate only after validating the opened descriptor, so a hard
-        // link cannot cause data loss in another file.
-        file.set_len(0)?;
-        // `mode` only applies when the file is new. Set permissions through
-        // the opened descriptor so existing files are also private without a
-        // path-based symlink race.
-        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    Ok(directory)
+}
+
+#[cfg(unix)]
+fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+    use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+    let name = CString::new(name)
+        .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+    let descriptor = unsafe {
+        libc::openat(
+            directory.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_WRONLY
+                | libc::O_CREAT
+                | libc::O_NOFOLLOW
+                | libc::O_NONBLOCK
+                | libc::O_CLOEXEC,
+            0o600,
+        )
+    };
+    if descriptor < 0 {
+        return Err(io::Error::last_os_error());
     }
+    let file = unsafe { fs::File::from_raw_fd(descriptor) };
+    let metadata = file.metadata()?;
+    if !metadata.is_file()
+        || metadata.uid() != unsafe { libc::geteuid() }
+        || metadata.nlink() != 1
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump target is not a private user-owned regular file",
+        ));
+    }
+    // Truncate only after validating the opened descriptor, so a hard link
+    // cannot cause data loss in another file.
+    file.set_len(0)?;
+    file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
 
-fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {
-    let mut file = private_dump_file(path)?;
+#[cfg(unix)]
+fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
+    let mut file = private_dump_file(directory, name)?;
     file.write_all(contents.as_bytes())?;
     Ok(())
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3760,6 +3760,16 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
             continue;
         }
+        let Some(name) = name.to_str() else { continue };
+        let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
+        let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
+            continue;
+        };
+        let process_alive = unsafe { libc::kill(pid, 0) == 0 }
+            || io::Error::last_os_error().raw_os_error() == Some(libc::EPERM);
+        if process_alive {
+            continue;
+        }
         let name = CString::new(name_bytes)
             .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
         let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
@@ -3880,7 +3890,43 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
 }
 
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
+fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let size = unsafe { libc::flistxattr(directory.as_raw_fd(), std::ptr::null_mut(), 0) };
+    if size < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if size == 0 {
+        return Ok(());
+    }
+    let mut names = vec![0u8; size as usize];
+    let read =
+        unsafe { libc::flistxattr(directory.as_raw_fd(), names.as_mut_ptr().cast(), names.len()) };
+    if read < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    for name in names[..read as usize].split(|byte| *byte == 0) {
+        if name == b"system.posix_acl_access" || name == b"system.posix_acl_default" {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "dump directory has a POSIX ACL",
+            ));
+        }
+    }
+    Ok(())
+}
+
+#[cfg(all(unix, not(target_os = "macos"), not(target_os = "linux")))]
+fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::PermissionDenied,
+        "cannot validate dump directory ACLs on this Unix target",
+    ))
+}
+
+#[cfg(not(unix))]
 fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
     Ok(())
 }
@@ -4851,7 +4897,7 @@ mod tests {
     fn private_dump_directory_prunes_stale_temporary_dumps() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
-        let stale_path = dump_path.join(".mirror-1.txt.tmp-123-1");
+        let stale_path = dump_path.join(".mirror-1.txt.tmp-99999999-1");
         let directory = private_dump_directory(&dump_path).unwrap();
         drop(directory);
         fs::write(&stale_path, b"partial secret").unwrap();

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3675,7 +3675,16 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
     }
-    options.open(path)
+    let file = options.open(path)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        // `mode` only applies when the file is new. Set permissions through
+        // the opened descriptor so existing files are also private without a
+        // path-based symlink race.
+        file.set_permissions(fs::Permissions::from_mode(0o600))?;
+    }
+    Ok(file)
 }
 
 fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5319,9 +5319,96 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_dump_acl_accepts_deny_and_rejects_allow_entries() {
-        assert!(macos_dump_acl_tag_is_safe(0x0000_0200));
-        assert!(!macos_dump_acl_tag_is_safe(0x0000_0100));
+        assert!(macos_dump_acl_tag_is_safe(2));
+        assert!(!macos_dump_acl_tag_is_safe(1));
         assert!(!macos_dump_acl_tag_is_safe(99));
+    }
+
+    #[cfg(target_os = "macos")]
+    fn macos_dump_directory_with_acl(tags: &[libc::c_int]) -> (tempfile::TempDir, fs::File) {
+        use std::os::fd::AsRawFd;
+
+        unsafe extern "C" {
+            fn acl_init(count: libc::c_int) -> *mut libc::c_void;
+            fn acl_create_entry(
+                acl: *mut *mut libc::c_void,
+                entry: *mut *mut libc::c_void,
+            ) -> libc::c_int;
+            fn acl_set_tag_type(entry: *mut libc::c_void, tag: libc::c_int) -> libc::c_int;
+            fn acl_set_fd_np(
+                fd: libc::c_int,
+                acl: *mut libc::c_void,
+                acl_type: libc::c_int,
+            ) -> libc::c_int;
+            fn acl_free(object: *mut libc::c_void) -> libc::c_int;
+        }
+
+        struct Acl(*mut libc::c_void);
+        impl Drop for Acl {
+            fn drop(&mut self) {
+                unsafe { acl_free(self.0) };
+            }
+        }
+
+        const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+        let root = tempfile::tempdir().unwrap();
+        let directory = fs::File::open(root.path()).unwrap();
+        let mut acl = Acl(unsafe { acl_init(tags.len() as libc::c_int) });
+        assert!(!acl.0.is_null());
+        for &tag in tags {
+            let mut entry = std::ptr::null_mut();
+            assert_eq!(unsafe { acl_create_entry(&mut acl.0, &mut entry) }, 0);
+            assert_eq!(unsafe { acl_set_tag_type(entry, tag) }, 0);
+        }
+        assert_eq!(unsafe { acl_set_fd_np(directory.as_raw_fd(), acl.0, ACL_TYPE_EXTENDED) }, 0);
+        (root, directory)
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_dump_acl_accepts_a_deny_only_acl() {
+        let (_root, directory) = macos_dump_directory_with_acl(&[2]);
+        assert!(reject_extended_acl(&directory).is_ok());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_dump_acl_rejects_an_allow_after_a_deny() {
+        let (_root, directory) = macos_dump_directory_with_acl(&[2, 1]);
+        let error = reject_extended_acl(&directory).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_dump_acl_advances_through_repeated_deny_entries() {
+        use std::time::{Duration, Instant};
+
+        if std::env::var_os("CMUX_MACOS_ACL_CHILD").is_some() {
+            let (_root, directory) = macos_dump_directory_with_acl(&[2, 2]);
+            assert!(reject_extended_acl(&directory).is_ok());
+            return;
+        }
+
+        let mut child = std::process::Command::new(std::env::current_exe().unwrap())
+            .arg("--nocapture")
+            .arg("macos_dump_acl_advances_through_repeated_deny_entries")
+            .env("CMUX_MACOS_ACL_CHILD", "1")
+            .spawn()
+            .unwrap();
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            if let Some(status) = child.try_wait().unwrap() {
+                assert!(status.success(), "ACL child exited with {status}");
+                return;
+            }
+            if Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                panic!("ACL scan did not advance through all entries");
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3678,7 +3678,13 @@ impl Drop for RemoteSession {
 }
 
 #[cfg(unix)]
-fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+struct PrivateDumpDirectory {
+    output: fs::File,
+    temporary: fs::File,
+}
+
+#[cfg(unix)]
+fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::ffi::OsStrExt;
@@ -3736,7 +3742,45 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         directory = unsafe { fs::File::from_raw_fd(next) };
     }
     validate_dump_directory(&directory, true)?;
-    prune_stale_dump_temps(&directory)?;
+    let temporary = open_private_child_directory(&directory, ".cmux-dump-tmp")?;
+    prune_stale_dump_temps(&temporary)?;
+    Ok(PrivateDumpDirectory { output: directory, temporary })
+}
+
+#[cfg(unix)]
+fn open_private_child_directory(parent: &fs::File, name: &str) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    let name = CString::new(name).map_err(|_| io::ErrorKind::InvalidInput)?;
+    let mut descriptor = unsafe {
+        libc::openat(
+            parent.as_raw_fd(),
+            name.as_ptr(),
+            libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+        )
+    };
+    if descriptor < 0 {
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::NotFound {
+            return Err(error);
+        }
+        if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        descriptor = unsafe {
+            libc::openat(
+                parent.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        if descriptor < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    let directory = unsafe { fs::File::from_raw_fd(descriptor) };
+    validate_dump_directory(&directory, true)?;
     Ok(directory)
 }
 
@@ -3956,7 +4000,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
 }
 
 #[cfg(unix)]
-fn write_private_dump<F>(directory: &fs::File, name: &str, write_contents: F) -> io::Result<()>
+fn write_private_dump<F>(directory: &PrivateDumpDirectory, name: &str, write_contents: F) -> io::Result<()>
 where
     F: FnOnce(&mut fs::File) -> io::Result<()>,
 {
@@ -3971,7 +4015,7 @@ where
     for _ in 0..16 {
         let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
         let candidate = format!(".{name}.tmp-{}-{id}", unsafe { libc::getpid() });
-        match private_dump_file(directory, &candidate) {
+        match private_dump_file(&directory.temporary, &candidate) {
             Ok(candidate_file) => {
                 temp_name = Some(CString::new(candidate).expect("generated temp name is valid"));
                 file = Some(candidate_file);
@@ -3992,22 +4036,22 @@ where
     drop(file);
     if let Err(error) = result {
         unsafe {
-            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+            libc::unlinkat(directory.temporary.as_raw_fd(), temp_name.as_ptr(), 0);
         }
         return Err(error);
     }
     let status = unsafe {
         libc::renameat(
-            directory.as_raw_fd(),
+            directory.temporary.as_raw_fd(),
             temp_name.as_ptr(),
-            directory.as_raw_fd(),
+            directory.output.as_raw_fd(),
             final_name.as_ptr(),
         )
     };
     if status != 0 {
         let error = io::Error::last_os_error();
         unsafe {
-            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+            libc::unlinkat(directory.temporary.as_raw_fd(), temp_name.as_ptr(), 0);
         }
         return Err(error);
     }
@@ -4859,7 +4903,8 @@ mod tests {
         let path = root.path().join("dumps");
         let directory = private_dump_directory(&path).unwrap();
 
-        assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+        assert_eq!(directory.output.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+        assert_eq!(directory.temporary.metadata().unwrap().permissions().mode() & 0o777, 0o700);
     }
 
     #[cfg(unix)]
@@ -4882,9 +4927,9 @@ mod tests {
     fn private_dump_directory_prunes_stale_temporary_dumps() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
-        let stale_path = dump_path.join(".mirror-1.txt.tmp-99999999-1");
         let directory = private_dump_directory(&dump_path).unwrap();
         drop(directory);
+        let stale_path = dump_path.join(".cmux-dump-tmp/.mirror-1.txt.tmp-99999999-1");
         fs::write(&stale_path, b"partial secret").unwrap();
 
         let _directory = private_dump_directory(&dump_path).unwrap();
@@ -4958,7 +5003,9 @@ mod tests {
             fs::read_dir(&dump_path)
                 .unwrap()
                 .filter_map(Result::ok)
-                .all(|entry| entry.file_name() == "mirror.txt")
+                .all(|entry| {
+                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+                })
         );
     }
 
@@ -4991,7 +5038,7 @@ mod tests {
         fs::write(&final_path, b"previous").unwrap();
         fs::hard_link(&final_path, &linked_path).unwrap();
 
-        let error = private_dump_file(&directory, "mirror.txt").unwrap_err();
+        let error = private_dump_file(&directory.output, "mirror.txt").unwrap_err();
 
         assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
@@ -5017,7 +5064,9 @@ mod tests {
             fs::read_dir(&dump_path)
                 .unwrap()
                 .filter_map(Result::ok)
-                .all(|entry| entry.file_name() == "mirror.txt")
+                .all(|entry| {
+                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+                })
         );
     }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -56,6 +56,39 @@ const REMOTE_FRAME_DUMP_MAX_FILES: usize = 32;
 const REMOTE_FRAME_DUMP_MAX_BYTES: u64 = 8 * 1024 * 1024;
 const REMOTE_TERMINAL_DIMENSION_MAX: u64 = 10_000;
 const REMOTE_TERMINAL_CELL_MAX: u64 = 1024 * 1024;
+
+#[cfg(unix)]
+#[derive(Debug, Clone, Copy)]
+struct PrivateDumpEmissionBudget {
+    remaining_files: usize,
+    remaining_bytes: u64,
+}
+
+#[cfg(unix)]
+impl PrivateDumpEmissionBudget {
+    fn new() -> Self {
+        Self::with_limits(REMOTE_FRAME_DUMP_MAX_FILES, REMOTE_FRAME_DUMP_MAX_BYTES)
+    }
+
+    fn with_limits(maximum_files: usize, maximum_bytes: u64) -> Self {
+        Self { remaining_files: maximum_files, remaining_bytes: maximum_bytes }
+    }
+
+    fn can_fit(&self, bytes: u64) -> bool {
+        self.remaining_files > 0 && bytes <= self.remaining_bytes
+    }
+
+    fn has_capacity(&self) -> bool {
+        self.remaining_files > 0 && self.remaining_bytes > 0
+    }
+
+    fn commit(&mut self, bytes: u64) {
+        debug_assert!(self.can_fit(bytes));
+        self.remaining_files = self.remaining_files.saturating_sub(1);
+        self.remaining_bytes = self.remaining_bytes.saturating_sub(bytes);
+    }
+}
+
 const INTERACTIVE_LATENCY_BUCKET_UPPER_US: [u64; 18] = [
     50,
     100,
@@ -3679,29 +3712,65 @@ impl Drop for RemoteSession {
             for entry in &logs.entries {
                 entries_by_surface.entry(entry.surface).or_default().push(&entry.line);
             }
+            // A session can retain more surfaces than the directory's final
+            // retention set. Bound the amount emitted during teardown too;
+            // the final prune below still accounts for dumps from other
+            // sessions and concurrent writers.
+            let mut emission_budget = PrivateDumpEmissionBudget::new();
+            let mut emission_budget_exhausted = false;
             for surface in self.surfaces.lock().unwrap().values() {
+                if !emission_budget.has_capacity() {
+                    emission_budget_exhausted = true;
+                    break;
+                }
                 let mirror_name = format!("mirror-{}.txt", surface.id);
                 let mirror = dump_mirror(surface);
-                if let Err(error) = write_private_dump(&directory, &mirror_name, |file| {
-                    file.write_all(mirror.as_bytes())
-                }) {
-                    crate::client_log::error(
-                        "mux-dump",
-                        &format!("cannot write private dump {mirror_name}: {error}"),
-                    );
+                let mirror_bytes = mirror.len() as u64;
+                if emission_budget.can_fit(mirror_bytes) {
+                    if let Err(error) = write_private_dump(&directory, &mirror_name, |file| {
+                        file.write_all(mirror.as_bytes())
+                    }) {
+                        crate::client_log::error(
+                            "mux-dump",
+                            &format!("cannot write private dump {mirror_name}: {error}"),
+                        );
+                    } else {
+                        emission_budget.commit(mirror_bytes);
+                    }
+                } else {
+                    emission_budget_exhausted = true;
                 }
                 let frames_name = format!("frames-{}.log", surface.id);
-                if let Err(error) = write_private_dump(&directory, &frames_name, |file| {
-                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                        writeln!(file, "{line}")?;
+                let frame_bytes = entries_by_surface
+                    .get(&surface.id)
+                    .into_iter()
+                    .flatten()
+                    .fold(0_u64, |total, line| {
+                        total.saturating_add((line.len() as u64).saturating_add(1))
+                    });
+                if emission_budget.can_fit(frame_bytes) {
+                    if let Err(error) = write_private_dump(&directory, &frames_name, |file| {
+                        for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                            writeln!(file, "{line}")?;
+                        }
+                        Ok(())
+                    }) {
+                        crate::client_log::error(
+                            "mux-dump",
+                            &format!("cannot write private dump {frames_name}: {error}"),
+                        );
+                    } else {
+                        emission_budget.commit(frame_bytes);
                     }
-                    Ok(())
-                }) {
-                    crate::client_log::error(
-                        "mux-dump",
-                        &format!("cannot write private dump {frames_name}: {error}"),
-                    );
+                } else {
+                    emission_budget_exhausted = true;
                 }
+            }
+            if emission_budget_exhausted {
+                crate::client_log::error(
+                    "mux-dump",
+                    "private dump emission budget exhausted; later surface dumps were skipped",
+                );
             }
             if let Err(error) = prune_dump_files(&directory.output) {
                 crate::client_log::error(
@@ -5322,6 +5391,23 @@ mod tests {
         assert_eq!(retained.len(), 2);
         let bytes = retained.iter().map(|entry| entry.metadata().unwrap().len()).sum::<u64>();
         assert_eq!(bytes, 10);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_emission_budget_enforces_file_and_byte_caps() {
+        let mut budget = PrivateDumpEmissionBudget::with_limits(2, 10);
+
+        assert!(budget.can_fit(4));
+        budget.commit(4);
+        assert_eq!(budget.remaining_files, 1);
+        assert_eq!(budget.remaining_bytes, 6);
+
+        assert!(budget.can_fit(6));
+        budget.commit(6);
+        assert_eq!(budget.remaining_files, 0);
+        assert_eq!(budget.remaining_bytes, 0);
+        assert!(!budget.can_fit(0));
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3708,6 +3708,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
             name.as_ptr(),
             libc::O_WRONLY
                 | libc::O_CREAT
+                | libc::O_EXCL
                 | libc::O_NOFOLLOW
                 | libc::O_NONBLOCK
                 | libc::O_CLOEXEC,
@@ -3728,9 +3729,9 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
             "dump target is not a private user-owned regular file",
         ));
     }
-    // Truncate only after validating the opened descriptor, so a hard link
-    // cannot cause data loss in another file.
-    file.set_len(0)?;
+    // Exclusive creation means an existing hard link or symlink is never
+    // opened, and no previously existing file is truncated. A repeated dump
+    // is skipped when its deterministic name already exists.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3955,7 +3955,7 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
             libc::openat(
                 directory.as_raw_fd(),
                 name.as_ptr(),
-                libc::O_RDONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+                libc::O_RDWR | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
             )
         };
         if descriptor < 0 {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3673,12 +3673,24 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
-        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
     let file = options.open(path)?;
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
+        use std::os::unix::fs::{MetadataExt, PermissionsExt};
+        let metadata = file.metadata()?;
+        // O_NOFOLLOW protects only the final path component. Verify the
+        // opened descriptor as well, so a stale or malicious dump entry
+        // cannot block on a FIFO or redirect output to a device. A link count
+        // above one indicates a hard link, which could otherwise truncate a
+        // different file when the dump is refreshed.
+        if !metadata.is_file() || metadata.nlink() != 1 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("dump target is not a private regular file: {}", path.display()),
+            ));
+        }
         // `mode` only applies when the file is new. Set permissions through
         // the opened descriptor so existing files are also private without a
         // path-based symlink race.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4812,6 +4812,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_prunes_stale_temporary_dumps() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let stale_path = dump_path.join(".mirror-1.txt.tmp-123-1");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        drop(directory);
+        fs::write(&stale_path, b"partial secret").unwrap();
+
+        let _directory = private_dump_directory(&dump_path).unwrap();
+
+        assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4266,6 +4266,12 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
         return Err(io::Error::last_os_error());
     }
     let file = unsafe { fs::File::from_raw_fd(descriptor) };
+    // Claim the temporary file before any validation work. The stale-temp
+    // reaper uses the same advisory lock and must never see this file as idle
+    // while it is being prepared for a dump.
+    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
+        return Err(io::Error::last_os_error());
+    }
     let metadata = file.metadata()?;
     if !metadata.is_file() || metadata.uid() != unsafe { libc::geteuid() } || metadata.nlink() != 1
     {
@@ -4277,9 +4283,6 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     // Exclusive creation means an existing hard link or symlink is never
     // opened, and no previously existing file is truncated.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
-    if unsafe { libc::flock(file.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } != 0 {
-        return Err(io::Error::last_os_error());
-    }
     Ok(file)
 }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4190,11 +4190,14 @@ fn prune_dump_files_with_limits(
             delete_dump_file(directory, &dump.name)?;
         }
     }
-    let mut total_bytes = dumps.iter().map(|dump| dump.bytes).sum::<u64>();
+    // A directory can contain files close to the maximum `u64` file size.
+    // Sum in a wider type so the byte cap cannot wrap before it is enforced.
+    let maximum_bytes = u128::from(maximum_bytes);
+    let mut total_bytes = dumps.iter().map(|dump| u128::from(dump.bytes)).sum::<u128>();
     while total_bytes > maximum_bytes {
         let dump = dumps.remove(0);
         delete_dump_file(directory, &dump.name)?;
-        total_bytes = total_bytes.saturating_sub(dump.bytes);
+        total_bytes = total_bytes.saturating_sub(u128::from(dump.bytes));
     }
     Ok(())
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3661,13 +3661,17 @@ impl Drop for RemoteSession {
             }
             for surface in self.surfaces.lock().unwrap().values() {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
-                let _ = write_private_dump(&directory, &mirror_name, &dump_mirror(surface));
+                let mirror = dump_mirror(surface);
+                let _ = write_private_dump(&directory, &mirror_name, |file| {
+                    file.write_all(mirror.as_bytes())
+                });
                 let frames_name = format!("frames-{}.log", surface.id);
-                let mut frames = String::new();
-                for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
-                    let _ = writeln!(frames, "{line}");
-                }
-                let _ = write_private_dump(&directory, &frames_name, &frames);
+                let _ = write_private_dump(&directory, &frames_name, |file| {
+                    for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
+                        writeln!(file, "{line}")?;
+                    }
+                    Ok(())
+                });
             }
         }
     }
@@ -3677,6 +3681,17 @@ impl Drop for RemoteSession {
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
+    let existed = match fs::symlink_metadata(path) {
+        Ok(metadata) if metadata.is_dir() => true,
+        Ok(_) => {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                format!("dump path is not a directory: {}", path.display()),
+            ));
+        }
+        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+        Err(error) => return Err(error),
+    };
     fs::create_dir_all(path)?;
     let directory = fs::OpenOptions::new()
         .read(true)
@@ -3689,7 +3704,16 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
-    directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    if existed {
+        if metadata.mode() & 0o077 != 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                format!("dump directory is not private: {}", path.display()),
+            ));
+        }
+    } else {
+        directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    }
     Ok(directory)
 }
 
@@ -3729,56 +3753,61 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
         ));
     }
     // Exclusive creation means an existing hard link or symlink is never
-    // opened, and no previously existing file is truncated. A repeated dump
-    // is skipped when its deterministic name already exists.
+    // opened, and no previously existing file is truncated. The temporary
+    // file is atomically renamed into the deterministic final name below.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
 
 #[cfg(unix)]
-fn write_private_dump(directory: &fs::File, name: &str, contents: &str) -> io::Result<()> {
+fn write_private_dump<F>(directory: &fs::File, name: &str, write_contents: F) -> io::Result<()>
+where
+    F: FnOnce(&mut fs::File) -> io::Result<()>,
+{
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
 
     static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    for _ in 0..16 {
-        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
-        let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
-        let mut file = match private_dump_file(directory, &temp) {
-            Ok(file) => file,
-            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-            Err(error) => return Err(error),
-        };
-        let result = (|| {
-            file.write_all(contents.as_bytes())?;
-            file.sync_all()?;
-            drop(file);
-            let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-            let status = unsafe {
-                libc::renameat(
-                    directory.as_raw_fd(),
-                    temp_name.as_ptr(),
-                    directory.as_raw_fd(),
-                    final_name.as_ptr(),
-                )
+    let (mut file, temp) = 'allocate: loop {
+        for _ in 0..16 {
+            let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+            let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
+            let file = match private_dump_file(directory, &temp) {
+                Ok(file) => break 'allocate (file, temp),
+                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+                Err(error) => return Err(error),
             };
-            if status != 0 {
-                return Err(io::Error::last_os_error());
-            }
-            Ok(())
-        })();
-        if result.is_ok() {
-            return Ok(());
         }
+        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"));
+    };
+    let result = (|| {
+        write_contents(&mut file)?;
+        file.sync_all()?;
+        drop(file);
         let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-        unsafe {
-            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        let status = unsafe {
+            libc::renameat(
+                directory.as_raw_fd(),
+                temp_name.as_ptr(),
+                directory.as_raw_fd(),
+                final_name.as_ptr(),
+            )
+        };
+        if status != 0 {
+            return Err(io::Error::last_os_error());
         }
-        return result;
+        Ok(())
+    })();
+    if result.is_ok() {
+        return Ok(());
     }
-    Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"))
+    let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
+    unsafe {
+        libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+    }
+    result
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3734,7 +3734,43 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private: {}", path.display()),
         ));
     }
+    prune_stale_dump_temps(&directory, path)?;
     Ok(directory)
+}
+
+#[cfg(unix)]
+fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
+    use std::ffi::CString;
+    use std::os::fd::AsRawFd;
+    use std::os::unix::ffi::OsStrExt;
+    use std::os::unix::fs::MetadataExt;
+
+    let uid = unsafe { libc::geteuid() };
+    for entry in fs::read_dir(path)? {
+        let entry = entry?;
+        let name = entry.file_name();
+        let name_bytes = name.as_os_str().as_bytes();
+        let is_dump_temp = (name_bytes.starts_with(b".mirror-")
+            || name_bytes.starts_with(b".frames-"))
+            && name_bytes.windows(b".tmp-".len()).any(|part| part == b".tmp-");
+        if !is_dump_temp {
+            continue;
+        }
+        let metadata = fs::symlink_metadata(entry.path())?;
+        if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
+            continue;
+        }
+        let name = CString::new(name_bytes)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+        let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::NotFound {
+                return Err(error);
+            }
+        }
+    }
+    Ok(())
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3920,15 +3920,12 @@ impl Drop for DumpDirectoryLock<'_> {
 fn lock_dump_directory(directory: &fs::File) -> io::Result<DumpDirectoryLock<'_>> {
     use std::os::fd::AsRawFd;
 
-    loop {
-        if unsafe { libc::flock(directory.as_raw_fd(), libc::LOCK_EX) } == 0 {
-            return Ok(DumpDirectoryLock { directory });
-        }
-        let error = io::Error::last_os_error();
-        if error.kind() != io::ErrorKind::Interrupted {
-            return Err(error);
-        }
+    // Dumping is best-effort. Never let a stalled peer holding this advisory
+    // lock block session teardown or directory cleanup.
+    if unsafe { libc::flock(directory.as_raw_fd(), libc::LOCK_EX | libc::LOCK_NB) } == 0 {
+        return Ok(DumpDirectoryLock { directory });
     }
+    Err(io::Error::last_os_error())
 }
 
 #[cfg(unix)]
@@ -4364,7 +4361,15 @@ where
         }
         return Err(error);
     }
-    let _output_lock = lock_dump_directory(&directory.output)?;
+    let _output_lock = match lock_dump_directory(&directory.output) {
+        Ok(lock) => lock,
+        Err(error) => {
+            unsafe {
+                libc::unlinkat(directory.temporary.as_raw_fd(), temp_name.as_ptr(), 0);
+            }
+            return Err(error);
+        }
+    };
     let status = unsafe {
         libc::renameat(
             directory.temporary.as_raw_fd(),
@@ -5338,10 +5343,8 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn private_dump_file_waits_for_directory_lock_before_creation() {
+    fn private_dump_file_skips_when_directory_lock_is_held() {
         use std::os::fd::AsRawFd;
-        use std::sync::mpsc::channel;
-        use std::time::Duration;
 
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
@@ -5349,19 +5352,13 @@ mod tests {
         let temporary_path = dump_path.join(".cmux-dump-files/.cmux-dump-tmp");
         let temp_path = temporary_path.join(".mirror-1.txt.tmp-99999999-1");
         assert_eq!(unsafe { libc::flock(directory.temporary.as_raw_fd(), libc::LOCK_EX) }, 0);
-        let (created_tx, created_rx) = channel();
-        let worker = std::thread::spawn(move || {
-            let temporary = fs::File::open(&temporary_path).unwrap();
-            let file = private_dump_file(&temporary, ".mirror-1.txt.tmp-99999999-1").unwrap();
-            created_tx.send(()).unwrap();
-            (temporary, file)
-        });
-
-        assert!(created_rx.recv_timeout(Duration::from_millis(100)).is_err());
+        let temporary = fs::File::open(&temporary_path).unwrap();
+        let error = private_dump_file(&temporary, ".mirror-1.txt.tmp-99999999-1").unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::WouldBlock);
         assert!(!temp_path.exists());
         assert_eq!(unsafe { libc::flock(directory.temporary.as_raw_fd(), libc::LOCK_UN) }, 0);
-        created_rx.recv_timeout(Duration::from_secs(2)).unwrap();
-        let (temporary, file) = worker.join().unwrap();
+        let file = private_dump_file(&temporary, ".mirror-1.txt.tmp-99999999-1").unwrap();
+        assert!(temp_path.exists());
         drop(file);
         drop(temporary);
     }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3738,6 +3738,8 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
     use std::ptr;
 
+    // Any extended ACL can carry non-owner grants or inheritance. Reject the
+    // directory instead of trying to interpret ACE ordering and masks.
     let descriptor = directory.as_raw_fd();
     let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
     if size < 0 {

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -82,10 +82,13 @@ impl PrivateDumpEmissionBudget {
         self.remaining_files > 0 && self.remaining_bytes > 0
     }
 
-    fn commit(&mut self, bytes: u64) {
-        debug_assert!(self.can_fit(bytes));
+    fn reserve(&mut self, bytes: u64) -> bool {
+        if !self.can_fit(bytes) {
+            return false;
+        }
         self.remaining_files = self.remaining_files.saturating_sub(1);
         self.remaining_bytes = self.remaining_bytes.saturating_sub(bytes);
+        true
     }
 }
 
@@ -3726,7 +3729,9 @@ impl Drop for RemoteSession {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
                 let mirror = dump_mirror(surface);
                 let mirror_bytes = mirror.len() as u64;
-                if emission_budget.can_fit(mirror_bytes) {
+                // Reserve before opening the temporary file so failed writes
+                // cannot turn teardown into an unbounded retry loop.
+                if emission_budget.reserve(mirror_bytes) {
                     if let Err(error) = write_private_dump(&directory, &mirror_name, |file| {
                         file.write_all(mirror.as_bytes())
                     }) {
@@ -3734,8 +3739,6 @@ impl Drop for RemoteSession {
                             "mux-dump",
                             &format!("cannot write private dump {mirror_name}: {error}"),
                         );
-                    } else {
-                        emission_budget.commit(mirror_bytes);
                     }
                 } else {
                     emission_budget_exhausted = true;
@@ -3748,7 +3751,7 @@ impl Drop for RemoteSession {
                     .fold(0_u64, |total, line| {
                         total.saturating_add((line.len() as u64).saturating_add(1))
                     });
-                if emission_budget.can_fit(frame_bytes) {
+                if emission_budget.reserve(frame_bytes) {
                     if let Err(error) = write_private_dump(&directory, &frames_name, |file| {
                         for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
                             writeln!(file, "{line}")?;
@@ -3759,8 +3762,6 @@ impl Drop for RemoteSession {
                             "mux-dump",
                             &format!("cannot write private dump {frames_name}: {error}"),
                         );
-                    } else {
-                        emission_budget.commit(frame_bytes);
                     }
                 } else {
                     emission_budget_exhausted = true;
@@ -5398,16 +5399,14 @@ mod tests {
     fn private_dump_emission_budget_enforces_file_and_byte_caps() {
         let mut budget = PrivateDumpEmissionBudget::with_limits(2, 10);
 
-        assert!(budget.can_fit(4));
-        budget.commit(4);
+        assert!(budget.reserve(4));
         assert_eq!(budget.remaining_files, 1);
         assert_eq!(budget.remaining_bytes, 6);
 
-        assert!(budget.can_fit(6));
-        budget.commit(6);
+        assert!(budget.reserve(6));
         assert_eq!(budget.remaining_files, 0);
         assert_eq!(budget.remaining_bytes, 0);
-        assert!(!budget.can_fit(0));
+        assert!(!budget.reserve(0));
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3680,87 +3680,132 @@ impl Drop for RemoteSession {
 #[cfg(unix)]
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
     use std::ffi::CString;
+    use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-
-    // Validate existing ancestors before create_dir_all follows them, then
-    // validate again after creation to catch newly created components. A
-    // writable non-sticky ancestor permits another user to replace the dump
-    // directory between path operations and redirect secret-bearing output.
-    validate_dump_ancestors(path)?;
-
-    let existed = match fs::symlink_metadata(path) {
-        Ok(metadata) if metadata.is_dir() => true,
-        Ok(_) => {
-            return Err(io::Error::new(
-                io::ErrorKind::InvalidInput,
-                format!("dump path is not a directory: {}", path.display()),
-            ));
-        }
-        Err(error) if error.kind() == io::ErrorKind::NotFound => false,
-        Err(error) => return Err(error),
-    };
-    if !existed {
-        if let Some(parent) = path.parent().filter(|parent| !parent.as_os_str().is_empty()) {
-            fs::create_dir_all(parent)?;
-        }
-        let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
-            io::Error::new(io::ErrorKind::InvalidInput, "invalid dump directory path")
-        })?;
-        let status = unsafe { libc::mkdir(path.as_ptr(), 0o700) };
-        if status != 0 {
+    let start = if path.is_absolute() { "/" } else { "." };
+    let start = CString::new(start).unwrap();
+    let fd =
+        unsafe { libc::open(start.as_ptr(), libc::O_RDONLY | libc::O_DIRECTORY | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let mut directory = unsafe { fs::File::from_raw_fd(fd) };
+    for component in path.components() {
+        use std::path::Component;
+        let Component::Normal(component) = component else {
+            if matches!(component, Component::ParentDir) {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "dump path must not contain '..'",
+                ));
+            }
+            continue;
+        };
+        validate_dump_directory(&directory, false)?;
+        let component =
+            CString::new(component.as_bytes()).map_err(|_| io::ErrorKind::InvalidInput)?;
+        let next = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                component.as_ptr(),
+                libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+            )
+        };
+        let next = if next >= 0 {
+            next
+        } else {
             let error = io::Error::last_os_error();
-            if error.kind() != io::ErrorKind::AlreadyExists {
+            if error.kind() != io::ErrorKind::NotFound {
                 return Err(error);
             }
-        }
+            if unsafe { libc::mkdirat(directory.as_raw_fd(), component.as_ptr(), 0o700) } != 0 {
+                return Err(io::Error::last_os_error());
+            }
+            let next = unsafe {
+                libc::openat(
+                    directory.as_raw_fd(),
+                    component.as_ptr(),
+                    libc::O_RDONLY | libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC,
+                )
+            };
+            if next < 0 {
+                return Err(io::Error::last_os_error());
+            }
+            next
+        };
+        directory = unsafe { fs::File::from_raw_fd(next) };
     }
-    validate_dump_ancestors(path)?;
-    let directory = fs::OpenOptions::new()
-        .read(true)
-        .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-        .open(path)?;
-    let metadata = directory.metadata()?;
-    if !metadata.is_dir() || metadata.uid() != unsafe { libc::geteuid() } {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!("dump directory is not private and user-owned: {}", path.display()),
-        ));
-    }
-    reject_extended_acl(&directory)?;
-    if metadata.mode() & 0o077 != 0 {
-        return Err(io::Error::new(
-            io::ErrorKind::PermissionDenied,
-            format!("dump directory is not private: {}", path.display()),
-        ));
-    }
-    prune_stale_dump_temps(&directory, path)?;
+    validate_dump_directory(&directory, true)?;
+    prune_stale_dump_temps(&directory)?;
     Ok(directory)
 }
 
 #[cfg(unix)]
-fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
+fn validate_dump_directory(directory: &fs::File, private: bool) -> io::Result<()> {
+    use std::os::unix::fs::MetadataExt;
+    let metadata = directory.metadata()?;
+    let trusted_owner = metadata.uid() == unsafe { libc::geteuid() } || metadata.uid() == 0;
+    let sticky = metadata.mode() & 0o1000 != 0;
+    if !trusted_owner
+        || (!private && metadata.mode() & 0o022 != 0 && !sticky)
+        || (private && metadata.mode() & 0o077 != 0)
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump directory component is not private or trusted",
+        ));
+    }
+    reject_extended_acl(directory)
+}
+
+#[cfg(unix)]
+fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
-    use std::os::unix::ffi::OsStrExt;
-    use std::os::unix::fs::MetadataExt;
 
     let uid = unsafe { libc::geteuid() };
-    for entry in fs::read_dir(path)? {
-        let entry = entry?;
-        let name = entry.file_name();
-        let name_bytes = name.as_os_str().as_bytes();
+    let duplicate = unsafe { libc::dup(directory.as_raw_fd()) };
+    if duplicate < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let stream = unsafe { libc::fdopendir(duplicate) };
+    if stream.is_null() {
+        unsafe { libc::close(duplicate) };
+        return Err(io::Error::last_os_error());
+    }
+    loop {
+        let entry = unsafe { libc::readdir(stream) };
+        if entry.is_null() {
+            break;
+        }
+        let name = unsafe { std::ffi::CStr::from_ptr((*entry).d_name.as_ptr()) };
+        let name_bytes = name.to_bytes();
         let is_dump_temp = (name_bytes.starts_with(b".mirror-")
             || name_bytes.starts_with(b".frames-"))
             && name_bytes.windows(b".tmp-".len()).any(|part| part == b".tmp-");
         if !is_dump_temp {
             continue;
         }
-        let metadata = fs::symlink_metadata(entry.path())?;
-        if !metadata.is_file() || metadata.uid() != uid || metadata.nlink() != 1 {
+        let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+        if unsafe {
+            libc::fstatat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                metadata.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } != 0
+        {
             continue;
         }
-        let Some(name) = name.to_str() else { continue };
+        let metadata = unsafe { metadata.assume_init() };
+        if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
+            || metadata.st_uid != uid
+            || metadata.st_nlink != 1
+        {
+            continue;
+        }
+        let Some(name) = name.to_str().ok() else { continue };
         let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
         let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
             continue;
@@ -3770,8 +3815,7 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
         if process_alive {
             continue;
         }
-        let name = CString::new(name_bytes)
-            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+        let name = CString::new(name_bytes).map_err(|_| io::ErrorKind::InvalidInput)?;
         let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
         if status != 0 {
             let error = io::Error::last_os_error();
@@ -3780,77 +3824,8 @@ fn prune_stale_dump_temps(directory: &fs::File, path: &Path) -> io::Result<()> {
             }
         }
     }
-    Ok(())
-}
-
-#[cfg(unix)]
-fn validate_dump_ancestors(path: &Path) -> io::Result<()> {
-    use std::os::unix::fs::{MetadataExt, OpenOptionsExt};
-
-    let mut ancestor = path.parent();
-    while let Some(candidate) = ancestor {
-        if candidate.as_os_str().is_empty() {
-            break;
-        }
-        match fs::symlink_metadata(candidate) {
-            Ok(metadata) => {
-                let resolved = if metadata.file_type().is_symlink() {
-                    if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
-                        return Err(io::Error::new(
-                            io::ErrorKind::PermissionDenied,
-                            format!(
-                                "dump directory ancestor is not trusted: {}",
-                                candidate.display()
-                            ),
-                        ));
-                    }
-                    let resolved = fs::canonicalize(candidate)?;
-                    validate_dump_ancestors(&resolved)?;
-                    resolved
-                } else {
-                    candidate.to_path_buf()
-                };
-                let metadata = fs::symlink_metadata(&resolved)?;
-                if !metadata.is_dir() {
-                    return Err(io::Error::new(
-                        io::ErrorKind::InvalidInput,
-                        format!(
-                            "dump directory ancestor is not a directory: {}",
-                            candidate.display()
-                        ),
-                    ));
-                }
-                if metadata.uid() != unsafe { libc::geteuid() } && metadata.uid() != 0 {
-                    return Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        format!("dump directory ancestor is not trusted: {}", candidate.display()),
-                    ));
-                }
-                let mode = metadata.mode();
-                let sticky = mode & 0o1000 != 0;
-                if mode & 0o022 != 0 && !sticky {
-                    return Err(io::Error::new(
-                        io::ErrorKind::PermissionDenied,
-                        format!(
-                            "dump directory ancestor is writable without private protection: {}",
-                            candidate.display()
-                        ),
-                    ));
-                }
-                let directory = fs::OpenOptions::new()
-                    .read(true)
-                    .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
-                    .open(&resolved)?;
-                reject_extended_acl(&directory)?;
-            }
-            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
-            Err(error) => return Err(error),
-        }
-        let next = candidate.parent();
-        if next == Some(candidate) {
-            break;
-        }
-        ancestor = next;
+    unsafe {
+        libc::closedir(stream);
     }
     Ok(())
 }
@@ -4905,6 +4880,37 @@ mod tests {
         let _directory = private_dump_directory(&dump_path).unwrap();
 
         assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_directory_rejects_symlink_components() {
+        use std::os::unix::fs::symlink;
+
+        let root = tempfile::tempdir().unwrap();
+        let target = root.path().join("target");
+        fs::create_dir(&target).unwrap();
+        let link = root.path().join("link");
+        symlink(&target, &link).unwrap();
+
+        assert!(private_dump_directory(&link.join("dumps")).is_err());
+        assert!(!target.join("dumps").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opened_dump_directory_is_stable_across_path_replacement() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let original = root.path().join("original");
+        fs::rename(&dump_path, &original).unwrap();
+        fs::create_dir(&dump_path).unwrap();
+
+        write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"secret")).unwrap();
+
+        assert_eq!(fs::read(original.join("mirror.txt")).unwrap(), b"secret");
+        assert!(!dump_path.join("mirror.txt").exists());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3679,6 +3679,8 @@ impl Drop for RemoteSession {
 
 #[cfg(unix)]
 fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
     use std::os::unix::fs::{MetadataExt, OpenOptionsExt, PermissionsExt};
 
     let existed = match fs::symlink_metadata(path) {
@@ -3692,7 +3694,24 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
         Err(error) if error.kind() == io::ErrorKind::NotFound => false,
         Err(error) => return Err(error),
     };
-    fs::create_dir_all(path)?;
+    if !existed {
+        if let Some(parent) = path
+            .parent()
+            .filter(|parent| !parent.as_os_str().is_empty())
+        {
+            fs::create_dir_all(parent)?;
+        }
+        let path = CString::new(path.as_os_str().as_bytes()).map_err(|_| {
+            io::Error::new(io::ErrorKind::InvalidInput, "invalid dump directory path")
+        })?;
+        let status = unsafe { libc::mkdir(path.as_ptr(), 0o700) };
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.kind() != io::ErrorKind::AlreadyExists {
+                return Err(error);
+            }
+        }
+    }
     let directory = fs::OpenOptions::new()
         .read(true)
         .custom_flags(libc::O_DIRECTORY | libc::O_NOFOLLOW | libc::O_CLOEXEC)
@@ -3704,15 +3723,11 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private and user-owned: {}", path.display()),
         ));
     }
-    if existed {
-        if metadata.mode() & 0o077 != 0 {
-            return Err(io::Error::new(
-                io::ErrorKind::PermissionDenied,
-                format!("dump directory is not private: {}", path.display()),
-            ));
-        }
-    } else {
-        directory.set_permissions(fs::Permissions::from_mode(0o700))?;
+    if metadata.mode() & 0o077 != 0 {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            format!("dump directory is not private: {}", path.display()),
+        ));
     }
     Ok(directory)
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -19,7 +19,7 @@ use cmux_tui_core::{
     MuxEventReceiver, NotificationEvent, NotificationLevel, PairingChallenge, PointerSemanticProbe,
     PointerSnapshotProbe, REMOTE_SESSION_MESSAGE_MAX_BYTES, Rgb, SurfaceId, SurfaceKind,
     TerminalPointerSnapshot,
-    platform::transport,
+    platform::{restrict_directory, transport},
     server::{
         CLEAR_HISTORY_CAPABILITY, CLEAR_HISTORY_KEY_CAPABILITY, CREATION_RECEIPTS_CAPABILITY,
         CREATION_SELECTOR_FALLBACKS_CAPABILITY, GUARDED_BROWSER_POINTER_CAPABILITY,
@@ -3644,6 +3644,10 @@ impl Drop for RemoteSession {
             return;
         };
         let _ = fs::create_dir_all(dir);
+        // Frame mirrors contain terminal output and may include secrets. Keep
+        // the opt-in dump directory and files private even when the process
+        // runs with a permissive umask.
+        let _ = restrict_directory(dir);
         let logs = self.frame_logs.lock().unwrap();
         let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
         for entry in &logs.entries {
@@ -3651,9 +3655,9 @@ impl Drop for RemoteSession {
         }
         for surface in self.surfaces.lock().unwrap().values() {
             let path = dir.join(format!("mirror-{}.txt", surface.id));
-            let _ = fs::write(path, dump_mirror(surface));
+            let _ = write_private_dump(&path, &dump_mirror(surface));
             let frames = dir.join(format!("frames-{}.log", surface.id));
-            if let Ok(file) = fs::File::create(frames) {
+            if let Ok(file) = private_dump_file(&frames) {
                 let mut writer = io::BufWriter::new(file);
                 for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
                     let _ = writeln!(writer, "{line}");
@@ -3661,6 +3665,23 @@ impl Drop for RemoteSession {
             }
         }
     }
+}
+
+fn private_dump_file(path: &Path) -> io::Result<fs::File> {
+    let mut options = fs::OpenOptions::new();
+    options.write(true).create(true).truncate(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        options.mode(0o600).custom_flags(libc::O_NOFOLLOW);
+    }
+    options.open(path)
+}
+
+fn write_private_dump(path: &Path, contents: &str) -> io::Result<()> {
+    let mut file = private_dump_file(path)?;
+    file.write_all(contents.as_bytes())?;
+    Ok(())
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4731,6 +4731,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_rejects_writable_ancestor_without_sticky_bit() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        fs::set_permissions(root.path(), fs::Permissions::from_mode(0o777)).unwrap();
+        let path = root.path().join("dumps");
+
+        let error = private_dump_directory(&path).unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+        assert!(!path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
         let root = tempfile::tempdir().unwrap();
         let directory = private_dump_directory(root.path()).unwrap();
@@ -4765,6 +4780,44 @@ mod tests {
 
         assert_eq!(fs::read(&final_path).unwrap(), b"replacement");
         assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_file_rejects_existing_hard_link_without_truncation() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        let linked_path = root.path().join("mirror-backup.txt");
+        fs::write(&final_path, b"previous").unwrap();
+        fs::hard_link(&final_path, &linked_path).unwrap();
+
+        let error = private_dump_file(&directory, "mirror.txt").unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::AlreadyExists);
+        assert_eq!(fs::read(&final_path).unwrap(), b"previous");
+        assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_rename_failure_preserves_previous_directory_and_cleans_temp() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        fs::create_dir(&final_path).unwrap();
+
+        let error = write_private_dump(&directory, "mirror.txt", |file| {
+            file.write_all(b"replacement")
+        })
+        .unwrap_err();
+
+        assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
+        assert!(final_path.is_dir());
+        assert!(fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| entry.file_name() == "mirror.txt"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4115,6 +4115,23 @@ fn delete_dump_file(directory: &fs::File, name: &[u8]) -> io::Result<()> {
     Ok(())
 }
 
+// These values come from Darwin's sys/acl.h. The acl_tag_t values (1 and 2)
+// are separate from the ACL type value (0x100) and the entry selectors (0/-1).
+#[cfg(target_os = "macos")]
+const MACOS_ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+
+#[cfg(target_os = "macos")]
+const MACOS_ACL_FIRST_ENTRY: libc::c_int = 0;
+
+#[cfg(target_os = "macos")]
+const MACOS_ACL_NEXT_ENTRY: libc::c_int = -1;
+
+#[cfg(all(target_os = "macos", test))]
+const MACOS_ACL_EXTENDED_ALLOW: libc::c_int = 1;
+
+#[cfg(target_os = "macos")]
+const MACOS_ACL_EXTENDED_DENY: libc::c_int = 2;
+
 #[cfg(target_os = "macos")]
 fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
@@ -4137,10 +4154,7 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
         }
     }
 
-    const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
-    const ACL_FIRST_ENTRY: libc::c_int = 0;
-    const ACL_NEXT_ENTRY: libc::c_int = -1;
-    let acl = unsafe { acl_get_fd_np(directory.as_raw_fd(), ACL_TYPE_EXTENDED) };
+    let acl = unsafe { acl_get_fd_np(directory.as_raw_fd(), MACOS_ACL_TYPE_EXTENDED) };
     if acl.is_null() {
         let error = io::Error::last_os_error();
         if matches!(
@@ -4157,7 +4171,7 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     }
     let acl = Acl(acl);
     let mut entry = std::ptr::null_mut();
-    let mut entry_id = ACL_FIRST_ENTRY;
+    let mut entry_id = MACOS_ACL_FIRST_ENTRY;
     loop {
         let status = unsafe { acl_get_entry(acl.0, entry_id, &mut entry) };
         if status != 0 {
@@ -4177,14 +4191,13 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
                 "dump directory ACL grants access; remove allow entries or choose another directory",
             ));
         }
-        entry_id = ACL_NEXT_ENTRY;
+        entry_id = MACOS_ACL_NEXT_ENTRY;
     }
 }
 
 #[cfg(target_os = "macos")]
 fn macos_dump_acl_tag_is_safe(tag: libc::c_int) -> bool {
-    const ACL_EXTENDED_DENY: libc::c_int = 2;
-    tag == ACL_EXTENDED_DENY
+    tag == MACOS_ACL_EXTENDED_DENY
 }
 
 #[cfg(target_os = "linux")]
@@ -5321,8 +5334,8 @@ mod tests {
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_dump_acl_accepts_deny_and_rejects_allow_entries() {
-        assert!(macos_dump_acl_tag_is_safe(2));
-        assert!(!macos_dump_acl_tag_is_safe(1));
+        assert!(macos_dump_acl_tag_is_safe(MACOS_ACL_EXTENDED_DENY));
+        assert!(!macos_dump_acl_tag_is_safe(MACOS_ACL_EXTENDED_ALLOW));
         assert!(!macos_dump_acl_tag_is_safe(99));
     }
 
@@ -5352,7 +5365,6 @@ mod tests {
             }
         }
 
-        const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
         let root = tempfile::tempdir().unwrap();
         let directory = fs::File::open(root.path()).unwrap();
         let mut acl = Acl(unsafe { acl_init(tags.len() as libc::c_int) });
@@ -5362,21 +5374,25 @@ mod tests {
             assert_eq!(unsafe { acl_create_entry(&mut acl.0, &mut entry) }, 0);
             assert_eq!(unsafe { acl_set_tag_type(entry, tag) }, 0);
         }
-        assert_eq!(unsafe { acl_set_fd_np(directory.as_raw_fd(), acl.0, ACL_TYPE_EXTENDED) }, 0);
+        assert_eq!(
+            unsafe { acl_set_fd_np(directory.as_raw_fd(), acl.0, MACOS_ACL_TYPE_EXTENDED) },
+            0
+        );
         (root, directory)
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_dump_acl_accepts_a_deny_only_acl() {
-        let (_root, directory) = macos_dump_directory_with_acl(&[2]);
+        let (_root, directory) = macos_dump_directory_with_acl(&[MACOS_ACL_EXTENDED_DENY]);
         assert!(reject_extended_acl(&directory).is_ok());
     }
 
     #[cfg(target_os = "macos")]
     #[test]
     fn macos_dump_acl_rejects_an_allow_after_a_deny() {
-        let (_root, directory) = macos_dump_directory_with_acl(&[2, 1]);
+        let (_root, directory) =
+            macos_dump_directory_with_acl(&[MACOS_ACL_EXTENDED_DENY, MACOS_ACL_EXTENDED_ALLOW]);
         let error = reject_extended_acl(&directory).unwrap_err();
         assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
     }
@@ -5387,7 +5403,8 @@ mod tests {
         use std::time::{Duration, Instant};
 
         if std::env::var_os("CMUX_MACOS_ACL_CHILD").is_some() {
-            let (_root, directory) = macos_dump_directory_with_acl(&[2, 2]);
+            let (_root, directory) =
+                macos_dump_directory_with_acl(&[MACOS_ACL_EXTENDED_DENY, MACOS_ACL_EXTENDED_DENY]);
             assert!(reject_extended_acl(&directory).is_ok());
             return;
         }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3678,6 +3678,7 @@ impl Drop for RemoteSession {
 }
 
 #[cfg(unix)]
+#[derive(Debug)]
 struct PrivateDumpDirectory {
     output: fs::File,
     temporary: fs::File,

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -52,6 +52,8 @@ const INTERACTIVE_WRITE_QUEUE_BYTES: usize = 8 * 1024 * 1024;
 pub(crate) const REMOTE_CONTROL_MESSAGE_MAX_BYTES: usize = REMOTE_SESSION_MESSAGE_MAX_BYTES;
 const REMOTE_FRAME_LOG_MAX_ENTRIES: usize = 16 * 1024;
 const REMOTE_FRAME_LOG_MAX_BYTES: usize = 2 * 1024 * 1024;
+const REMOTE_FRAME_DUMP_MAX_FILES: usize = 32;
+const REMOTE_FRAME_DUMP_MAX_BYTES: u64 = 8 * 1024 * 1024;
 const REMOTE_TERMINAL_DIMENSION_MAX: u64 = 10_000;
 const REMOTE_TERMINAL_CELL_MAX: u64 = 1024 * 1024;
 const INTERACTIVE_LATENCY_BUCKET_UPPER_US: [u64; 18] = [
@@ -3774,6 +3776,7 @@ fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
     validate_dump_directory(&directory, true)?;
     let temporary = open_private_child_directory(&directory, ".cmux-dump-tmp")?;
     prune_stale_dump_temps(&temporary)?;
+    prune_dump_files(&directory)?;
     Ok(PrivateDumpDirectory { output: directory, temporary })
 }
 
@@ -3954,6 +3957,128 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
                 return Err(error);
             }
         }
+    }
+    Ok(())
+}
+
+#[cfg(unix)]
+fn is_private_dump_name(name: &[u8]) -> bool {
+    [
+        (&b"mirror-"[..], &b".txt"[..]),
+        (&b"frames-"[..], &b".log"[..]),
+    ]
+    .into_iter()
+    .any(|(prefix, suffix)| {
+        name.strip_prefix(prefix)
+            .and_then(|name| name.strip_suffix(suffix))
+            .is_some_and(|id| !id.is_empty() && id.iter().all(|byte| byte.is_ascii_digit()))
+    })
+}
+
+#[cfg(unix)]
+fn prune_dump_files(directory: &fs::File) -> io::Result<()> {
+    prune_dump_files_with_limits(
+        directory,
+        REMOTE_FRAME_DUMP_MAX_FILES,
+        REMOTE_FRAME_DUMP_MAX_BYTES,
+    )
+}
+
+#[cfg(unix)]
+fn prune_dump_files_with_limits(
+    directory: &fs::File,
+    maximum_files: usize,
+    maximum_bytes: u64,
+) -> io::Result<()> {
+    use std::os::fd::{AsRawFd, FromRawFd};
+
+    struct DumpFile {
+        name: Vec<u8>,
+        modified: (u64, u32),
+        bytes: u64,
+    }
+
+    let duplicate = unsafe { libc::dup(directory.as_raw_fd()) };
+    if duplicate < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    let stream = unsafe { libc::fdopendir(duplicate) };
+    if stream.is_null() {
+        unsafe { libc::close(duplicate) };
+        return Err(io::Error::last_os_error());
+    }
+    let stream = DirectoryStream(stream);
+    let mut dumps = Vec::new();
+    loop {
+        let entry = unsafe { libc::readdir(stream.0) };
+        if entry.is_null() {
+            break;
+        }
+        let name = unsafe { std::ffi::CStr::from_ptr((*entry).d_name.as_ptr()) };
+        let name_bytes = name.to_bytes();
+        if !is_private_dump_name(name_bytes) {
+            continue;
+        }
+        let mut metadata = std::mem::MaybeUninit::<libc::stat>::uninit();
+        if unsafe {
+            libc::fstatat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                metadata.as_mut_ptr(),
+                libc::AT_SYMLINK_NOFOLLOW,
+            )
+        } != 0
+        {
+            continue;
+        }
+        let metadata = unsafe { metadata.assume_init() };
+        if metadata.st_mode & libc::S_IFMT != libc::S_IFREG
+            || metadata.st_uid != unsafe { libc::geteuid() }
+            || metadata.st_nlink != 1
+        {
+            continue;
+        }
+        let descriptor = unsafe {
+            libc::openat(
+                directory.as_raw_fd(),
+                name.as_ptr(),
+                libc::O_WRONLY | libc::O_NOFOLLOW | libc::O_NONBLOCK | libc::O_CLOEXEC,
+            )
+        };
+        let modified = if descriptor >= 0 {
+            let file = unsafe { fs::File::from_raw_fd(descriptor) };
+            unsafe { libc::fchmod(file.as_raw_fd(), 0o600) };
+            file.metadata()
+                .ok()
+                .and_then(|metadata| metadata.modified().ok())
+                .and_then(|modified| modified.duration_since(std::time::UNIX_EPOCH).ok())
+                .map(|modified| (modified.as_secs(), modified.subsec_nanos()))
+                .unwrap_or((0, 0))
+        } else {
+            (0, 0)
+        };
+        dumps.push(DumpFile {
+            name: name_bytes.to_vec(),
+            modified,
+            bytes: metadata.st_size.max(0) as u64,
+        });
+    }
+    dumps.sort_by(|left, right| {
+        left.modified.cmp(&right.modified).then_with(|| left.name.cmp(&right.name))
+    });
+    let mut total_bytes = dumps.iter().map(|dump| dump.bytes).sum::<u64>();
+    while dumps.len() > maximum_files || total_bytes > maximum_bytes {
+        let dump = dumps.remove(0);
+        let name = std::ffi::CString::new(dump.name)
+            .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
+        let status = unsafe { libc::unlinkat(directory.as_raw_fd(), name.as_ptr(), 0) };
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::ENOENT) {
+                return Err(error);
+            }
+        }
+        total_bytes = total_bytes.saturating_sub(dump.bytes);
     }
     Ok(())
 }
@@ -5050,6 +5175,50 @@ mod tests {
         let _directory = private_dump_directory(&dump_path).unwrap();
 
         assert!(!stale_path.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_pruning_enforces_file_and_byte_caps_oldest_first() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::PermissionsExt;
+
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let files = [
+            ("mirror-1.txt", b"old-".as_slice(), 1_i64),
+            ("frames-1.log", b"middle".as_slice(), 2_i64),
+            ("mirror-2.txt", b"new-".as_slice(), 3_i64),
+        ];
+        for (name, contents, modified) in files {
+            let path = dump_path.join(name);
+            fs::write(&path, contents).unwrap();
+            fs::set_permissions(&path, fs::Permissions::from_mode(0o600)).unwrap();
+            let path = std::ffi::CString::new(path.as_os_str().as_bytes()).unwrap();
+            let times = [
+                libc::timespec { tv_sec: modified, tv_nsec: 0 },
+                libc::timespec { tv_sec: modified, tv_nsec: 0 },
+            ];
+            assert_eq!(unsafe { libc::utimensat(libc::AT_FDCWD, path.as_ptr(), times.as_ptr(), 0) }, 0);
+        }
+
+        prune_dump_files_with_limits(&directory.output, 2, 10).unwrap();
+
+        assert!(!dump_path.join("mirror-1.txt").exists());
+        assert!(dump_path.join("frames-1.log").exists());
+        assert!(dump_path.join("mirror-2.txt").exists());
+        let retained = fs::read_dir(&dump_path)
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| is_private_dump_name(entry.file_name().as_os_str().as_bytes()))
+            .collect::<Vec<_>>();
+        assert_eq!(retained.len(), 2);
+        let bytes = retained
+            .iter()
+            .map(|entry| entry.metadata().unwrap().len())
+            .sum::<u64>();
+        assert_eq!(bytes, 10);
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4894,6 +4894,21 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_directory_preserves_unowned_matching_files() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let unrelated_path = dump_path.join(".mirror-notes.tmp-99999999-backup");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        drop(directory);
+        fs::write(&unrelated_path, b"user data").unwrap();
+
+        let _directory = private_dump_directory(&dump_path).unwrap();
+
+        assert_eq!(fs::read(&unrelated_path).unwrap(), b"user data");
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_directory_rejects_symlink_components() {
         use std::os::unix::fs::symlink;
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5349,9 +5349,13 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
-        assert!(fs::read_dir(dump_path.join(".cmux-dump-files")).unwrap().filter_map(Result::ok).all(|entry| {
-            entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
-        }));
+        assert!(
+            fs::read_dir(dump_path.join(".cmux-dump-files")).unwrap().filter_map(Result::ok).all(
+                |entry| {
+                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+                }
+            )
+        );
     }
 
     #[cfg(unix)]
@@ -5405,9 +5409,13 @@ mod tests {
 
         assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
         assert!(final_path.is_dir());
-        assert!(fs::read_dir(dump_path.join(".cmux-dump-files")).unwrap().filter_map(Result::ok).all(|entry| {
-            entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
-        }));
+        assert!(
+            fs::read_dir(dump_path.join(".cmux-dump-files")).unwrap().filter_map(Result::ok).all(
+                |entry| {
+                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+                }
+            )
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4138,6 +4138,8 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     }
 
     const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
+    const ACL_FIRST_ENTRY: libc::c_int = 0;
+    const ACL_NEXT_ENTRY: libc::c_int = -1;
     let acl = unsafe { acl_get_fd_np(directory.as_raw_fd(), ACL_TYPE_EXTENDED) };
     if acl.is_null() {
         let error = io::Error::last_os_error();
@@ -4155,7 +4157,7 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     }
     let acl = Acl(acl);
     let mut entry = std::ptr::null_mut();
-    let mut entry_id = 0;
+    let mut entry_id = ACL_FIRST_ENTRY;
     loop {
         let status = unsafe { acl_get_entry(acl.0, entry_id, &mut entry) };
         if status != 0 {
@@ -4175,13 +4177,13 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
                 "dump directory ACL grants access; remove allow entries or choose another directory",
             ));
         }
-        entry_id = 1;
+        entry_id = ACL_NEXT_ENTRY;
     }
 }
 
 #[cfg(target_os = "macos")]
 fn macos_dump_acl_tag_is_safe(tag: libc::c_int) -> bool {
-    const ACL_EXTENDED_DENY: libc::c_int = 0x0000_0200;
+    const ACL_EXTENDED_DENY: libc::c_int = 2;
     tag == ACL_EXTENDED_DENY
 }
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3729,7 +3729,54 @@ fn private_dump_directory(path: &Path) -> io::Result<fs::File> {
             format!("dump directory is not private: {}", path.display()),
         ));
     }
+    reject_extended_acl(&directory)?;
     Ok(directory)
+}
+
+#[cfg(target_os = "macos")]
+fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+    use std::ptr;
+
+    let descriptor = directory.as_raw_fd();
+    let size = unsafe { libc::flistxattr(descriptor, ptr::null_mut(), 0, 0) };
+    if size < 0 {
+        let error = io::Error::last_os_error();
+        if matches!(error.raw_os_error(), Some(libc::ENOTSUP) | Some(libc::ENOSYS)) {
+            return Ok(());
+        }
+        return Err(error);
+    }
+    if size == 0 {
+        return Ok(());
+    }
+    let mut names = vec![0_u8; size as usize];
+    let size = unsafe {
+        libc::flistxattr(
+            descriptor,
+            names.as_mut_ptr().cast(),
+            names.len(),
+            0,
+        )
+    };
+    if size < 0 {
+        return Err(io::Error::last_os_error());
+    }
+    if names[..size as usize]
+        .split(|byte| *byte == 0)
+        .any(|name| name == b"com.apple.acl.text")
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::PermissionDenied,
+            "dump directory has an extended ACL",
+        ));
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn reject_extended_acl(_directory: &fs::File) -> io::Result<()> {
+    Ok(())
 }
 
 #[cfg(unix)]
@@ -3783,24 +3830,53 @@ where
 
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    let mut file = match private_dump_file(directory, name) {
-        Ok(file) => file,
-        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
-            // Replace only through the validated directory descriptor. This
-            // avoids truncating a hard link and leaves no crash-prone temp
-            // files behind.
-            let status = unsafe {
-                libc::unlinkat(directory.as_raw_fd(), final_name.as_ptr(), 0)
-            };
-            if status != 0 {
-                return Err(error);
+    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(1);
+    let mut temp_name = None;
+    let mut file = None;
+    for _ in 0..16 {
+        let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        let candidate = format!(".{name}.tmp-{}-{id}", unsafe { libc::getpid() });
+        match private_dump_file(directory, &candidate) {
+            Ok(candidate_file) => {
+                temp_name = Some(CString::new(candidate).expect("generated temp name is valid"));
+                file = Some(candidate_file);
+                break;
             }
-            private_dump_file(directory, name)?
+            Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
+            Err(error) => return Err(error),
         }
-        Err(error) => return Err(error),
+    }
+    let temp_name = temp_name.ok_or_else(|| {
+        io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "could not allocate a private dump temporary file",
+        )
+    })?;
+    let mut file = file.expect("temporary file is present when its name is present");
+    let result = write_contents(&mut file).and_then(|()| file.sync_all());
+    drop(file);
+    if let Err(error) = result {
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return Err(error);
+    }
+    let status = unsafe {
+        libc::renameat(
+            directory.as_raw_fd(),
+            temp_name.as_ptr(),
+            directory.as_raw_fd(),
+            final_name.as_ptr(),
+        )
     };
-    write_contents(&mut file)?;
-    file.sync_all()
+    if status != 0 {
+        let error = io::Error::last_os_error();
+        unsafe {
+            libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
+        }
+        return Err(error);
+    }
+    Ok(())
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4111,10 +4111,7 @@ fn private_dump_modified_time(metadata: &libc::stat) -> (u64, u32) {
     #[cfg(not(any(target_os = "aix", target_os = "hurd")))]
     let nanoseconds = metadata.st_mtime_nsec;
 
-    (
-        u64::try_from(seconds).unwrap_or(0),
-        u32::try_from(nanoseconds).unwrap_or(0),
-    )
+    (u64::try_from(seconds).unwrap_or(0), u32::try_from(nanoseconds).unwrap_or(0))
 }
 
 #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3669,12 +3669,14 @@ impl Drop for RemoteSession {
 
 fn private_dump_file(path: &Path) -> io::Result<fs::File> {
     let mut options = fs::OpenOptions::new();
-    options.write(true).create(true).truncate(true);
+    options.write(true).create(true);
     #[cfg(unix)]
     {
         use std::os::unix::fs::OpenOptionsExt;
         options.mode(0o600).custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK);
     }
+    #[cfg(not(unix))]
+    options.truncate(true);
     let file = options.open(path)?;
     #[cfg(unix)]
     {
@@ -3691,6 +3693,9 @@ fn private_dump_file(path: &Path) -> io::Result<fs::File> {
                 format!("dump target is not a private regular file: {}", path.display()),
             ));
         }
+        // Truncate only after validating the opened descriptor, so a hard
+        // link cannot cause data loss in another file.
+        file.set_len(0)?;
         // `mode` only applies when the file is new. Set permissions through
         // the opened descriptor so existing files are also private without a
         // path-based symlink race.

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3901,10 +3901,42 @@ impl Drop for DirectoryStream {
 }
 
 #[cfg(unix)]
+struct DumpDirectoryLock<'a> {
+    directory: &'a fs::File,
+}
+
+#[cfg(unix)]
+impl Drop for DumpDirectoryLock<'_> {
+    fn drop(&mut self) {
+        use std::os::fd::AsRawFd;
+
+        unsafe {
+            libc::flock(self.directory.as_raw_fd(), libc::LOCK_UN);
+        }
+    }
+}
+
+#[cfg(unix)]
+fn lock_dump_directory(directory: &fs::File) -> io::Result<DumpDirectoryLock<'_>> {
+    use std::os::fd::AsRawFd;
+
+    loop {
+        if unsafe { libc::flock(directory.as_raw_fd(), libc::LOCK_EX) } == 0 {
+            return Ok(DumpDirectoryLock { directory });
+        }
+        let error = io::Error::last_os_error();
+        if error.kind() != io::ErrorKind::Interrupted {
+            return Err(error);
+        }
+    }
+}
+
+#[cfg(unix)]
 fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, FromRawFd};
 
+    let _directory_lock = lock_dump_directory(directory)?;
     let uid = unsafe { libc::geteuid() };
     let duplicate = unsafe { libc::dup(directory.as_raw_fd()) };
     if duplicate < 0 {
@@ -4009,6 +4041,7 @@ fn prune_dump_files_with_limits(
 ) -> io::Result<()> {
     use std::os::fd::{AsRawFd, FromRawFd};
 
+    let _directory_lock = lock_dump_directory(directory)?;
     struct DumpFile {
         name: Vec<u8>,
         modified: (u64, u32),
@@ -4247,6 +4280,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
     use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::fs::{MetadataExt, PermissionsExt};
 
+    let _directory_lock = lock_dump_directory(directory)?;
     let name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
     let descriptor = unsafe {
@@ -4330,6 +4364,7 @@ where
         }
         return Err(error);
     }
+    let _output_lock = lock_dump_directory(&directory.output)?;
     let status = unsafe {
         libc::renameat(
             directory.temporary.as_raw_fd(),

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4985,7 +4985,8 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn private_dump_directory_rejects_symlink_components() {
+    fn private_dump_directory_normalizes_symlink_components() {
+        use std::os::unix::fs::PermissionsExt;
         use std::os::unix::fs::symlink;
 
         let root = tempfile::tempdir().unwrap();
@@ -4994,8 +4995,18 @@ mod tests {
         let link = root.path().join("link");
         symlink(&target, &link).unwrap();
 
-        assert!(private_dump_directory(&link.join("dumps")).is_err());
-        assert!(!target.join("dumps").exists());
+        let directory = private_dump_directory(&link.join("dumps")).unwrap();
+
+        assert_eq!(directory.output.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+        assert!(target.join("dumps").is_dir());
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_dump_acl_accepts_deny_and_rejects_allow_entries() {
+        assert!(macos_dump_acl_tag_is_safe(2));
+        assert!(!macos_dump_acl_tag_is_safe(1));
+        assert!(!macos_dump_acl_tag_is_safe(99));
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3753,8 +3753,7 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
         ));
     }
     // Exclusive creation means an existing hard link or symlink is never
-    // opened, and no previously existing file is truncated. The temporary
-    // file is atomically renamed into the deterministic final name below.
+    // opened, and no previously existing file is truncated.
     file.set_permissions(fs::Permissions::from_mode(0o600))?;
     Ok(file)
 }
@@ -3767,47 +3766,26 @@ where
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
 
-    static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
     let final_name = CString::new(name)
         .map_err(|_| io::Error::new(io::ErrorKind::InvalidInput, "invalid dump file name"))?;
-    let (mut file, temp) = 'allocate: loop {
-        for _ in 0..16 {
-            let id = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
-            let temp = format!(".{name}.tmp-{}-{id}", std::process::id());
-            let file = match private_dump_file(directory, &temp) {
-                Ok(file) => break 'allocate (file, temp),
-                Err(error) if error.kind() == io::ErrorKind::AlreadyExists => continue,
-                Err(error) => return Err(error),
+    let mut file = match private_dump_file(directory, name) {
+        Ok(file) => file,
+        Err(error) if error.kind() == io::ErrorKind::AlreadyExists => {
+            // Replace only through the validated directory descriptor. This
+            // avoids truncating a hard link and leaves no crash-prone temp
+            // files behind.
+            let status = unsafe {
+                libc::unlinkat(directory.as_raw_fd(), final_name.as_ptr(), 0)
             };
+            if status != 0 {
+                return Err(error);
+            }
+            private_dump_file(directory, name)?
         }
-        return Err(io::Error::new(io::ErrorKind::AlreadyExists, "could not allocate a private dump file"));
+        Err(error) => return Err(error),
     };
-    let result = (|| {
-        write_contents(&mut file)?;
-        file.sync_all()?;
-        drop(file);
-        let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-        let status = unsafe {
-            libc::renameat(
-                directory.as_raw_fd(),
-                temp_name.as_ptr(),
-                directory.as_raw_fd(),
-                final_name.as_ptr(),
-            )
-        };
-        if status != 0 {
-            return Err(io::Error::last_os_error());
-        }
-        Ok(())
-    })();
-    if result.is_ok() {
-        return Ok(());
-    }
-    let temp_name = CString::new(temp.as_str()).expect("generated temp name has no NUL");
-    unsafe {
-        libc::unlinkat(directory.as_raw_fd(), temp_name.as_ptr(), 0);
-    }
-    result
+    write_contents(&mut file)?;
+    file.sync_all()
 }
 
 fn parse_kitty_image_aliases(

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4651,6 +4651,44 @@ mod tests {
         assert_eq!(directory.metadata().unwrap().permissions().mode() & 0o777, 0o700);
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_write_failure_preserves_previous_dump_and_cleans_temp() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        fs::write(&final_path, b"previous").unwrap();
+
+        let error = write_private_dump(&directory, "mirror.txt", |_file| {
+            Err(io::Error::other("simulated dump failure"))
+        })
+        .unwrap_err();
+
+        assert_eq!(error.kind(), io::ErrorKind::Other);
+        assert_eq!(fs::read(&final_path).unwrap(), b"previous");
+        assert!(fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .all(|entry| entry.file_name() == "mirror.txt"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn private_dump_replacement_does_not_modify_hard_linked_previous_dump() {
+        let root = tempfile::tempdir().unwrap();
+        let directory = private_dump_directory(root.path()).unwrap();
+        let final_path = root.path().join("mirror.txt");
+        let linked_path = root.path().join("mirror-backup.txt");
+        fs::write(&final_path, b"previous").unwrap();
+        fs::hard_link(&final_path, &linked_path).unwrap();
+
+        write_private_dump(&directory, "mirror.txt", |file| file.write_all(b"replacement"))
+            .unwrap();
+
+        assert_eq!(fs::read(&final_path).unwrap(), b"replacement");
+        assert_eq!(fs::read(&linked_path).unwrap(), b"previous");
+    }
+
     #[test]
     fn disabled_frame_logging_does_not_format_hot_path_messages() {
         struct FormattingProbe(Arc<AtomicBool>);

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5407,6 +5407,28 @@ mod tests {
     }
 
     #[cfg(target_os = "macos")]
+    fn macos_set_text_acl(path: &Path, rule: &str) {
+        let status =
+            std::process::Command::new("chmod").args(["+a", rule]).arg(path).status().unwrap();
+        assert!(status.success(), "chmod failed with {status}");
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn macos_dump_acl_matches_system_textual_rules() {
+        let deny_root = tempfile::tempdir().unwrap();
+        macos_set_text_acl(deny_root.path(), "everyone deny write");
+        let deny_directory = fs::File::open(deny_root.path()).unwrap();
+        assert!(reject_extended_acl(&deny_directory).is_ok());
+
+        let allow_root = tempfile::tempdir().unwrap();
+        macos_set_text_acl(allow_root.path(), "everyone allow read");
+        let allow_directory = fs::File::open(allow_root.path()).unwrap();
+        let error = reject_extended_acl(&allow_directory).unwrap_err();
+        assert_eq!(error.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[cfg(target_os = "macos")]
     fn macos_dump_directory_with_acl(tags: &[libc::c_int]) -> (tempfile::TempDir, fs::File) {
         use std::os::fd::AsRawFd;
 

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3805,7 +3805,7 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         {
             continue;
         }
-        let Some(name) = name.to_str() else { continue };
+        let Ok(name) = name.to_str() else { continue };
         let Some((_, suffix)) = name.rsplit_once(".tmp-") else { continue };
         let Some(pid) = suffix.split('-').next().and_then(|pid| pid.parse().ok()) else {
             continue;

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3763,7 +3763,10 @@ fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
                 return Err(error);
             }
             if unsafe { libc::mkdirat(directory.as_raw_fd(), component.as_ptr(), 0o700) } != 0 {
-                return Err(io::Error::last_os_error());
+                let error = io::Error::last_os_error();
+                if error.raw_os_error() != Some(libc::EEXIST) {
+                    return Err(error);
+                }
             }
             let next = unsafe {
                 libc::openat(
@@ -3814,6 +3817,10 @@ fn normalize_dump_path(path: &Path) -> io::Result<PathBuf> {
                 "dump path has no existing ancestor",
             ));
         }
+        if existing.as_os_str().is_empty() {
+            existing.push(".");
+            break;
+        }
     }
     let mut normalized = fs::canonicalize(existing)?;
     for component in missing.into_iter().rev() {
@@ -3841,7 +3848,10 @@ fn open_private_child_directory(parent: &fs::File, name: &str) -> io::Result<fs:
             return Err(error);
         }
         if unsafe { libc::mkdirat(parent.as_raw_fd(), name.as_ptr(), 0o700) } != 0 {
-            return Err(io::Error::last_os_error());
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() != Some(libc::EEXIST) {
+                return Err(error);
+            }
         }
         descriptor = unsafe {
             libc::openat(
@@ -5160,6 +5170,15 @@ mod tests {
 
         assert_eq!(directory.output.metadata().unwrap().permissions().mode() & 0o777, 0o700);
         assert_eq!(directory.temporary.metadata().unwrap().permissions().mode() & 0o777, 0o700);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn relative_dump_path_with_new_directory_has_a_current_directory_ancestor() {
+        let normalized = normalize_dump_path(Path::new("new-private-dumps")).unwrap();
+
+        assert!(normalized.ends_with("new-private-dumps"));
+        assert!(normalized.is_absolute());
     }
 
     #[cfg(unix)]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -4152,11 +4152,12 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     let mut entry_id = 0;
     loop {
         let status = unsafe { acl_get_entry(acl.0, entry_id, &mut entry) };
-        if status == 0 {
-            return Ok(());
-        }
-        if status < 0 {
-            return Err(io::Error::last_os_error());
+        if status != 0 {
+            let error = io::Error::last_os_error();
+            if error.raw_os_error() == Some(libc::EINVAL) {
+                return Ok(());
+            }
+            return Err(error);
         }
         let mut tag = 0;
         if unsafe { acl_get_tag_type(entry, &mut tag) } != 0 {
@@ -5400,7 +5401,7 @@ mod tests {
         let root = tempfile::tempdir().unwrap();
         let dump_path = root.path().join("dumps");
         let directory = private_dump_directory(&dump_path).unwrap();
-        let final_path = dump_path.join("mirror.txt");
+        let final_path = dump_path.join(".cmux-dump-files/mirror.txt");
         fs::create_dir(&final_path).unwrap();
 
         let error =

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3759,6 +3759,18 @@ fn validate_dump_directory(directory: &fs::File, private: bool) -> io::Result<()
 }
 
 #[cfg(unix)]
+struct DirectoryStream(*mut libc::DIR);
+
+#[cfg(unix)]
+impl Drop for DirectoryStream {
+    fn drop(&mut self) {
+        unsafe {
+            libc::closedir(self.0);
+        }
+    }
+}
+
+#[cfg(unix)]
 fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
     use std::ffi::CString;
     use std::os::fd::AsRawFd;
@@ -3773,8 +3785,9 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
         unsafe { libc::close(duplicate) };
         return Err(io::Error::last_os_error());
     }
+    let stream = DirectoryStream(stream);
     loop {
-        let entry = unsafe { libc::readdir(stream) };
+        let entry = unsafe { libc::readdir(stream.0) };
         if entry.is_null() {
             break;
         }
@@ -3823,9 +3836,6 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
                 return Err(error);
             }
         }
-    }
-    unsafe {
-        libc::closedir(stream);
     }
     Ok(())
 }

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -3648,12 +3648,30 @@ impl Drop for RemoteSession {
             // Secure descriptor-relative file creation is not available in
             // this implementation. Do not emit secret-bearing dumps through
             // path-based APIs on unsupported targets.
-            let _ = dir;
+            crate::client_log::error(
+                "mux-dump",
+                &format!(
+                    "CMUX_MUX_DEBUG_MIRROR_DUMP={} is unsupported on this platform; no dump was written",
+                    dir.display()
+                ),
+            );
             return;
         }
         #[cfg(unix)]
         {
-            let Ok(directory) = private_dump_directory(dir) else { return };
+            let directory = match private_dump_directory(dir) {
+                Ok(directory) => directory,
+                Err(error) => {
+                    crate::client_log::error(
+                        "mux-dump",
+                        &format!(
+                            "cannot use CMUX_MUX_DEBUG_MIRROR_DUMP={}: {error}; choose a directory owned by the current user with mode 0700",
+                            dir.display()
+                        ),
+                    );
+                    return;
+                }
+            };
             let logs = self.frame_logs.lock().unwrap();
             let mut entries_by_surface: HashMap<SurfaceId, Vec<&str>> = HashMap::new();
             for entry in &logs.entries {
@@ -3662,16 +3680,26 @@ impl Drop for RemoteSession {
             for surface in self.surfaces.lock().unwrap().values() {
                 let mirror_name = format!("mirror-{}.txt", surface.id);
                 let mirror = dump_mirror(surface);
-                let _ = write_private_dump(&directory, &mirror_name, |file| {
+                if let Err(error) = write_private_dump(&directory, &mirror_name, |file| {
                     file.write_all(mirror.as_bytes())
-                });
+                }) {
+                    crate::client_log::error(
+                        "mux-dump",
+                        &format!("cannot write private dump {mirror_name}: {error}"),
+                    );
+                }
                 let frames_name = format!("frames-{}.log", surface.id);
-                let _ = write_private_dump(&directory, &frames_name, |file| {
+                if let Err(error) = write_private_dump(&directory, &frames_name, |file| {
                     for line in entries_by_surface.get(&surface.id).into_iter().flatten() {
                         writeln!(file, "{line}")?;
                     }
                     Ok(())
-                });
+                }) {
+                    crate::client_log::error(
+                        "mux-dump",
+                        &format!("cannot write private dump {frames_name}: {error}"),
+                    );
+                }
             }
         }
     }
@@ -3689,6 +3717,7 @@ fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
     use std::ffi::CString;
     use std::os::fd::{AsRawFd, FromRawFd};
     use std::os::unix::ffi::OsStrExt;
+    let path = normalize_dump_path(path)?;
     let start = if path.is_absolute() { "/" } else { "." };
     let start = CString::new(start).unwrap();
     let fd =
@@ -3746,6 +3775,42 @@ fn private_dump_directory(path: &Path) -> io::Result<PrivateDumpDirectory> {
     let temporary = open_private_child_directory(&directory, ".cmux-dump-tmp")?;
     prune_stale_dump_temps(&temporary)?;
     Ok(PrivateDumpDirectory { output: directory, temporary })
+}
+
+#[cfg(unix)]
+fn normalize_dump_path(path: &Path) -> io::Result<PathBuf> {
+    use std::path::Component;
+
+    if path.components().any(|component| matches!(component, Component::ParentDir)) {
+        return Err(io::Error::new(io::ErrorKind::InvalidInput, "dump path must not contain '..'"));
+    }
+    let mut existing = path.to_path_buf();
+    let mut missing = Vec::new();
+    loop {
+        match fs::symlink_metadata(&existing) {
+            Ok(_) => break,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {}
+            Err(error) => return Err(error),
+        }
+        let Some(name) = existing.file_name().map(ToOwned::to_owned) else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "dump path has no existing ancestor",
+            ));
+        };
+        missing.push(name);
+        if !existing.pop() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "dump path has no existing ancestor",
+            ));
+        }
+    }
+    let mut normalized = fs::canonicalize(existing)?;
+    for component in missing.into_iter().rev() {
+        normalized.push(component);
+    }
+    Ok(normalized)
 }
 
 #[cfg(unix)]
@@ -3897,13 +3962,22 @@ fn prune_stale_dump_temps(directory: &fs::File) -> io::Result<()> {
 fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
     use std::os::fd::AsRawFd;
 
-    // `acl_get_fd_np` reads the effective macOS ACL from the opened
-    // descriptor, including inherited ACEs that are not exposed by the mode
-    // bits. Reject any extended ACL instead of attempting to interpret ACE
-    // ordering, principals, and inheritance flags here.
     unsafe extern "C" {
         fn acl_get_fd_np(fd: libc::c_int, acl_type: libc::c_int) -> *mut libc::c_void;
+        fn acl_get_entry(
+            acl: *mut libc::c_void,
+            entry_id: libc::c_int,
+            entry: *mut *mut libc::c_void,
+        ) -> libc::c_int;
+        fn acl_get_tag_type(entry: *mut libc::c_void, tag: *mut libc::c_int) -> libc::c_int;
         fn acl_free(object: *mut libc::c_void) -> libc::c_int;
+    }
+
+    struct Acl(*mut libc::c_void);
+    impl Drop for Acl {
+        fn drop(&mut self) {
+            unsafe { acl_free(self.0) };
+        }
     }
 
     const ACL_TYPE_EXTENDED: libc::c_int = 0x0000_0100;
@@ -3922,10 +3996,35 @@ fn reject_extended_acl(directory: &fs::File) -> io::Result<()> {
         }
         return Err(error);
     }
-    unsafe {
-        acl_free(acl);
+    let acl = Acl(acl);
+    let mut entry = std::ptr::null_mut();
+    let mut entry_id = 0;
+    loop {
+        let status = unsafe { acl_get_entry(acl.0, entry_id, &mut entry) };
+        if status == 0 {
+            return Ok(());
+        }
+        if status < 0 {
+            return Err(io::Error::last_os_error());
+        }
+        let mut tag = 0;
+        if unsafe { acl_get_tag_type(entry, &mut tag) } != 0 {
+            return Err(io::Error::last_os_error());
+        }
+        if !macos_dump_acl_tag_is_safe(tag) {
+            return Err(io::Error::new(
+                io::ErrorKind::PermissionDenied,
+                "dump directory ACL grants access; remove allow entries or choose another directory",
+            ));
+        }
+        entry_id = 1;
     }
-    Err(io::Error::new(io::ErrorKind::PermissionDenied, "dump directory has an extended ACL"))
+}
+
+#[cfg(target_os = "macos")]
+fn macos_dump_acl_tag_is_safe(tag: libc::c_int) -> bool {
+    const ACL_EXTENDED_DENY: libc::c_int = 2;
+    tag == ACL_EXTENDED_DENY
 }
 
 #[cfg(target_os = "linux")]
@@ -4012,7 +4111,11 @@ fn private_dump_file(directory: &fs::File, name: &str) -> io::Result<fs::File> {
 }
 
 #[cfg(unix)]
-fn write_private_dump<F>(directory: &PrivateDumpDirectory, name: &str, write_contents: F) -> io::Result<()>
+fn write_private_dump<F>(
+    directory: &PrivateDumpDirectory,
+    name: &str,
+    write_contents: F,
+) -> io::Result<()>
 where
     F: FnOnce(&mut fs::File) -> io::Result<()>,
 {
@@ -5041,14 +5144,9 @@ mod tests {
 
         assert_eq!(error.kind(), io::ErrorKind::Other);
         assert_eq!(fs::read(&final_path).unwrap(), b"previous");
-        assert!(
-            fs::read_dir(&dump_path)
-                .unwrap()
-                .filter_map(Result::ok)
-                .all(|entry| {
-                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
-                })
-        );
+        assert!(fs::read_dir(&dump_path).unwrap().filter_map(Result::ok).all(|entry| {
+            entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+        }));
     }
 
     #[cfg(unix)]
@@ -5102,14 +5200,9 @@ mod tests {
 
         assert!(matches!(error.raw_os_error(), Some(libc::EISDIR) | Some(libc::ENOTEMPTY)));
         assert!(final_path.is_dir());
-        assert!(
-            fs::read_dir(&dump_path)
-                .unwrap()
-                .filter_map(Result::ok)
-                .all(|entry| {
-                    entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
-                })
-        );
+        assert!(fs::read_dir(&dump_path).unwrap().filter_map(Result::ok).all(|entry| {
+            entry.file_name() == "mirror.txt" || entry.file_name() == ".cmux-dump-tmp"
+        }));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/session/remote.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/remote.rs
@@ -5399,6 +5399,26 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn private_dump_pruning_counts_hard_linked_entries_toward_file_cap() {
+        let root = tempfile::tempdir().unwrap();
+        let dump_path = root.path().join("dumps");
+        let directory = private_dump_directory(&dump_path).unwrap();
+        let linked_dump = dump_path.join(".cmux-dump-files/mirror-1.txt");
+        let external_link = root.path().join("linked-dump-backup.txt");
+        let other_dump = dump_path.join(".cmux-dump-files/frames-1.log");
+        fs::write(&linked_dump, b"linked").unwrap();
+        fs::hard_link(&linked_dump, &external_link).unwrap();
+        fs::write(&other_dump, b"other").unwrap();
+
+        prune_dump_files_with_limits(&directory.output, 1, 1024).unwrap();
+
+        assert!(!linked_dump.exists());
+        assert_eq!(fs::read(&external_link).unwrap(), b"linked");
+        assert!(other_dump.exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn private_dump_emission_budget_enforces_file_and_byte_caps() {
         let mut budget = PrivateDumpEmissionBudget::with_limits(2, 10);
 

--- a/cmux-tui/spec/native-frontend.md
+++ b/cmux-tui/spec/native-frontend.md
@@ -172,4 +172,5 @@ recognized dumps below its `.cmux-dump-files/` child and uses a separate
 `.cmux-dump-tmp/` child for in-progress files. Files left directly in the
 named directory are not managed by dump retention. This layout isolates the
 retention set from unrelated user files and is part of the diagnostic switch's
-migration contract.
+migration contract. A single session teardown also emits at most 32
+recognized dump files and 8 MiB before the final retention pass.

--- a/cmux-tui/spec/native-frontend.md
+++ b/cmux-tui/spec/native-frontend.md
@@ -167,4 +167,9 @@ API.
 TUI retains frame logs and writes terminal mirror contents on drop to the named
 directory. Those files can contain terminal secrets. Tooling must treat the
 directory as sensitive, opt-in storage and must not enable it for ordinary
-sessions.
+sessions. The named directory is the private storage root. The TUI writes
+recognized dumps below its `.cmux-dump-files/` child and uses a separate
+`.cmux-dump-tmp/` child for in-progress files. Files left directly in the
+named directory are not managed by dump retention. This layout isolates the
+retention set from unrelated user files and is part of the diagnostic switch's
+migration contract.


### PR DESCRIPTION
## Summary
Bound opt-in CMUX_MUX_DEBUG_MIRROR_DUMP storage to 32 recognized dump files and 8 MiB, deleting the oldest owner-only regular dump files first. Existing stale temporary cleanup remains descriptor-relative. Existing dump files are tightened to mode 0600 before they are considered for retention.

The dump remains explicit opt-in. Errors report only operation, file name, path, and OS error, never terminal contents.

## Testing
- `git diff --check`
- Blacksmith focused cmux-tui-core/remote test will run on hosted Linux.
- Exact hosted cmux-tui workflow will run the focused retention test.

## Review Trigger
Review descriptor-relative pruning, oldest-first ordering, byte/file caps, owner-only permissions, and content-free errors.

## Checklist
- [x] Current main base
- [x] No source-shape tests
- [x] Explicit debug opt-in preserved
- [ ] Canonical review
- [ ] Hosted focused workflow

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bounded debug frame dump retention so opt-in `CMUX_MUX_DEBUG_MIRROR_DUMP` dumps are private, atomically replaced, and capped at 32 files and 8 MiB. Previously dumps could land in permissive directories with unbounded growth; now they fail closed on unsupported platforms and reject unsafe targets.

**Bug Fixes**
- Validates each dump directory component for owner, mode, sticky bit, and extended ACLs; macOS deny-only entries are accepted, and ACL tag handling is verified against system textual rules.
- Serializes ownership validation and dump writes with non-blocking locks so a stalled peer can't stall teardown; concurrent writers use per-process temp names; stale cleanup removes only owner-only, single-link, unlocked files.
- Writes dumps with mode 0600, syncs before publish, and atomically renames from an isolated temp directory.
- Bounds dump emission during a single teardown to the same 32-file and 8 MiB caps, charging failed dump attempts to the budget.
- Prunes only owner-owned recognized dump files, oldest-first, to file and byte caps, once per session; hard-linked entries count toward the caps and are unlinked without modifying the shared inode.
- Reports errors with only the operation, file name, path, and OS error; dump contents never appear in logs.
- On non-Unix platforms, no dump is written and an error is logged.

**Migration**
- The dump directory must be owned by the current user or root with mode 0700, no group/other write, and no extended ACLs; existing dump files are tightened to 0600 before retention.
- Dumps now write into a `.cmux-dump-files/` subdirectory instead of directly into the configured path; old files left directly in that path are no longer managed by retention.

<sup>Written for commit a4f55f19a378dd6d8b089952c9e19e69f3ec7c22. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Improved diagnostic dump protection by validating storage locations and preventing unsafe access, including symlinks, hard links, and platform-specific permission issues.
  * Dumps are written privately and finalized safely to reduce incomplete or exposed files while preserving existing data.

* **Bug Fixes**
  * Added automatic cleanup of temporary files and retention limits of 32 files or 8 MiB for diagnostic dumps.
  * On non-Unix platforms, diagnostic dump writing is unsupported and clearly reported instead of producing files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->