### PR TITLE
Strip cmux-tui and remove unused Rust dependencies

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -655,7 +655,6 @@ dependencies = [
 name = "cmux-remote"
 version = "0.1.0"
 dependencies = [
- "anyhow",
  "async-trait",
  "axum",
  "base64",
@@ -681,7 +680,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "snow",
- "socket2 0.5.10",
  "subtle",
  "tempfile",
  "tokio",
@@ -763,7 +761,6 @@ dependencies = [
  "cmux-tui-machine-protocol",
  "crossbeam-channel",
  "crossterm",
- "fs4",
  "getrandom 0.3.4",
  "ghostty-vt",
  "glob",
@@ -817,7 +814,6 @@ dependencies = [
  "ghostty-vt",
  "jsonschema",
  "libc",
- "portable-pty",
  "regex",
  "rusqlite",
  "serde",
@@ -2067,7 +2063,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.5",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -2315,7 +2311,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.5",
+ "socket2",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -3042,7 +3038,7 @@ dependencies = [
  "objc2-system-configuration",
  "pin-project-lite",
  "serde",
- "socket2 0.6.5",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -3102,7 +3098,7 @@ dependencies = [
  "pin-project-lite",
  "rustc-hash",
  "rustls",
- "socket2 0.6.5",
+ "socket2",
  "thiserror 2.0.19",
  "tokio",
  "tokio-stream",
@@ -3145,7 +3141,7 @@ checksum = "02bba20e097a5a16cd0ad14ec882fae1e80a092a124e9422fc4dddd92e96a647"
 dependencies = [
  "cfg_aliases 0.2.2",
  "libc",
- "socket2 0.6.5",
+ "socket2",
  "tracing",
  "windows-sys 0.61.2",
 ]
@@ -3796,7 +3792,7 @@ dependencies = [
  "rand 0.10.2",
  "serde",
  "smallvec",
- "socket2 0.6.5",
+ "socket2",
  "time",
  "tokio",
  "tokio-util",
@@ -4751,16 +4747,6 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "socket2"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
@@ -5163,7 +5149,7 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.5",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]

--- a/cmux-tui/crates/cmux-remote/Cargo.toml
+++ b/cmux-tui/crates/cmux-remote/Cargo.toml
@@ -12,10 +12,9 @@ workspace = true
 
 [features]
 default = ["iroh-transport"]
-iroh-transport = ["dep:iroh", "dep:socket2"]
+iroh-transport = ["dep:iroh"]
 
 [dependencies]
-anyhow.workspace = true
 async-trait.workspace = true
 axum.workspace = true
 base64.workspace = true
@@ -37,7 +36,6 @@ libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-socket2 = { workspace = true, optional = true }
 snow.workspace = true
 subtle.workspace = true
 tokio.workspace = true

--- a/cmux-tui/crates/cmux-tui-core/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui-core/Cargo.toml
@@ -15,7 +15,6 @@ ghostty-vt.workspace = true
 cmux-tui-cdp.workspace = true
 cmux-pty.workspace = true
 cmux-remote-protocol.workspace = true
-portable-pty.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 anyhow.workspace = true

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -46,7 +46,6 @@ parking_lot.workspace = true
 sha2.workspace = true
 uuid.workspace = true
 wait-timeout.workspace = true
-fs4.workspace = true
 
 [target.'cfg(unix)'.dependencies]
 cmux-remote.workspace = true

--- a/scripts/strip-release-bundle.sh
+++ b/scripts/strip-release-bundle.sh
@@ -42,6 +42,7 @@ strip_if_macho() {
 
 strip_if_macho "$APP_PATH/Contents/MacOS/cmux"
 strip_if_macho "$APP_PATH/Contents/Resources/bin/cmux"
+strip_if_macho "$APP_PATH/Contents/Resources/bin/cmux-tui"
 strip_if_macho "$APP_PATH/Contents/Resources/bin/cmux-diff-sidecar"
 
 if [ -d "$APP_PATH/Contents/PlugIns" ]; then

--- a/tests/test_strip_release_bundle.sh
+++ b/tests/test_strip_release_bundle.sh
@@ -16,6 +16,7 @@ mkdir -p \
 for path in \
   "$APP/Contents/MacOS/cmux" \
   "$APP/Contents/Resources/bin/cmux" \
+  "$APP/Contents/Resources/bin/cmux-tui" \
   "$APP/Contents/Resources/bin/cmux-diff-sidecar" \
   "$APP/Contents/Resources/bin/ghostty" \
   "$APP/Contents/PlugIns/CmuxDockTilePlugin.plugin/Contents/MacOS/CmuxDockTilePlugin" \
@@ -30,7 +31,7 @@ done
 cat > "$TMP_DIR/tools/file" <<'EOF'
 #!/usr/bin/env bash
 case "$1" in
-  *"/Contents/MacOS/cmux"|*"/Contents/Resources/bin/cmux"|*"/Contents/Resources/bin/cmux-diff-sidecar"|*"CmuxDockTilePlugin"|*"libcmux_"*)
+  *"/Contents/MacOS/cmux"|*"/Contents/Resources/bin/cmux"|*"/Contents/Resources/bin/cmux-tui"|*"/Contents/Resources/bin/cmux-diff-sidecar"|*"CmuxDockTilePlugin"|*"libcmux_"*)
     printf '%s: Mach-O universal binary\n' "$1"
     ;;
   *)
@@ -55,6 +56,7 @@ expected="$TMP_DIR/expected.log"
 printf '%s\n' \
   "-S -x $APP/Contents/MacOS/cmux" \
   "-S -x $APP/Contents/Resources/bin/cmux" \
+  "-S -x $APP/Contents/Resources/bin/cmux-tui" \
   "-S -x $APP/Contents/Resources/bin/cmux-diff-sidecar" \
   "-S -x $APP/Contents/PlugIns/CmuxDockTilePlugin.plugin/Contents/MacOS/CmuxDockTilePlugin" \
   "-S -x $APP/Contents/Frameworks/libcmux_command_palette_nucleo_ffi.dylib" \


### PR DESCRIPTION
Summary:
- Strip cmux-tui in the release bundle before signing.
- Remove unused fs4 from cmux-tui, unused anyhow and optional socket2 from cmux-remote, and unused portable-pty from cmux-tui-core.
- Refresh cmux-tui Cargo.lock.

Measured impact:
- cmux-tui strip experiment saved 8.06 MiB raw, about 1.4 MB compressed per arm64 build.
- Dependency cleanup reduced the Linux release binary by 64 bytes because those crates were already absent after linker elimination.

Verification:
- tests/test_strip_release_bundle.sh passes.
- cargo build -p cmux-tui --locked --release passes on Blacksmith testbox.
- cargo machete reports only intentional or unrelated warnings in Cloudflare and SDK example packages.
- cargo test -p cmux-tui --locked ran 1652 unit tests and 57 CLI tests. Existing flaky failures remain in five UI/app tests and three CLI integration tests; no failure points to the dependency or strip changes.

Computer Use permissions were audited. The main app does not call TCC APIs or run cmux-cua. The helper has a stable bundle identity and refreshHelperStatusAfterPermissionChange recovers the helper after permission changes without restarting the main app.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791111592&installation_model_id=21920&pr_number=11934&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11934&signature=41c4e3a5162be710870a90eba9b91a575c62a7593b55767d0b6ebacaaacafb7a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Strips the `cmux-tui` binary from the release bundle before signing, saving about 1.4 MB compressed per arm64 build.

**Dependencies**
- Removes unused `fs4` from `cmux-tui`, `anyhow` and optional `socket2` from `cmux-remote`, and `portable-pty` from `cmux-tui-core`.
- Refreshes the `cmux-tui` lockfile. These crates were already linker-eliminated, so the cleanup has negligible binary size impact.

<sup>Written for commit b37398188baa8861e5ab43d3feb7ddba1ea6c7b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

