### PR TITLE
feat: surface workspace completion status on iOS

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncWorkspaceListResponse.swift
@@ -50,6 +50,8 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
         /// sidebar badge shows). `nil` on Macs old enough not to emit it (the
         /// row then falls back to the boolean dot).
         public let unreadCount: Int?
+        /// The Mac sidebar's completion lane, when workspace status is visible.
+        public let taskStatus: String?
         /// Terminals belonging to this workspace.
         public let terminals: [Terminal]
         /// All workspace surfaces. `nil` when an older Mac omits the field.
@@ -73,6 +75,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             case lastActivityAt = "last_activity_at"
             case hasUnread = "has_unread"
             case unreadCount = "unread_count"
+            case taskStatus = "task_status"
             case terminals
             case surfaces
             case simulators
@@ -97,6 +100,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             lastActivityAt: Double?,
             hasUnread: Bool?,
             unreadCount: Int? = nil,
+            taskStatus: String? = nil,
             terminals: [Terminal],
             surfaces: [Surface]? = nil,
             simulators: [MobileSimulatorPanelDescriptor] = []
@@ -116,6 +120,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             self.lastActivityAt = lastActivityAt
             self.hasUnread = hasUnread
             self.unreadCount = unreadCount
+            self.taskStatus = taskStatus
             self.terminals = terminals
             self.surfaces = surfaces
             self.simulators = simulators
@@ -139,6 +144,7 @@ public struct MobileSyncWorkspaceListResponse: Decodable, Sendable {
             lastActivityAt = try container.decodeIfPresent(Double.self, forKey: .lastActivityAt)
             hasUnread = try container.decodeIfPresent(Bool.self, forKey: .hasUnread)
             unreadCount = try container.decodeIfPresent(Int.self, forKey: .unreadCount)
+            taskStatus = try container.decodeIfPresent(String.self, forKey: .taskStatus)
             terminals = try container.decode([Terminal].self, forKey: .terminals)
             surfaces = try container.decodeIfPresent([Surface].self, forKey: .surfaces)
             simulators = try container.decodeIfPresent(

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileWorkspacePreview+RemoteMapping.swift
@@ -20,6 +20,7 @@ extension MobileWorkspacePreview {
             lastActivityAt: remote.lastActivityAt.map { Date(timeIntervalSince1970: $0) },
             hasUnread: remote.hasUnread ?? false,
             unreadCount: remote.unreadCount,
+            taskStatus: remote.taskStatus.flatMap(MobileWorkspaceTaskStatus.init(rawValue:)),
             terminals: remote.terminals.map { terminal in
                 MobileTerminalPreview(remote: terminal)
             },

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspacePreview.swift
@@ -91,6 +91,9 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
     /// badge shows). `nil` when connected to a Mac old enough not to emit it;
     /// the indicator then falls back to the plain dot.
     public var unreadCount: Int?
+    /// The Mac sidebar's inferred or manually overridden completion lane.
+    /// `nil` means status is hidden or unsupported by the Mac.
+    public var taskStatus: MobileWorkspaceTaskStatus?
     /// The terminals contained in the workspace, in display order.
     public var terminals: [MobileTerminalPreview]
     /// Every Mac-rendered surface, in the Mac workspace's spatial order.
@@ -158,6 +161,7 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
         lastActivityAt: Date? = nil,
         hasUnread: Bool = false,
         unreadCount: Int? = nil,
+        taskStatus: MobileWorkspaceTaskStatus? = nil,
         terminals: [MobileTerminalPreview],
         surfaces: [MobileSurfacePreview] = [],
         simulators: [MobileSimulatorPanelDescriptor] = []
@@ -179,6 +183,7 @@ public struct MobileWorkspacePreview: Identifiable, Equatable, Sendable {
         self.lastActivityAt = lastActivityAt
         self.hasUnread = hasUnread
         self.unreadCount = unreadCount
+        self.taskStatus = taskStatus
         self.terminals = terminals
         self.surfaces = surfaces
         self.simulators = simulators

--- a/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceTaskStatus.swift
+++ b/Packages/iOS/CmuxMobileShellModel/Sources/CmuxMobileShellModel/MobileWorkspaceTaskStatus.swift
@@ -1,0 +1,30 @@
+public import Foundation
+
+/// The completion lane reported by the Mac for a workspace.
+public enum MobileWorkspaceTaskStatus: String, Codable, CaseIterable, Sendable {
+    case todo
+    case working
+    case needsAttention = "needs-attention"
+    case review
+    case done
+
+    public var label: String {
+        switch self {
+        case .todo: "To Do"
+        case .working: "Working"
+        case .needsAttention: "Needs Attention"
+        case .review: "Review"
+        case .done: "Done"
+        }
+    }
+
+    public var systemImage: String {
+        switch self {
+        case .todo: "circle"
+        case .working: "circle.dotted"
+        case .needsAttention: "exclamationmark.circle.fill"
+        case .review: "eye.circle.fill"
+        case .done: "checkmark.circle.fill"
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspacePreview+Display.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspacePreview+Display.swift
@@ -82,6 +82,9 @@ extension MobileWorkspacePreview {
             parts.append(displayDescription)
         }
         parts.append(previewLine)
+        if let taskStatus {
+            parts.append(taskStatus.label)
+        }
         // A healthy connection contributes no status text anywhere, including VoiceOver.
         if connectionStatus != .connected {
             parts.append(connectionStatus.label)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceRow.swift
@@ -94,6 +94,12 @@ struct WorkspaceRow: View {
                         changesChipView(changesChip)
                     }
                 }
+                if let taskStatus = workspace.taskStatus {
+                    Label(taskStatus.label, systemImage: taskStatus.systemImage)
+                        .font(.caption)
+                        .foregroundStyle(taskStatus == .done ? .green : .secondary)
+                        .accessibilityIdentifier("MobileWorkspaceCompletionStatus-\(workspace.id.rawValue)")
+                }
             }
         }
         .overlay(alignment: .leading) {
@@ -118,6 +124,7 @@ struct WorkspaceRow: View {
             }
         }
         .contentShape(Rectangle())
+        .opacity(workspace.taskStatus == .done ? 0.6 : 1)
     }
 
     @ViewBuilder

--- a/Sources/TerminalController+MobileWorkspaceList.swift
+++ b/Sources/TerminalController+MobileWorkspaceList.swift
@@ -305,6 +305,11 @@ extension TerminalController {
             // Mac sidebar renders). Kept alongside has_unread so released phones
             // that only know the boolean keep working.
             "unread_count": unreadCount,
+            "task_status": v2OrNull(
+                WorkspaceTodoFeature.isEnabled && !workspace.todoState.statusHidden
+                    ? workspace.effectiveTaskStatus.rawValue
+                    : nil
+            ),
             "terminals": terminals,
             "surfaces": surfaces,
             "simulators": simulators


### PR DESCRIPTION
Surfaces the Mac workspace completion lane in iOS workspace rows.

- Adds additive task_status to workspace.list
- Decodes it into a shared mobile status model
- Shows labeled status and dims completed rows
- Includes status in VoiceOver summaries

Verification: swift test --package-path Packages/iOS/CmuxMobileShellModel --disable-sandbox

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11902"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791079076&installation_model_id=21920&pr_number=11902&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11902&signature=39c17d8f28dbed3711279fd597bd05c70bcded8bad5d9944ed011f10ddcfb5e4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Surfaces each workspace's Mac completion lane on iOS workspace rows: the Mac now emits `task_status` in the `workspace.list` payload, and iOS shows the status label and icon, dims done rows, and includes the status in VoiceOver summaries.

Older Macs, status-hidden workspaces, and workspaces with hidden completion state fall back to today's rows with no indicator.

<sup>Written for commit 6cfa5ef249acbcf498c2daf3c206855213353f7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11902?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added workspace task-status support across Mac and iOS.
  - Workspace rows now display status labels and icons for Todo, Working, Needs Attention, Review, and Done.
  - Completed workspaces appear visually subdued, with done statuses highlighted in green.
  - VoiceOver summaries now include task status when available.
  - Task status remains optional when unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->