### PR TITLE
Make OpenCode cmux hooks nonblocking

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -32644,19 +32644,27 @@ struct CMUXCLI {
     private static let openCodeSessionPluginMarker = "cmux-opencode-session-plugin-marker"
     private static let openCodeSessionPluginFilename = "cmux-session.js"
     private static let openCodeSessionPluginSource = #"""
-// cmux-opencode-session-plugin-marker v1
+// cmux-opencode-session-plugin-marker v2
 // Bridges OpenCode session lifecycle events into cmux's restorable session store.
 // Installed by `cmux hooks opencode install` or `cmux hooks setup`.
 // DO NOT EDIT MANUALLY. cmux upgrades this file in place.
 
-import { spawnSync } from "node:child_process";
+import { spawn } from "node:child_process";
 import * as fs from "node:fs";
 import * as path from "node:path";
 
 const CMUX_PLUGIN_INSTALLED_KEY = Symbol.for("cmux.session.restore.plugin.installed");
 const MAX_TRACKED_SESSIONS = 100;
+const MAX_ACTIVE_HOOKS = 4;
+const MAX_PENDING_HOOKS = 256;
+const HOOK_TIMEOUT_MS = 5000;
 const messageRoles = new Map();
 const sessions = new Map();
+const pendingHooks = [];
+const activeHookSessions = new Set();
+const reservedTerminalSessions = new Set();
+let activeHookCount = 0;
+let hookDrainScheduled = false;
 
 function firstString(...values) {
   for (const value of values) {
@@ -32683,6 +32691,7 @@ function sessionState(sessionId) {
       lastUserMessage: null,
       assistantPreamble: null,
       cwd: null,
+      sessionStartSent: false,
       updatedAt: Date.now(),
     });
   }
@@ -32822,12 +32831,128 @@ function hookEnvironment(cwd) {
   return env;
 }
 
+function scheduleHookDrain() {
+  if (hookDrainScheduled) return;
+  hookDrainScheduled = true;
+  queueMicrotask(() => {
+    hookDrainScheduled = false;
+    drainHookQueue();
+  });
+}
+
+function finishHookDispatch(sessionId) {
+  activeHookSessions.delete(sessionId);
+  activeHookCount = Math.max(0, activeHookCount - 1);
+  drainHookQueue();
+}
+
+function dispatchHook(invocation) {
+  let child = null;
+  let timeout = null;
+  let settled = false;
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    if (timeout) clearTimeout(timeout);
+    finishHookDispatch(invocation.sessionId);
+  };
+
+  try {
+    child = spawn(invocation.cmux, ["hooks", "opencode", invocation.subcommand], {
+      env: invocation.env,
+      stdio: ["pipe", "ignore", "ignore"],
+      detached: true,
+    });
+    child.once("error", settle);
+    child.once("close", settle);
+    child.stdin.on("error", () => {});
+    child.stdin.end(invocation.payload);
+    // Neither a slow hook process nor its stdin pipe may keep OpenCode's event
+    // loop alive. The timeout bounds the four detached children we retain.
+    child.stdin.unref?.();
+    child.unref();
+    timeout = setTimeout(() => {
+      try {
+        // Release the lane immediately after SIGKILL. Waiting for the child
+        // close event can strand a lane when the OS delays process reaping.
+        child.kill("SIGKILL");
+        settle();
+      } catch (_) {
+        settle();
+      }
+    }, HOOK_TIMEOUT_MS);
+    timeout.unref?.();
+  } catch (_) {
+    settle();
+  }
+}
+
+function drainHookQueue() {
+  while (activeHookCount < MAX_ACTIVE_HOOKS && pendingHooks.length > 0) {
+    const index = pendingHooks.findIndex(
+      (invocation) => !activeHookSessions.has(invocation.sessionId)
+    );
+    if (index < 0) return;
+    const [invocation] = pendingHooks.splice(index, 1);
+    activeHookSessions.add(invocation.sessionId);
+    activeHookCount += 1;
+    dispatchHook(invocation);
+  }
+}
+
+function enqueueHook(invocation) {
+  // Coalesce only the newest uninterrupted run of this session's same event.
+  // Crossing another lifecycle event is an ordering boundary: start, stop,
+  // end, start must remain four ordered transitions even when dispatch stalls.
+  for (let index = pendingHooks.length - 1; index >= 0; index -= 1) {
+    const pending = pendingHooks[index];
+    if (pending.sessionId !== invocation.sessionId) continue;
+    if (pending.subcommand === invocation.subcommand) {
+      pendingHooks[index] = invocation;
+      scheduleHookDrain();
+      return true;
+    }
+    break;
+  }
+
+  const isStart = invocation.subcommand === "session-start";
+  const isEnd = invocation.subcommand === "session-end";
+  const hasTerminalReservation = reservedTerminalSessions.has(invocation.sessionId);
+  if (isStart && hasTerminalReservation) {
+    // The durable session already has an accepted start. A pruned in-memory
+    // metadata entry must not generate another one.
+    return true;
+  }
+
+  // Every accepted start reserves room for its matching end. End admission
+  // consumes that reservation, so a full queue cannot strand a durable active
+  // session. Starts and ends may evict nonterminal stop refreshes under load.
+  const reservationDelta = isStart ? 1 : (isEnd && hasTerminalReservation ? -1 : 0);
+  let projectedCost = pendingHooks.length + 1
+    + reservedTerminalSessions.size + reservationDelta;
+  while (projectedCost > MAX_PENDING_HOOKS && invocation.subcommand !== "stop") {
+    const stopIndex = pendingHooks.findIndex((pending) => pending.subcommand === "stop");
+    if (stopIndex < 0) break;
+    pendingHooks.splice(stopIndex, 1);
+    projectedCost -= 1;
+  }
+  if (projectedCost > MAX_PENDING_HOOKS) return false;
+
+  pendingHooks.push(invocation);
+  if (isStart) reservedTerminalSessions.add(invocation.sessionId);
+  if (isEnd && hasTerminalReservation) {
+    reservedTerminalSessions.delete(invocation.sessionId);
+  }
+  scheduleHookDrain();
+  return true;
+}
+
 function sendHook(subcommand, ctx, event, extra = {}) {
-  if (process.env.CMUX_OPENCODE_HOOKS_DISABLED === "1") return;
-  if (!process.env.CMUX_SURFACE_ID) return;
+  if (process.env.CMUX_OPENCODE_HOOKS_DISABLED === "1") return false;
+  if (!process.env.CMUX_SURFACE_ID) return false;
 
   const sessionId = sessionIdFor(event);
-  if (!sessionId) return;
+  if (!sessionId) return false;
 
   const cwd = cwdFor(ctx, event);
   const state = sessionState(sessionId);
@@ -32841,16 +32966,22 @@ function sendHook(subcommand, ctx, event, extra = {}) {
   };
   const context = extra.context || contextForSession(sessionId);
   if (context) payload.context = context;
-  const cmux = process.env.CMUX_OPENCODE_CMUX_BIN || "cmux";
-  try {
-    spawnSync(cmux, ["hooks", "opencode", subcommand], {
-      input: JSON.stringify(payload),
-      encoding: "utf8",
-      env: hookEnvironment(cwd),
-      stdio: ["pipe", "ignore", "ignore"],
-      timeout: 5000,
-    });
-  } catch (_) {}
+  const cmux = process.env.CMUX_OPENCODE_CMUX_BIN || process.env.CMUX_BUNDLED_CLI_PATH || "cmux";
+  return enqueueHook({
+    cmux,
+    subcommand,
+    sessionId,
+    payload: JSON.stringify(payload),
+    env: hookEnvironment(cwd),
+  });
+}
+
+function sendSessionStartOnce(ctx, event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+  const state = sessionState(sessionId);
+  if (state.sessionStartSent) return;
+  if (sendHook("session-start", ctx, event)) state.sessionStartSent = true;
 }
 
 function trackMessage(event) {
@@ -32893,14 +33024,15 @@ const CMUXSessionRestore = async (ctx) => {
       const props = eventProperties(event);
       switch (event && event.type) {
         case "session.created":
-          sendHook("session-start", ctx, event);
+          sendSessionStartOnce(ctx, event);
           break;
         case "session.updated":
           if (props.info && props.info.time && props.info.time.archived) {
-            sendHook("session-end", ctx, event);
-            dropSession(sessionIdFor(event));
+            if (sendHook("session-end", ctx, event)) {
+              dropSession(sessionIdFor(event));
+            }
           } else {
-            sendHook("session-start", ctx, event);
+            sendSessionStartOnce(ctx, event);
           }
           break;
         case "session.status":
@@ -32912,8 +33044,9 @@ const CMUXSessionRestore = async (ctx) => {
           sendHook("stop", ctx, event);
           break;
         case "session.deleted":
-          sendHook("session-end", ctx, event);
-          dropSession(sessionIdFor(event));
+          if (sendHook("session-end", ctx, event)) {
+            dropSession(sessionIdFor(event));
+          }
           break;
         default:
           break;

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -194,24 +194,37 @@ final class OpenCodeHookRegressionTests: XCTestCase {
         let fixture = try makeOpenCodePluginFixture(fakeCmuxLines: [
             "payload=\"$(cat)\"",
             "printf '%s|%s\\n' \"$3\" \"$payload\" >> \"$TEST_HOOK_CAPTURE\"",
-            "if [ \"$3\" = \"session-start\" ]; then IFS= read -r _ < \"$TEST_HOOK_RELEASE_FIFO\"; fi",
+            "if [ \"$3\" = \"session-start\" ]; then /usr/bin/nc -U \"$TEST_HOOK_RELEASE_SOCKET\" >/dev/null; fi",
         ])
         defer { try? FileManager.default.removeItem(at: fixture.root) }
 
         let capture = fixture.root.appendingPathComponent("hooks.txt", isDirectory: false)
-        let releaseFIFO = fixture.root.appendingPathComponent("release.fifo", isDirectory: false)
-        XCTAssertEqual(mkfifo(releaseFIFO.path, S_IRUSR | S_IWUSR), 0)
+        let releaseSocket = fixture.root.appendingPathComponent("release.sock", isDirectory: false)
         var environment = fixture.environment
         environment["TEST_HOOK_CAPTURE"] = capture.path
-        environment["TEST_HOOK_RELEASE_FIFO"] = releaseFIFO.path
+        environment["TEST_HOOK_RELEASE_SOCKET"] = releaseSocket.path
 
         let harness = fixture.root.appendingPathComponent("overload.mjs", isDirectory: false)
         try """
         import fs from "node:fs";
-        import { spawn } from "node:child_process";
+        import net from "node:net";
         import plugin from \(javaScriptString(fixture.pluginURL.absoluteString));
 
         const hooks = await plugin({ directory: process.cwd() });
+        let releaseStarts = false;
+        const heldStarts = [];
+        const releaseServer = net.createServer((socket) => {
+          socket.on("error", () => {});
+          if (releaseStarts) {
+            socket.end("release\\n");
+          } else {
+            heldStarts.push(socket);
+          }
+        });
+        await new Promise((resolve, reject) => {
+          releaseServer.once("error", reject);
+          releaseServer.listen(process.env.TEST_HOOK_RELEASE_SOCKET, resolve);
+        });
         const captureLines = () => fs.existsSync(process.env.TEST_HOOK_CAPTURE)
           ? fs.readFileSync(process.env.TEST_HOOK_CAPTURE, "utf8").trim().split("\\n").filter(Boolean)
           : [];
@@ -250,11 +263,8 @@ final class OpenCodeHookRegressionTests: XCTestCase {
         await hooks.event({ event: { type: "session.deleted", properties: { info: terminalInfo } } });
 
         await waitFor("four blocked session starts", () => records().length >= 4);
-        const fifoWriter = fs.openSync(process.env.TEST_HOOK_RELEASE_FIFO, "w");
-        const releaser = spawn("/usr/bin/yes", ["release"], {
-          stdio: ["ignore", fifoWriter, "ignore"],
-        });
-        fs.closeSync(fifoWriter);
+        releaseStarts = true;
+        for (const socket of heldStarts.splice(0)) socket.end("release\\n");
         await waitFor(
           "the terminal hook reserved while the queue was full",
           () => records().some((record) =>
@@ -262,7 +272,7 @@ final class OpenCodeHookRegressionTests: XCTestCase {
               && record.subcommand === "session-end"
           )
         );
-        releaser.kill("SIGKILL");
+        await new Promise((resolve) => releaseServer.close(resolve));
         console.log(JSON.stringify(records()));
         """.write(to: harness, atomically: true, encoding: .utf8)
 

--- a/cmuxTests/OpenCodeHookRegressionTests.swift
+++ b/cmuxTests/OpenCodeHookRegressionTests.swift
@@ -9,6 +9,284 @@ final class OpenCodeHookRegressionTests: XCTestCase {
         let timedOut: Bool
     }
 
+    func testOpenCodeLifecycleHookDeliveryDoesNotBlockOnCmuxProcessExit() throws {
+        let fixture = try makeOpenCodePluginFixture(fakeCmuxLines: [
+            "sleep 1",
+            "cat >/dev/null",
+        ])
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let harness = fixture.root.appendingPathComponent("nonblocking.mjs", isDirectory: false)
+        try """
+        import plugin from \(javaScriptString(fixture.pluginURL.absoluteString));
+        const hooks = await plugin({ directory: process.cwd() });
+        const startedAt = performance.now();
+        await hooks.event({ event: {
+          type: "session.created",
+          properties: { info: { id: "session-nonblocking", directory: process.cwd() } },
+        } });
+        console.log(String(performance.now() - startedAt));
+        """.write(to: harness, atomically: true, encoding: .utf8)
+
+        let result = runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: ["node", harness.path],
+            environment: fixture.environment,
+            timeout: 3
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let elapsedMilliseconds = try XCTUnwrap(Double(result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)))
+        XCTAssertLessThan(elapsedMilliseconds, 250, "OpenCode event callback blocked for \(elapsedMilliseconds) ms")
+    }
+
+    func testOpenCodeSessionUpdatedDoesNotRepeatSessionStartHook() throws {
+        let fixture = try makeOpenCodePluginFixture(fakeCmuxLines: [
+            "printf '%s\\n' \"$*\" >> \"$TEST_HOOK_CAPTURE\"",
+            "cat >/dev/null",
+        ])
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let capture = fixture.root.appendingPathComponent("hooks.txt", isDirectory: false)
+        var environment = fixture.environment
+        environment["TEST_HOOK_CAPTURE"] = capture.path
+
+        let harness = fixture.root.appendingPathComponent("dedupe.mjs", isDirectory: false)
+        try """
+        import fs from "node:fs";
+        import plugin from \(javaScriptString(fixture.pluginURL.absoluteString));
+        const hooks = await plugin({ directory: process.cwd() });
+        const info = { id: "session-dedupe", directory: process.cwd() };
+        await hooks.event({ event: { type: "session.created", properties: { info } } });
+        await hooks.event({ event: { type: "session.updated", properties: { info } } });
+        await hooks.event({ event: { type: "session.updated", properties: { info } } });
+        await hooks.event({ event: { type: "session.updated", properties: { info } } });
+        await new Promise((resolve, reject) => {
+          if (fs.existsSync(process.env.TEST_HOOK_CAPTURE)) return resolve();
+          const watcher = fs.watch(\(javaScriptString(fixture.root.path)), () => {
+            if (!fs.existsSync(process.env.TEST_HOOK_CAPTURE)) return;
+            watcher.close();
+            clearTimeout(timeout);
+            resolve();
+          });
+          const timeout = setTimeout(() => {
+            watcher.close();
+            reject(new Error("hook capture was not created"));
+          }, 2000);
+        });
+        """.write(to: harness, atomically: true, encoding: .utf8)
+
+        let result = runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: ["node", harness.path],
+            environment: environment,
+            timeout: 3
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let invocations = try String(contentsOf: capture, encoding: .utf8)
+            .split(separator: "\n")
+            .filter { $0.contains("hooks opencode session-start") }
+        XCTAssertEqual(invocations.count, 1, "session.updated repeated session-start: \(invocations)")
+    }
+
+    func testOpenCodeLifecycleHooksStayOrderedPerSessionWhileOtherSessionsDispatch() throws {
+        let fixture = try makeOpenCodePluginFixture(fakeCmuxLines: [
+            "payload=\"$(cat)\"",
+            "printf '%s|%s\\n' \"$3\" \"$payload\" >> \"$TEST_HOOK_CAPTURE\"",
+            "case \"$payload\" in",
+            "  *session-ordered*)",
+            "    cat \"$TEST_HOOK_RELEASE_FIFO\" >/dev/null",
+            "    ;;",
+            "esac",
+        ])
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let capture = fixture.root.appendingPathComponent("hooks.txt", isDirectory: false)
+        let releaseFIFO = fixture.root.appendingPathComponent("release.fifo", isDirectory: false)
+        XCTAssertEqual(mkfifo(releaseFIFO.path, S_IRUSR | S_IWUSR), 0)
+        var environment = fixture.environment
+        environment["TEST_HOOK_CAPTURE"] = capture.path
+        environment["TEST_HOOK_RELEASE_FIFO"] = releaseFIFO.path
+
+        let harness = fixture.root.appendingPathComponent("ordered.mjs", isDirectory: false)
+        try """
+        import fs from "node:fs";
+        import plugin from \(javaScriptString(fixture.pluginURL.absoluteString));
+
+        const hooks = await plugin({ directory: process.cwd() });
+        const orderedInfo = { id: "session-ordered", directory: process.cwd() };
+        const otherInfo = { id: "session-other", directory: process.cwd() };
+        const captureLines = () => fs.existsSync(process.env.TEST_HOOK_CAPTURE)
+          ? fs.readFileSync(process.env.TEST_HOOK_CAPTURE, "utf8").trim().split("\\n").filter(Boolean)
+          : [];
+        const waitForLineCount = (count) => new Promise((resolve, reject) => {
+          const ready = () => captureLines().length >= count;
+          if (ready()) return resolve();
+          const watcher = fs.watch(\(javaScriptString(fixture.root.path)), () => {
+            if (!ready()) return;
+            watcher.close();
+            clearTimeout(timeout);
+            resolve();
+          });
+          const timeout = setTimeout(() => {
+            watcher.close();
+            reject(new Error(`hook capture did not reach ${count} lines`));
+          }, 2000);
+        });
+        const records = () => captureLines().map((line) => {
+          const separator = line.indexOf("|");
+          const payload = JSON.parse(line.slice(separator + 1));
+          return { subcommand: line.slice(0, separator), sessionId: payload.session_id };
+        });
+        const releaseOrderedHook = () => fs.writeFileSync(
+          process.env.TEST_HOOK_RELEASE_FIFO,
+          "release\\n"
+        );
+
+        await hooks.event({ event: { type: "session.created", properties: { info: orderedInfo } } });
+        await waitForLineCount(1);
+
+        await hooks.event({ event: { type: "session.idle", properties: { info: orderedInfo } } });
+        await hooks.event({ event: { type: "session.idle", properties: { info: orderedInfo } } });
+        await hooks.event({ event: { type: "session.deleted", properties: { info: orderedInfo } } });
+        await hooks.event({ event: { type: "session.created", properties: { info: orderedInfo } } });
+        await hooks.event({ event: { type: "session.created", properties: { info: otherInfo } } });
+        await waitForLineCount(2);
+
+        const beforeRelease = records();
+        releaseOrderedHook();
+        await waitForLineCount(3);
+        releaseOrderedHook();
+        await waitForLineCount(4);
+        releaseOrderedHook();
+        await waitForLineCount(5);
+        const afterRelease = records();
+        releaseOrderedHook();
+        console.log(JSON.stringify({ beforeRelease, afterRelease }));
+        """.write(to: harness, atomically: true, encoding: .utf8)
+
+        let result = runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: ["node", harness.path],
+            environment: environment,
+            timeout: 4
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let snapshot = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [String: Any]
+        )
+        let beforeRelease = try XCTUnwrap(snapshot["beforeRelease"] as? [[String: String]])
+        XCTAssertEqual(beforeRelease.compactMap { $0["sessionId"] }.sorted(), ["session-ordered", "session-other"])
+        XCTAssertEqual(beforeRelease.compactMap { $0["subcommand"] }, ["session-start", "session-start"])
+
+        let afterRelease = try XCTUnwrap(snapshot["afterRelease"] as? [[String: String]])
+        let orderedCommands = afterRelease
+            .filter { $0["sessionId"] == "session-ordered" }
+            .compactMap { $0["subcommand"] }
+        XCTAssertEqual(orderedCommands, ["session-start", "stop", "session-end", "session-start"])
+    }
+
+    func testOpenCodeQueueOverloadPreservesEveryAcceptedStartEndPair() throws {
+        let fixture = try makeOpenCodePluginFixture(fakeCmuxLines: [
+            "payload=\"$(cat)\"",
+            "printf '%s|%s\\n' \"$3\" \"$payload\" >> \"$TEST_HOOK_CAPTURE\"",
+            "if [ \"$3\" = \"session-start\" ]; then IFS= read -r _ < \"$TEST_HOOK_RELEASE_FIFO\"; fi",
+        ])
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let capture = fixture.root.appendingPathComponent("hooks.txt", isDirectory: false)
+        let releaseFIFO = fixture.root.appendingPathComponent("release.fifo", isDirectory: false)
+        XCTAssertEqual(mkfifo(releaseFIFO.path, S_IRUSR | S_IWUSR), 0)
+        var environment = fixture.environment
+        environment["TEST_HOOK_CAPTURE"] = capture.path
+        environment["TEST_HOOK_RELEASE_FIFO"] = releaseFIFO.path
+
+        let harness = fixture.root.appendingPathComponent("overload.mjs", isDirectory: false)
+        try """
+        import fs from "node:fs";
+        import { spawn } from "node:child_process";
+        import plugin from \(javaScriptString(fixture.pluginURL.absoluteString));
+
+        const hooks = await plugin({ directory: process.cwd() });
+        const captureLines = () => fs.existsSync(process.env.TEST_HOOK_CAPTURE)
+          ? fs.readFileSync(process.env.TEST_HOOK_CAPTURE, "utf8").trim().split("\\n").filter(Boolean)
+          : [];
+        const records = () => captureLines().map((line) => {
+          const separator = line.indexOf("|");
+          const payload = JSON.parse(line.slice(separator + 1));
+          return { subcommand: line.slice(0, separator), sessionId: payload.session_id };
+        });
+        const waitFor = (description, predicate) => new Promise((resolve, reject) => {
+          if (predicate()) return resolve();
+          const watcher = fs.watch(\(javaScriptString(fixture.root.path)), () => {
+            if (!predicate()) return;
+            watcher.close();
+            clearTimeout(timeout);
+            resolve();
+          });
+          const timeout = setTimeout(() => {
+            watcher.close();
+            reject(new Error(`timed out waiting for ${description}`));
+          }, 6000);
+        });
+
+        const sessionIds = [
+          "session-terminal-reservation",
+          ...Array.from({ length: 300 }, (_, index) => `session-overload-${index}`),
+        ];
+        for (const sessionId of sessionIds) {
+          const info = { id: sessionId, directory: process.cwd() };
+          await hooks.event({ event: { type: "session.created", properties: { info } } });
+        }
+        for (const sessionId of sessionIds.slice(1)) {
+          const info = { id: sessionId, directory: process.cwd() };
+          await hooks.event({ event: { type: "session.deleted", properties: { info } } });
+        }
+        const terminalInfo = { id: sessionIds[0], directory: process.cwd() };
+        await hooks.event({ event: { type: "session.deleted", properties: { info: terminalInfo } } });
+
+        await waitFor("four blocked session starts", () => records().length >= 4);
+        const fifoWriter = fs.openSync(process.env.TEST_HOOK_RELEASE_FIFO, "w");
+        const releaser = spawn("/usr/bin/yes", ["release"], {
+          stdio: ["ignore", fifoWriter, "ignore"],
+        });
+        fs.closeSync(fifoWriter);
+        await waitFor(
+          "the terminal hook reserved while the queue was full",
+          () => records().some((record) =>
+            record.sessionId === "session-terminal-reservation"
+              && record.subcommand === "session-end"
+          )
+        );
+        releaser.kill("SIGKILL");
+        console.log(JSON.stringify(records()));
+        """.write(to: harness, atomically: true, encoding: .utf8)
+
+        let result = runProcess(
+            executablePath: "/usr/bin/env",
+            arguments: ["node", harness.path],
+            environment: environment,
+            timeout: 10
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        let records = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(result.stdout.utf8)) as? [[String: String]]
+        )
+        let starts = records.filter { $0["subcommand"] == "session-start" }
+        let ends = records.filter { $0["subcommand"] == "session-end" }
+        XCTAssertGreaterThan(starts.count, 100, "fixture did not saturate the 256-slot queue")
+        XCTAssertLessThan(starts.count, 301, "the bounded queue admitted every overload session")
+        XCTAssertEqual(Set(starts.compactMap { $0["sessionId"] }), Set(ends.compactMap { $0["sessionId"] }))
+        XCTAssertEqual(starts.count, ends.count)
+        XCTAssertTrue(ends.contains { $0["sessionId"] == "session-terminal-reservation" })
+    }
+
     func testOpenCodeInstallHooksIsIdempotentForLegacySetupAlias() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory.appendingPathComponent("cmux-opencode-hooks-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
## Summary
- Dispatch generated OpenCode lifecycle hooks through a bounded asynchronous queue.
- Limit hook fan-out to four active children and 256 pending entries, coalescing repeated same-session transitions.
- Deduplicate `session-start` delivery from repeated `session.updated` events.
- Release queue lanes immediately when a timed-out hook is killed.

## Verification
- `swiftc -frontend -parse CLI/cmux.swift`
- `swiftc -frontend -parse cmuxTests/OpenCodeHookRegressionTests.swift`
- Generated plugin `node --check --input-type=module`
- Runtime fixture: callback returned in about 2 ms with a 1 second fake cmux process.
- Runtime overload fixture: 130 accepted starts and 130 matching ends from 301 sessions.
- Tagged fleet build attempted with `ocnb2`; blocked by existing `Sources/Cloud/VMTunnelManager.swift:329` error (`VMTunnelManager` has no member `completedConfig`).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11951"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791116483&installation_model_id=21920&pr_number=11951&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11951&signature=b0ab93e9f337e1512eb995275f197bfb58a1a27456946cd4f7465d0789c85fff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes OpenCode lifecycle hooks nonblocking so they no longer block OpenCode's event loop.

- Replaces synchronous `spawnSync` hook calls with a bounded async queue (4 active children, 256 pending entries).
- Coalesces repeated same-session lifecycle transitions and dedupes `session-start` delivery from `session.created` and `session.updated`.
- Drops hooks when the queue is full, except `session-end` for sessions with a previously accepted start.
- Releases queue lanes immediately when a hook times out after 5 seconds.

<sup>Written for commit 85d42042ad52792b79417613b2127e5a11514ba0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * OpenCode session hook delivery is now asynchronous, preventing session events from blocking while external processes respond.
  * Hook processing remains ordered per session while supporting concurrent activity across sessions.

* **Reliability**
  * Repeated session updates no longer trigger duplicate session-start events.
  * Queue limits, timeouts, and event coalescing improve behavior during high activity.
  * Accepted session lifecycle events are reliably paired and delivered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->