### PR TITLE
Harden provider and local security boundaries

### DIFF
--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -227,14 +227,26 @@ extension CMUXCLI {
                 defaultValue: "Updating /etc/hosts with your machines' internal names (sudo may prompt)…"
             ))
         }
-        // One sudo invocation does the copy, ownership/mode, and cache flush,
-        // so a cached credential from `vpn up`'s wg-quick call covers this too
-        // instead of prompting a second time.
-        let script = "cp '\(tempURL.path)' '\(hostsPath)' && chown root:wheel '\(hostsPath)' && chmod 644 '\(hostsPath)' && dscacheutil -flushcache; killall -HUP mDNSResponder 2>/dev/null || true"
-        let status = runInteractiveProcess(executablePath: "/usr/bin/sudo", arguments: ["/bin/sh", "-c", script])
+        // One sudo invocation does the copy and ownership/mode changes, so a
+        // cached credential from `vpn up`'s wg-quick call covers this too
+        // instead of prompting a second time. Cache invalidation does not
+        // require privilege and runs as separate argv-based commands below.
+        let status = runInteractiveProcess(
+            executablePath: "/usr/bin/sudo",
+            arguments: [
+                "/usr/sbin/install",
+                "-o", "root",
+                "-g", "wheel",
+                "-m", "644",
+                tempURL.path,
+                hostsPath,
+            ]
+        )
         guard status == 0 else {
             throw CLIError(message: "Updating /etc/hosts failed (exit \(status)). Check the output above.")
         }
+        _ = runInteractiveProcess(executablePath: "/usr/bin/dscacheutil", arguments: ["-flushcache"])
+        _ = runInteractiveProcess(executablePath: "/usr/bin/killall", arguments: ["-HUP", "mDNSResponder"])
         if jsonOutput {
             print(jsonString(["hosts_changed": true, "machine_count": entries.count]))
         } else if !quiet {

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketPasswordAuthorization.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketPasswordAuthorization.swift
@@ -41,7 +41,7 @@ public struct SocketPasswordAuthorization: Sendable {
             return true
         }
         guard let currentPassword else { return false }
-        return credentialFingerprint == fingerprint(currentPassword)
+        return constantTimeEqual(credentialFingerprint, fingerprint(currentPassword))
     }
 
     private func fingerprint(_ password: String) -> Data {

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketSecretComparison.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Model/SocketSecretComparison.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Compares fixed-size secret digests without returning early on a differing byte.
+@inline(never)
+func constantTimeEqual(_ lhs: Data, _ rhs: Data) -> Bool {
+    guard lhs.count == rhs.count else { return false }
+
+    var difference: UInt8 = 0
+    for (left, right) in zip(lhs, rhs) {
+        difference |= left ^ right
+    }
+    return difference == 0
+}
+
+func constantTimeEqual(_ lhs: Data?, _ rhs: Data?) -> Bool {
+    switch (lhs, rhs) {
+    case (nil, nil):
+        return true
+    case let (.some(left), .some(right)):
+        return constantTimeEqual(left, right)
+    default:
+        return false
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketConnectionAuthorizationState.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Server/SocketConnectionAuthorizationState.swift
@@ -31,7 +31,7 @@ final class SocketConnectionAuthorizationState: Sendable {
         state.withLock { state in
             let policyChanged = state.accessMode != accessMode
             let passwordChanged = accessMode.requiresPasswordAuth
-                && state.passwordFingerprint != fingerprint
+                && !constantTimeEqual(state.passwordFingerprint, fingerprint)
             state.accessMode = accessMode
             state.passwordFingerprint = fingerprint
             if policyChanged || passwordChanged {
@@ -59,7 +59,7 @@ final class SocketConnectionAuthorizationState: Sendable {
         let fingerprint = fingerprint(effectivePassword)
         return state.withLock { state in
             guard state.accessMode.requiresPasswordAuth,
-                  state.passwordFingerprint != fingerprint else {
+                  !constantTimeEqual(state.passwordFingerprint, fingerprint) else {
                 return nil
             }
             state.passwordFingerprint = fingerprint

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketPasswordAuthorizationTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/SocketPasswordAuthorizationTests.swift
@@ -70,4 +70,14 @@ struct SocketPasswordAuthorizationTests {
         ))
         #expect(!authorization.isAuthenticated)
     }
+
+    @Test func sameLengthWrongPasswordIsRejected() {
+        var authorization = SocketPasswordAuthorization()
+        authorization.authenticate(password: "configured-secret")
+
+        #expect(!authorization.permitsConnectionContinuation(
+            accessMode: .password,
+            currentPassword: "configured-secret-typo"
+        ))
+    }
 }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,8 +7,8 @@ Global app preferences live in `~/.config/cmux/cmux.json`.
 `cmuxOnly` allows the cmux CLI and programs started from cmux terminals. This
 uses the process ancestry of the caller, so a program launched inside a cmux
 terminal is trusted even when it later starts another process or leaves the
-terminal's original process group. Use `password` or another restrictive mode
-when untrusted code may run inside a cmux terminal. `allowAll` also grants
+terminal's original process group. Use `password` or `cmuxOnly` when untrusted
+code may run inside a cmux terminal. `allowAll` also grants
 access to other local macOS users and is unsafe on a shared Mac.
 
 ## `mobile.artifactFolderAccess`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,6 +2,15 @@
 
 Global app preferences live in `~/.config/cmux/cmux.json`.
 
+## Automation socket trust boundary
+
+`cmuxOnly` allows the cmux CLI and programs started from cmux terminals. This
+uses the process ancestry of the caller, so a program launched inside a cmux
+terminal is trusted even when it later starts another process or leaves the
+terminal's original process group. Use `password` or another restrictive mode
+when untrusted code may run inside a cmux terminal. `allowAll` also grants
+access to other local macOS users and is unsafe on a shared Mac.
+
 ## `mobile.artifactFolderAccess`
 
 Controls which files and folders cmux on iOS may browse after a chat references a directory or a directory path appears in a terminal.

--- a/web/services/coderouter/opencodeProxy.ts
+++ b/web/services/coderouter/opencodeProxy.ts
@@ -1,3 +1,6 @@
+import { lookup as dnsLookup } from "node:dns/promises";
+import { isIP } from "node:net";
+
 import { authenticateRouteToken, selectAccountForRequest } from "./repository";
 import { freshCredential } from "./refresh";
 import { fetchProviderRead } from "./providerFetch";
@@ -39,6 +42,7 @@ type OpenCodeDependencies = {
   readonly credential: typeof freshCredential;
   readonly remoteConfig: (accessToken: string, signal?: AbortSignal) => Promise<Record<string, unknown>>;
   readonly fetch?: typeof fetch;
+  readonly resolveProviderURL?: typeof resolveProviderURL;
 };
 
 /** Runtime seams used by tests to exercise request-wide timeout behavior. */
@@ -330,7 +334,24 @@ export async function proxyOpenCodeRequest(
       false,
     );
   }
-  const target = new URL(base);
+  const target = await (dependencies.resolveProviderURL ?? resolveProviderURL)(base);
+  if (!target) {
+    captureOpenCodeHealth({
+      requestId,
+      identity: auth,
+      startedAt,
+      status: 502,
+      outcome: "invalid_provider",
+      failureStage: "provider_config",
+      attempts: resolved.attempts,
+    });
+    return apiError(
+      "invalid_provider",
+      "OpenCode returned an unsafe or invalid provider endpoint.",
+      502,
+      false,
+    );
+  }
   target.pathname = `${target.pathname.replace(/\/+$/, "")}/${path
     .map(encodeURIComponent)
     .join("/")}`;
@@ -678,23 +699,106 @@ function apiError(
   );
 }
 
+type ProviderLookupAddress = { readonly address: string; readonly family: number };
+type ProviderLookup = (hostname: string) => Promise<readonly ProviderLookupAddress[]>;
+
 function safeProviderURL(value: string): boolean {
   try {
     const url = new URL(value);
     if (url.protocol !== "https:" || url.username || url.password) return false;
-    const hostname = url.hostname.toLowerCase();
-    return (
-      hostname !== "localhost" &&
-      hostname !== "0.0.0.0" &&
-      hostname !== "::1" &&
-      !/^127\./.test(hostname) &&
-      !/^10\./.test(hostname) &&
-      !/^192\.168\./.test(hostname) &&
-      !/^172\.(1[6-9]|2[0-9]|3[01])\./.test(hostname)
-    );
+    return !unsafeProviderAddress(url.hostname);
   } catch {
     return false;
   }
+}
+
+async function resolveProviderURL(
+  value: string,
+  lookup: ProviderLookup = defaultProviderLookup,
+): Promise<URL | null> {
+  // Resolve every hostname before proxying it so private answers cannot pass
+  // through the URL parser. The provider catalog is trusted, but this remains
+  // defense-in-depth; the fetch implementation may perform a later lookup.
+  if (!safeProviderURL(value)) return null;
+  const url = new URL(value);
+  const hostname = normalizeProviderHostname(url.hostname);
+  if (isIP(hostname) !== 0) return url;
+  try {
+    const addresses = await lookup(hostname);
+    if (addresses.length === 0 || addresses.some(({ address }) => unsafeProviderAddress(address))) {
+      return null;
+    }
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultProviderLookup(hostname: string): Promise<readonly ProviderLookupAddress[]> {
+  return dnsLookup(hostname, { all: true, verbatim: true });
+}
+
+function normalizeProviderHostname(hostname: string): string {
+  return hostname.replace(/^\[/, "").replace(/\]$/, "").toLowerCase();
+}
+
+function unsafeProviderAddress(value: string): boolean {
+  const address = normalizeProviderHostname(value);
+  const family = isIP(address);
+  if (family === 4) return unsafeIPv4Address(address);
+  if (family !== 6) {
+    return address === "localhost" || address === "localhost.localdomain";
+  }
+
+  const firstHextet = Number.parseInt(address.split(":", 1)[0] || "0", 16);
+  if (
+    address === "::" ||
+    address === "::1" ||
+    (firstHextet >= 0xfe80 && firstHextet <= 0xfebf) ||
+    (firstHextet & 0xfe00) === 0xfc00 ||
+    (firstHextet & 0xff00) === 0xff00
+  ) {
+    return true;
+  }
+
+  const mappedIPv4 = mappedIPv4Address(address);
+  return mappedIPv4 !== null && unsafeIPv4Address(mappedIPv4);
+}
+
+function unsafeIPv4Address(value: string): boolean {
+  const octets = value.split(".").map(Number);
+  if (octets.length !== 4 || octets.some((octet) => !Number.isInteger(octet) || octet < 0 || octet > 255)) {
+    return false;
+  }
+  const [first, second] = octets;
+  return (
+    first === 0 ||
+    first === 10 ||
+    first === 127 ||
+    (first === 100 && second >= 64 && second <= 127) ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 198 && (second === 18 || second === 19)) ||
+    first >= 224
+  );
+}
+
+function mappedIPv4Address(value: string): string | null {
+  const prefix = "::ffff:";
+  if (!value.startsWith(prefix)) return null;
+  const groups = value.slice(prefix.length).split(":");
+  if (groups.length !== 2) return null;
+  const numbers = groups.map((group) => Number.parseInt(group, 16));
+  if (numbers.some((number) => !Number.isInteger(number) || number < 0 || number > 0xffff)) {
+    return null;
+  }
+  return [
+    numbers[0] >> 8,
+    numbers[0] & 0xff,
+    numbers[1] >> 8,
+    numbers[1] & 0xff,
+  ].join(".");
 }
 
 function filteredResponseHeaders(input: Headers): Headers {
@@ -725,4 +829,9 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-export const __test = { rewriteProviders, safeProviderURL, openCodeAccount };
+export const __test = {
+  rewriteProviders,
+  safeProviderURL,
+  resolveProviderURL,
+  openCodeAccount,
+};

--- a/web/tests/coderouter-opencode-proxy.test.ts
+++ b/web/tests/coderouter-opencode-proxy.test.ts
@@ -102,7 +102,10 @@ describe("coderouter OpenCode Go proxy VM-bound route tokens", () => {
 
   function dependencies(
     authenticated: string[] = [],
-    overrides: { fetch?: typeof fetch } = {},
+    overrides: {
+      fetch?: typeof fetch;
+      resolveProviderURL?: (value: string) => Promise<URL | null>;
+    } = {},
   ) {
     return {
       authenticate: async (token: string) => {

--- a/web/tests/coderouter-opencode-proxy.test.ts
+++ b/web/tests/coderouter-opencode-proxy.test.ts
@@ -136,6 +136,7 @@ describe("coderouter OpenCode Go proxy VM-bound route tokens", () => {
           models: { "model-1": { name: "Model One" } },
         },
       }),
+      resolveProviderURL: async (value: string) => new URL(value),
       ...overrides,
     };
   }
@@ -221,6 +222,29 @@ describe("coderouter OpenCode Go proxy VM-bound route tokens", () => {
     );
     expect(response.status).toBe(401);
     expect(authenticated).toEqual([]);
+  });
+
+  test("rejects a provider hostname when DNS resolves it to a private address", async () => {
+    const response = await proxyOpenCodeRequest(
+      new Request("https://cmux.example/api/coderouter/opencode/proxy/go/chat", {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${CLI_TOKEN}`,
+          "x-coderouter-route-token": CLI_TOKEN,
+        },
+        body: "{}",
+      }),
+      "go",
+      ["chat"],
+      dependencies([], {
+        resolveProviderURL: async (value: string) => __test.resolveProviderURL(
+          value,
+          async () => [{ address: "100.64.0.1", family: 4 }],
+        ),
+      }),
+    );
+    expect(response.status).toBe(502);
+    await expect(response.json()).resolves.toMatchObject({ error: "invalid_provider" });
   });
 
   test("propagates caller cancellation to the OpenCode upstream", async () => {

--- a/web/tests/coderouter-opencode-proxy.test.ts
+++ b/web/tests/coderouter-opencode-proxy.test.ts
@@ -52,6 +52,20 @@ describe("coderouter OpenCode Go proxy", () => {
     expect(__test.safeProviderURL("https://127.0.0.1/v1")).toBe(false);
     expect(__test.safeProviderURL("https://10.0.0.1/v1")).toBe(false);
     expect(__test.safeProviderURL("https://192.168.1.4/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://169.254.169.254/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://100.64.0.1/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://[fe80::1]/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://[fd00::1]/v1")).toBe(false);
+    expect(__test.safeProviderURL("https://[::ffff:127.0.0.1]/v1")).toBe(false);
+  });
+
+  test("rejects provider hostnames that resolve to private addresses", async () => {
+    await expect(__test.resolveProviderURL("https://provider.example/v1", async () => [
+      { address: "169.254.169.254", family: 4 },
+    ])).resolves.toBeNull();
+    await expect(__test.resolveProviderURL("https://provider.example/v1", async () => [
+      { address: "2001:db8::10", family: 6 },
+    ])).resolves.toMatchObject({ hostname: "provider.example" });
   });
 
   test("routes around an unavailable OpenCode account", async () => {


### PR DESCRIPTION
## Summary
- reject unsafe provider IP literals and DNS answers before OpenCode proxying
- compare socket password digests in constant time
- replace the VPN `/etc/hosts` shell command with argv-based `sudo install`
- document the `cmuxOnly` descendant trust boundary

## Scope decisions
- `allowAll` keeps its existing opt-in confirmation and warning to preserve scriptability.
- Existing macOS entitlements remain because normal terminal workflows depend on broad capabilities.
- SSH `accept-new` remains because the external-link confirmation already shows the generated command.
- No self-hosted in-process rate limiter was added.

## Verification
- `bun test tests/coderouter-opencode-proxy.test.ts` (12 passed)
- `bun run typecheck`
- `bun run eslint services/coderouter/opencodeProxy.ts tests/coderouter-opencode-proxy.test.ts` (one pre-existing unused-variable warning)
- `swift test --package-path Packages/macOS/CmuxControlSocket` (436 passed)
- Tagged reload attempted with `CMUX_DEV_BACKEND_MODE=local`; cloud backend was at 12/12 running stacks, so cloud API dogfood is unverified.

The provider DNS check runs before `fetch`; it rejects private answers but does not pin a changing DNS answer to the later connection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11943"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791114288&installation_model_id=21920&pr_number=11943&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11943&signature=f6d83a239ecbfc17072d393b0e3bcdc551a394672ec4a5f129ff297e044dbb6d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the OpenCode provider proxy against SSRF and tightens local security boundaries for socket password checks and the VPN hosts update.

**Provider proxy**
- DNS-resolves provider hostnames before proxying and rejects any that resolve to private, link-local, loopback, or other unsafe addresses.
- Rejects unsafe IP literals in provider URLs, including IPv4-mapped IPv6 addresses.
- Unsafe endpoints return a 502 `invalid_provider` error and a health event.

**Local hardening**
- Socket password fingerprint comparisons now use constant-time equality.
- The VPN `/etc/hosts` update uses argv-based `sudo install` instead of a shell command; cache flush and mDNSResponder restart run unprivileged.
- Documented the `cmuxOnly` descendant trust boundary in `docs/configuration.md`.

`allowAll` keeps its opt-in confirmation, macOS entitlements and SSH `accept-new` remain unchanged, and no in-process rate limiter was added.

<sup>Written for commit 10fc1f886b9f0335d6c4459733c9bb9cb1d18828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11943?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Strengthened automation socket password verification with timing-resistant comparisons.
  * Improved protection against unsafe provider destinations by blocking private, loopback, link-local, multicast, and other restricted network addresses.
  * Improved `/etc/hosts` updates with safer permissions and clearer cache-refresh handling.

* **Documentation**
  * Added guidance on automation socket trust boundaries and access modes, including `cmuxOnly`, `password`, and `allowAll`.

* **Bug Fixes**
  * Provider requests now return a clear error when DNS resolution identifies an invalid destination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->