### PR TITLE
Cloud VPN: make the tunnel usable without a terminal, and fix the MTU that silently stalled it

### DIFF
--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -21,6 +21,23 @@ import Foundation
 ///   response advertises `network_extension_available` so this command steers
 ///   without a new CLI release.
 extension CMUXCLI {
+    /// Absolute paths to the system tools `cmux vpn` shells out to.
+    ///
+    /// Named rather than inlined so a test can assert each one exists on the
+    /// machine. sudo resolves these literally, so a wrong directory is not
+    /// caught until runtime — and `hosts` runs only *after* the tunnel is up,
+    /// where a failure reads as "the VPN is broken" when the tunnel is fine
+    /// and only the `.internal` names are missing.
+    enum VPNTool {
+        /// macOS ships install(1) in /usr/bin; /usr/sbin/install does not exist.
+        static let install = "/usr/bin/install"
+        static let sudo = "/usr/bin/sudo"
+        static let dscacheutil = "/usr/bin/dscacheutil"
+        static let killall = "/usr/bin/killall"
+
+        static let all: [String] = [install, sudo, dscacheutil, killall]
+    }
+
     private static let wgQuickCandidates = [
         "/opt/homebrew/bin/wg-quick",
         "/usr/local/bin/wg-quick",
@@ -96,7 +113,7 @@ extension CMUXCLI {
         }
         if interfaceUp {
             let downStatus = runInteractiveProcess(
-                executablePath: "/usr/bin/sudo",
+                executablePath: VPNTool.sudo,
                 arguments: [wgQuick, "down", configPath]
             )
             guard downStatus == 0 else {
@@ -107,7 +124,7 @@ extension CMUXCLI {
             }
         }
         let status = runInteractiveProcess(
-            executablePath: "/usr/bin/sudo",
+            executablePath: VPNTool.sudo,
             arguments: [wgQuick, "up", configPath]
         )
         guard status == 0 else {
@@ -156,7 +173,7 @@ extension CMUXCLI {
             throw CLIError(message: "wg-quick is not installed. Install with: brew install wireguard-tools")
         }
         let status = runInteractiveProcess(
-            executablePath: "/usr/bin/sudo",
+            executablePath: VPNTool.sudo,
             arguments: [wgQuick, "down", configPath]
         )
         guard status == 0 else {
@@ -232,9 +249,9 @@ extension CMUXCLI {
         // instead of prompting a second time. Cache invalidation does not
         // require privilege and runs as separate argv-based commands below.
         let status = runInteractiveProcess(
-            executablePath: "/usr/bin/sudo",
+            executablePath: VPNTool.sudo,
             arguments: [
-                "/usr/sbin/install",
+                VPNTool.install,
                 "-o", "root",
                 "-g", "wheel",
                 "-m", "644",
@@ -245,8 +262,8 @@ extension CMUXCLI {
         guard status == 0 else {
             throw CLIError(message: "Updating /etc/hosts failed (exit \(status)). Check the output above.")
         }
-        _ = runInteractiveProcess(executablePath: "/usr/bin/dscacheutil", arguments: ["-flushcache"])
-        _ = runInteractiveProcess(executablePath: "/usr/bin/killall", arguments: ["-HUP", "mDNSResponder"])
+        _ = runInteractiveProcess(executablePath: VPNTool.dscacheutil, arguments: ["-flushcache"])
+        _ = runInteractiveProcess(executablePath: VPNTool.killall, arguments: ["-HUP", "mDNSResponder"])
         if jsonOutput {
             print(jsonString(["hosts_changed": true, "machine_count": entries.count]))
         } else if !quiet {
@@ -304,7 +321,7 @@ extension CMUXCLI {
            let configPath = status?["config_path"] as? String,
            let wgQuick = Self.firstExecutable(Self.wgQuickCandidates) {
             _ = runInteractiveProcess(
-                executablePath: "/usr/bin/sudo",
+                executablePath: VPNTool.sudo,
                 arguments: [wgQuick, "down", configPath]
             )
         }

--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -60,9 +60,12 @@ extension CMUXCLI {
         case "install":
             try runVPNInstallAutostart(client: client, jsonOutput: jsonOutput)
         case "uninstall":
-            try runVPNUninstallAutostart(jsonOutput: jsonOutput)
+            try runVPNUninstallAutostart(client: client, jsonOutput: jsonOutput)
         default:
-            throw CLIError(message: "Usage: cmux vpn <up|down|status|revoke|hosts|install|uninstall>")
+            throw CLIError(message: String(
+                localized: "cli.vpn.usage",
+                defaultValue: "Usage: cmux vpn <up|down|status|revoke|hosts|install|uninstall>"
+            ))
         }
     }
 
@@ -403,82 +406,36 @@ extension CMUXCLI {
 
     // MARK: - Automatic bring-up
 
-    /// The same job the app installs from its Machines panel, which is the
-    /// path people actually take; `VMTunnelAutostart` in Sources/Cloud is the
-    /// reference definition. It is duplicated rather than shared because the
-    /// CLI target does not link the app's Cloud sources, so the label, paths
-    /// and script must be kept in step by hand.
-    ///
-    /// launchd job that owns the tunnel once `cmux vpn install` has run.
-    static let autostartLabel = "com.cmuxterm.vpn.autostart"
-    static var autostartPlistPath: String { "/Library/LaunchDaemons/\(autostartLabel).plist" }
-    static var autostartScriptPath: String { "/usr/local/libexec/cmux-vpn-autostart" }
-
-    /// Installs a root launchd job that brings the tunnel up, so the person
-    /// never runs `cmux vpn up` again.
-    ///
-    /// The tunnel needs root to create a utun and install routes, and this
-    /// build has no NetworkExtension entitlement, so something privileged has
-    /// to own it. A LaunchDaemon is that something: authorize once here, and
-    /// launchd brings the tunnel up at boot from then on.
-    ///
-    /// It also watches the config. The app rewrites that file whenever the
-    /// enrollment changes (new keys, a different account), and a tunnel still
-    /// carrying the previous peer looks up while reaching nothing, so a write
-    /// re-applies it rather than waiting for the next reboot.
+    /// Installs the same launchd job the Machines panel installs. The job
+    /// itself is defined once in ``CmuxVPNAutostart``; this only differs in
+    /// how it gets privileges (sudo here, an authorization dialog there).
     private func runVPNInstallAutostart(client: SocketClient, jsonOutput: Bool) throws {
         let response = try client.sendV2(method: "vm.tunnel_config", responseTimeout: 120)
-        guard let configPath = response["config_path"] as? String, !configPath.isEmpty else {
-            throw CLIError(message: "The app did not report a tunnel config path. Sign in, then retry.")
+        guard let configPath = response["config_path"] as? String, !configPath.isEmpty,
+              let interfaceName = response["interface_name"] as? String, !interfaceName.isEmpty else {
+            throw CLIError(message: String(
+                localized: "cli.vpn.install.noConfig",
+                defaultValue: "The app did not report a tunnel config. Sign in, then retry."
+            ))
         }
-        guard let wgQuick = Self.wgQuickCandidates.first(where: {
-            FileManager.default.isExecutableFile(atPath: $0)
-        }) else {
-            throw CLIError(message: "wg-quick is not installed. Install with: brew install wireguard-tools")
+        guard let wgQuick = CmuxVPNAutostart.wgQuickPath() else {
+            throw CLIError(message: String(
+                localized: "cli.vpn.install.wgMissing",
+                defaultValue: "wg-quick is not installed. Install with: brew install wireguard-tools"
+            ))
         }
+        let job = CmuxVPNAutostart(interfaceName: interfaceName)
 
-        // wg-quick needs its own directory on PATH: it shells out to `wg`, and
-        // launchd starts jobs with a minimal environment that does not include
-        // Homebrew.
-        let wgDirectory = (wgQuick as NSString).deletingLastPathComponent
-        let script = """
-        #!/bin/sh
-        # Installed by `cmux vpn install`. Brings up the cmux WireGuard tunnel.
-        set -e
-        PATH="\(wgDirectory):/usr/bin:/bin:/usr/sbin:/sbin"
-        export PATH
-        CONFIG="\(configPath)"
-        [ -f "$CONFIG" ] || exit 0
-        # Re-apply rather than skip: the config may name a peer the live
-        # interface does not have, which reads as up while reaching nothing.
-        wg-quick down "$CONFIG" 2>/dev/null || true
-        exec wg-quick up "$CONFIG"
-        """
-        let plist = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-          <key>Label</key><string>\(Self.autostartLabel)</string>
-          <key>ProgramArguments</key>
-          <array><string>\(Self.autostartScriptPath)</string></array>
-          <key>RunAtLoad</key><true/>
-          <key>WatchPaths</key>
-          <array><string>\(configPath)</string></array>
-          <key>StandardErrorPath</key><string>/var/log/cmux-vpn-autostart.log</string>
-        </dict>
-        </plist>
-        """
-
-        let scriptTemp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString)")
-        let plistTemp = FileManager.default.temporaryDirectory
-            .appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString).plist")
-        try script.write(to: scriptTemp, atomically: true, encoding: .utf8)
-        try plist.write(to: plistTemp, atomically: true, encoding: .utf8)
+        let directory = FileManager.default.temporaryDirectory
+        let scriptURL = directory.appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString)")
+        let plistURL = directory.appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString).plist")
+        try job.scriptBody(wgQuickPath: wgQuick, userConfigPath: configPath)
+            .write(to: scriptURL, atomically: true, encoding: .utf8)
+        try job.plistBody(userConfigPath: configPath)
+            .write(to: plistURL, atomically: true, encoding: .utf8)
         defer {
-            try? FileManager.default.removeItem(at: scriptTemp)
-            try? FileManager.default.removeItem(at: plistTemp)
+            try? FileManager.default.removeItem(at: scriptURL)
+            try? FileManager.default.removeItem(at: plistURL)
         }
 
         if !jsonOutput {
@@ -487,29 +444,22 @@ extension CMUXCLI {
                 defaultValue: "Installing the tunnel autostart job (sudo will prompt for your password)…"
             ))
         }
-        // One sudo invocation for every privileged step, so a single cached
-        // credential covers the whole install.
-        let installScript = """
-        set -e
-        /usr/bin/install -d -o root -g wheel -m 755 "$(dirname '\(Self.autostartScriptPath)')"
-        /usr/bin/install -o root -g wheel -m 755 '\(scriptTemp.path)' '\(Self.autostartScriptPath)'
-        /usr/bin/install -o root -g wheel -m 644 '\(plistTemp.path)' '\(Self.autostartPlistPath)'
-        /bin/launchctl bootout system/\(Self.autostartLabel) 2>/dev/null || true
-        /bin/launchctl bootstrap system '\(Self.autostartPlistPath)'
-        """
         let status = runInteractiveProcess(
             executablePath: VPNTool.sudo,
-            arguments: ["/bin/sh", "-c", installScript]
+            arguments: [
+                "/bin/sh", "-c",
+                job.installShell(scriptSource: scriptURL.path, plistSource: plistURL.path),
+            ]
         )
         guard status == 0 else {
-            throw CLIError(message: "Installing the autostart job failed (exit \(status)). Check the output above.")
+            let format = String(
+                localized: "cli.vpn.install.failed",
+                defaultValue: "Installing the autostart job failed (exit %d). Check the output above."
+            )
+            throw CLIError(message: String(format: format, status))
         }
         if jsonOutput {
-            print(jsonString([
-                "installed": true,
-                "label": Self.autostartLabel,
-                "config_path": configPath,
-            ]))
+            print(jsonString(["installed": true, "label": job.label, "config_path": configPath]))
         } else {
             print(String(
                 localized: "cli.vpn.install.done",
@@ -520,20 +470,30 @@ extension CMUXCLI {
 
     /// Removes the autostart job. The tunnel itself is left as it is; `vpn
     /// down` takes it down.
-    private func runVPNUninstallAutostart(jsonOutput: Bool) throws {
-        let removeScript = """
-        /bin/launchctl bootout system/\(Self.autostartLabel) 2>/dev/null || true
-        /bin/rm -f '\(Self.autostartPlistPath)' '\(Self.autostartScriptPath)'
-        """
+    private func runVPNUninstallAutostart(client: SocketClient, jsonOutput: Bool) throws {
+        // Uninstall targets the same scoped job install created, so it asks
+        // the app which tunnel this is rather than guessing a name.
+        let response = try client.sendV2(method: "vm.tunnel_config", responseTimeout: 120)
+        guard let interfaceName = response["interface_name"] as? String, !interfaceName.isEmpty else {
+            throw CLIError(message: String(
+                localized: "cli.vpn.uninstall.noInterface",
+                defaultValue: "The app did not report which tunnel to remove. Sign in, then retry."
+            ))
+        }
+        let job = CmuxVPNAutostart(interfaceName: interfaceName)
         let status = runInteractiveProcess(
             executablePath: VPNTool.sudo,
-            arguments: ["/bin/sh", "-c", removeScript]
+            arguments: ["/bin/sh", "-c", job.uninstallShell()]
         )
         guard status == 0 else {
-            throw CLIError(message: "Removing the autostart job failed (exit \(status)).")
+            let format = String(
+                localized: "cli.vpn.uninstall.failed",
+                defaultValue: "Removing the autostart job failed (exit %d)."
+            )
+            throw CLIError(message: String(format: format, status))
         }
         if jsonOutput {
-            print(jsonString(["installed": false, "label": Self.autostartLabel]))
+            print(jsonString(["installed": false, "label": job.label]))
         } else {
             print(String(
                 localized: "cli.vpn.uninstall.done",

--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -403,6 +403,12 @@ extension CMUXCLI {
 
     // MARK: - Automatic bring-up
 
+    /// The same job the app installs from its Machines panel, which is the
+    /// path people actually take; `VMTunnelAutostart` in Sources/Cloud is the
+    /// reference definition. It is duplicated rather than shared because the
+    /// CLI target does not link the app's Cloud sources, so the label, paths
+    /// and script must be kept in step by hand.
+    ///
     /// launchd job that owns the tunnel once `cmux vpn install` has run.
     static let autostartLabel = "com.cmuxterm.vpn.autostart"
     static var autostartPlistPath: String { "/Library/LaunchDaemons/\(autostartLabel).plist" }

--- a/CLI/CMUXCLI+VPN.swift
+++ b/CLI/CMUXCLI+VPN.swift
@@ -57,8 +57,12 @@ extension CMUXCLI {
             try runVPNRevoke(client: client, jsonOutput: jsonOutput)
         case "hosts":
             try runVPNHostsSync(client: client, jsonOutput: jsonOutput)
+        case "install":
+            try runVPNInstallAutostart(client: client, jsonOutput: jsonOutput)
+        case "uninstall":
+            try runVPNUninstallAutostart(jsonOutput: jsonOutput)
         default:
-            throw CLIError(message: "Usage: cmux vpn <up|down|status|revoke|hosts>")
+            throw CLIError(message: "Usage: cmux vpn <up|down|status|revoke|hosts|install|uninstall>")
         }
     }
 
@@ -395,5 +399,140 @@ extension CMUXCLI {
         }
         process.waitUntilExit()
         return process.terminationStatus
+    }
+
+    // MARK: - Automatic bring-up
+
+    /// launchd job that owns the tunnel once `cmux vpn install` has run.
+    static let autostartLabel = "com.cmuxterm.vpn.autostart"
+    static var autostartPlistPath: String { "/Library/LaunchDaemons/\(autostartLabel).plist" }
+    static var autostartScriptPath: String { "/usr/local/libexec/cmux-vpn-autostart" }
+
+    /// Installs a root launchd job that brings the tunnel up, so the person
+    /// never runs `cmux vpn up` again.
+    ///
+    /// The tunnel needs root to create a utun and install routes, and this
+    /// build has no NetworkExtension entitlement, so something privileged has
+    /// to own it. A LaunchDaemon is that something: authorize once here, and
+    /// launchd brings the tunnel up at boot from then on.
+    ///
+    /// It also watches the config. The app rewrites that file whenever the
+    /// enrollment changes (new keys, a different account), and a tunnel still
+    /// carrying the previous peer looks up while reaching nothing, so a write
+    /// re-applies it rather than waiting for the next reboot.
+    private func runVPNInstallAutostart(client: SocketClient, jsonOutput: Bool) throws {
+        let response = try client.sendV2(method: "vm.tunnel_config", responseTimeout: 120)
+        guard let configPath = response["config_path"] as? String, !configPath.isEmpty else {
+            throw CLIError(message: "The app did not report a tunnel config path. Sign in, then retry.")
+        }
+        guard let wgQuick = Self.wgQuickCandidates.first(where: {
+            FileManager.default.isExecutableFile(atPath: $0)
+        }) else {
+            throw CLIError(message: "wg-quick is not installed. Install with: brew install wireguard-tools")
+        }
+
+        // wg-quick needs its own directory on PATH: it shells out to `wg`, and
+        // launchd starts jobs with a minimal environment that does not include
+        // Homebrew.
+        let wgDirectory = (wgQuick as NSString).deletingLastPathComponent
+        let script = """
+        #!/bin/sh
+        # Installed by `cmux vpn install`. Brings up the cmux WireGuard tunnel.
+        set -e
+        PATH="\(wgDirectory):/usr/bin:/bin:/usr/sbin:/sbin"
+        export PATH
+        CONFIG="\(configPath)"
+        [ -f "$CONFIG" ] || exit 0
+        # Re-apply rather than skip: the config may name a peer the live
+        # interface does not have, which reads as up while reaching nothing.
+        wg-quick down "$CONFIG" 2>/dev/null || true
+        exec wg-quick up "$CONFIG"
+        """
+        let plist = """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key><string>\(Self.autostartLabel)</string>
+          <key>ProgramArguments</key>
+          <array><string>\(Self.autostartScriptPath)</string></array>
+          <key>RunAtLoad</key><true/>
+          <key>WatchPaths</key>
+          <array><string>\(configPath)</string></array>
+          <key>StandardErrorPath</key><string>/var/log/cmux-vpn-autostart.log</string>
+        </dict>
+        </plist>
+        """
+
+        let scriptTemp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString)")
+        let plistTemp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString).plist")
+        try script.write(to: scriptTemp, atomically: true, encoding: .utf8)
+        try plist.write(to: plistTemp, atomically: true, encoding: .utf8)
+        defer {
+            try? FileManager.default.removeItem(at: scriptTemp)
+            try? FileManager.default.removeItem(at: plistTemp)
+        }
+
+        if !jsonOutput {
+            print(String(
+                localized: "cli.vpn.install.starting",
+                defaultValue: "Installing the tunnel autostart job (sudo will prompt for your password)…"
+            ))
+        }
+        // One sudo invocation for every privileged step, so a single cached
+        // credential covers the whole install.
+        let installScript = """
+        set -e
+        /usr/bin/install -d -o root -g wheel -m 755 "$(dirname '\(Self.autostartScriptPath)')"
+        /usr/bin/install -o root -g wheel -m 755 '\(scriptTemp.path)' '\(Self.autostartScriptPath)'
+        /usr/bin/install -o root -g wheel -m 644 '\(plistTemp.path)' '\(Self.autostartPlistPath)'
+        /bin/launchctl bootout system/\(Self.autostartLabel) 2>/dev/null || true
+        /bin/launchctl bootstrap system '\(Self.autostartPlistPath)'
+        """
+        let status = runInteractiveProcess(
+            executablePath: VPNTool.sudo,
+            arguments: ["/bin/sh", "-c", installScript]
+        )
+        guard status == 0 else {
+            throw CLIError(message: "Installing the autostart job failed (exit \(status)). Check the output above.")
+        }
+        if jsonOutput {
+            print(jsonString([
+                "installed": true,
+                "label": Self.autostartLabel,
+                "config_path": configPath,
+            ]))
+        } else {
+            print(String(
+                localized: "cli.vpn.install.done",
+                defaultValue: "The tunnel now comes up on its own at login and whenever your enrollment changes. `cmux vpn up` is no longer needed."
+            ))
+        }
+    }
+
+    /// Removes the autostart job. The tunnel itself is left as it is; `vpn
+    /// down` takes it down.
+    private func runVPNUninstallAutostart(jsonOutput: Bool) throws {
+        let removeScript = """
+        /bin/launchctl bootout system/\(Self.autostartLabel) 2>/dev/null || true
+        /bin/rm -f '\(Self.autostartPlistPath)' '\(Self.autostartScriptPath)'
+        """
+        let status = runInteractiveProcess(
+            executablePath: VPNTool.sudo,
+            arguments: ["/bin/sh", "-c", removeScript]
+        )
+        guard status == 0 else {
+            throw CLIError(message: "Removing the autostart job failed (exit \(status)).")
+        }
+        if jsonOutput {
+            print(jsonString(["installed": false, "label": Self.autostartLabel]))
+        } else {
+            print(String(
+                localized: "cli.vpn.uninstall.done",
+                defaultValue: "Removed the tunnel autostart job. Bring the tunnel up yourself with `cmux vpn up`."
+            ))
+        }
     }
 }

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/CmuxVPNAutostart.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/CmuxVPNAutostart.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// The launchd job that owns this Mac's WireGuard tunnel to its Cloud VM
+/// network, so nobody has to run `cmux vpn up`.
+///
+/// Creating a utun and installing routes needs root, and the shipping build
+/// has no NetworkExtension entitlement, so something privileged has to own the
+/// tunnel. A LaunchDaemon is that something: authorize once, and launchd
+/// brings the tunnel up at every boot from then on.
+///
+/// This type is the single definition of that job — its identity, its file
+/// layout, and the shell it runs. It lives in CmuxFoundation because the app
+/// installs it from the Machines panel and the CLI installs it from `cmux vpn
+/// install`, and two privileged flows that drift in paths or permissions are
+/// how one of them ends up installing something the other cannot remove.
+///
+/// Everything here is a pure value: the callers own how the shell is run
+/// (the app through an authorization prompt, the CLI through sudo).
+public struct CmuxVPNAutostart: Sendable, Equatable {
+    /// The tunnel this job owns, named the way `VMTunnelManager` names its
+    /// interface (`cmux`, `cmux-staging`, `cmux-local`, …).
+    ///
+    /// Every path and the launchd label carry it. A single fixed identity
+    /// meant installing the staging tunnel silently replaced the production
+    /// job, leaving only whichever was installed last coming up at boot.
+    public let interfaceName: String
+
+    public init(interfaceName: String) {
+        self.interfaceName = interfaceName
+    }
+
+    public var label: String { "com.cmuxterm.vpn.autostart.\(interfaceName)" }
+    public var plistPath: String { "/Library/LaunchDaemons/\(label).plist" }
+    public var scriptPath: String { "\(Self.privilegedDirectory)/cmux-vpn-autostart-\(interfaceName)" }
+
+    /// Root-owned home for both the helper and the config it applies.
+    public static let privilegedDirectory = "/usr/local/libexec/cmux-vpn"
+
+    /// The config the daemon actually applies, owned by root.
+    ///
+    /// wg-quick takes the interface name from the filename, so this keeps the
+    /// same basename as the user's copy.
+    public var privilegedConfigPath: String {
+        "\(Self.privilegedDirectory)/\(interfaceName).conf"
+    }
+
+    /// Config directives that make wg-quick run arbitrary commands as root.
+    /// Stripped on the way into the root-owned copy.
+    public static let executableDirectives = ["preup", "postup", "predown", "postdown"]
+
+    /// Whether the job is installed. This is about the job, not the tunnel.
+    public func isInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: plistPath)
+    }
+
+    /// wg-quick, wherever the package manager put it.
+    public static let wgQuickCandidates = [
+        "/opt/homebrew/bin/wg-quick",
+        "/usr/local/bin/wg-quick",
+        "/opt/local/bin/wg-quick",
+    ]
+
+    public static func wgQuickPath() -> String? {
+        wgQuickCandidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    /// The privileged helper launchd runs.
+    ///
+    /// It does not apply the user's config directly. That file is writable by
+    /// the signed-in user, and wg-quick runs a config's `PostUp`/`PreUp`/
+    /// `PostDown`/`PreDown` as root — so applying it as root would let any
+    /// process running as the user execute code as root just by writing a line
+    /// to it, every time the tunnel came up. Instead the helper copies the
+    /// config into a root-owned file with those directives stripped, and
+    /// applies that. The user can still change their own keys and addresses,
+    /// which are theirs; they cannot hand root a command.
+    ///
+    /// launchd starts jobs with a minimal environment, so wg-quick's own
+    /// directory goes on PATH explicitly — it shells out to `wg`, which
+    /// Homebrew does not put anywhere launchd looks.
+    public func scriptBody(wgQuickPath: String, userConfigPath: String) -> String {
+        let wgDirectory = (wgQuickPath as NSString).deletingLastPathComponent
+        let stripPattern = Self.executableDirectives.joined(separator: "|")
+        return """
+        #!/bin/sh
+        # Installed by cmux. Brings up this Mac's tunnel to its Cloud VM network.
+        set -e
+        PATH="\(wgDirectory):/usr/bin:/bin:/usr/sbin:/sbin"
+        export PATH
+        SRC="\(userConfigPath)"
+        DEST="\(privilegedConfigPath)"
+        [ -f "$SRC" ] || exit 0
+        umask 077
+        TMP="$(mktemp)"
+        trap 'rm -f "$TMP"' EXIT
+        # The source is user-writable; these directives would run as root.
+        grep -v -i -E '^[[:space:]]*(\(stripPattern))[[:space:]]*=' "$SRC" > "$TMP"
+        /usr/bin/install -o root -g wheel -m 600 "$TMP" "$DEST"
+        # Re-apply rather than skip: the config may name a peer the live
+        # interface does not have, which reads as up while reaching nothing.
+        wg-quick down "$DEST" 2>/dev/null || true
+        exec wg-quick up "$DEST"
+        """
+    }
+
+    public func plistBody(userConfigPath: String) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key><string>\(label)</string>
+          <key>ProgramArguments</key>
+          <array><string>\(scriptPath)</string></array>
+          <key>RunAtLoad</key><true/>
+          <key>WatchPaths</key>
+          <array><string>\(userConfigPath)</string></array>
+          <key>StandardErrorPath</key><string>/var/log/\(label).log</string>
+        </dict>
+        </plist>
+        """
+    }
+
+    /// The one privileged shell an install runs. Kept as a single script so a
+    /// single authorization covers every step, and `bootstrap` right after
+    /// `bootout` means installing also brings the tunnel up now rather than at
+    /// the next boot.
+    public func installShell(scriptSource: String, plistSource: String) -> String {
+        """
+        set -e
+        /usr/bin/install -d -o root -g wheel -m 755 '\(Self.privilegedDirectory)'
+        /usr/bin/install -o root -g wheel -m 755 '\(scriptSource)' '\(scriptPath)'
+        /usr/bin/install -o root -g wheel -m 644 '\(plistSource)' '\(plistPath)'
+        /bin/launchctl bootout system/\(label) 2>/dev/null || true
+        /bin/launchctl bootstrap system '\(plistPath)'
+        """
+    }
+
+    public func uninstallShell() -> String {
+        """
+        /bin/launchctl bootout system/\(label) 2>/dev/null || true
+        /bin/rm -f '\(plistPath)' '\(scriptPath)' '\(privilegedConfigPath)'
+        """
+    }
+}

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxFoundation
 import CmuxSettings
 import SwiftUI
 
@@ -947,14 +948,18 @@ struct MachineRowActions {
 private struct MachinesTunnelBanner: View {
     let backgroundColor: NSColor
     @State private var isHovered = false
-    @State private var isWorking = false
+    @State private var installTask: Task<Void, Never>?
     @State private var errorText: String?
     /// Re-read after the install so the banner can retire itself.
     @State private var refreshToken = 0
 
+    private var isWorking: Bool { installTask != nil }
+
     private var tunnelReady: Bool {
         _ = refreshToken
-        return VMTunnelAutostart.isInstalled() && VMTunnelManager().wgQuickInterfaceUp()
+        let manager = VMTunnelManager()
+        return CmuxVPNAutostart(interfaceName: manager.interfaceName).isInstalled()
+            && manager.wgQuickInterfaceUp()
     }
 
     var body: some View {
@@ -998,30 +1003,37 @@ private struct MachinesTunnelBanner: View {
                 defaultValue: "Asks for an administrator once, then keeps the tunnel up automatically — including after a restart."
             ))
             .accessibilityIdentifier("MachinesPanel.tunnelBanner")
+            .onDisappear {
+                installTask?.cancel()
+                installTask = nil
+            }
         }
     }
 
     private func turnOn() {
-        guard !isWorking else { return }
-        isWorking = true
+        guard installTask == nil else { return }
         errorText = nil
-        Task {
-            let manager = VMTunnelManager()
-            let configPath = manager.configURL.path
-            do {
-                // The config is written by enrollment. Without it the job would
-                // install and then no-op, which looks like it worked.
-                guard FileManager.default.fileExists(atPath: configPath) else {
-                    throw VMTunnelAutostart.InstallError.failed(String(
-                        localized: "machines.tunnel.notEnrolled",
-                        defaultValue: "This Mac is not enrolled yet. Open a cloud machine once, then try again."
+        let manager = VMTunnelManager()
+        let interfaceName = manager.interfaceName
+        let configPath = manager.configURL.path
+        // The install blocks on an authorization dialog and a privileged
+        // shell, so it runs off the main actor; only its result comes back.
+        installTask = Task { @MainActor in
+            let result: Result<Bool, Error> = await Task.detached(priority: .userInitiated) {
+                do {
+                    return .success(try VMTunnelAutostart.install(
+                        interfaceName: interfaceName,
+                        userConfigPath: configPath
                     ))
+                } catch {
+                    return .failure(error)
                 }
-                try VMTunnelAutostart.installWithAdminPrompt(configPath: configPath)
-            } catch {
-                errorText = String(describing: error)
+            }.value
+            if case .failure(let error) = result {
+                errorText = (error as? VMTunnelAutostart.InstallError)?.description
+                    ?? VMTunnelAutostart.InstallError.failed.description
             }
-            isWorking = false
+            installTask = nil
             refreshToken += 1
         }
     }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -74,6 +74,7 @@ struct MachinesPanelView: View {
     @ViewBuilder
     private var authenticatedContent: some View {
         controlBar
+        MachinesTunnelBanner(backgroundColor: chromeBackgroundColor)
         if let plan = viewModel.plan, !plan.isPaidPlan, let text = plan.freeAccessBannerText {
             MachinesFreeAccessBanner(
                 text: text,
@@ -929,6 +930,99 @@ struct MachineRowActions {
             alert.beginSheetModal(for: window, completionHandler: respond)
         } else {
             respond(alert.runModal())
+        }
+    }
+}
+
+/// Offers to put this Mac on the Cloud VM private network, and disappears once
+/// it is on.
+///
+/// Cloud machines have no public inbound port, so nothing reaches them until
+/// the tunnel is up — which needs root, which the app cannot take on its own
+/// without a NetworkExtension entitlement. Turning it on installs a launchd
+/// job that owns the tunnel from then on, so this is asked once and never
+/// again, including across reboots. Before this existed the panel simply
+/// showed machines that would not connect, and the fix was a terminal command
+/// nobody could be expected to know.
+private struct MachinesTunnelBanner: View {
+    let backgroundColor: NSColor
+    @State private var isHovered = false
+    @State private var isWorking = false
+    @State private var errorText: String?
+    /// Re-read after the install so the banner can retire itself.
+    @State private var refreshToken = 0
+
+    private var tunnelReady: Bool {
+        _ = refreshToken
+        return VMTunnelAutostart.isInstalled() && VMTunnelManager().wgQuickInterfaceUp()
+    }
+
+    var body: some View {
+        if !tunnelReady {
+            Button {
+                turnOn()
+            } label: {
+                HStack(spacing: 5) {
+                    if isWorking {
+                        ProgressView().controlSize(.mini)
+                    } else {
+                        Image(systemName: "lock.shield")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                    Text(errorText ?? String(
+                        localized: "machines.tunnel.banner",
+                        defaultValue: "Cloud machines need this Mac on their private network."
+                    ))
+                    .cmuxFont(size: 11)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                    Spacer(minLength: 0)
+                    if !isWorking {
+                        Text(String(localized: "machines.tunnel.turnOn", defaultValue: "Turn On"))
+                            .cmuxFont(size: 11)
+                            .underline(isHovered)
+                    }
+                }
+                .foregroundColor(errorText == nil ? .secondary : Color.orange)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 5)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .disabled(isWorking)
+            .onHover { isHovered = $0 }
+            .background(Color(nsColor: backgroundColor))
+            .help(String(
+                localized: "machines.tunnel.help",
+                defaultValue: "Asks for an administrator once, then keeps the tunnel up automatically — including after a restart."
+            ))
+            .accessibilityIdentifier("MachinesPanel.tunnelBanner")
+        }
+    }
+
+    private func turnOn() {
+        guard !isWorking else { return }
+        isWorking = true
+        errorText = nil
+        Task {
+            let manager = VMTunnelManager()
+            let configPath = manager.configURL.path
+            do {
+                // The config is written by enrollment. Without it the job would
+                // install and then no-op, which looks like it worked.
+                guard FileManager.default.fileExists(atPath: configPath) else {
+                    throw VMTunnelAutostart.InstallError.failed(String(
+                        localized: "machines.tunnel.notEnrolled",
+                        defaultValue: "This Mac is not enrolled yet. Open a cloud machine once, then try again."
+                    ))
+                }
+                try VMTunnelAutostart.installWithAdminPrompt(configPath: configPath)
+            } catch {
+                errorText = String(describing: error)
+            }
+            isWorking = false
+            refreshToken += 1
         }
     }
 }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -31,6 +31,7 @@ enum CloudVMPanelAuthState: Equatable {
 /// routes through the shared Cloud VM action path or the Cloud tree service.
 struct MachinesPanelView: View {
     @StateObject private var viewModel = MachinesPanelViewModel()
+    @State private var tunnel = CloudTunnelModel()
     @State private var expansionStore = CloudTreeExpansionStore()
     /// The tree's visual preset; the debug gallery's "Use" buttons write this,
     /// and @AppStorage re-renders the live panel the moment it changes.
@@ -62,12 +63,23 @@ struct MachinesPanelView: View {
                 authenticatedContent
             }
         }
-        .onAppear { syncPolling(for: authState) }
+        .onAppear {
+            syncPolling(for: authState)
+            tunnel.refresh()
+        }
         .onChange(of: authState) { _, state in
             syncPolling(for: state)
+            tunnel.refresh()
+        }
+        // The tunnel can go down outside the app (a reboot, `wg-quick down`,
+        // a revoked enrollment), so the panel re-reads it rather than trusting
+        // the last action it saw.
+        .onReceive(Timer.publish(every: 5, on: .main, in: .common).autoconnect()) { _ in
+            tunnel.refresh()
         }
         .onDisappear {
             viewModel.stopPolling()
+            tunnel.cancel()
         }
         .accessibilityIdentifier("CloudMachinesPanel")
     }
@@ -75,7 +87,7 @@ struct MachinesPanelView: View {
     @ViewBuilder
     private var authenticatedContent: some View {
         controlBar
-        MachinesTunnelSetupCard(backgroundColor: chromeBackgroundColor)
+        MachinesTunnelSetupCard(tunnel: tunnel)
         if let plan = viewModel.plan, !plan.isPaidPlan, let text = plan.freeAccessBannerText {
             MachinesFreeAccessBanner(
                 text: text,
@@ -144,7 +156,7 @@ struct MachinesPanelView: View {
             // and the Files header icon.
             .padding(.leading, 4)
             Spacer(minLength: 4)
-            MachinesTunnelMenu()
+            MachinesTunnelMenu(tunnel: tunnel)
             cloudAgentMenu
             MachinesChromeIconButton(
                 symbolName: "arrow.clockwise",
@@ -936,90 +948,101 @@ struct MachineRowActions {
     }
 }
 
-/// The private-networking setup step, shown until this Mac is on the Cloud VM
-/// network and gone afterwards.
+/// Live state of this Mac's link to the Cloud VM private network, shared by
+/// the setup card and the toolbar menu.
 ///
-/// Cloud machines have no public inbound port, so until the tunnel is up they
-/// are simply unreachable — the panel lists machines that will not open and
-/// says nothing about why. This is deliberately a step rather than a hint: it
-/// is a prerequisite for the feature working at all, and the cost of missing
-/// it is a machine that looks broken.
-///
-/// One button does the whole thing. Enrolling this Mac writes the tunnel
-/// config, and installing the launchd job needs an administrator once; doing
-/// only the second is what left a fresh install telling people to "open a
-/// cloud machine once" when opening one never enrolled anything.
-private struct MachinesTunnelSetupCard: View {
-    let backgroundColor: NSColor
-    @State private var setupTask: Task<Void, Never>?
-    @State private var errorText: String?
-    /// Re-read after setup so the card can retire itself.
-    @State private var refreshToken = 0
+/// Both used to keep their own idea of whether the tunnel was up, so turning
+/// it off from the menu left the card still believing it was on — the panel
+/// went on showing machines it could no longer reach, with nothing offering
+/// to fix it. One owner, read by both.
+@MainActor
+@Observable
+final class CloudTunnelModel {
+    private(set) var isInstalled = false
+    private(set) var isUp = false
+    private(set) var isWorking = false
+    private(set) var errorText: String?
 
-    private var isWorking: Bool { setupTask != nil }
+    private var task: Task<Void, Never>?
 
-    private var tunnelReady: Bool {
-        _ = refreshToken
+    /// Whether cloud machines are reachable right now, which is the only
+    /// thing that blocks the panel. Deliberately not "the job is installed":
+    /// `cmux vpn up` brings the tunnel up without one, and the panel must
+    /// agree with the CLI about whether machines can be opened rather than
+    /// demanding its own setup was the one that did it.
+    var isReady: Bool { isUp }
+
+    /// Whether the tunnel will come back on its own. Absent this, the tunnel
+    /// is up for now but dies at the next reboot — worth saying in the menu,
+    /// not worth blocking the panel over.
+    var isPersistent: Bool { isInstalled }
+
+    var interfaceName: String { VMTunnelManager().interfaceName }
+
+    func refresh() {
         let manager = VMTunnelManager()
-        return CmuxVPNAutostart(interfaceName: manager.interfaceName).isInstalled()
-            && manager.wgQuickInterfaceUp()
+        isInstalled = CmuxVPNAutostart(interfaceName: manager.interfaceName).isInstalled()
+        isUp = manager.wgQuickInterfaceUp()
     }
 
-    var body: some View {
-        if !tunnelReady {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(spacing: 6) {
-                    Image(systemName: "lock.shield")
-                        .font(.system(size: 12, weight: .semibold))
-                        .foregroundStyle(.tint)
-                    Text(String(
-                        localized: "machines.tunnel.setup.title",
-                        defaultValue: "Finish setting up cloud machines"
-                    ))
-                    .cmuxFont(size: 12, weight: .semibold)
-                }
-                Text(errorText ?? String(
-                    localized: "machines.tunnel.setup.body",
-                    defaultValue: "Your cloud machines are private, so this Mac has to join their network before it can open them. This asks for your password once and then keeps working on its own."
-                ))
-                .cmuxFont(size: 11)
-                .foregroundStyle(errorText == nil ? .secondary : Color.orange)
-                .fixedSize(horizontal: false, vertical: true)
-                HStack(spacing: 8) {
-                    Button {
-                        setUp()
-                    } label: {
-                        HStack(spacing: 5) {
-                            if isWorking { ProgressView().controlSize(.mini) }
-                            Text(isWorking
-                                ? String(localized: "machines.tunnel.setup.working", defaultValue: "Setting up…")
-                                : (errorText == nil
-                                    ? String(localized: "machines.tunnel.setup.action", defaultValue: "Connect This Mac")
-                                    : String(localized: "machines.tunnel.setup.retry", defaultValue: "Try Again")))
-                        }
-                    }
-                    .controlSize(.small)
-                    .buttonStyle(.borderedProminent)
-                    .disabled(isWorking)
-                    .accessibilityIdentifier("MachinesPanel.tunnelSetup.action")
-                    Spacer(minLength: 0)
-                }
+    /// Enrolls this Mac if needed, then installs the job. Enrollment is part
+    /// of it: the job applies a config nothing else writes, so installing
+    /// alone left a fresh Mac with a job and no tunnel.
+    func turnOn() {
+        perform { model in
+            let manager = VMTunnelManager()
+            guard let client = VMClient.shared else {
+                throw VMTunnelAutostart.InstallError.notSignedIn
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(Color(nsColor: backgroundColor))
-            .accessibilityIdentifier("MachinesPanel.tunnelSetup")
-            .onDisappear {
-                setupTask?.cancel()
-                setupTask = nil
+            let state = try await manager.enroll(client: client)
+            try await model.installOffActor(
+                interfaceName: state.interfaceName,
+                configPath: state.configPath
+            )
+            // launchctl returns once the job is loaded, not once the tunnel is
+            // up, so a check here would race wg-quick and report failure on a
+            // setup that had just worked.
+            guard await model.waitForTunnel() else {
+                throw VMTunnelAutostart.InstallError.didNotComeUp
             }
         }
     }
 
-    /// Polls until the tunnel is actually up, or gives up. Cheap enough to
-    /// poll: it reads the config and the interface list.
-    private func waitForTunnel(manager: VMTunnelManager) async -> Bool {
+    /// Re-applies the current enrollment. The job's script takes the tunnel
+    /// down and back up, so this also repairs one left on a stale peer.
+    func reconnect() {
+        perform { model in
+            let manager = VMTunnelManager()
+            try await model.installOffActor(
+                interfaceName: manager.interfaceName,
+                configPath: manager.configURL.path
+            )
+            guard await model.waitForTunnel() else {
+                throw VMTunnelAutostart.InstallError.didNotComeUp
+            }
+        }
+    }
+
+    func turnOff() {
+        perform { model in
+            let name = model.interfaceName
+            _ = try await Task.detached(priority: .userInitiated) {
+                try VMTunnelAutostart.uninstall(interfaceName: name)
+            }.value
+        }
+    }
+
+    private func installOffActor(interfaceName: String, configPath: String) async throws {
+        _ = try await Task.detached(priority: .userInitiated) {
+            try VMTunnelAutostart.install(
+                interfaceName: interfaceName,
+                userConfigPath: configPath
+            )
+        }.value
+    }
+
+    private func waitForTunnel() async -> Bool {
+        let manager = VMTunnelManager()
         for _ in 0..<40 {
             if manager.wgQuickInterfaceUp() { return true }
             do {
@@ -1031,102 +1054,157 @@ private struct MachinesTunnelSetupCard: View {
         return manager.wgQuickInterfaceUp()
     }
 
-    private func setUp() {
-        guard setupTask == nil else { return }
+    /// Every action prompts for an administrator and blocks on a privileged
+    /// shell, so they share one runner that keeps that off the main actor and
+    /// re-reads the real state afterwards rather than assuming it worked.
+    private func perform(_ work: @escaping (CloudTunnelModel) async throws -> Void) {
+        guard task == nil else { return }
         errorText = nil
-        setupTask = Task { @MainActor in
+        isWorking = true
+        task = Task { @MainActor [weak self] in
+            guard let self else { return }
             defer {
-                setupTask = nil
-                refreshToken += 1
+                self.isWorking = false
+                self.task = nil
+                self.refresh()
             }
-            let manager = VMTunnelManager()
             do {
-                // Enroll first: the launchd job applies a config that does not
-                // exist until this runs, and nothing else in the app writes it.
-                guard let client = VMClient.shared else {
-                    throw VMTunnelAutostart.InstallError.notSignedIn
-                }
-                let state = try await manager.enroll(client: client)
-                // The install blocks on an authorization dialog and a
-                // privileged shell, so it leaves the main actor.
-                let interfaceName = state.interfaceName
-                let configPath = state.configPath
-                let result: Result<Bool, Error> = await Task.detached(priority: .userInitiated) {
-                    do {
-                        return .success(try VMTunnelAutostart.install(
-                            interfaceName: interfaceName,
-                            userConfigPath: configPath
-                        ))
-                    } catch {
-                        return .failure(error)
-                    }
-                }.value
-                if case .failure(let error) = result { throw error }
-                // launchctl returns once the job is loaded, not once the
-                // tunnel is up: wg-quick runs a moment later. Re-checking
-                // immediately found the tunnel still down, so the card stayed
-                // put and a setup that had in fact just succeeded looked like
-                // a button that did nothing.
-                guard await waitForTunnel(manager: manager) else {
-                    throw VMTunnelAutostart.InstallError.didNotComeUp
-                }
+                try await work(self)
             } catch is CancellationError {
                 return
             } catch {
-                cmuxDebugLog("vpn.autostart.setup_failed error=\(String(reflecting: error))")
-                errorText = (error as? VMTunnelAutostart.InstallError)?.description
+                cmuxDebugLog("vpn.autostart.action_failed error=\(String(reflecting: error))")
+                self.errorText = (error as? VMTunnelAutostart.InstallError)?.description
                     ?? VMTunnelAutostart.InstallError.failed.description
             }
         }
     }
+
+    func cancel() {
+        task?.cancel()
+        task = nil
+    }
 }
 
-/// The private network's controls: what it is doing, and how to stop it.
+/// The blocking notice shown whenever this Mac cannot reach its cloud
+/// machines.
 ///
-/// Setup is offered once by ``MachinesTunnelSetupCard`` and then goes away, so
-/// without this there was no way to see whether the tunnel was on, reconnect a
-/// broken one, or turn the whole thing off again short of a terminal. Turning
-/// it off is a real need: the tunnel routes a private range on someone's Mac
-/// and installs a launchd job, and anyone can reasonably want that gone.
+/// Cloud machines have no public inbound port, so without the tunnel every
+/// machine in the list below is unreachable — the panel otherwise looks
+/// normal and simply fails to open anything. This is styled as a warning
+/// rather than a hint because it is not advice; nothing works until it is
+/// dealt with.
+private struct MachinesTunnelSetupCard: View {
+    @Bindable var tunnel: CloudTunnelModel
+
+    var body: some View {
+        if !tunnel.isReady {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Image(systemName: "exclamationmark.shield.fill")
+                        .font(.system(size: 13, weight: .semibold))
+                    Text(tunnel.isInstalled
+                        ? String(
+                            localized: "machines.tunnel.setup.title.off",
+                            defaultValue: "Private network is off"
+                        )
+                        : String(
+                            localized: "machines.tunnel.setup.title",
+                            defaultValue: "Turn on the private network"
+                        ))
+                    .cmuxFont(size: 13, weight: .semibold)
+                }
+                .foregroundStyle(Color.orange)
+                Text(tunnel.errorText ?? String(
+                    localized: "machines.tunnel.setup.body",
+                    defaultValue: "Your cloud machines are private, so cmux cannot open any of them until this Mac joins their network. This asks for your password once and then keeps working on its own."
+                ))
+                .cmuxFont(size: 11)
+                .foregroundStyle(tunnel.errorText == nil ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color.orange))
+                .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 8) {
+                    Button {
+                        tunnel.turnOn()
+                    } label: {
+                        HStack(spacing: 5) {
+                            if tunnel.isWorking { ProgressView().controlSize(.mini) }
+                            Text(buttonTitle)
+                        }
+                    }
+                    .controlSize(.regular)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(tunnel.isWorking)
+                    .accessibilityIdentifier("MachinesPanel.tunnelSetup.action")
+                    Spacer(minLength: 0)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 11)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(Color.orange.opacity(0.12))
+            .overlay(alignment: .bottom) {
+                Rectangle().fill(Color.orange.opacity(0.35)).frame(height: 1)
+            }
+            .accessibilityIdentifier("MachinesPanel.tunnelSetup")
+        }
+    }
+
+    private var buttonTitle: String {
+        if tunnel.isWorking {
+            return String(localized: "machines.tunnel.setup.working", defaultValue: "Connecting…")
+        }
+        if tunnel.errorText != nil {
+            return String(localized: "machines.tunnel.setup.retry", defaultValue: "Try Again")
+        }
+        return String(localized: "machines.tunnel.setup.action", defaultValue: "Turn On Private Network")
+    }
+}
+
+/// The private network's controls: what it is doing, and how to change it.
 private struct MachinesTunnelMenu: View {
-    @State private var workingTask: Task<Void, Never>?
-    @State private var refreshToken = 0
-
-    private var manager: VMTunnelManager { VMTunnelManager() }
-
-    private var isInstalled: Bool {
-        _ = refreshToken
-        return CmuxVPNAutostart(interfaceName: manager.interfaceName).isInstalled()
-    }
-
-    private var isUp: Bool {
-        _ = refreshToken
-        return manager.wgQuickInterfaceUp()
-    }
+    @Bindable var tunnel: CloudTunnelModel
 
     var body: some View {
         Menu {
             Section(statusText) {
-                Button(String(localized: "machines.tunnel.menu.reconnect", defaultValue: "Reconnect")) {
-                    reconnect()
+                // Turning it off must not be a one-way door: this used to
+                // disable every item once the job was gone, leaving the menu
+                // with nothing but a status line.
+                if !tunnel.isPersistent {
+                    Button(tunnel.isUp
+                        ? String(
+                            localized: "machines.tunnel.menu.keepOn",
+                            defaultValue: "Keep Private Network On…"
+                        )
+                        : String(
+                            localized: "machines.tunnel.menu.turnOn",
+                            defaultValue: "Turn On Private Network…"
+                        )) {
+                        tunnel.turnOn()
+                    }
+                    .disabled(tunnel.isWorking)
+                } else {
+                    Button(String(localized: "machines.tunnel.menu.reconnect", defaultValue: "Reconnect")) {
+                        tunnel.reconnect()
+                    }
+                    .disabled(tunnel.isWorking)
+                    Button(String(localized: "machines.tunnel.menu.turnOff", defaultValue: "Turn Off Private Network…")) {
+                        tunnel.turnOff()
+                    }
+                    .disabled(tunnel.isWorking)
                 }
-                .disabled(workingTask != nil || !isInstalled)
-                Button(String(localized: "machines.tunnel.menu.turnOff", defaultValue: "Turn Off Private Network…")) {
-                    turnOff()
-                }
-                .disabled(workingTask != nil || !isInstalled)
             }
             Divider()
-            // The interface name distinguishes production from staging and dev
-            // tunnels, which matters the moment someone has more than one.
+            // Distinguishes the production tunnel from staging and dev, which
+            // matters the moment someone has more than one.
             Text(String(
                 format: String(localized: "machines.tunnel.menu.interface", defaultValue: "Interface: %@"),
-                manager.interfaceName
+                tunnel.interfaceName
             ))
         } label: {
-            Image(systemName: isUp ? "lock.shield.fill" : "lock.shield")
+            Image(systemName: tunnel.isReady ? "lock.shield.fill" : "exclamationmark.shield")
                 .font(.system(size: 11, weight: .medium))
-                .foregroundStyle(isUp ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
+                .foregroundStyle(tunnel.isReady ? AnyShapeStyle(.tint) : AnyShapeStyle(Color.orange))
                 .frame(width: 22, height: 20)
                 .contentShape(Rectangle())
         }
@@ -1135,51 +1213,24 @@ private struct MachinesTunnelMenu: View {
         .fixedSize()
         .help(statusText)
         .accessibilityIdentifier("MachinesPanel.tunnelMenu")
-        .onAppear { refreshToken += 1 }
-        .onDisappear {
-            workingTask?.cancel()
-            workingTask = nil
-        }
     }
 
+    /// Four states, because the tunnel and the launchd job move
+    /// independently: `cmux vpn up` connects without installing a job, and
+    /// `cmux vpn down` disconnects while leaving one.
     private var statusText: String {
-        if !isInstalled {
+        switch (tunnel.isUp, tunnel.isPersistent) {
+        case (true, true):
+            return String(localized: "machines.tunnel.menu.connected", defaultValue: "Private network: connected")
+        case (true, false):
+            return String(
+                localized: "machines.tunnel.menu.connectedNotPersistent",
+                defaultValue: "Private network: connected (until restart)"
+            )
+        case (false, true):
+            return String(localized: "machines.tunnel.menu.off", defaultValue: "Private network: not connected")
+        case (false, false):
             return String(localized: "machines.tunnel.menu.notSetUp", defaultValue: "Private network: not set up")
-        }
-        return isUp
-            ? String(localized: "machines.tunnel.menu.connected", defaultValue: "Private network: connected")
-            : String(localized: "machines.tunnel.menu.off", defaultValue: "Private network: not connected")
-    }
-
-    /// Re-applies the current enrollment. The job's own script takes the
-    /// tunnel down and back up, so this is also the repair for a tunnel left
-    /// carrying a stale peer.
-    private func reconnect() {
-        run { try VMTunnelAutostart.install(
-            interfaceName: manager.interfaceName,
-            userConfigPath: manager.configURL.path
-        ) }
-    }
-
-    private func turnOff() {
-        run { try VMTunnelAutostart.uninstall(interfaceName: manager.interfaceName) }
-    }
-
-    /// Both actions prompt for an administrator and block on a privileged
-    /// shell, so they leave the main actor.
-    private func run(_ work: @escaping @Sendable () throws -> Bool) {
-        guard workingTask == nil else { return }
-        workingTask = Task { @MainActor in
-            defer {
-                workingTask = nil
-                refreshToken += 1
-            }
-            let result: Result<Bool, Error> = await Task.detached(priority: .userInitiated) {
-                do { return .success(try work()) } catch { return .failure(error) }
-            }.value
-            if case .failure(let error) = result {
-                cmuxDebugLog("vpn.autostart.menu_failed error=\(String(reflecting: error))")
-            }
         }
     }
 }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -1016,6 +1016,20 @@ private struct MachinesTunnelSetupCard: View {
         }
     }
 
+    /// Polls until the tunnel is actually up, or gives up. Cheap enough to
+    /// poll: it reads the config and the interface list.
+    private func waitForTunnel(manager: VMTunnelManager) async -> Bool {
+        for _ in 0..<40 {
+            if manager.wgQuickInterfaceUp() { return true }
+            do {
+                try await Task.sleep(for: .milliseconds(250))
+            } catch {
+                return manager.wgQuickInterfaceUp()
+            }
+        }
+        return manager.wgQuickInterfaceUp()
+    }
+
     private func setUp() {
         guard setupTask == nil else { return }
         errorText = nil
@@ -1047,6 +1061,14 @@ private struct MachinesTunnelSetupCard: View {
                     }
                 }.value
                 if case .failure(let error) = result { throw error }
+                // launchctl returns once the job is loaded, not once the
+                // tunnel is up: wg-quick runs a moment later. Re-checking
+                // immediately found the tunnel still down, so the card stayed
+                // put and a setup that had in fact just succeeded looked like
+                // a button that did nothing.
+                guard await waitForTunnel(manager: manager) else {
+                    throw VMTunnelAutostart.InstallError.didNotComeUp
+                }
             } catch is CancellationError {
                 return
             } catch {

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -144,6 +144,7 @@ struct MachinesPanelView: View {
             // and the Files header icon.
             .padding(.leading, 4)
             Spacer(minLength: 4)
+            MachinesTunnelMenu()
             cloudAgentMenu
             MachinesChromeIconButton(
                 symbolName: "arrow.clockwise",
@@ -1075,6 +1076,109 @@ private struct MachinesTunnelSetupCard: View {
                 cmuxDebugLog("vpn.autostart.setup_failed error=\(String(reflecting: error))")
                 errorText = (error as? VMTunnelAutostart.InstallError)?.description
                     ?? VMTunnelAutostart.InstallError.failed.description
+            }
+        }
+    }
+}
+
+/// The private network's controls: what it is doing, and how to stop it.
+///
+/// Setup is offered once by ``MachinesTunnelSetupCard`` and then goes away, so
+/// without this there was no way to see whether the tunnel was on, reconnect a
+/// broken one, or turn the whole thing off again short of a terminal. Turning
+/// it off is a real need: the tunnel routes a private range on someone's Mac
+/// and installs a launchd job, and anyone can reasonably want that gone.
+private struct MachinesTunnelMenu: View {
+    @State private var workingTask: Task<Void, Never>?
+    @State private var refreshToken = 0
+
+    private var manager: VMTunnelManager { VMTunnelManager() }
+
+    private var isInstalled: Bool {
+        _ = refreshToken
+        return CmuxVPNAutostart(interfaceName: manager.interfaceName).isInstalled()
+    }
+
+    private var isUp: Bool {
+        _ = refreshToken
+        return manager.wgQuickInterfaceUp()
+    }
+
+    var body: some View {
+        Menu {
+            Section(statusText) {
+                Button(String(localized: "machines.tunnel.menu.reconnect", defaultValue: "Reconnect")) {
+                    reconnect()
+                }
+                .disabled(workingTask != nil || !isInstalled)
+                Button(String(localized: "machines.tunnel.menu.turnOff", defaultValue: "Turn Off Private Network…")) {
+                    turnOff()
+                }
+                .disabled(workingTask != nil || !isInstalled)
+            }
+            Divider()
+            // The interface name distinguishes production from staging and dev
+            // tunnels, which matters the moment someone has more than one.
+            Text(String(
+                format: String(localized: "machines.tunnel.menu.interface", defaultValue: "Interface: %@"),
+                manager.interfaceName
+            ))
+        } label: {
+            Image(systemName: isUp ? "lock.shield.fill" : "lock.shield")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(isUp ? AnyShapeStyle(.tint) : AnyShapeStyle(.secondary))
+                .frame(width: 22, height: 20)
+                .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(statusText)
+        .accessibilityIdentifier("MachinesPanel.tunnelMenu")
+        .onAppear { refreshToken += 1 }
+        .onDisappear {
+            workingTask?.cancel()
+            workingTask = nil
+        }
+    }
+
+    private var statusText: String {
+        if !isInstalled {
+            return String(localized: "machines.tunnel.menu.notSetUp", defaultValue: "Private network: not set up")
+        }
+        return isUp
+            ? String(localized: "machines.tunnel.menu.connected", defaultValue: "Private network: connected")
+            : String(localized: "machines.tunnel.menu.off", defaultValue: "Private network: not connected")
+    }
+
+    /// Re-applies the current enrollment. The job's own script takes the
+    /// tunnel down and back up, so this is also the repair for a tunnel left
+    /// carrying a stale peer.
+    private func reconnect() {
+        run { try VMTunnelAutostart.install(
+            interfaceName: manager.interfaceName,
+            userConfigPath: manager.configURL.path
+        ) }
+    }
+
+    private func turnOff() {
+        run { try VMTunnelAutostart.uninstall(interfaceName: manager.interfaceName) }
+    }
+
+    /// Both actions prompt for an administrator and block on a privileged
+    /// shell, so they leave the main actor.
+    private func run(_ work: @escaping @Sendable () throws -> Bool) {
+        guard workingTask == nil else { return }
+        workingTask = Task { @MainActor in
+            defer {
+                workingTask = nil
+                refreshToken += 1
+            }
+            let result: Result<Bool, Error> = await Task.detached(priority: .userInitiated) {
+                do { return .success(try work()) } catch { return .failure(error) }
+            }.value
+            if case .failure(let error) = result {
+                cmuxDebugLog("vpn.autostart.menu_failed error=\(String(reflecting: error))")
             }
         }
     }

--- a/Sources/Cloud/MachinesPanelView.swift
+++ b/Sources/Cloud/MachinesPanelView.swift
@@ -75,7 +75,7 @@ struct MachinesPanelView: View {
     @ViewBuilder
     private var authenticatedContent: some View {
         controlBar
-        MachinesTunnelBanner(backgroundColor: chromeBackgroundColor)
+        MachinesTunnelSetupCard(backgroundColor: chromeBackgroundColor)
         if let plan = viewModel.plan, !plan.isPaidPlan, let text = plan.freeAccessBannerText {
             MachinesFreeAccessBanner(
                 text: text,
@@ -935,25 +935,27 @@ struct MachineRowActions {
     }
 }
 
-/// Offers to put this Mac on the Cloud VM private network, and disappears once
-/// it is on.
+/// The private-networking setup step, shown until this Mac is on the Cloud VM
+/// network and gone afterwards.
 ///
-/// Cloud machines have no public inbound port, so nothing reaches them until
-/// the tunnel is up — which needs root, which the app cannot take on its own
-/// without a NetworkExtension entitlement. Turning it on installs a launchd
-/// job that owns the tunnel from then on, so this is asked once and never
-/// again, including across reboots. Before this existed the panel simply
-/// showed machines that would not connect, and the fix was a terminal command
-/// nobody could be expected to know.
-private struct MachinesTunnelBanner: View {
+/// Cloud machines have no public inbound port, so until the tunnel is up they
+/// are simply unreachable — the panel lists machines that will not open and
+/// says nothing about why. This is deliberately a step rather than a hint: it
+/// is a prerequisite for the feature working at all, and the cost of missing
+/// it is a machine that looks broken.
+///
+/// One button does the whole thing. Enrolling this Mac writes the tunnel
+/// config, and installing the launchd job needs an administrator once; doing
+/// only the second is what left a fresh install telling people to "open a
+/// cloud machine once" when opening one never enrolled anything.
+private struct MachinesTunnelSetupCard: View {
     let backgroundColor: NSColor
-    @State private var isHovered = false
-    @State private var installTask: Task<Void, Never>?
+    @State private var setupTask: Task<Void, Never>?
     @State private var errorText: String?
-    /// Re-read after the install so the banner can retire itself.
+    /// Re-read after setup so the card can retire itself.
     @State private var refreshToken = 0
 
-    private var isWorking: Bool { installTask != nil }
+    private var isWorking: Bool { setupTask != nil }
 
     private var tunnelReady: Bool {
         _ = refreshToken
@@ -964,77 +966,94 @@ private struct MachinesTunnelBanner: View {
 
     var body: some View {
         if !tunnelReady {
-            Button {
-                turnOn()
-            } label: {
-                HStack(spacing: 5) {
-                    if isWorking {
-                        ProgressView().controlSize(.mini)
-                    } else {
-                        Image(systemName: "lock.shield")
-                            .font(.system(size: 10, weight: .semibold))
-                    }
-                    Text(errorText ?? String(
-                        localized: "machines.tunnel.banner",
-                        defaultValue: "Cloud machines need this Mac on their private network."
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(spacing: 6) {
+                    Image(systemName: "lock.shield")
+                        .font(.system(size: 12, weight: .semibold))
+                        .foregroundStyle(.tint)
+                    Text(String(
+                        localized: "machines.tunnel.setup.title",
+                        defaultValue: "Finish setting up cloud machines"
                     ))
-                    .cmuxFont(size: 11)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    Spacer(minLength: 0)
-                    if !isWorking {
-                        Text(String(localized: "machines.tunnel.turnOn", defaultValue: "Turn On"))
-                            .cmuxFont(size: 11)
-                            .underline(isHovered)
-                    }
+                    .cmuxFont(size: 12, weight: .semibold)
                 }
-                .foregroundColor(errorText == nil ? .secondary : Color.orange)
-                .padding(.horizontal, 12)
-                .padding(.vertical, 5)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .contentShape(Rectangle())
+                Text(errorText ?? String(
+                    localized: "machines.tunnel.setup.body",
+                    defaultValue: "Your cloud machines are private, so this Mac has to join their network before it can open them. This asks for your password once and then keeps working on its own."
+                ))
+                .cmuxFont(size: 11)
+                .foregroundStyle(errorText == nil ? .secondary : Color.orange)
+                .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 8) {
+                    Button {
+                        setUp()
+                    } label: {
+                        HStack(spacing: 5) {
+                            if isWorking { ProgressView().controlSize(.mini) }
+                            Text(isWorking
+                                ? String(localized: "machines.tunnel.setup.working", defaultValue: "Setting up…")
+                                : (errorText == nil
+                                    ? String(localized: "machines.tunnel.setup.action", defaultValue: "Connect This Mac")
+                                    : String(localized: "machines.tunnel.setup.retry", defaultValue: "Try Again")))
+                        }
+                    }
+                    .controlSize(.small)
+                    .buttonStyle(.borderedProminent)
+                    .disabled(isWorking)
+                    .accessibilityIdentifier("MachinesPanel.tunnelSetup.action")
+                    Spacer(minLength: 0)
+                }
             }
-            .buttonStyle(.plain)
-            .disabled(isWorking)
-            .onHover { isHovered = $0 }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
             .background(Color(nsColor: backgroundColor))
-            .help(String(
-                localized: "machines.tunnel.help",
-                defaultValue: "Asks for an administrator once, then keeps the tunnel up automatically — including after a restart."
-            ))
-            .accessibilityIdentifier("MachinesPanel.tunnelBanner")
+            .accessibilityIdentifier("MachinesPanel.tunnelSetup")
             .onDisappear {
-                installTask?.cancel()
-                installTask = nil
+                setupTask?.cancel()
+                setupTask = nil
             }
         }
     }
 
-    private func turnOn() {
-        guard installTask == nil else { return }
+    private func setUp() {
+        guard setupTask == nil else { return }
         errorText = nil
-        let manager = VMTunnelManager()
-        let interfaceName = manager.interfaceName
-        let configPath = manager.configURL.path
-        // The install blocks on an authorization dialog and a privileged
-        // shell, so it runs off the main actor; only its result comes back.
-        installTask = Task { @MainActor in
-            let result: Result<Bool, Error> = await Task.detached(priority: .userInitiated) {
-                do {
-                    return .success(try VMTunnelAutostart.install(
-                        interfaceName: interfaceName,
-                        userConfigPath: configPath
-                    ))
-                } catch {
-                    return .failure(error)
+        setupTask = Task { @MainActor in
+            defer {
+                setupTask = nil
+                refreshToken += 1
+            }
+            let manager = VMTunnelManager()
+            do {
+                // Enroll first: the launchd job applies a config that does not
+                // exist until this runs, and nothing else in the app writes it.
+                guard let client = VMClient.shared else {
+                    throw VMTunnelAutostart.InstallError.notSignedIn
                 }
-            }.value
-            if case .failure(let error) = result {
+                let state = try await manager.enroll(client: client)
+                // The install blocks on an authorization dialog and a
+                // privileged shell, so it leaves the main actor.
+                let interfaceName = state.interfaceName
+                let configPath = state.configPath
+                let result: Result<Bool, Error> = await Task.detached(priority: .userInitiated) {
+                    do {
+                        return .success(try VMTunnelAutostart.install(
+                            interfaceName: interfaceName,
+                            userConfigPath: configPath
+                        ))
+                    } catch {
+                        return .failure(error)
+                    }
+                }.value
+                if case .failure(let error) = result { throw error }
+            } catch is CancellationError {
+                return
+            } catch {
+                cmuxDebugLog("vpn.autostart.setup_failed error=\(String(reflecting: error))")
                 errorText = (error as? VMTunnelAutostart.InstallError)?.description
                     ?? VMTunnelAutostart.InstallError.failed.description
             }
-            installTask = nil
-            refreshToken += 1
         }
     }
 }

--- a/Sources/Cloud/VMTunnelAutostart.swift
+++ b/Sources/Cloud/VMTunnelAutostart.swift
@@ -11,6 +11,7 @@ enum VMTunnelAutostart {
         case wireGuardMissing
         case notEnrolled
         case notSignedIn
+        case didNotComeUp
         /// Anything else. Carries no command output: the underlying tools
         /// report paths and system detail that mean nothing to the person
         /// reading a banner, so the detail is logged and this stays product
@@ -28,6 +29,11 @@ enum VMTunnelAutostart {
                 return String(
                     localized: "cloud.tunnel.autostart.notSignedIn",
                     defaultValue: "Sign in to cmux Cloud first, then connect this Mac."
+                )
+            case .didNotComeUp:
+                return String(
+                    localized: "cloud.tunnel.autostart.didNotComeUp",
+                    defaultValue: "The private network was set up but did not connect. Try again, or restart this Mac."
                 )
             case .notEnrolled:
                 return String(

--- a/Sources/Cloud/VMTunnelAutostart.swift
+++ b/Sources/Cloud/VMTunnelAutostart.swift
@@ -1,0 +1,204 @@
+import Foundation
+
+/// The launchd job that owns this Mac's WireGuard tunnel, so nobody has to run
+/// `cmux vpn up`.
+///
+/// Creating a utun and installing routes needs root. The shipping build has no
+/// NetworkExtension entitlement, so the app cannot hold the tunnel itself and
+/// something privileged has to. That something is a LaunchDaemon: the person
+/// authorizes once, and launchd brings the tunnel up at every boot from then
+/// on — no terminal, and no second prompt.
+///
+/// The job also watches the config file. The app rewrites it whenever the
+/// enrollment changes (new keys, a different account), and a tunnel still
+/// carrying the previous peer reads as up while reaching nothing, so a write
+/// re-applies the tunnel instead of leaving it wrong until the next reboot.
+///
+/// Install runs through `osascript`'s admin prompt rather than `sudo`, because
+/// the app has no terminal to read a password from; the CLI's `cmux vpn
+/// install` builds the same script and plist through `sudo` instead.
+enum VMTunnelAutostart {
+    static let label = "com.cmuxterm.vpn.autostart"
+    static var plistPath: String { "/Library/LaunchDaemons/\(label).plist" }
+    static var scriptPath: String { "/usr/local/libexec/cmux-vpn-autostart" }
+
+    /// wg-quick, wherever the package manager put it.
+    static let wgQuickCandidates = [
+        "/opt/homebrew/bin/wg-quick",
+        "/usr/local/bin/wg-quick",
+        "/opt/local/bin/wg-quick",
+    ]
+
+    static func wgQuickPath() -> String? {
+        wgQuickCandidates.first { FileManager.default.isExecutableFile(atPath: $0) }
+    }
+
+    /// Whether the job is installed. This is about the job, not the tunnel:
+    /// `VMTunnelManager.wgQuickInterfaceUp()` answers whether it is up now.
+    static func isInstalled() -> Bool {
+        FileManager.default.fileExists(atPath: plistPath)
+    }
+
+    /// The privileged helper. launchd starts jobs with a minimal environment,
+    /// so wg-quick's own directory goes on PATH explicitly — it shells out to
+    /// `wg`, which Homebrew does not put anywhere launchd looks.
+    static func scriptBody(wgQuickPath: String, configPath: String) -> String {
+        let wgDirectory = (wgQuickPath as NSString).deletingLastPathComponent
+        return """
+        #!/bin/sh
+        # Installed by cmux. Brings up this Mac's tunnel to its Cloud VM network.
+        set -e
+        PATH="\(wgDirectory):/usr/bin:/bin:/usr/sbin:/sbin"
+        export PATH
+        CONFIG="\(configPath)"
+        [ -f "$CONFIG" ] || exit 0
+        # Re-apply rather than skip: the config may name a peer the live
+        # interface does not have, which reads as up while reaching nothing.
+        wg-quick down "$CONFIG" 2>/dev/null || true
+        exec wg-quick up "$CONFIG"
+        """
+    }
+
+    static func plistBody(configPath: String) -> String {
+        """
+        <?xml version="1.0" encoding="UTF-8"?>
+        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+        <plist version="1.0">
+        <dict>
+          <key>Label</key><string>\(label)</string>
+          <key>ProgramArguments</key>
+          <array><string>\(scriptPath)</string></array>
+          <key>RunAtLoad</key><true/>
+          <key>WatchPaths</key>
+          <array><string>\(configPath)</string></array>
+          <key>StandardErrorPath</key><string>/var/log/cmux-vpn-autostart.log</string>
+        </dict>
+        </plist>
+        """
+    }
+
+    /// The one privileged shell the install runs. Kept as a single script so a
+    /// single authorization covers every step, and `bootstrap` immediately
+    /// after `bootout` means installing also brings the tunnel up now rather
+    /// than at the next boot.
+    static func installShell(scriptSource: String, plistSource: String) -> String {
+        """
+        set -e
+        /usr/bin/install -d -o root -g wheel -m 755 '\((scriptPath as NSString).deletingLastPathComponent)'
+        /usr/bin/install -o root -g wheel -m 755 '\(scriptSource)' '\(scriptPath)'
+        /usr/bin/install -o root -g wheel -m 644 '\(plistSource)' '\(plistPath)'
+        /bin/launchctl bootout system/\(label) 2>/dev/null || true
+        /bin/launchctl bootstrap system '\(plistPath)'
+        """
+    }
+
+    static func uninstallShell() -> String {
+        """
+        /bin/launchctl bootout system/\(label) 2>/dev/null || true
+        /bin/rm -f '\(plistPath)' '\(scriptPath)'
+        """
+    }
+}
+
+// MARK: - Installing from the app
+
+extension VMTunnelAutostart {
+    enum InstallError: Error, CustomStringConvertible {
+        case wgQuickMissing
+        case failed(String)
+
+        var description: String {
+            switch self {
+            case .wgQuickMissing:
+                return String(
+                    localized: "cloud.tunnel.autostart.wgMissing",
+                    defaultValue: "WireGuard is not installed on this Mac. Install it with: brew install wireguard-tools"
+                )
+            case .failed(let detail):
+                return detail
+            }
+        }
+    }
+
+    /// Installs the job, prompting for an administrator once through the
+    /// standard macOS dialog.
+    ///
+    /// The whole privileged sequence goes into a temp script and AppleScript
+    /// runs that one path, rather than interpolating it into a `do shell
+    /// script` string: the sequence already contains both quote characters,
+    /// and nesting it inside AppleScript's own quoting is the kind of thing
+    /// that works until a path has a space in it.
+    ///
+    /// Running this while the job is already installed is fine and is how a
+    /// re-enrollment is repaired: the script re-applies the tunnel.
+    static func installWithAdminPrompt(configPath: String) throws {
+        guard let wgQuick = wgQuickPath() else { throw InstallError.wgQuickMissing }
+
+        let directory = FileManager.default.temporaryDirectory
+        let scriptURL = directory.appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString)")
+        let plistURL = directory.appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString).plist")
+        let runnerURL = directory.appendingPathComponent("cmux-vpn-install-\(UUID().uuidString).sh")
+        defer {
+            for url in [scriptURL, plistURL, runnerURL] {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+        do {
+            try scriptBody(wgQuickPath: wgQuick, configPath: configPath)
+                .write(to: scriptURL, atomically: true, encoding: .utf8)
+            try plistBody(configPath: configPath)
+                .write(to: plistURL, atomically: true, encoding: .utf8)
+            try installShell(scriptSource: scriptURL.path, plistSource: plistURL.path)
+                .write(to: runnerURL, atomically: true, encoding: .utf8)
+        } catch {
+            throw InstallError.failed(error.localizedDescription)
+        }
+
+        try runPrivileged(shellScriptAt: runnerURL.path)
+    }
+
+    static func uninstallWithAdminPrompt() throws {
+        let runnerURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-vpn-uninstall-\(UUID().uuidString).sh")
+        defer { try? FileManager.default.removeItem(at: runnerURL) }
+        do {
+            try uninstallShell().write(to: runnerURL, atomically: true, encoding: .utf8)
+        } catch {
+            throw InstallError.failed(error.localizedDescription)
+        }
+        try runPrivileged(shellScriptAt: runnerURL.path)
+    }
+
+    /// Cancelling the authorization dialog is a choice, not a failure, so it
+    /// reports as `false` rather than throwing an error the UI would show as a
+    /// problem. AppleScript uses -128 for "user cancelled".
+    @discardableResult
+    private static func runPrivileged(shellScriptAt path: String) throws -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
+        process.arguments = [
+            "-e",
+            "do shell script \"/bin/sh \" & quoted form of \"\(path)\" with administrator privileges",
+        ]
+        let errorPipe = Pipe()
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = errorPipe
+        do {
+            try process.run()
+        } catch {
+            throw InstallError.failed(error.localizedDescription)
+        }
+        let errorText = String(
+            data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        process.waitUntilExit()
+        if process.terminationStatus == 0 { return true }
+        if errorText.contains("-128") { return false }
+        throw InstallError.failed(
+            errorText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                ? "Setting up the tunnel failed (exit \(process.terminationStatus))."
+                : errorText.trimmingCharacters(in: .whitespacesAndNewlines)
+        )
+    }
+}

--- a/Sources/Cloud/VMTunnelAutostart.swift
+++ b/Sources/Cloud/VMTunnelAutostart.swift
@@ -10,6 +10,7 @@ enum VMTunnelAutostart {
     enum InstallError: Error, CustomStringConvertible {
         case wireGuardMissing
         case notEnrolled
+        case notSignedIn
         /// Anything else. Carries no command output: the underlying tools
         /// report paths and system detail that mean nothing to the person
         /// reading a banner, so the detail is logged and this stays product
@@ -22,6 +23,11 @@ enum VMTunnelAutostart {
                 return String(
                     localized: "cloud.tunnel.autostart.wireGuardMissing",
                     defaultValue: "cmux needs WireGuard on this Mac to reach your cloud machines' private network."
+                )
+            case .notSignedIn:
+                return String(
+                    localized: "cloud.tunnel.autostart.notSignedIn",
+                    defaultValue: "Sign in to cmux Cloud first, then connect this Mac."
                 )
             case .notEnrolled:
                 return String(

--- a/Sources/Cloud/VMTunnelAutostart.swift
+++ b/Sources/Cloud/VMTunnelAutostart.swift
@@ -1,139 +1,58 @@
+import CmuxFoundation
 import Foundation
 
-/// The launchd job that owns this Mac's WireGuard tunnel, so nobody has to run
-/// `cmux vpn up`.
+/// Installs the tunnel's launchd job from the app, prompting for an
+/// administrator through the standard macOS dialog.
 ///
-/// Creating a utun and installing routes needs root. The shipping build has no
-/// NetworkExtension entitlement, so the app cannot hold the tunnel itself and
-/// something privileged has to. That something is a LaunchDaemon: the person
-/// authorizes once, and launchd brings the tunnel up at every boot from then
-/// on — no terminal, and no second prompt.
-///
-/// The job also watches the config file. The app rewrites it whenever the
-/// enrollment changes (new keys, a different account), and a tunnel still
-/// carrying the previous peer reads as up while reaching nothing, so a write
-/// re-applies the tunnel instead of leaving it wrong until the next reboot.
-///
-/// Install runs through `osascript`'s admin prompt rather than `sudo`, because
-/// the app has no terminal to read a password from; the CLI's `cmux vpn
-/// install` builds the same script and plist through `sudo` instead.
+/// ``CmuxVPNAutostart`` owns what the job *is*; this owns getting it installed
+/// without a terminal. The CLI installs the same job through sudo.
 enum VMTunnelAutostart {
-    static let label = "com.cmuxterm.vpn.autostart"
-    static var plistPath: String { "/Library/LaunchDaemons/\(label).plist" }
-    static var scriptPath: String { "/usr/local/libexec/cmux-vpn-autostart" }
-
-    /// wg-quick, wherever the package manager put it.
-    static let wgQuickCandidates = [
-        "/opt/homebrew/bin/wg-quick",
-        "/usr/local/bin/wg-quick",
-        "/opt/local/bin/wg-quick",
-    ]
-
-    static func wgQuickPath() -> String? {
-        wgQuickCandidates.first { FileManager.default.isExecutableFile(atPath: $0) }
-    }
-
-    /// Whether the job is installed. This is about the job, not the tunnel:
-    /// `VMTunnelManager.wgQuickInterfaceUp()` answers whether it is up now.
-    static func isInstalled() -> Bool {
-        FileManager.default.fileExists(atPath: plistPath)
-    }
-
-    /// The privileged helper. launchd starts jobs with a minimal environment,
-    /// so wg-quick's own directory goes on PATH explicitly — it shells out to
-    /// `wg`, which Homebrew does not put anywhere launchd looks.
-    static func scriptBody(wgQuickPath: String, configPath: String) -> String {
-        let wgDirectory = (wgQuickPath as NSString).deletingLastPathComponent
-        return """
-        #!/bin/sh
-        # Installed by cmux. Brings up this Mac's tunnel to its Cloud VM network.
-        set -e
-        PATH="\(wgDirectory):/usr/bin:/bin:/usr/sbin:/sbin"
-        export PATH
-        CONFIG="\(configPath)"
-        [ -f "$CONFIG" ] || exit 0
-        # Re-apply rather than skip: the config may name a peer the live
-        # interface does not have, which reads as up while reaching nothing.
-        wg-quick down "$CONFIG" 2>/dev/null || true
-        exec wg-quick up "$CONFIG"
-        """
-    }
-
-    static func plistBody(configPath: String) -> String {
-        """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-          <key>Label</key><string>\(label)</string>
-          <key>ProgramArguments</key>
-          <array><string>\(scriptPath)</string></array>
-          <key>RunAtLoad</key><true/>
-          <key>WatchPaths</key>
-          <array><string>\(configPath)</string></array>
-          <key>StandardErrorPath</key><string>/var/log/cmux-vpn-autostart.log</string>
-        </dict>
-        </plist>
-        """
-    }
-
-    /// The one privileged shell the install runs. Kept as a single script so a
-    /// single authorization covers every step, and `bootstrap` immediately
-    /// after `bootout` means installing also brings the tunnel up now rather
-    /// than at the next boot.
-    static func installShell(scriptSource: String, plistSource: String) -> String {
-        """
-        set -e
-        /usr/bin/install -d -o root -g wheel -m 755 '\((scriptPath as NSString).deletingLastPathComponent)'
-        /usr/bin/install -o root -g wheel -m 755 '\(scriptSource)' '\(scriptPath)'
-        /usr/bin/install -o root -g wheel -m 644 '\(plistSource)' '\(plistPath)'
-        /bin/launchctl bootout system/\(label) 2>/dev/null || true
-        /bin/launchctl bootstrap system '\(plistPath)'
-        """
-    }
-
-    static func uninstallShell() -> String {
-        """
-        /bin/launchctl bootout system/\(label) 2>/dev/null || true
-        /bin/rm -f '\(plistPath)' '\(scriptPath)'
-        """
-    }
-}
-
-// MARK: - Installing from the app
-
-extension VMTunnelAutostart {
     enum InstallError: Error, CustomStringConvertible {
-        case wgQuickMissing
-        case failed(String)
+        case wireGuardMissing
+        case notEnrolled
+        /// Anything else. Carries no command output: the underlying tools
+        /// report paths and system detail that mean nothing to the person
+        /// reading a banner, so the detail is logged and this stays product
+        /// copy.
+        case failed
 
         var description: String {
             switch self {
-            case .wgQuickMissing:
+            case .wireGuardMissing:
                 return String(
-                    localized: "cloud.tunnel.autostart.wgMissing",
-                    defaultValue: "WireGuard is not installed on this Mac. Install it with: brew install wireguard-tools"
+                    localized: "cloud.tunnel.autostart.wireGuardMissing",
+                    defaultValue: "cmux needs WireGuard on this Mac to reach your cloud machines' private network."
                 )
-            case .failed(let detail):
-                return detail
+            case .notEnrolled:
+                return String(
+                    localized: "cloud.tunnel.autostart.notEnrolled",
+                    defaultValue: "This Mac is not on the network yet. Open a cloud machine once, then try again."
+                )
+            case .failed:
+                return String(
+                    localized: "cloud.tunnel.autostart.failed",
+                    defaultValue: "cmux could not set up the private network connection. Try again."
+                )
             }
         }
     }
 
-    /// Installs the job, prompting for an administrator once through the
-    /// standard macOS dialog.
+    /// Installs the job for `interfaceName`, applying `userConfigPath`.
     ///
-    /// The whole privileged sequence goes into a temp script and AppleScript
-    /// runs that one path, rather than interpolating it into a `do shell
-    /// script` string: the sequence already contains both quote characters,
-    /// and nesting it inside AppleScript's own quoting is the kind of thing
-    /// that works until a path has a space in it.
+    /// Blocking: it waits on an authorization dialog and a privileged shell.
+    /// Callers run it off the main actor.
     ///
-    /// Running this while the job is already installed is fine and is how a
-    /// re-enrollment is repaired: the script re-applies the tunnel.
-    static func installWithAdminPrompt(configPath: String) throws {
-        guard let wgQuick = wgQuickPath() else { throw InstallError.wgQuickMissing }
-
+    /// Returns false when the person cancels the dialog, which is a choice
+    /// rather than a failure and leaves nothing to report.
+    @discardableResult
+    static func install(interfaceName: String, userConfigPath: String) throws -> Bool {
+        guard FileManager.default.fileExists(atPath: userConfigPath) else {
+            throw InstallError.notEnrolled
+        }
+        guard let wgQuick = CmuxVPNAutostart.wgQuickPath() else {
+            throw InstallError.wireGuardMissing
+        }
+        let job = CmuxVPNAutostart(interfaceName: interfaceName)
         let directory = FileManager.default.temporaryDirectory
         let scriptURL = directory.appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString)")
         let plistURL = directory.appendingPathComponent("cmux-vpn-autostart-\(UUID().uuidString).plist")
@@ -144,35 +63,43 @@ extension VMTunnelAutostart {
             }
         }
         do {
-            try scriptBody(wgQuickPath: wgQuick, configPath: configPath)
+            try job.scriptBody(wgQuickPath: wgQuick, userConfigPath: userConfigPath)
                 .write(to: scriptURL, atomically: true, encoding: .utf8)
-            try plistBody(configPath: configPath)
+            try job.plistBody(userConfigPath: userConfigPath)
                 .write(to: plistURL, atomically: true, encoding: .utf8)
-            try installShell(scriptSource: scriptURL.path, plistSource: plistURL.path)
+            try job.installShell(scriptSource: scriptURL.path, plistSource: plistURL.path)
                 .write(to: runnerURL, atomically: true, encoding: .utf8)
         } catch {
-            throw InstallError.failed(error.localizedDescription)
+            cmuxDebugLog("vpn.autostart.write_failed error=\(String(reflecting: error))")
+            throw InstallError.failed
         }
-
-        try runPrivileged(shellScriptAt: runnerURL.path)
+        return try runPrivileged(shellScriptAt: runnerURL.path)
     }
 
-    static func uninstallWithAdminPrompt() throws {
+    @discardableResult
+    static func uninstall(interfaceName: String) throws -> Bool {
+        let job = CmuxVPNAutostart(interfaceName: interfaceName)
         let runnerURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-vpn-uninstall-\(UUID().uuidString).sh")
         defer { try? FileManager.default.removeItem(at: runnerURL) }
         do {
-            try uninstallShell().write(to: runnerURL, atomically: true, encoding: .utf8)
+            try job.uninstallShell().write(to: runnerURL, atomically: true, encoding: .utf8)
         } catch {
-            throw InstallError.failed(error.localizedDescription)
+            cmuxDebugLog("vpn.autostart.write_failed error=\(String(reflecting: error))")
+            throw InstallError.failed
         }
-        try runPrivileged(shellScriptAt: runnerURL.path)
+        return try runPrivileged(shellScriptAt: runnerURL.path)
     }
 
-    /// Cancelling the authorization dialog is a choice, not a failure, so it
-    /// reports as `false` rather than throwing an error the UI would show as a
-    /// problem. AppleScript uses -128 for "user cancelled".
-    @discardableResult
+    /// Runs one shell script with administrator rights.
+    ///
+    /// The script is passed by path rather than interpolated into the
+    /// AppleScript: the privileged sequence already contains both quote
+    /// characters, and nesting it inside AppleScript's own quoting is the kind
+    /// of thing that works until a path has a space in it.
+    ///
+    /// Cancelling reports `false` rather than throwing; AppleScript uses -128
+    /// for "user cancelled".
     private static func runPrivileged(shellScriptAt path: String) throws -> Bool {
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/osascript")
@@ -186,7 +113,8 @@ extension VMTunnelAutostart {
         do {
             try process.run()
         } catch {
-            throw InstallError.failed(error.localizedDescription)
+            cmuxDebugLog("vpn.autostart.spawn_failed error=\(String(reflecting: error))")
+            throw InstallError.failed
         }
         let errorText = String(
             data: errorPipe.fileHandleForReading.readDataToEndOfFile(),
@@ -195,10 +123,8 @@ extension VMTunnelAutostart {
         process.waitUntilExit()
         if process.terminationStatus == 0 { return true }
         if errorText.contains("-128") { return false }
-        throw InstallError.failed(
-            errorText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                ? "Setting up the tunnel failed (exit \(process.terminationStatus))."
-                : errorText.trimmingCharacters(in: .whitespacesAndNewlines)
-        )
+        // Diagnostics stay here; the banner gets product copy.
+        cmuxDebugLog("vpn.autostart.failed status=\(process.terminationStatus) output=\(errorText)")
+        throw InstallError.failed
     }
 }

--- a/Sources/Cloud/VMTunnelManager.swift
+++ b/Sources/Cloud/VMTunnelManager.swift
@@ -381,7 +381,13 @@ struct VMTunnelManager: Sendable {
             let advertised = lines[index]
                 .split(separator: "=", maxSplits: 1).last
                 .flatMap { Int($0.trimmingCharacters(in: .whitespaces)) }
-            lines[index] = "MTU = \(min(advertised ?? safeTunnelMTU, safeTunnelMTU))"
+            // A malformed or absent value falls back rather than being
+            // written through: `MTU = 0` parses fine and then the tunnel
+            // cannot start at all.
+            let usable = (advertised ?? safeTunnelMTU) >= minimumTunnelMTU
+                ? (advertised ?? safeTunnelMTU)
+                : safeTunnelMTU
+            lines[index] = "MTU = \(min(usable, safeTunnelMTU))"
         } else if let interfaceIndex = lines.firstIndex(where: {
             $0.trimmingCharacters(in: .whitespaces).lowercased() == "[interface]"
         }) {
@@ -394,6 +400,10 @@ struct VMTunnelManager: Sendable {
     /// ~1370 the provider path actually carries, with room for a peer whose
     /// underlay is slightly smaller, and well above IPv6's 1280 floor.
     static let safeTunnelMTU = 1360
+
+    /// IPv6's minimum link MTU. Anything at or below this is a malformed
+    /// advertisement rather than a small link.
+    static let minimumTunnelMTU = 1280
 
     private func ensureStateDir() throws {
         try FileManager.default.createDirectory(

--- a/Sources/Cloud/VMTunnelManager.swift
+++ b/Sources/Cloud/VMTunnelManager.swift
@@ -362,8 +362,38 @@ struct VMTunnelManager: Sendable {
                 throw TunnelError.configMalformed("no [Peer] section in server config")
             }
         }
+        // Clamp the MTU the server asked for. Freestyle's config says 1380,
+        // but the path only carries ~1370: the VPC link is 1450 and WireGuard
+        // over an IPv6 endpoint costs 80 bytes (40 IPv6 + 8 UDP + 32 WireGuard),
+        // so a full-size 1380-byte packet is silently dropped.
+        //
+        // The failure is invisible until it is expensive. Handshake, ping and
+        // TCP SYN all fit, so the tunnel comes up, `wg show` reports a live
+        // peer, and the daemon port accepts connections — then the first
+        // response larger than the path stalls in the sender's queue forever
+        // and every command fails with a transport timeout. Measured against a
+        // live machine: 1368 bytes through, 1372 dropped, and a 12 KB snapshot
+        // stuck unsent until the MTU came down.
+        //
+        // A smaller MTU than the path allows only costs throughput, so this
+        // takes the lower of the two rather than trusting the server's number.
+        if let index = lines.firstIndex(where: { key(of: $0) == "mtu" }) {
+            let advertised = lines[index]
+                .split(separator: "=", maxSplits: 1).last
+                .flatMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+            lines[index] = "MTU = \(min(advertised ?? safeTunnelMTU, safeTunnelMTU))"
+        } else if let interfaceIndex = lines.firstIndex(where: {
+            $0.trimmingCharacters(in: .whitespaces).lowercased() == "[interface]"
+        }) {
+            lines.insert("MTU = \(safeTunnelMTU)", at: interfaceIndex + 1)
+        }
         return lines.joined(separator: "\n")
     }
+
+    /// Ceiling for the tunnel MTU (see ``completedConfig``). 1360 sits under the
+    /// ~1370 the provider path actually carries, with room for a peer whose
+    /// underlay is slightly smaller, and well above IPv6's 1280 floor.
+    static let safeTunnelMTU = 1360
 
     private func ensureStateDir() throws {
         try FileManager.default.createDirectory(

--- a/cmux-tui/crates/cmux-remote/src/identity.rs
+++ b/cmux-tui/crates/cmux-remote/src/identity.rs
@@ -268,6 +268,21 @@ impl ClientIdentityStore {
         let fingerprint = public_key_fingerprint(&public_key);
         let now = unix_time()?;
         let (transaction, mut candidate) = self.reload_client_state().await?;
+        // A route hint is an address, and an address reaches one daemon at a
+        // time. Cloud VPCs recycle addresses, so `ws://10.16.133.2:1337/` names
+        // a different machine once the previous one is destroyed. Leaving the
+        // hint on the previous occupant left the route ambiguous forever: the
+        // store accumulated one entry per machine that ever held the address,
+        // and `remote connect <route>` then failed with "multiple known daemons
+        // match this route" until the stale entries were pruned by hand. The
+        // daemon being pinned here is the one answering at these addresses now,
+        // so it takes them from whoever held them before.
+        for (other_fingerprint, other) in candidate.daemons.iter_mut() {
+            if other_fingerprint == &fingerprint {
+                continue;
+            }
+            other.route_hints.retain(|hint| !route_hints.contains(hint));
+        }
         if let Some(existing) = candidate.daemons.get_mut(&fingerprint) {
             if decode_key(&existing.public_key)? != public_key {
                 return Err(IdentityError::Invalid("known daemon fingerprint collision".into()));

--- a/cmux-tui/crates/cmux-tui/src/remote_cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/remote_cli.rs
@@ -2451,7 +2451,20 @@ async fn select_known_daemon(
         }
         [] if daemons.len() > 1 => Err(anyhow!("multiple known daemons; use --daemon FINGERPRINT")),
         [] => Err(anyhow!("no known daemons; connect with an invitation or trusted carrier")),
-        _ => Err(anyhow!("multiple known daemons match this route; use --daemon FINGERPRINT")),
+        // Several daemons claiming one address means that address was recycled
+        // between machines. Newly pinned daemons now take the hint from the
+        // previous occupant (see pin_daemon_with_auth), but a store written
+        // before that still carries the old entries, and re-enrolling does not
+        // rewrite history. The address reaches exactly one daemon today, and
+        // that is the one most recently used, so prefer it rather than failing
+        // and making the caller pass --daemon for a machine it cannot name.
+        _ => matching
+            .iter()
+            .max_by_key(|daemon| daemon.last_used_at_unix)
+            .cloned()
+            .ok_or_else(|| {
+                anyhow!("multiple known daemons match this route; use --daemon FINGERPRINT")
+            }),
     }
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2941,6 +2941,7 @@
 		B43AFCE7099305905825EA0A /* VMTunnelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */; };
 		ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A47FAD328D6669A5B40CE3 /* VMTunnelManagerTests.swift */; };
 		F6AAAA235B7F431E8D1D2E94 /* VMTunnelStalenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87BDCAB46A44D7596A4784D /* VMTunnelStalenessTests.swift */; };
+		C11322FF0000000000000091 /* VPNToolPathTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C11322FF0000000000000092 /* VPNToolPathTests.swift */; };
 		C10084230000000000000001 /* WebKitBrowserPaneEngineAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10084230000000000000002 /* WebKitBrowserPaneEngineAdapter.swift */; };
 		A10020000000000000000019 /* WebSurfaceSelectionEvaluationOwner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1002000000000000000001A /* WebSurfaceSelectionEvaluationOwner.swift */; };
 		A10020000000000000000011 /* WebSurfaceSelectionReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = A10020000000000000000012 /* WebSurfaceSelectionReader.swift */; };
@@ -6065,6 +6066,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelManager.swift; sourceTree = "<group>"; };
 		74A47FAD328D6669A5B40CE3 /* VMTunnelManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMTunnelManagerTests.swift; sourceTree = "<group>"; };
 		E87BDCAB46A44D7596A4784D /* VMTunnelStalenessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelStalenessTests.swift; sourceTree = "<group>"; };
+		C11322FF0000000000000092 /* VPNToolPathTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VPNToolPathTests.swift; sourceTree = "<group>"; };
 		C10084230000000000000002 /* WebKitBrowserPaneEngineAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/WebKitBrowserPaneEngineAdapter.swift; sourceTree = "<group>"; };
 		A1002000000000000000001A /* WebSurfaceSelectionEvaluationOwner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/WebSurfaceSelectionEvaluationOwner.swift; sourceTree = "<group>"; };
 		A10020000000000000000012 /* WebSurfaceSelectionReader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/WebSurfaceSelectionReader.swift; sourceTree = "<group>"; };
@@ -8799,6 +8801,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 			isa = PBXGroup;
 			children = (
 				C11322A20000000000000001 /* CloudManualMirrorTransportTests.swift */,
+				C11322FF0000000000000092 /* VPNToolPathTests.swift */,
 				9520B0019520B0019520B001 /* HermesFirstClassSupportTests.swift */,
 				A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */,
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
@@ -13124,6 +13127,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */,
 				ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */,
 				F6AAAA235B7F431E8D1D2E94 /* VMTunnelStalenessTests.swift in Sources */,
+				C11322FF0000000000000091 /* VPNToolPathTests.swift in Sources */,
 				063BC42CEE257D6213A2E30C /* WindowAndDragTests.swift in Sources */,
 				A59170000000000000000001 /* WindowAppearanceSnapshotPaneBackgroundTests.swift in Sources */,
 				F4200000A1B2C3D4E5F60718 /* WindowAppearanceSnapshotTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2938,6 +2938,7 @@
 		DCFD2C3A4F04C00C62720EE5 /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
 		F1C699902D31503EE3D492DF /* VMMachineKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */; };
 		C37800000000000000000001 /* VMSSHCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37800000000000000000002 /* VMSSHCommandTests.swift */; };
+		B43AFCE7099305905825EA1B /* VMTunnelAutostart.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC85CE06E4F64991DAA4B1 /* VMTunnelAutostart.swift */; };
 		B43AFCE7099305905825EA0A /* VMTunnelManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */; };
 		ABE558B281D671A6DDDDD066 /* VMTunnelManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74A47FAD328D6669A5B40CE3 /* VMTunnelManagerTests.swift */; };
 		F6AAAA235B7F431E8D1D2E94 /* VMTunnelStalenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E87BDCAB46A44D7596A4784D /* VMTunnelStalenessTests.swift */; };
@@ -6063,6 +6064,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		C37800000000000000000004 /* VMDefaultCloudCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMDefaultCloudCommandTests.swift; sourceTree = "<group>"; };
 		6EECEC1A2D3CFC13D4343F46 /* VMMachineKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMMachineKind.swift; sourceTree = "<group>"; };
 		C37800000000000000000002 /* VMSSHCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMSSHCommandTests.swift; sourceTree = "<group>"; };
+		03EC85CE06E4F64991DAA4B1 /* VMTunnelAutostart.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelAutostart.swift; sourceTree = "<group>"; };
 		03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelManager.swift; sourceTree = "<group>"; };
 		74A47FAD328D6669A5B40CE3 /* VMTunnelManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VMTunnelManagerTests.swift; sourceTree = "<group>"; };
 		E87BDCAB46A44D7596A4784D /* VMTunnelStalenessTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMTunnelStalenessTests.swift; sourceTree = "<group>"; };
@@ -6754,6 +6756,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				D1F0A00100000000000000B4 /* PresenceSettings.swift */,
 				9CEC6F0035B71AE59FA45BA7 /* VMClientSocketCommands.swift */,
 				03EC85CE06E4F64991DAA433 /* VMTunnelManager.swift */,
+				03EC85CE06E4F64991DAA4B1 /* VMTunnelAutostart.swift */,
 				D9143D900F124494A55F859F /* CloudMachinesFeature.swift */,
 				08610D114C8CF23877176D7E /* MachinesPanelView.swift */,
 				68672B3C63D4E348AFA4DEF7 /* MachinesPanelViewModel.swift */,
@@ -11990,6 +11993,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
 				93AF7E8EC956FE883E252322 /* VMClientTelemetry.swift in Sources */,
 				F1C699902D31503EE3D492DF /* VMMachineKind.swift in Sources */,
+				B43AFCE7099305905825EA1B /* VMTunnelAutostart.swift in Sources */,
 				B43AFCE7099305905825EA0A /* VMTunnelManager.swift in Sources */,
 				C10084230000000000000001 /* WebKitBrowserPaneEngineAdapter.swift in Sources */,
 				A10020000000000000000019 /* WebSurfaceSelectionEvaluationOwner.swift in Sources */,

--- a/cmuxTests/VPNToolPathTests.swift
+++ b/cmuxTests/VPNToolPathTests.swift
@@ -1,0 +1,37 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// `cmux vpn` shells out to system tools by absolute path, and sudo resolves
+/// those paths literally — nothing searches PATH and nothing validates them
+/// until the command runs.
+///
+/// `/usr/sbin/install` shipped here once. macOS puts install(1) in `/usr/bin`,
+/// so `vpn hosts` died with "sudo: /usr/sbin/install: command not found" —
+/// and because the hosts sync runs *after* wg-quick, the tunnel was already up
+/// and healthy. It read as "the VPN is broken" when routing was fine and only
+/// the `.internal` names were missing.
+@Suite
+struct VPNToolPathTests {
+    @Test
+    func everyToolPathExistsAndIsExecutable() {
+        for path in CMUXCLI.VPNTool.all {
+            #expect(
+                FileManager.default.isExecutableFile(atPath: path),
+                "cmux vpn shells out to \(path), which is not an executable on this machine"
+            )
+        }
+    }
+
+    /// Pins the specific mistake: install(1) lives in /usr/bin on macOS.
+    @Test
+    func installComesFromUsrBinNotUsrSbin() {
+        #expect(CMUXCLI.VPNTool.install == "/usr/bin/install")
+        #expect(!FileManager.default.fileExists(atPath: "/usr/sbin/install"))
+    }
+}

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -41,6 +41,7 @@ import {
   DEVBOX_DESKTOP_UNIT,
   devboxDesktopOpenUrl,
 } from "../images/desktop";
+import type { Span } from "@opentelemetry/api";
 import { recordSpanError, setSpanAttributes, withVmSpan } from "../telemetry";
 import {
   CMUX_TUI_BINARY_PATH,
@@ -1028,7 +1029,7 @@ export class FreestyleProvider implements VMProvider {
           // first attach doesn't race the unit; attach re-verifies anyway.
           try {
             await this.ensureCmuxTuiRunning(vm, vmId);
-            await this.announceOnPrivateNetwork(vm, data);
+            await this.announceOnPrivateNetwork(vm, data, span);
           } catch (healErr) {
             recordSpanError(span, healErr);
           }
@@ -1209,7 +1210,7 @@ export class FreestyleProvider implements VMProvider {
           if (!bundleResult || bundleResult.exitCode === CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT) {
             healed = true;
             await this.ensureCmuxTuiRunning(vm, vmId);
-            await this.announceOnPrivateNetwork(vm, data);
+            await this.announceOnPrivateNetwork(vm, data, span);
             bundleResult = await this.execResult(vm, cmuxTuiAttachBundleCommand({ deviceFingerprint: fingerprint }));
           }
           if (!bundleResult || bundleResult.exitCode !== 0) {
@@ -1373,14 +1374,25 @@ export class FreestyleProvider implements VMProvider {
    * something dials in. Never fails the open: not being announced costs a
    * retry, while throwing here would cost the machine.
    */
-  private async announceOnPrivateNetwork(vm: Vm, data: FreestyleRouteAddresses): Promise<void> {
+  private async announceOnPrivateNetwork(vm: Vm, data: FreestyleRouteAddresses, span: Span): Promise<void> {
     const { networkIpv4 } = freestyleNetworkAddressMetadata(data);
-    if (!networkIpv4) return;
+    if (!networkIpv4) {
+      setSpanAttributes(span, { "cmux.vm.network.announced": false });
+      return;
+    }
     try {
-      await this.execResult(vm, freestyleAnnounceOnNetworkCommand(networkIpv4), EXEC_OVERHEAD_TIMEOUT_MS);
+      const result = await this.execResult(vm, freestyleAnnounceOnNetworkCommand(networkIpv4), EXEC_OVERHEAD_TIMEOUT_MS);
+      // Recorded because the failure it prevents is invisible: an announce
+      // that quietly does nothing looks exactly like one that worked, and the
+      // machine simply stays unreachable until it happens to transmit.
+      setSpanAttributes(span, {
+        "cmux.vm.network.announced": result?.exitCode === 0,
+        "cmux.vm.network.announce_exit": result?.exitCode ?? -1,
+      });
     } catch {
       // A machine that cannot announce is still worth handing back; the dial
       // may simply need one retry.
+      setSpanAttributes(span, { "cmux.vm.network.announced": false });
     }
   }
 

--- a/web/services/vms/drivers/freestyle.ts
+++ b/web/services/vms/drivers/freestyle.ts
@@ -148,6 +148,8 @@ export const FREESTYLE_PERSISTENT_IDLE_TIMEOUT_SECONDS = -1;
 /** The exec API rejects timeoutMs above 300000 (5 minutes per exec). */
 const MAX_EXEC_TIMEOUT_MS = 300_000;
 const EXEC_OVERHEAD_TIMEOUT_MS = 15_000;
+/** How long the announce waits for the guest to bring its private address up. */
+const ANNOUNCE_ADDRESS_WAIT_SECONDS = 10;
 const ROUTE_TOKEN_TTL_SECONDS = 12 * 60 * 60;
 /** Guest-side edge probe: 30 attempts x (5 s curl + 2 s sleep) worst case, under the 300 s exec cap. */
 const EDGE_DOMAIN = /^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)+$/i;
@@ -280,6 +282,46 @@ type FreestyleNetworkAddress = {
  * the daemon is dialed on. The public fallback below stays v6 — Freestyle
  * allocates no public v4 at all.
  */
+/**
+ * Announce the machine on its private network so the other side can reach it.
+ *
+ * The VPC is a flat L2 segment, and the provider side does not have a path to
+ * a member until that member has put a frame on the wire. A machine that has
+ * only ever been talked *to* is therefore invisible: from the owner's Mac a
+ * freshly created machine drops everything — ICMP included — while the same
+ * machine reaches the Mac fine, and it starts working the moment it sends
+ * anything of its own. That made every new machine look like it hung at
+ * "connecting" until something incidental woke it, and made the failure look
+ * intermittent rather than ordered.
+ *
+ * A gratuitous ARP is the smallest thing that announces a member, needs no
+ * knowledge of who is listening, and is what ARP already defines for exactly
+ * this ("I am here, at this address"). Best-effort: a machine with no private
+ * address, or an image without arping, is left alone rather than failing the
+ * open.
+ */
+export function freestyleAnnounceOnNetworkCommand(privateIpv4: string): string {
+  const address = shellQuote(privateIpv4);
+  return [
+    `ADDR=${address}`,
+    "IFACE=",
+    // The guest configures the address some time after the platform allocates
+    // it, and this runs as soon as the daemon answers, so the interface is
+    // often not up yet. Without the wait the lookup below finds nothing and
+    // the announce silently does nothing — which is exactly the failure it is
+    // here to prevent, only harder to see.
+    `for _ in $(seq 1 ${ANNOUNCE_ADDRESS_WAIT_SECONDS}); do`,
+    // The private address may sit on a VLAN sub-interface, so find whichever
+    // interface actually holds it rather than assuming a name.
+    `  IFACE=$(ip -o -4 addr show 2>/dev/null | awk -v a="$ADDR/" '$4 ~ "^" a {print $2; exit}')`,
+    '  [ -n "$IFACE" ] && break',
+    "  sleep 1",
+    "done",
+    `[ -n "$IFACE" ] && command -v arping >/dev/null 2>&1 && arping -A -c 2 -I "$IFACE" "$ADDR" >/dev/null 2>&1`,
+    "true",
+  ].join("; ");
+}
+
 export function freestyleCmuxRemoteRoute(addresses: FreestyleRouteAddresses, vmId: string): string {
   const networks = addresses.vpcs ?? addresses.networks ?? [];
   for (const network of networks) {
@@ -986,6 +1028,7 @@ export class FreestyleProvider implements VMProvider {
           // first attach doesn't race the unit; attach re-verifies anyway.
           try {
             await this.ensureCmuxTuiRunning(vm, vmId);
+            await this.announceOnPrivateNetwork(vm, data);
           } catch (healErr) {
             recordSpanError(span, healErr);
           }
@@ -1166,6 +1209,7 @@ export class FreestyleProvider implements VMProvider {
           if (!bundleResult || bundleResult.exitCode === CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT) {
             healed = true;
             await this.ensureCmuxTuiRunning(vm, vmId);
+            await this.announceOnPrivateNetwork(vm, data);
             bundleResult = await this.execResult(vm, cmuxTuiAttachBundleCommand({ deviceFingerprint: fingerprint }));
           }
           if (!bundleResult || bundleResult.exitCode !== 0) {
@@ -1322,6 +1366,24 @@ export class FreestyleProvider implements VMProvider {
    * because a machine from an older bake boots the daemon on 0.0.0.0, which
    * the public-IPv6 route cannot reach.
    */
+  /**
+   * Best-effort: put the machine on the wire so the owner's Mac can reach it
+   * (see ``freestyleAnnounceOnNetworkCommand``). Runs after the daemon is up
+   * and before the route is handed out, which is the last moment before
+   * something dials in. Never fails the open: not being announced costs a
+   * retry, while throwing here would cost the machine.
+   */
+  private async announceOnPrivateNetwork(vm: Vm, data: FreestyleRouteAddresses): Promise<void> {
+    const { networkIpv4 } = freestyleNetworkAddressMetadata(data);
+    if (!networkIpv4) return;
+    try {
+      await this.execResult(vm, freestyleAnnounceOnNetworkCommand(networkIpv4), EXEC_OVERHEAD_TIMEOUT_MS);
+    } catch {
+      // A machine that cannot announce is still worth handing back; the dial
+      // may simply need one retry.
+    }
+  }
+
   private async ensureCmuxTuiRunning(vm: Vm, vmId: string): Promise<void> {
     const healthy = await this.execResult(vm, freestyleDaemonSettledCommand(), DAEMON_SETTLE_TIMEOUT_MS + EXEC_OVERHEAD_TIMEOUT_MS);
     if (healthy?.exitCode === 0) return;


### PR DESCRIPTION
Four fixes found while dogfooding Cloud VMs over the WireGuard tunnel. Each was diagnosed against live machines.

## The MTU that stalled every connection

The provider config asks for `MTU = 1380`, but the path only carries ~1370: the VPC link is 1450 and WireGuard over an IPv6 endpoint costs 80 bytes (40 IPv6 + 8 UDP + 32 WireGuard).

The 10-byte overshoot is invisible until it is expensive. Handshake, ping and TCP SYN all fit, so the tunnel comes up, `wg show` reports a live peer, and the daemon port accepts connections — then the first large response stalls unsent forever. It surfaced as machines that connect and then fail every command with `transport error: Resource temporarily unavailable (os error 35)`, which reads as a broken daemon rather than a broken MTU.

Measured against a live machine:

```
1368 bytes → through          1372 bytes → dropped
daemon send queue: 12408 bytes stuck unsent
after clamping:    queue 0, snapshot returns, link connected
```

The config writer now takes the lower of the server's value and a safe ceiling. Too small only costs throughput. **The server-side value is still wrong and worth fixing at the source.**

## Turning the tunnel on without a terminal

Cloud machines have no public inbound port, so nothing reaches them until this Mac is on the private network — previously only via `cmux vpn up`, retyped after every reboot, with no sign in the UI that this was what the panel wanted.

The Machines panel now says so and offers to fix it. "Turn On" asks for an administrator once through the standard macOS dialog and hands the tunnel to a launchd job, so it comes up at every boot and the banner retires itself. A LaunchDaemon rather than the app holding the tunnel, because creating a utun and installing routes needs root and the shipping build has no NetworkExtension entitlement. The job watches the config too: the app rewrites it on re-enrollment, and a tunnel still carrying the previous peer reads as up while reaching nothing.

`cmux vpn install` / `uninstall` stay for people already in a terminal.

## `cmux vpn hosts` never worked

`/usr/sbin/install` does not exist on macOS; install(1) is in `/usr/bin`, and sudo resolves the path literally. Since the hosts sync runs after wg-quick, the tunnel was already up and only the `.internal` names were missing — so it read as a broken VPN. A stale block was the visible symptom: `/etc/hosts` still carried names from an earlier `10.17.26.0/24` network long after the machines had moved.

## Recycled addresses made a route permanently ambiguous

A VPC recycles addresses, so `ws://10.16.133.2:1337/` names a different machine once the previous one is destroyed. The known-daemon store kept the hint on every machine that had ever held the address, so after three the route failed with `multiple known daemons match this route; use --daemon FINGERPRINT` — unanswerable from the app, which has an address and no way to name which dead occupant it means. Pinning now takes the hint from the previous holder, and selection prefers the most recently used for stores written before that.

## Test plan

- [x] MTU clamp verified live: seeded a config with `MTU = 1380`, app rewrote it to `1360`
- [x] Confirmed the stall and its disappearance against a live machine (send queue 12408 → 0, snapshot returns)
- [x] `cmux vpn hosts` reaches sudo's prompt instead of "command not found"
- [x] Builds; new `vpn` verbs dispatch; banner preconditions hold locally
- [ ] The install itself needs an interactive administrator prompt, so it is unrun here
- [ ] cmux-tui changes are not compiled (those builds do not run on macOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791134969&installation_model_id=21920&pr_number=11960&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11960&signature=30ae35fb99f8d22edb4203452b5213ce8d4d6d56a64e1a2bf3b68a988f3d0524"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Cloud VPN issues found while dogfooding and makes joining the private network a setup step: tunnels now come up without a terminal, large transfers no longer stall silently, new machines are reachable immediately, `cmux vpn hosts` works on macOS, and recycled VPC addresses no longer leave routes ambiguous.

**New Features**
- The Machines panel shows a setup card when the tunnel is off; one button enrolls this Mac and installs a launchd job, so the tunnel comes up at boot and re-applies on config changes, and the card waits for the tunnel to come up before reporting done. The job strips `PreUp`/`PostUp`/`PreDown`/`PostDown` from its root-owned config copy so the user-writable source cannot hand root a command, and its identity derives from the tunnel's interface name so staging cannot replace the production job.
- A toolbar menu shows the tunnel's state and offers Reconnect and Turn Off, with Turn On available again after a teardown; the menu and card share one state that re-reads the system, so the panel agrees with the CLI and catches tunnels brought down outside the app, reporting "connected (until restart)" when no job backs the tunnel.
- `cmux vpn install` and `cmux vpn uninstall` build the same job from the CLI for terminal users.
- New machines send a gratuitous ARP before their route is handed out, so a machine that has only been talked *to* is reachable without waiting for it to speak first; telemetry records whether the announce ran.

**Bug Fixes**
- Clamps the tunnel MTU to 1360; the provider's 1380 overshoots the ~1370-byte path and stalled large transfers while handshake, ping, and TCP SYN succeeded. A malformed `MTU = 0` is floored at IPv6's minimum instead of being written through.
- `cmux vpn hosts` now calls `/usr/bin/install`; macOS has no `/usr/sbin/install`, so every sync failed after the tunnel was up and left stale `/etc/hosts` entries.
- Route hints now move to the daemon currently holding a recycled address, and selection prefers the most recently used daemon instead of erroring.

The server-side MTU is still 1380 at the source and is worth fixing there.

<sup>Written for commit 85fe5166ba54e1b611c2c3ee0471dc5aadffdd84. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11960?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added `cmux vpn install` and `cmux vpn uninstall` commands for persistent VPN startup and configuration updates.
  * Added in-app controls to connect, reconnect, or disconnect from the Cloud VM private network.
  * Improved private-network connectivity when Cloud VMs are created, resumed, or reconnected.
* **Bug Fixes**
  * VPN tunnel configurations now enforce safe MTU limits for improved connectivity.
  * Improved remote daemon selection when route information is duplicated or stale.
  * Corrected system tool resolution used by VPN commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->