### PR TITLE
web: speed up production Next builds

### DIFF
--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -62,6 +62,15 @@ const tuiInstallerHeaderRules = [
 
 const nextConfig: NextConfig = {
   poweredByHeader,
+  typescript: {
+    // The full project typecheck runs as its own CI job. Keep test and tool
+    // files out of Next's production-build check so the same work is not done
+    // twice and application errors still fail the build.
+    tsconfigPath:
+      process.env.NODE_ENV === "production"
+        ? "tsconfig.next.json"
+        : "tsconfig.json",
+  },
   allowedDevOrigins: directDevBackendAllowedHost
     ? [directDevBackendAllowedHost]
     : undefined,
@@ -69,6 +78,10 @@ const nextConfig: NextConfig = {
   partialPrefetching: true,
   experimental: {
     exposeTestingApiInProductionBuild: process.env.NEXT_INSTANT_TEST === "1",
+    // Vercel restores .next/cache between deployments. Local and CI builds do
+    // not have a durable cache, so avoid writing and compacting a large cache
+    // database that cannot be reused by the next build.
+    turbopackFileSystemCacheForBuild: process.env.VERCEL === "1",
     instantInsights: {
       validationLevel: "warning",
     },

--- a/web/tsconfig.next.json
+++ b/web/tsconfig.next.json
@@ -1,0 +1,24 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "react", "react-dom"]
+  },
+  "include": [
+    "next-env.d.ts",
+    ".next/types/**/*.ts",
+    "app/**/*.ts",
+    "app/**/*.tsx",
+    "data/**/*.ts",
+    "db/**/*.ts",
+    "i18n/**/*.ts",
+    "messages/**/*.ts",
+    "orpc/**/*.ts",
+    "services/**/*.ts",
+    "types/**/*.ts",
+    "instrumentation.ts",
+    "proxy.ts",
+    "security-headers.ts",
+    "next.config.ts"
+  ],
+  "exclude": ["node_modules", "tests", "e2e", "scripts", "tools"]
+}


### PR DESCRIPTION
## Summary
- use a production-only TypeScript project that excludes tests and tooling from Next's duplicate build check
- keep full application type checking in the existing CI `web-typecheck` job
- disable Turbopack build filesystem caching for local and CI builds without durable cache; keep it enabled on Vercel

## Verification
- `bun test tests/vercel-build-inputs.test.ts tests/docs-search-index.test.ts`
- `bun run typecheck`
- `SKIP_ENV_VALIDATION=1 VERCEL=1 bun run build`

Measured warm build time dropped from 74s to 52s in the worktree. TypeScript phase dropped from 27s to 7s.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11936"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791113057&installation_model_id=21920&pr_number=11936&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11936&signature=7ac87ffa5400ae44ccf0e137c53bb38ff0c58139061616b04d2fd692cd521710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up production Next.js builds by running Next's type check against a production-only TypeScript project that excludes tests and tooling, and by disabling Turbopack's build filesystem cache for local and CI builds. Full application type checking still runs in the `web-typecheck` CI job; Turbopack caching stays enabled on Vercel where the cache is durable. Warm build time drops from 74s to 52s in the worktree, with the TypeScript phase down from 27s to 7s.

<sup>Written for commit 45b871cef4213de815b05120254f934e874668fa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

