### PR TITLE
Remove iroh from default cmux-tui builds

### DIFF
--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -98,9 +98,8 @@ tungstenite = { version = "0.29", default-features = false, features = ["handsha
 uds_windows = "1.2"
 windows-sys = { version = "0.61", features = ["Win32_Foundation", "Win32_Security", "Win32_Storage_FileSystem", "Win32_System_Diagnostics_ToolHelp", "Win32_System_JobObjects", "Win32_System_Threading"] }
 regex = "1"
-# reqwest and time are already in the dependency graph via iroh; declaring
-# them here adds no new transitive code. chatmux-relay uses reqwest for the
-# single pairing bootstrap POST and time for enrollment expiry parsing.
+# chatmux-relay uses reqwest for the single pairing bootstrap POST and time
+# for enrollment expiry parsing. cmux-tui also uses reqwest for Cloud spend.
 # rustls-no-provider: ride the ring provider the tree already enables via
 # tungstenite instead of pulling in aws-lc-rs (cmake/nasm native builds).
 reqwest = { version = "0.13", default-features = false, features = ["rustls-no-provider", "json"] }

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -73,7 +73,7 @@ cmux-tui-core = { path = "crates/cmux-tui-core" }
 cmux-tui-cdp = { path = "crates/cmux-tui-cdp" }
 cmux-pty = { path = "crates/cmux-pty" }
 cmux-remote-protocol = { path = "crates/cmux-remote-protocol" }
-cmux-remote = { path = "crates/cmux-remote" }
+cmux-remote = { path = "crates/cmux-remote", default-features = false }
 cmux-tui-machine-agent-protocol = { path = "crates/cmux-tui-machine-agent-protocol" }
 cmux-tui-machine-protocol = { path = "crates/cmux-tui-machine-protocol" }
 anyhow = "1"

--- a/cmux-tui/Cargo.toml
+++ b/cmux-tui/Cargo.toml
@@ -137,7 +137,7 @@ rusqlite = { version = "=0.39.0", default-features = false, features = ["bundled
 sha2 = "0.10"
 socket2 = { version = "0.5", features = ["all"] }
 snow = "0.10"
-tokio = { version = "1", features = ["fs", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
+tokio = { version = "1", features = ["fs", "io-std", "io-util", "macros", "net", "process", "rt-multi-thread", "signal", "sync", "time"] }
 tokio-tungstenite = { version = "0.29", default-features = false, features = ["connect", "handshake", "rustls-tls-native-roots"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tower = { version = "0.5", features = ["util"] }

--- a/cmux-tui/crates/cmux-remote/Cargo.toml
+++ b/cmux-tui/crates/cmux-remote/Cargo.toml
@@ -11,7 +11,7 @@ description = "Authenticated remote daemon, transports, and workspace services f
 workspace = true
 
 [features]
-default = ["iroh-transport"]
+default = []
 iroh-transport = ["dep:iroh"]
 
 [dependencies]

--- a/cmux-tui/crates/cmux-remote/src/provider/iroh.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/iroh.rs
@@ -4,7 +4,6 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::path::Path;
-use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;
@@ -22,59 +21,13 @@ use crate::daemon::{InboundLink, NetworkPeer, RemoteDaemon};
 use crate::link::{FrameLink, LinkError};
 use crate::observability::{TransportPathKind, TransportPathSnapshot, TransportSnapshot};
 use crate::provider::{
-    CarrierEvidence, ConnectRequest, LengthDelimitedLink, LinkGroup, LinkRequest,
-    ProviderCapabilities, ProviderError, SupportedClientAuthModes, TransportProvider,
-    sanitized_route,
+    CMUX_IROH_ALPN, CarrierEvidence, ConnectRequest, IrohPathMode, LengthDelimitedLink, LinkGroup,
+    LinkRequest, ProviderCapabilities, ProviderError, ROUTING_DIRECT_ADDRS, ROUTING_NODE_ID,
+    ROUTING_RELAY_URL, SupportedClientAuthModes, TransportProvider, sanitized_route,
 };
 use crate::secure_directory::{DirectoryAccess, ensure_secure_directory};
 
-/// ALPN negotiated by cmux remote sessions over Iroh.
-pub const CMUX_IROH_ALPN: &[u8] = b"dev.cmux.remote/1";
-
-/// Optional routing key containing a node ID when it is not present in the URL.
-pub const ROUTING_NODE_ID: &str = "node_id";
-/// Optional routing key containing one Iroh relay URL.
-pub const ROUTING_RELAY_URL: &str = "relay_url";
-/// Optional routing key containing comma or whitespace separated socket addresses.
-pub const ROUTING_DIRECT_ADDRS: &str = "direct_addrs";
 const AUTO_RELAY_BOOTSTRAP_TIMEOUT: Duration = Duration::from_secs(2);
-
-/// Constrains which network paths an Iroh endpoint may use.
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
-pub enum IrohPathMode {
-    /// Prefer a direct path when available and retain relay fallback.
-    #[default]
-    Auto,
-    /// Disable relay transports and require an explicit direct address.
-    DirectOnly,
-    /// Disable IP transports and require an explicit relay URL.
-    RelayOnly,
-}
-
-impl fmt::Display for IrohPathMode {
-    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
-        formatter.write_str(match self {
-            Self::Auto => "auto",
-            Self::DirectOnly => "direct-only",
-            Self::RelayOnly => "relay-only",
-        })
-    }
-}
-
-impl FromStr for IrohPathMode {
-    type Err = String;
-
-    fn from_str(value: &str) -> Result<Self, Self::Err> {
-        match value {
-            "auto" => Ok(Self::Auto),
-            "direct-only" => Ok(Self::DirectOnly),
-            "relay-only" => Ok(Self::RelayOnly),
-            other => Err(format!(
-                "Iroh path mode must be auto, direct-only, or relay-only, got {other:?}"
-            )),
-        }
-    }
-}
 
 /// Load a stable carrier key or create it with owner-only permissions. Noise
 /// remains the daemon identity, but a stable Iroh key keeps published route

--- a/cmux-tui/crates/cmux-remote/src/provider/iroh.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/iroh.rs
@@ -4,6 +4,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::net::SocketAddr;
 use std::path::Path;
+use std::str::FromStr;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex as StdMutex};
 use std::time::Duration;

--- a/cmux-tui/crates/cmux-remote/src/provider/iroh_config.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/iroh_config.rs
@@ -1,0 +1,62 @@
+use std::fmt;
+use std::str::FromStr;
+
+/// ALPN negotiated by cmux remote sessions over Iroh.
+pub const CMUX_IROH_ALPN: &[u8] = b"dev.cmux.remote/1";
+
+/// Optional routing key containing a node ID when it is not present in the URL.
+pub const ROUTING_NODE_ID: &str = "node_id";
+/// Optional routing key containing one Iroh relay URL.
+pub const ROUTING_RELAY_URL: &str = "relay_url";
+/// Optional routing key containing comma or whitespace separated socket addresses.
+pub const ROUTING_DIRECT_ADDRS: &str = "direct_addrs";
+
+/// Constrains which network paths an Iroh endpoint may use.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum IrohPathMode {
+    /// Prefer a direct path when available and retain relay fallback.
+    #[default]
+    Auto,
+    /// Disable relay transports and require an explicit direct address.
+    DirectOnly,
+    /// Disable IP transports and require an explicit relay URL.
+    RelayOnly,
+}
+
+impl fmt::Display for IrohPathMode {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Auto => "auto",
+            Self::DirectOnly => "direct-only",
+            Self::RelayOnly => "relay-only",
+        })
+    }
+}
+
+impl FromStr for IrohPathMode {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "auto" => Ok(Self::Auto),
+            "direct-only" => Ok(Self::DirectOnly),
+            "relay-only" => Ok(Self::RelayOnly),
+            other => Err(format!(
+                "Iroh path mode must be auto, direct-only, or relay-only, got {other:?}"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::IrohPathMode;
+
+    #[test]
+    fn path_mode_parsing_does_not_require_the_transport_feature() {
+        assert_eq!("auto".parse(), Ok(IrohPathMode::Auto));
+        assert_eq!("direct-only".parse(), Ok(IrohPathMode::DirectOnly));
+        assert_eq!("relay-only".parse(), Ok(IrohPathMode::RelayOnly));
+        assert!("direct".parse::<IrohPathMode>().is_err());
+    }
+}

--- a/cmux-tui/crates/cmux-remote/src/provider/mod.rs
+++ b/cmux-tui/crates/cmux-remote/src/provider/mod.rs
@@ -6,6 +6,7 @@
 
 #[cfg(feature = "iroh-transport")]
 mod iroh;
+mod iroh_config;
 mod relay;
 mod ssh;
 mod stream;
@@ -27,8 +28,10 @@ use crate::observability::TransportSnapshot;
 
 #[cfg(feature = "iroh-transport")]
 pub use iroh::{
-    CMUX_IROH_ALPN, IrohListener, IrohPathMode, IrohProvider, IrohProviderConfig, IrohRoute,
-    ROUTING_DIRECT_ADDRS, ROUTING_NODE_ID, ROUTING_RELAY_URL, load_or_create_iroh_secret,
+    IrohListener, IrohProvider, IrohProviderConfig, IrohRoute, load_or_create_iroh_secret,
+};
+pub use iroh_config::{
+    CMUX_IROH_ALPN, IrohPathMode, ROUTING_DIRECT_ADDRS, ROUTING_NODE_ID, ROUTING_RELAY_URL,
 };
 pub use relay::{
     RelayClientConfig, RelayCredentialSource, RelayDaemonConfig, RelayDaemonRegistration,

--- a/cmux-tui/crates/cmux-terminal-client/Cargo.toml
+++ b/cmux-tui/crates/cmux-terminal-client/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 base64.workspace = true
 bytes.workspace = true
-cmux-remote = { workspace = true, default-features = false }
+cmux-remote.workspace = true
 cmux-remote-protocol.workspace = true
 cmux-tui-core.workspace = true
 getrandom.workspace = true

--- a/cmux-tui/crates/cmux-terminal-client/Cargo.toml
+++ b/cmux-tui/crates/cmux-terminal-client/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 base64.workspace = true
 bytes.workspace = true
-cmux-remote.workspace = true
+cmux-remote = { workspace = true, default-features = false }
 cmux-remote-protocol.workspace = true
 cmux-tui-core.workspace = true
 getrandom.workspace = true

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -52,7 +52,7 @@ uuid.workspace = true
 wait-timeout.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-cmux-remote = { workspace = true, default-features = false }
+cmux-remote.workspace = true
 cmux-remote-protocol.workspace = true
 tokio.workspace = true
 # Machine spend readout: one small JSON GET every few minutes from inside a

--- a/cmux-tui/crates/cmux-tui/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui/Cargo.toml
@@ -10,6 +10,10 @@ description = "cmux-tui: tmux-like terminal multiplexer TUI backed by libghostty
 [lints]
 workspace = true
 
+[features]
+default = []
+iroh-transport = ["cmux-remote/iroh-transport"]
+
 [[bin]]
 name = "cmux-tui"
 path = "src/main.rs"
@@ -48,11 +52,11 @@ uuid.workspace = true
 wait-timeout.workspace = true
 
 [target.'cfg(unix)'.dependencies]
-cmux-remote.workspace = true
+cmux-remote = { workspace = true, default-features = false }
 cmux-remote-protocol.workspace = true
 tokio.workspace = true
 # Machine spend readout: one small JSON GET every few minutes from inside a
-# Cloud VM. Both crates are already in the graph via chatmux-relay and iroh.
+# Cloud VM. chatmux-relay already uses reqwest for pairing bootstrap.
 reqwest.workspace = true
 rustls.workspace = true
 url.workspace = true

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -2041,7 +2041,7 @@ async fn run_daemon(
             Ok((unix, websocket, workspace_http, relays, iroh, admin, info))
         }
         .await;
-        let (unix, websocket, workspace_http, relays, iroh, admin, info) = match transport_setup {
+        let (unix, websocket, workspace_http, relays, _iroh, admin, info) = match transport_setup {
             Ok(transports) => transports,
             Err(error) => {
                 return finalize_daemon_authorization(auth, state_dir, lifecycle_id, vec![error])
@@ -2069,7 +2069,7 @@ async fn run_daemon(
                 .push(anyhow::Error::new(error).context("workspace HTTP shutdown failed"));
         }
         #[cfg(feature = "iroh-transport")]
-        if let Some(listener) = iroh
+        if let Some(listener) = _iroh
             && let Err(error) = listener.shutdown().await
         {
             shutdown_failures

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -1942,9 +1942,7 @@ async fn run_daemon(
 
             #[cfg(not(feature = "iroh-transport"))]
             if options.iroh {
-                return Err(anyhow!(
-                    "Iroh transport is not included in this cmux-tui build"
-                ));
+                return Err(anyhow!("Iroh transport is not included in this cmux-tui build"));
             }
             #[cfg(feature = "iroh-transport")]
             let iroh = match options.iroh {

--- a/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_runtime.rs
@@ -33,11 +33,14 @@ use cmux_remote::identity::{
 };
 use cmux_remote::observability::ClientConnectionSnapshot;
 use cmux_remote::provider::{
-    ConnectRequest, DirectWebSocketProvider, IrohListener, IrohPathMode, IrohProvider,
-    IrohProviderConfig, LinkGroup, ProviderError, RelayClientConfig, RelayCredentialSource,
-    RelayDaemonConfig, RelayDaemonRegistration, RelayProvider, SshProvider, SshProviderConfig,
-    SupportedClientAuthModes, TransportProvider, UnixProvider, load_or_create_iroh_secret,
-    register_relay_daemon_with_credentials, sanitized_route, sanitized_route_text,
+    ConnectRequest, DirectWebSocketProvider, IrohPathMode, LinkGroup, ProviderError,
+    RelayClientConfig, RelayCredentialSource, RelayDaemonConfig, RelayDaemonRegistration,
+    RelayProvider, SshProvider, SshProviderConfig, SupportedClientAuthModes, TransportProvider,
+    UnixProvider, register_relay_daemon_with_credentials, sanitized_route, sanitized_route_text,
+};
+#[cfg(feature = "iroh-transport")]
+use cmux_remote::provider::{
+    IrohListener, IrohProvider, IrohProviderConfig, load_or_create_iroh_secret,
 };
 use cmux_remote::secure_directory::{DirectoryAccess, ensure_secure_directory};
 use cmux_remote::service::{EndpointRole, ServiceMultiplexer};
@@ -443,9 +446,12 @@ pub fn client_provider_registry(
     providers.register(Arc::new(UnixProvider::new(MAX_CARRIER_FRAME_BYTES)))?;
     providers.register(Arc::new(SshProvider::new(ssh)?))?;
     providers.register(Arc::new(RoutedRelayProvider { routes: relay_routes }))?;
+    #[cfg(feature = "iroh-transport")]
     providers.register(Arc::new(IrohProvider::new(
         IrohProviderConfig::default().with_path_mode(iroh_path),
     )?))?;
+    #[cfg(not(feature = "iroh-transport"))]
+    let _ = iroh_path;
     Ok(providers)
 }
 
@@ -1934,6 +1940,13 @@ async fn run_daemon(
                 relays.push(result.context("relay registration task failed")??);
             }
 
+            #[cfg(not(feature = "iroh-transport"))]
+            if options.iroh {
+                return Err(anyhow!(
+                    "Iroh transport is not included in this cmux-tui build"
+                ));
+            }
+            #[cfg(feature = "iroh-transport")]
             let iroh = match options.iroh {
                 true => {
                     let config = IrohProviderConfig {
@@ -1949,6 +1962,8 @@ async fn run_daemon(
                 }
                 false => None,
             };
+            #[cfg(not(feature = "iroh-transport"))]
+            let iroh = None::<()>;
 
             let mut routes = Vec::new();
             for route in &options.advertised_routes {
@@ -1974,6 +1989,7 @@ async fn run_daemon(
             } else {
                 None
             };
+            #[cfg(feature = "iroh-transport")]
             let iroh_node_id = if let Some(listener) = &iroh {
                 let route = listener.route().await?;
                 let hints = route.routing_hints();
@@ -1993,6 +2009,8 @@ async fn run_daemon(
             } else {
                 None
             };
+            #[cfg(not(feature = "iroh-transport"))]
+            let iroh_node_id = None;
             if let Some(route) = websocket_route {
                 push_unique_route(&mut routes, route);
             }
@@ -2052,6 +2070,7 @@ async fn run_daemon(
             shutdown_failures
                 .push(anyhow::Error::new(error).context("workspace HTTP shutdown failed"));
         }
+        #[cfg(feature = "iroh-transport")]
         if let Some(listener) = iroh
             && let Err(error) = listener.shutdown().await
         {


### PR DESCRIPTION
## Summary

- disable the iroh transport in normal cmux-tui and cmux-terminal-client builds
- retain its small route configuration types behind an opt-in feature
- return a clear error when a normal build receives `--iroh`
- make the existing Tokio stdio requirement explicit

## Size

Blacksmith x86_64 Linux release build:

| form | with iroh | without iroh | saved |
| --- | ---: | ---: | ---: |
| raw | 69,914,848 B | 50,498,088 B | 19,416,760 B |
| stripped | 56,252,360 B | 41,136,360 B | 15,116,000 B |
| gzip -9 | 22,275,524 B | 16,549,248 B | 5,726,276 B |

The release dependency graph drops 111 package-version nodes, including iroh, iroh-dns, iroh-relay, noq, portmapper, and Linux netlink crates.

## Verification

- `cargo fmt --all -- --check`
- `cargo build -p cmux-tui --locked --release`
- `cargo test -p cmux-tui --locked --no-default-features --no-run`
- `cargo test -p cmux-remote --locked --no-fail-fast`, 497 unit tests and all integration tests passed
- `cargo build -p cmux-tui --locked --release --features iroh-transport`
- normal release invocation with `--remote --iroh` exits 1 with the build-disabled error

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791115245&installation_model_id=21920&pr_number=11945&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11945&signature=12c3e2fdcde4a1b524ae988c44702207b1111669ae02f93127a613b7648be730"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes iroh from the default `cmux-tui` and `cmux-remote` builds, cutting the release binary by about 19 MB and dropping 111 dependency packages from the graph. iroh transport is now opt-in via the `iroh-transport` feature, and builds without it fail with a clear error when passed `--iroh`.

- `IrohPathMode` and related route constants stay available in all builds via the new `iroh_config` module.
- Tokio's `io-std` feature is now declared explicitly.
- Builds that need iroh must enable `--features iroh-transport`.

<sup>Written for commit 21225feb9d8987162ca3607a9bfd833b206cc6ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for selecting Iroh connection paths: automatic, direct-only, or relay-only.
  - Added an optional Iroh transport feature that can be enabled when needed.

- **Changes**
  - Iroh transport is no longer enabled by default, reducing the default installation footprint.
  - Requests for Iroh connectivity now report an error when the optional transport is unavailable.

- **Tests**
  - Added coverage for valid and invalid Iroh connection mode values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->