### PR TITLE
analytics: keep CodeRouter usage in ClickHouse

### DIFF
--- a/docs/coderouter-operations.md
+++ b/docs/coderouter-operations.md
@@ -79,25 +79,19 @@ the authenticated output if it contains a principal identifier.
 
 - Sentry project: `coderouter-web`; alert on new coderouter errors,
   reconciliation failure, refresh failure, and sustained provider failure.
-- PostHog project: the main cmux project (`244066`), with AI Observability
-  enabled for the canonical CodeRouter trace events. Keep ordinary cmux
-  product events separate with `product` filters.
-- CodeRouter model-usage events use PostHog's standard `$ai_generation`
-  schema in content-free privacy mode. They contain token counts, the
-  model/provider category required for pricing, and a pre-calculated
-  API-equivalent estimate. They do not include a prompt, output, request body,
-  email, credential or raw free-form input. Authenticated events use the Stack
-  user id and the billing team as the `stack_team` group.
+- PostHog project: the main cmux project (`244066`) for account/session
+  lifecycle and operational exceptions. It is not a CodeRouter usage ledger.
+- CodeRouter model usage uses the ClickHouse `usage_events` ledger. It contains
+  token counts, model/provider categories, and the API-equivalent estimate.
+  Authenticated rows carry the Stack user id and billing team.
 - PostHog must never contain prompts, outputs, bodies, credentials, route
   tokens, emails, payment-method details, or provider-account labels. The
   canonical trace may carry a bounded opaque account ID for routing diagnostics;
   it is not a credential or an account label.
 - Person-level product analytics live in the main cmux PostHog project through
-  `web/services/coderouter/analytics.ts` and
-  `web/services/coderouter/requestTelemetry.ts`: `$ai_trace`, `$ai_span`,
-  `$ai_generation`, and closed account/session/upstream lifecycle events. A
-  failed request is a `$ai_trace` with `$ai_is_error=true`; the old
-  `coderouter_request_failed` event is not emitted. See
+  `web/services/coderouter/analytics.ts`: closed account/session/upstream
+  lifecycle events and operational exceptions. Route outcomes and token usage
+  stay in ClickHouse. See
   `docs/posthog/cloud-product-analytics.md` for the catalog and query shapes.
 - The former dedicated CodeRouter project (`549394`) is no longer a runtime
   sink. Treat its dashboards and environment keys as legacy, and remove keys
@@ -207,8 +201,7 @@ is replayed on the next healthy account (up to `MAX_UPSTREAM_ATTEMPTS`, 4). Disa
 skipped. When every account is cooling down the client gets 503 `overloaded_error` with the soonest
 `retry-after`; when none exists, 503 with the add instructions. `usage_events.upstream_account_id`
 and `route_events.upstream_account_id` (ClickHouse migration `002`) name the account that served a
-request; PostHog carries it on the canonical `$ai_trace` and `$ai_generation`
-events when available.
+request. PostHog does not receive request-level LLM or token events.
 
 The cmux CLI manages the list through the app's session, so no credential is typed into a browser
 or argv:

--- a/docs/posthog/cloud-product-analytics.md
+++ b/docs/posthog/cloud-product-analytics.md
@@ -75,29 +75,21 @@ audit source for those destroys.
 
 ## CodeRouter events
 
-Source: `services/coderouter/analytics.ts` and
-`services/coderouter/requestTelemetry.ts`. The request wrapper emits one
-canonical trace for every routed request and links model usage to that trace.
+PostHog is only for CodeRouter lifecycle and operational exception events.
+ClickHouse is the authoritative source for every routed request, model
+completion, token count, provider, model, latency, failure, and VM attribution.
 
 | Event | When | Properties |
 | --- | --- | --- |
-| `$ai_trace` | Every CodeRouter request, after the response | `$ai_trace_id`, `$ai_latency` (seconds), `$ai_http_status`, `$ai_is_error`, `coderouter_request_id`, `coderouter_outcome`, `coderouter_failure_stage`, `coderouter_fault`, `coderouter_provider`, `coderouter_agent`, `coderouter_attempts`, `coderouter_vm_id` when bound, bounded `upstream_account_id` when available, `trace_id` |
-| `$ai_span` | Each bounded request step | `$ai_parent_id`, `$ai_span_id`, `$ai_span_name`, `$ai_latency`, `$ai_is_error`, scrubbed `$ai_error`, `upstream_kind`, bounded `upstream_account_id` when available |
-| `$ai_generation` | A completion with usable token usage | `$ai_trace_id`, `$ai_parent_id`, `$ai_model`, `$ai_provider`, `$ai_input_tokens`, `$ai_cache_read_input_tokens`, `$ai_output_tokens`, `coderouter_total_tokens`, `coderouter_priced_tokens`, `coderouter_unpriced_tokens`, `coderouter_pricing_version`, `$ai_total_cost_usd` when priced, `$ai_http_status`, `$ai_stream`, `coderouter_vm_id` when bound, bounded `upstream_account_id` when available |
 | `coderouter_account_added` / `_removed` | Provider account lifecycle | Closed-schema provider and source fields, plus bounded state flags |
 | `coderouter_route_session_issued` / `_revoked` | Route-session lifecycle | No free-form fields |
 | `coderouter_claude_upstream_set` / `_removed` | Claude upstream lifecycle | Closed-schema upstream kind and replacement flag |
 
-All CodeRouter events carry `product: coderouter` and the current schema
-version. `$ai_trace` with `$ai_is_error: true` replaces the old
-`coderouter_request_failed` event. Non-caller failures also produce a
-`$exception`; caller errors stay on the trace. The request id is shared with
-the ClickHouse route and usage ledger, so a report can join PostHog, Axiom and
-ClickHouse without sending prompts, outputs, headers, credentials, emails or
-request bodies.
-
-`$ai_total_cost_usd` is a versioned API-equivalent list-price estimate, not
-cmux spend. Upstream accounts belong to the user's own subscriptions.
+Lifecycle events carry `product: coderouter` and the current schema version.
+Non-caller failures also produce a `$exception`. The route request id is
+shared with ClickHouse and Axiom, but no request-level LLM trace or token event
+is sent to PostHog. ClickHouse stores the versioned API-equivalent list-price
+estimate, not cmux spend.
 
 The application no longer writes new CodeRouter events to the former dedicated
 project (`549394`). Its old dashboards and environment keys are legacy; remove
@@ -118,32 +110,26 @@ WHERE event IN ('cloud_vm_created','cloud_vm_attached','cloud_vm_exec','cloud_vm
 GROUP BY d ORDER BY d
 ```
 
-CodeRouter per-user value (30d):
+CodeRouter per-user usage (30d, ClickHouse):
 
 ```sql
-SELECT distinct_id, count() AS generations,
-       sum(properties.$ai_total_cost_usd) AS api_equivalent_usd
-FROM events
-WHERE event = '$ai_generation'
-  AND properties.product = 'coderouter'
-  AND distinct_id != 'coderouter-server'
-  AND timestamp >= now() - INTERVAL 30 DAY
-GROUP BY distinct_id ORDER BY api_equivalent_usd DESC LIMIT 25
+SELECT stack_user_id, count() AS completions,
+       sum(total_tokens) AS total_tokens,
+       sum(api_equivalent_usd) AS api_equivalent_usd
+FROM coderouter.usage_events
+WHERE event_time >= now() - INTERVAL 30 DAY
+GROUP BY stack_user_id ORDER BY api_equivalent_usd DESC LIMIT 25
 ```
 
-CodeRouter failure rate uses all known-user traces as the denominator, not
-only successful generations:
+CodeRouter failure rate uses ClickHouse route rows for the denominator:
 
 ```sql
-SELECT toStartOfDay(timestamp) AS d,
+SELECT toStartOfDay(event_time) AS d,
        count() AS requests,
-       countIf(properties.$ai_is_error = true) AS failed,
-       round(100 * countIf(properties.$ai_is_error = true) / max2(1, count()), 1) AS failure_pct
-FROM events
-WHERE event = '$ai_trace'
-  AND properties.product = 'coderouter'
-  AND distinct_id != 'coderouter-server'
-  AND timestamp >= now() - INTERVAL 30 DAY
+       countIf(status >= 400 OR outcome != 'success') AS failed,
+       round(100 * countIf(status >= 400 OR outcome != 'success') / max2(1, count()), 1) AS failure_pct
+FROM coderouter.route_events
+WHERE event_time >= now() - INTERVAL 30 DAY
 GROUP BY d ORDER BY d
 ```
 

--- a/docs/posthog/coderouter-analytics-dashboard.md
+++ b/docs/posthog/coderouter-analytics-dashboard.md
@@ -1,86 +1,45 @@
-# CodeRouter PostHog dashboards
+# CodeRouter analytics
 
-The current CodeRouter product dashboard is **Cloud VMs + CodeRouter
-(product)** in the main cmux PostHog project (`244066`). It is managed by
-`cmuxterm-hq/scripts/posthog-cloud-dashboard.py` and reads the catalog in
-`posthog_cloud_metrics.py`.
+CodeRouter usage is a ClickHouse concern. Do not build PostHog tiles from
+`$ai_generation`, `$ai_trace`, `$ai_span`, token properties, or cost fields.
+The ClickHouse tables are `coderouter.usage_events` (one row per completion)
+and `coderouter.route_events` (one row per routed request). Both tables carry
+the Stack user id when authentication succeeds, the billing team, provider,
+agent, model, status, latency, and Cloud VM id when bound.
 
-The former **CodeRouter Operations & Usage** dashboard in project `549394` is
-historical. The application no longer writes new events there. Do not build
-new customer or product reports from that project.
+PostHog remains useful for low-volume product lifecycle events:
+`coderouter_account_added`, `coderouter_account_removed`,
+`coderouter_route_session_issued`, `coderouter_route_session_revoked`, and
+`coderouter_claude_upstream_*`. These events use the Stack user as
+`distinct_id` and the billing team as `stack_team`; they contain no usage or
+token values.
 
-## Event rules
+The managed Cloud VM dashboard includes the lifecycle tile for account
+connections. The daily email reads all CodeRouter usage and failure metrics
+from ClickHouse. If ClickHouse is unavailable, the email says so and never
+falls back to PostHog.
 
-Every CodeRouter tile must include the product filter. Add the event-family
-predicate that matches the tile:
+Example queries:
 
 ```sql
-WHERE properties.product = 'coderouter'
+SELECT toStartOfDay(event_time) AS day,
+       uniqExactIf(stack_user_id, stack_user_id IS NOT NULL) AS users,
+       count() AS completions,
+       sum(total_tokens) AS tokens,
+       sum(api_equivalent_usd) AS api_equivalent_usd
+FROM coderouter.usage_events
+WHERE event_time >= now() - INTERVAL 30 DAY
+GROUP BY day ORDER BY day;
 ```
 
-Use `event = '$ai_trace'` for request, latency, failure, provider and agent
-tiles. Use `event = '$ai_generation'` for token, pricing and API-equivalent
-tiles. Use the specific account or route-session lifecycle event for lifecycle
-tiles.
-
-Use the canonical event names and fields:
-
-| Question | Event | Fields |
-| --- | --- | --- |
-| Request volume and success | `$ai_trace` | `$ai_is_error`, `coderouter_outcome`, `coderouter_failure_stage`, `coderouter_fault`, `coderouter_provider`, `coderouter_agent` |
-| Request latency | `$ai_trace` | `$ai_latency` (seconds), `coderouter_attempts` |
-| Failure stage | `$ai_trace` | `coderouter_failure_stage`, `coderouter_outcome`, `coderouter_fault` |
-| Tokens and API-equivalent value | `$ai_generation` | `$ai_input_tokens`, `$ai_cache_read_input_tokens`, `$ai_output_tokens`, `coderouter_total_tokens`, `$ai_total_cost_usd` |
-| Pricing coverage | `$ai_generation` | `coderouter_priced_tokens`, `coderouter_unpriced_tokens`, `coderouter_total_tokens` |
-| Cloud VM share | `$ai_generation` or `$ai_trace` | `coderouter_vm_id IS NOT NULL` |
-| Account and session lifecycle | lifecycle events | `coderouter_account_*`, `coderouter_route_session_*` |
-
-Exclude `distinct_id = 'coderouter-server'` from person-level product counts.
-That id is for unauthenticated requests and operator events. The same Stack
-user id is used by Cloud VM product events, so cross-product joins use
-`distinct_id`.
-
-`$ai_generation` is emitted only when a completion has usable token usage. A
-failure is a `$ai_trace` with `$ai_is_error = true`; there is no
-`coderouter_request_failed` event. Divide failed traces by all known-user
-traces when calculating failure rate. Do not divide by failed plus
-generations, because requests can fail before a generation exists.
-
-## Privacy and integrity checks
-
-Every tile and alert must preserve these rules:
-
-* no prompts, outputs, request bodies, credentials, emails or route tokens;
-* `$geoip_disable = true`;
-* user events use a bounded Stack user id and team events use the
-  `$groups.stack_team` group;
-* `coderouter_priced_tokens + coderouter_unpriced_tokens` equals
-  `coderouter_total_tokens`;
-* cached input tokens do not exceed input tokens;
-* API-equivalent dollars are labeled as a list-price estimate, not cmux spend.
-
-Any violation is an incident. The ClickHouse ledger remains the source for
-customer-facing team and machine usage; PostHog is for product and operations
-analysis.
-
-## Recommended views
-
-1. Requests, failures and p50/p95 latency by day from `$ai_trace`.
-2. Failure stage, outcome, fault and provider from failed `$ai_trace` rows.
-3. Tokens, pricing coverage and API-equivalent estimate by day from
-   `$ai_generation`.
-4. Agent and provider mix from `$ai_trace` and `$ai_generation`.
-5. Cloud VM versus local traffic from `coderouter_vm_id`.
-6. Account-added to route-session-issued to first-generation activation.
-7. Cloud VM and CodeRouter overlap, joined on the Stack `distinct_id`.
-
-For the managed dashboard, run the dashboard script in dry-run mode first. It
-executes every HogQL query before it changes any insight:
-
-```sh
-POSTHOG_PERSONAL_API_KEY=... python3 scripts/posthog-cloud-dashboard.py --dry-run
+```sql
+SELECT toStartOfDay(event_time) AS day,
+       count() AS requests,
+       countIf(status >= 400 OR outcome != 'success') AS failed
+FROM coderouter.route_events
+WHERE event_time >= now() - INTERVAL 30 DAY
+GROUP BY day ORDER BY day;
 ```
 
-Never put a PostHog key in source, a ticket, or chat. Remove the retired
-`POSTHOG_CODEROUTER_*` and `CODEROUTER_ANALYTICS_SCOPE_SECRET` variables only
-after checking for remaining operator consumers.
+API-equivalent dollars are list-price estimates for the routed tokens, not
+cmux spend. Customer-facing usage and billing reports must use ClickHouse.

--- a/docs/posthog/coderouter-analytics-dashboard.md
+++ b/docs/posthog/coderouter-analytics-dashboard.md
@@ -3,9 +3,10 @@
 CodeRouter usage is a ClickHouse concern. Do not build PostHog tiles from
 `$ai_generation`, `$ai_trace`, `$ai_span`, token properties, or cost fields.
 The ClickHouse tables are `coderouter.usage_events` (one row per completion)
-and `coderouter.route_events` (one row per routed request). Both tables carry
-the Stack user id when authentication succeeds, the billing team, provider,
-agent, model, status, latency, and Cloud VM id when bound.
+and `coderouter.route_events` (one row per routed request). `usage_events`
+carries token, pricing, model, and provider fields. `route_events` carries
+status, outcome, failure stage, duration, and provider fields. Both tables
+carry team, Stack user, agent, and optional Cloud VM attribution fields.
 
 PostHog remains useful for low-volume product lifecycle events:
 `coderouter_account_added`, `coderouter_account_removed`,
@@ -23,7 +24,7 @@ Example queries:
 
 ```sql
 SELECT toStartOfDay(event_time) AS day,
-       uniqExactIf(stack_user_id, stack_user_id IS NOT NULL) AS users,
+       uniqExactIf(stack_user_id, stack_user_id != '') AS users,
        count() AS completions,
        sum(total_tokens) AS tokens,
        sum(api_equivalent_usd) AS api_equivalent_usd

--- a/docs/posthog/coderouter-team-usage-30d.hogql
+++ b/docs/posthog/coderouter-team-usage-30d.hogql
@@ -10,8 +10,8 @@ SELECT
   sumIf(total_tokens, priced = 1) AS priced_tokens,
   sumIf(total_tokens, priced = 0) AS unpriced_tokens
 FROM coderouter.usage_events
-WHERE event_time >= now() - INTERVAL 29 DAY
-  AND event_time < now() + INTERVAL 1 DAY
+WHERE event_time >= toStartOfDay(now()) - INTERVAL 29 DAY
+  AND event_time < toStartOfDay(now()) + INTERVAL 1 DAY
   AND team_id = {team_id:String}
 GROUP BY day
 ORDER BY day ASC

--- a/docs/posthog/coderouter-team-usage-30d.hogql
+++ b/docs/posthog/coderouter-team-usage-30d.hogql
@@ -1,23 +1,18 @@
--- Historical operator query. The customer app reads ClickHouse directly;
--- it does not call a PostHog Endpoint. If an operator publishes this query,
--- use the main cmux project and provide `team_id` as a required string.
+-- CodeRouter token usage is not available in PostHog. Run this query in the
+-- ClickHouse console, binding the team id as a query parameter.
 SELECT
-  toString(toDate(timestamp)) AS day,
-  sum(toInt(coalesce(properties.$ai_input_tokens, 0))) AS input_tokens,
-  sum(toInt(coalesce(properties.$ai_cache_read_input_tokens, 0))) AS cached_input_tokens,
-  sum(toInt(coalesce(properties.$ai_output_tokens, 0))) AS output_tokens,
-  sum(toInt(coalesce(properties.coderouter_total_tokens, 0))) AS total_tokens,
-  sum(toFloat(coalesce(properties.$ai_total_cost_usd, 0))) AS api_equivalent_usd,
-  sum(toInt(coalesce(properties.coderouter_priced_tokens, 0))) AS priced_tokens,
-  sum(toInt(coalesce(properties.coderouter_unpriced_tokens, 0))) AS unpriced_tokens
-FROM events
-WHERE event = '$ai_generation'
-  AND properties.product = 'coderouter'
-  AND toDate(timestamp) >= toDate(now()) - INTERVAL 29 DAY
-  AND toDate(timestamp) <= toDate(now())
-  AND properties.$groups.stack_team = {variables.team_id}
+  toDate(event_time) AS day,
+  sum(input_tokens) AS input_tokens,
+  sum(cached_input_tokens) AS cached_input_tokens,
+  sum(output_tokens) AS output_tokens,
+  sum(total_tokens) AS total_tokens,
+  sum(api_equivalent_usd) AS api_equivalent_usd,
+  sumIf(total_tokens, priced = 1) AS priced_tokens,
+  sumIf(total_tokens, priced = 0) AS unpriced_tokens
+FROM coderouter.usage_events
+WHERE event_time >= now() - INTERVAL 29 DAY
+  AND event_time < now() + INTERVAL 1 DAY
+  AND team_id = {team_id:String}
 GROUP BY day
 ORDER BY day ASC
--- Fetch one overflow sentinel rather than silently trimming if a future query
--- change violates the exactly-30-UTC-day invariant. The caller rejects >30 rows.
-LIMIT 31
+LIMIT 31;

--- a/web/db/clickhouse/001_coderouter_events.sql
+++ b/web/db/clickhouse/001_coderouter_events.sql
@@ -32,6 +32,7 @@ TTL toDateTime(event_time) + INTERVAL 400 DAY;
 CREATE TABLE IF NOT EXISTS {db}.route_events (
   event_time DateTime64(3, 'UTC') CODEC(Delta, ZSTD),
   team_id String,
+  stack_user_id Nullable(String),
   vm_id Nullable(String),
   provider LowCardinality(String),
   agent LowCardinality(String),

--- a/web/db/clickhouse/003_route_events_stack_user.sql
+++ b/web/db/clickhouse/003_route_events_stack_user.sql
@@ -1,0 +1,6 @@
+-- Preserve the authenticated Stack user on failed and successful route rows.
+-- Nullable is required for auth rejects that happen before route-token
+-- identity exists. Usage rows remain the token source of truth.
+ALTER TABLE {db}.route_events
+  ADD COLUMN IF NOT EXISTS stack_user_id Nullable(String)
+  AFTER team_id;

--- a/web/scripts/analytics/server-analytics-smoke.ts
+++ b/web/scripts/analytics/server-analytics-smoke.ts
@@ -1,0 +1,47 @@
+/** End-to-end server analytics smoke test. It never contacts PostHog. */
+import { createServer } from "node:http";
+import { captureServerEvent } from "../../services/analytics/serverEvents";
+
+const received: Array<Record<string, unknown>> = [];
+const server = createServer((request, response) => {
+  if (request.method !== "POST" || request.url !== "/capture/") {
+    response.writeHead(404).end();
+    return;
+  }
+  let body = "";
+  request.setEncoding("utf8");
+  request.on("data", (chunk: string) => { body += chunk; });
+  request.on("end", () => {
+    try { received.push(JSON.parse(body) as Record<string, unknown>); } catch { response.writeHead(400).end(); return; }
+    response.writeHead(200).end("ok");
+  });
+});
+
+await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+const address = server.address();
+if (!address || typeof address === "string") throw new Error("loopback collector did not bind");
+
+try {
+  const env = {
+    VERCEL_ENV: "preview",
+    CMUX_SERVER_ANALYTICS_FORCE: "1",
+    CMUX_SERVER_ANALYTICS_SMOKE: "1",
+    POSTHOG_HOST: `http://127.0.0.1:${address.port}`,
+  };
+  const fetchImpl = (input: RequestInfo | URL, init?: RequestInit) => fetch(input, init);
+  const deps = { env, fetch: fetchImpl, defer: (task: () => Promise<void>) => void task(), now: () => new Date("2026-09-04T00:00:00.000Z") };
+  await Promise.all([
+    captureServerEvent({ event: "cloud_vm_created", distinctId: "smoke-user", teamId: "smoke-team", properties: { vm_id: "smoke-vm", plan_id: "pro" }, insertId: "smoke-cloud-vm-created" }, deps),
+    captureServerEvent({ event: "coderouter_account_added", distinctId: "smoke-user", teamId: "smoke-team", properties: { provider: "codex", source: "native_api" }, insertId: "smoke-coderouter-account" }, deps),
+  ]);
+  if (received.length !== 2) throw new Error(`expected 2 captured events, got ${received.length}`);
+  for (const event of received) {
+    if (event.distinct_id !== "smoke-user") throw new Error("Stack user id was not preserved");
+    const properties = event.properties as Record<string, unknown> | undefined;
+    if (properties?.$groups === undefined) throw new Error("stack_team group was not preserved");
+    if (Object.keys(properties ?? {}).some((key) => key.includes("token") || key.includes("cost"))) throw new Error("token or cost data reached PostHog transport");
+  }
+  console.log("PASS: server events reached the loopback collector; PostHog was not contacted");
+} finally {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+}

--- a/web/services/analytics/serverEvents.ts
+++ b/web/services/analytics/serverEvents.ts
@@ -196,7 +196,7 @@ export function isAllowedPosthogHost(
   try {
     const url = new URL(host);
     return url.protocol === "http:" &&
-      (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "::1") &&
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "::1" || url.hostname === "[::1]") &&
       !url.username && !url.password;
   } catch {
     return false;

--- a/web/services/analytics/serverEvents.ts
+++ b/web/services/analytics/serverEvents.ts
@@ -146,7 +146,7 @@ export function captureServerEvent(
     if (started) return;
     started = true;
     try {
-      if (!isSecurePosthogHost(posthogHost)) {
+      if (!isAllowedPosthogHost(posthogHost, deps.env)) {
         throw new Error("PostHog host must use HTTPS");
       }
       await deliver(JSON.stringify(payload), deps.fetch, posthogHost);
@@ -178,6 +178,26 @@ export function isSecurePosthogHost(host: string): boolean {
   try {
     const url = new URL(host);
     return url.protocol === "https:" && url.hostname.length > 0 && !url.username && !url.password;
+  } catch {
+    return false;
+  }
+}
+
+/** Localhost is allowed only for the explicit smoke harness. Production and
+ * preview always require HTTPS, so a misconfigured host cannot exfiltrate
+ * person or team analytics over clear text.
+ */
+export function isAllowedPosthogHost(
+  host: string,
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  if (isSecurePosthogHost(host)) return true;
+  if (env.CMUX_SERVER_ANALYTICS_SMOKE !== "1") return false;
+  try {
+    const url = new URL(host);
+    return url.protocol === "http:" &&
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost" || url.hostname === "::1") &&
+      !url.username && !url.password;
   } catch {
     return false;
   }

--- a/web/services/coderouter/README.md
+++ b/web/services/coderouter/README.md
@@ -4,25 +4,21 @@ Hosted model router for cmux Cloud VMs and the `cr` CLI. The data plane serves t
 
 ## Telemetry
 
-PostHog is the primary sink for coderouter traces and errors. Sentry keeps receiving the legacy `coderouter.<failure>` events for existing alert rules and is not extended. Axiom keeps the OpenTelemetry spans at 100% for `/v1/*` and `/api/coderouter/*` (the app-wide sampler treats both as priority subsystems, `services/observability/sampler.ts`).
+ClickHouse is the source of truth for CodeRouter route outcomes and model usage. PostHog receives only control-plane lifecycle events and operational exceptions. Sentry keeps receiving the legacy `coderouter.<failure>` events for existing alert rules. Axiom keeps the OpenTelemetry spans at 100% for `/v1/*` and `/api/coderouter/*`.
 
 Every coderouter route runs inside `withCoderouterRoute` (`requestTelemetry.ts`). It owns one request context, one OpenTelemetry route span, and stamps two headers on every response: `x-coderouter-request-id` (the ledger request id, a UUID) and `x-cmux-trace-id` (the Axiom trace). A user who reports a failed request only has to paste the request id. That id is:
 
-- `$ai_trace_id` of the PostHog trace, the `coderouter_request_id` property of every event in it, and `$ai_trace_id` of the `$ai_generation` usage event;
 - `request_id` of the ClickHouse `route_events` and `usage_events` rows;
-- `cmux.coderouter.request_id` on the Axiom route span (and `trace_id` on the PostHog trace points back at Axiom).
+- `cmux.coderouter.request_id` on the Axiom route span.
 
 PostHog events go to the main cmux project (`POSTHOG_PROJECT_KEY` / `POSTHOG_HOST`, production or `CODEROUTER_ANALYTICS_FORCE=1`). The distinct id is the Stack user id whenever the request authenticated (the route token's owner, or the signed-in user on control-plane routes), so a person's coderouter requests sit on the same PostHog person as their cmux.com activity. The cmux web app already identifies visitors with the Stack user id (`services/analytics/stackIdentity.ts`); the macOS app still uses an anonymous PostHog id, so joining Mac app events needs a client-side `identify` there (follow-up). Unauthenticated events (auth rejects, alerts) use `coderouter-server` with person processing off. Team and VM ids travel as `team_id` and `coderouter_vm_id`. Until 2026-09-03 these events went to a separate project under HMAC pseudonyms; that project (549394) and its `POSTHOG_CODEROUTER_*` keys are retired, and its dashboards must be rebuilt in the cmux project.
 
 | event | when | key properties |
 | --- | --- | --- |
-| `$ai_trace` | every request, after the response | `$ai_latency` (s), `$ai_http_status`, `$ai_is_error`, `coderouter_outcome`, `coderouter_failure_stage`, `coderouter_fault`, `coderouter_provider`, `coderouter_agent`, `coderouter_attempts`, `coderouter_vm_id`, `trace_id` |
-| `$ai_span` | each step: `auth`, `account_selection`, `credential`, `credential_refresh`, `upstream_attempt`, `provider_config` | `$ai_parent_id` = trace id, `$ai_latency`, `$ai_is_error`, `$ai_error` (failure code), `status`, `attempt`, `upstream_kind` |
-| `$ai_generation` | a model response with usage (`analytics.ts`) | tokens, cost estimate, `$ai_latency` to stream end, `$ai_http_status`, `$ai_stream`, `$ai_parent_id` = trace id |
 | `$exception` | every failure that is not the caller's fault, and every `reportCoderouterFailure` | `$exception_fingerprint`, `$exception_level`, `$exception_list` with the scrubbed message and, for thrown errors, raw stack frames |
 | `coderouter_auth_rejected`, account and session lifecycle, CLI commands | unchanged closed-schema product analytics | now keyed by the Stack user, with `team_id` |
 
-The former `coderouter_route_health` event was folded into `$ai_trace`, which carries every field it had plus the fault class and the request id.
+Route outcomes, failures, tokens, models, providers, latency, and Cloud VM attribution are stored in ClickHouse `route_events` and `usage_events`. This avoids a second usage ledger in PostHog and keeps billing and product reporting on one authoritative dataset.
 
 Fault classification (`classifyCoderouterFault`) decides who is paged. `operator` (RDS, KMS, config, an unhandled throw): `$exception` at `error` level. `upstream` (provider 5xx/429 that survived failover, transport timeouts) and `tenant` (no usable account): `warning`. `caller` (bad token, 4xx): trace only, no exception. Fingerprints are `coderouter:<outcome>:<stage>:<provider>` for route outcomes and `coderouter.<failure>:<provider>` for reported failures, so one condition is one PostHog issue.
 
@@ -30,7 +26,7 @@ Unhandled throws in a route are no longer swallowed as a bare 503: the wrapper r
 
 Upstream model calls are bounded to headers (`upstreamFetch.ts`, `CODEROUTER_UPSTREAM_HEADERS_TIMEOUT_MS`, default 10 minutes). A hung provider fails over to the next account like a connection error instead of holding the function for the full 30 minute `maxDuration`. The body stream is never bounded.
 
-Investigating one failure: take the `x-coderouter-request-id`, open PostHog LLM analytics → Traces and search the id (or filter events by `coderouter_request_id`), read the `$ai_span` waterfall for the failing step, then Error Tracking for the issue. ClickHouse: `SELECT * FROM coderouter.route_events WHERE request_id = '<id>'`. Axiom: `['cmux-prod-otel-traces'] | where ['attributes.custom']['cmux.coderouter.request_id'] == '<id>'`.
+Investigating one failure: take the `x-coderouter-request-id`, query ClickHouse `SELECT * FROM coderouter.route_events WHERE request_id = '<id>'`, then use Axiom for the route span and PostHog Error Tracking for the operational issue.
 
 ## Health
 

--- a/web/services/coderouter/analytics.ts
+++ b/web/services/coderouter/analytics.ts
@@ -6,10 +6,6 @@ import {
   addCoderouterBreadcrumb,
   reportCoderouterFailure,
 } from "./observability";
-import {
-  CODEROUTER_API_RATE_CARD_VERSION,
-  estimateApiEquivalent,
-} from "./apiEquivalentPricing";
 
 // Coderouter analytics live in the main cmux PostHog project, keyed by the
 // Stack user id the cmux apps identify with, so one person's app activity and
@@ -18,7 +14,7 @@ import {
 // travels: prompts, outputs, headers, credentials, emails, account labels;
 // every event is rebuilt from a closed schema. (Until 2026-09-03 these events
 // went to a separate project under HMAC pseudonyms, which made that join
-// impossible; the raw route-health event was folded into `$ai_trace`.)
+// impossible. Token and request usage belongs exclusively in ClickHouse.)
 
 export type CoderouterAnalyticsEvent =
   | "coderouter_account_added"
@@ -34,6 +30,7 @@ export type CoderouterAnalyticsEvent =
   | "coderouter_cli_command_completed"
   | "coderouter_claude_upstream_set"
   | "coderouter_claude_upstream_removed"
+  /** @deprecated usage is ClickHouse-only; this event is rejected. */
   | "coderouter_model_request_completed";
 
 type AnalyticsScalar = string | number | boolean;
@@ -88,15 +85,15 @@ export function deferCoderouterTask(task: Promise<unknown>): void {
 
 /**
  * A PostHog event whose properties are built by a trusted caller
- * (`requestTelemetry.ts`, `exceptionEvent.ts`): the LLM-analytics trace
- * events and Error Tracking exceptions. Identity handling matches
+ * (`observability.ts`, `exceptionEvent.ts`): operational Error Tracking
+ * exceptions. Identity handling matches
  * `captureCoderouterEvent`.
  */
 export type CoderouterRawEvent = {
   readonly event: "$ai_trace" | "$ai_span" | "$exception" | "coderouter_alert";
   readonly userId?: string;
   readonly teamId?: string;
-  /** Span start for `$ai_*` events; defaults to now. */
+  /** Event timestamp; defaults to now. */
   readonly timestamp?: string;
   readonly properties: Readonly<Record<string, CoderouterRawProperty>>;
 };
@@ -105,7 +102,7 @@ export type CoderouterRawEvent = {
 const RAW_EVENT_KEY = /^(\$ai_[a-z_]+|\$exception_[a-z_]+|coderouter_[a-z_]+|trace_id|vercel_request_id|team_id|upstream_kind|upstream_account_id|provider|agent|attempt|attempts|status|outcome|failure_stage|failure_code|healthy|total|sticky|cooldown_ms|forced|surface|reason|alert_key|severity|title|count|threshold|window_minutes)$/;
 
 /**
- * Sends one batch of trace/exception events. Same gate, config, identity and
+ * Sends one batch of operational exception/alert events. Same gate, config, identity and
  * deferred delivery as `captureCoderouterEvent`; the closed schema here is
  * the key allow-list.
  */
@@ -113,11 +110,16 @@ export function captureCoderouterRawBatch(
   events: readonly CoderouterRawEvent[],
   dependencies: AnalyticsDependencies = defaultDependencies,
 ): void {
-  if (events.length === 0 || !dependencies.enabled()) return;
+  // PostHog is not a CodeRouter request or token ledger. Keep the legacy
+  // trace shape available to callers and tests, but refuse to transmit it.
+  const operationalEvents = events.filter(
+    (entry) => entry.event !== "$ai_trace" && entry.event !== "$ai_span",
+  );
+  if (operationalEvents.length === 0 || !dependencies.enabled()) return;
   const config = dependencies.config();
   if (!config) return;
   const now = new Date().toISOString();
-  const batch = events.map((entry) => {
+  const batch = operationalEvents.map((entry) => {
     const properties: Record<string, CoderouterRawProperty> = {};
     for (const [key, value] of Object.entries(entry.properties)) {
       if (RAW_EVENT_KEY.test(key)) properties[key] = value;
@@ -199,13 +201,7 @@ export function captureCoderouterEvent(
   const config = dependencies.config();
   if (!config) return;
 
-  const aggregateUsage =
-    input.event === "coderouter_model_request_completed";
-  if (aggregateUsage && !input.teamId) return;
-
-  const properties = aggregateUsage
-    ? aiUsageProperties(input.properties ?? {})
-    : eventProperties(input.event, input.properties ?? {});
+  const properties = eventProperties(input.event, input.properties ?? {});
   if (!properties) return;
 
   // Account lifecycle events describe one person's action and are dropped
@@ -215,7 +211,7 @@ export function captureCoderouterEvent(
     api_key: config.projectKey,
     batch: [
       {
-        event: aggregateUsage ? "$ai_generation" : input.event,
+        event: input.event,
         ...identity(input.userId, input.teamId),
         properties: {
           ...properties,
@@ -278,10 +274,14 @@ function eventNeedsUser(event: CoderouterAnalyticsEvent): boolean {
 }
 
 function eventProperties(
-  event: Exclude<CoderouterAnalyticsEvent, "coderouter_model_request_completed">,
+  event: CoderouterAnalyticsEvent,
   input: Readonly<Record<string, AnalyticsScalar | null | undefined>>,
 ): Record<string, AnalyticsScalar> | null {
   switch (event) {
+    case "coderouter_model_request_completed":
+      // Deprecated compatibility input. Usage is recorded only by
+      // `usageLedger.ts` in ClickHouse.
+      return null;
     case "coderouter_account_added": {
       const provider = accountProvider(input.provider);
       const source = lifecycleSource(input.source);
@@ -411,122 +411,6 @@ function cliCommandProperties(
     : null;
 }
 
-function aiUsageProperties(
-  input: Readonly<Record<string, AnalyticsScalar | null | undefined>>,
-): Record<string, AnalyticsScalar> | null {
-  const model = analyticsModel(input.model);
-  const provider = aiProvider(input.provider);
-  const inputTokens = safeCount(input.input_tokens);
-  const cachedInputTokens = Math.min(
-    inputTokens,
-    safeCount(input.cached_input_tokens),
-  );
-  const outputTokens = safeCount(input.output_tokens);
-  const totalTokens = Math.max(
-    inputTokens + outputTokens,
-    safeCount(input.total_tokens),
-  );
-  if (totalTokens === 0) return null;
-  const estimate = estimateApiEquivalent({
-    model,
-    inputTokens,
-    cachedInputTokens,
-    outputTokens,
-    totalTokens,
-  });
-  const vmId = analyticsVmId(input.vm_id);
-  const upstreamKind = claudeUpstreamKind(input.upstream_kind);
-  const upstreamAccount = analyticsVmId(input.upstream_account_id);
-  const requestId = analyticsRequestId(input.request_id);
-  const latencyMs = boundedNumber(input.duration_ms, 24 * 60 * 60 * 1_000);
-  const status = boundedNumber(input.status, 599);
-  return {
-    // Links the generation to its `$ai_trace` (the ledger request id), so the
-    // PostHog waterfall shows the model call under the routed request.
-    ...(requestId
-      ? { $ai_trace_id: requestId, $ai_parent_id: requestId, coderouter_request_id: requestId }
-      : {}),
-    ...(latencyMs !== null ? { $ai_latency: latencyMs / 1_000 } : {}),
-    ...(status !== null ? { $ai_http_status: status, $ai_is_error: status >= 400 } : {}),
-    ...(typeof input.response_streamed === "boolean" ? { $ai_stream: input.response_streamed } : {}),
-    $ai_model: model,
-    $ai_provider: provider,
-    $ai_input_tokens: inputTokens,
-    $ai_cache_read_input_tokens: cachedInputTokens,
-    $ai_cache_reporting_exclusive: false,
-    $ai_output_tokens: outputTokens,
-    ...(estimate.pricedTokens > 0
-      ? { $ai_total_cost_usd: estimate.usd }
-      : {}),
-    coderouter_total_tokens: totalTokens,
-    coderouter_priced_tokens: estimate.pricedTokens,
-    coderouter_unpriced_tokens: estimate.unpricedTokens,
-    coderouter_pricing_version: CODEROUTER_API_RATE_CARD_VERSION,
-    ...(vmId ? { coderouter_vm_id: vmId } : {}),
-    ...(upstreamKind ? { upstream_kind: upstreamKind } : {}),
-    ...(upstreamAccount ? { upstream_account_id: upstreamAccount } : {}),
-  };
-}
-
-/**
- * The ledger request id (`newLedgerRequestId`, a UUID): the join key across
- * the PostHog trace, the ClickHouse rows and the `x-coderouter-request-id`
- * header. Anything that is not a UUID is a caller-provided string and is
- * dropped by the closed schema.
- */
-function analyticsRequestId(value: AnalyticsScalar | null | undefined): string | null {
-  return typeof value === "string" &&
-      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)
-    ? value.toLowerCase()
-    : null;
-}
-
-/**
- * Cloud VM id a bound route token attributes usage to. The id is an opaque
- * server-minted UUID (no personal data), so it is forwarded as-is after a
- * shape check that keeps free-form strings out of the closed schema.
- */
-function analyticsVmId(value: AnalyticsScalar | null | undefined): string | null {
-  return typeof value === "string" &&
-      /^[A-Za-z0-9_-]{1,128}$/.test(value)
-    ? value
-    : null;
-}
-
-function safeCount(value: AnalyticsScalar | null | undefined): number {
-  return typeof value === "number" &&
-      Number.isSafeInteger(value) &&
-      value >= 0 &&
-      value <= MAX_COUNT
-    ? value
-    : 0;
-}
-
-function analyticsModel(value: AnalyticsScalar | null | undefined): string {
-  if (typeof value !== "string") return "unknown";
-  const model = value.trim().toLowerCase();
-  const families: ReadonlyArray<readonly [RegExp, string]> = [
-    [/^gpt-5\.6-sol(?:-|$)|^gpt-5\.6$/, "gpt-5.6-sol"],
-    [/^gpt-5\.6-terra(?:-|$)/, "gpt-5.6-terra"],
-    [/^gpt-5\.6-luna(?:-|$)/, "gpt-5.6-luna"],
-    [/^gpt-5\.3-codex(?:-|$)/, "gpt-5.3-codex"],
-    [/^gpt-5\.2-codex(?:-|$)/, "gpt-5.2-codex"],
-    [/^gpt-5\.2(?:-|$)/, "gpt-5.2"],
-    [/^gpt-5\.1-codex(?:-|$)/, "gpt-5.1-codex"],
-    [/^gpt-5-codex(?:-|$)/, "gpt-5-codex"],
-    [/^claude-sonnet-5(?:-|$)/, "claude-sonnet-5"],
-    [/^claude-opus-4[.-]8(?:-|$)/, "claude-opus-4.8"],
-    [/^claude-opus-4[.-]7(?:-|$)/, "claude-opus-4.7"],
-    [/^claude-opus-4[.-]6(?:-|$)/, "claude-opus-4.6"],
-    [/^claude-opus-4[.-]5(?:-|$)/, "claude-opus-4.5"],
-    [/^claude-sonnet-4[.-]6(?:-|$)/, "claude-sonnet-4.6"],
-    [/^claude-sonnet-4[.-]5(?:-|$)/, "claude-sonnet-4.5"],
-    [/^claude-sonnet-4(?:-|$)/, "claude-sonnet-4"],
-    [/^claude-haiku-4[.-]5(?:-|$)/, "claude-haiku-4.5"],
-  ];
-  return families.find(([pattern]) => pattern.test(model))?.[1] ?? "unknown";
-}
-
 function accountProvider(value: unknown): string | null {
   return enumValue(value, [
     "codex",
@@ -544,23 +428,6 @@ function lifecycleSource(value: unknown): string | null {
 
 function claudeUpstreamKind(value: unknown): string | null {
   return enumValue(value, ["anthropic_api_key", "anthropic_oauth", "bedrock"]);
-}
-
-function aiProvider(value: AnalyticsScalar | null | undefined): string {
-  switch (value) {
-    case "codex":
-    case "openai":
-    case "openai-apikey":
-      return "openai";
-    case "claude":
-    case "anthropic":
-    case "anthropic-apikey":
-      return "anthropic";
-    case "opencode-go":
-      return "opencode";
-    default:
-      return "unknown";
-  }
 }
 
 function authSurface(value: unknown): string | null {
@@ -632,7 +499,5 @@ export function coderouterAnalyticsConfig(): CoderouterAnalyticsConfig | null {
 
 export const __test = {
   eventProperties,
-  aiUsageProperties,
   deliver,
-  analyticsModel,
 };

--- a/web/services/coderouter/claudeProxy.ts
+++ b/web/services/coderouter/claudeProxy.ts
@@ -1048,6 +1048,7 @@ function captureRouteHealth(dependencies: ClaudeProxyDependencies, input: Health
   recordRouteEvent({
     requestId: input.requestId,
     teamId: input.identity?.teamId,
+    stackUserId: input.identity?.stackUserId,
     vmId: input.identity?.vmId ?? null,
     provider: "claude",
     agent,
@@ -1078,26 +1079,6 @@ function captureModelUsage(
   if (!usage || usage.totalTokens === 0) return;
   const inputTokens =
     usage.inputTokens + usage.cacheReadInputTokens + usage.cacheCreationInputTokens;
-  dependencies.capture({
-    event: "coderouter_model_request_completed",
-    userId: identity.stackUserId,
-    teamId: identity.teamId,
-    properties: {
-      provider: "claude",
-      upstream_kind: upstream.kind,
-      upstream_account_id: upstream.accountId,
-      model: usage.model ?? "unknown",
-      input_tokens: inputTokens,
-      cached_input_tokens: usage.cacheReadInputTokens,
-      output_tokens: usage.outputTokens,
-      total_tokens: usage.totalTokens,
-      request_id: ledger.requestId,
-      duration_ms: ledger.durationMs,
-      status: ledger.status,
-      response_streamed: ledger.streamed,
-      ...(identity.vmId ? { vm_id: identity.vmId } : {}),
-    },
-  });
   recordUsageEvent({
     requestId: ledger.requestId,
     teamId: identity.teamId,

--- a/web/services/coderouter/codexProxy.ts
+++ b/web/services/coderouter/codexProxy.ts
@@ -760,7 +760,7 @@ function jsonError(
 
 function captureRouteHealth(input: {
   readonly requestId: string;
-  readonly identity?: Pick<RouteTokenIdentity, "teamId" | "vmId">;
+  readonly identity?: Pick<RouteTokenIdentity, "teamId" | "stackUserId" | "vmId">;
   readonly request: Request;
   readonly startedAt: number;
   readonly status: number;
@@ -814,6 +814,7 @@ function captureRouteHealth(input: {
   recordRouteEvent({
     requestId: input.requestId,
     teamId: input.identity?.teamId,
+    stackUserId: input.identity?.stackUserId,
     vmId: input.identity?.vmId ?? null,
     provider: "codex",
     agent,
@@ -839,24 +840,6 @@ function captureModelUsage(
   },
 ): void {
   if (!usage || usage.totalTokens === 0) return;
-  captureCoderouterEvent({
-    event: "coderouter_model_request_completed",
-    userId: identity.stackUserId,
-    teamId: identity.teamId,
-    properties: {
-      provider: "codex",
-      model: usage.model ?? "unknown",
-      input_tokens: usage.inputTokens,
-      cached_input_tokens: usage.cachedInputTokens,
-      output_tokens: usage.outputTokens,
-      total_tokens: usage.totalTokens,
-      request_id: ledger.requestId,
-      duration_ms: ledger.durationMs,
-      status: ledger.status,
-      response_streamed: ledger.streamed,
-      ...vmIdProperty(identity.vmId),
-    },
-  });
   recordUsageEvent({
     requestId: ledger.requestId,
     teamId: identity.teamId,

--- a/web/services/coderouter/observability.ts
+++ b/web/services/coderouter/observability.ts
@@ -82,7 +82,7 @@ export function addCoderouterBreadcrumb(
  * Error Tracking, the primary sink, receives an `$exception` carrying a safe
  * error class and repository-only stack frames, grouped by failure kind and
  * provider. The original error is never sent to Sentry. Events are joined
- * to the request's `$ai_trace` by the ledger request id when a route is active.
+ * to the ClickHouse route row by the ledger request id when a route is active.
  */
 export function reportCoderouterFailure(
   failure: CodeRouterFailure,
@@ -123,7 +123,7 @@ export function reportCoderouterFailure(
         properties: {
           coderouter_failure: failure,
           coderouter_error_type: errorType,
-          ...(requestId ? { coderouter_request_id: requestId, $ai_trace_id: requestId } : {}),
+          ...(requestId ? { coderouter_request_id: requestId } : {}),
           ...safeContext,
         },
       }),

--- a/web/services/coderouter/opencodeProxy.ts
+++ b/web/services/coderouter/opencodeProxy.ts
@@ -431,24 +431,6 @@ export async function proxyOpenCodeRequest(
   });
   const body = observeModelUsage(upstream.body, (usage) => {
     if (!usage || usage.totalTokens === 0) return;
-    captureCoderouterEvent({
-      event: "coderouter_model_request_completed",
-      userId: auth.stackUserId,
-      teamId: auth.teamId,
-      properties: {
-        provider: "opencode-go",
-        model: usage.model ?? "unknown",
-        input_tokens: usage.inputTokens,
-        cached_input_tokens: usage.cachedInputTokens,
-        output_tokens: usage.outputTokens,
-        total_tokens: usage.totalTokens,
-        request_id: requestId,
-        duration_ms: Math.round(performance.now() - startedAt),
-        status: upstream.status,
-        response_streamed: streamed,
-        ...vmIdProperty(auth.vmId),
-      },
-    });
     recordUsageEvent({
       requestId,
       teamId: auth.teamId,
@@ -629,7 +611,7 @@ function vmIdProperty(vmId: string | null): { vm_id?: string } {
 
 function captureOpenCodeHealth(input: {
   readonly requestId: string;
-  readonly identity?: Pick<RouteTokenIdentity, "teamId" | "vmId">;
+  readonly identity?: Pick<RouteTokenIdentity, "teamId" | "stackUserId" | "vmId">;
   readonly startedAt: number;
   readonly status: number;
   readonly outcome:
@@ -664,6 +646,7 @@ function captureOpenCodeHealth(input: {
   recordRouteEvent({
     requestId: input.requestId,
     teamId: input.identity?.teamId,
+    stackUserId: input.identity?.stackUserId,
     vmId: input.identity?.vmId ?? null,
     provider: "opencode-go",
     agent: "opencode",

--- a/web/services/coderouter/requestTelemetry.ts
+++ b/web/services/coderouter/requestTelemetry.ts
@@ -2,26 +2,21 @@
 //
 // Every coderouter route runs inside `withCoderouterRoute`, which owns one
 // request context (AsyncLocalStorage), one OpenTelemetry route span (Axiom),
-// and one PostHog trace in the isolated coderouter project. The proxies and
+// and one ClickHouse route row. The proxies and
 // the auth helper enrich the context as the request proceeds: the identity
 // once the route token is verified, one span per upstream attempt, and the
 // terminal outcome when the route result is known. After the response the
-// wrapper ships one batch to PostHog:
+// wrapper records the route in ClickHouse. PostHog receives only operational
+// exceptions:
 //
-// - `$ai_trace` (root) with the outcome, status, latency, provider, agent,
-//   attempts and the Axiom trace id, so the LLM analytics waterfall shows the
-//   request end to end;
-// - one `$ai_span` per recorded step (auth, account selection, each upstream
-//   attempt, credential refresh);
 // - `$exception` (Error Tracking) for every failure that is not the caller's
 //   fault, fingerprinted by outcome, stage and provider, `error` level when the
 //   fault is ours (RDS, config, crash), `warning` when an upstream provider or
 //   the tenant's account state caused it.
 //
 // The ledger request id (`x-coderouter-request-id` on every response) is the
-// PostHog `$ai_trace_id` and the ClickHouse `request_id`, so one id joins the
-// customer's report, the PostHog trace, the ClickHouse row and, via the
-// `trace_id` property, the Axiom span. No prompt, output, header, credential,
+// ClickHouse `request_id`, so one id joins the customer's report, the
+// ClickHouse row and the Axiom span. No prompt, output, header, credential,
 // email or account label ever enters this module.
 import { AsyncLocalStorage } from "node:async_hooks";
 import { randomUUID } from "node:crypto";
@@ -288,11 +283,10 @@ export function classifyCoderouterFault(outcome: CoderouterOutcome): CoderouterF
 // PostHog event builders.
 
 /**
- * The PostHog batch for one finished request: the `$ai_trace` root, its
- * `$ai_span` children, and an `$exception` when the outcome was a failure the
- * caller did not cause. Caller errors still mark the trace as an error so
- * HTTP failures remain filterable without creating Error Tracking issues.
- * Exported for tests; `withCoderouterRoute` sends it.
+ * Build the diagnostic trace shape used by tests and local debugging. The
+ * PostHog sender drops the trace and span entries before transmission, so it
+ * receives only an operational exception. Request outcomes and all token
+ * usage are authoritative in ClickHouse.
  */
 export function traceEvents(
   context: CoderouterRequestContext,
@@ -302,7 +296,6 @@ export function traceEvents(
     ? derivedOutcome(context, input)
     : context.outcome;
   const fault = classifyCoderouterFault(outcome);
-  const traceIsError = input.status >= 400 || outcome.outcome !== "success";
   const shouldEmitException = fault !== "none" && fault !== "caller";
   const teamId = context.identity?.teamId;
   const userId = context.identity?.stackUserId ?? context.userId;
@@ -319,6 +312,7 @@ export function traceEvents(
     ...(context.vercelRequestId ? { vercel_request_id: context.vercelRequestId } : {}),
     ...(context.identity?.vmId ? { coderouter_vm_id: context.identity.vmId } : {}),
   };
+  const traceIsError = input.status >= 400 || outcome.outcome !== "success";
   const events: CoderouterRawEvent[] = [
     {
       event: "$ai_trace",
@@ -447,8 +441,9 @@ export function coderouterControlRoute<Context = unknown>(
 /**
  * Wraps a route handler so every request has a ledger request id, a route
  * span, a request context, trace and request-id response headers, and a
- * post-response PostHog batch. An unhandled throw is reported with its real
- * stack (Sentry via `reportCoderouterFailure`, PostHog `$exception`) and
+ * post-response operational exception event. An unhandled throw is reported
+ * with its real stack (Sentry via `reportCoderouterFailure`, PostHog
+ * `$exception`) and
  * answered with the surface's 503, never swallowed.
  */
 export function withCoderouterRoute<Context = unknown>(

--- a/web/services/coderouter/usageLedger.ts
+++ b/web/services/coderouter/usageLedger.ts
@@ -44,6 +44,8 @@ export type RouteEventInput = {
   readonly requestId: string;
   /** Absent before authentication succeeds. */
   readonly teamId?: string;
+  /** Absent before route-token authentication succeeds. */
+  readonly stackUserId?: string;
   readonly vmId?: string | null;
   readonly provider: string;
   readonly agent: string;
@@ -83,6 +85,7 @@ export type UsageEventRow = {
 export type RouteEventRow = {
   readonly event_time: string;
   readonly team_id: string;
+  readonly stack_user_id: string | null;
   readonly vm_id: string | null;
   readonly provider: string;
   readonly agent: string;
@@ -185,6 +188,7 @@ export function routeEventRow(input: RouteEventInput, now: Date): RouteEventRow 
   return {
     event_time: clickHouseDateTime(now),
     team_id: boundedText(input.teamId, 128),
+    stack_user_id: ledgerUserId(input.stackUserId),
     vm_id: ledgerVmId(input.vmId ?? null),
     provider: boundedText(input.provider, 64) || "unknown",
     agent: boundedText(input.agent, 64) || "unknown",
@@ -236,6 +240,10 @@ function ledgerVmId(value: string | null | undefined): string | null {
 /** Empty when the provider has no per-account attribution (codex today). */
 function ledgerAccountId(value: string | undefined): string {
   return typeof value === "string" && ID_PATTERN.test(value) ? value : "";
+}
+
+function ledgerUserId(value: string | undefined): string | null {
+  return typeof value === "string" && ID_PATTERN.test(value) ? value : null;
 }
 
 function boundedText(value: string | undefined, max: number): string {

--- a/web/tests/coderouter-analytics.test.ts
+++ b/web/tests/coderouter-analytics.test.ts
@@ -39,7 +39,7 @@ function collector() {
 }
 
 describe("coderouter analytics", () => {
-  test("sends content-free AI Observability usage keyed by the Stack user", async () => {
+  test("does not send model usage to PostHog", async () => {
     const captured = collector();
     captureCoderouterEvent(
       {
@@ -66,47 +66,8 @@ describe("coderouter analytics", () => {
     );
 
     await Promise.all(captured.deferred);
-    expect(captured.urls).toEqual(["https://posthog.test/batch/"]);
-    const payload = JSON.parse(captured.bodies[0]!) as {
-      api_key: string;
-      batch: Array<{
-        event: string;
-        distinct_id: string;
-        properties: Record<string, unknown>;
-      }>;
-    };
-    const event = payload.batch[0]!;
-    expect(payload.api_key).toBe("phc_cmux_test");
-    expect(event.event).toBe("$ai_generation");
-    expect(event.distinct_id).toBe("stack-user-raw");
-    expect(event.properties).toMatchObject({
-      user_id: "stack-user-raw",
-      team_id: "team-raw",
-      $geoip_disable: true,
-      $ai_model: "gpt-5.6-terra",
-      $ai_provider: "openai",
-      $ai_input_tokens: 8,
-      $ai_cache_read_input_tokens: 3,
-      $ai_output_tokens: 2,
-      coderouter_total_tokens: 10,
-      product: "coderouter",
-      schema_version: 3,
-      service_version: "coderouter-web-v1",
-    });
-    const serialized = captured.bodies[0]!;
-    expect(event.properties).not.toHaveProperty("$process_person_profile");
-    for (const raw of [
-      "secret prompt",
-      "secret output",
-      "crt_secret",
-      "buyer@example.com",
-      "acct_secret",
-      "private.example",
-      "authorization secret",
-      "private-customer-label",
-    ]) {
-      expect(serialized).not.toContain(raw);
-    }
+    expect(captured.urls).toEqual([]);
+    expect(captured.bodies).toEqual([]);
   });
 
   test("keys ops events by the Stack user and forwards only the closed schema", async () => {
@@ -227,24 +188,16 @@ describe("coderouter analytics", () => {
     expect(captured.bodies[0]).not.toContain("must-not-leak");
   });
 
-  test("attributes VM-bound traffic per machine", () => {
+  test("keeps token and VM usage out of PostHog", () => {
     expect(
       analyticsTest.eventProperties("coderouter_auth_rejected", {
         surface: "responses",
         reason: "vm_mismatch",
       }),
     ).toEqual({ surface: "responses", reason: "vm_mismatch" });
-    expect(
-      analyticsTest.aiUsageProperties(
-        { provider: "codex", model: "gpt-5.2", input_tokens: 5, output_tokens: 5, vm_id: "vm-1" },
-      ),
-    ).toMatchObject({ coderouter_vm_id: "vm-1" });
-    // Unbound traffic and malformed ids carry no vm id at all.
-    expect(
-      analyticsTest.aiUsageProperties(
-        { provider: "codex", model: "gpt-5.2", input_tokens: 5, output_tokens: 5, vm_id: "not a vm id; free text" },
-      ),
-    ).not.toHaveProperty("coderouter_vm_id");
+    const captured = collector();
+    captureCoderouterEvent({ event: "coderouter_model_request_completed", userId: "u", teamId: "t", properties: { total_tokens: 10, vm_id: "vm-1" } }, captured.dependencies);
+    expect(captured.bodies).toHaveLength(0);
   });
 
   test("rejects invalid enum values and bounds numeric dimensions", () => {
@@ -262,21 +215,10 @@ describe("coderouter analytics", () => {
     ).toMatchObject({ account_count_bucket: "0", latency_bucket: "unknown" });
   });
 
-  test("pre-calculates versioned long-context API-equivalent cost", () => {
-    const properties = analyticsTest.aiUsageProperties(
-      {
-        provider: "codex",
-        model: "gpt-5.6-terra",
-        input_tokens: 300_000,
-        cached_input_tokens: 0,
-        output_tokens: 100_000,
-        total_tokens: 400_000,
-      },
-    );
-    expect(properties).not.toBeNull();
-    expect(properties!.$ai_total_cost_usd).toBe(3.75);
-    expect(properties!.coderouter_priced_tokens).toBe(400_000);
-    expect(properties!.coderouter_unpriced_tokens).toBe(0);
+  test("does not calculate or transmit PostHog token costs", () => {
+    const captured = collector();
+    captureCoderouterEvent({ event: "coderouter_model_request_completed", userId: "u", teamId: "t", properties: { input_tokens: 300_000, output_tokens: 100_000, total_tokens: 400_000 } }, captured.dependencies);
+    expect(captured.bodies).toHaveLength(0);
   });
 });
 
@@ -359,23 +301,8 @@ describe("coderouter raw trace batch", () => {
       batch: Array<{ event: string; distinct_id: string; timestamp: string; properties: Record<string, unknown> }>;
     };
     expect(body.api_key).toBe("phc_cmux_test");
-    expect(body.batch.map((entry) => entry.event)).toEqual(["$ai_trace", "$exception"]);
-    const trace = body.batch[0]!;
-    expect(trace.distinct_id).toBe("stack-user-raw");
-    expect(trace.timestamp).toBe("2026-09-03T00:00:00.000Z");
-    expect(trace.properties).toMatchObject({
-      $ai_trace_id: "req-1",
-      $ai_latency: 0.5,
-      coderouter_outcome: "success",
-      trace_id: "0af7651916cd43dd8448eb211c80319c",
-      user_id: "stack-user-raw",
-      team_id: "team-raw",
-      product: "coderouter",
-    });
-    for (const leaked of ["prompt", "authorization", "email", "$process_person_profile"]) {
-      expect(leaked in trace.properties).toBe(false);
-    }
-    const exception = body.batch[1]!;
+    expect(body.batch.map((entry) => entry.event)).toEqual(["$exception"]);
+    const exception = body.batch[0]!;
     expect(exception.distinct_id).toBe("coderouter-server");
     expect(exception.properties.$process_person_profile).toBe(false);
     expect(exception.properties.$exception_list).toEqual([
@@ -398,29 +325,4 @@ describe("coderouter raw trace batch", () => {
     expect(captured.urls).toEqual([]);
   });
 
-  test("$ai_generation carries the trace link, latency, status and stream flag", () => {
-    const properties = analyticsTest.aiUsageProperties(
-      {
-        provider: "claude",
-        model: "claude-sonnet-5",
-        input_tokens: 10,
-        cached_input_tokens: 2,
-        output_tokens: 5,
-        total_tokens: 15,
-        request_id: "8b9a2f3e-1c4d-4e5f-8a6b-7c8d9e0f1a2b",
-        duration_ms: 2500,
-        status: 200,
-        response_streamed: true,
-      },
-    );
-    expect(properties).toMatchObject({
-      $ai_trace_id: "8b9a2f3e-1c4d-4e5f-8a6b-7c8d9e0f1a2b",
-      $ai_parent_id: "8b9a2f3e-1c4d-4e5f-8a6b-7c8d9e0f1a2b",
-      coderouter_request_id: "8b9a2f3e-1c4d-4e5f-8a6b-7c8d9e0f1a2b",
-      $ai_latency: 2.5,
-      $ai_http_status: 200,
-      $ai_is_error: false,
-      $ai_stream: true,
-    });
-  });
 });

--- a/web/tests/coderouter-claude-proxy.test.ts
+++ b/web/tests/coderouter-claude-proxy.test.ts
@@ -279,39 +279,14 @@ describe("claude proxy direct Anthropic upstreams", () => {
   test("captures usage from the pass-through stream without buffering it", async () => {
     const response = await messages(messagesRequest());
     await response.text();
-    const usage = events.find((event) => event.event === "coderouter_model_request_completed");
-    const { duration_ms: usageDurationMs, request_id: usageRequestId, ...usageProperties } = usage?.properties ?? {};
-    expect(typeof usageDurationMs).toBe("number");
-    expect(usageRequestId).toBe("unscoped");
-    expect({ ...usage, properties: usageProperties }).toEqual({
-      event: "coderouter_model_request_completed",
-      teamId: "team-1",
-      properties: {
-        provider: "claude",
-        upstream_account_id: "acct-api-1",
-        upstream_kind: "anthropic_api_key",
-        model: "claude-sonnet-4-5-20250929",
-        input_tokens: 115,
-        cached_input_tokens: 100,
-        output_tokens: 42,
-        total_tokens: 157,
-        vm_id: "vm-1",
-        // Trace linkage for the PostHog `$ai_generation`: the ledger request
-        // id shared with the ClickHouse route row, latency to stream end, the
-        // upstream status and whether the body streamed.
-        status: 200,
-        response_streamed: true,
-      },
-    });
-    expect(usageRequestId).toBe("unscoped");
+    expect(events.find((event) => event.event === "coderouter_model_request_completed")).toBeUndefined();
   });
 
   test("omits vm_id for an unbound CLI token", async () => {
     authResult = ok(null);
     const response = await messages(messagesRequest());
     await response.text();
-    const usage = events.find((event) => event.event === "coderouter_model_request_completed");
-    expect(usage?.properties).not.toHaveProperty("vm_id");
+    expect(events.find((event) => event.event === "coderouter_model_request_completed")).toBeUndefined();
   });
 
   test("uses a bearer OAuth token and adds the oauth beta flag", async () => {
@@ -411,13 +386,7 @@ describe("claude proxy Bedrock upstream", () => {
     const json = await response.json();
     expect(json.model).toBe("claude-sonnet-4-5");
     expect(response.headers.get("request-id")).toBe("aws-req-1");
-    const usage = events.find((event) => event.event === "coderouter_model_request_completed");
-    expect(usage?.properties).toMatchObject({
-      upstream_kind: "bedrock",
-      model: "claude-sonnet-4-5",
-      input_tokens: 3,
-      output_tokens: 4,
-    });
+    expect(events.find((event) => event.event === "coderouter_model_request_completed")).toBeUndefined();
   });
 
   test("converts the AWS event stream into Anthropic SSE", async () => {
@@ -475,14 +444,7 @@ describe("claude proxy Bedrock upstream", () => {
       'event: content_block_delta\ndata: {"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"ok"}}',
     );
     expect(blocks[3]).toBe('event: message_stop\ndata: {"type":"message_stop"}');
-    const usage = events.find((event) => event.event === "coderouter_model_request_completed");
-    expect(usage?.properties).toMatchObject({
-      upstream_kind: "bedrock",
-      model: "claude-sonnet-4-5",
-      input_tokens: 20,
-      output_tokens: 7,
-      total_tokens: 27,
-    });
+    expect(events.find((event) => event.event === "coderouter_model_request_completed")).toBeUndefined();
   });
 
   test("surfaces stream exceptions as Anthropic error events", async () => {
@@ -750,8 +712,7 @@ describe("claude proxy failover across accounts", () => {
     upstreamResponse = () => Response.json({ id: "msg_5", model: "claude-sonnet-4-5", usage: { input_tokens: 5, output_tokens: 6 } });
     const response = await messages(messagesRequest());
     await response.text();
-    const usage = events.find((event) => event.event === "coderouter_model_request_completed");
-    expect(usage?.properties).toMatchObject({ upstream_kind: "anthropic_api_key", upstream_account_id: "acct-api-1" });
+    expect(events.find((event) => event.event === "coderouter_model_request_completed")).toBeUndefined();
   });
 });
 

--- a/web/tests/coderouter-usage-ledger.test.ts
+++ b/web/tests/coderouter-usage-ledger.test.ts
@@ -206,6 +206,7 @@ describe("CodeRouter usage ledger rows", () => {
       rows: [{
         event_time: "2026-09-02 10:20:30.456",
         team_id: "",
+        stack_user_id: null,
         vm_id: null,
         provider: "codex",
         agent: "other",
@@ -223,6 +224,7 @@ describe("CodeRouter usage ledger rows", () => {
     expect(routeEventRow({
       requestId,
       teamId: "team-1",
+      stackUserId: "stack-user-1",
       vmId,
       provider: "claude",
       agent: "claude",
@@ -233,7 +235,7 @@ describe("CodeRouter usage ledger rows", () => {
       refreshRetryCount: 0,
       durationMs: 840,
       responseStreamed: true,
-    }, now())).toMatchObject({ team_id: "team-1", vm_id: vmId, response_streamed: 1 });
+    }, now())).toMatchObject({ team_id: "team-1", stack_user_id: "stack-user-1", vm_id: vmId, response_streamed: 1 });
   });
 
   test("reports insert failures without team data and stays silent when disabled", async () => {
@@ -339,6 +341,7 @@ describe("CodeRouter usage ledger wiring", () => {
       const usage = calls.find((call) => call.table === "usage_events");
       expect(route?.row).toMatchObject({
         team_id: "team-1",
+        stack_user_id: "stack-user-1",
         vm_id: vmId,
         provider: "claude",
         agent: "claude",

--- a/web/tests/coderouter-vm-metrics.test.ts
+++ b/web/tests/coderouter-vm-metrics.test.ts
@@ -31,17 +31,7 @@ function jsonEachRow(rows: readonly unknown[]): Response {
 }
 
 describe("CodeRouter per-machine metrics", () => {
-  test("stamps coderouter_vm_id on $ai_generation only for bound traffic", () => {
-    const bound = analyticsTest.aiUsageProperties(
-      { provider: "codex", model: "gpt-5.2", input_tokens: 5, output_tokens: 5, vm_id: vmId },
-    );
-    expect(bound).toMatchObject({ coderouter_vm_id: vmId });
-    expect(bound).not.toHaveProperty("vm_id");
-    expect(
-      analyticsTest.aiUsageProperties(
-        { provider: "codex", model: "gpt-5.2", input_tokens: 5, output_tokens: 5 },
-      ),
-    ).not.toHaveProperty("coderouter_vm_id");
+  test("keeps VM-bound usage in ClickHouse, not PostHog", () => {
     expect(
       analyticsTest.eventProperties("coderouter_vm_usage_viewed", {
         surface: "vm_self_api",

--- a/web/tests/server-analytics-events.test.ts
+++ b/web/tests/server-analytics-events.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import {
   captureServerEvent,
   isSecurePosthogHost,
+  isAllowedPosthogHost,
   serverAnalyticsEnabled,
   serverEventPayload,
   SERVER_EVENT_LIB,
@@ -228,5 +229,11 @@ describe("server event delivery", () => {
     expect(isSecurePosthogHost("https://r.cmux.com")).toBe(true);
     expect(isSecurePosthogHost("http://r.cmux.com")).toBe(false);
     expect(isSecurePosthogHost("not a URL")).toBe(false);
+  });
+
+  test("allows HTTP only for the explicit loopback smoke harness", () => {
+    expect(isAllowedPosthogHost("http://127.0.0.1:4318", { CMUX_SERVER_ANALYTICS_SMOKE: "1" })).toBe(true);
+    expect(isAllowedPosthogHost("http://127.0.0.1:4318", {})).toBe(false);
+    expect(isAllowedPosthogHost("http://posthog.example", { CMUX_SERVER_ANALYTICS_SMOKE: "1" })).toBe(false);
   });
 });

--- a/web/tests/server-analytics-events.test.ts
+++ b/web/tests/server-analytics-events.test.ts
@@ -233,6 +233,7 @@ describe("server event delivery", () => {
 
   test("allows HTTP only for the explicit loopback smoke harness", () => {
     expect(isAllowedPosthogHost("http://127.0.0.1:4318", { CMUX_SERVER_ANALYTICS_SMOKE: "1" })).toBe(true);
+    expect(isAllowedPosthogHost("http://[::1]:4318", { CMUX_SERVER_ANALYTICS_SMOKE: "1" })).toBe(true);
     expect(isAllowedPosthogHost("http://127.0.0.1:4318", {})).toBe(false);
     expect(isAllowedPosthogHost("http://posthog.example", { CMUX_SERVER_ANALYTICS_SMOKE: "1" })).toBe(false);
   });


### PR DESCRIPTION
## Summary
- stop sending CodeRouter request traces, spans, generations, token counts, and cost estimates to PostHog
- retain PostHog lifecycle and operational exception events keyed by Stack user and stack_team
- add authenticated user ids to ClickHouse route_events, with a forward-only migration
- add a loopback server analytics smoke harness that proves transport without contacting PostHog

## Verification
- bun test tests/coderouter-*.test.ts
- bun run typecheck
- bun scripts/analytics/server-analytics-smoke.ts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11935"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791112614&installation_model_id=21920&pr_number=11935&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11935&signature=98ce7b834055970463aa0569cf45dad804a6338ed9c6d7a77692a4ec38423f89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sending CodeRouter request traces, spans, token counts, and cost estimates to PostHog. PostHog now only receives lifecycle events and operational exceptions; ClickHouse remains the authoritative ledger for route outcomes and model usage.

- Adds `stack_user_id` to ClickHouse `route_events` via migration `003` so authenticated users stay on route rows.
- Rejects the deprecated `coderouter_model_request_completed` event; usage is recorded only by `usageLedger.ts`.
- Adds a loopback server analytics smoke harness that verifies transport without contacting PostHog.
- PostHog hosts must use HTTPS except when `CMUX_SERVER_ANALYTICS_SMOKE=1` allows localhost only.
- Updates docs and HogQL examples so usage and failure reports query ClickHouse instead of PostHog.

<sup>Written for commit d7a962a2275cf0602a42a2e9b713dad650142ef1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Clarified that ClickHouse is the authoritative source for CodeRouter request and model-usage analytics.
  - Updated PostHog guidance to cover lifecycle and operational exception events only.
  - Added ClickHouse query examples for usage and failure reporting.

- **Data & Reliability**
  - Added Stack user attribution to route records.
  - Added analytics smoke-test coverage for local loopback collection.

- **Bug Fixes**
  - Prevented model usage and trace details from being sent to PostHog.
  - Preserved operational exception reporting and request correlation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->