### PR TITLE
Recover the last command for restored terminals

### DIFF
--- a/CLI/CMUXCLI+CommandSuggestions.swift
+++ b/CLI/CMUXCLI+CommandSuggestions.swift
@@ -124,6 +124,7 @@ extension CMUXCLI {
         "list-panes",
         "list-status",
         "list-windows",
+        "last-command",
         "list-workspaces",
         "log",
         "login",

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4887,7 +4887,7 @@ struct CMUXCLI {
         if normalizedCommand == "window" {
             return false
         }
-        if normalizedCommand == "surface-resume" {
+        if normalizedCommand == "surface-resume" || normalizedCommand == "last-command" {
             return false
         }
         if normalizedCommand == "restore" {
@@ -7195,6 +7195,19 @@ struct CMUXCLI {
                 windowOverride: windowId
             )
 
+        case "last-command":
+            let action = commandArgs.first?.lowercased()
+            let resumeArgs = ["show", "get", "run", "execute"].contains(action ?? "")
+                ? commandArgs
+                : ["show"] + commandArgs
+            try runSurfaceResumeCommand(
+                commandArgs: resumeArgs,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowId
+            )
+
         case "close-surface":
             let csWsFlag = optionValue(commandArgs, name: "--workspace")
             let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowId)
@@ -9483,6 +9496,36 @@ struct CMUXCLI {
                 print("No resume binding")
             }
 
+        case "run", "execute":
+            try validateSurfaceResumeValueOptions(
+                rest,
+                optionNames: Self.surfaceResumeTargetValueOptions,
+                context: "surface resume \(subcommand)"
+            )
+            let params = try surfaceResumeTarget(rest, client: client, windowOverride: windowOverride).params
+            let payload = try client.sendV2(method: "surface.resume.get", params: params)
+            guard let binding = payload["resume_binding"] as? [String: Any],
+                  let command = binding["command"] as? String,
+                  !command.isEmpty,
+                  let workspaceID = payload["workspace_id"] as? String,
+                  let surfaceID = payload["surface_id"] as? String else {
+                throw CLIError(message: String(
+                    localized: "cli.surfaceResume.error.noCommand",
+                    defaultValue: "No recoverable command is available for this surface"
+                ))
+            }
+            let runPayload = try client.sendV2(method: "surface.send_text", params: [
+                "workspace_id": workspaceID,
+                "surface_id": surfaceID,
+                "text": command + "\n",
+            ])
+            printV2Payload(
+                runPayload,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                fallbackText: v2SendSummary(runPayload, idFormat: idFormat)
+            )
+
         case "clear":
             try validateSurfaceResumeValueOptions(
                 rest,
@@ -9518,6 +9561,14 @@ struct CMUXCLI {
         }
         if command == "surface-resume" {
             try validateSurfaceResumeCommandValueOptions(commandArgs)
+            return
+        }
+        if command == "last-command" {
+            let action = commandArgs.first?.lowercased()
+            let resumeArgs = ["show", "get", "run", "execute"].contains(action ?? "")
+                ? commandArgs
+                : ["show"] + commandArgs
+            try validateSurfaceResumeCommandValueOptions(resumeArgs)
         }
     }
 
@@ -9532,7 +9583,7 @@ struct CMUXCLI {
                 context: "surface resume set"
             )
             try validateSurfaceResumeSetCommandTokensBeforeSocket(rest)
-        case "show", "get":
+        case "show", "get", "run", "execute":
             try validateSurfaceResumeValueOptions(
                 rest,
                 optionNames: Self.surfaceResumeTargetValueOptions,
@@ -19814,6 +19865,10 @@ struct CMUXCLI {
               cmux surface-health --workspace workspace:2
             """
         case "surface", "surface-resume":
+            let runHelp = String(
+                localized: "cli.surfaceResume.help.run",
+                defaultValue: "cmux surface resume run [--json] [flags]    Execute the saved command in that surface"
+            )
             return """
             Usage: cmux surface ls [<machine>|local] [--refresh] [--json]
                    cmux surface open <resource> [--workspace <id|ref|index>] [--pane <id|ref>] [--left|--right|--up|--down|--tab] [--new] [--focus <true|false>]
@@ -19822,6 +19877,7 @@ struct CMUXCLI {
                    cmux surface resume set [flags] --shell <command>
                    cmux surface resume show [--json] [flags]
                    cmux surface resume get [--json] [flags]
+                   \(runHelp)
                    cmux surface resume clear [flags]
 
             ls / open / new-terminal: the surface catalog. Terminals, VNC screens and browsers
@@ -19852,6 +19908,16 @@ struct CMUXCLI {
               cmux surface resume set --kind opencode --checkpoint ses_123 -- opencode --session ses_123
               cmux surface resume show --json
             """
+        case "last-command":
+            return String(
+                localized: "cli.lastCommand.help",
+                defaultValue: """
+                Usage: cmux last-command [show|run] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--json]
+
+                Show the command recovered for a restored terminal, or explicitly run it in that same surface.
+                With no action, the command is only printed.
+                """
+            )
         case "debug-terminals":
             return """
             Usage: cmux debug-terminals

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
@@ -37,6 +37,10 @@ public struct CommandPaletteContextKeys: Hashable, Sendable {
     public static let workspaceHasAbove = CommandPaletteContextKeys(rawValue: "workspace.hasAbove")
     /// Whether a workspace exists below the selection.
     public static let workspaceHasBelow = CommandPaletteContextKeys(rawValue: "workspace.hasBelow")
+    /// Whether moving the workspace to the top of its pin tier changes order.
+    public static let workspaceCanMoveToTop = CommandPaletteContextKeys(rawValue: "workspace.canMoveToTop")
+    /// Whether moving the workspace to the bottom of its pin tier changes order.
+    public static let workspaceCanMoveToBottom = CommandPaletteContextKeys(rawValue: "workspace.canMoveToBottom")
     /// Whether mark-read is available for the workspace.
     public static let workspaceCanMarkRead = CommandPaletteContextKeys(rawValue: "workspace.canMarkRead")
     /// Whether mark-unread is available for the workspace.

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
@@ -8,6 +8,11 @@ public import Foundation
 /// order-change publication inverts through `WorkspaceOrderHosting`.
 @MainActor
 public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
+    private enum TierPlacement {
+        case top
+        case bottom
+    }
+
     private let model: WorkspacesModel<Tab>
     private let planner = WorkspaceReorderPlanner()
     private weak var host: (any WorkspaceOrderHosting)?
@@ -32,35 +37,164 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
     /// Moves the given workspaces to the top of their pin tiers, preserving
     /// their relative order (group members hoist behind their anchors).
     public func moveTabsToTop(_ tabIds: Set<UUID>) {
-        guard !tabIds.isEmpty else { return }
+        moveTabs(tabIds, to: .top)
+    }
+
+    /// Returns whether moving the given workspaces to the top of their pin
+    /// tiers would change the sidebar's top-level workspace order.
+    ///
+    /// - Parameter tabIds: The workspace identifiers to evaluate.
+    /// - Returns: `true` when a move-to-top action would change the order.
+    public func canMoveTabsToTop(_ tabIds: Set<UUID>) -> Bool {
+        canMoveTabs(tabIds, to: .top)
+    }
+
+    /// Moves the given workspaces to the bottom of their pin tiers, preserving
+    /// their relative order (group members follow their anchors).
+    public func moveTabsToBottom(_ tabIds: Set<UUID>) {
+        moveTabs(tabIds, to: .bottom)
+    }
+
+    /// Returns whether moving the given workspaces to the bottom of their pin
+    /// tiers would change the sidebar's top-level workspace order.
+    ///
+    /// - Parameter tabIds: The workspace identifiers to evaluate.
+    /// - Returns: `true` when a move-to-bottom action would change the order.
+    public func canMoveTabsToBottom(_ tabIds: Set<UUID>) -> Bool {
+        canMoveTabs(tabIds, to: .bottom)
+    }
+
+    /// Returns each workspace's tier-relative move availability in one pass.
+    ///
+    /// Group members share their group's top-level row availability, so a
+    /// sidebar can project boundary action state without evaluating each row
+    /// against the complete workspace model.
+    public func tierMoveAvailabilityByTabId() -> [UUID: WorkspaceTierMoveAvailability] {
+        guard !model.tabs.isEmpty else { return [:] }
+
+        if model.workspaceGroups.isEmpty {
+            return tierMoveAvailability(
+                ids: model.tabs.map(\.id),
+                pinnedIds: Set(model.tabs.filter(\.isPinned).map(\.id))
+            )
+        }
+
+        let topLevelIds = model.sidebarTopLevelWorkspaceIds()
+        let availabilityByTopLevelId = tierMoveAvailability(
+            ids: topLevelIds,
+            pinnedIds: model.sidebarTopLevelPinnedWorkspaceIds()
+        )
+        let groupsById = Dictionary(uniqueKeysWithValues: model.workspaceGroups.map { ($0.id, $0) })
+        return Dictionary(uniqueKeysWithValues: model.tabs.map { tab in
+            let topLevelId = tab.groupId.flatMap { groupsById[$0]?.anchorWorkspaceId } ?? tab.id
+            return (tab.id, availabilityByTopLevelId[topLevelId] ?? WorkspaceTierMoveAvailability(
+                canMoveToTop: false,
+                canMoveToBottom: false
+            ))
+        })
+    }
+
+    /// Determines whether a tier-relative move would change the top-level order.
+    private func canMoveTabs(_ tabIds: Set<UUID>, to placement: TierPlacement) -> Bool {
+        guard !tabIds.isEmpty else { return false }
         let selectedTabs = model.tabs.filter { tabIds.contains($0.id) }
-        guard !selectedTabs.isEmpty else { return }
+        guard !selectedTabs.isEmpty else { return false }
+
+        if !model.workspaceGroups.isEmpty {
+            let topLevelIds = model.sidebarTopLevelWorkspaceIds()
+            let selectedTopLevelIds = model.topLevelWorkspaceIds(for: selectedTabs)
+            let desiredTopLevelIds = tierOrderedIds(
+                topLevelIds,
+                selectedIds: Set(selectedTopLevelIds),
+                pinnedIds: model.sidebarTopLevelPinnedWorkspaceIds(),
+                placement: placement
+            )
+            return desiredTopLevelIds != topLevelIds
+        }
+
+        let workspaceIds = model.tabs.map(\.id)
+        let desiredWorkspaceIds = tierOrderedIds(
+            workspaceIds,
+            selectedIds: Set(selectedTabs.map(\.id)),
+            pinnedIds: Set(model.tabs.filter(\.isPinned).map(\.id)),
+            placement: placement
+        )
+        return desiredWorkspaceIds != workspaceIds
+    }
+
+    /// Applies a tier-relative move through the shared group and pin ordering path.
+    private func moveTabs(_ tabIds: Set<UUID>, to placement: TierPlacement) {
+        guard canMoveTabs(tabIds, to: placement) else { return }
+        let selectedTabs = model.tabs.filter { tabIds.contains($0.id) }
         let previousOrder = model.tabs.map(\.id)
 
         if !model.workspaceGroups.isEmpty {
             model.moveWorkspaceGroupMembersAfterAnchors(workspaceIds: selectedTabs.map(\.id))
-            let topLevelIds = model.sidebarTopLevelWorkspaceIdsIncludingEmptyGroups()
+            let topLevelIds = model.sidebarTopLevelWorkspaceIds()
             let selectedTopLevelIds = model.topLevelWorkspaceIds(for: selectedTabs)
-            let selectedTopLevelIdSet = Set(selectedTopLevelIds)
-            let pinnedTopLevelIds = model.sidebarTopLevelPinnedWorkspaceIdsIncludingEmptyGroups()
-            let desiredTopLevelIds =
-                selectedTopLevelIds.filter { pinnedTopLevelIds.contains($0) } +
-                topLevelIds.filter { pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) } +
-                selectedTopLevelIds.filter { !pinnedTopLevelIds.contains($0) } +
-                topLevelIds.filter { !pinnedTopLevelIds.contains($0) && !selectedTopLevelIdSet.contains($0) }
+            let desiredTopLevelIds = tierOrderedIds(
+                topLevelIds,
+                selectedIds: Set(selectedTopLevelIds),
+                pinnedIds: model.sidebarTopLevelPinnedWorkspaceIds(),
+                placement: placement
+            )
             model.normalizeWorkspaceGroupRunsPreservingOrder(desiredTopLevelIds)
-            model.syncWorkspaceGroupsOrderToAnchorOrder(preferredTopLevelIds: desiredTopLevelIds)
+            model.syncWorkspaceGroupsOrderToAnchorOrder()
         } else {
-            let remainingTabs = model.tabs.filter { !tabIds.contains($0.id) }
-            let selectedPinned = selectedTabs.filter { $0.isPinned }
-            let selectedUnpinned = selectedTabs.filter { !$0.isPinned }
-            let remainingPinned = remainingTabs.filter { $0.isPinned }
-            let remainingUnpinned = remainingTabs.filter { !$0.isPinned }
-            model.tabs = selectedPinned + remainingPinned + selectedUnpinned + remainingUnpinned
+            let tabsById = Dictionary(uniqueKeysWithValues: model.tabs.map { ($0.id, $0) })
+            let desiredWorkspaceIds = tierOrderedIds(
+                model.tabs.map(\.id),
+                selectedIds: Set(selectedTabs.map(\.id)),
+                pinnedIds: Set(model.tabs.filter(\.isPinned).map(\.id)),
+                placement: placement
+            )
+            model.tabs = desiredWorkspaceIds.compactMap { tabsById[$0] }
         }
         if model.tabs.map(\.id) != previousOrder {
             host?.workspaceOrderDidChange(movedWorkspaceIds: selectedTabs.map(\.id))
         }
+    }
+
+    /// Computes a tier-preserving order for selected workspace ids.
+    private func tierOrderedIds(
+        _ ids: [UUID],
+        selectedIds: Set<UUID>,
+        pinnedIds: Set<UUID>,
+        placement: TierPlacement
+    ) -> [UUID] {
+        let selectedPinned = ids.filter { selectedIds.contains($0) && pinnedIds.contains($0) }
+        let selectedUnpinned = ids.filter { selectedIds.contains($0) && !pinnedIds.contains($0) }
+        let remainingPinned = ids.filter { !selectedIds.contains($0) && pinnedIds.contains($0) }
+        let remainingUnpinned = ids.filter { !selectedIds.contains($0) && !pinnedIds.contains($0) }
+        switch placement {
+        case .top:
+            return selectedPinned + remainingPinned + selectedUnpinned + remainingUnpinned
+        case .bottom:
+            return remainingPinned + selectedPinned + remainingUnpinned + selectedUnpinned
+        }
+    }
+
+    /// Computes each id's top and bottom availability within its pin tier.
+    private func tierMoveAvailability(
+        ids: [UUID],
+        pinnedIds: Set<UUID>
+    ) -> [UUID: WorkspaceTierMoveAvailability] {
+        let pinnedIdsInOrder = ids.filter { pinnedIds.contains($0) }
+        let unpinnedIdsInOrder = ids.filter { !pinnedIds.contains($0) }
+        var availabilityById: [UUID: WorkspaceTierMoveAvailability] = [:]
+        availabilityById.reserveCapacity(ids.count)
+
+        for tierIds in [pinnedIdsInOrder, unpinnedIdsInOrder] where !tierIds.isEmpty {
+            let firstId = tierIds[0]
+            let lastId = tierIds[tierIds.count - 1]
+            for id in tierIds {
+                availabilityById[id] = WorkspaceTierMoveAvailability(
+                    canMoveToTop: id != firstId,
+                    canMoveToBottom: id != lastId
+                )
+            }
+        }
+        return availabilityById
     }
 
     /// Moves a workspace to the top of the unpinned tier for a notification

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceTierMoveAvailability.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceTierMoveAvailability.swift
@@ -1,0 +1,18 @@
+/// The tier-relative move actions available for one workspace.
+public struct WorkspaceTierMoveAvailability: Equatable, Sendable {
+    /// Whether the workspace can move to the top of its pin tier.
+    public let canMoveToTop: Bool
+
+    /// Whether the workspace can move to the bottom of its pin tier.
+    public let canMoveToBottom: Bool
+
+    /// Creates the availability for one workspace's tier-relative move actions.
+    ///
+    /// - Parameters:
+    ///   - canMoveToTop: Whether move-to-top would change the workspace order.
+    ///   - canMoveToBottom: Whether move-to-bottom would change the workspace order.
+    public init(canMoveToTop: Bool, canMoveToBottom: Bool) {
+        self.canMoveToTop = canMoveToTop
+        self.canMoveToBottom = canMoveToBottom
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceCoordinatorTests.swift
@@ -142,6 +142,86 @@ struct WorkspaceCoordinatorTests {
     }
 
     @Test
+    func moveTabsToBottomKeepsPinnedTierAboveUnpinned() {
+        let (model, host, _, reorder) = makeWorld()
+        let pinnedA = CoordinatorStubTab(isPinned: true)
+        let pinnedB = CoordinatorStubTab(isPinned: true)
+        let plain1 = CoordinatorStubTab()
+        let plain2 = CoordinatorStubTab()
+        model.tabs = [pinnedA, pinnedB, plain1, plain2]
+
+        reorder.moveTabsToBottom([pinnedA.id, plain1.id])
+
+        #expect(model.tabs.map(\.id) == [pinnedB.id, pinnedA.id, plain2.id, plain1.id])
+        #expect(host.orderChanges.last?.sorted(by: { $0.uuidString < $1.uuidString })
+            == [pinnedA.id, plain1.id].sorted(by: { $0.uuidString < $1.uuidString }))
+    }
+
+    @Test
+    func canMoveTabsToTierBoundariesIsFalseForTheFirstAndLastWorkspaceInEachPinTier() {
+        let (model, _, _, reorder) = makeWorld()
+        let pinnedA = CoordinatorStubTab(isPinned: true)
+        let pinnedB = CoordinatorStubTab(isPinned: true)
+        let plainA = CoordinatorStubTab()
+        let plainB = CoordinatorStubTab()
+        model.tabs = [pinnedA, pinnedB, plainA, plainB]
+
+        let availabilityByTabId = reorder.tierMoveAvailabilityByTabId()
+        #expect(availabilityByTabId[pinnedA.id] == .init(canMoveToTop: false, canMoveToBottom: true))
+        #expect(availabilityByTabId[pinnedB.id] == .init(canMoveToTop: true, canMoveToBottom: false))
+        #expect(availabilityByTabId[plainA.id] == .init(canMoveToTop: false, canMoveToBottom: true))
+        #expect(availabilityByTabId[plainB.id] == .init(canMoveToTop: true, canMoveToBottom: false))
+
+        #expect(!reorder.canMoveTabsToTop([pinnedA.id]))
+        #expect(!reorder.canMoveTabsToTop([plainA.id]))
+        #expect(reorder.canMoveTabsToTop([pinnedB.id]))
+        #expect(reorder.canMoveTabsToTop([plainB.id]))
+        #expect(reorder.canMoveTabsToBottom([pinnedA.id]))
+        #expect(reorder.canMoveTabsToBottom([plainA.id]))
+        #expect(!reorder.canMoveTabsToBottom([pinnedB.id]))
+        #expect(!reorder.canMoveTabsToBottom([plainB.id]))
+    }
+
+    @Test
+    func moveTabsToBottomMovesAGroupedSelectionWithItsAnchor() throws {
+        let (model, host, groups, reorder) = makeWorld()
+        let first = CoordinatorStubTab()
+        let groupedFirst = CoordinatorStubTab()
+        let groupedSecond = CoordinatorStubTab()
+        let last = CoordinatorStubTab()
+        model.tabs = [first, groupedFirst, groupedSecond, last]
+        let groupId = try #require(groups.createWorkspaceGroup(name: "G", childWorkspaceIds: [
+            groupedFirst.id,
+            groupedSecond.id,
+        ]))
+        let group = try #require(model.workspaceGroups.first(where: { $0.id == groupId }))
+
+        reorder.moveTabsToBottom([groupedSecond.id])
+
+        #expect(model.tabs.map(\.id) == [
+            first.id,
+            last.id,
+            group.anchorWorkspaceId,
+            groupedSecond.id,
+            groupedFirst.id,
+        ])
+        #expect(!reorder.canMoveTabsToBottom([groupedSecond.id]))
+        #expect(reorder.canMoveTabsToTop([groupedSecond.id]))
+        #expect(!reorder.canMoveTabsToBottom([groupedFirst.id]))
+        #expect(reorder.tierMoveAvailabilityByTabId()[groupedFirst.id]
+            == .init(canMoveToTop: true, canMoveToBottom: false))
+        #expect(reorder.tierMoveAvailabilityByTabId()[groupedSecond.id]
+            == .init(canMoveToTop: true, canMoveToBottom: false))
+
+        let orderAtBottom = model.tabs.map(\.id)
+        let notificationsAtBottom = host.orderChanges
+        reorder.moveTabsToBottom([groupedFirst.id])
+
+        #expect(model.tabs.map(\.id) == orderAtBottom)
+        #expect(host.orderChanges == notificationsAtBottom)
+    }
+
+    @Test
     func reorderWorkspaceClampsUnpinnedAbovePinnedBoundary() {
         let (model, host, _, reorder) = makeWorld()
         _ = host

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -1,6 +1,27 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "cli.lastCommand.help": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "Usage: cmux last-command [show|run] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--json]\n\nShow the command recovered for a restored terminal, or explicitly run it in that same surface.\nWith no action, the command is only printed." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "使用方法: cmux last-command [show|run] [--workspace <id|ref|index>] [--surface <id|ref|index>] [--window <id|ref|index>] [--json]\n\n復元されたターミナルから回収したコマンドを表示するか、同じサーフェスで明示的に実行します。\nアクションを省略すると、コマンドの表示のみを行います。" } }
+      }
+    },
+    "cli.surfaceResume.error.noCommand": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "No recoverable command is available for this surface" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このサーフェスには復元可能なコマンドがありません" } }
+      }
+    },
+    "cli.surfaceResume.help.run": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": { "stringUnit": { "state": "translated", "value": "cmux surface resume run [--json] [flags]    Execute the saved command in that surface" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "cmux surface resume run [--json] [flags]    保存されたコマンドをそのサーフェスで実行" } }
+      }
+    },
     "cli.help.readScreen": {
       "extractionState": "manual",
       "localizations": {

--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -86435,6 +86435,31 @@
         }
       }
     },
+    "contextMenu.moveToBottom": {
+      "extractionState": "manual",
+      "localizations": {
+        "ar": { "stringUnit": { "state": "translated", "value": "نقل إلى الأسفل" } },
+        "bs": { "stringUnit": { "state": "translated", "value": "Pomjeri na dno" } },
+        "da": { "stringUnit": { "state": "translated", "value": "Flyt til bunden" } },
+        "de": { "stringUnit": { "state": "translated", "value": "Ans Ende verschieben" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Move to Bottom" } },
+        "es": { "stringUnit": { "state": "translated", "value": "Mover al final" } },
+        "fr": { "stringUnit": { "state": "translated", "value": "Déplacer en bas" } },
+        "it": { "stringUnit": { "state": "translated", "value": "Sposta in fondo" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "一番下に移動" } },
+        "km": { "stringUnit": { "state": "translated", "value": "ផ្លាស់ទីទៅបាត" } },
+        "ko": { "stringUnit": { "state": "translated", "value": "맨 아래로 이동" } },
+        "nb": { "stringUnit": { "state": "translated", "value": "Flytt til bunnen" } },
+        "pl": { "stringUnit": { "state": "translated", "value": "Przenieś na dół" } },
+        "pt-BR": { "stringUnit": { "state": "translated", "value": "Mover para o Final" } },
+        "ru": { "stringUnit": { "state": "translated", "value": "Переместить в конец" } },
+        "th": { "stringUnit": { "state": "translated", "value": "ย้ายไปด้านล่าง" } },
+        "tr": { "stringUnit": { "state": "translated", "value": "En Alta Taşı" } },
+        "uk": { "stringUnit": { "state": "translated", "value": "Перемістити в кінець" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "移到底部" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "移至最下方" } }
+      }
+    },
     "contextMenu.moveUp": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6835,6 +6835,14 @@ struct ContentView: View {
                 (workspaceIndex ?? tabManager.tabs.count - 1) < tabManager.tabs.count - 1
             )
             snapshot.setBool(
+                CommandPaletteContextKeys.workspaceCanMoveToTop,
+                tabManager.canMoveTabsToTop([workspace.id])
+            )
+            snapshot.setBool(
+                CommandPaletteContextKeys.workspaceCanMoveToBottom,
+                tabManager.canMoveTabsToBottom([workspace.id])
+            )
+            snapshot.setBool(
                 CommandPaletteContextKeys.workspaceCanMarkRead,
                 sidebarUnread.canMarkWorkspaceRead(forWorkspaceIds: [workspace.id])
             )
@@ -7549,7 +7557,17 @@ struct ContentView: View {
                 subtitle: workspaceSubtitle,
                 keywords: ["workspace", "move", "top", "reorder"],
                 when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
-                enablement: { $0.bool(CommandPaletteContextKeys.workspaceHasAbove) }
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceCanMoveToTop) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.moveWorkspaceToBottom",
+                title: constant(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")),
+                subtitle: workspaceSubtitle,
+                keywords: ["workspace", "move", "bottom", "reorder"],
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) },
+                enablement: { $0.bool(CommandPaletteContextKeys.workspaceCanMoveToBottom) }
             )
         )
         contributions.append(
@@ -8661,6 +8679,14 @@ struct ContentView: View {
                 return
             }
             tabManager.moveTabsToTop([workspace.id])
+            tabManager.selectWorkspace(workspace)
+        }
+        registry.register(commandId: "palette.moveWorkspaceToBottom") {
+            guard let workspace = tabManager.selectedWorkspace else {
+                NSSound.beep()
+                return
+            }
+            tabManager.moveTabsToBottom([workspace.id])
             tabManager.selectWorkspace(workspace)
         }
         WorkspaceTodoPaletteCommands.registerHandlers(in: &registry, tabManager: tabManager)
@@ -11968,6 +11994,7 @@ struct VerticalTabsSidebar: View, Equatable {
         // root row construction independent from notification publications.
         let unreadSnapshot = SidebarUnreadSnapshot()
         let unreadSummariesByWorkspaceId = unreadSnapshot.summaryByWorkspaceId
+        let tierMoveAvailabilityByTabId = tabManager.tierMoveAvailabilityByTabId()
         let notificationIndex = SidebarWorkspaceNotificationIndex(
             notifications: notificationStore.notifications
         )
@@ -11977,7 +12004,8 @@ struct VerticalTabsSidebar: View, Equatable {
                 workspaceRowInput(
                     workspace,
                     renderContext: renderContext,
-                    unreadSummariesByWorkspaceId: unreadSummariesByWorkspaceId
+                    unreadSummariesByWorkspaceId: unreadSummariesByWorkspaceId,
+                    tierMoveAvailabilityByTabId: tierMoveAvailabilityByTabId
                 )
             )
         })
@@ -11998,6 +12026,8 @@ struct VerticalTabsSidebar: View, Equatable {
             workspaceRowsById: workspaceRowInputsById,
             groupRowsById: groupRowSnapshotsById,
             selectedContextTargetIds: renderContext.selectedContextTargetIds,
+            canMoveSelectedTargetsToTop: tabManager.canMoveTabsToTop(Set(renderContext.selectedContextTargetIds)),
+            canMoveSelectedTargetsToBottom: tabManager.canMoveTabsToBottom(Set(renderContext.selectedContextTargetIds)),
             anchorWorkspaceIds: Set(renderContext.workspaceGroups.compactMap(\.liveAnchorWorkspaceId)),
             workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
             canCreateEmptyGroup: tabManager.selectedTab?.isRemoteTmuxMirror != true,
@@ -13709,6 +13739,7 @@ struct VerticalTabsSidebar: View, Equatable {
         // Shared notification/selection projections are built once here; full
         // row trees and row-specific closure binding remain lazy.
         let unreadSummariesByWorkspaceId = unreadSnapshot.summaryByWorkspaceId
+        let tierMoveAvailabilityByTabId = tabManager.tierMoveAvailabilityByTabId()
         let notificationIndex = SidebarWorkspaceNotificationIndex(
             notifications: notificationStore.notifications
         )
@@ -13718,7 +13749,8 @@ struct VerticalTabsSidebar: View, Equatable {
                 workspaceRowInput(
                     workspace,
                     renderContext: renderContext,
-                    unreadSummariesByWorkspaceId: unreadSummariesByWorkspaceId
+                    unreadSummariesByWorkspaceId: unreadSummariesByWorkspaceId,
+                    tierMoveAvailabilityByTabId: tierMoveAvailabilityByTabId
                 )
             )
         })
@@ -13740,6 +13772,8 @@ struct VerticalTabsSidebar: View, Equatable {
             workspaceRowsById: workspaceRowInputsById,
             groupRowsById: groupRowSnapshotsById,
             selectedContextTargetIds: renderContext.selectedContextTargetIds,
+            canMoveSelectedTargetsToTop: tabManager.canMoveTabsToTop(Set(renderContext.selectedContextTargetIds)),
+            canMoveSelectedTargetsToBottom: tabManager.canMoveTabsToBottom(Set(renderContext.selectedContextTargetIds)),
             anchorWorkspaceIds: Set(renderContext.workspaceGroups.compactMap(\.liveAnchorWorkspaceId)),
             workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
             canCreateEmptyGroup: tabManager.selectedTab?.isRemoteTmuxMirror != true,
@@ -14535,7 +14569,8 @@ struct VerticalTabsSidebar: View, Equatable {
     private func workspaceRowInput(
         _ tab: Workspace,
         renderContext: WorkspaceListRenderContext,
-        unreadSummariesByWorkspaceId: [UUID: SidebarWorkspaceUnreadSummary]
+        unreadSummariesByWorkspaceId: [UUID: SidebarWorkspaceUnreadSummary],
+        tierMoveAvailabilityByTabId: [UUID: WorkspaceTierMoveAvailability]
     ) -> SidebarWorkspaceRowInput {
 #if DEBUG
         sidebarLazyContractProbe.workspaceRowInputProjection?()
@@ -14555,6 +14590,7 @@ struct VerticalTabsSidebar: View, Equatable {
             in: renderContext.pinResolutionContext,
             target: contextMenuPinTarget
         )
+        let tierMoveAvailability = tierMoveAvailabilityByTabId[tab.id]
         let unreadSummary = unreadSummariesByWorkspaceId[tab.id]
             ?? SidebarWorkspaceUnreadSummary(unreadCount: 0, latestNotificationText: nil)
         let liveLatestNotificationText: String? = renderContext.tabItemSettings.showsNotificationMessage
@@ -14657,6 +14693,8 @@ struct VerticalTabsSidebar: View, Equatable {
             checklistAddFieldActivationToken: checklistAddFieldActivationTokens[tab.id] ?? 0,
             isChecklistPopoverPresented: checklistPopoverWorkspaceId == tab.id,
             isRemoteContextMenuEligible: tab.isRemoteWorkspace && !tab.isManagedCloudVMWorkspace,
+            canMoveToTop: tierMoveAvailability?.canMoveToTop ?? false,
+            canMoveToBottom: tierMoveAvailability?.canMoveToBottom ?? false,
             remoteConnectionState: tab.remoteConnectionState,
             contextMenuPinState: contextMenuPinState,
             inferredTaskStatus: tab.inferredTaskStatus,
@@ -14756,6 +14794,10 @@ struct VerticalTabsSidebar: View, Equatable {
             },
             moveTargetsToTop: { targetIds in
                 tabManager.moveTabsToTop(Set(targetIds))
+                syncWorkspaceRowSelectionAfterMutation()
+            },
+            moveTargetsToBottom: { targetIds in
+                tabManager.moveTabsToBottom(Set(targetIds))
                 syncWorkspaceRowSelectionAfterMutation()
             },
             currentWindowMoveTargets: {

--- a/Sources/DockSplitStore+SessionRestore.swift
+++ b/Sources/DockSplitStore+SessionRestore.swift
@@ -234,13 +234,23 @@ extension DockSplitStore {
         )
         guard let terminalSnapshot = snapshot.terminal else { return nil }
         let policy = Workspace.makeSessionRestorePolicyService()
+        let persistedResumeBinding = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+            existing: terminalSnapshot.resumeBinding,
+            restorableAgentExists: terminalSnapshot.agent != nil,
+            shellActivityState: .unknown,
+            automaticTitle: snapshot.title,
+            hasCustomTitle: snapshot.customTitle != nil,
+            scrollback: terminalSnapshot.scrollback,
+            workingDirectory: terminalSnapshot.workingDirectory ?? snapshot.directory,
+            allowAutomaticTitleFallback: true
+        )
         let restorableAgent = Workspace.restorableAgentForSessionRestore(
             terminalSnapshot.agent,
-            resumeBinding: terminalSnapshot.resumeBinding
+            resumeBinding: persistedResumeBinding
         )
         let hibernation = restorableAgent != nil ? terminalSnapshot.hibernation : nil
         let resumeBinding = Workspace.resumeBindingForSessionRestore(
-            terminalSnapshot.resumeBinding,
+            persistedResumeBinding,
             restorableAgent: restorableAgent
         )
         // A persisted agent snapshot can coexist with a non-agent binding

--- a/Sources/DockSplitStore+SessionSnapshot.swift
+++ b/Sources/DockSplitStore+SessionSnapshot.swift
@@ -307,6 +307,15 @@ extension DockSplitStore {
             if let scrollback {
                 restoredTerminalScrollbackByPanelId[panelId] = scrollback
             }
+            let snapshotResumeBinding = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+                existing: resumeBinding,
+                restorableAgentExists: restorableAgent != nil,
+                shellActivityState: terminal.shellActivity.state,
+                automaticTitle: titleMetadata.title,
+                hasCustomTitle: titleMetadata.customTitle != nil,
+                scrollback: scrollback,
+                workingDirectory: directory
+            )
             let sessionFontSize: Float32?
             let sessionFontSizeChangeTokens: [UUID]?
             if let terminalFontSizeSnapshotProjection {
@@ -337,7 +346,7 @@ extension DockSplitStore {
                         lastActivityAt: $0.lastActivityAt.timeIntervalSince1970
                     )
                 },
-                resumeBinding: resumeBinding,
+                resumeBinding: snapshotResumeBinding,
                 managedAgentResumeBinding: managedResumeBinding,
                 textBoxDraft: terminal.sessionTextBoxDraftSnapshot(),
                 isRemoteTerminal: transfer?.isRemoteTerminal ?? false,

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1,4 +1,5 @@
 import CoreGraphics
+import CmuxAgentChat
 import CmuxBrowser
 import CmuxCore
 import Foundation
@@ -489,6 +490,55 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
 
     static func shellSingleQuoted(_ value: String) -> String {
         "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+extension SurfaceResumeBindingSnapshot {
+    /// Builds manual-only recovery metadata for an ordinary shell command.
+    /// Existing agent/tmux bindings always win; semantic prompt history is
+    /// preferred, with the automatic process title used only while a command
+    /// was known to be running when the snapshot was captured.
+    static func recoveredShellCommandBinding(
+        existing: Self?,
+        restorableAgentExists: Bool,
+        shellActivityState: PanelShellActivityState,
+        automaticTitle: String?,
+        hasCustomTitle: Bool,
+        scrollback: String?,
+        workingDirectory: String?,
+        allowAutomaticTitleFallback: Bool = false
+    ) -> Self? {
+        let previousRecovery = existing?.source == "session-command" ? existing : nil
+        if restorableAgentExists { return existing }
+        if let existing, existing.source != "session-command" { return existing }
+
+        let parsedCommand: String? = scrollback.flatMap { text in
+            var parser = OSC133CommandParser()
+            parser.consume(text)
+            let command = parser.blocks.last?.command
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            return command.isEmpty ? nil : command
+        }
+        let titleCandidate = automaticTitle?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let genericTitles: Set<String> = ["terminal", "shell", "bash", "zsh", "fish", "nu", "sh"]
+        let runningTitle = (allowAutomaticTitleFallback || shellActivityState == .commandRunning) &&
+            !hasCustomTitle &&
+            titleCandidate.map { !genericTitles.contains($0.lowercased()) } == true
+                ? titleCandidate
+                : nil
+        let command = (parsedCommand ?? runningTitle)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let command, !command.isEmpty else { return previousRecovery }
+
+        return Self(
+            kind: "shell",
+            command: command,
+            cwd: workingDirectory,
+            source: "session-command",
+            autoResume: false,
+            approvalPolicy: .manual
+        )
     }
 }
 

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift
@@ -642,10 +642,18 @@ struct SidebarWorkspaceRowMenuBuilder {
         })
         menu.addItem(item(
             String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top"),
-            enabled: !targetIds.isEmpty
+            enabled: tabManager.canMoveTabsToTop(Set(targetIds))
         ) { [weak tabManager, commands] in
             guard let tabManager else { return }
             tabManager.moveTabsToTop(Set(commands.contextMenuWorkspaceIds))
+            commands.syncSelectionAfterMutation()
+        })
+        menu.addItem(item(
+            String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom"),
+            enabled: tabManager.canMoveTabsToBottom(Set(targetIds))
+        ) { [weak tabManager, commands] in
+            guard let tabManager else { return }
+            tabManager.moveTabsToBottom(Set(commands.contextMenuWorkspaceIds))
             commands.syncSelectionAfterMutation()
         })
 

--- a/Sources/SidebarWorkspaceContextMenuSnapshot.swift
+++ b/Sources/SidebarWorkspaceContextMenuSnapshot.swift
@@ -8,6 +8,8 @@ import Foundation
 /// the notification store.
 struct SidebarWorkspaceContextMenuSnapshot: Equatable {
     let targetWorkspaceIds: [UUID]
+    let canMoveTargetsToTop: Bool
+    let canMoveTargetsToBottom: Bool
     let remoteTargetWorkspaceIds: [UUID]
     let allRemoteTargetsConnecting: Bool
     let allRemoteTargetsDisconnected: Bool

--- a/Sources/SidebarWorkspaceContextMenuTargetAggregate.swift
+++ b/Sources/SidebarWorkspaceContextMenuTargetAggregate.swift
@@ -8,6 +8,8 @@ import Foundation
 /// grouping, unread, and notification aggregation during row realization.
 struct SidebarWorkspaceContextMenuTargetAggregate: Equatable {
     let targetWorkspaceIds: [UUID]
+    let canMoveTargetsToTop: Bool
+    let canMoveTargetsToBottom: Bool
     let remoteTargetWorkspaceIds: [UUID]
     let allRemoteTargetsConnecting: Bool
     let allRemoteTargetsDisconnected: Bool
@@ -23,11 +25,15 @@ struct SidebarWorkspaceContextMenuTargetAggregate: Equatable {
     @MainActor
     init(
         targetWorkspaceIds: [UUID],
+        canMoveTargetsToTop: Bool,
+        canMoveTargetsToBottom: Bool,
         workspaceRowsById: [UUID: SidebarWorkspaceRowInput],
         anchorWorkspaceIds: Set<UUID>,
         notificationIndex: SidebarWorkspaceNotificationIndex
     ) {
         self.targetWorkspaceIds = targetWorkspaceIds
+        self.canMoveTargetsToTop = canMoveTargetsToTop
+        self.canMoveTargetsToBottom = canMoveTargetsToBottom
         remoteTargetWorkspaceIds = targetWorkspaceIds.filter {
             workspaceRowsById[$0]?.isRemoteContextMenuEligible == true
         }

--- a/Sources/SidebarWorkspaceRowActions.swift
+++ b/Sources/SidebarWorkspaceRowActions.swift
@@ -17,6 +17,7 @@ struct SidebarWorkspaceRowActions {
     let closeWorkspace: () -> Void
     let moveBy: (Int) -> Void
     let moveTargetsToTop: ([UUID]) -> Void
+    let moveTargetsToBottom: ([UUID]) -> Void
     /// Resolves volatile app-window topology when the deferred menu is presented.
     let currentWindowMoveTargets: () -> [SidebarWorkspaceWindowMoveTarget]
     let moveTargetsToWindow: ([UUID], UUID) -> Void

--- a/Sources/SidebarWorkspaceRowInput.swift
+++ b/Sources/SidebarWorkspaceRowInput.swift
@@ -40,6 +40,8 @@ struct SidebarWorkspaceRowInput {
     let checklistAddFieldActivationToken: Int
     let isChecklistPopoverPresented: Bool
     let isRemoteContextMenuEligible: Bool
+    let canMoveToTop: Bool
+    let canMoveToBottom: Bool
     let remoteConnectionState: WorkspaceRemoteConnectionState
     let contextMenuPinState: WorkspaceActionDispatcher.PinState?
     let inferredTaskStatus: WorkspaceTaskStatus
@@ -79,6 +81,8 @@ struct SidebarWorkspaceRowInput {
             isChecklistPopoverPresented: isChecklistPopoverPresented,
             contextMenu: SidebarWorkspaceContextMenuSnapshot(
                 targetWorkspaceIds: targetAggregate.targetWorkspaceIds,
+                canMoveTargetsToTop: targetAggregate.canMoveTargetsToTop,
+                canMoveTargetsToBottom: targetAggregate.canMoveTargetsToBottom,
                 remoteTargetWorkspaceIds: targetAggregate.remoteTargetWorkspaceIds,
                 allRemoteTargetsConnecting: targetAggregate.allRemoteTargetsConnecting,
                 allRemoteTargetsDisconnected: targetAggregate.allRemoteTargetsDisconnected,

--- a/Sources/SidebarWorkspaceRowsSnapshot.swift
+++ b/Sources/SidebarWorkspaceRowsSnapshot.swift
@@ -20,6 +20,8 @@ struct SidebarWorkspaceRowsSnapshot {
         workspaceRowsById: [UUID: SidebarWorkspaceRowInput],
         groupRowsById: [UUID: SidebarWorkspaceGroupRowSnapshot],
         selectedContextTargetIds: [UUID],
+        canMoveSelectedTargetsToTop: Bool,
+        canMoveSelectedTargetsToBottom: Bool,
         anchorWorkspaceIds: Set<UUID>,
         workspaceGroupMenuSnapshot: WorkspaceGroupMenuSnapshot,
         canCreateEmptyGroup: Bool,
@@ -33,6 +35,8 @@ struct SidebarWorkspaceRowsSnapshot {
         self.notificationIndex = notificationIndex
         selectedContextMenuTargetAggregate = SidebarWorkspaceContextMenuTargetAggregate(
             targetWorkspaceIds: selectedContextTargetIds,
+            canMoveTargetsToTop: canMoveSelectedTargetsToTop,
+            canMoveTargetsToBottom: canMoveSelectedTargetsToBottom,
             workspaceRowsById: workspaceRowsById,
             anchorWorkspaceIds: anchorWorkspaceIds,
             notificationIndex: notificationIndex
@@ -48,6 +52,8 @@ struct SidebarWorkspaceRowsSnapshot {
         }
         return SidebarWorkspaceContextMenuTargetAggregate(
             targetWorkspaceIds: [input.workspaceId],
+            canMoveTargetsToTop: input.canMoveToTop,
+            canMoveTargetsToBottom: input.canMoveToBottom,
             workspaceRowsById: workspaceRowsById,
             anchorWorkspaceIds: anchorWorkspaceIds,
             notificationIndex: notificationIndex

--- a/Sources/TabItemView+WorkspaceContextMenu.swift
+++ b/Sources/TabItemView+WorkspaceContextMenu.swift
@@ -219,7 +219,12 @@ extension TabItemView {
         Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
             actions.moveTargetsToTop(targetIds)
         }
-        .disabled(targetIds.isEmpty)
+        .disabled(!context.canMoveTargetsToTop)
+
+        Button(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")) {
+            actions.moveTargetsToBottom(targetIds)
+        }
+        .disabled(!context.canMoveTargetsToBottom)
 
         Menu(moveMenuTitle) {
             Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1891,6 +1891,22 @@ class TabManager: ObservableObject {
         workspaceReordering.moveTabsToTop(tabIds)
     }
 
+    func canMoveTabsToTop(_ tabIds: Set<UUID>) -> Bool {
+        workspaceReordering.canMoveTabsToTop(tabIds)
+    }
+
+    func moveTabsToBottom(_ tabIds: Set<UUID>) {
+        workspaceReordering.moveTabsToBottom(tabIds)
+    }
+
+    func canMoveTabsToBottom(_ tabIds: Set<UUID>) -> Bool {
+        workspaceReordering.canMoveTabsToBottom(tabIds)
+    }
+
+    func tierMoveAvailabilityByTabId() -> [UUID: WorkspaceTierMoveAvailability] {
+        workspaceReordering.tierMoveAvailabilityByTabId()
+    }
+
     func moveTabToTopForNotification(_ tabId: UUID) {
         workspaceReordering.moveTabToTopForNotification(tabId)
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -655,6 +655,15 @@ extension Workspace {
                 includeScrollback: includeScrollback,
                 allowFallbackScrollback: shouldPersistScrollback || allowDebugFallbackScrollback || hasRestoredScrollbackFallback
             )
+            let snapshotResumeBinding = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+                existing: resumeBinding,
+                restorableAgentExists: effectiveRestorableAgent != nil,
+                shellActivityState: panelShellActivityStates[panelId] ?? .unknown,
+                automaticTitle: panelTitle,
+                hasCustomTitle: customTitle != nil,
+                scrollback: resolvedScrollback,
+                workingDirectory: directory
+            )
             let sessionFontSize: Float32?
             let sessionFontSizeChangeTokens: [UUID]?
             if let terminalFontSizeSnapshotProjection {
@@ -685,7 +694,7 @@ extension Workspace {
                         lastActivityAt: $0.lastActivityAt.timeIntervalSince1970
                     )
                 },
-                resumeBinding: resumeBinding,
+                resumeBinding: snapshotResumeBinding,
                 textBoxDraft: terminalPanel.sessionTextBoxDraftSnapshot(),
                 isRemoteTerminal: activeRemoteTerminalSurfaceIds.contains(panelId),
                 remotePTYSessionID: remotePTYSessionIDForSnapshot(panelId: panelId),
@@ -1528,7 +1537,16 @@ extension Workspace {
         switch snapshot.type {
         case .terminal:
             let snapshotRestorableAgent = snapshot.terminal?.agent
-            let persistedResumeBinding = snapshot.terminal?.resumeBinding
+            let persistedResumeBinding = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+                existing: snapshot.terminal?.resumeBinding,
+                restorableAgentExists: snapshotRestorableAgent != nil,
+                shellActivityState: .unknown,
+                automaticTitle: snapshot.title,
+                hasCustomTitle: snapshot.customTitle != nil,
+                scrollback: snapshot.terminal?.scrollback,
+                workingDirectory: snapshot.terminal?.workingDirectory ?? snapshot.directory,
+                allowAutomaticTitleFallback: true
+            )
             let restorableAgent = Self.restorableAgentForSessionRestore(
                 snapshotRestorableAgent,
                 resumeBinding: persistedResumeBinding

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1346,6 +1346,22 @@ struct cmuxApp: App {
         manager.selectWorkspace(workspace)
     }
 
+    private func moveSelectedWorkspaceToBottom(in manager: TabManager) {
+        guard let workspace = manager.selectedWorkspace else { return }
+        manager.moveTabsToBottom([workspace.id])
+        manager.selectWorkspace(workspace)
+    }
+
+    private func selectedWorkspaceCanMoveToBottom(in manager: TabManager, workspace: Workspace?) -> Bool {
+        guard let workspace else { return false }
+        return manager.canMoveTabsToBottom([workspace.id])
+    }
+
+    private func selectedWorkspaceCanMoveToTop(in manager: TabManager, workspace: Workspace?) -> Bool {
+        guard let workspace else { return false }
+        return manager.canMoveTabsToTop([workspace.id])
+    }
+
     private func moveSelectedWorkspace(in manager: TabManager, toWindow windowId: UUID) {
         guard let workspace = manager.selectedWorkspace else { return }
         _ = AppDelegate.shared?.moveWorkspaceToWindow(workspaceId: workspace.id, windowId: windowId, focus: true)
@@ -1447,7 +1463,12 @@ struct cmuxApp: App {
         Button(String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top")) {
             moveSelectedWorkspaceToTop(in: manager)
         }
-        .disabled(workspace == nil || workspaceIndex == 0)
+        .disabled(!selectedWorkspaceCanMoveToTop(in: manager, workspace: workspace))
+
+        Button(String(localized: "contextMenu.moveToBottom", defaultValue: "Move to Bottom")) {
+            moveSelectedWorkspaceToBottom(in: manager)
+        }
+        .disabled(!selectedWorkspaceCanMoveToBottom(in: manager, workspace: workspace))
 
         Menu(String(localized: "contextMenu.moveWorkspaceToWindow", defaultValue: "Move Workspace to Window")) {
             Button(String(localized: "contextMenu.newWindow", defaultValue: "New Window")) {

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -13,6 +13,70 @@ import Testing
 
 @Suite(.serialized)
 struct AgentSessionAutoResumeSwiftTests {
+    @Test("Plain shell snapshots retain a manual command when no agent resume binding exists")
+    func plainShellCommandBecomesManualResumeBinding() throws {
+        let cwd = "/tmp/cmux-last-command"
+        let command = "python3 -m http.server 8080"
+        let scrollback = "\u{001B}]133;A\u{0007}$ \u{001B}]133;B\u{0007}\(command)\u{001B}]133;C\u{0007}Serving..."
+
+        let parsed = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+            existing: nil,
+            restorableAgentExists: false,
+            shellActivityState: .promptIdle,
+            automaticTitle: "unrelated title",
+            hasCustomTitle: false,
+            scrollback: scrollback,
+            workingDirectory: cwd
+        )
+        let parsedBinding = try #require(parsed)
+        #expect(parsedBinding.command == command)
+        #expect(parsedBinding.cwd == cwd)
+        #expect(parsedBinding.kind == "shell")
+        #expect(parsedBinding.source == "session-command")
+        #expect(parsedBinding.approvalPolicy == .manual)
+        #expect(parsedBinding.autoResume == false)
+
+        let runningTitle = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+            existing: nil,
+            restorableAgentExists: false,
+            shellActivityState: .commandRunning,
+            automaticTitle: command,
+            hasCustomTitle: false,
+            scrollback: nil,
+            workingDirectory: cwd
+        )
+        #expect(runningTitle?.command == command)
+
+        let customTitle = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+            existing: nil,
+            restorableAgentExists: false,
+            shellActivityState: .commandRunning,
+            automaticTitle: command,
+            hasCustomTitle: true,
+            scrollback: nil,
+            workingDirectory: cwd
+        )
+        #expect(customTitle == nil)
+
+        let agentBinding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "codex resume session-123",
+            cwd: cwd,
+            source: "agent-hook",
+            autoResume: true
+        )
+        let preserved = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+            existing: agentBinding,
+            restorableAgentExists: true,
+            shellActivityState: .commandRunning,
+            automaticTitle: command,
+            hasCustomTitle: false,
+            scrollback: scrollback,
+            workingDirectory: cwd
+        )
+        #expect(preserved == agentBinding)
+    }
+
     /// Regression for #9619: cmux-owned restore input is an implementation
     /// detail, not a user or agent title. Preserve the automatic title captured
     /// before relaunch through that bootstrap event, then accept the first real

--- a/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
+++ b/cmuxTests/AgentSessionAutoResumeSwiftTests.swift
@@ -14,6 +14,7 @@ import Testing
 @Suite(.serialized)
 struct AgentSessionAutoResumeSwiftTests {
     @Test("Plain shell snapshots retain a manual command when no agent resume binding exists")
+    @MainActor
     func plainShellCommandBecomesManualResumeBinding() throws {
         let cwd = "/tmp/cmux-last-command"
         let command = "python3 -m http.server 8080"
@@ -58,6 +59,17 @@ struct AgentSessionAutoResumeSwiftTests {
         )
         #expect(customTitle == nil)
 
+        let genericTitle = SurfaceResumeBindingSnapshot.recoveredShellCommandBinding(
+            existing: nil,
+            restorableAgentExists: false,
+            shellActivityState: .commandRunning,
+            automaticTitle: "Terminal",
+            hasCustomTitle: false,
+            scrollback: nil,
+            workingDirectory: cwd
+        )
+        #expect(genericTitle == nil)
+
         let agentBinding = SurfaceResumeBindingSnapshot(
             kind: "codex",
             command: "codex resume session-123",
@@ -75,6 +87,28 @@ struct AgentSessionAutoResumeSwiftTests {
             workingDirectory: cwd
         )
         #expect(preserved == agentBinding)
+
+        let source = Workspace()
+        defer { source.teardownAllPanels() }
+        let sourcePanelID = try #require(source.focusedPanelId)
+        #expect(source.updatePanelTitle(panelId: sourcePanelID, title: command))
+        var legacySnapshot = source.sessionSnapshot(includeScrollback: false)
+        let legacyPanelIndex = try #require(
+            legacySnapshot.panels.firstIndex { $0.id == sourcePanelID }
+        )
+        legacySnapshot.panels[legacyPanelIndex].terminal?.resumeBinding = nil
+
+        let restored = Workspace()
+        defer { restored.teardownAllPanels() }
+        let restoredIDs = restored.restoreSessionSnapshot(legacySnapshot)
+        let restoredPanelID = try #require(restoredIDs[sourcePanelID])
+        let restoredBinding = try #require(
+            restored.surfaceResumeBinding(panelId: restoredPanelID)
+        )
+        #expect(restoredBinding.command == command)
+        #expect(restoredBinding.source == "session-command")
+        #expect(restoredBinding.approvalPolicy == .manual)
+        #expect(restoredBinding.autoResume == false)
     }
 
     /// Regression for #9619: cmux-owned restore input is an implementation

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -217,6 +217,59 @@ import Testing
         )
     }
 
+    @Test func testSurfaceResumeRunSendsRecoveredCommandToExactSurface() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = "/tmp/cmux-resume-run-\(UUID().uuidString.prefix(8)).sock"
+        let workspaceID = UUID().uuidString.lowercased()
+        let surfaceID = UUID().uuidString.lowercased()
+        let command = "python3 -m http.server 8080"
+        let getResponseData = try JSONSerialization.data(withJSONObject: [
+            "ok": true,
+            "result": [
+                "workspace_id": workspaceID,
+                "surface_id": surfaceID,
+                "resume_binding": ["command": command],
+            ],
+        ])
+        let responder = try UnixSocketResponder(
+            path: socketPath,
+            responses: [
+                String(decoding: getResponseData, as: UTF8.self),
+                #"{"ok":true,"result":{"sent":true}}"#,
+            ]
+        )
+        defer { responder.stop() }
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: ["last-command", "run"],
+            environment: environment,
+            timeout: 5
+        )
+        #expect(!result.timedOut, Comment(rawValue: result.diagnostics))
+        #expect(result.status == 0, Comment(rawValue: result.diagnostics))
+
+        let requests = try responder.receivedRequests.map { request -> [String: Any] in
+            let data = try #require(request.data(using: .utf8))
+            return try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        }
+        #expect(requests.compactMap { $0["method"] as? String } == [
+            "surface.resume.get",
+            "surface.send_text",
+        ])
+        let sendParams = try #require(requests.last?["params"] as? [String: Any])
+        #expect(sendParams["workspace_id"] as? String == workspaceID)
+        #expect(sendParams["surface_id"] as? String == surfaceID)
+        #expect(sendParams["text"] as? String == command + "\n")
+    }
+
     @Test func testIOSContextFromTerminalFallsBackToWorkspaceSimulator() throws {
         let cliPath = try bundledCLIPath()
         let workspaceID = UUID().uuidString.lowercased()

--- a/justa
+++ b/justa
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -eu
+
+repo_root=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+exec just --justfile "$repo_root/justfile.aje" "$@"

--- a/justfile.aje
+++ b/justfile.aje
@@ -1,0 +1,11 @@
+set shell := ["zsh", "-cu"]
+
+# Build an isolated Debug app for testing. The reload script prints its app path.
+test-build:
+    ./scripts/reload.sh --tag aje-test-build
+
+# Build a fixed app with the release bundle identifier, then install it under a
+# distinct name. Quit the normal cmux app before launching this one: both apps
+# intentionally share the release session snapshot and bundle identity.
+release-build:
+    set -euo pipefail; log="$(mktemp -t cmux-aje-release.XXXXXX)"; trap 'rm -f "$log"' EXIT; ./scripts/reload.sh --tag aje-release --name "cmux AJE" --bundle-id com.cmuxterm.app 2>&1 | tee "$log"; app="$(sed -n 's/^  //p' "$log" | grep '\.app$' | head -n 1)"; test -n "$app"; dest="$HOME/Applications/cmux AJE.app"; mkdir -p "$HOME/Applications"; rm -rf "$dest"; ditto "$app" "$dest"; ./scripts/sign-dev-app.sh "$dest"; encoded="$(printf '%s' "$dest" | sed 's/ /%20/g')"; printf '\nInstalled app:\n  %s\n\nOpen: [cmux AJE.app](file://%s)\n' "$dest" "$encoded"

--- a/scripts/sign-dev-app.sh
+++ b/scripts/sign-dev-app.sh
@@ -1,0 +1,42 @@
+#!/bin/zsh
+
+set -euo pipefail
+
+if [[ $# -ne 1 ]]; then
+    echo "Usage: $0 <app-bundle>" >&2
+    exit 2
+fi
+
+app_path="$1"
+if [[ ! -d "$app_path" ]]; then
+    echo "error: app bundle not found: $app_path" >&2
+    exit 1
+fi
+
+signing_identity="${CMUX_SIGNING_IDENTITY:-}"
+if [[ -z "$signing_identity" ]]; then
+    signing_identity="$(security find-identity -v -p codesigning \
+        | sed -n '/Apple Development:/ { s/^[[:space:]]*[0-9]*) \([[:xdigit:]]\{40\}\) .*/\1/; p; q; }' \
+        | head -n 1)"
+fi
+if [[ -z "$signing_identity" ]]; then
+    signing_identity="$(security find-identity -v -p codesigning \
+        | sed -n '/Developer ID Application:/ { s/^[[:space:]]*[0-9]*) \([[:xdigit:]]\{40\}\) .*/\1/; p; q; }' \
+        | head -n 1)"
+fi
+if [[ -z "$signing_identity" ]]; then
+    echo "error: no Apple Development or Developer ID signing identity found" >&2
+    exit 1
+fi
+
+echo "Signing $(basename "$app_path") with: $signing_identity"
+/usr/bin/codesign \
+    --force \
+    --deep \
+    --timestamp=none \
+    --preserve-metadata=entitlements,requirements,flags \
+    --sign "$signing_identity" \
+    "$app_path"
+/usr/bin/codesign --verify --deep --strict "$app_path"
+/usr/bin/codesign -dv --verbose=2 "$app_path" 2>&1 \
+    | sed -n '/^Identifier=/p; /^TeamIdentifier=/p; /^Authority=/p; /^Signature=/p'


### PR DESCRIPTION
## Summary
- retain ordinary shell commands as manual-only resume bindings during session snapshot/restore
- add `cmux last-command` to show the recovered command and `cmux last-command run` to execute it in the exact surface
- support existing saved sessions by recovering from their automatic tab title when semantic shell history is unavailable

## Safety
- commands are never executed automatically
- custom and generic shell titles are excluded from title fallback
- existing agent and tmux resume bindings continue to take precedence
- CLI lookup and execution preserve the targeted workspace/surface and do not focus the app

## Validation
- `./scripts/reload.sh --tag last-command-resume` succeeded
- built CLI: `cmux last-command --help` succeeded
- localization catalog JSON validated; new CLI strings include English and Japanese
- focused tests were added, but execution is blocked by pre-existing `cmuxTests` fixture compile errors in sidebar tests (missing newly-required move-to-top/bottom initializer arguments)

## Regression commit sequence
1. `a4363a3944f` adds the regression test
2. `9bb44261641` adds the implementation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791076083&installation_model_id=21920&pr_number=11892&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11892&signature=1ac0e712af57acd56cb6bd6837e26600158e165d60b6cd65284140fa1e4dc3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Recovers the last command for restored plain shell terminals so it can be shown or re-run manually. Previously these commands were lost on restore; now they are saved as a manual resume binding and exposed via the new `cmux last-command` CLI.

**Command recovery**
- `cmux last-command` shows the recovered command; `cmux last-command run` executes it in the exact surface.
- Existing agent and tmux resume bindings still win; automatic title fallback only applies when no custom or generic title exists.

**Sidebar reordering**
- Adds "Move to Bottom" for workspaces, with boundary detection so no-op moves are disabled.
- Moves can be evaluated for multiple selections at once.

<sup>Written for commit 9bb44261641a06253fb0d1ce6bed094fe0ee379c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `last-command` CLI command with options to view, retrieve, run, or execute a saved command on its associated surface.
  - Added “Move to Bottom” for workspaces, with accurate availability for both top and bottom actions.
  - Added localized “Move to Bottom” menu text.

- **Bug Fixes**
  - Improved terminal session restoration so shell commands can be recovered for manual resume, including legacy sessions.
  - Improved command execution to report when no saved command is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->