### PR TITLE
Align iOS terminal keyboard control with attachment button

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -404,7 +404,7 @@ struct TerminalComposerView: View {
                 }
             }
         }
-        .padding(.horizontal, 12)
+        .padding(.horizontal, MobileComposerLayout.standard.horizontalInset)
         // Tighter above the field than below (the user reported too much top
         // padding); the band height is still driven by content + this padding,
         // so the host's re-measure stays correct.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -404,7 +404,7 @@ struct TerminalComposerView: View {
                 }
             }
         }
-        .padding(.horizontal, MobileComposerLayout.horizontalInset)
+        .padding(.horizontal, MobileComposerLayout().horizontalInset)
         // Tighter above the field than below (the user reported too much top
         // padding); the band height is still driven by content + this padding,
         // so the host's re-measure stays correct.

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalComposerView.swift
@@ -404,7 +404,7 @@ struct TerminalComposerView: View {
                 }
             }
         }
-        .padding(.horizontal, MobileComposerLayout.standard.horizontalInset)
+        .padding(.horizontal, MobileComposerLayout.horizontalInset)
         // Tighter above the field than below (the user reported too much top
         // padding); the band height is still driven by content + this padding,
         // so the host's re-measure stays correct.

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerLayout.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerLayout.swift
@@ -5,7 +5,12 @@ public import CoreGraphics
 /// Keeping the leading margin in the support package prevents the UIKit keyboard
 /// control and the SwiftUI attachment controls from drifting apart as either
 /// surface evolves.
-public enum MobileComposerLayout {
+public struct MobileComposerLayout: Sendable {
+    /// Creates shared composer geometry with the standard horizontal inset.
+    public init(horizontalInset: CGFloat = 12) {
+        self.horizontalInset = horizontalInset
+    }
+
     /// Leading and trailing margin used by the terminal composer chrome.
-    public static let horizontalInset: CGFloat = 12
+    public let horizontalInset: CGFloat
 }

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerLayout.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerLayout.swift
@@ -5,13 +5,7 @@ public import CoreGraphics
 /// Keeping the leading margin in the support package prevents the UIKit keyboard
 /// control and the SwiftUI attachment controls from drifting apart as either
 /// surface evolves.
-public struct MobileComposerLayout: Sendable {
-    public static let standard = Self()
-
+public enum MobileComposerLayout {
     /// Leading and trailing margin used by the terminal composer chrome.
-    public let horizontalInset: CGFloat
-
-    public init(horizontalInset: CGFloat = 12) {
-        self.horizontalInset = horizontalInset
-    }
+    public static let horizontalInset: CGFloat = 12
 }

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerLayout.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/MobileComposerLayout.swift
@@ -1,0 +1,17 @@
+public import CoreGraphics
+
+/// Shared horizontal geometry for the terminal composer and its keyboard dock.
+///
+/// Keeping the leading margin in the support package prevents the UIKit keyboard
+/// control and the SwiftUI attachment controls from drifting apart as either
+/// surface evolves.
+public struct MobileComposerLayout: Sendable {
+    public static let standard = Self()
+
+    /// Leading and trailing margin used by the terminal composer chrome.
+    public let horizontalInset: CGFloat
+
+    public init(horizontalInset: CGFloat = 12) {
+        self.horizontalInset = horizontalInset
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -266,7 +266,7 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     private var themeChromeColor: UIColor { themeBarColor.terminalReadableForeground }
     /// Match the leading margin used by the terminal composer attachment
     /// controls so the keyboard toggle sits on the same vertical guide.
-    private static let accessoryHorizontalInset = MobileComposerLayout.standard.horizontalInset
+    private static let accessoryHorizontalInset = MobileComposerLayout.horizontalInset
     private static let accessoryButtonFont = UIFont.systemFont(ofSize: 14, weight: .medium)
     /// One shared SF Symbol config for every icon on the bar (paste, zoom,
     /// arrows, settings, keyboard toggle) so all glyphs render at one size.

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -266,7 +266,7 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     private var themeChromeColor: UIColor { themeBarColor.terminalReadableForeground }
     /// Match the leading margin used by the terminal composer attachment
     /// controls so the keyboard toggle sits on the same vertical guide.
-    private static let accessoryHorizontalInset = MobileComposerLayout.horizontalInset
+    private static let accessoryHorizontalInset = MobileComposerLayout().horizontalInset
     private static let accessoryButtonFont = UIFont.systemFont(ofSize: 14, weight: .medium)
     /// One shared SF Symbol config for every icon on the bar (paste, zoom,
     /// arrows, settings, keyboard toggle) so all glyphs render at one size.

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/TerminalInputTextView.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileSupport
 import CmuxMobileTerminalKit
 import Foundation
 import UIKit
@@ -263,7 +264,9 @@ final class TerminalInputTextView: UIView, UIKeyInput, UITextInput {
     }
     private var themeBarColor: UIColor { terminalTheme.terminalBackgroundUIColor }
     private var themeChromeColor: UIColor { themeBarColor.terminalReadableForeground }
-    private static let accessoryHorizontalInset: CGFloat = 16
+    /// Match the leading margin used by the terminal composer attachment
+    /// controls so the keyboard toggle sits on the same vertical guide.
+    private static let accessoryHorizontalInset = MobileComposerLayout.standard.horizontalInset
     private static let accessoryButtonFont = UIFont.systemFont(ofSize: 14, weight: .medium)
     /// One shared SF Symbol config for every icon on the bar (paste, zoom,
     /// arrows, settings, keyboard toggle) so all glyphs render at one size.

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6515,6 +6515,29 @@ final class cmuxUITests: XCTestCase {
         XCTAssertEqual(XCTWaiter.wait(for: [normalSend], timeout: 4), .completed)
     }
 
+    /// The terminal keyboard toggle and the composer attachment control share
+    /// the same leading guide, so the two bottom-dock controls read as one
+    /// aligned column when the keyboard is visible.
+    @MainActor
+    func testTerminalKeyboardToggleAlignsWithComposerAttachment() async throws {
+        let server = try MobileSyncMockHostServer()
+        let port = try await server.start()
+        defer { server.stop() }
+
+        let app = try launchConnectedApp(port: port)
+        let keyboardToggle = app.buttons["terminal.inputAccessory.hideKeyboard"]
+        let attachment = app.descendants(matching: .any)[Composer.attachButton]
+        XCTAssertTrue(keyboardToggle.waitForExistence(timeout: 8))
+        XCTAssertTrue(attachment.waitForExistence(timeout: 8))
+
+        XCTAssertEqual(
+            keyboardToggle.frame.minX,
+            attachment.frame.minX,
+            accuracy: 1,
+            "Terminal keyboard toggle and composer attachment must share the leading guide"
+        )
+    }
+
     /// Freeze fuzzing for the keyboard + layout interactions, modeled on
     /// `testFastPinchZoomDoesNotHangOrCorrupt`. The user report: "Sometimes the
     /// terminal on iOS freezes; we should do some fuzzing around here." The

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6530,6 +6530,14 @@ final class cmuxUITests: XCTestCase {
         defer { app.terminate() }
 
         XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 12))
+        let composerField = app.descendants(matching: .any)[Composer.field]
+        XCTAssertTrue(composerField.waitForExistence(timeout: 8))
+        composerField.tap()
+        XCTAssertTrue(
+            app.keyboards.firstMatch.waitForExistence(timeout: 8),
+            "Keyboard must be visible before checking the terminal accessory control"
+        )
+
         let keyboardToggle = app.buttons["terminal.inputAccessory.hideKeyboard"]
         let attachment = app.descendants(matching: .any)[Composer.attachButton]
         XCTAssertTrue(keyboardToggle.waitForExistence(timeout: 8))

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -6519,12 +6519,17 @@ final class cmuxUITests: XCTestCase {
     /// the same leading guide, so the two bottom-dock controls read as one
     /// aligned column when the keyboard is visible.
     @MainActor
-    func testTerminalKeyboardToggleAlignsWithComposerAttachment() async throws {
-        let server = try MobileSyncMockHostServer()
-        let port = try await server.start()
-        defer { server.stop() }
+    func testTerminalKeyboardToggleAlignsWithComposerAttachment() throws {
+        // Use the deterministic workspace-detail fixture instead of a mock
+        // network attach, so this geometry assertion is isolated from pairing
+        // and simulator loopback timing.
+        let app = launchApp(mockData: false, environment: [
+            "CMUX_UITEST_WORKSPACE_DETAIL_DELAYED_TERMINAL": "1",
+            "CMUX_MOBILE_SOAK_OPEN_SELECTED_WORKSPACE": "1",
+        ])
+        defer { app.terminate() }
 
-        let app = try launchConnectedApp(port: port)
+        XCTAssertTrue(app.otherElements["MobileTerminalSurface"].waitForExistence(timeout: 12))
         let keyboardToggle = app.buttons["terminal.inputAccessory.hideKeyboard"]
         let attachment = app.descendants(matching: .any)[Composer.attachButton]
         XCTAssertTrue(keyboardToggle.waitForExistence(timeout: 8))


### PR DESCRIPTION
## Summary

- Share the composer horizontal inset between the SwiftUI attachment controls and the UIKit terminal keyboard dock.
- Add an XCUITest that asserts both controls share the same leading frame.

The previous keyboard toggle used a 16 pt inset while the attachment controls used 12 pt. Both now use the shared `MobileComposerLayout` 12 pt guide.

## Verification

- Cloud macOS tagged build `kbalgn` succeeded.
- Cloud iOS archive/export succeeded for runtime-equivalent pre-rebase head `9783696b62b0b80ee2060fbea21763f1d6226873`.
- Focused iOS test passed in [run 33890783859](https://github.com/manaflow-ai/cmux/actions/runs/33890783859), including `testTerminalKeyboardToggleAlignsWithComposerAttachment`. The aggregate workflow remains red because package-conventions lint reports existing repository violations outside this diff.
- Current head `19bcd337323118247ecce9ee8ff08009934be295` is the same four commits rebased onto current `main`; required checks pass and the exact-head local autoreview found no actionable findings.
- Local isolated simulator preflight captured the aligned terminal surface at `artifacts/feat-ios-kb-attachment-align/simulator-terminal.png` on the same tagged build flow.
- The tagged iOS archive installed on the personal iPhone `4A52829D-6427-599F-A166-4058881D2DF4`, but signed setup could not complete because the tagged Mac did not reach the expected auth state. No plain fallback launch was used.

Apple HIG references: [Layout](https://developer.apple.com/design/human-interface-guidelines/layout), [Virtual keyboards](https://developer.apple.com/design/human-interface-guidelines/virtual-keyboards).
