### PR TITLE
Ensure dev Cloud backends get Pro access

### DIFF
--- a/web/scripts/load-dev-env.sh
+++ b/web/scripts/load-dev-env.sh
@@ -57,6 +57,13 @@ if ! grep -q '^STACK_SUPER_SECRET_ADMIN_KEY=' "$cmux_secret_file"; then
   unset STACK_SUPER_SECRET_ADMIN_KEY
 fi
 
+# Local and remote development backends are test environments. Give their
+# authenticated users the Pro VM entitlement so the desktop dev build can
+# exercise Cloud flows without a billing prompt. Production and Vercel
+# processes do not source this file, and the explicit 0 override remains
+# available for plan-gating tests.
+export CMUX_LOCAL_DEV_PRO="${CMUX_LOCAL_DEV_PRO:-1}"
+
 # Vercel intentionally redacts sensitive values when an environment is pulled.
 # Recover the staging relay signer from a chmod-600 local file so downloaded
 # environments cannot silently start a web server that never publishes Iroh.

--- a/web/scripts/load-dev-env.test.mjs
+++ b/web/scripts/load-dev-env.test.mjs
@@ -11,9 +11,9 @@ const scriptPath = fileURLToPath(new URL("./load-dev-env.sh", import.meta.url));
 function sourceDevEnv({
   downloadedKeyID = "",
   downloadedPrivateKey = "",
-  keyFileContents,
+  keyFileContents = "",
   localKeyID = "",
-}) {
+} = {}) {
   const home = mkdtempSync(path.join(tmpdir(), "cmux-load-dev-env-"));
   const secrets = path.join(home, ".secrets");
   const envFile = path.join(secrets, "cmuxterm-dev.env");
@@ -38,7 +38,7 @@ function sourceDevEnv({
       "bash",
       [
         "-c",
-        `source "$1"; printf '%s\\0%s' "\${CMUX_RELAY_POLICY_KEY_ID-}" "\${CMUX_RELAY_POLICY_PRIVATE_KEY_PEM-}"`,
+        `source "$1"; printf '%s\\0%s\\0%s' "\${CMUX_RELAY_POLICY_KEY_ID-}" "\${CMUX_RELAY_POLICY_PRIVATE_KEY_PEM-}" "\${CMUX_LOCAL_DEV_PRO-}"`,
         "bash",
         scriptPath,
       ],
@@ -47,6 +47,7 @@ function sourceDevEnv({
         env: {
           ...process.env,
           HOME: home,
+          CMUX_LOCAL_DEV_PRO: "",
           CMUXTERM_ENV_FILE: envFile,
           CMUX_RELAY_POLICY_KEY_ID: "",
           CMUX_RELAY_POLICY_PRIVATE_KEY_PEM: "",
@@ -102,4 +103,9 @@ test("custom local fallback key id remains coupled to its private key", () => {
 
   assert.equal(keyID, "custom-local-key-id");
   assert.equal(loadedPrivateKey, privateKey);
+});
+
+test("development backends default to Pro VM access", () => {
+  const [, , developmentPro] = sourceDevEnv();
+  assert.equal(developmentPro, "1");
 });


### PR DESCRIPTION
## Summary
- grant authenticated development backends the Pro VM entitlement by default
- keep the explicit CMUX_LOCAL_DEV_PRO=0 override for plan-gating tests

## Verification
- bash -n web/scripts/load-dev-env.sh
- node --test web/scripts/load-dev-env.test.mjs
- git diff --check
- fresh direct-GCP cmux DEV dpro build shows 0 of 50 machines and no upgrade prompt
- authenticated vm ls reports planId=pro

Production and Vercel processes do not source this development environment loader.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791093887&installation_model_id=21920&pr_number=11924&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11924&signature=8b38f6a510d8b13c0ae17e9237bec4841481e7f94d278a3594734dea1145a3a1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defaults `CMUX_LOCAL_DEV_PRO` to 1 in the development environment loader so authenticated dev Cloud backends receive the Pro VM entitlement without a billing prompt.

- Keeps the explicit `CMUX_LOCAL_DEV_PRO=0` override for plan-gating tests.
- Production and Vercel processes don't source this loader, so they're unaffected.

<sup>Written for commit 93a93897c6ccffd164906a1aa3dd99330eacfe9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Development environments now provide authenticated users with Pro VM access by default.
  - Developers can explicitly disable Pro access when testing plan-based restrictions.

- **Tests**
  - Added coverage verifying the default Pro VM entitlement in development environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->