### PR TITLE
fix(sidebar): ignore ephemeral ports and limit sidebar port links count

### DIFF
--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -622,8 +622,12 @@ extension PortScanner {
                 guard portText.allSatisfy(\.isNumber),
                       let port = Int(portText),
                       port > 0,
-                      port <= 65_535 else {
-                    parseIncompletePIDs.insert(currentPID)
+                      port < 49_152 else {
+                    // Ignore invalid ports and ephemeral/dynamic port range (49152..65535)
+                    // which are typically OS ephemeral sockets or internal agent IPC/RPC listeners.
+                    if let port = Int(portText), (port <= 0 || port > 65_535) {
+                        parseIncompletePIDs.insert(currentPID)
+                    }
                     continue
                 }
                 portsByPID[currentPID, default: []].insert(port)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -910,7 +910,9 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
                 self?.actions?.onOpenPullRequest(pr.url)
             }
         }
-        let ports = settings.visibleAuxiliaryDetails.showsPorts ? snapshot.listeningPorts : []
+        let allPorts = settings.visibleAuxiliaryDetails.showsPorts ? snapshot.listeningPorts : []
+        let maxDisplayPorts = 5
+        let ports = Array(allPorts.prefix(maxDisplayPorts))
         Self.pool(&portButtons, count: ports.count, parent: contentContainer) { SidebarRowLinkButton() }
         for (index, port) in ports.enumerated() {
             portButtons[index].configure(


### PR DESCRIPTION
### Summary
When running AI agent CLI tools (e.g. Claude Code, Antigravity/AGY) inside terminal panes, processes often bind many ephemeral loopback TCP ports (>49152) for internal IPC/RPC.

Previously, `PortScanner` captured all listening ports without filtering, causing `SidebarWorkspaceRowCellView` to wrap dozens of port buttons across the entire row. This made selecting the workspace almost impossible without inadvertently clicking a port button and triggering `openInBrowser(localhost:<port>)`.

### Changes
1. Filter out dynamic/ephemeral ports (range 49152..65535) during `lsof` port detection in `PortScanner+Process.swift`.
2. Limit maximum displayed ports to 5 on workspace sidebar rows in `SidebarWorkspaceRowCellView.swift` to avoid unbounded layout growth.
3. Ensure workspace row selection is preserved and protected against accidental port clicks.

### Testing
- Tested with agent CLI processes listening on multiple ephemeral ports (> 49152).
- Verified standard dev server ports (3000, 5173, 8080) continue to display and work as expected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791078851&installation_model_id=21920&pr_number=11900&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11900&signature=c4ae144bcd3d173a609a22e8a33832af5f5f5986fe2b9e0907fe5e788251c37b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops agent CLI processes from cluttering the sidebar with ephemeral port buttons. Previously all listening ports were shown, causing rows to wrap and making workspace selection difficult. Now ephemeral ports (49152-65535) are ignored and at most 5 port links are displayed per row.

<sup>Written for commit 8e1a79d61913f17060b6275c97cbe44e97bfcc7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11900?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Dynamic and ephemeral ports are now handled correctly when scanning listening ports.
  - Invalid port values continue to be flagged appropriately.

- **Improvements**
  - Workspace sidebar rows now display up to five listening ports, keeping the interface concise when more ports are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->