### PR TITLE
Trace dashboard and Stack Auth timings

### DIFF
--- a/web/app/[locale]/dashboard/admin/page.tsx
+++ b/web/app/[locale]/dashboard/admin/page.tsx
@@ -5,6 +5,8 @@ import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { ADMIN_EMAIL_DOMAINS, isAdminUser } from "@/services/admin/access";
 import { loadProListSnapshot, type ProListSnapshot } from "@/services/admin/proList";
+import { withPrioritySpan } from "@/services/telemetry";
+import { withStackAuthSpan } from "@/services/auth/stackTelemetry";
 
 import { AdminProPanel } from "./admin-pro-panel";
 
@@ -20,7 +22,16 @@ export default async function DashboardAdminPage({
   if (!isStackConfigured()) {
     redirect("/");
   }
-  const user = await getStackServerApp().getUser({ or: "return-null" });
+  const user = await withPrioritySpan(
+    "cmux-admin-dashboard",
+    "cmux.admin.auth",
+    { "http.route": "/dashboard/admin", "cmux.locale": locale },
+    () => withStackAuthSpan(
+      "get_user",
+      () => getStackServerApp().getUser({ or: "return-null" }),
+      { "cmux.auth.flow": "admin_page" },
+    ),
+  );
   if (!user || user.isAnonymous) {
     redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/admin")));
   }
@@ -35,7 +46,12 @@ export default async function DashboardAdminPage({
   // error state with a retry, but never blocks the rest of the page.
   let initialSnapshot: ProListSnapshot | null = null;
   try {
-    initialSnapshot = await loadProListSnapshot();
+    initialSnapshot = await withPrioritySpan(
+      "cmux-admin-dashboard",
+      "cmux.admin.pro_list",
+      { "http.route": "/dashboard/admin", "cmux.locale": locale },
+      () => loadProListSnapshot(),
+    );
   } catch (error) {
     console.error("admin.pro_list.initial_load_failed", {
       failure: error instanceof Error ? error.name : "unknown",

--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -36,6 +36,8 @@ import {
 } from "../components/ai-account-forms";
 import { ClaudeUpstreamSection } from "../components/claude-upstream-forms";
 import { CoderouterPageHeader } from "../components/dashboard-page-headers";
+import { withPrioritySpan } from "@/services/telemetry";
+import { withStackAuthSpan } from "@/services/auth/stackTelemetry";
 
 // The page resolves as one server render. Keeping the auth and data work in
 // this Suspense boundary prevents a header-only response while the private
@@ -127,9 +129,11 @@ export async function CoderouterOverviewContent({
   // is no private page cache here, so a prefetched response cannot outlive a
   // team grant or expose management controls after revocation.
   const requestHeaders = await headers();
-  const authorization = await resolveCoderouterAuthorization(
-    requestHeaders,
-    team,
+  const authorization = await withPrioritySpan(
+    "cmux-coderouter-dashboard",
+    "cmux.coderouter.auth",
+    { "http.route": "/dashboard/coderouter", "cmux.locale": locale },
+    () => resolveCoderouterAuthorization(requestHeaders, team),
   );
   if (authorization.kind === "unavailable") {
     return renderCoderouterLoadError(locale);
@@ -145,10 +149,30 @@ export async function CoderouterOverviewContent({
   const [tPage, t, accountState, metrics, claudeUpstream, machineUsage] = await Promise.all([
     getTranslations({ locale, namespace: "dashboard.coderouter" }),
     getTranslations({ locale, namespace: "dashboard.aiAccounts" }),
-    loadAccounts(selectedTeam, accessToken),
-    loadCoderouterTeamMetrics(selectedTeam.id),
-    loadClaudeUpstream(selectedTeam.id),
-    loadMachineUsage(selectedTeam.id),
+    withPrioritySpan(
+      "cmux-coderouter-dashboard",
+      "cmux.coderouter.accounts",
+      { "cmux.team_id": selectedTeam.id },
+      () => loadAccounts(selectedTeam, accessToken),
+    ),
+    withPrioritySpan(
+      "cmux-coderouter-dashboard",
+      "cmux.coderouter.team_metrics",
+      { "cmux.team_id": selectedTeam.id },
+      () => loadCoderouterTeamMetrics(selectedTeam.id),
+    ),
+    withPrioritySpan(
+      "cmux-coderouter-dashboard",
+      "cmux.coderouter.claude_upstream",
+      { "cmux.team_id": selectedTeam.id },
+      () => loadClaudeUpstream(selectedTeam.id),
+    ),
+    withPrioritySpan(
+      "cmux-coderouter-dashboard",
+      "cmux.coderouter.machine_usage",
+      { "cmux.team_id": selectedTeam.id },
+      () => loadMachineUsage(selectedTeam.id),
+    ),
   ]);
   const dateFormatter = new Intl.DateTimeFormat(locale, {
     dateStyle: "medium",
@@ -294,13 +318,17 @@ async function resolveCoderouterAuthorization(
         if (!user) return null;
         const [authorized, authJson] = await Promise.all([
           authorizedSubrouterTeams(user),
-          getStackServerApp().getAuthJson({
-            tokenStore: {
-              headers: {
-                get: (name: string) => requestHeaders.get(name),
+          withStackAuthSpan(
+            "get_auth_json",
+            () => getStackServerApp().getAuthJson({
+              tokenStore: {
+                headers: {
+                  get: (name: string) => requestHeaders.get(name),
+                },
               },
-            },
-          }).catch(() => {
+            }),
+            { "cmux.auth.flow": "coderouter_dashboard" },
+          ).catch(() => {
             throw new SubrouterAuthorizationUnavailableError(
               "Stack session refresh unavailable",
             );

--- a/web/app/[locale]/dashboard/coderouter/page.tsx
+++ b/web/app/[locale]/dashboard/coderouter/page.tsx
@@ -152,25 +152,25 @@ export async function CoderouterOverviewContent({
     withPrioritySpan(
       "cmux-coderouter-dashboard",
       "cmux.coderouter.accounts",
-      { "cmux.team_id": selectedTeam.id },
+      { "cmux.team_scope": "selected" },
       () => loadAccounts(selectedTeam, accessToken),
     ),
     withPrioritySpan(
       "cmux-coderouter-dashboard",
       "cmux.coderouter.team_metrics",
-      { "cmux.team_id": selectedTeam.id },
+      { "cmux.team_scope": "selected" },
       () => loadCoderouterTeamMetrics(selectedTeam.id),
     ),
     withPrioritySpan(
       "cmux-coderouter-dashboard",
       "cmux.coderouter.claude_upstream",
-      { "cmux.team_id": selectedTeam.id },
+      { "cmux.team_scope": "selected" },
       () => loadClaudeUpstream(selectedTeam.id),
     ),
     withPrioritySpan(
       "cmux-coderouter-dashboard",
       "cmux.coderouter.machine_usage",
-      { "cmux.team_id": selectedTeam.id },
+      { "cmux.team_scope": "selected" },
       () => loadMachineUsage(selectedTeam.id),
     ),
   ]);

--- a/web/app/[locale]/dashboard/page.tsx
+++ b/web/app/[locale]/dashboard/page.tsx
@@ -4,6 +4,8 @@ import { Link } from "@/i18n/navigation";
 import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { isVaultEnabled } from "@/services/vault/config";
+import { withPrioritySpan } from "@/services/telemetry";
+import { withStackAuthSpan } from "@/services/auth/stackTelemetry";
 
 
 export default async function DashboardIndexPage({
@@ -16,7 +18,16 @@ export default async function DashboardIndexPage({
   if (!isStackConfigured()) {
     redirect("/");
   }
-  const user = await getStackServerApp().getUser({ or: "return-null" });
+  const user = await withPrioritySpan(
+    "cmux-dashboard",
+    "cmux.dashboard.auth",
+    { "http.route": "/dashboard", "cmux.locale": locale },
+    () => withStackAuthSpan(
+      "get_user",
+      () => getStackServerApp().getUser({ or: "return-null" }),
+      { "cmux.auth.flow": "dashboard" },
+    ),
+  );
   if (!user) {
     redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard")));
   }

--- a/web/app/lib/stack.ts
+++ b/web/app/lib/stack.ts
@@ -4,6 +4,7 @@ import { stackApiBaseURL } from "../../services/auth/stackApiBaseURL";
 import { cloudDb } from "../../db/client";
 import { withFreshAccountMetadataUser } from "../../services/account/metadataMutation";
 import { canonicalizeEmailForMatching } from "../../services/billing/emailMatching";
+import { withStackAuthSpan } from "../../services/auth/stackTelemetry";
 
 // env.ts trims every runtimeEnv source, so consumers receive sanitized values
 // regardless of whether zod validation is skipped.
@@ -165,26 +166,35 @@ async function updateStackUserViaApi(
   const baseURL = /\/api\/v1$/u.test(normalizedBaseURL)
     ? normalizedBaseURL
     : `${normalizedBaseURL}/api/v1`;
-  const response = await fetch(
-    `${baseURL.replace(/\/+$/, "")}/users/${encodeURIComponent(userId)}`,
-    {
-      method: "PATCH",
-      headers: {
-        "content-type": "application/json",
-        // Stack's current SDK uses the Hexclave-prefixed names; retain the
-        // Stack aliases for older project API versions during the migration.
-        "x-hexclave-access-type": "server",
-        "x-hexclave-project-id": projectId,
-        "x-hexclave-secret-server-key": secretServerKey,
-        "x-hexclave-override-error-status": "true",
-        "x-stack-access-type": "server",
-        "x-stack-project-id": projectId,
-        "x-stack-secret-server-key": secretServerKey,
-        "x-stack-override-error-status": "true",
-      },
-      body: JSON.stringify(patch),
-      signal: AbortSignal.timeout(10_000),
+  const response = await withStackAuthSpan(
+    "user_update",
+    async (span) => {
+      const response = await fetch(
+        `${baseURL.replace(/\/+$/, "")}/users/${encodeURIComponent(userId)}`,
+        {
+          method: "PATCH",
+          headers: {
+            "content-type": "application/json",
+            // Stack's current SDK uses the Hexclave-prefixed names; retain the
+            // Stack aliases for older project API versions during the migration.
+            "x-hexclave-access-type": "server",
+            "x-hexclave-project-id": projectId,
+            "x-hexclave-secret-server-key": secretServerKey,
+            "x-hexclave-override-error-status": "true",
+            "x-stack-access-type": "server",
+            "x-stack-project-id": projectId,
+            "x-stack-secret-server-key": secretServerKey,
+            "x-stack-override-error-status": "true",
+          },
+          body: JSON.stringify(patch),
+          signal: AbortSignal.timeout(10_000),
+        },
+      );
+      span.setAttribute("http.response.status_code", response.status);
+      span.setAttribute("cmux.external.success", response.ok);
+      return response;
     },
+    { "cmux.auth.flow": "server_user_update" },
   );
   if (!response.ok) {
     // Do not include response bodies: Stack can echo account data or provider

--- a/web/services/admin/proList.ts
+++ b/web/services/admin/proList.ts
@@ -12,6 +12,7 @@ import { and, desc, eq, inArray, isNotNull, isNull } from "drizzle-orm";
 import { cloudDb } from "../../db/client";
 import { adminPlanGrants, stripeCustomers, stripeSubscriptions } from "../../db/schema";
 import { getStackServerApp } from "../../app/lib/stack";
+import { withStackAuthSpan } from "../auth/stackTelemetry";
 import {
   ACTIVE_STRIPE_PRO_STATUSES,
   PRO_PLAN_ID,
@@ -320,9 +321,15 @@ export function isValidScanCursor(value: string): boolean {
 function defaultProListStackApp(): ProListStackApp {
   const app = getStackServerApp();
   return {
-    getTeam: (teamId) => app.getTeam(teamId),
-    listUsers: (options) => app.listUsers(options),
-    listTeams: (options) => app.listTeams(options),
+    getTeam: (teamId) => withStackAuthSpan("get_team", () => app.getTeam(teamId), {
+      "cmux.auth.flow": "admin_pro_list",
+    }),
+    listUsers: (options) => withStackAuthSpan("list_users", () => app.listUsers(options), {
+      "cmux.auth.flow": "admin_pro_list",
+    }),
+    listTeams: (options) => withStackAuthSpan("list_teams", () => app.listTeams(options), {
+      "cmux.auth.flow": "admin_pro_list",
+    }),
   };
 }
 

--- a/web/services/admin/routeAuth.ts
+++ b/web/services/admin/routeAuth.ts
@@ -4,6 +4,7 @@ import { getStackServerApp, isStackConfigured } from "../../app/lib/stack";
 import { authProviderErrorResponse } from "../vms/authErrors";
 import { jsonResponse, parseBearer } from "../vms/routeHelpers";
 import { isAdminUser } from "./access";
+import { withStackAuthSpan } from "../auth/stackTelemetry";
 
 const ANONYMOUS_IF_EXISTS = "anonymous-if-exists[deprecated]" as const;
 
@@ -47,7 +48,9 @@ export async function requireAdmin(request: NextRequest): Promise<AdminGate> {
       });
   let user: Awaited<ReturnType<typeof loadUser>>;
   try {
-    user = await loadUser();
+    user = await withStackAuthSpan("get_user", loadUser, {
+      "cmux.auth.flow": "admin_route",
+    });
   } catch (error) {
     return { ok: false, response: authProviderErrorResponse(error, "admin.auth") };
   }

--- a/web/services/auth/stackTelemetry.ts
+++ b/web/services/auth/stackTelemetry.ts
@@ -1,0 +1,28 @@
+import {
+  withSpan,
+  type MaybeAttributes,
+  type SpanCallback,
+} from "../telemetry";
+
+/**
+ * Time one Stack Auth SDK or API operation. Stack currently sends these
+ * server calls through its Hexclave-compatible API headers, so the transport
+ * is recorded as an attribute without exposing credentials or request data.
+ */
+export function withStackAuthSpan<T>(
+  operation: string,
+  fn: SpanCallback<T>,
+  attributes: MaybeAttributes = {},
+): Promise<T> {
+  return withSpan(
+    "cmux-stack-auth",
+    `cmux.stack_auth.${operation}`,
+    {
+      "cmux.external.service": "stack-auth",
+      "cmux.external.transport": "hexclave",
+      "cmux.external.operation": operation,
+      ...attributes,
+    },
+    fn,
+  );
+}

--- a/web/services/observability/sampler.ts
+++ b/web/services/observability/sampler.ts
@@ -18,12 +18,15 @@ import {
 export const VM_PRIORITY_PATH_PREFIX = "/api/vm";
 
 /**
- * Coderouter is the second always-kept subsystem: its data plane (`/v1/*`,
- * the OpenCode proxy) and control plane (`/api/coderouter/*`) carry paid
- * model traffic at a few requests per minute, and every failed request is
- * something a customer will ask about by request id.
+ * Coderouter and admin traffic are also always kept: these routes are low
+ * volume, and every failed request needs a complete service breakdown.
  */
-export const PRIORITY_PATH_PREFIXES = [VM_PRIORITY_PATH_PREFIX, "/v1", "/api/coderouter"] as const;
+export const PRIORITY_PATH_PREFIXES = [
+  VM_PRIORITY_PATH_PREFIX,
+  "/v1",
+  "/api/coderouter",
+  "/api/admin",
+] as const;
 const PRIORITY_SUBSYSTEMS: ReadonlySet<string> = new Set(["vm-cloud", "coderouter"]);
 
 const PRIORITY_PATH_ATTRIBUTE_KEYS = ["http.route", "url.path", "http.target"] as const;
@@ -51,6 +54,7 @@ export function isPrioritySpan(spanName: string, attributes: Attributes): boolea
   // A high-volume endpoint can opt out of the always-kept path set while
   // retaining the same route wrapper and response headers.
   if (attributes["cmux.priority"] === false) return false;
+  if (attributes["cmux.priority"] === true) return true;
   const subsystem = attributes["cmux.subsystem"];
   if (typeof subsystem === "string" && PRIORITY_SUBSYSTEMS.has(subsystem)) return true;
   for (const key of PRIORITY_PATH_ATTRIBUTE_KEYS) {
@@ -95,7 +99,7 @@ class VmPriorityRootSampler implements Sampler {
 }
 
 /**
- * The app-wide trace sampler: keep 100% of Cloud VM and coderouter traces, head-sample
+ * The app-wide trace sampler: keep 100% of Cloud VM, coderouter, and admin traces, head-sample
  * everything else at `CMUX_OTEL_BASE_SAMPLE_RATIO` (default 2%). Children
  * follow their root's decision, so a kept VM trace keeps its pg/fetch/
  * provider child spans and a dropped page-load trace drops all of its own.

--- a/web/services/subrouter/requestContext.ts
+++ b/web/services/subrouter/requestContext.ts
@@ -14,6 +14,7 @@ import {
   parseNativeStackTokens,
 } from "../vms/auth";
 import { getStackServerApp } from "../../app/lib/stack";
+import { withStackAuthSpan } from "../auth/stackTelemetry";
 import {
   createHostedSubrouterClient,
   type HostedSubrouterClient,
@@ -112,9 +113,11 @@ export async function resolveSubrouterRequestContext(
       // authoritative token instead of the possibly stale request header.
       let accessToken: string | null | undefined;
       try {
-        const authoritativeTokens = await getStackServerApp().getAuthJson({
-          tokenStore,
-        });
+        const authoritativeTokens = await withStackAuthSpan(
+          "get_auth_json",
+          () => getStackServerApp().getAuthJson({ tokenStore }),
+          { "cmux.auth.flow": "subrouter_request" },
+        );
         accessToken = authoritativeTokens?.accessToken;
       } catch (error) {
         console.error("Subrouter Stack token refresh unavailable", {

--- a/web/services/telemetry.ts
+++ b/web/services/telemetry.ts
@@ -134,16 +134,17 @@ export function setSpanAttributes(span: Span, attributes: MaybeAttributes): void
 
 export function recordSpanError(span: Span, err: unknown): void {
   if (err instanceof Error) {
+    const name = scrubText(err.name).slice(0, 80);
     const message = scrubText(err.message).slice(0, ERROR_CAUSE_MESSAGE_MAX);
     const stack = err.stack ? scrubText(err.stack).slice(0, 4_000) : undefined;
     span.recordException({
-      name: err.name,
+      name,
       message,
       ...(stack ? { stack } : {}),
     });
     span.setStatus({ code: SpanStatusCode.ERROR, message });
     span.setAttributes({
-      "cmux.error_name": err.name,
+      "cmux.error_name": name,
       "cmux.error_message": message,
     });
     const causes = summarizeErrorCauses(err);
@@ -271,7 +272,9 @@ export function summarizeErrorCauses(err: unknown): ErrorCauseSummary | undefine
       body?: { code?: unknown };
       cause?: unknown;
     };
-    const name = typeof record.name === "string" ? record.name : typeof current;
+    const name = scrubText(
+      typeof record.name === "string" ? record.name : typeof current,
+    ).slice(0, 80);
     const message = typeof record.message === "string" ? record.message : String(current);
     parts.push(`${name}: ${scrubText(message).slice(0, ERROR_CAUSE_MESSAGE_MAX)}`);
     const status = [record.status, record.statusCode, record.response?.status].find(
@@ -281,7 +284,9 @@ export function summarizeErrorCauses(err: unknown): ErrorCauseSummary | undefine
     const causeCode = [record.body?.code, record.code].find(
       (value) => typeof value === "string" && value.length > 0,
     );
-    if (code === undefined && typeof causeCode === "string") code = causeCode.slice(0, 80);
+    if (code === undefined && typeof causeCode === "string") {
+      code = scrubText(causeCode).slice(0, 80);
+    }
     current = record.cause;
   }
   if (depth === 0) return undefined;

--- a/web/services/telemetry.ts
+++ b/web/services/telemetry.ts
@@ -53,6 +53,35 @@ export async function withSpan<T>(
   );
 }
 
+/**
+ * Keep a small, explicitly named operation even when its surrounding request
+ * was dropped by head sampling. The parent remains linked for correlation,
+ * while the operation becomes the root of a sampled trace.
+ */
+export async function withPrioritySpan<T>(
+  tracerName: string,
+  name: string,
+  attributes: MaybeAttributes,
+  fn: SpanCallback<T>,
+): Promise<T> {
+  const parent = trace.getSpanContext(otelContext.active());
+  const reRoot =
+    parent !== undefined &&
+    trace.isSpanContextValid(parent) &&
+    (parent.traceFlags & TraceFlags.SAMPLED) === 0;
+  const links = reRoot ? [{ context: parent }] : undefined;
+  return withSpan(
+    tracerName,
+    name,
+    { "cmux.priority": true, ...attributes },
+    fn,
+    {
+      context: reRoot ? trace.deleteSpan(otelContext.active()) : undefined,
+      links,
+    },
+  );
+}
+
 export async function withApiRouteSpan<T extends Response>(
   request: Request,
   route: string,

--- a/web/services/telemetry.ts
+++ b/web/services/telemetry.ts
@@ -73,7 +73,7 @@ export async function withPrioritySpan<T>(
   return withSpan(
     tracerName,
     name,
-    { "cmux.priority": true, ...attributes },
+    { ...attributes, "cmux.priority": true },
     fn,
     {
       context: reRoot ? trace.deleteSpan(otelContext.active()) : undefined,
@@ -134,11 +134,17 @@ export function setSpanAttributes(span: Span, attributes: MaybeAttributes): void
 
 export function recordSpanError(span: Span, err: unknown): void {
   if (err instanceof Error) {
-    span.recordException(err);
-    span.setStatus({ code: SpanStatusCode.ERROR, message: err.message });
+    const message = scrubText(err.message).slice(0, ERROR_CAUSE_MESSAGE_MAX);
+    const stack = err.stack ? scrubText(err.stack).slice(0, 4_000) : undefined;
+    span.recordException({
+      name: err.name,
+      message,
+      ...(stack ? { stack } : {}),
+    });
+    span.setStatus({ code: SpanStatusCode.ERROR, message });
     span.setAttributes({
       "cmux.error_name": err.name,
-      "cmux.error_message": scrubText(err.message),
+      "cmux.error_message": message,
     });
     const causes = summarizeErrorCauses(err);
     if (causes) {
@@ -151,7 +157,7 @@ export function recordSpanError(span: Span, err: unknown): void {
     }
     return;
   }
-  const message = String(err);
+  const message = scrubText(String(err)).slice(0, ERROR_CAUSE_MESSAGE_MAX);
   span.recordException(message);
   span.setStatus({ code: SpanStatusCode.ERROR, message });
   span.setAttributes({

--- a/web/services/vms/auth.ts
+++ b/web/services/vms/auth.ts
@@ -7,6 +7,7 @@ import {
   type StackAccessTokenIdentity,
 } from "../auth/stackAccessToken";
 import { recordAuthResolution } from "../auth/authTelemetry";
+import { withStackAuthSpan } from "../auth/stackTelemetry";
 import {
   deleteIdentitySnapshot,
   identitySnapshotTtlMs,
@@ -303,6 +304,7 @@ export async function verifyBrowserSessionRequest(
       },
     }),
     signal,
+    "get_user",
   );
   return user && !user.isAnonymous ? user : null;
 }
@@ -341,12 +343,16 @@ function subrouterStackAuthorizationTimeoutMs(
 async function stackAuthorizationCall<T>(
   operation: () => Promise<T>,
   signal: AbortSignal | undefined,
+  operationName = "request",
 ): Promise<T> {
-  if (!signal) return operation();
+  const timedOperation = () => withStackAuthSpan(operationName, operation, {
+    "cmux.auth.deadline_gated": signal !== undefined,
+  });
+  if (!signal) return timedOperation();
   const release = await acquireStackAuthorizationSlot(signal);
   let pending: Promise<T>;
   try {
-    pending = Promise.resolve().then(operation);
+    pending = Promise.resolve().then(timedOperation);
   } catch (error) {
     release();
     throw new SubrouterAuthorizationUnavailableError(
@@ -520,6 +526,7 @@ export async function verifyRequest(
           return stackServerApp.getUser({ tokenStore: tokens });
         },
         options.subrouterAuthorizationSignal,
+        "get_user",
       );
     } catch (error) {
       // The circuit's own fast-fail must not count as a new upstream throttle,
@@ -559,6 +566,7 @@ export async function verifyRequest(
       },
     }),
     options.subrouterAuthorizationSignal,
+    "get_user",
   );
   if (user) {
     const resolved = await authedUserFromStackUser(user, options);
@@ -829,6 +837,7 @@ async function listAllStackTeams(
         limit: STACK_TEAM_PAGE_SIZE,
       }),
       signal,
+      "list_teams",
     );
     teams.push(...page);
     const nextCursor = normalizedOptionalString(page.nextCursor);
@@ -854,6 +863,7 @@ async function findStackTeam(
       limit: STACK_TEAM_PAGE_SIZE,
     }),
     signal,
+    "list_teams",
   );
   const match = page.find(
     (candidate) => billingTeamFromUnknown(candidate)?.id === teamId,

--- a/web/tests/telemetry-sampler.test.ts
+++ b/web/tests/telemetry-sampler.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, describe, expect, test } from "bun:test";
-import { context as otelContext, trace, TraceFlags } from "@opentelemetry/api";
+import { context as otelContext, trace, TraceFlags, type Span } from "@opentelemetry/api";
 import { AsyncLocalStorageContextManager } from "@opentelemetry/context-async-hooks";
 import {
   BasicTracerProvider,
@@ -9,7 +9,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 
 import { buildCmuxTraceSampler, isPriorityPath, isPrioritySpan, isVmPrioritySpan } from "../services/observability/sampler";
-import { withApiRouteSpan, withPrioritySpan } from "../services/telemetry";
+import { recordSpanError, withApiRouteSpan, withPrioritySpan } from "../services/telemetry";
 
 describe("buildCmuxTraceSampler", () => {
   const neverSample = buildCmuxTraceSampler({ CMUX_OTEL_BASE_SAMPLE_RATIO: "0" });
@@ -188,6 +188,34 @@ describe("withApiRouteSpan re-rooting under head sampling", () => {
     expect(spans[0]?.name).toBe("cmux.dashboard.auth");
     expect(spans[0]?.parentSpanContext).toBeUndefined();
     expect(spans[0]?.links[0]?.context.traceId).toBe("1af7651916cd43dd8448eb211c80319c");
+  });
+
+  test("priority marker cannot be disabled by caller attributes", async () => {
+    exporter.reset();
+    await withPrioritySpan(
+      "cmux-dashboard",
+      "cmux.dashboard.auth",
+      { "cmux.priority": false },
+      async () => undefined,
+    );
+    expect(exporter.getFinishedSpans()[0]?.attributes["cmux.priority"]).toBe(true);
+  });
+
+  test("span exception payloads redact sensitive error text", () => {
+    let recorded: unknown;
+    const span = {
+      recordException(exception: unknown) {
+        recorded = exception;
+      },
+      setStatus() {},
+      setAttributes() {},
+    } as unknown as Span;
+    recordSpanError(span, new Error("request failed Bearer super-secret-token"));
+    expect(recorded).toEqual({
+      name: "Error",
+      message: "request failed [redacted]",
+      stack: expect.stringContaining("request failed [redacted]"),
+    });
   });
 
   test("a vm route inside a sampled trace nests normally", async () => {

--- a/web/tests/telemetry-sampler.test.ts
+++ b/web/tests/telemetry-sampler.test.ts
@@ -201,20 +201,64 @@ describe("withApiRouteSpan re-rooting under head sampling", () => {
     expect(exporter.getFinishedSpans()[0]?.attributes["cmux.priority"]).toBe(true);
   });
 
-  test("span exception payloads redact sensitive error text", () => {
+  test("every span error sink redacts sensitive Error metadata", () => {
     let recorded: unknown;
+    let status: unknown;
+    const attributes: Record<string, unknown> = {};
     const span = {
       recordException(exception: unknown) {
         recorded = exception;
       },
-      setStatus() {},
-      setAttributes() {},
+      setStatus(value: unknown) {
+        status = value;
+      },
+      setAttributes(value: Record<string, unknown>) {
+        Object.assign(attributes, value);
+      },
     } as unknown as Span;
-    recordSpanError(span, new Error("request failed Bearer super-secret-token"));
+    const cause = Object.assign(new Error("cause Bearer cause-secret-token"), {
+      name: "Cause Bearer cause-name-secret",
+      code: "crt_0123456789abcdef0123456789abcdef",
+    });
+    const error = new Error("request failed Bearer super-secret-token", { cause });
+    error.name = "Top Bearer top-name-secret";
+    recordSpanError(span, error);
     expect(recorded).toEqual({
-      name: "Error",
+      name: "Top [redacted]",
       message: "request failed [redacted]",
       stack: expect.stringContaining("request failed [redacted]"),
+    });
+    expect(status).toEqual({ code: 2, message: "request failed [redacted]" });
+    expect(attributes).toMatchObject({
+      "cmux.error_name": "Top [redacted]",
+      "cmux.error_message": "request failed [redacted]",
+      "cmux.error_cause_chain": "Cause [redacted]: cause [redacted]",
+      "cmux.error_cause_code": "[redacted]",
+    });
+    expect(JSON.stringify({ recorded, status, attributes })).not.toContain("secret");
+  });
+
+  test("non-Error inputs are redacted in every span sink", () => {
+    let recorded: unknown;
+    let status: unknown;
+    const attributes: Record<string, unknown> = {};
+    const span = {
+      recordException(exception: unknown) {
+        recorded = exception;
+      },
+      setStatus(value: unknown) {
+        status = value;
+      },
+      setAttributes(value: Record<string, unknown>) {
+        Object.assign(attributes, value);
+      },
+    } as unknown as Span;
+    recordSpanError(span, "request failed Bearer primitive-secret-token");
+    expect(recorded).toBe("request failed [redacted]");
+    expect(status).toEqual({ code: 2, message: "request failed [redacted]" });
+    expect(attributes).toEqual({
+      "cmux.error_name": "NonError",
+      "cmux.error_message": "request failed [redacted]",
     });
   });
 

--- a/web/tests/telemetry-sampler.test.ts
+++ b/web/tests/telemetry-sampler.test.ts
@@ -9,7 +9,7 @@ import {
 } from "@opentelemetry/sdk-trace-base";
 
 import { buildCmuxTraceSampler, isPriorityPath, isPrioritySpan, isVmPrioritySpan } from "../services/observability/sampler";
-import { withApiRouteSpan } from "../services/telemetry";
+import { withApiRouteSpan, withPrioritySpan } from "../services/telemetry";
 
 describe("buildCmuxTraceSampler", () => {
   const neverSample = buildCmuxTraceSampler({ CMUX_OTEL_BASE_SAMPLE_RATIO: "0" });
@@ -53,6 +53,9 @@ describe("buildCmuxTraceSampler", () => {
     expect(isPriorityPath("/v10/models")).toBe(false);
     expect(isPriorityPath("/api/coderouterx")).toBe(false);
     expect(isPrioritySpan("GET /api/coderouter/health", { "cmux.priority": false })).toBe(false);
+    expect(decideRoot("GET /api/admin/pro-users", { "http.route": "/api/admin/pro-users" })).toBe(
+      SamplingDecision.RECORD_AND_SAMPLED,
+    );
   });
 
   test("a client-sent sampled traceparent cannot bypass the ratio", () => {
@@ -110,6 +113,7 @@ describe("buildCmuxTraceSampler", () => {
     // Prefix semantics are intentional: /api/vm/... and /api/vm itself.
     expect(isVmPrioritySpan("GET", { "url.path": "/api/vm" })).toBe(true);
   });
+
 });
 
 describe("withApiRouteSpan re-rooting under head sampling", () => {
@@ -168,6 +172,22 @@ describe("withApiRouteSpan re-rooting under head sampling", () => {
         async () => new Response("{}", { status: 200 }),
       ));
     expect(exporter.getFinishedSpans().length).toBe(0);
+  });
+
+  test("explicit priority spans are kept and linked when the request is dropped", async () => {
+    exporter.reset();
+    await otelContext.with(unsampledParentContext(), () =>
+      withPrioritySpan(
+        "cmux-dashboard",
+        "cmux.dashboard.auth",
+        { "http.route": "/dashboard" },
+        async () => undefined,
+      ));
+    const spans = exporter.getFinishedSpans();
+    expect(spans.length).toBe(1);
+    expect(spans[0]?.name).toBe("cmux.dashboard.auth");
+    expect(spans[0]?.parentSpanContext).toBeUndefined();
+    expect(spans[0]?.links[0]?.context.traceId).toBe("1af7651916cd43dd8448eb211c80319c");
   });
 
   test("a vm route inside a sampled trace nests normally", async () => {


### PR DESCRIPTION
## What changed

Adds named, sampled traces for dashboard, CodeRouter, and admin server work. Stack Auth SDK calls now emit operation spans for `get_user`, `get_auth_json`, `get_team`, `list_users`, and `list_teams`. Direct Hexclave-compatible user updates record HTTP status and duration.

Dashboard and admin spans are explicitly prioritized, so they are retained even when the surrounding request is dropped by the 2% head sampler. Admin API routes are always kept with the existing low-volume priority set.

No tokens, SQL text, emails, or request bodies are recorded.

## Verification

- `bun test tests/telemetry-sampler.test.ts tests/stack-auth-error-alert.test.ts tests/stack-browser-session-handoff.test.ts tests/stack-analytics-identity.test.ts`
- `bun run typecheck`
- targeted ESLint pass

The first commit contains the regression coverage. The second commit contains the implementation.

Residual risk: browser hydration time still needs a browser trace linked to these server spans, and framework-generated fetch spans may still be less detailed than the named stage spans.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11921"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791092836&installation_model_id=21920&pr_number=11921&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11921&signature=5fef5a755b5574cf9ac1e5b796d3f698e476ada8aa0533626d6ecc159b346214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds named, sampled traces for dashboard, CodeRouter, and admin work so these low-volume operations are kept even when the surrounding request is dropped by the 2% head sampler. Stack Auth SDK calls now emit operation spans for `get_user`, `get_auth_json`, `get_team`, `list_users`, and `list_teams`; it changes nothing about request handling or the existing sampler behavior.

- Admin API routes are added to the always-kept priority path set.
- Direct Stack user updates record HTTP status and success as span attributes.
- Dashboard and coderouter spans record only the team scope, never team identifiers.
- Error names, messages, stack traces, and cause chains are scrubbed and truncated in span records; non-Error values are scrubbed too, and no tokens, SQL text, emails, or request bodies are recorded.

<sup>Written for commit 8ad592c9c67d3f08b4e008b2c8d169f5c7532a91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Observability**
  * Expanded monitoring coverage for authentication, administrator, dashboard, Coderouter, and virtual machine access flows.
  * Added timing, status, and operation details for user, team, and data-loading activities.
  * Prioritized administrator and other critical requests for more consistent diagnostic visibility.
  * Improved trace linking and protected sensitive information in recorded error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->