### PR TITLE
Grant Pro automatically in local development

### DIFF
--- a/skills/cmux-billing/SKILL.md
+++ b/skills/cmux-billing/SKILL.md
@@ -22,7 +22,7 @@ Read before changing billing, pricing, Stripe, Pro entitlement, checkout, webhoo
 - Use `web/scripts/stripe/dev-stack.sh`.
 - Local `bun dev` accounts use the development Stack project and receive a
   non-persistent Pro entitlement automatically. This applies only when
-  `NODE_ENV=development`, `VERCEL_ENV` is unset, and
+  `CMUX_LOCAL_DEV_PRO=1`, `NODE_ENV=development`, `VERCEL_ENV` is unset, and
   `NEXT_PUBLIC_STACK_PROJECT_ID` is the development project. Release and
   preview deployments remain billing-backed. Use `dev-grant.sh` only when
   testing an explicit manual grant or a non-local deployment.

--- a/skills/cmux-billing/SKILL.md
+++ b/skills/cmux-billing/SKILL.md
@@ -20,6 +20,12 @@ Read before changing billing, pricing, Stripe, Pro entitlement, checkout, webhoo
 ## Dev workflow
 
 - Use `web/scripts/stripe/dev-stack.sh`.
+- Local `bun dev` accounts use the development Stack project and receive a
+  non-persistent Pro entitlement automatically. This applies only when
+  `NODE_ENV=development`, `VERCEL_ENV` is unset, and
+  `NEXT_PUBLIC_STACK_PROJECT_ID` is the development project. Release and
+  preview deployments remain billing-backed. Use `dev-grant.sh` only when
+  testing an explicit manual grant or a non-local deployment.
 - The tagged app bakes `CMUX_PORT` into `Info.plist`; run the dev server on the tag's printed port, never a hardcoded one.
 - Per-branch Docker Postgres ports collide with other agents' containers. Use `--db-port` and never stop containers you did not create.
 - `/app-pricing` requires `cmux_app=1`. `cmux_scheme` threads the native deeplink return scheme; `cmux-dev-*` schemes are honored only for localhost requests.

--- a/web/app/app-pricing/page.tsx
+++ b/web/app/app-pricing/page.tsx
@@ -3,7 +3,12 @@ import { NextRequest } from "next/server";
 import { redirect } from "next/navigation";
 import { getStackServerApp, isStackConfigured } from "../lib/stack";
 import { validatedNativeCallbackScheme } from "../lib/native-callback";
-import { FREE_PLAN_ID, resolveProPlanStatus } from "../../services/billing/pro";
+import {
+  FREE_PLAN_ID,
+  isDevelopmentProAccessEnabled,
+  PRO_PLAN_ID,
+  resolveProPlanStatus,
+} from "../../services/billing/pro";
 import enMessages from "../../messages/en.json";
 import {
   appPricingCheckoutURL,
@@ -189,11 +194,11 @@ export default async function AppPricingPage({
                 {snapshot.isPro ? (
                   <div className="space-y-2">
                     <DisabledButton>{pricing.currentPlan}</DisabledButton>
-                    {appStorePaymentGated ? null : (
+                    {snapshot.authenticated && !appStorePaymentGated ? (
                       <SecondaryLink href="/api/billing/portal">
                         {pricing.manageBilling}
                       </SecondaryLink>
-                    )}
+                    ) : null}
                   </div>
                 ) : appStorePaymentGated ? (
                   <DisabledButton>{pricing.billingUnavailable}</DisabledButton>
@@ -319,6 +324,7 @@ export default async function AppPricingPage({
 
 type AppPlanSnapshot = {
   authenticated: boolean;
+  developmentPro: boolean;
   planId: string;
   isPro: boolean;
   billingManagement: "stripe" | "none";
@@ -329,6 +335,7 @@ async function currentPlanSnapshot(): Promise<AppPlanSnapshot> {
   if (!isStackConfigured()) {
     return {
       authenticated: false,
+      developmentPro: false,
       planId: FREE_PLAN_ID,
       isPro: false,
       billingManagement: "none",
@@ -338,10 +345,24 @@ async function currentPlanSnapshot(): Promise<AppPlanSnapshot> {
 
   const user = await getStackServerApp().getUser({ or: ANONYMOUS_IF_EXISTS });
   if (!user) {
+    const developmentPro = isDevelopmentProAccessEnabled();
     return {
       authenticated: false,
-      planId: FREE_PLAN_ID,
-      isPro: false,
+      developmentPro,
+      planId: developmentPro ? PRO_PLAN_ID : FREE_PLAN_ID,
+      isPro: developmentPro,
+      billingManagement: "none",
+      email: null,
+    };
+  }
+
+  const developmentPro = user.isAnonymous && isDevelopmentProAccessEnabled();
+  if (developmentPro) {
+    return {
+      authenticated: false,
+      developmentPro: true,
+      planId: PRO_PLAN_ID,
+      isPro: true,
       billingManagement: "none",
       email: null,
     };
@@ -350,6 +371,7 @@ async function currentPlanSnapshot(): Promise<AppPlanSnapshot> {
   const status = await resolveProPlanStatus(user);
   return {
     authenticated: !user.isAnonymous,
+    developmentPro: false,
     planId: status.planId,
     isPro: status.isPro,
     billingManagement: status.billingManagement,
@@ -417,6 +439,9 @@ function appPricingBanner(
   }
   if (billing === "invalid_relay") {
     return { message: pricing.billingInvalidRelay };
+  }
+  if (snapshot.developmentPro) {
+    return null;
   }
   if (!snapshot.authenticated) {
     return {

--- a/web/app/app-pricing/page.tsx
+++ b/web/app/app-pricing/page.tsx
@@ -194,7 +194,7 @@ export default async function AppPricingPage({
                 {snapshot.isPro ? (
                   <div className="space-y-2">
                     <DisabledButton>{pricing.currentPlan}</DisabledButton>
-                    {snapshot.authenticated && !appStorePaymentGated ? (
+                    {snapshot.billingManagement === "stripe" && !appStorePaymentGated ? (
                       <SecondaryLink href="/api/billing/portal">
                         {pricing.manageBilling}
                       </SecondaryLink>

--- a/web/scripts/dev-local.sh
+++ b/web/scripts/dev-local.sh
@@ -142,6 +142,9 @@ cmux web dev
   CMUX_WEB_EXTRA_SECRET_ENV_FILE=${CMUX_WEB_EXTRA_SECRET_ENV_FILE:-}
 EOF
 
+# This explicit opt-in is consumed by the billing guard. It is set only by
+# this local development launcher, never by preview or production config.
+export CMUX_LOCAL_DEV_PRO=1
 next dev --port "$CMUX_PORT" &
 next_pid=$!
 

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -34,6 +34,21 @@ export const TEAM_PLAN_ID = "team";
 // Existing operator grants may still use `cmuxVmPlan: "founders"`.
 export const FOUNDERS_PLAN_ID = "founders";
 export const FREE_PLAN_ID = "free";
+/** Stack project used by the local cmux development server. */
+export const DEVELOPMENT_STACK_PROJECT_ID = "454ecd03-1db2-4050-845e-4ce5b0cd9895";
+
+/**
+ * Local development accounts are Pro by default. This is intentionally tied
+ * to both Next's development runtime and the non-production Stack project so
+ * a misconfigured preview or production process cannot grant access.
+ */
+export function isDevelopmentProAccessEnabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  return env.NODE_ENV === "development" &&
+    !env.VERCEL_ENV &&
+    env.NEXT_PUBLIC_STACK_PROJECT_ID === DEVELOPMENT_STACK_PROJECT_ID;
+}
 /**
  * Plan ids an operator may write to `clientReadOnlyMetadata.cmuxVmPlan` to
  * grant Pro without a Stripe subscription. Mirrors `isPaidVmPlan` in
@@ -103,6 +118,7 @@ export async function syncProPlanMetadata(
 
 export type ProReconcileUser = ProMetadataCustomer & {
   readonly id?: string;
+  readonly isAnonymous?: boolean;
 };
 
 export type ActiveStripeSubscriptionQuery = (stackUserId: string) => Promise<boolean>;
@@ -180,11 +196,23 @@ export async function resolveProPlanStatus(
     /** Optional state snapshot used by checkout and deterministic callers. */
     stripeBillingStatus?: StripeBillingStatus | StripeBillingStatusQuery;
     withFreshMetadataUser?: FreshProMetadataUserMutation;
+    /** Runtime environment override used by deterministic callers and tests. */
+    environment?: Record<string, string | undefined>;
   } = {},
 ): Promise<ProPlanStatus> {
   const metadata = proMetadataRecord(user.clientReadOnlyMetadata);
   const hasManualVmPlanOverride = hasManualVmOverride(metadata);
   const metadataPlanId = planIdFromMetadata(metadata);
+  if (!user.isAnonymous && isDevelopmentProAccessEnabled(options.environment)) {
+    return {
+      planId: PRO_PLAN_ID,
+      isPro: true,
+      billingManagement: "none",
+      metadataPlanId,
+      hasManualVmPlanOverride,
+      metadataChanged: false,
+    };
+  }
   const hasLegacyQueryOverrides = Boolean(
     options.hasActiveStripeSubscription || options.hasStripeCustomer,
   );

--- a/web/services/billing/pro.ts
+++ b/web/services/billing/pro.ts
@@ -39,13 +39,15 @@ export const DEVELOPMENT_STACK_PROJECT_ID = "454ecd03-1db2-4050-845e-4ce5b0cd989
 
 /**
  * Local development accounts are Pro by default. This is intentionally tied
- * to both Next's development runtime and the non-production Stack project so
- * a misconfigured preview or production process cannot grant access.
+ * to the local launcher, Next's development runtime, and the non-production
+ * Stack project so a misconfigured preview or production process cannot grant
+ * access.
  */
 export function isDevelopmentProAccessEnabled(
   env: Record<string, string | undefined> = process.env,
 ): boolean {
   return env.NODE_ENV === "development" &&
+    env.CMUX_LOCAL_DEV_PRO === "1" &&
     !env.VERCEL_ENV &&
     env.NEXT_PUBLIC_STACK_PROJECT_ID === DEVELOPMENT_STACK_PROJECT_ID;
 }

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -27,6 +27,10 @@ import {
   resolveBillingTeam,
   type BillingTeamLike,
 } from "../billing/teamResolution";
+import {
+  isDevelopmentProAccessEnabled,
+  PRO_PLAN_ID,
+} from "../billing/pro";
 
 export type AuthedUser = {
   id: string;
@@ -746,13 +750,20 @@ async function authedUserFromStackUser(
     selectedTeam,
     listTeams: async () => listedTeams,
   });
-  const userBillingPlanId = billingPlanIdFromMetadata(user.clientReadOnlyMetadata) ?? null;
-  const billingPlanId = billingPlanIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ?? userBillingPlanId;
+  const developmentPro = !user.isAnonymous && isDevelopmentProAccessEnabled();
+  const userBillingPlanId = developmentPro
+    ? PRO_PLAN_ID
+    : billingPlanIdFromMetadata(user.clientReadOnlyMetadata) ?? null;
+  const billingPlanId = developmentPro
+    ? PRO_PLAN_ID
+    : billingPlanIdFromMetadata(billingTeam?.clientReadOnlyMetadata) ?? userBillingPlanId;
   const billingSeats = billingSeatsFromMetadata(billingTeam?.clientReadOnlyMetadata);
   const authedTeams = teams.map((team) => ({
     id: team.id,
     displayName: team.displayName,
-    billingPlanId: billingPlanIdFromMetadata(team.clientReadOnlyMetadata),
+    billingPlanId: developmentPro
+      ? PRO_PLAN_ID
+      : billingPlanIdFromMetadata(team.clientReadOnlyMetadata),
     billingSeats: billingSeatsFromMetadata(team.clientReadOnlyMetadata),
   }));
 
@@ -850,6 +861,7 @@ function hasAccountDeletionMetadataFlag(metadata: unknown): boolean {
 
 type StackUserLike = {
   readonly id: string;
+  readonly isAnonymous?: boolean;
   readonly displayName: string | null;
   readonly primaryEmail: string | null;
   readonly clientReadOnlyMetadata?: unknown;

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -34,6 +34,7 @@ import {
 
 export type AuthedUser = {
   id: string;
+  isAnonymous?: boolean;
   displayName: string | null;
   primaryEmail: string | null;
   billingCustomerType: "team" | "user";
@@ -770,6 +771,7 @@ async function authedUserFromStackUser(
   return {
     user: {
       id: user.id,
+      isAnonymous: user.isAnonymous === true,
       displayName: user.displayName,
       primaryEmail: user.primaryEmail,
       billingCustomerType: billingTeam ? "team" : "user",

--- a/web/services/vms/entitlements.ts
+++ b/web/services/vms/entitlements.ts
@@ -55,7 +55,7 @@ export function resolveVmEntitlements(
   options: VmEntitlementOptions = {},
 ): VmEntitlements {
   const billing = resolveBillingContext(user, options);
-  if (isDevelopmentProAccessEnabled(env)) {
+  if (!user.isAnonymous && isDevelopmentProAccessEnabled(env)) {
     return {
       planId: PRO_PLAN_ID,
       billingCustomerType: billing.billingCustomerType,

--- a/web/services/vms/entitlements.ts
+++ b/web/services/vms/entitlements.ts
@@ -1,6 +1,11 @@
 import type { AuthedUser } from "./auth";
 import type { BillingCustomerType } from "./billingGateway";
-import { TEAM_PLAN_ID, isPaidPlanId } from "../billing/pro";
+import {
+  isDevelopmentProAccessEnabled,
+  PRO_PLAN_ID,
+  TEAM_PLAN_ID,
+  isPaidPlanId,
+} from "../billing/pro";
 import { PAID_MAX_ACTIVE_VMS_DEFAULT, PLAN_MACHINE_MEMORY_MB } from "./machineSpec";
 
 export {
@@ -50,6 +55,14 @@ export function resolveVmEntitlements(
   options: VmEntitlementOptions = {},
 ): VmEntitlements {
   const billing = resolveBillingContext(user, options);
+  if (isDevelopmentProAccessEnabled(env)) {
+    return {
+      planId: PRO_PLAN_ID,
+      billingCustomerType: billing.billingCustomerType,
+      billingTeamId: billing.billingTeamId,
+      maxActiveVms: maxActiveVmsForPlan(PRO_PLAN_ID, env, { seats: billing.billingSeats }),
+    };
+  }
   const configuredDefaultPlan = env.CMUX_VM_DEFAULT_PLAN;
   // A deployment-wide default is useful for local/demo fixtures, but it must
   // never grant a paid entitlement to an account with no billing metadata in

--- a/web/tests/billing-pro.test.ts
+++ b/web/tests/billing-pro.test.ts
@@ -170,8 +170,13 @@ describe("resolveProPlanStatus", () => {
   test("local development Stack accounts receive Pro without a billing grant", async () => {
     expect(isDevelopmentProAccessEnabled({
       NODE_ENV: "development",
+      CMUX_LOCAL_DEV_PRO: "1",
       NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
     })).toBe(true);
+    expect(isDevelopmentProAccessEnabled({
+      NODE_ENV: "development",
+      NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+    })).toBe(false);
     expect(isDevelopmentProAccessEnabled({
       NODE_ENV: "production",
       NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
@@ -185,6 +190,7 @@ describe("resolveProPlanStatus", () => {
     await expect(resolveProPlanStatus(user, {
       environment: {
         NODE_ENV: "development",
+        CMUX_LOCAL_DEV_PRO: "1",
         NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
       },
     })).resolves.toEqual({
@@ -199,6 +205,7 @@ describe("resolveProPlanStatus", () => {
     await expect(resolveProPlanStatus({ ...user, isAnonymous: true }, {
       environment: {
         NODE_ENV: "development",
+        CMUX_LOCAL_DEV_PRO: "1",
         NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
       },
       hasActiveStripeSubscription: async () => false,

--- a/web/tests/billing-pro.test.ts
+++ b/web/tests/billing-pro.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   FREE_PLAN_ID,
+  isDevelopmentProAccessEnabled,
   isTestflightEligible,
   PRO_PLAN_ID,
   reconcileProPlanMetadata,
@@ -166,6 +167,47 @@ describe("reconcileProPlanMetadata", () => {
 });
 
 describe("resolveProPlanStatus", () => {
+  test("local development Stack accounts receive Pro without a billing grant", async () => {
+    expect(isDevelopmentProAccessEnabled({
+      NODE_ENV: "development",
+      NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+    })).toBe(true);
+    expect(isDevelopmentProAccessEnabled({
+      NODE_ENV: "production",
+      NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+    })).toBe(false);
+    expect(isDevelopmentProAccessEnabled({
+      NODE_ENV: "development",
+      NEXT_PUBLIC_STACK_PROJECT_ID: "9790718f-14cd-4f7e-824d-eaf527a82b82",
+    })).toBe(false);
+
+    const user = metadataUser({}, "user-local-dev");
+    await expect(resolveProPlanStatus(user, {
+      environment: {
+        NODE_ENV: "development",
+        NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+      },
+    })).resolves.toEqual({
+      planId: PRO_PLAN_ID,
+      isPro: true,
+      billingManagement: "none",
+      metadataPlanId: null,
+      hasManualVmPlanOverride: false,
+      metadataChanged: false,
+    });
+
+    await expect(resolveProPlanStatus({ ...user, isAnonymous: true }, {
+      environment: {
+        NODE_ENV: "development",
+        NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+      },
+      hasActiveStripeSubscription: async () => false,
+    })).resolves.toMatchObject({
+      planId: FREE_PLAN_ID,
+      isPro: false,
+    });
+  });
+
   test("reloads metadata inside the account mutation lease before reconciling Pro", async () => {
     const staleUser = metadataUser({}, "user-racing-testflight");
     const freshUser = metadataUser({

--- a/web/tests/vm-pro-gate.test.ts
+++ b/web/tests/vm-pro-gate.test.ts
@@ -29,6 +29,7 @@ describe("Cloud VM Pro gate", () => {
       billingSeats: null,
     }, {
       NODE_ENV: "development",
+      CMUX_LOCAL_DEV_PRO: "1",
       NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
     });
     expect(entitlements.planId).toBe(PRO_PLAN_ID);

--- a/web/tests/vm-pro-gate.test.ts
+++ b/web/tests/vm-pro-gate.test.ts
@@ -6,12 +6,35 @@ import {
   isVmFreeProvisioningAllowed,
   isVmProGateBlocked,
   isVmProGateEnforced,
+  resolveVmEntitlements,
 } from "../services/vms/entitlements";
+import { PRO_PLAN_ID } from "../services/billing/pro";
 import { vmRequiresProResponse } from "../services/vms/routeHelpers";
 
 const ent = (planId: string) => ({ planId });
 
 describe("Cloud VM Pro gate", () => {
+  test("local development Stack accounts resolve to the paid plan", () => {
+    const entitlements = resolveVmEntitlements({
+      id: "local-dev-user",
+      displayName: null,
+      primaryEmail: "dev@example.com",
+      billingCustomerType: "user",
+      billingTeamId: "local-dev-user",
+      selectedTeamId: null,
+      teams: [],
+      teamIds: [],
+      userBillingPlanId: null,
+      billingPlanId: null,
+      billingSeats: null,
+    }, {
+      NODE_ENV: "development",
+      NEXT_PUBLIC_STACK_PROJECT_ID: "454ecd03-1db2-4050-845e-4ce5b0cd9895",
+    });
+    expect(entitlements.planId).toBe(PRO_PLAN_ID);
+    expect(entitlements.maxActiveVms).toBeGreaterThan(0);
+  });
+
   test("isPaidVmPlan recognizes pro, team, and founders, not free", () => {
     expect(isPaidVmPlan("pro")).toBe(true);
     expect(isPaidVmPlan("team")).toBe(true);


### PR DESCRIPTION
## Summary
- treat signed-in accounts on the local development Stack project as Pro
- apply the same development-only entitlement to Cloud VM APIs
- keep anonymous users, previews, releases, and production billing unchanged

## Tests
- bun test tests/billing-pro.test.ts tests/vm-pro-gate.test.ts
- bun run typecheck
- bunx eslint services/billing/pro.ts services/vms/auth.ts services/vms/entitlements.ts tests/billing-pro.test.ts tests/vm-pro-gate.test.ts

Regression and fix are separate commits.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11906"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791080601&installation_model_id=21920&pr_number=11906&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11906&signature=d63645ef83e15e391ae90176c8a86ac3929c718d599a962bef44cb93c8012890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grants Pro automatically to signed-in accounts on the local development Stack project, so local dev no longer needs a manual billing grant. Anonymous webview users in local dev now also see the Pro pricing page. Preview, release, and production billing are unchanged.

- Applies the grant only when `NODE_ENV=development`, `CMUX_LOCAL_DEV_PRO=1` (set only by the local dev launcher), `VERCEL_ENV` is unset, and `NEXT_PUBLIC_STACK_PROJECT_ID` points at the development project, so misconfigured preview or production processes cannot grant Pro.
- Extends the same development-only entitlement to Cloud VM plan resolution and VM entitlements, and hides the manage-billing link from anonymous users who receive the dev grant.

<sup>Written for commit 4f31ac4b9211f8a02b0f1058f4046959d04999b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Local development accounts can opt into Pro access when using the development environment.
  * The pricing page now displays eligible local development users as Pro without requiring authentication or billing setup.
  * Local development Pro access includes corresponding Pro VM entitlements.

* **Documentation**
  * Added guidance explaining when development Pro access is enabled and how to test manual billing grants.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->