### PR TITLE
Fix held Liquid Glass clipping in iOS shortcut row

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryEdgeFadeScrollView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/AccessoryEdgeFadeScrollView.swift
@@ -18,6 +18,23 @@ import UIKit
 /// gradient's frame tracks `bounds` (whose origin IS the content offset) to
 /// stay glued to the visible viewport rather than scrolling with the content.
 final class AccessoryEdgeFadeScrollView: UIScrollView {
+    /// Extra vertical room for UIKit's Liquid Glass press/lift presentation.
+    ///
+    /// A glass button keeps its hit frame while the system draws the held
+    /// material slightly beyond that frame. The shortcut row is only as tall
+    /// as its buttons, so a row-sized mask clips the top and bottom of that
+    /// transient presentation. The overscan is symmetric to keep the button
+    /// centerline fixed while leaving the horizontal fade boundary unchanged.
+    nonisolated static let heldGlassVerticalOverscan: CGFloat = 8
+
+    /// Returns the mask frame that preserves a held glass button's vertical lift.
+    nonisolated static func maskBounds(
+        for bounds: CGRect,
+        verticalOverscan: CGFloat = heldGlassVerticalOverscan
+    ) -> CGRect {
+        bounds.insetBy(dx: 0, dy: -max(0, verticalOverscan))
+    }
+
     /// Width in points of the leading fade band, and the scroll distance over
     /// which the fade ramps from nothing to full strength. Sized near one
     /// button width (`accessoryButtonMinWidth` is 32) so a key dissolves over
@@ -56,6 +73,10 @@ final class AccessoryEdgeFadeScrollView: UIScrollView {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
+        // The mask below is the horizontal viewport boundary. Allow the
+        // system's held-state glass lift to render into the vertical overscan
+        // instead of applying UIScrollView's default bounds clip first.
+        clipsToBounds = false
         layer.mask = fadeMask
     }
 
@@ -77,7 +98,7 @@ final class AccessoryEdgeFadeScrollView: UIScrollView {
         // so the gradient tracks finger-driven scrolling without trailing.
         CATransaction.begin()
         CATransaction.setDisableActions(true)
-        fadeMask.frame = bounds
+        fadeMask.frame = Self.maskBounds(for: bounds)
         fadeMask.colors = [
             UIColor(white: 0, alpha: edgeAlpha).cgColor,
             UIColor(white: 0, alpha: 1).cgColor,

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/AccessoryEdgeFadeTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/AccessoryEdgeFadeTests.swift
@@ -33,4 +33,16 @@ struct AccessoryEdgeFadeTests {
         #expect(AccessoryEdgeFadeScrollView.fadeBandFraction(viewportWidth: 10, fadeWidth: 24) == 1)
         #expect(AccessoryEdgeFadeScrollView.fadeBandFraction(viewportWidth: 0, fadeWidth: 24) == 0)
     }
+
+    @Test("held glass gets vertical mask overscan")
+    func heldGlassMaskOverscan() {
+        let rowBounds = CGRect(x: 0, y: 0, width: 240, height: 28)
+        let maskBounds = AccessoryEdgeFadeScrollView.maskBounds(for: rowBounds)
+
+        #expect(maskBounds.minX == rowBounds.minX)
+        #expect(maskBounds.maxX == rowBounds.maxX)
+        #expect(maskBounds.minY < rowBounds.minY)
+        #expect(maskBounds.maxY > rowBounds.maxY)
+        #expect(maskBounds.midY == rowBounds.midY)
+    }
 }


### PR DESCRIPTION
## Summary
- keep the shortcut scroll view from clipping UIKit's held Liquid Glass lift
- overscan only the fade mask vertically, preserving the horizontal edge fade
- add a geometry regression test for the overscan contract

The change follows Apple's [Buttons HIG](https://developer.apple.com/design/human-interface-guidelines/buttons) press-state guidance by preserving the system-rendered held state.

## Verification
- `git diff --check`
- cloud macOS tagged build: `lgovr`
- cloud iOS archive/install attempted for simulator and Aziz iPhone
- isolated simulator terminal preview: selected Shift shortcut renders without top/bottom clipping
- local Swift package test could not start because the worktree lacks the generated `GhosttyKit.xcframework` binary target

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791131814&installation_model_id=21920&pr_number=11959&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11959&signature=a2149668b666f040ad665114a574473a17d8a182a191999ab54bf7718c929230"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS shortcut row clipping UIKit's held Liquid Glass presentation by adding vertical overscan to the edge fade mask, preserving the system-rendered pressed state. Added a regression test to lock in the mask's vertical expansion without changing the horizontal fade.

<sup>Written for commit 7fc4a8bf88d6d9d88a5ca0d7bf72974b631d7d41. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved edge fade scrolling visuals on iOS when held glass effects are active.
  - Prevented the glass lift effect from being clipped at the scroll view’s boundaries.

- **Tests**
  - Added coverage confirming that the fade mask expands vertically while preserving its horizontal bounds and center.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->