### PR TITLE
test(auth): prove request cache isolates concurrent users

### DIFF
--- a/web/tests/stack-request-cache.test.ts
+++ b/web/tests/stack-request-cache.test.ts
@@ -1,0 +1,80 @@
+import { AsyncLocalStorage } from "node:async_hooks";
+import { describe, expect, mock, test } from "bun:test";
+
+// Use the same React Server Components build that Next uses. Bun's default
+// React condition makes cache() a no-op and would give false test confidence.
+const reactServer = await import(
+  // @ts-expect-error Next's internal React Server Components build has no public types.
+  "next/dist/compiled/react-experimental/react.react-server.js",
+);
+mock.module("react", () => reactServer);
+const React = await import("react");
+const { renderToReadableStream } = await import(
+  // @ts-expect-error Next's internal React Server Components renderer has no public types.
+  "next/dist/compiled/react-server-dom-turbopack/server.node",
+);
+
+const requestIdentity = new AsyncLocalStorage<{ readonly id: string }>();
+const getUser = mock(async () => ({
+  id: requestIdentity.getStore()?.id ?? "missing-request-context",
+}));
+
+mock.module("@stackframe/stack", () => ({
+  StackServerApp: class {
+    getUser = getUser;
+  },
+}));
+mock.module("../app/env", () => ({
+  env: {
+    NEXT_PUBLIC_STACK_PROJECT_ID: "project-id",
+    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: "publishable-key",
+    STACK_SECRET_SERVER_KEY: "secret-key",
+  },
+}));
+mock.module("../services/auth/stackApiBaseURL", () => ({
+  stackApiBaseURL: () => "https://stack.test",
+}));
+mock.module("../db/client", () => ({ cloudDb: () => ({}) }));
+mock.module("../services/account/metadataMutation", () => ({
+  withFreshAccountMetadataUser: async () => undefined,
+}));
+mock.module("../services/billing/emailMatching", () => ({
+  canonicalizeEmailForMatching: (email: string) => email,
+}));
+mock.module("../services/auth/stackTelemetry", () => ({
+  withStackAuthSpan: async <T>(
+    _operation: string,
+    fn: (span: unknown) => Promise<T>,
+  ) => fn({ setAttribute: () => undefined }),
+}));
+
+const { getRequestScopedStackUser } = await import("../app/lib/stack");
+
+async function renderForIdentity(id: string): Promise<string> {
+  return requestIdentity.run({ id }, async () => {
+    async function Probe() {
+      const first = getRequestScopedStackUser("dashboard");
+      const second = getRequestScopedStackUser("admin_page");
+      const [firstUser, secondUser] = await Promise.all([first, second]);
+      return React.createElement("p", null, `${firstUser?.id}:${secondUser?.id}`);
+    }
+
+    const stream = await renderToReadableStream(React.createElement(Probe), {});
+    return new Response(stream).text();
+  });
+}
+
+describe("request-scoped Stack user cache", () => {
+  test("deduplicates one render without sharing identity across concurrent renders", async () => {
+    getUser.mockClear();
+
+    const [alice, bob] = await Promise.all([
+      renderForIdentity("alice"),
+      renderForIdentity("bob"),
+    ]);
+
+    expect(alice).toContain("alice:alice");
+    expect(bob).toContain("bob:bob");
+    expect(getUser).toHaveBeenCalledTimes(2);
+  });
+});


### PR DESCRIPTION
Adds a React Server Components regression test for request-scoped Stack user caching.

The test renders two concurrent requests with different identities, asserts each render receives its own identity, and asserts duplicate reads within one render make one Stack call.

Verification:
- `bun test tests/stack-request-cache.test.ts` with Next RSC renderer: pass
- targeted ESLint: pass
- full typecheck has unrelated existing fetch/preconnect errors; no errors from this test

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791113869&installation_model_id=21920&pr_number=11939&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11939&signature=c86352a5fe64b4bd8861f3b42445e8dd3e5561a301c6770070a4ad553ce40c5a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a regression test proving the request-scoped Stack user cache isolates concurrent requests and deduplicates reads within a single render.

- Uses Next's internal React Server Components build so `cache()` behaves as it does in production, instead of Bun's default no-op.
- Renders two concurrent requests with different identities and asserts each render receives its own user.
- Asserts that two reads inside one render result in exactly one Stack call.

<sup>Written for commit 76d94431e670d05e222fd9d18497e9024a8da75f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage ensuring user data is fetched only once during a single server-side render.
  * Added coverage confirming concurrent renders remain isolated and return the correct user for each request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->