### PR TITLE
Silence read state mutation failures

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActionFailure.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActionFailure.swift
@@ -2,9 +2,12 @@ import CmuxMobileShell
 import CmuxMobileSupport
 import CmuxMobileToast
 import Foundation
+import OSLog
 import SwiftUI
 
-enum WorkspaceActionToastAction {
+private let workspaceActionFailureLog = Logger(subsystem: "dev.cmux.ios", category: "workspace-action")
+
+enum WorkspaceActionToastAction: Equatable {
     case createWorkspace
     case createWorkspaceInGroup
     case createWorkspaceGroup
@@ -30,34 +33,9 @@ extension WorkspaceShellView {
         action: WorkspaceActionToastAction
     ) {
         guard case let .failure(failure) = result else { return }
-        let title = Self.workspaceActionFailureTitle(action: action)
-        let reason = Self.workspaceActionFailureReasonText(failure)
-        guard toasts.isEnabled else {
-            // The shelved toast presenter falls back to the legacy dismissible
-            // bottom banner, with the same title and reason joined into its
-            // single-line message.
-            withAnimation(.snappy(duration: 0.2)) {
-                workspaceActionToast = WorkspaceActionToastContent(
-                    message: String.localizedStringWithFormat(
-                        L10n.string(
-                            "mobile.workspaceAction.failure.legacyFormat",
-                            defaultValue: "%1$@: %2$@"
-                        ),
-                        title,
-                        reason
-                    )
-                )
-            }
-            return
-        }
-        toasts.present(.failure(
-            reason,
-            title: title,
-            // One key per action: a repeat of the same failed action re-bumps
-            // the visible toast (even if the reason changed) instead of
-            // queueing near-duplicates.
-            coalescingKey: "workspaceAction.failure.\(action)"
-        ))
+        // Workspace mutations are best-effort from mobile. Keep failures in
+        // diagnostics without interrupting the workspace UI.
+        workspaceActionFailureLog.debug("Ignoring action failure: \(String(describing: action), privacy: .public), \(String(describing: failure), privacy: .public)")
     }
 
     func dismissWorkspaceActionToast() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActionFailure.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+WorkspaceActionFailure.swift
@@ -5,7 +5,7 @@ import Foundation
 import OSLog
 import SwiftUI
 
-private let workspaceActionFailureLog = Logger(subsystem: "dev.cmux.ios", category: "workspace-action")
+nonisolated private let workspaceActionFailureLog = Logger(subsystem: "dev.cmux.ios", category: "workspace-action")
 
 enum WorkspaceActionToastAction: Equatable {
     case createWorkspace
@@ -35,7 +35,7 @@ extension WorkspaceShellView {
         guard case let .failure(failure) = result else { return }
         // Workspace mutations are best-effort from mobile. Keep failures in
         // diagnostics without interrupting the workspace UI.
-        workspaceActionFailureLog.debug("Ignoring action failure: \(String(describing: action), privacy: .public), \(String(describing: failure), privacy: .public)")
+        workspaceActionFailureLog.debug("Ignoring action failure: \(String(describing: action), privacy: .public), \(String(describing: failure), privacy: .private)")
     }
 
     func dismissWorkspaceActionToast() {


### PR DESCRIPTION
Mark read/unread is best-effort synchronization. Suppress failure toasts when the Mac is temporarily disconnected, while retaining a debug log entry for diagnostics.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791082732&installation_model_id=21920&pr_number=11912&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11912&signature=9db386fc0ef5c54b58f6f5bf202c04c8c94031eb24399da902faf870ed180af7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops workspace action failures from interrupting the user. Failed workspace mutations no longer show failure toasts or the legacy banner fallback; they're now logged as debug entries only, since these mutations are best-effort from mobile.

<sup>Written for commit bd1cedd60bba22ef00e6b2867b53fb41257aa1bd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Workspace actions that cannot be completed no longer display failure notifications or legacy banners.
  * These best-effort failures are handled quietly and recorded in diagnostic logs for troubleshooting.
  * Read and unread actions continue without interrupting the user when an update fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->