### PR TITLE
ci(tui): add hosted Windows platform test lane

### DIFF
--- a/.github/workflows/cmux-tui.yml
+++ b/.github/workflows/cmux-tui.yml
@@ -529,6 +529,63 @@ jobs:
         working-directory: cmux-tui
         run: python3 scripts/smoke-attach.py
 
+  test-windows:
+    name: test (windows)
+    needs: validate-inputs
+    if: inputs.mode == 'full'
+    runs-on: windows-latest
+    timeout-minutes: 40
+    env:
+      CARGO_TARGET_X86_64_PC_WINDOWS_GNU_RUSTFLAGS: -C link-arg=-fuse-ld=lld
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit }}
+
+      - name: Require exact checkout
+        shell: bash
+        env:
+          EXACT_COMMIT: ${{ inputs.commit }}
+        run: test "$(git rev-parse HEAD)" = "$EXACT_COMMIT"
+
+      - name: Init ghostty submodule
+        run: git submodule update --init --depth 1 ghostty
+
+      - name: Resolve Ghostty Zig version
+        id: ghostty-zig-version
+        shell: bash
+        run: |
+          version="$(bash ./scripts/ghostty-zig-version.sh)"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install zig
+        uses: mlugg/setup-zig@8d6198c65fb0feaa111df26e6b467fea8345e46f # v2.0.5
+        with:
+          version: ${{ steps.ghostty-zig-version.outputs.version }}
+
+      - name: Set up pinned Rust
+        uses: ./.github/actions/setup-cmux-tui-rust
+
+      - name: Install Rust target
+        shell: bash
+        run: |
+          rustup target add x86_64-pc-windows-gnu
+          printf '%s\n' 'C:\msys64\mingw64\bin' >> "$GITHUB_PATH"
+
+      - name: Verify LLVM GNU linker
+        shell: bash
+        run: ld.lld --version
+
+      - name: Run Windows platform Cargo tests
+        working-directory: cmux-tui
+        shell: bash
+        run: |
+          unset CMUX_GHOSTTY_SRC
+          cargo test -p cmux-tui-core --lib --locked \
+            --target x86_64-pc-windows-gnu \
+            platform::tests:: -- --test-threads=1
+
   cdp-browser-smoke:
     name: CDP browser smoke (${{ matrix.os }})
     needs: validate-inputs
@@ -725,6 +782,7 @@ jobs:
       - web-frontend
       - valgrind-leak-check
       - test
+      - test-windows
       - cdp-browser-smoke
       - bindings-e2e
       - build-artifacts
@@ -737,6 +795,7 @@ jobs:
       WEB_RESULT: ${{ needs.web-frontend.result }}
       VALGRIND_RESULT: ${{ needs.valgrind-leak-check.result }}
       TEST_RESULT: ${{ needs.test.result }}
+      WINDOWS_TEST_RESULT: ${{ needs.test-windows.result }}
       CDP_BROWSER_RESULT: ${{ needs.cdp-browser-smoke.result }}
       BINDINGS_RESULT: ${{ needs.bindings-e2e.result }}
       ARTIFACT_RESULT: ${{ needs.build-artifacts.result }}
@@ -756,6 +815,9 @@ jobs:
           require_success "input validation" "$VALIDATE_RESULT"
           require_success "Rust MSRV check" "$MSRV_RESULT"
           require_success "Rust tests" "$TEST_RESULT"
+          if [[ "$MODE" == "full" ]]; then
+            require_success "Windows Rust tests" "$WINDOWS_TEST_RESULT"
+          fi
           require_success "dogfood artifact build" "$ARTIFACT_RESULT"
           if [[ "$MODE" == "full" ]]; then
             require_success "web frontend" "$WEB_RESULT"


### PR DESCRIPTION
Add a full-gate Windows GNU job for the existing cmux-tui-core platform tests. The package workflow already builds and smoke-tests Windows artifacts, but it does not run these unit tests.

This is the current-main successor to https://github.com/manaflow-ai/cmux/pull/11496. That PR remains open until this successor merges.

Verification:
- `actionlint .github/workflows/cmux-tui.yml`
- `git diff --check origin/main...HEAD`
- No local Cargo or Rust build
- Exact hosted Windows run and canonical review will follow on this PR head.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hosted Windows test lane for `cmux-tui-core` so full-gate runs now execute the platform unit tests on Windows, not just build and smoke-test artifacts.

**Details**
- The new `test-windows` job runs only in `full` mode and executes `platform::tests::` on the GNU target.
- The full-gate status check now requires the Windows test result in `full` mode.

<sup>Written for commit 6e42b3b736772d50a38c3ca1b8d369bc515de8e3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

