### PR TITLE
perf: deduplicate dashboard Stack user reads

### DIFF
--- a/web/app/[locale]/dashboard/admin/page.tsx
+++ b/web/app/[locale]/dashboard/admin/page.tsx
@@ -1,12 +1,11 @@
 import { getTranslations } from "next-intl/server";
 import { notFound, redirect } from "next/navigation";
 
-import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { getRequestScopedStackUser, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { ADMIN_EMAIL_DOMAINS, isAdminUser } from "@/services/admin/access";
 import { loadProListSnapshot, type ProListSnapshot } from "@/services/admin/proList";
 import { withPrioritySpan } from "@/services/telemetry";
-import { withStackAuthSpan } from "@/services/auth/stackTelemetry";
 
 import { AdminProPanel } from "./admin-pro-panel";
 
@@ -26,11 +25,7 @@ export default async function DashboardAdminPage({
     "cmux-admin-dashboard",
     "cmux.admin.auth",
     { "http.route": "/dashboard/admin", "cmux.locale": locale },
-    () => withStackAuthSpan(
-      "get_user",
-      () => getStackServerApp().getUser({ or: "return-null" }),
-      { "cmux.auth.flow": "admin_page" },
-    ),
+    () => getRequestScopedStackUser("admin_page"),
   );
   if (!user || user.isAnonymous) {
     redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard/admin")));

--- a/web/app/[locale]/dashboard/page.tsx
+++ b/web/app/[locale]/dashboard/page.tsx
@@ -1,11 +1,10 @@
 import { getTranslations } from "next-intl/server";
 import { redirect } from "next/navigation";
 import { Link } from "@/i18n/navigation";
-import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { getRequestScopedStackUser, isStackConfigured } from "@/app/lib/stack";
 import { localizedVaultPath, vaultSignInHref } from "@/app/lib/vault-auth";
 import { isVaultEnabled } from "@/services/vault/config";
 import { withPrioritySpan } from "@/services/telemetry";
-import { withStackAuthSpan } from "@/services/auth/stackTelemetry";
 
 
 export default async function DashboardIndexPage({
@@ -22,11 +21,7 @@ export default async function DashboardIndexPage({
     "cmux-dashboard",
     "cmux.dashboard.auth",
     { "http.route": "/dashboard", "cmux.locale": locale },
-    () => withStackAuthSpan(
-      "get_user",
-      () => getStackServerApp().getUser({ or: "return-null" }),
-      { "cmux.auth.flow": "dashboard" },
-    ),
+    () => getRequestScopedStackUser("dashboard"),
   );
   if (!user) {
     redirect(vaultSignInHref(localizedVaultPath(locale, "/dashboard")));

--- a/web/app/lib/stack.ts
+++ b/web/app/lib/stack.ts
@@ -1,3 +1,5 @@
+import { trace } from "@opentelemetry/api";
+import { cache } from "react";
 import { StackServerApp } from "@stackframe/stack";
 import { env } from "../env";
 import { stackApiBaseURL } from "../../services/auth/stackApiBaseURL";
@@ -14,6 +16,37 @@ const secretServerKey = env.STACK_SECRET_SERVER_KEY;
 
 let stackServerAppCache: StackServerApp<true> | null = null;
 let nonRedirectingStackServerAppCache: StackServerApp<true> | null = null;
+
+type RequestStackUser = Awaited<ReturnType<StackServerApp<true>["getUser"]>>;
+
+// React creates one value per server render. This map deduplicates repeated
+// read-only user lookups without sharing auth state between users or requests.
+const requestStackUserCache = cache(
+  () => new Map<string, Promise<RequestStackUser>>(),
+);
+
+/** Resolve the current browser user once per server render. */
+export function getRequestScopedStackUser(flow: string): Promise<RequestStackUser> {
+  const cache = requestStackUserCache();
+  const key = "current-user";
+  const existing = cache.get(key);
+  if (existing) {
+    trace.getActiveSpan()?.setAttribute("cmux.auth.request_cache", "hit");
+    return existing;
+  }
+
+  trace.getActiveSpan()?.setAttribute("cmux.auth.request_cache", "miss");
+  const pending = withStackAuthSpan(
+    "get_user",
+    () => getStackServerApp().getUser({ or: "return-null" }),
+    { "cmux.auth.flow": flow },
+  );
+  cache.set(key, pending);
+  void pending.catch(() => {
+    if (cache.get(key) === pending) cache.delete(key);
+  });
+  return pending;
+}
 
 export function isStackConfigured(): boolean {
   return Boolean(projectId && publishableClientKey && secretServerKey);


### PR DESCRIPTION
## Fixed
Dashboard and admin pages can now reuse the same read-only Stack user lookup during one server render.

## How
React request-scoped memoization stores only the current render promise. Failed calls are removed. Axiom records `cmux.auth.request_cache` as `hit` or `miss`. Authorization remains request-fresh and no webhook or shared auth cache was added.

## Verification
- `bun run typecheck`
- targeted ESLint
- `bun test tests/telemetry-sampler.test.ts`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11933"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791110346&installation_model_id=21920&pr_number=11933&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11933&signature=6fad329b4ab4fdf5cd7e43ee38d96c126de1ddcb0d2c62c88c4b637940a5e55a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reuses a single read-only Stack user lookup across dashboard and admin pages during one server render, replacing each page's duplicate `getUser()` call.

- React's request-scoped `cache()` stores only the current render's promise; failed lookups are evicted.
- Telemetry records `cmux.auth.request_cache` as `hit` or `miss`.
- Authorization stays request-fresh; no webhook or shared auth cache was added.

<sup>Written for commit 13a4063b7d57f77df2f7471390ba21817123d180. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved dashboard and admin page authentication handling for more consistent signed-in user detection.
  - Reduced repeated user lookups during page rendering, helping dashboard pages load more efficiently.
  - Added safer handling for failed user lookups so subsequent requests can retry normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->