### PR TITLE
Fix blank terminal surface after completion notification

### DIFF
--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceGroupCoordinator.swift
@@ -243,9 +243,14 @@ public final class WorkspaceGroupCoordinator<Tab: WorkspaceTabRepresenting> {
             }
         }
         guard currentIndex != targetIndex else { return }
-        let workspace = model.tabs.remove(at: currentIndex)
         let insertAt = currentIndex < targetIndex ? targetIndex - 1 : targetIndex
-        model.tabs.insert(workspace, at: max(0, min(insertAt, model.tabs.count)))
+        model.replaceTabs { currentTabs in
+            var reordered = currentTabs
+            let workspace = reordered.remove(at: currentIndex)
+            let destination = max(0, min(insertAt, reordered.count))
+            reordered.insert(workspace, at: destination)
+            return reordered
+        }
     }
 
     // MARK: - Membership

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Coordinators/WorkspaceReorderCoordinator.swift
@@ -93,8 +93,12 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
             guard index != pinnedCount else { return }
             let tab = model.tabs[index]
             guard !tab.isPinned else { return }
-            model.tabs.remove(at: index)
-            model.tabs.insert(tab, at: pinnedCount)
+            model.replaceTabs { currentTabs in
+                var reordered = currentTabs
+                let movedTab = reordered.remove(at: index)
+                reordered.insert(movedTab, at: pinnedCount)
+                return reordered
+            }
         }
         if model.tabs.map(\.id) != previousOrder {
             host?.workspaceOrderDidChange(movedWorkspaceIds: [tabId])
@@ -152,8 +156,12 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
             return true
         }
 
-        let workspace = model.tabs.remove(at: plan.fromIndex)
-        model.tabs.insert(workspace, at: plan.toIndex)
+        model.replaceTabs { currentTabs in
+            var reordered = currentTabs
+            let workspace = reordered.remove(at: plan.fromIndex)
+            reordered.insert(workspace, at: plan.toIndex)
+            return reordered
+        }
         if isDragOperation {
             applyDragInferredGroupMembership(workspaceId: tabId, explicitGroupId: explicitGroupId)
         } else if !model.workspaceGroups.isEmpty {
@@ -895,14 +903,21 @@ public final class WorkspaceReorderCoordinator<Tab: WorkspaceTabRepresenting> {
     }
 
     private func reorderTabForPinnedState(_ tab: Tab) {
-        guard let index = model.tabs.firstIndex(where: { $0.id == tab.id }) else { return }
+        guard model.tabs.contains(where: { $0.id == tab.id }) else { return }
         if tab.groupId != nil {
             model.normalizeWorkspaceGroupContiguity()
             return
         }
-        model.tabs.remove(at: index)
-        let pinnedCount = model.leadingGlobalPinnedRowCount()
-        let insertIndex = min(pinnedCount, model.tabs.count)
-        model.tabs.insert(tab, at: insertIndex)
+        model.replaceTabs { currentTabs in
+            var reordered = currentTabs
+            guard let currentIndex = reordered.firstIndex(where: { $0.id == tab.id }) else {
+                return currentTabs
+            }
+            let movedTab = reordered.remove(at: currentIndex)
+            let pinnedCount = reordered.prefix { model.isGlobalPinnedRow($0) }.count
+            let insertIndex = min(pinnedCount, reordered.count)
+            reordered.insert(movedTab, at: insertIndex)
+            return reordered
+        }
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+AtomicTabsMutation.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/Model/WorkspacesModel+AtomicTabsMutation.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension WorkspacesModel {
+    /// Replaces the workspace order through one `tabs` assignment.
+    ///
+    /// `tabs` is the publication boundary used by the app to reconcile mounted
+    /// workspace portals. Mutating an array in place (for example, `remove`
+    /// followed by `insert`) publishes an intermediate order that can omit the
+    /// selected workspace and tear down its terminal surface. Reorder callers
+    /// use this helper to keep every observable snapshot self-consistent.
+    func replaceTabs(_ transform: ([Tab]) -> [Tab]) {
+        tabs = transform(tabs)
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceReorderAtomicityTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceReorderAtomicityTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+
+@testable import CmuxWorkspaces
+
+/// Captures the snapshots that a window-side observer would receive while a
+/// workspace reorder is applied.  The app's ContentView uses the same
+/// willSet boundary to decide which workspace portals remain mounted.
+@MainActor
+private final class ReorderPublicationHost: WorkspacesHosting, WorkspaceOrderHosting {
+    typealias Tab = CoordinatorStubTab
+
+    private(set) var tabSnapshots: [[UUID]] = []
+    private(set) var orderChanges: [[UUID]] = []
+
+    func resetSnapshots() {
+        tabSnapshots.removeAll()
+        orderChanges.removeAll()
+    }
+
+    func workspaceTabsWillChange(to newValue: [CoordinatorStubTab]) {
+        tabSnapshots.append(newValue.map(\.id))
+    }
+
+    func workspaceGroupsWillChange(to newValue: [WorkspaceGroup]) {}
+    func selectedWorkspaceIdWillChange(to newValue: UUID?) {}
+    func selectedWorkspaceIdDidChange(from oldValue: UUID?) {}
+
+    func workspaceOrderDidChange(movedWorkspaceIds: [UUID]) {
+        orderChanges.append(movedWorkspaceIds)
+    }
+}
+
+@MainActor
+struct WorkspaceReorderAtomicityTests {
+    @Test
+    func notificationReorderPublishesOnlyCoherentWorkspaceSnapshots() {
+        let model = WorkspacesModel<CoordinatorStubTab>()
+        let host = ReorderPublicationHost()
+        model.attach(host: host)
+        let reorder = WorkspaceReorderCoordinator(model: model)
+        reorder.attach(host: host)
+
+        let first = CoordinatorStubTab()
+        let selected = CoordinatorStubTab()
+        let last = CoordinatorStubTab()
+        model.tabs = [first, selected, last]
+        model.selectedTabId = selected.id
+        host.resetSnapshots()
+
+        reorder.moveTabToTopForNotification(selected.id)
+
+        #expect(host.tabSnapshots == [[selected.id, first.id, last.id]])
+        #expect(host.tabSnapshots.allSatisfy { $0.contains(selected.id) })
+        #expect(host.orderChanges == [[selected.id]])
+    }
+}

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceReorderAtomicityTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceReorderAtomicityTests.swift
@@ -33,13 +33,22 @@ private final class ReorderPublicationHost: WorkspacesHosting, WorkspaceOrderHos
 
 @MainActor
 struct WorkspaceReorderAtomicityTests {
-    @Test
-    func notificationReorderPublishesOnlyCoherentWorkspaceSnapshots() {
+    private func makeWorld() -> (
+        model: WorkspacesModel<CoordinatorStubTab>,
+        host: ReorderPublicationHost,
+        reorder: WorkspaceReorderCoordinator<CoordinatorStubTab>
+    ) {
         let model = WorkspacesModel<CoordinatorStubTab>()
         let host = ReorderPublicationHost()
         model.attach(host: host)
         let reorder = WorkspaceReorderCoordinator(model: model)
         reorder.attach(host: host)
+        return (model, host, reorder)
+    }
+
+    @Test
+    func notificationReorderPublishesOnlyCoherentWorkspaceSnapshots() {
+        let (model, host, reorder) = makeWorld()
 
         let first = CoordinatorStubTab()
         let selected = CoordinatorStubTab()
@@ -53,5 +62,38 @@ struct WorkspaceReorderAtomicityTests {
         #expect(host.tabSnapshots == [[selected.id, first.id, last.id]])
         #expect(host.tabSnapshots.allSatisfy { $0.contains(selected.id) })
         #expect(host.orderChanges == [[selected.id]])
+    }
+
+    @Test
+    func explicitReorderPublishesOnlyCoherentWorkspaceSnapshots() {
+        let (model, host, reorder) = makeWorld()
+        let first = CoordinatorStubTab()
+        let selected = CoordinatorStubTab()
+        let last = CoordinatorStubTab()
+        model.tabs = [first, selected, last]
+        model.selectedTabId = selected.id
+        host.resetSnapshots()
+
+        #expect(reorder.reorderWorkspace(tabId: selected.id, toIndex: 0))
+
+        #expect(host.tabSnapshots == [[selected.id, first.id, last.id]])
+        #expect(host.tabSnapshots.allSatisfy { $0.contains(selected.id) })
+    }
+
+    @Test
+    func pinTransitionPublishesOnlyCoherentWorkspaceSnapshots() {
+        let (model, host, reorder) = makeWorld()
+        let pinned = CoordinatorStubTab(isPinned: true)
+        let selected = CoordinatorStubTab()
+        let last = CoordinatorStubTab()
+        model.tabs = [pinned, selected, last]
+        model.selectedTabId = selected.id
+        host.resetSnapshots()
+
+        reorder.setPinned(selected, pinned: true)
+
+        #expect(host.tabSnapshots.count == 1)
+        #expect(host.tabSnapshots.allSatisfy { $0.contains(selected.id) })
+        #expect(model.tabs.map(\.id) == [pinned.id, selected.id, last.id])
     }
 }

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceReorderAtomicityTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/WorkspaceReorderAtomicityTests.swift
@@ -92,8 +92,7 @@ struct WorkspaceReorderAtomicityTests {
 
         reorder.setPinned(selected, pinned: true)
 
-        #expect(host.tabSnapshots.count == 1)
-        #expect(host.tabSnapshots.allSatisfy { $0.contains(selected.id) })
+        #expect(host.tabSnapshots == [[pinned.id, selected.id, last.id]])
         #expect(model.tabs.map(\.id) == [pinned.id, selected.id, last.id])
     }
 }


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/2817.

When a completion notification reordered a non-top workspace, the workspace
reorder coordinator mutated `tabs` with `remove` followed by `insert`. The
`WorkspacesModel.tabs` `willSet` hook publishes each mutation immediately.
`ContentView` therefore received one snapshot without the selected workspace,
reconciled its mount plan to an empty set, and tore down the selected terminal
portal before the second snapshot added it back. That lifecycle churn is why
the Metal surface could stay blank until a later focus/workspace transition.

The fix adds a model-owned `replaceTabs` boundary for pure order transforms and
routs every coordinator reorder through one `tabs` assignment: notification
reorder, explicit reorder, pin-tier moves, and in-group placement. Intentional
close/detach lifecycle removals remain separate so teardown semantics do not
change.

## Regression and verification

The regression is split into a failing test commit and the runtime fix:

1. `d4dd2994ba` adds `WorkspaceReorderAtomicityTests`; against the old code it
   fails with the observable snapshots `[[other, other], [selected, other,
   other]]`.
2. `458979ae25` applies the atomic publication fix.
3. `a32021e216` tightens the pin-transition assertion per review.

Commands/results:

- AWS runner: `swift test --package-path Packages/macOS/CmuxWorkspaces` — 225
  tests in 31 suites passed at `a32021e216`.
- Tagged fleet build from current `origin/main`:
  `CMUX_DEV_BACKEND_MODE=local CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-2817-blank-surface-redraw --launch`
  — `BUILD SUCCEEDED` on `cmuxs-mac-mini-2-1.1`, source HEAD
  `458979ae25` (the only later change is a test assertion).
- Real-app dogfood on the tagged fleet archive: created two workspaces,
  selected the second (non-top) workspace, delivered a completion notification
  to its terminal surface, and captured the window immediately without a
  workspace/focus round-trip. Terminal text remained rendered while the
  sidebar reordered and showed the unread badge. The post-fix log has
  `notification.store.add`/`record` followed by sidebar updates and no
  `ws.mount.reconcile mounted=[]` eviction.

Before/after evidence:

```text
Before (regression test): selected workspace absent from one published tabs snapshot;
the mount projection becomes empty, then remounts it.

After (fleet log):
05:57:53.457 notification.sync.deliver workspace=C2BF5209 surface=38D669AA
05:57:53.458 notification.store.add workspace=C2BF5209 surface=38D669AA
05:57:53.460 notification.store.record workspace=C2BF5209 surface=38D669AA
05:57:53.475 sidebar.table.rowsBuild items=2
05:57:53.497 sidebar.table.apply structural=1 contentChanges=2 rows=2
```

The local volume ran out of space while `reload-cloud.sh --launch` extracted
the 336 MB archive (the app is about 690 MB uncompressed), so the final archive
was exercised on its fleet GUI host rather than deleting unrelated agents'
caches. The remote build and screenshots are the same tagged
`cmux DEV issue-2817-blank-surface-redraw` artifact.

## Trade-offs

- Reorder observers now see one coherent order snapshot rather than the
  accidental remove/insert intermediate states. This removes a lifecycle race;
  it does not add a timer, display-link, manual draw loop, or focus workaround.
- The helper is scoped to reorder transforms. Close/detach and restore lifecycle
  paths were not rewritten because their intermediate removal is a deliberate
  teardown signal.
- No user-facing strings or shortcuts changed, so no localization/settings
  migration was needed.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace and tab reordering to prevent transient inconsistent states.
  * Preserved the selected workspace and its terminal surface during reorder and pinning operations.
  * Ensured observers receive a single, coherent workspace snapshot when order or pin status changes.

* **Tests**
  * Added coverage for workspace moves, reordering, and pin-state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->