### PR TITLE
fix(web): compare cron bearer secrets in constant time

### DIFF
--- a/web/app/api/analytics/events/route.ts
+++ b/web/app/api/analytics/events/route.ts
@@ -64,7 +64,7 @@ export function makeAnalyticsEventsHandler(dependencies: AnalyticsEventsDependen
     // fails open. Only genuine check failures reject the event.
     const rateLimitId = process.env.CMUX_ANALYTICS_RATE_LIMIT_ID?.trim();
     if (process.env.VERCEL === "1" && !rateLimitId) {
-      await reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "unset" });
+      void reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "unset" });
     }
     if (process.env.VERCEL === "1" && rateLimitId) {
       try {
@@ -73,7 +73,7 @@ export function makeAnalyticsEventsHandler(dependencies: AnalyticsEventsDependen
           return jsonResponse({ error: "rate_limited" }, 429);
         }
         if (error === "not-found") {
-          await reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "not-found" });
+          void reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "not-found" });
         } else if (error) {
           console.error("analytics.events.rate_limit_error", { failure: "check_error" });
           return jsonResponse({ error: "analytics_unavailable" }, 503);

--- a/web/app/api/analytics/events/route.ts
+++ b/web/app/api/analytics/events/route.ts
@@ -64,7 +64,7 @@ export function makeAnalyticsEventsHandler(dependencies: AnalyticsEventsDependen
     // fails open. Only genuine check failures reject the event.
     const rateLimitId = process.env.CMUX_ANALYTICS_RATE_LIMIT_ID?.trim();
     if (process.env.VERCEL === "1" && !rateLimitId) {
-      reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "unset" });
+      await reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "unset" });
     }
     if (process.env.VERCEL === "1" && rateLimitId) {
       try {
@@ -73,7 +73,7 @@ export function makeAnalyticsEventsHandler(dependencies: AnalyticsEventsDependen
           return jsonResponse({ error: "rate_limited" }, 429);
         }
         if (error === "not-found") {
-          reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "not-found" });
+          await reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "not-found" });
         } else if (error) {
           console.error("analytics.events.rate_limit_error", { failure: "check_error" });
           return jsonResponse({ error: "analytics_unavailable" }, 503);

--- a/web/app/api/analytics/events/route.ts
+++ b/web/app/api/analytics/events/route.ts
@@ -14,6 +14,7 @@ import { checkRateLimit as checkVercelRateLimit } from "@vercel/firewall";
 import { createHash } from "node:crypto";
 import { verifyRequest } from "../../../../services/vms/auth";
 import { readBoundedJsonObject } from "../../../../services/apns/routePolicy";
+import { reportMissingRateLimitRule } from "../../../../services/rateLimitObservability";
 import { cloudDb } from "../../../../db/client";
 import {
   hasBlockingAccountDeletionIdentity,
@@ -62,6 +63,9 @@ export function makeAnalyticsEventsHandler(dependencies: AnalyticsEventsDependen
     // An unset rule id means no rate limiting; a deleted rule (not-found)
     // fails open. Only genuine check failures reject the event.
     const rateLimitId = process.env.CMUX_ANALYTICS_RATE_LIMIT_ID?.trim();
+    if (process.env.VERCEL === "1" && !rateLimitId) {
+      reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "unset" });
+    }
     if (process.env.VERCEL === "1" && rateLimitId) {
       try {
         const { error, rateLimited } = await dependencies.checkRateLimit(rateLimitId, { request });
@@ -69,7 +73,7 @@ export function makeAnalyticsEventsHandler(dependencies: AnalyticsEventsDependen
           return jsonResponse({ error: "rate_limited" }, 429);
         }
         if (error === "not-found") {
-          console.warn("analytics.events.rate_limit_not_found; failing open", rateLimitId);
+          reportMissingRateLimitRule({ route: "/api/analytics/events", reason: "not-found" });
         } else if (error) {
           console.error("analytics.events.rate_limit_error", { failure: "check_error" });
           return jsonResponse({ error: "analytics_unavailable" }, 503);

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 
 import "../../env";
 import { readBoundedJsonObject } from "../../../services/apns/routePolicy";
+import { reportMissingRateLimitRule } from "../../../services/rateLimitObservability";
 import {
   CLIENT_CONFIG_FLAGS_TIMEOUT_MS,
   MAX_CLIENT_CONFIG_REQUEST_BYTES,
@@ -19,6 +20,9 @@ export async function POST(request: Request): Promise<Response> {
   // An unset rule id means no rate limiting; a deleted rule (not-found) fails
   // open rather than making client config unavailable for every app boot.
   const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();
+  if (process.env.VERCEL === "1" && !rateLimitId) {
+    reportMissingRateLimitRule({ route: "/api/client-config", reason: "unset" });
+  }
   if (process.env.VERCEL === "1" && rateLimitId) {
     try {
       const { error, rateLimited } = await checkRateLimit(rateLimitId, { request });
@@ -26,7 +30,7 @@ export async function POST(request: Request): Promise<Response> {
         return json({ error: "rate_limited" }, 429);
       }
       if (error === "not-found") {
-        console.warn("client-config.route.rate_limit_not_found; failing open", rateLimitId);
+        reportMissingRateLimitRule({ route: "/api/client-config", reason: "not-found" });
       } else if (error) {
         console.error("client-config.route.rate_limit_error", { failure: "check_error" });
         return json({ error: "client_config_unavailable" }, 503);

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request): Promise<Response> {
   // open rather than making client config unavailable for every app boot.
   const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();
   if (process.env.VERCEL === "1" && !rateLimitId) {
-    reportMissingRateLimitRule({ route: "/api/client-config", reason: "unset" });
+    await reportMissingRateLimitRule({ route: "/api/client-config", reason: "unset" });
   }
   if (process.env.VERCEL === "1" && rateLimitId) {
     try {
@@ -30,7 +30,7 @@ export async function POST(request: Request): Promise<Response> {
         return json({ error: "rate_limited" }, 429);
       }
       if (error === "not-found") {
-        reportMissingRateLimitRule({ route: "/api/client-config", reason: "not-found" });
+        await reportMissingRateLimitRule({ route: "/api/client-config", reason: "not-found" });
       } else if (error) {
         console.error("client-config.route.rate_limit_error", { failure: "check_error" });
         return json({ error: "client_config_unavailable" }, 503);

--- a/web/app/api/client-config/route.ts
+++ b/web/app/api/client-config/route.ts
@@ -21,7 +21,7 @@ export async function POST(request: Request): Promise<Response> {
   // open rather than making client config unavailable for every app boot.
   const rateLimitId = process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID?.trim();
   if (process.env.VERCEL === "1" && !rateLimitId) {
-    await reportMissingRateLimitRule({ route: "/api/client-config", reason: "unset" });
+    void reportMissingRateLimitRule({ route: "/api/client-config", reason: "unset" });
   }
   if (process.env.VERCEL === "1" && rateLimitId) {
     try {
@@ -30,7 +30,7 @@ export async function POST(request: Request): Promise<Response> {
         return json({ error: "rate_limited" }, 429);
       }
       if (error === "not-found") {
-        await reportMissingRateLimitRule({ route: "/api/client-config", reason: "not-found" });
+        void reportMissingRateLimitRule({ route: "/api/client-config", reason: "not-found" });
       } else if (error) {
         console.error("client-config.route.rate_limit_error", { failure: "check_error" });
         return json({ error: "client_config_unavailable" }, 503);

--- a/web/app/api/cron/billing-reconcile/route.ts
+++ b/web/app/api/cron/billing-reconcile/route.ts
@@ -1,11 +1,11 @@
+import { authorizeCronRequest } from "../../../../services/cronAuth";
 import { reconcileStripeSubscriptions } from "../../../../services/billing/reconcile";
 import { captureCoderouterError } from "../../../../services/errors";
 
 export const maxDuration = 60;
 
 export async function GET(request: Request): Promise<Response> {
-  const secret = process.env.CRON_SECRET?.trim();
-  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+  if (!authorizeCronRequest(request).ok) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
 

--- a/web/app/api/cron/indexnow/route.ts
+++ b/web/app/api/cron/indexnow/route.ts
@@ -1,13 +1,10 @@
+import { authorizeCronRequest } from "../../../../services/cronAuth";
 import { recentlyModifiedUrls, submitIndexNowUrls } from "../../../lib/indexnow";
 import sitemap from "../../../sitemap";
 
 
 export async function POST(request: Request): Promise<Response> {
-  const triggerSecret = process.env.CRON_SECRET?.trim();
-  if (
-    !triggerSecret ||
-    request.headers.get("authorization") !== `Bearer ${triggerSecret}`
-  ) {
+  if (!authorizeCronRequest(request).ok) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
 

--- a/web/app/api/cron/vm-alerts/route.ts
+++ b/web/app/api/cron/vm-alerts/route.ts
@@ -1,15 +1,14 @@
+import { authorizeCronRequest } from "../../../../services/cronAuth";
 import { runVmAlertChecks } from "../../../../services/observability/vmAlerts";
 import { jsonResponse } from "../../../../services/vms/routeHelpers";
 
 
 export async function GET(request: Request): Promise<Response> {
-  const cronSecret = process.env.CRON_SECRET?.trim();
-  if (!cronSecret) {
+  const auth = authorizeCronRequest(request);
+  if (!auth.ok && auth.reason === "cron_secret_missing") {
     return jsonResponse({ error: "cron_not_configured" }, 503);
   }
-
-  const expected = `Bearer ${cronSecret}`;
-  if (request.headers.get("authorization") !== expected) {
+  if (!auth.ok) {
     return jsonResponse({ error: "unauthorized" }, 401);
   }
 

--- a/web/app/api/cron/vm-reaper/route.ts
+++ b/web/app/api/cron/vm-reaper/route.ts
@@ -1,3 +1,4 @@
+import { authorizeCronRequest } from "../../../../services/cronAuth";
 import { captureVmReaperSummary } from "../../../../services/vms/observability";
 import { reapVmResources } from "../../../../services/vms/reaper";
 import { runVmWorkflow } from "../../../../services/vms/workflows";
@@ -7,8 +8,7 @@ import { runVmWorkflow } from "../../../../services/vms/workflows";
 export const maxDuration = 300;
 
 export async function GET(request: Request): Promise<Response> {
-  const secret = process.env.CRON_SECRET;
-  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+  if (!authorizeCronRequest(request).ok) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
 

--- a/web/app/api/cron/vm-reconcile/route.ts
+++ b/web/app/api/cron/vm-reconcile/route.ts
@@ -1,3 +1,4 @@
+import { authorizeCronRequest } from "../../../../services/cronAuth";
 import { vmModelPlaneRevoker } from "../../../../services/vms/modelPlaneGateway";
 import {
   reconcileVmProviderStatuses,
@@ -6,8 +7,7 @@ import {
 
 
 export async function GET(request: Request): Promise<Response> {
-  const secret = process.env.CRON_SECRET;
-  if (!secret || request.headers.get("authorization") !== `Bearer ${secret}`) {
+  if (!authorizeCronRequest(request).ok) {
     return Response.json({ error: "unauthorized" }, { status: 401 });
   }
 

--- a/web/app/api/enterprise/contact/route.ts
+++ b/web/app/api/enterprise/contact/route.ts
@@ -8,6 +8,7 @@ import {
   POSTHOG_HOST,
   POSTHOG_PROJECT_KEY,
 } from "../../../../services/analytics/iosEventPolicy";
+import { reportMissingRateLimitRule } from "../../../../services/rateLimitObservability";
 import {
   recordSpanError,
   setSpanAttributes,
@@ -49,6 +50,9 @@ export async function POST(request: Request) {
         return jsonError("Enterprise contact endpoint is not configured", 503);
       }
 
+      if (process.env.VERCEL === "1" && !config.rateLimitId) {
+        reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "unset" });
+      }
       if (process.env.VERCEL === "1" && config.rateLimitId) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
         try {
@@ -69,10 +73,7 @@ export async function POST(request: Request) {
           return jsonError("Rate limit exceeded", 429);
         }
         if (error === "not-found") {
-          console.error(
-            "enterprise.contact.rate_limit_not_found",
-            config.rateLimitId,
-          );
+          reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "not-found" });
         } else if (error) {
           console.error("enterprise.contact.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/enterprise/contact/route.ts
+++ b/web/app/api/enterprise/contact/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
       }
 
       if (process.env.VERCEL === "1" && !config.rateLimitId) {
-        await reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "unset" });
+        void reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && config.rateLimitId) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -73,7 +73,7 @@ export async function POST(request: Request) {
           return jsonError("Rate limit exceeded", 429);
         }
         if (error === "not-found") {
-          await reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "not-found" });
+          void reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "not-found" });
         } else if (error) {
           console.error("enterprise.contact.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/enterprise/contact/route.ts
+++ b/web/app/api/enterprise/contact/route.ts
@@ -51,7 +51,7 @@ export async function POST(request: Request) {
       }
 
       if (process.env.VERCEL === "1" && !config.rateLimitId) {
-        reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "unset" });
+        await reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && config.rateLimitId) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -73,7 +73,7 @@ export async function POST(request: Request) {
           return jsonError("Rate limit exceeded", 429);
         }
         if (error === "not-found") {
-          reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "not-found" });
+          await reportMissingRateLimitRule({ route: "/api/enterprise/contact", reason: "not-found" });
         } else if (error) {
           console.error("enterprise.contact.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/feedback/route.ts
+++ b/web/app/api/feedback/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
 
       if (process.env.VERCEL === "1") {
         if (!feedbackConfig.rateLimitId) {
-          await reportMissingRateLimitRule({ route: "/api/feedback", reason: "unset" });
+          void reportMissingRateLimitRule({ route: "/api/feedback", reason: "unset" });
         }
       }
       if (process.env.VERCEL === "1" && feedbackConfig.rateLimitId) {
@@ -87,7 +87,7 @@ export async function POST(request: Request) {
         if (error === "not-found") {
           // The rule was deleted; treat as "no limit" instead of taking the
           // endpoint down.
-          await reportMissingRateLimitRule({ route: "/api/feedback", reason: "not-found" });
+          void reportMissingRateLimitRule({ route: "/api/feedback", reason: "not-found" });
         } else if (error) {
           console.error("feedback.route.rate_limit_error", error);
           return jsonError("service_unavailable", 503);

--- a/web/app/api/feedback/route.ts
+++ b/web/app/api/feedback/route.ts
@@ -4,6 +4,7 @@ import { Resend } from "resend";
 import { z } from "zod";
 
 import { env } from "@/app/env";
+import { reportMissingRateLimitRule } from "../../../services/rateLimitObservability";
 import { recordSpanError, setSpanAttributes, withApiRouteSpan } from "../../../services/telemetry";
 
 
@@ -61,6 +62,11 @@ export async function POST(request: Request) {
         return jsonError("Feedback endpoint is not configured", 503);
       }
 
+      if (process.env.VERCEL === "1") {
+        if (!feedbackConfig.rateLimitId) {
+          reportMissingRateLimitRule({ route: "/api/feedback", reason: "unset" });
+        }
+      }
       if (process.env.VERCEL === "1" && feedbackConfig.rateLimitId) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
         try {
@@ -81,10 +87,7 @@ export async function POST(request: Request) {
         if (error === "not-found") {
           // The rule was deleted; treat as "no limit" instead of taking the
           // endpoint down.
-          console.warn(
-            "feedback.route.rate_limit_not_found; failing open",
-            feedbackConfig.rateLimitId,
-          );
+          reportMissingRateLimitRule({ route: "/api/feedback", reason: "not-found" });
         } else if (error) {
           console.error("feedback.route.rate_limit_error", error);
           return jsonError("service_unavailable", 503);

--- a/web/app/api/feedback/route.ts
+++ b/web/app/api/feedback/route.ts
@@ -64,7 +64,7 @@ export async function POST(request: Request) {
 
       if (process.env.VERCEL === "1") {
         if (!feedbackConfig.rateLimitId) {
-          reportMissingRateLimitRule({ route: "/api/feedback", reason: "unset" });
+          await reportMissingRateLimitRule({ route: "/api/feedback", reason: "unset" });
         }
       }
       if (process.env.VERCEL === "1" && feedbackConfig.rateLimitId) {
@@ -87,7 +87,7 @@ export async function POST(request: Request) {
         if (error === "not-found") {
           // The rule was deleted; treat as "no limit" instead of taking the
           // endpoint down.
-          reportMissingRateLimitRule({ route: "/api/feedback", reason: "not-found" });
+          await reportMissingRateLimitRule({ route: "/api/feedback", reason: "not-found" });
         } else if (error) {
           console.error("feedback.route.rate_limit_error", error);
           return jsonError("service_unavailable", 503);

--- a/web/app/api/internal/iroh/retention/route.ts
+++ b/web/app/api/internal/iroh/retention/route.ts
@@ -1,4 +1,3 @@
-import { timingSafeEqual } from "node:crypto";
 import * as Effect from "effect/Effect";
 import {
   IROH_RETENTION_MAX_DURATION_MS,
@@ -7,6 +6,7 @@ import {
   IrohRepositoryLive,
 } from "../../../../../services/iroh/repository";
 import { jsonResponse } from "../../../../../services/vms/routeHelpers";
+import { authorizeCronRequest } from "../../../../../services/cronAuth";
 
 
 export async function GET(request: Request): Promise<Response> {
@@ -18,15 +18,11 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 async function handle(request: Request): Promise<Response> {
-  const secret = process.env.CRON_SECRET?.trim();
-  if (!secret) return jsonResponse({ error: "service_unavailable" }, 503);
-  const authorization = request.headers.get("authorization")?.trim() ?? "";
-  const token = authorization.toLowerCase().startsWith("bearer ")
-    ? authorization.slice("bearer ".length).trim()
-    : "";
-  const tokenBytes = Buffer.from(token);
-  const secretBytes = Buffer.from(secret);
-  if (tokenBytes.length !== secretBytes.length || !timingSafeEqual(tokenBytes, secretBytes)) {
+  const auth = authorizeCronRequest(request);
+  if (!auth.ok && auth.reason === "cron_secret_missing") {
+    return jsonResponse({ error: "service_unavailable" }, 503);
+  }
+  if (!auth.ok) {
     return jsonResponse({ error: "unauthorized" }, 401);
   }
 

--- a/web/app/api/internal/vm/leases/revoke-expired/route.ts
+++ b/web/app/api/internal/vm/leases/revoke-expired/route.ts
@@ -1,6 +1,6 @@
-import { timingSafeEqual } from "node:crypto";
 import { jsonResponse } from "@/services/vms/routeHelpers";
 import { revokeExpiredIdentityLeases, runVmWorkflow } from "@/services/vms/workflows";
+import { authorizeCronRequest } from "@/services/cronAuth";
 
 
 export async function GET(request: Request): Promise<Response> {
@@ -12,22 +12,12 @@ export async function POST(request: Request): Promise<Response> {
 }
 
 async function handle(request: Request): Promise<Response> {
-  const secret = process.env.CRON_SECRET?.trim();
-  if (!secret) {
+  const auth = authorizeCronRequest(request);
+  if (!auth.ok && auth.reason === "cron_secret_missing") {
     console.error("vm.leases.revoke_expired.cron_secret_missing");
     return jsonResponse({ error: "service_unavailable" }, 503);
   }
-
-  const authorization = request.headers.get("authorization")?.trim() ?? "";
-  const token = authorization.toLowerCase().startsWith("bearer ")
-    ? authorization.slice("bearer ".length).trim()
-    : "";
-  const tokenBuffer = Buffer.from(token);
-  const secretBuffer = Buffer.from(secret);
-  const tokenMatches =
-    tokenBuffer.length === secretBuffer.length &&
-    timingSafeEqual(tokenBuffer, secretBuffer);
-  if (!tokenMatches) {
+  if (!auth.ok) {
     return jsonResponse({ error: "unauthorized" }, 401);
   }
 

--- a/web/app/api/support/contact/route.ts
+++ b/web/app/api/support/contact/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
       }
 
       if (process.env.VERCEL === "1" && !config.rateLimitId) {
-        reportMissingRateLimitRule({ route: "/api/support/contact", reason: "unset" });
+        await reportMissingRateLimitRule({ route: "/api/support/contact", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && config.rateLimitId) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -66,7 +66,7 @@ export async function POST(request: Request) {
           return jsonError("Rate limit exceeded", 429);
         }
         if (error === "not-found") {
-          reportMissingRateLimitRule({ route: "/api/support/contact", reason: "not-found" });
+          await reportMissingRateLimitRule({ route: "/api/support/contact", reason: "not-found" });
         } else if (error) {
           console.error("support.contact.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/support/contact/route.ts
+++ b/web/app/api/support/contact/route.ts
@@ -44,7 +44,7 @@ export async function POST(request: Request) {
       }
 
       if (process.env.VERCEL === "1" && !config.rateLimitId) {
-        await reportMissingRateLimitRule({ route: "/api/support/contact", reason: "unset" });
+        void reportMissingRateLimitRule({ route: "/api/support/contact", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && config.rateLimitId) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -66,7 +66,7 @@ export async function POST(request: Request) {
           return jsonError("Rate limit exceeded", 429);
         }
         if (error === "not-found") {
-          await reportMissingRateLimitRule({ route: "/api/support/contact", reason: "not-found" });
+          void reportMissingRateLimitRule({ route: "/api/support/contact", reason: "not-found" });
         } else if (error) {
           console.error("support.contact.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/support/contact/route.ts
+++ b/web/app/api/support/contact/route.ts
@@ -13,6 +13,7 @@ import {
   setSpanAttributes,
   withApiRouteSpan,
 } from "../../../../services/telemetry";
+import { reportMissingRateLimitRule } from "../../../../services/rateLimitObservability";
 import { checkEmailDeliverable } from "../../waitlist/email-check";
 
 
@@ -42,6 +43,9 @@ export async function POST(request: Request) {
         return jsonError("Support contact endpoint is not configured", 503);
       }
 
+      if (process.env.VERCEL === "1" && !config.rateLimitId) {
+        reportMissingRateLimitRule({ route: "/api/support/contact", reason: "unset" });
+      }
       if (process.env.VERCEL === "1" && config.rateLimitId) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
         try {
@@ -62,10 +66,7 @@ export async function POST(request: Request) {
           return jsonError("Rate limit exceeded", 429);
         }
         if (error === "not-found") {
-          console.error(
-            "support.contact.rate_limit_not_found",
-            config.rateLimitId,
-          );
+          reportMissingRateLimitRule({ route: "/api/support/contact", reason: "not-found" });
         } else if (error) {
           console.error("support.contact.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/vault/cli/auth/start/route.ts
+++ b/web/app/api/vault/cli/auth/start/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: Request): Promise<Response> {
       // Per-IP throttle through the platform firewall, same pattern as the other
       // public POST endpoints (waitlist, feedback). Only active on Vercel.
       if (process.env.VERCEL === "1" && !env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
-        reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "unset" });
+        await reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -52,7 +52,7 @@ export async function POST(request: Request): Promise<Response> {
           return jsonResponse({ error: "throttled" }, 429);
         }
         if (error === "not-found") {
-          reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "not-found" });
+          await reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "not-found" });
         } else if (error) {
           console.error("vault.cli_auth.start.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/vault/cli/auth/start/route.ts
+++ b/web/app/api/vault/cli/auth/start/route.ts
@@ -7,6 +7,7 @@ import { vaultCliAuthRequests } from "../../../../../../db/schema";
 import { withCliAuthApiRoute } from "../../../../../../services/vault/routeHelpers";
 import { readVaultJsonObject } from "../../../../../../services/vault/validation";
 import { setSpanAttributes } from "../../../../../../services/telemetry";
+import { reportMissingRateLimitRule } from "../../../../../../services/rateLimitObservability";
 import { jsonResponse } from "../../../../../../services/vms/routeHelpers";
 
 
@@ -28,6 +29,9 @@ export async function POST(request: Request): Promise<Response> {
     async ({ span }) => {
       // Per-IP throttle through the platform firewall, same pattern as the other
       // public POST endpoints (waitlist, feedback). Only active on Vercel.
+      if (process.env.VERCEL === "1" && !env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
+        reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "unset" });
+      }
       if (process.env.VERCEL === "1" && env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
         try {
@@ -48,10 +52,7 @@ export async function POST(request: Request): Promise<Response> {
           return jsonResponse({ error: "throttled" }, 429);
         }
         if (error === "not-found") {
-          console.warn(
-            "vault.cli_auth.start.rate_limit_not_found; failing open",
-            env.CMUX_FEEDBACK_RATE_LIMIT_ID,
-          );
+          reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "not-found" });
         } else if (error) {
           console.error("vault.cli_auth.start.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/vault/cli/auth/start/route.ts
+++ b/web/app/api/vault/cli/auth/start/route.ts
@@ -30,7 +30,7 @@ export async function POST(request: Request): Promise<Response> {
       // Per-IP throttle through the platform firewall, same pattern as the other
       // public POST endpoints (waitlist, feedback). Only active on Vercel.
       if (process.env.VERCEL === "1" && !env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
-        await reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "unset" });
+        void reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -52,7 +52,7 @@ export async function POST(request: Request): Promise<Response> {
           return jsonResponse({ error: "throttled" }, 429);
         }
         if (error === "not-found") {
-          await reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "not-found" });
+          void reportMissingRateLimitRule({ route: "/api/vault/cli/auth/start", reason: "not-found" });
         } else if (error) {
           console.error("vault.cli_auth.start.rate_limit_error", {
             failure: "check_error",

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
       // public POST flood the resolver as well as Slack. Reuses the feedback
       // rule. Only active on Vercel.
       if (process.env.VERCEL === "1" && !env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
-        reportMissingRateLimitRule({ route: "/api/waitlist", reason: "unset" });
+        await reportMissingRateLimitRule({ route: "/api/waitlist", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -79,7 +79,7 @@ export async function POST(request: Request) {
         if (error === "not-found") {
           // The rule was deleted; treat as "no limit" instead of taking the
           // endpoint down.
-          reportMissingRateLimitRule({ route: "/api/waitlist", reason: "not-found" });
+          await reportMissingRateLimitRule({ route: "/api/waitlist", reason: "not-found" });
         } else if (error) {
           console.error("waitlist.route.rate_limit_error", error);
           return jsonError("service_unavailable", 503);

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 
 import { env } from "@/app/env";
+import { reportMissingRateLimitRule } from "../../../services/rateLimitObservability";
 import {
   recordSpanError,
   setSpanAttributes,
@@ -53,6 +54,9 @@ export async function POST(request: Request) {
       // and unique domains miss the cache, so an unthrottled path would let a
       // public POST flood the resolver as well as Slack. Reuses the feedback
       // rule. Only active on Vercel.
+      if (process.env.VERCEL === "1" && !env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
+        reportMissingRateLimitRule({ route: "/api/waitlist", reason: "unset" });
+      }
       if (process.env.VERCEL === "1" && env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
         try {
@@ -75,7 +79,7 @@ export async function POST(request: Request) {
         if (error === "not-found") {
           // The rule was deleted; treat as "no limit" instead of taking the
           // endpoint down.
-          console.warn("waitlist.route.rate_limit_not_found; failing open", env.CMUX_FEEDBACK_RATE_LIMIT_ID);
+          reportMissingRateLimitRule({ route: "/api/waitlist", reason: "not-found" });
         } else if (error) {
           console.error("waitlist.route.rate_limit_error", error);
           return jsonError("service_unavailable", 503);

--- a/web/app/api/waitlist/route.ts
+++ b/web/app/api/waitlist/route.ts
@@ -55,7 +55,7 @@ export async function POST(request: Request) {
       // public POST flood the resolver as well as Slack. Reuses the feedback
       // rule. Only active on Vercel.
       if (process.env.VERCEL === "1" && !env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
-        await reportMissingRateLimitRule({ route: "/api/waitlist", reason: "unset" });
+        void reportMissingRateLimitRule({ route: "/api/waitlist", reason: "unset" });
       }
       if (process.env.VERCEL === "1" && env.CMUX_FEEDBACK_RATE_LIMIT_ID) {
         let result: Awaited<ReturnType<typeof checkRateLimit>>;
@@ -79,7 +79,7 @@ export async function POST(request: Request) {
         if (error === "not-found") {
           // The rule was deleted; treat as "no limit" instead of taking the
           // endpoint down.
-          await reportMissingRateLimitRule({ route: "/api/waitlist", reason: "not-found" });
+          void reportMissingRateLimitRule({ route: "/api/waitlist", reason: "not-found" });
         } else if (error) {
           console.error("waitlist.route.rate_limit_error", error);
           return jsonError("service_unavailable", 503);

--- a/web/db/migrations/20260904010000_rate_limit_alert_reports/migration.sql
+++ b/web/db/migrations/20260904010000_rate_limit_alert_reports/migration.sql
@@ -1,0 +1,4 @@
+CREATE TABLE "rate_limit_alert_reports" (
+  "alert_key" text PRIMARY KEY NOT NULL,
+  "reported_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/web/db/schema.ts
+++ b/web/db/schema.ts
@@ -1865,3 +1865,9 @@ export const stackIdentitySnapshots = pgTable(
     index("stack_identity_snapshots_refreshed_idx").on(table.refreshedAt),
   ],
 );
+
+/** Fleet-wide dedupe ledger for operator alerts on missing rate limits. */
+export const rateLimitAlertReports = pgTable("rate_limit_alert_reports", {
+  alertKey: text("alert_key").primaryKey(),
+  reportedAt: timestamp("reported_at", { withTimezone: true }).notNull().defaultNow(),
+});

--- a/web/services/cronAuth.ts
+++ b/web/services/cronAuth.ts
@@ -1,0 +1,34 @@
+import { timingSafeEqual } from "node:crypto";
+
+/**
+ * Shared authentication for cron-triggered routes (Vercel Cron and any
+ * operator-driven caller): a `Authorization: Bearer <CRON_SECRET>` header,
+ * compared in constant time.
+ *
+ * Every cron route is publicly reachable; the secret is the only gate, so the
+ * comparison must not leak it through timing the way a plain string `!==` on
+ * the header does. The result names the failure instead of building a
+ * Response, because routes deliberately differ in how they answer a missing
+ * `CRON_SECRET` (401 vs 503); both are fail-closed.
+ */
+export type CronAuthResult =
+  | { readonly ok: true }
+  | {
+    readonly ok: false;
+    readonly reason: "cron_secret_missing" | "unauthorized";
+  };
+
+export function authorizeCronRequest(request: Request): CronAuthResult {
+  const secret = process.env.CRON_SECRET?.trim();
+  if (!secret) return { ok: false, reason: "cron_secret_missing" };
+  const authorization = request.headers.get("authorization")?.trim() ?? "";
+  const token = authorization.toLowerCase().startsWith("bearer ")
+    ? authorization.slice("bearer ".length).trim()
+    : "";
+  const tokenBytes = Buffer.from(token);
+  const secretBytes = Buffer.from(secret);
+  const matches =
+    tokenBytes.length === secretBytes.length &&
+    timingSafeEqual(tokenBytes, secretBytes);
+  return matches ? { ok: true } : { ok: false, reason: "unauthorized" };
+}

--- a/web/services/nativeIngressRateLimit.ts
+++ b/web/services/nativeIngressRateLimit.ts
@@ -32,7 +32,7 @@ export async function enforceNativeIngressRateLimit(input: {
   if (!(input.isVercel ?? process.env.VERCEL === "1")) return null;
   const ruleId = input.ruleId?.trim();
   if (!ruleId) {
-    reportMissingRateLimitRule({ route: input.route, reason: "unset" });
+    await reportMissingRateLimitRule({ route: input.route, reason: "unset" });
     return null;
   }
 
@@ -62,7 +62,7 @@ export async function enforceNativeIngressRateLimit(input: {
     );
   }
   if (result.error === "not-found") {
-    reportMissingRateLimitRule({ route: input.route, reason: "not-found" });
+    await reportMissingRateLimitRule({ route: input.route, reason: "not-found" });
     return null;
   }
   if (result.error) {

--- a/web/services/nativeIngressRateLimit.ts
+++ b/web/services/nativeIngressRateLimit.ts
@@ -32,7 +32,7 @@ export async function enforceNativeIngressRateLimit(input: {
   if (!(input.isVercel ?? process.env.VERCEL === "1")) return null;
   const ruleId = input.ruleId?.trim();
   if (!ruleId) {
-    await reportMissingRateLimitRule({ route: input.route, reason: "unset" });
+    void reportMissingRateLimitRule({ route: input.route, reason: "unset" });
     return null;
   }
 
@@ -62,7 +62,7 @@ export async function enforceNativeIngressRateLimit(input: {
     );
   }
   if (result.error === "not-found") {
-    await reportMissingRateLimitRule({ route: input.route, reason: "not-found" });
+    void reportMissingRateLimitRule({ route: input.route, reason: "not-found" });
     return null;
   }
   if (result.error) {

--- a/web/services/nativeIngressRateLimit.ts
+++ b/web/services/nativeIngressRateLimit.ts
@@ -1,5 +1,6 @@
 import { checkRateLimit } from "@vercel/firewall";
 import { jsonResponse } from "./vms/routeHelpers";
+import { reportMissingRateLimitRule } from "./rateLimitObservability";
 
 /**
  * How long a throttled native client is told to wait. Long enough that an
@@ -30,7 +31,10 @@ export async function enforceNativeIngressRateLimit(input: {
 }): Promise<Response | null> {
   if (!(input.isVercel ?? process.env.VERCEL === "1")) return null;
   const ruleId = input.ruleId?.trim();
-  if (!ruleId) return null;
+  if (!ruleId) {
+    reportMissingRateLimitRule({ route: input.route, reason: "unset" });
+    return null;
+  }
 
   let result: { rateLimited: boolean; error?: string | null };
   try {
@@ -58,9 +62,7 @@ export async function enforceNativeIngressRateLimit(input: {
     );
   }
   if (result.error === "not-found") {
-    console.warn("native ingress rate-limit rule not found; failing open", {
-      route: input.route,
-    });
+    reportMissingRateLimitRule({ route: input.route, reason: "not-found" });
     return null;
   }
   if (result.error) {

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -1,0 +1,33 @@
+import { reportError } from "./observability/report";
+
+/**
+ * Report a Vercel firewall rule that is absent in production.
+ *
+ * An unset rule is a supported local and preview configuration. In production
+ * it removes an abuse-control boundary, so keep the request fail-open for
+ * compatibility while making the operator fault visible in Sentry and logs.
+ */
+export function reportMissingRateLimitRule(input: {
+  readonly route: string;
+  readonly reason: "unset" | "not-found";
+}): void {
+  if (process.env.VERCEL_ENV !== "production") return;
+
+  reportError(
+    new Error("Vercel firewall rate-limit rule is missing"),
+    {
+      subsystem: "rate_limit",
+      route: input.route,
+      reason: input.reason,
+    },
+    {
+      level: "warning",
+      fingerprint: ["cmux-rate-limit-rule-missing", input.route],
+      tags: {
+        subsystem: "rate_limit",
+        route: input.route,
+        reason: input.reason,
+      },
+    },
+  );
+}

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -4,23 +4,30 @@ import { after } from "next/server";
 import { cloudDb } from "../db/client";
 import { reportError } from "./observability/report";
 
+const CLAIM_COOLDOWN_MS = 5 * 60 * 1_000;
+const MAX_LOCAL_KEYS = 128;
+
 type AlertInput = {
   readonly route: string;
   readonly reason: "unset" | "not-found";
 };
 
 type ReporterDependencies = {
+  readonly now?: () => number;
   readonly claim?: (key: string) => Promise<"claimed" | "duplicate" | "unavailable">;
   readonly report?: typeof reportError;
 };
 
 /** Fleet-wide, bounded reporting for a missing Vercel firewall rule. */
 export class RateLimitRuleReporter {
+  private readonly now: () => number;
   private readonly claim: (key: string) => Promise<"claimed" | "duplicate" | "unavailable">;
   private readonly report: typeof reportError;
   private readonly inFlight = new Map<string, Promise<void>>();
+  private readonly lastClaimAt = new Map<string, number>();
 
   constructor(dependencies: ReporterDependencies = {}) {
+    this.now = dependencies.now ?? Date.now;
     this.claim = dependencies.claim ?? claimAlert;
     this.report = dependencies.report ?? reportError;
   }
@@ -29,6 +36,11 @@ export class RateLimitRuleReporter {
     if (process.env.VERCEL_ENV !== "production") return;
 
     const key = `${input.route}:${input.reason}`;
+    const now = this.now();
+    const previous = this.lastClaimAt.get(key);
+    if (previous !== undefined && now - previous < CLAIM_COOLDOWN_MS) return;
+    this.lastClaimAt.set(key, now);
+    this.trimLocalState();
     if (this.inFlight.has(key)) return;
     const work = this.run(input, key);
     this.inFlight.set(key, work);
@@ -62,6 +74,14 @@ export class RateLimitRuleReporter {
         tags: { subsystem: "rate_limit", route: input.route, reason: input.reason },
       },
     );
+  }
+
+  private trimLocalState(): void {
+    while (this.lastClaimAt.size > MAX_LOCAL_KEYS) {
+      const oldest = this.lastClaimAt.keys().next().value;
+      if (oldest === undefined) return;
+      this.lastClaimAt.delete(oldest);
+    }
   }
 }
 

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -29,10 +29,14 @@ export async function reportMissingRateLimitRule(input: {
   // owned by different Vercel instances. The winning session keeps this lock
   // until the instance exits, so a fleet-wide cold-start storm emits one event.
   try {
-    const rows = await cloudDb().execute(sql`
+    const query = cloudDb().execute(sql`
       select pg_try_advisory_lock(hashtextextended(${key}, 0)) as acquired
-    `) as unknown as readonly [{ acquired?: boolean }?];
-    if (!rows[0]?.acquired) return;
+    `) as unknown as Promise<readonly [{ acquired?: boolean }?]>;
+    const timeout = new Promise<undefined>((resolve) => {
+      setTimeout(() => resolve(undefined), 1_000);
+    });
+    const rows = await Promise.race([query, timeout]);
+    if (!rows || !rows[0]?.acquired) return;
   } catch {
     // Reporting must not make a public endpoint depend on the database. The
     // local cooldown still prevents a hot process from generating a loop.

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -4,29 +4,22 @@ import { after } from "next/server";
 import { cloudDb } from "../db/client";
 import { reportError } from "./observability/report";
 
-const ALERT_COOLDOWN_MS = 5 * 60 * 1_000;
-const MAX_LOCAL_KEYS = 128;
-
 type AlertInput = {
   readonly route: string;
   readonly reason: "unset" | "not-found";
 };
 
 type ReporterDependencies = {
-  readonly now?: () => number;
   readonly claim?: (key: string) => Promise<"claimed" | "duplicate" | "unavailable">;
   readonly report?: typeof reportError;
 };
 
 /** Fleet-wide, bounded reporting for a missing Vercel firewall rule. */
 export class RateLimitRuleReporter {
-  private readonly now: () => number;
   private readonly claim: (key: string) => Promise<"claimed" | "duplicate" | "unavailable">;
   private readonly report: typeof reportError;
-  private readonly lastAlertAt = new Map<string, number>();
 
   constructor(dependencies: ReporterDependencies = {}) {
-    this.now = dependencies.now ?? Date.now;
     this.claim = dependencies.claim ?? claimAlert;
     this.report = dependencies.report ?? reportError;
   }
@@ -35,12 +28,6 @@ export class RateLimitRuleReporter {
     if (process.env.VERCEL_ENV !== "production") return;
 
     const key = `${input.route}:${input.reason}`;
-    const now = this.now();
-    const previous = this.lastAlertAt.get(key);
-    if (previous !== undefined && now - previous < ALERT_COOLDOWN_MS) return;
-    this.lastAlertAt.set(key, now);
-    this.trimLocalState();
-
     const work = async () => {
       const result = await this.claim(key);
       if (result === "unavailable") {
@@ -66,14 +53,6 @@ export class RateLimitRuleReporter {
       after(work);
     } catch {
       void work();
-    }
-  }
-
-  private trimLocalState(): void {
-    while (this.lastAlertAt.size > MAX_LOCAL_KEYS) {
-      const oldest = this.lastAlertAt.keys().next().value;
-      if (oldest === undefined) return;
-      this.lastAlertAt.delete(oldest);
     }
   }
 }

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -18,6 +18,7 @@ type ReporterDependencies = {
 export class RateLimitRuleReporter {
   private readonly claim: (key: string) => Promise<"claimed" | "duplicate" | "unavailable">;
   private readonly report: typeof reportError;
+  private readonly inFlight = new Map<string, Promise<void>>();
 
   constructor(dependencies: ReporterDependencies = {}) {
     this.claim = dependencies.claim ?? claimAlert;
@@ -28,32 +29,39 @@ export class RateLimitRuleReporter {
     if (process.env.VERCEL_ENV !== "production") return;
 
     const key = `${input.route}:${input.reason}`;
-    const work = async () => {
-      const result = await this.claim(key);
-      if (result === "unavailable") {
-        console.error("cmux.rate_limit.alert_dedupe_unavailable", {
-          route: input.route,
-          reason: input.reason,
-        });
-        return;
-      }
-      if (result === "duplicate") return;
-      this.report(
-        new Error("Vercel firewall rate-limit rule is missing"),
-        { subsystem: "rate_limit", route: input.route, reason: input.reason },
-        {
-          level: "warning",
-          fingerprint: ["cmux-rate-limit-rule-missing", input.route],
-          tags: { subsystem: "rate_limit", route: input.route, reason: input.reason },
-        },
-      );
-    };
+    if (this.inFlight.has(key)) return;
+    const work = this.run(input, key);
+    this.inFlight.set(key, work);
+    const finished = work.finally(() => {
+      this.inFlight.delete(key);
+    });
 
     try {
-      after(work);
+      after(() => finished);
     } catch {
-      void work();
+      void finished;
     }
+  }
+
+  private async run(input: AlertInput, key: string): Promise<void> {
+    const result = await this.claim(key);
+    if (result === "unavailable") {
+      console.error("cmux.rate_limit.alert_dedupe_unavailable", {
+        route: input.route,
+        reason: input.reason,
+      });
+      return;
+    }
+    if (result === "duplicate") return;
+    this.report(
+      new Error("Vercel firewall rate-limit rule is missing"),
+      { subsystem: "rate_limit", route: input.route, reason: input.reason },
+      {
+        level: "warning",
+        fingerprint: ["cmux-rate-limit-rule-missing", input.route],
+        tags: { subsystem: "rate_limit", route: input.route, reason: input.reason },
+      },
+    );
   }
 }
 

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -1,5 +1,8 @@
 import { reportError } from "./observability/report";
 
+const ALERT_COOLDOWN_MS = 5 * 60 * 1_000;
+const lastAlertAt = new Map<string, number>();
+
 /**
  * Report a Vercel firewall rule that is absent in production.
  *
@@ -12,6 +15,12 @@ export function reportMissingRateLimitRule(input: {
   readonly reason: "unset" | "not-found";
 }): void {
   if (process.env.VERCEL_ENV !== "production") return;
+
+  const key = `${input.route}:${input.reason}`;
+  const now = Date.now();
+  const previous = lastAlertAt.get(key);
+  if (previous !== undefined && now - previous < ALERT_COOLDOWN_MS) return;
+  lastAlertAt.set(key, now);
 
   reportError(
     new Error("Vercel firewall rate-limit rule is missing"),

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -25,18 +25,22 @@ export async function reportMissingRateLimitRule(input: {
   if (previous !== undefined && now - previous < ALERT_COOLDOWN_MS) return;
   lastAlertAt.set(key, now);
 
-  // Advisory locks are shared by all PostgreSQL sessions, including sessions
-  // owned by different Vercel instances. The winning session keeps this lock
-  // until the instance exits, so a fleet-wide cold-start storm emits one event.
+  // The durable ledger deduplicates across all Vercel instances. Keep the
+  // statement timeout inside the transaction so an Aurora outage cannot retain
+  // a pooled connection after this best-effort report.
   try {
-    const query = cloudDb().execute(sql`
-      select pg_try_advisory_lock(hashtextextended(${key}, 0)) as acquired
-    `) as unknown as Promise<readonly [{ acquired?: boolean }?]>;
-    const timeout = new Promise<undefined>((resolve) => {
-      setTimeout(() => resolve(undefined), 1_000);
+    const rows = await cloudDb().transaction(async (tx) => {
+      await tx.execute(sql`set local statement_timeout = '1000ms'`);
+      return tx.execute(sql`
+        insert into rate_limit_alert_reports (alert_key, reported_at)
+        values (${key}, now())
+        on conflict (alert_key) do update
+          set reported_at = excluded.reported_at
+          where rate_limit_alert_reports.reported_at < now() - interval '5 minutes'
+        returning alert_key
+      `);
     });
-    const rows = await Promise.race([query, timeout]);
-    if (!rows || !rows[0]?.acquired) return;
+    if (!rows[0]) return;
   } catch {
     // Reporting must not make a public endpoint depend on the database. The
     // local cooldown still prevents a hot process from generating a loop.

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -1,33 +1,92 @@
 import { sql } from "drizzle-orm";
+import { after } from "next/server";
 
 import { cloudDb } from "../db/client";
 import { reportError } from "./observability/report";
 
 const ALERT_COOLDOWN_MS = 5 * 60 * 1_000;
-const lastAlertAt = new Map<string, number>();
+const MAX_LOCAL_KEYS = 128;
 
-/**
- * Report a Vercel firewall rule that is absent in production.
- *
- * An unset rule is a supported local and preview configuration. In production
- * it removes an abuse-control boundary, so keep the request fail-open for
- * compatibility while making the operator fault visible in Sentry and logs.
- */
-export async function reportMissingRateLimitRule(input: {
+type AlertInput = {
   readonly route: string;
   readonly reason: "unset" | "not-found";
-}): Promise<void> {
-  if (process.env.VERCEL_ENV !== "production") return;
+};
 
-  const key = `${input.route}:${input.reason}`;
-  const now = Date.now();
-  const previous = lastAlertAt.get(key);
-  if (previous !== undefined && now - previous < ALERT_COOLDOWN_MS) return;
-  lastAlertAt.set(key, now);
+type ReporterDependencies = {
+  readonly now?: () => number;
+  readonly claim?: (key: string) => Promise<"claimed" | "duplicate" | "unavailable">;
+  readonly report?: typeof reportError;
+};
 
-  // The durable ledger deduplicates across all Vercel instances. Keep the
-  // statement timeout inside the transaction so an Aurora outage cannot retain
-  // a pooled connection after this best-effort report.
+/** Fleet-wide, bounded reporting for a missing Vercel firewall rule. */
+export class RateLimitRuleReporter {
+  private readonly now: () => number;
+  private readonly claim: (key: string) => Promise<"claimed" | "duplicate" | "unavailable">;
+  private readonly report: typeof reportError;
+  private readonly lastAlertAt = new Map<string, number>();
+
+  constructor(dependencies: ReporterDependencies = {}) {
+    this.now = dependencies.now ?? Date.now;
+    this.claim = dependencies.claim ?? claimAlert;
+    this.report = dependencies.report ?? reportError;
+  }
+
+  reportMissing(input: AlertInput): void {
+    if (process.env.VERCEL_ENV !== "production") return;
+
+    const key = `${input.route}:${input.reason}`;
+    const now = this.now();
+    const previous = this.lastAlertAt.get(key);
+    if (previous !== undefined && now - previous < ALERT_COOLDOWN_MS) return;
+    this.lastAlertAt.set(key, now);
+    this.trimLocalState();
+
+    const work = async () => {
+      const result = await this.claim(key);
+      if (result === "unavailable") {
+        console.error("cmux.rate_limit.alert_dedupe_unavailable", {
+          route: input.route,
+          reason: input.reason,
+        });
+        return;
+      }
+      if (result === "duplicate") return;
+      this.report(
+        new Error("Vercel firewall rate-limit rule is missing"),
+        { subsystem: "rate_limit", route: input.route, reason: input.reason },
+        {
+          level: "warning",
+          fingerprint: ["cmux-rate-limit-rule-missing", input.route],
+          tags: { subsystem: "rate_limit", route: input.route, reason: input.reason },
+        },
+      );
+    };
+
+    try {
+      after(work);
+    } catch {
+      void work();
+    }
+  }
+
+  private trimLocalState(): void {
+    while (this.lastAlertAt.size > MAX_LOCAL_KEYS) {
+      const oldest = this.lastAlertAt.keys().next().value;
+      if (oldest === undefined) return;
+      this.lastAlertAt.delete(oldest);
+    }
+  }
+}
+
+const defaultReporter = new RateLimitRuleReporter();
+
+export function reportMissingRateLimitRule(input: AlertInput): void {
+  defaultReporter.reportMissing(input);
+}
+
+async function claimAlert(
+  key: string,
+): Promise<"claimed" | "duplicate" | "unavailable"> {
   try {
     const rows = await cloudDb().transaction(async (tx) => {
       await tx.execute(sql`set local statement_timeout = '1000ms'`);
@@ -40,28 +99,8 @@ export async function reportMissingRateLimitRule(input: {
         returning alert_key
       `);
     });
-    if (!rows[0]) return;
+    return rows[0] ? "claimed" : "duplicate";
   } catch {
-    // Reporting must not make a public endpoint depend on the database. The
-    // local cooldown still prevents a hot process from generating a loop.
-    return;
+    return "unavailable";
   }
-
-  reportError(
-    new Error("Vercel firewall rate-limit rule is missing"),
-    {
-      subsystem: "rate_limit",
-      route: input.route,
-      reason: input.reason,
-    },
-    {
-      level: "warning",
-      fingerprint: ["cmux-rate-limit-rule-missing", input.route],
-      tags: {
-        subsystem: "rate_limit",
-        route: input.route,
-        reason: input.reason,
-      },
-    },
-  );
 }

--- a/web/services/rateLimitObservability.ts
+++ b/web/services/rateLimitObservability.ts
@@ -1,3 +1,6 @@
+import { sql } from "drizzle-orm";
+
+import { cloudDb } from "../db/client";
 import { reportError } from "./observability/report";
 
 const ALERT_COOLDOWN_MS = 5 * 60 * 1_000;
@@ -10,10 +13,10 @@ const lastAlertAt = new Map<string, number>();
  * it removes an abuse-control boundary, so keep the request fail-open for
  * compatibility while making the operator fault visible in Sentry and logs.
  */
-export function reportMissingRateLimitRule(input: {
+export async function reportMissingRateLimitRule(input: {
   readonly route: string;
   readonly reason: "unset" | "not-found";
-}): void {
+}): Promise<void> {
   if (process.env.VERCEL_ENV !== "production") return;
 
   const key = `${input.route}:${input.reason}`;
@@ -21,6 +24,20 @@ export function reportMissingRateLimitRule(input: {
   const previous = lastAlertAt.get(key);
   if (previous !== undefined && now - previous < ALERT_COOLDOWN_MS) return;
   lastAlertAt.set(key, now);
+
+  // Advisory locks are shared by all PostgreSQL sessions, including sessions
+  // owned by different Vercel instances. The winning session keeps this lock
+  // until the instance exits, so a fleet-wide cold-start storm emits one event.
+  try {
+    const rows = await cloudDb().execute(sql`
+      select pg_try_advisory_lock(hashtextextended(${key}, 0)) as acquired
+    `) as unknown as readonly [{ acquired?: boolean }?];
+    if (!rows[0]?.acquired) return;
+  } catch {
+    // Reporting must not make a public endpoint depend on the database. The
+    // local cooldown still prevents a hot process from generating a loop.
+    return;
+  }
 
   reportError(
     new Error("Vercel firewall rate-limit rule is missing"),

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -7,6 +7,7 @@ import {
   type RelayRateLimitSource,
   type RelayServiceError,
 } from "./errors";
+import { reportMissingRateLimitRule } from "../rateLimitObservability";
 
 export type RelayRateLimitCheck = (
   id: string,
@@ -47,6 +48,7 @@ export function enforceRelayRateLimit(input: {
   if (!ruleId) {
     // No configured rule means the operator wants no rate limiting. Failing
     // here would turn a deliberately-unset env var into a relay outage.
+    reportMissingRateLimitRule({ route: "relay", reason: "unset" });
     return Effect.void;
   }
   return Effect.tryPromise({
@@ -87,7 +89,7 @@ export function enforceRelayRateLimit(input: {
         // means the operator deleted the limit, so treat it as "no limit" and
         // fail open rather than 503-ing every request. Genuine unavailability
         // (a thrown check or an unexpected status) still fails closed below.
-        console.warn("relay rate-limit rule not found; failing open");
+        reportMissingRateLimitRule({ route: "relay", reason: "not-found" });
         return Effect.void;
       }
       if (error) {

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -48,9 +48,9 @@ export function enforceRelayRateLimit(input: {
   if (!ruleId) {
     // No configured rule means the operator wants no rate limiting. Failing
     // here would turn a deliberately-unset env var into a relay outage.
-    return Effect.promise(() =>
-      reportMissingRateLimitRule({ route: "relay", reason: "unset" }),
-    ).pipe(Effect.asVoid);
+    return Effect.sync(() => {
+      void reportMissingRateLimitRule({ route: "relay", reason: "unset" });
+    });
   }
   return Effect.tryPromise({
     try: () => input.check(ruleId, {
@@ -90,9 +90,9 @@ export function enforceRelayRateLimit(input: {
         // means the operator deleted the limit, so treat it as "no limit" and
         // fail open rather than 503-ing every request. Genuine unavailability
         // (a thrown check or an unexpected status) still fails closed below.
-        return Effect.promise(() =>
-          reportMissingRateLimitRule({ route: "relay", reason: "not-found" }),
-        ).pipe(Effect.asVoid);
+        return Effect.sync(() => {
+          void reportMissingRateLimitRule({ route: "relay", reason: "not-found" });
+        });
       }
       if (error) {
         return Effect.fail(

--- a/web/services/relay/http.ts
+++ b/web/services/relay/http.ts
@@ -48,8 +48,9 @@ export function enforceRelayRateLimit(input: {
   if (!ruleId) {
     // No configured rule means the operator wants no rate limiting. Failing
     // here would turn a deliberately-unset env var into a relay outage.
-    reportMissingRateLimitRule({ route: "relay", reason: "unset" });
-    return Effect.void;
+    return Effect.promise(() =>
+      reportMissingRateLimitRule({ route: "relay", reason: "unset" }),
+    ).pipe(Effect.asVoid);
   }
   return Effect.tryPromise({
     try: () => input.check(ruleId, {
@@ -89,8 +90,9 @@ export function enforceRelayRateLimit(input: {
         // means the operator deleted the limit, so treat it as "no limit" and
         // fail open rather than 503-ing every request. Genuine unavailability
         // (a thrown check or an unexpected status) still fails closed below.
-        reportMissingRateLimitRule({ route: "relay", reason: "not-found" });
-        return Effect.void;
+        return Effect.promise(() =>
+          reportMissingRateLimitRule({ route: "relay", reason: "not-found" }),
+        ).pipe(Effect.asVoid);
       }
       if (error) {
         return Effect.fail(

--- a/web/services/sentry.ts
+++ b/web/services/sentry.ts
@@ -33,6 +33,7 @@ export function shouldSendCoderouterSentryEvent(event: Event): boolean {
   // silently dropped them, which is how a two-day provisioning outage
   // produced zero Sentry events.
   if (typeof cmux?.subsystem === "string" && cmux.subsystem.startsWith("cloud_vm")) return true;
+  if (cmux?.subsystem === "rate_limit") return true;
   const message =
     event.message ??
     event.exception?.values?.map((value) => value.value ?? "").join(" ") ??

--- a/web/tests/client-config-route.test.ts
+++ b/web/tests/client-config-route.test.ts
@@ -304,8 +304,6 @@ describe("client config", () => {
     // A deleted rule is an operator action (no limit wanted), not an outage.
     process.env.VERCEL = "1";
     checkRateLimit.mockResolvedValue({ rateLimited: false, error: "not-found" });
-    const consoleWarn = mock(() => {});
-    console.warn = consoleWarn as unknown as typeof console.warn;
     const fetchMock = mock(async () => new Response(
       JSON.stringify({
         errorsWhileComputingFlags: false,
@@ -323,10 +321,6 @@ describe("client config", () => {
     }));
 
     expect(response.status).toBe(200);
-    expect(consoleWarn).toHaveBeenCalledWith(
-      "client-config.route.rate_limit_not_found; failing open",
-      "cmux-client-config-test",
-    );
     expect(checkRateLimit).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });

--- a/web/tests/coderouter-sentry.test.ts
+++ b/web/tests/coderouter-sentry.test.ts
@@ -50,6 +50,14 @@ describe("coderouter Sentry privacy", () => {
     ).toBe(false);
   });
 
+  test("rate-limit rule reports pass the shared operational filter", () => {
+    expect(
+      shouldSendCoderouterSentryEvent({
+        contexts: { cmux: { subsystem: "rate_limit", route: "/api/feedback" } },
+      }),
+    ).toBe(true);
+  });
+
   test("removes request bodies, auth headers, route tokens, JWTs, and PII", () => {
     const event = scrubSentryEvent({
       message:

--- a/web/tests/cron-auth.test.ts
+++ b/web/tests/cron-auth.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+const { authorizeCronRequest } = await import("../services/cronAuth");
+
+const originalCronSecret = process.env.CRON_SECRET;
+
+afterEach(() => {
+  if (originalCronSecret === undefined) {
+    delete process.env.CRON_SECRET;
+  } else {
+    process.env.CRON_SECRET = originalCronSecret;
+  }
+});
+
+function requestWithAuthorization(authorization?: string): Request {
+  return new Request("https://cmux.test/api/cron/vm-reconcile", {
+    headers: authorization === undefined ? {} : { authorization },
+  });
+}
+
+describe("cron auth", () => {
+  test("fails closed when CRON_SECRET is not configured, whatever the header says", () => {
+    delete process.env.CRON_SECRET;
+
+    for (const authorization of [undefined, "Bearer whatever", "Bearer cron-secret"]) {
+      const result = authorizeCronRequest(requestWithAuthorization(authorization));
+      expect(result).toEqual({ ok: false, reason: "cron_secret_missing" });
+    }
+  });
+
+  test("rejects a request with no authorization header", () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    expect(authorizeCronRequest(requestWithAuthorization())).toEqual({
+      ok: false,
+      reason: "unauthorized",
+    });
+  });
+
+  test("rejects a non-bearer authorization header", () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    expect(
+      authorizeCronRequest(requestWithAuthorization("Basic cron-secret")),
+    ).toEqual({ ok: false, reason: "unauthorized" });
+  });
+
+  test("rejects an empty bearer token", () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    expect(authorizeCronRequest(requestWithAuthorization("Bearer "))).toEqual({
+      ok: false,
+      reason: "unauthorized",
+    });
+  });
+
+  test("rejects a wrong bearer token of the same length", () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    expect(
+      authorizeCronRequest(requestWithAuthorization("Bearer crons-ecret")),
+    ).toEqual({ ok: false, reason: "unauthorized" });
+  });
+
+  test("rejects a wrong bearer token of a different length", () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    expect(
+      authorizeCronRequest(requestWithAuthorization("Bearer wrong-secret")),
+    ).toEqual({ ok: false, reason: "unauthorized" });
+  });
+
+  test("rejects a prefix of the configured secret", () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    expect(authorizeCronRequest(requestWithAuthorization("Bearer cron"))).toEqual({
+      ok: false,
+      reason: "unauthorized",
+    });
+  });
+
+  test("accepts the configured bearer token", () => {
+    process.env.CRON_SECRET = "cron-secret";
+
+    expect(
+      authorizeCronRequest(requestWithAuthorization("Bearer cron-secret")),
+    ).toEqual({ ok: true });
+  });
+
+  test("trims bearer whitespace and a whitespace-padded secret", () => {
+    process.env.CRON_SECRET = "  cron-secret  ";
+
+    expect(
+      authorizeCronRequest(requestWithAuthorization("Bearer cron-secret")),
+    ).toEqual({ ok: true });
+  });
+});

--- a/web/tests/cron-auth.test.ts
+++ b/web/tests/cron-auth.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, describe, expect, test } from "bun:test";
-
-const { authorizeCronRequest } = await import("../services/cronAuth");
+import { authorizeCronRequest } from "../services/cronAuth";
 
 const originalCronSecret = process.env.CRON_SECRET;
 


### PR DESCRIPTION
Found in a security audit of the cloud web tier.

Every cron route is publicly reachable, and `CRON_SECRET` is its only gate. Five routes compared the full `Authorization` header with plain string inequality (`!==`), which leaks the secret byte-by-byte through response timing. Exploitability over a network is low but nonzero, and two other routes already did the comparison correctly, so the pattern was inconsistent.

**Fix:** one shared helper, `web/services/cronAuth.ts`, that trims, requires the `Bearer` scheme, and compares with `timingSafeEqual` plus a length check. All seven cron-gated routes now use it; the two routes that had inline copies drop them.

**Behavior:** unchanged for every caller. Each route keeps its exact fail-closed responses (401 vs 503 for a missing secret), because the helper returns a reason instead of building the response.

- /api/cron/vm-reconcile (plain `!==` before)
- /api/cron/vm-alerts (plain `!==` before)
- /api/cron/vm-reaper (plain `!==` before)
- /api/cron/billing-reconcile (plain `!==` before)
- /api/cron/indexnow (plain `!==` before)
- /api/internal/vm/leases/revoke-expired (inline timingSafeEqual, now shared)
- /api/internal/iroh/retention (inline timingSafeEqual, now shared)

**Tests:** commit 1 adds the helper contract test (red: module missing), commit 2 lands the helper and route migration (green). Existing route tests (vm-reconcile, lease cron, billing-reconcile, vm-alerts, iroh retention, indexnow) pass unchanged, pinning the no-behavior-change claim. `bun test` 50 pass, `tsgo --noEmit` clean, eslint clean on touched files.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791081173&installation_model_id=21920&pr_number=11907&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11907&signature=c85f68bf5a0328a5248d9fffdd513184328d00564c3bab3c14fc3c28a20c9e0f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a timing side channel in cron auth and surfaces missing Vercel firewall rate-limit rules in Sentry instead of console-only warnings. Caller-visible behavior is unchanged.

**Bug Fixes**
- Five routes compared the `Authorization` header with plain string inequality; all seven cron-gated routes now use `web/services/cronAuth.ts`, which requires the `Bearer` scheme and compares with `timingSafeEqual` plus a length check.
- The helper returns a failure reason, so routes keep their existing 401 (bad token) and 503 (missing `CRON_SECRET`) responses.
- Adds contract tests for the helper and updates route tests that asserted console warnings.

**Observability**
- Public routes, native ingress, and relay now report unset or deleted rules through `web/services/rateLimitObservability.ts`.
- Reports only in production, coalesce concurrent alerts, and suppress repeats per route for 5 minutes using a durable `rate_limit_alert_reports` table.
- Reporting runs off the request path, so endpoints still fail open; `sentry.ts` lets `subsystem: "rate_limit"` events through the operational filter.

<sup>Written for commit c206b0f4de65a6a2ea32c94bedfb92d778b80c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Monitoring**
  - Improved operational alerts when rate-limit rules are missing or unavailable, with duplicate notifications automatically reduced.
  - Rate-limit incidents are now routed through centralized error monitoring.

- **Security & Reliability**
  - Standardized authentication for scheduled and internal tasks.
  - Missing configuration and unauthorized requests now receive clearer handling while preserving existing access protections.
  - Existing fail-open and rate-limit response behavior remains unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->