### PR TITLE
ci: avoid full history fetch in workflow guard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,7 +138,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
-          fetch-depth: 0
+          # Guard tests inspect the checked-out tree only. A shallow checkout
+          # avoids downloading the full cmux history before macOS CI can start.
+          fetch-depth: 1
           persist-credentials: false
 
       - name: Validate macOS runner guards


### PR DESCRIPTION
## Summary
- use a shallow checkout for workflow-guard-tests
- preserve the full guard test set while removing an unnecessary history download

## Evidence
- actionlint passes
- test_ci_self_hosted_guard.sh passes
- test_ci_release_sdk_lane.sh passes
- test_ci_change_areas.py passes

The recent full CI run spent about 72 seconds in the workflow-guard checkout before its checks started.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791086191&installation_model_id=21920&pr_number=11916&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11916&signature=3f63ea1fc91c57d4cd6792d4fd830ddf5a9edfc9545a5d60ae9302b806841668"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the workflow-guard-tests job to a shallow checkout (`fetch-depth: 1`) so macOS CI no longer downloads the full repository history before running guard checks. The guard tests only inspect the checked-out tree, so the change doesn't affect test coverage.

<sup>Written for commit 9c69a59b5b80e7b8be36bd697f915c28e2cfeca5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Reduced repository history downloaded during macOS continuous integration checks, improving workflow efficiency without changing product functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->