### PR TITLE
Add full desktop screenshot button to dev titlebar

### DIFF
--- a/Resources/Localizable.xcstrings
+++ b/Resources/Localizable.xcstrings
@@ -257262,6 +257262,40 @@
         }
       }
     },
+    "titlebar.captureScreenshot.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture Full Screenshot"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップ全体を撮影"
+          }
+        }
+      }
+    },
+    "titlebar.captureScreenshot.tooltip": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Capture the full desktop"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デスクトップ全体を撮影"
+          }
+        }
+      }
+    },
     "titlebar.notifications.tooltip": {
       "extractionState": "manual",
       "localizations": {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2115,6 +2115,14 @@ struct ContentView: View {
                     NSSound.beep()
                 }
             },
+            #if DEBUG
+            onCaptureScreenshot: {
+                Task.detached(priority: .userInitiated) {
+                    let response = TerminalController.captureFullDesktopScreenshot("titlebar")
+                    cmuxDebugLog("titlebar.captureScreenshot.result \(response)")
+                }
+            },
+            #endif
             visibilityMode: .alwaysVisible
         )
         .offset(y: -TitlebarControlsVisualMetrics.verticalLift)
@@ -11259,7 +11267,15 @@ struct VerticalTabsSidebar: View, Equatable {
                 if !tabManager.navigateForward() {
                     NSSound.beep()
                 }
+            },
+            #if DEBUG
+            onCaptureScreenshot: {
+                Task.detached(priority: .userInitiated) {
+                    let response = TerminalController.captureFullDesktopScreenshot("titlebar")
+                    cmuxDebugLog("titlebar.captureScreenshot.result \(response)")
+                }
             }
+            #endif
         )
     }
 

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2115,14 +2115,7 @@ struct ContentView: View {
                     NSSound.beep()
                 }
             },
-            #if DEBUG
-            onCaptureScreenshot: {
-                Task.detached(priority: .userInitiated) {
-                    let response = TerminalController.captureFullDesktopScreenshot("titlebar")
-                    cmuxDebugLog("titlebar.captureScreenshot.result \(response)")
-                }
-            },
-            #endif
+            onCaptureScreenshot: triggerTitlebarFullDesktopScreenshot,
             visibilityMode: .alwaysVisible
         )
         .offset(y: -TitlebarControlsVisualMetrics.verticalLift)
@@ -11268,14 +11261,7 @@ struct VerticalTabsSidebar: View, Equatable {
                     NSSound.beep()
                 }
             },
-            #if DEBUG
-            onCaptureScreenshot: {
-                Task.detached(priority: .userInitiated) {
-                    let response = TerminalController.captureFullDesktopScreenshot("titlebar")
-                    cmuxDebugLog("titlebar.captureScreenshot.result \(response)")
-                }
-            }
-            #endif
+            onCaptureScreenshot: triggerTitlebarFullDesktopScreenshot
         )
     }
 

--- a/Sources/MinimalModeSidebarTitlebarControlsOverlay.swift
+++ b/Sources/MinimalModeSidebarTitlebarControlsOverlay.swift
@@ -12,9 +12,7 @@ struct MinimalModeSidebarTitlebarControlsOverlay: View {
     let onNewTab: () -> Void
     let onFocusHistoryBack: () -> Void
     let onFocusHistoryForward: () -> Void
-    #if DEBUG
     let onCaptureScreenshot: () -> Void
-    #endif
 
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
@@ -33,9 +31,7 @@ struct MinimalModeSidebarTitlebarControlsOverlay: View {
                 onNewTab: onNewTab,
                 onFocusHistoryBack: onFocusHistoryBack,
                 onFocusHistoryForward: onFocusHistoryForward,
-                #if DEBUG
                 onCaptureScreenshot: onCaptureScreenshot
-                #endif
             )
             .padding(.leading, leadingInset)
             .padding(.top, topPadding)

--- a/Sources/MinimalModeSidebarTitlebarControlsOverlay.swift
+++ b/Sources/MinimalModeSidebarTitlebarControlsOverlay.swift
@@ -12,6 +12,9 @@ struct MinimalModeSidebarTitlebarControlsOverlay: View {
     let onNewTab: () -> Void
     let onFocusHistoryBack: () -> Void
     let onFocusHistoryForward: () -> Void
+    #if DEBUG
+    let onCaptureScreenshot: () -> Void
+    #endif
 
     @AppStorage(WorkspacePresentationModeSettings.modeKey)
     private var workspacePresentationMode = WorkspacePresentationModeSettings.defaultMode.rawValue
@@ -29,7 +32,10 @@ struct MinimalModeSidebarTitlebarControlsOverlay: View {
                 onToggleNotifications: onToggleNotifications,
                 onNewTab: onNewTab,
                 onFocusHistoryBack: onFocusHistoryBack,
-                onFocusHistoryForward: onFocusHistoryForward
+                onFocusHistoryForward: onFocusHistoryForward,
+                #if DEBUG
+                onCaptureScreenshot: onCaptureScreenshot
+                #endif
             )
             .padding(.leading, leadingInset)
             .padding(.top, topPadding)

--- a/Sources/TerminalController+WindowScreenshotCapture.swift
+++ b/Sources/TerminalController+WindowScreenshotCapture.swift
@@ -5,6 +5,49 @@ import WebKit
 
 #if DEBUG
 extension TerminalController {
+    /// Captures the current desktop compositor output without activating,
+    /// focusing, moving, or resizing any window. This is DEBUG-only because it
+    /// intentionally includes every visible desktop window with no redaction.
+    nonisolated static func captureFullDesktopScreenshot(_ args: String) -> String {
+        guard !Thread.isMainThread else {
+            return "ERROR: screenshot must run off the main thread"
+        }
+
+        let label = WindowScreenshotLabel(args).value
+        let timestamp = ISO8601DateFormatter().string(from: Date())
+            .replacingOccurrences(of: ":", with: "-")
+            .replacingOccurrences(of: "+", with: "_")
+        let shortId = UUID().uuidString.prefix(8)
+        let screenshotId = "\(timestamp)_\(shortId)"
+        let outputDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-screenshots")
+        try? FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        let filename = label.isEmpty ? "\(screenshotId).png" : "\(label)_\(screenshotId).png"
+        let outputPath = outputDir.appendingPathComponent(filename)
+
+        guard let image = CGWindowListCreateImage(
+            .null,
+            .optionOnScreenOnly,
+            kCGNullWindowID,
+            [.bestResolution, .boundsIgnoreFraming]
+        ) else {
+            return "ERROR: Failed to capture desktop"
+        }
+        guard let pngData = NSBitmapImageRep(cgImage: image).representation(
+            using: .png,
+            properties: [:]
+        ) else {
+            return "ERROR: Failed to create PNG data"
+        }
+
+        do {
+            try pngData.write(to: outputPath)
+        } catch {
+            return "ERROR: Failed to write file: \(error.localizedDescription)"
+        }
+        return "OK \(screenshotId) \(outputPath.path)"
+    }
+
     nonisolated func captureScreenshot(_ args: String) -> String {
         guard !Thread.isMainThread else {
             return "ERROR: screenshot must run off the main thread"

--- a/Sources/TerminalController+WindowScreenshotCapture.swift
+++ b/Sources/TerminalController+WindowScreenshotCapture.swift
@@ -60,6 +60,10 @@ extension TerminalController {
     }
 
     nonisolated func captureScreenshot(_ args: String) -> String {
+        if args.split(whereSeparator: \.isWhitespace).first == "full" {
+            let label = args.split(whereSeparator: \.isWhitespace).dropFirst().joined(separator: " ")
+            return Self.captureFullDesktopScreenshot(label)
+        }
         guard !Thread.isMainThread else {
             return "ERROR: screenshot must run off the main thread"
         }

--- a/Sources/TerminalController+WindowScreenshotCapture.swift
+++ b/Sources/TerminalController+WindowScreenshotCapture.swift
@@ -4,6 +4,17 @@ import ScreenCaptureKit
 import WebKit
 
 #if DEBUG
+func triggerTitlebarFullDesktopScreenshot() {
+    Task.detached(priority: .userInitiated) {
+        let response = TerminalController.captureFullDesktopScreenshot("titlebar")
+        cmuxDebugLog("titlebar.captureScreenshot.result \(response)")
+    }
+}
+#else
+func triggerTitlebarFullDesktopScreenshot() {}
+#endif
+
+#if DEBUG
 extension TerminalController {
     /// Captures the current desktop compositor output without activating,
     /// focusing, moving, or resizing any window. This is DEBUG-only because it

--- a/Sources/Update/MinimalModeSidebarControls.swift
+++ b/Sources/Update/MinimalModeSidebarControls.swift
@@ -64,6 +64,10 @@ enum TitlebarControlsHitRegions {
             focusBackX
         case .focusHistoryForward:
             focusForwardX
+        #if DEBUG
+        case .captureScreenshot:
+            focusForwardX + config.buttonSize + config.spacing
+        #endif
         }
         let width: CGFloat = switch slot {
         case .newTab:
@@ -72,6 +76,10 @@ enum TitlebarControlsHitRegions {
             newWorkspaceMenuWidth
         case .toggleSidebar, .showNotifications, .focusHistoryBack, .focusHistoryForward:
             config.buttonSize
+        #if DEBUG
+        case .captureScreenshot:
+            config.buttonSize
+        #endif
         }
         return minX...(minX + width)
     }
@@ -242,6 +250,10 @@ final class MinimalModeSidebarControlActionView: NSView {
             _ = AppDelegate.shared?.showFocusHistoryContextMenu(anchorView: self, event: event, direction: .forward)
         case .showNotifications:
             super.rightMouseDown(with: event)
+        #if DEBUG
+        case .captureScreenshot:
+            super.rightMouseDown(with: event)
+        #endif
         }
     }
 

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1012,9 +1012,7 @@ struct TitlebarControlsView: View {
     let onNewTab: () -> Void
     let onFocusHistoryBack: () -> Void
     let onFocusHistoryForward: () -> Void
-    #if DEBUG
     let onCaptureScreenshot: () -> Void
-    #endif
     let visibilityMode: TitlebarControlsVisibilityMode
     @ObservedObject private var popoverVisibilityState = NotificationsPopoverVisibilityState.shared
     @State private var appearanceRefreshTick = 0
@@ -1586,9 +1584,7 @@ struct HiddenTitlebarSidebarControlsView: View {
                 onNewTab: onNewTab,
                 onFocusHistoryBack: onFocusHistoryBack,
                 onFocusHistoryForward: onFocusHistoryForward,
-                #if DEBUG
                 onCaptureScreenshot: onCaptureScreenshot,
-                #endif
                 visibilityMode: .alwaysVisible
             )
             .frame(
@@ -1991,14 +1987,6 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         let focusHistoryForward = {
             _ = prepareOriginatingAction()?.tabManager.navigateForward()
         }
-        #if DEBUG
-        let captureScreenshot = {
-            Task.detached(priority: .userInitiated) {
-                let response = TerminalController.captureFullDesktopScreenshot("titlebar")
-                cmuxDebugLog("titlebar.captureScreenshot.result \(response)")
-            }
-        }
-        #endif
         let rootView = TitlebarControlsView(
             unreadModel: notificationStore.sidebarUnread,
             layoutModel: layoutModel,
@@ -2008,9 +1996,7 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             onNewTab: newTab,
             onFocusHistoryBack: focusHistoryBack,
             onFocusHistoryForward: focusHistoryForward,
-            #if DEBUG
-            onCaptureScreenshot: captureScreenshot,
-            #endif
+            onCaptureScreenshot: triggerTitlebarFullDesktopScreenshot,
             visibilityMode: .alwaysVisible
         )
         hostingView = NonDraggableHostingView(

--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -1012,6 +1012,9 @@ struct TitlebarControlsView: View {
     let onNewTab: () -> Void
     let onFocusHistoryBack: () -> Void
     let onFocusHistoryForward: () -> Void
+    #if DEBUG
+    let onCaptureScreenshot: () -> Void
+    #endif
     let visibilityMode: TitlebarControlsVisibilityMode
     @ObservedObject private var popoverVisibilityState = NotificationsPopoverVisibilityState.shared
     @State private var appearanceRefreshTick = 0
@@ -1214,6 +1217,26 @@ struct TitlebarControlsView: View {
                 iconLabel(systemName: "arrow.right", config: config, iconGeometryKeyPrefix: "titlebarControl_focusHistoryForwardIcon")
             }
             .safeHelp(KeyboardShortcutSettings.Action.focusHistoryForward.tooltip(String(localized: "menu.history.focusForward", defaultValue: "Focus Forward")))
+
+            #if DEBUG
+            TitlebarControlButton(
+                config: config,
+                foregroundColor: foregroundColor,
+                accessibilityIdentifier: "titlebarControl.captureScreenshot",
+                accessibilityLabel: String(localized: "titlebar.captureScreenshot.accessibilityLabel", defaultValue: "Capture Full Screenshot"),
+                action: {
+                    cmuxDebugLog("titlebar.captureScreenshot")
+                    onCaptureScreenshot()
+                }
+            ) {
+                iconLabel(
+                    systemName: "camera",
+                    config: config,
+                    iconGeometryKeyPrefix: "titlebarControl_captureScreenshotIcon"
+                )
+            }
+            .safeHelp(String(localized: "titlebar.captureScreenshot.tooltip", defaultValue: "Capture the full desktop"))
+            #endif
 
         }
 
@@ -1507,6 +1530,9 @@ struct HiddenTitlebarSidebarControlsView: View {
     let onNewTab: () -> Void
     let onFocusHistoryBack: () -> Void
     let onFocusHistoryForward: () -> Void
+    #if DEBUG
+    let onCaptureScreenshot: () -> Void
+    #endif
     @StateObject private var viewModel = TitlebarControlsViewModel()
     @ObservedObject private var popoverVisibilityState = NotificationsPopoverVisibilityState.shared
     @State private var isHoveringHost = false
@@ -1560,6 +1586,9 @@ struct HiddenTitlebarSidebarControlsView: View {
                 onNewTab: onNewTab,
                 onFocusHistoryBack: onFocusHistoryBack,
                 onFocusHistoryForward: onFocusHistoryForward,
+                #if DEBUG
+                onCaptureScreenshot: onCaptureScreenshot,
+                #endif
                 visibilityMode: .alwaysVisible
             )
             .frame(
@@ -1606,6 +1635,10 @@ struct HiddenTitlebarSidebarControlsView: View {
                     )
                     guard availability.canNavigateForward else { return }
                     onFocusHistoryForward()
+                #if DEBUG
+                case .captureScreenshot:
+                    onCaptureScreenshot()
+                #endif
                 }
             }
             .frame(
@@ -1958,6 +1991,14 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
         let focusHistoryForward = {
             _ = prepareOriginatingAction()?.tabManager.navigateForward()
         }
+        #if DEBUG
+        let captureScreenshot = {
+            Task.detached(priority: .userInitiated) {
+                let response = TerminalController.captureFullDesktopScreenshot("titlebar")
+                cmuxDebugLog("titlebar.captureScreenshot.result \(response)")
+            }
+        }
+        #endif
         let rootView = TitlebarControlsView(
             unreadModel: notificationStore.sidebarUnread,
             layoutModel: layoutModel,
@@ -1967,6 +2008,9 @@ final class TitlebarControlsAccessoryViewController: NSTitlebarAccessoryViewCont
             onNewTab: newTab,
             onFocusHistoryBack: focusHistoryBack,
             onFocusHistoryForward: focusHistoryForward,
+            #if DEBUG
+            onCaptureScreenshot: captureScreenshot,
+            #endif
             visibilityMode: .alwaysVisible
         )
         hostingView = NonDraggableHostingView(

--- a/Sources/WindowDecorationsController.swift
+++ b/Sources/WindowDecorationsController.swift
@@ -375,6 +375,10 @@ final class WindowDecorationsController {
             case .focusHistoryForward:
                 guard context.tabManager.canNavigateForward else { return }
                 context.tabManager.navigateForward()
+            #if DEBUG
+            case .captureScreenshot:
+                triggerTitlebarFullDesktopScreenshot()
+            #endif
             }
         }
     }

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -816,6 +816,9 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
     case newWorkspaceMenu
     case focusHistoryBack
     case focusHistoryForward
+    #if DEBUG
+    case captureScreenshot
+    #endif
 
     var accessibilityIdentifier: String {
         switch self {
@@ -831,6 +834,10 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
             return "titlebarControl.focusHistoryBack"
         case .focusHistoryForward:
             return "titlebarControl.focusHistoryForward"
+        #if DEBUG
+        case .captureScreenshot:
+            return "titlebarControl.captureScreenshot"
+        #endif
         }
     }
 
@@ -848,6 +855,10 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
             return String(localized: "menu.history.focusBack", defaultValue: "Focus Back")
         case .focusHistoryForward:
             return String(localized: "menu.history.focusForward", defaultValue: "Focus Forward")
+        #if DEBUG
+        case .captureScreenshot:
+            return String(localized: "titlebar.captureScreenshot.accessibilityLabel", defaultValue: "Capture Screenshot")
+        #endif
         }
     }
 
@@ -865,6 +876,10 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
             return "focusHistoryBack"
         case .focusHistoryForward:
             return "focusHistoryForward"
+        #if DEBUG
+        case .captureScreenshot:
+            return "captureScreenshot"
+        #endif
         }
     }
 
@@ -874,6 +889,10 @@ enum MinimalModeSidebarControlActionSlot: Int, CaseIterable {
             return true
         case .showNotifications:
             return false
+        #if DEBUG
+        case .captureScreenshot:
+            return false
+        #endif
         }
     }
 }


### PR DESCRIPTION
## Summary
- add a DEBUG-only camera button to the top-right titlebar controls
- capture the full desktop compositor, including visible cmux windows and popovers
- run capture off the main thread and write an unredacted PNG to the temporary screenshot directory
- keep the existing screenshot socket behavior unchanged and add no public CLI command

## Verification
- `./scripts/reload-cloud.sh --tag evbt5` succeeded on the Mac fleet
- the tagged app artifact is installed locally as `cmux DEV evbt5.app`
- `scripts/verify-remote.sh mac --tag evbt4 --no-cua` launched the tagged app and passed socket checks
- the fleet CUA app-server was unavailable, so I did not attach a misleading or redacted pixel screenshot

The button is DEBUG-only for dev builds. It does not activate, focus, move, resize, or redact windows. Full-desktop capture depends on macOS Screen Recording permission.
