### PR TITLE
feat: connect Founder purchases to cmux accounts

### DIFF
--- a/web/app/[locale]/(landing)/billing/recover/page.tsx
+++ b/web/app/[locale]/(landing)/billing/recover/page.tsx
@@ -1,0 +1,66 @@
+import type { Metadata } from "next";
+import { getTranslations } from "next-intl/server";
+import { SiteHeader } from "../../../components/site-header";
+import { Link } from "../../../../../i18n/navigation";
+import { RecoverBillingForm } from "./recover-billing-form";
+import {
+  buildAlternates,
+  openGraphDefaults,
+  twitterSummary,
+} from "../../../../../i18n/seo";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ locale: string }>;
+}): Promise<Metadata> {
+  const { locale } = await params;
+  const t = await getTranslations({ locale, namespace: "billingRecovery" });
+  const alternates = buildAlternates(locale, "/billing/recover");
+  const title = t("metaTitle");
+  const description = t("metaDescription");
+  return {
+    title,
+    description,
+    alternates,
+    openGraph: { ...openGraphDefaults(locale, "website"), title, description },
+    twitter: twitterSummary(locale, title, description),
+  };
+}
+
+export default async function BillingRecoveryPage() {
+  const t = await getTranslations("billingRecovery");
+
+  return (
+    <div className="min-h-screen">
+      <SiteHeader section={t("eyebrow")} />
+      <main className="mx-auto grid w-full max-w-6xl gap-10 px-6 py-16 sm:py-20 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <section>
+          <p className="mb-3 text-sm font-medium text-muted">{t("eyebrow")}</p>
+          <h1 className="max-w-xl text-3xl font-medium tracking-tight">
+            {t("title")}
+          </h1>
+          <p className="mt-5 max-w-xl text-[15px] leading-relaxed text-muted">
+            {t("body")}
+          </p>
+          <p className="mt-8 max-w-xl border-l border-border pl-4 text-[15px] leading-relaxed text-muted">
+            {t("differentEmail")}
+          </p>
+        </section>
+
+        <section
+          aria-label={t("formAriaLabel")}
+          className="border border-border p-5 sm:p-6"
+        >
+          <RecoverBillingForm />
+          <Link
+            href="/"
+            className="mt-5 inline-block text-sm text-muted underline underline-offset-2 decoration-link-underline hover:text-foreground"
+          >
+            {t("backToHome")}
+          </Link>
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/web/app/[locale]/(landing)/billing/recover/recover-billing-form.tsx
+++ b/web/app/[locale]/(landing)/billing/recover/recover-billing-form.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import { useState, type FormEvent } from "react";
+
+export function RecoverBillingForm() {
+  const t = useTranslations("billingRecovery");
+  const [email, setEmail] = useState("");
+  const [status, setStatus] = useState<"idle" | "submitting" | "success" | "error">("idle");
+  const [error, setError] = useState("");
+
+  async function submit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (status === "submitting") return;
+    setStatus("submitting");
+    setError("");
+
+    try {
+      const response = await fetch("/api/billing/recover", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email }),
+      });
+      if (!response.ok) {
+        throw new Error(t("error"));
+      }
+      setStatus("success");
+    } catch (submitError) {
+      setError(submitError instanceof Error ? submitError.message : t("error"));
+      setStatus("error");
+    }
+  }
+
+  return (
+    <form onSubmit={submit} className="grid gap-5">
+      <label htmlFor="billing-recovery-email" className="grid gap-2 text-sm font-medium">
+        <span>{t("emailLabel")}</span>
+        <input
+          id="billing-recovery-email"
+          name="email"
+          type="email"
+          value={email}
+          onChange={(event) => {
+            setEmail(event.target.value);
+            if (status === "error") setStatus("idle");
+          }}
+          placeholder={t("emailPlaceholder")}
+          autoComplete="email"
+          required
+          className="h-11 w-full border border-border bg-background px-3 text-[15px] text-foreground outline-none transition-colors focus:border-foreground"
+        />
+      </label>
+
+      {status === "success" ? (
+        <p role="status" className="border border-border px-4 py-3 text-sm leading-relaxed">
+          {t("success")}
+        </p>
+      ) : null}
+      {status === "error" ? (
+        <p role="alert" className="border border-red-500/40 px-4 py-3 text-sm leading-relaxed">
+          {error}
+        </p>
+      ) : null}
+
+      <button
+        type="submit"
+        disabled={status === "submitting"}
+        className="inline-flex w-full items-center justify-center bg-foreground px-5 py-3 text-[15px] font-medium text-background transition-opacity hover:opacity-85 disabled:cursor-not-allowed disabled:opacity-55"
+      >
+        {status === "submitting" ? t("submitting") : t("submit")}
+      </button>
+    </form>
+  );
+}

--- a/web/app/[locale]/(landing)/billing/recover/recover-billing-form.tsx
+++ b/web/app/[locale]/(landing)/billing/recover/recover-billing-form.tsx
@@ -42,11 +42,12 @@ export function RecoverBillingForm() {
           value={email}
           onChange={(event) => {
             setEmail(event.target.value);
-            if (status === "error") setStatus("idle");
+            if (status !== "submitting") setStatus("idle");
           }}
           placeholder={t("emailPlaceholder")}
           autoComplete="email"
           required
+          disabled={status === "submitting"}
           className="h-11 w-full border border-border bg-background px-3 text-[15px] text-foreground outline-none transition-colors focus:border-foreground"
         />
       </label>

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -1,6 +1,7 @@
 import { getTranslations } from "next-intl/server";
 import { Suspense } from "react";
 import { SiteHeader } from "../components/site-header";
+import { Link } from "../../../i18n/navigation";
 import { ProCtaLink } from "../components/pro-cta-link";
 import { ProWelcomeBanner } from "../components/pro-welcome-banner";
 import {
@@ -159,6 +160,14 @@ export default async function PricingPage({
         <PricingIntervalProvider initialInterval={interval}>
           {/* Title */}
           <h1 className="text-2xl font-medium tracking-tight">{t("title")}</h1>
+          <p className="mt-3 text-sm text-muted">
+            <Link
+              href="/billing/recover"
+              className="underline underline-offset-2 decoration-link-underline hover:text-foreground"
+            >
+              {t("alreadyPaid")}
+            </Link>
+          </p>
           <PricingIntervalSelector
             billingPeriodLabel={t("billingPeriod")}
             monthlyLabel={t("monthly")}

--- a/web/app/api/stripe/founders-welcome/welcome-email.ts
+++ b/web/app/api/stripe/founders-welcome/welcome-email.ts
@@ -40,9 +40,11 @@ function buildBody(name: string): string {
       "text me on iMessage or WhatsApp, or we can just continue talking here. " +
       "I've CC'd my cofounder as well.",
     "",
-    "cmux iOS Beta is out for cmux Founder's Edition! If you have a different " +
-      "TestFlight email, please reply to this email with the new email address. " +
-      "Otherwise, we'll send it to the one on file.",
+    "cmux iOS Beta is out for cmux Founder's Edition! To connect this purchase " +
+      "to your cmux account, use the email from this purchase at " +
+      "https://cmux.com/billing/recover. We will send a secure sign-in link. " +
+      "If you already use cmux with another email, reply to this message so we " +
+      "can verify both addresses and move access safely.",
     "",
     "Best,",
     "Austin",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -3301,7 +3301,7 @@
     "metaTitle": "cmux Pro is active",
     "title": "cmux Pro is active",
     "body": "We created or upgraded your account with {email}. You can open cmux now or add more sign-in methods.",
-    "purchaseComplete": "Purchase complete",
+    "purchaseComplete": "You're all set",
     "proLabel": "Pro plan",
     "dashboardLink": "Go to dashboard",
     "emailLabel": "Purchase email",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,6 +1,20 @@
 {
   "billingRecovery": {
-    "message": "If we found an account, check your email for next steps"
+    "message": "If we found an account, check your email for next steps",
+    "metaTitle": "Connect your Founder purchase",
+    "metaDescription": "Use the email from your Founder purchase to create or recover your cmux account.",
+    "eyebrow": "Founder access",
+    "title": "Connect your Founder purchase",
+    "body": "Use the email from your Founder purchase. We will send a secure sign-in link that creates or recovers the cmux account for that purchase.",
+    "differentEmail": "Already have a cmux account with another email? Reply to your Founder welcome email. We will verify both addresses and move access safely.",
+    "formAriaLabel": "Connect a Founder purchase",
+    "emailLabel": "Purchase email",
+    "emailPlaceholder": "you@example.com",
+    "submit": "Send sign-in link",
+    "submitting": "Sending...",
+    "success": "If we found a purchase or account, check your email for next steps.",
+    "error": "We could not send the request. Try again later.",
+    "backToHome": "Back to cmux"
   },
   "vmDesktop": {
     "invalidTitle": "This desktop link isn't valid",
@@ -752,6 +766,7 @@
     "metaDescriptionNoVault": "cmux is a free, open source macOS terminal for AI coding agents. Upgrade to Pro for isolated Cloud VMs. Enterprise adds SSO and self-hosting.",
     "metaDescriptionNoVaultShort": "cmux is a free, open source macOS terminal. Pro adds isolated Cloud VMs; Enterprise adds SSO and self-hosting.",
     "title": "Pricing",
+    "alreadyPaid": "Already paid? Connect your purchase",
     "perMonth": "/mo",
     "perMonthBilledYearly": "/mo, billed yearly",
     "perUserMonth": "/user/mo",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1,6 +1,20 @@
 {
   "billingRecovery": {
-    "message": "アカウントが見つかった場合は、メールで次の手順をご確認ください"
+    "message": "アカウントが見つかった場合は、メールで次の手順をご確認ください",
+    "metaTitle": "Founder 購入を接続",
+    "metaDescription": "Founder 購入時のメールアドレスを使って cmux アカウントを作成または復元します。",
+    "eyebrow": "Founder アクセス",
+    "title": "Founder 購入を接続",
+    "body": "Founder 購入時に使ったメールアドレスを入力してください。その購入に紐づく cmux アカウントを作成または復元するための安全なサインインリンクを送信します。",
+    "differentEmail": "別のメールアドレスで cmux アカウントをすでにお持ちですか？Founder のウェルカムメールに返信してください。両方のアドレスを確認して、安全にアクセスを移行します。",
+    "formAriaLabel": "Founder 購入を接続",
+    "emailLabel": "購入時のメールアドレス",
+    "emailPlaceholder": "you@example.com",
+    "submit": "サインインリンクを送信",
+    "submitting": "送信中…",
+    "success": "購入またはアカウントが見つかった場合は、メールで次の手順をお知らせします。",
+    "error": "リクエストを送信できませんでした。しばらくしてから再試行してください。",
+    "backToHome": "cmux に戻る"
   },
   "vmDesktop": {
     "invalidTitle": "このデスクトップリンクは無効です",
@@ -752,6 +766,7 @@
     "metaDescriptionNoVault": "cmux はAIコーディングエージェント向けの無料・オープンソースの macOS ターミナルです。Pro では分離された Cloud VM が使えます。Enterprise は SSO とセルフホストに対応します。",
     "metaDescriptionNoVaultShort": "cmux は無料・オープンソースの macOS ターミナルです。Pro では Cloud VM を利用でき、Enterprise では SSO とセルフホストに対応します。",
     "title": "料金",
+    "alreadyPaid": "購入済みですか？購入を接続する",
     "perMonth": "/月",
     "perMonthBilledYearly": "/月（年払い）",
     "perUserMonth": "/ユーザー/月",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -3211,7 +3211,7 @@
     "metaTitle": "cmux Pro が有効になりました",
     "title": "cmux Pro が有効になりました",
     "body": "{email} のアカウントを作成またはアップグレードしました。cmux を開くか、サインイン方法を追加できます。",
-    "purchaseComplete": "購入が完了しました",
+    "purchaseComplete": "準備ができました",
     "proLabel": "Pro プラン",
     "dashboardLink": "ダッシュボードへ",
     "emailLabel": "購入メールアドレス",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -159,6 +159,20 @@ export default function middleware(incomingRequest: NextRequest) {
     });
   }
 
+  // Founder purchases can be completed before a Stack account exists. Keep
+  // the recovery URL stable in emails and payment-link follow-up while
+  // rendering the localized public page.
+  if (pathname === "/billing/recover" || pathname === "/billing/recover/") {
+    const locale = preferredAppRouteLocale(request);
+    const url = request.nextUrl.clone();
+    url.pathname = `/${locale}/billing/recover`;
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set("x-next-intl-locale", locale);
+    return NextResponse.rewrite(url, {
+      request: { headers: requestHeaders },
+    });
+  }
+
   // Other post-checkout pages still live outside the [locale] tree, like
   // /app-pricing. Without this bypass next-intl rewrites them into /<locale>/
   // billing/... which has no route and 404s through the pass-through layout.

--- a/web/tests/billing-success-page.test.tsx
+++ b/web/tests/billing-success-page.test.tsx
@@ -69,7 +69,7 @@ describe("billing success page", () => {
       });
       const html = renderToStaticMarkup(element);
       expect(html).toContain("cmux Pro is active");
-      expect(html).toContain("You're all set");
+      expect(html).toContain("You&#x27;re all set");
       expect(html).toContain("What you unlocked");
     } finally {
       acceptLanguage = "en";

--- a/web/tests/billing-success-page.test.tsx
+++ b/web/tests/billing-success-page.test.tsx
@@ -69,6 +69,7 @@ describe("billing success page", () => {
       });
       const html = renderToStaticMarkup(element);
       expect(html).toContain("cmux Pro is active");
+      expect(html).toContain("You're all set");
       expect(html).toContain("What you unlocked");
     } finally {
       acceptLanguage = "en";

--- a/web/tests/billing-success-proxy.test.ts
+++ b/web/tests/billing-success-proxy.test.ts
@@ -23,4 +23,20 @@ describe("billing success routing", () => {
       response.headers.get("x-middleware-request-x-next-intl-locale"),
     ).toBe("ja");
   });
+
+  test("keeps the public Founder recovery URL while localizing its page", () => {
+    const response = middleware(
+      new NextRequest("https://cmux.test/billing/recover", {
+        headers: { "accept-language": "ja" },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("location")).toBeNull();
+    const rewritten = new URL(response.headers.get("x-middleware-rewrite")!);
+    expect(rewritten.pathname).toBe("/ja/billing/recover");
+    expect(response.headers.get("x-middleware-request-x-next-intl-locale")).toBe(
+      "ja",
+    );
+  });
 });

--- a/web/tests/founders-welcome-email.test.ts
+++ b/web/tests/founders-welcome-email.test.ts
@@ -142,6 +142,16 @@ describe("foundersThreadRef", () => {
 });
 
 describe("buildFoundersWelcomeEmail", () => {
+  test("explains how to connect a purchase to a cmux account", () => {
+    const email = buildFoundersWelcomeEmail({
+      ...baseParams,
+      to: "customer@example.com",
+      sessionRef: "cs_recovery",
+    });
+    expect(email.text).toContain("https://cmux.com/billing/recover");
+    expect(email.text).toContain("reply to this message");
+  });
+
   test("X-Entity-Ref-ID differs across subscriptions but is stable per session", () => {
     const first = buildFoundersWelcomeEmail({
       ...baseParams,
@@ -272,7 +282,7 @@ describe("buildFoundersWelcomeEmail", () => {
     expect(anonymous.text.startsWith("Hi there!")).toBe(true);
   });
 
-  test("announces the iOS beta and asks for a corrected TestFlight email", () => {
+  test("announces the iOS beta and explains how to connect the purchase", () => {
     const email = buildFoundersWelcomeEmail({
       ...baseParams,
       to: "customer@example.com",
@@ -280,12 +290,14 @@ describe("buildFoundersWelcomeEmail", () => {
     });
 
     const iosBetaParagraph =
-      "cmux iOS Beta is out for cmux Founder's Edition! If you have a different " +
-      "TestFlight email, please reply to this email with the new email address. " +
-      "Otherwise, we'll send it to the one on file.";
+      "cmux iOS Beta is out for cmux Founder's Edition! To connect this purchase " +
+      "to your cmux account, use the email from this purchase at " +
+      "https://cmux.com/billing/recover. We will send a secure sign-in link. " +
+      "If you already use cmux with another email, reply to this message so we " +
+      "can verify both addresses and move access safely.";
 
-    // The new paragraph must be present verbatim (lowercase "cmux", "cmux
-    // Founder's Edition", and one-word "TestFlight" are intentional brand/style).
+    // Keep the recovery URL and support handoff in the same paragraph as the
+    // beta announcement so a founder has one clear next action.
     expect(email.text).toContain(iosBetaParagraph);
 
     // It must be its own block — separated by blank lines from the surrounding


### PR DESCRIPTION
## Summary
- add a public `/billing/recover` flow for Founder purchases that uses the purchase email as the recovery key
- link the flow from pricing and Founder welcome email copy
- keep existing account emails unchanged, with a support handoff for purchases made with a different email
- rename the billing success label to “You're all set”

## Design decision
The safe default is one mental model: use the email from the purchase. Automatic cross-email merging would require proof of control of both mailboxes and an explicit ownership transfer. The page sends a secure link for the purchase email and asks different-email cases to reply to the welcome email for manual verification.

## Verification
- `bun test tests/billing-success-proxy.test.ts tests/founders-welcome-email.test.ts tests/billing-success-page.test.tsx`
- `bun run typecheck`
- focused ESLint on changed files
- local screenshot at `captures/recovery-after-clean.png`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791113989&installation_model_id=21920&pr_number=11940&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11940&signature=454d9befa2a556ba37a181661828aa46175c3d3c63c0e2a15cf34d82d23cbb39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a public `/billing/recover` flow so Founder purchases can be connected to cmux accounts using the purchase email as the recovery key.

- Links the flow from the pricing page and the Founder welcome email.
- Sends a secure sign-in link to the purchase email; different-email cases reply to the welcome email for manual verification.
- Keeps the recovery URL stable in emails while the page is localized.
- Renames the billing success label to "You're all set."
- Resets the form status to idle when the email input changes after a success or error.

<sup>Written for commit 43c8253b31547da3983388bfba2680284f978dd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- before-and-after:start -->
| Preview |
|:---:|
| ![Preview](https://github.com/user-attachments/assets/75a3e499-fe9c-4c65-86ff-c2aab43aebda) |

<!-- before-and-after:end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a billing recovery page where customers can connect purchases using their purchase email.
  - Added localized recovery content, form validation feedback, success states, and navigation back home.
  - Added an “Already paid?” link to the pricing page.
  - Billing recovery URLs now support localized page rendering.

- **Updates**
  - Founder’s Edition welcome emails now include billing recovery instructions and secure sign-in guidance.
  - Updated English and Japanese billing-related messaging.

- **Tests**
  - Added coverage for billing recovery rendering, localization, routing, and welcome email content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->