### PR TITLE
iOS: enforce strict Tailscale connection selection

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionMethod.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionMethod.swift
@@ -94,12 +94,10 @@ extension MobileShellComposite {
     /// The method-pinned Iroh dial allowlist for one pairing, or `nil` when the
     /// pairing's effective method places no address pin on the Iroh dial.
     ///
-    /// Direct pins the dial to the user-enabled addresses. Tailscale Only on an
-    /// Iroh-identified pairing pins the dial to the pairing's numeric Tailscale
-    /// addresses: the method constrains PATHS while transport admission stays
-    /// the single auth authority, so control, background control, and terminal
-    /// lanes all live and die by the same dial policy. Legacy pairings without
-    /// an Iroh identity return `nil` and keep the grant-gated raw host lane.
+    /// Direct pins the dial to the user-enabled addresses. Tailscale Only does
+    /// not pin an Iroh dial: it selects the authorized raw Tailscale route, or
+    /// fails closed when that route is unavailable. Automatic remains the only
+    /// method that can select Iroh.
     ///
     /// An empty array means the method is pinned with nothing dialable:
     /// callers must fail closed and never substitute another path. Entries
@@ -127,38 +125,12 @@ extension MobileShellComposite {
                 )
             }
         case .tailscale:
-            guard pairing.routes.contains(where: { $0.kind == .iroh }) else {
-                return nil
-            }
-            return Self.irohTailscaleDialCandidates(for: pairing)
+            return nil
         case .automatic:
             return nil
         }
     }
 
-    /// Numeric Tailscale addresses a Tailscale Only pairing may pin its Iroh
-    /// dial to, deduplicated across the stored reconnect routes and the
-    /// device-local legacy grant list. Ports are never copied: a stored
-    /// Tailscale port names the legacy TCP listener, while the pin joins the
-    /// broker-published Iroh UDP port at dial time.
-    nonisolated static func irohTailscaleDialCandidates(
-        for pairing: MobilePairedMac
-    ) -> [CmxIrohDirectDialCandidate] {
-        var seen: Set<String> = []
-        var candidates: [CmxIrohDirectDialCandidate] = []
-        for route in pairing.routes + (pairing.legacyTailscaleRoutes ?? []) {
-            guard route.kind == .tailscale,
-                  case let .hostPort(host, _) = route.endpoint,
-                  let address = try? CmxIrohCustomPrivateAddress(host),
-                  seen.insert(address.value).inserted else {
-                continue
-            }
-            candidates.append(
-                CmxIrohDirectDialCandidate(address: address.value, port: nil)
-            )
-        }
-        return candidates
-    }
 
     /// Zero-touch discovery yields Iroh candidates only. It is pointless only
     /// when the app default is Tailscale AND no stored pairing opted back into

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ConnectionRecovery.swift
@@ -586,10 +586,10 @@ extension MobileShellComposite {
     /// Reconnects an already-paired Mac through its full route set.
     ///
     /// This path is used only when the set contains an authenticated Iroh peer
-    /// route or an exact locally grandfathered Tailscale route. Iroh pins the
-    /// pairing and removes raw fallbacks; the Tailscale exception is bound to
-    /// the previously paired device, address, and port. The synthetic ticket
-    /// names the already-paired device and never creates a new pairing.
+    /// route or an exact locally authorized Tailscale route. Automatic and
+    /// Direct use Iroh; Tailscale uses only the authorized Tailscale endpoint.
+    /// The synthetic ticket names the already-paired device and never creates a
+    /// new pairing.
     func connectStoredMacRoutes(
         name: String,
         routes: [CmxAttachRoute],
@@ -622,9 +622,9 @@ extension MobileShellComposite {
         }
     }
 
-    /// Connects an existing pairing through its strongest supported transport.
-    /// A supported Iroh identity pins the attempt to Iroh. Raw Tailscale/custom
-    /// host routes remain available only for legacy pairings without Iroh.
+    /// Connects an existing pairing through its selected transport. Automatic
+    /// and Direct may use Iroh. Tailscale uses only an exact locally authorized
+    /// Tailscale route, even when the pairing also advertises Iroh.
     @discardableResult
     func connectStoredMac(
         name: String,
@@ -741,22 +741,22 @@ extension MobileShellComposite {
                 forMacDeviceID: pairedMacDeviceID,
                 instanceTag: instanceTagExpectation.expectedTag
             )
-        // Direct and Tailscale Only ride the Iroh lane below: identity-checked
-        // and encrypted, with transport admission as the single auth
-        // authority. The method's addresses (user-enabled Direct entries, or
-        // the pairing's numeric Tailscale addresses) are the COMPLETE per-dial
-        // path allowlist (no relay, no advertised or discovered paths), so
-        // resolve them from the caller's fresh row first for the same
-        // startup-restore reason as the method above, and fail closed when
-        // nothing is dialable. Raw host/port dialing cannot carry the account
-        // credential (plaintext TCP), so it stays reserved for legacy
-        // pairings without an Iroh identity (nil candidates below).
-        let methodPinnedCandidates = irohMethodPinnedDialCandidates(
-            forMacDeviceID: pairedMacDeviceID,
-            instanceTag: instanceTagExpectation.expectedTag,
-            knownPairing: knownPairing
-        ) ?? (resolvedMethod == .direct ? [] : nil)
+        // Direct is the only method that supplies an Iroh address allowlist.
+        // Tailscale selects an authorized raw Tailscale route below and must
+        // never be converted into an Iroh dial, even when both route kinds are
+        // advertised by the pairing.
+        let methodPinnedCandidates: [CmxIrohDirectDialCandidate]?
+        if resolvedMethod == .direct {
+            methodPinnedCandidates = irohMethodPinnedDialCandidates(
+                forMacDeviceID: pairedMacDeviceID,
+                instanceTag: instanceTagExpectation.expectedTag,
+                knownPairing: knownPairing
+            ) ?? []
+        } else {
+            methodPinnedCandidates = nil
+        }
         if let methodPinnedCandidates, methodPinnedCandidates.isEmpty {
+            applyOperationalError(MobileShellConnectionError.insecureManualRoute)
             return .failed(.unsupportedRoute)
         }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
@@ -765,7 +765,6 @@ extension MobileShellComposite {
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes,
             tailscaleRequirement: resolvedMethod == .tailscale
-                && methodPinnedCandidates == nil
                 ? Self.TailscaleRouteRequirement(
                     macDeviceID: pairedMacDeviceID,
                     grantRoutes: legacyTailscaleRoutes
@@ -773,11 +772,14 @@ extension MobileShellComposite {
                 : nil
         )
         if methodPinnedCandidates != nil {
-            // A pinned method never rides the dev loopback or any host/port
-            // lane: the allowlist constrains the Iroh dial exclusively.
+            // Direct never rides the dev loopback or any host/port lane: the
+            // allowlist constrains the Iroh dial exclusively.
             pinnedRoutes = pinnedRoutes.filter { $0.kind == .iroh }
         }
-        guard let firstRoute = pinnedRoutes.first else { return .failed(.unsupportedRoute) }
+        guard let firstRoute = pinnedRoutes.first else {
+            applyOperationalError(MobileShellConnectionError.insecureManualRoute)
+            return .failed(.unsupportedRoute)
+        }
 
         var outcome: StoredMacReconnectOutcome = .failed(.unknown)
 
@@ -817,6 +819,7 @@ extension MobileShellComposite {
                     )
                 }
                 if !disconnectForAuthorizationFailureIfNeeded(error) {
+                    applyOperationalError(error)
                     connectionState = .disconnected
                     macConnectionStatus = .unavailable
                     clearRemoteConnectionContext()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -151,14 +151,6 @@ extension MobileShellComposite {
     public nonisolated static func hasUsableTailscaleAuthorization(
         in macs: [MobilePairedMac]
     ) -> Bool {
-        // An Iroh-identified pairing with a numeric Tailscale address dials
-        // the Iroh lane pinned to that address: admission authenticates it,
-        // so no device-local legacy grant is required.
-        for mac in macs where mac.routes.contains(where: { $0.kind == .iroh }) {
-            if !irohTailscaleDialCandidates(for: mac).isEmpty {
-                return true
-            }
-        }
         var authorizedEndpoints: Set<MobileTailscaleAuthorizationEndpoint> = []
         for mac in macs {
             for route in mac.legacyTailscaleRoutes ?? [] {
@@ -233,13 +225,9 @@ extension MobileShellComposite {
 
     /// Supported routes for reconnecting an already-paired Mac.
     ///
-    /// Unlike the legacy host/port helper, this preserves Iroh peer routes. Once
-    /// a supported Iroh route exists, it also pins the pairing to Iroh and drops
-    /// every raw host/port fallback. A numeric Tailscale route is first copied
-    /// into the pinned Iroh route as a private fallback address, so Tailscale can
-    /// still carry Iroh without receiving a Stack bearer. Otherwise an admission
-    /// or revocation failure could silently downgrade around the Iroh device
-    /// grant. Pairings without an authenticated Iroh identity remain fail-closed.
+    /// Unlike the legacy host/port helper, this preserves Iroh peer routes for
+    /// the Automatic and Direct methods. An explicit Tailscale requirement
+    /// filters the result to exact locally authorized Tailscale endpoints.
     ///
     /// `tailscaleRequirement` represents the user's explicit Tailscale-only
     /// connection method. Only stored Tailscale routes carrying a device-local
@@ -289,27 +277,22 @@ extension MobileShellComposite {
         supportedKinds: [CmxAttachTransportKind]
     ) -> [CmxAttachRoute] {
         let method = connectionMethod(for: mac)
-        // Tailscale Only on an Iroh-identified pairing rides the Iroh lane
-        // pinned to the pairing's numeric Tailscale addresses; the raw
-        // grant-gated host lane remains only for legacy pairings without an
-        // Iroh identity, so admission stays the single auth authority.
-        let tailscaleRidesPinnedIroh = method == .tailscale
-            && mac.routes.contains { $0.kind == .iroh }
         let routes = Self.storedReconnectRoutes(
             mac.routes,
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes,
-            tailscaleRequirement: method == .tailscale && !tailscaleRidesPinnedIroh
+            tailscaleRequirement: method == .tailscale
                 ? TailscaleRouteRequirement(
                     macDeviceID: mac.macDeviceID,
                     grantRoutes: mac.legacyTailscaleRoutes ?? []
                 )
                 : nil
         )
-        // A pinned method rides the Iroh lane EXCLUSIVELY: the transport
-        // dials only the method's allowlisted addresses, and no dev-loopback
-        // or host/port lane may substitute when they are unreachable.
-        return method == .direct || tailscaleRidesPinnedIroh
+        // Direct rides the Iroh lane EXCLUSIVELY: the transport dials only the
+        // method's allowlisted addresses, and no dev-loopback or host/port lane
+        // may substitute when they are unreachable. Tailscale routes remain
+        // Tailscale routes, with Iroh excluded by the requirement above.
+        return method == .direct
             ? routes.filter { $0.kind == .iroh }
             : routes
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalLane.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalLane.swift
@@ -17,10 +17,10 @@ extension MobileShellComposite {
               let activeTicket else {
             return
         }
-        // A lane request can redial the peer session, so it must carry the
-        // same method-pinned allowlist as the control dial or a Direct or
-        // Tailscale Only Computer's lane reconnect could ride relay or
-        // discovered paths the method forbids.
+        // A Direct lane request can redial the peer session, so it must carry
+        // the same method-pinned allowlist as the control dial or it could
+        // ride relay or discovered paths the method forbids. Tailscale
+        // sessions use their raw route and never enter this Iroh lane.
         let request = CmxByteTransportRequest(
             route: activeRoute,
             expectedPeerDeviceID: activeTicket.macDeviceID,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3141,18 +3141,23 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let activeMac = loadedActiveMac.flatMap {
             isHidden($0) || isDemonstrationPairedMac($0) ? nil : $0
         }
+        let allMacs = loadedMacs.filter {
+            !isHidden($0) && !isDemonstrationPairedMac($0)
+        }
         // Reconnect candidates include every saved Computer, but strict
         // Tailscale owns the recovery pass only for the selected foreground
         // pairing. When there is no retained foreground identity (for example
         // launch restore), the store's active row is the selection authority.
+        // A retained key can outlive its row after deletion or scope refresh;
+        // fall back to the current active row instead of letting a stale key
+        // make a selected Tailscale pairing look like an unrelated candidate.
         let retainedForegroundKey = foregroundOrRecoveryMacKey
+        let retainedForegroundKeyIsPresent = retainedForegroundKey != .anonymousForeground
+            && allMacs.contains { MacPairingKey($0) == retainedForegroundKey }
         let reconnectSelectionKey: MacPairingKey? =
-            retainedForegroundKey == .anonymousForeground
-                ? activeMac.map(MacPairingKey.init)
-                : retainedForegroundKey
-        let allMacs = loadedMacs.filter {
-            !isHidden($0) && !isDemonstrationPairedMac($0)
-        }
+            retainedForegroundKeyIsPresent
+                ? retainedForegroundKey
+                : activeMac.map(MacPairingKey.init)
         // Candidate Macs in priority order: the active Mac first, then every
         // other saved Mac. Rows with no locally usable route stay in the list so
         // one authenticated registry snapshot can upgrade an older Tailscale

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3158,15 +3158,29 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             retainedForegroundKeyIsPresent
                 ? retainedForegroundKey
                 : activeMac.map(MacPairingKey.init)
-        // Candidate Macs in priority order: the active Mac first, then every
-        // other saved Mac. Rows with no locally usable route stay in the list so
-        // one authenticated registry snapshot can upgrade an older Tailscale
-        // pairing, or recover a route that was never persisted locally.
+        // Candidate Macs in priority order: the retained foreground selection,
+        // the store-active Mac, then every other saved Mac. Rows with no locally
+        // usable route stay in the list so one authenticated registry snapshot
+        // can upgrade an older Tailscale pairing, or recover a route that was
+        // never persisted locally.
         var candidates: [MobilePairedMac] = []
-        if let activeMac {
+        // A retained foreground selection is more authoritative than a stale
+        // store-active row. Try it first so another saved Mac cannot connect
+        // successfully and mask a strict Tailscale failure on the selection.
+        if let reconnectSelectionKey,
+           let selectedMac = allMacs.first(where: {
+               MacPairingKey($0) == reconnectSelectionKey
+           }) {
+            candidates.append(selectedMac)
+        }
+        if let activeMac,
+           !candidates.contains(where: { $0.id == activeMac.id }) {
             candidates.append(activeMac)
         }
-        candidates.append(contentsOf: allMacs.filter { $0.id != activeMac?.id })
+        let selectedCandidateIDs = Set(candidates.map(\.id))
+        candidates.append(contentsOf: allMacs.filter { mac in
+            !selectedCandidateIDs.contains(mac.id)
+        })
         // A newer attempt may have started while we awaited the store read; if so,
         // let it own the flags rather than marking ourselves the active reconnect.
         guard generation == storedMacReconnectGeneration else { return .superseded }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -9689,9 +9689,22 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             forMacDeviceID: requestedMacDeviceID ?? ticket.macDeviceID,
             instanceTag: instanceTagExpectation.expectedTag
         )
+        // User-entered Tailscale authorization is scoped to the exact fresh
+        // pairing route it came from. It must not disable Direct's Iroh
+        // allowlist merely because another route is authorized in the same
+        // account/session. Preserve the explicit pairing event only when this
+        // ticket itself names the authorized Tailscale endpoint; stored and
+        // unrelated tickets remain pinned to their Direct candidates.
+        let hasFreshExplicitTailscaleAuthorization = pairedMacDeviceID == nil
+            && ticket.routes.contains { route in
+                Self.userTailscalePairingAuthorization(
+                    for: route,
+                    authorizations: userTailscalePairingAuthorizations
+                ) != nil
+            }
         let directOnlyDialCandidates = directOnlyDialCandidates
-            ?? (userTailscalePairingAuthorizations.isEmpty
-                && resolvedMethod == .direct
+            ?? (resolvedMethod == .direct
+                && !hasFreshExplicitTailscaleAuthorization
                 ? irohMethodPinnedDialCandidates(
                     forMacDeviceID: requestedMacDeviceID ?? ticket.macDeviceID,
                     instanceTag: instanceTagExpectation.expectedTag

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3181,6 +3181,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
         var firstCandidateNeedingMacUpdate: MobilePairedMac?
         var attemptedAutomaticIroh = false
+        var strictTailscaleFailure = false
         var lastDialOutcome: StoredMacReconnectOutcome = .failed(.noRoute)
         // Try each candidate until one connects, so a single offline Mac never
         // blocks the others.
@@ -3196,7 +3197,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                   ) else { break }
             // Tailscale Only excludes Iroh for every pairing. Automatic may
             // use Iroh, while Direct has its own address allowlist.
-            let irohReconnectIsBlocked = connectionMethod(for: mac) == .tailscale
+            let candidateUsesStrictTailscale = connectionMethod(for: mac) == .tailscale
+            let irohReconnectIsBlocked = candidateUsesStrictTailscale
                 || automaticIrohReconnectIsBlocked(accountID: scope.userID)
             let localRoutes = storedReconnectRoutes(mac).filter {
                 !irohReconnectIsBlocked || $0.kind != .iroh
@@ -3232,7 +3234,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     }
                 )
             }
-            if connectionState != .connected, !tailscaleOnly,
+            if connectionState != .connected,
+               !candidateUsesStrictTailscale,
                !automaticIrohReconnectIsBlocked(accountID: scope.userID) {
                 switch await freshReconnectRoutesAfterLocalFailure(
                     for: mac,
@@ -3265,6 +3268,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 }
             }
             if connectionState == .connected { break }
+            if candidateUsesStrictTailscale {
+                // An explicit Tailscale selection owns this reconnect pass.
+                // Do not promote another saved Mac or discover an Iroh peer
+                // after its authorized Tailscale route fails.
+                applyOperationalError(MobileShellConnectionError.insecureManualRoute)
+                strictTailscaleFailure = true
+                break
+            }
         }
         // A saved authenticated route is the cheapest and most authoritative
         // recovery path. Broker discovery can be slow for accounts with a large
@@ -3273,6 +3284,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // behind an unrelated account-wide discovery request.
         var zeroTouchCandidates: [MobilePairedMac] = []
         if connectionState != .connected, !tailscaleOnly,
+           !strictTailscaleFailure,
            !automaticIrohReconnectIsBlocked(accountID: scope.userID) {
             zeroTouchCandidates = await discoverZeroTouchIrohCandidates(
                 scope: scope,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3141,6 +3141,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let activeMac = loadedActiveMac.flatMap {
             isHidden($0) || isDemonstrationPairedMac($0) ? nil : $0
         }
+        // Reconnect candidates include every saved Computer, but strict
+        // Tailscale owns the recovery pass only for the selected foreground
+        // pairing. When there is no retained foreground identity (for example
+        // launch restore), the store's active row is the selection authority.
+        let retainedForegroundKey = foregroundOrRecoveryMacKey
+        let reconnectSelectionKey: MacPairingKey? =
+            retainedForegroundKey == .anonymousForeground
+                ? activeMac.map(MacPairingKey.init)
+                : retainedForegroundKey
         let allMacs = loadedMacs.filter {
             !isHidden($0) && !isDemonstrationPairedMac($0)
         }
@@ -3219,6 +3228,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // Raw Tailscale/TCP is bearer-capable only for an exact local route
             // retained by the pairing. A selected Tailscale method has no Iroh
             // fallback, so an absent or stale grant remains unavailable.
+            let candidateOwnsForegroundSelection = reconnectSelectionKey
+                == MacPairingKey(mac)
             if localCanConnectSecurely {
                 attemptedAutomaticIroh = attemptedAutomaticIroh || localHasIroh
                 lastDialOutcome = await connectStoredMacOutcome(
@@ -3268,11 +3279,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 }
             }
             if connectionState == .connected { break }
-            if candidateUsesStrictTailscale {
+            if candidateUsesStrictTailscale && candidateOwnsForegroundSelection {
                 // An explicit Tailscale selection owns this reconnect pass.
                 // Do not promote another saved Mac or discover an Iroh peer
                 // after its authorized Tailscale route fails.
-                applyOperationalError(MobileShellConnectionError.insecureManualRoute)
+                if connectionError == nil {
+                    applyOperationalError(MobileShellConnectionError.insecureManualRoute)
+                }
                 strictTailscaleFailure = true
                 break
             }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3194,12 +3194,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                       instanceTag: mac.instanceTag,
                       scope: scope
                   ) else { break }
-            // Tailscale Only blocks the Iroh lane only for legacy pairings
-            // without an Iroh identity; an identified pairing rides Iroh
-            // pinned to its Tailscale addresses (same lane the terminal
-            // lanes ride, same admission authority).
-            let irohReconnectIsBlocked = (connectionMethod(for: mac) == .tailscale
-                && !mac.routes.contains { $0.kind == .iroh })
+            // Tailscale Only excludes Iroh for every pairing. Automatic may
+            // use Iroh, while Direct has its own address allowlist.
+            let irohReconnectIsBlocked = connectionMethod(for: mac) == .tailscale
                 || automaticIrohReconnectIsBlocked(accountID: scope.userID)
             let localRoutes = storedReconnectRoutes(mac).filter {
                 !irohReconnectIsBlocked || $0.kind != .iroh
@@ -3218,8 +3215,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 && mac.routes.contains { $0.kind == .tailscale }
 
             // Raw Tailscale/TCP is bearer-capable only for an exact local route
-            // grandfathered during the v7-to-v8 migration. Every fresh, changed,
-            // restored, or registry route remains a hint for discovering Iroh.
+            // retained by the pairing. A selected Tailscale method has no Iroh
+            // fallback, so an absent or stale grant remains unavailable.
             if localCanConnectSecurely {
                 attemptedAutomaticIroh = attemptedAutomaticIroh || localHasIroh
                 lastDialOutcome = await connectStoredMacOutcome(
@@ -9674,15 +9671,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // allowlist from their freshly loaded row and pass it in; ticket
         // dials resolve it here from the published pairing list, using the
         // caller's pairing identity so a sibling build sharing the device id
-        // cannot supply the wrong method. `nil` means the target's method
-        // pins no addresses (automatic, or a legacy pairing without an Iroh
-        // identity).
+        // cannot supply the wrong method. Tailscale never supplies Iroh dial
+        // candidates, because its selected route must remain Tailscale.
+        let resolvedMethod = connectionMethod(
+            forMacDeviceID: requestedMacDeviceID ?? ticket.macDeviceID,
+            instanceTag: instanceTagExpectation.expectedTag
+        )
         let directOnlyDialCandidates = directOnlyDialCandidates
             ?? (userTailscalePairingAuthorizations.isEmpty
+                && resolvedMethod == .direct
                 ? irohMethodPinnedDialCandidates(
                     forMacDeviceID: requestedMacDeviceID ?? ticket.macDeviceID,
                     instanceTag: instanceTagExpectation.expectedTag
-                )
+                ) ?? []
                 : nil)
         let supportedRoutes = supportedRoutes(
             for: ticket,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -9685,10 +9685,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // caller's pairing identity so a sibling build sharing the device id
         // cannot supply the wrong method. Tailscale never supplies Iroh dial
         // candidates, because its selected route must remain Tailscale.
-        let resolvedMethod = connectionMethod(
-            forMacDeviceID: requestedMacDeviceID ?? ticket.macDeviceID,
-            instanceTag: instanceTagExpectation.expectedTag
-        )
+        // Stored reconnect callers already resolved Direct and supplied its
+        // allowlist. Avoid rescanning every saved pairing in that hot path.
+        let resolvedMethod: MobileConnectionMethod? = directOnlyDialCandidates == nil
+            ? connectionMethod(
+                forMacDeviceID: requestedMacDeviceID ?? ticket.macDeviceID,
+                instanceTag: instanceTagExpectation.expectedTag
+            )
+            : nil
         // User-entered Tailscale authorization is scoped to the exact fresh
         // pairing route it came from. It must not disable Direct's Iroh
         // allowlist merely because another route is authorized in the same
@@ -10506,6 +10510,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }
         }
 
+        // Direct's explicit allowlist is already authoritative, so return its
+        // Iroh-only route set before resolving the per-pairing method again.
+        if directOnly {
+            return supportedRoutes.filter { $0.kind == .iroh }
+        }
+
         // The explicit Tailscale method is strict: only authorized Tailscale
         // destinations may be dialed, and an unavailable route leaves the app
         // disconnected instead of silently switching to Iroh. The method is
@@ -10521,7 +10531,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // encrypted; the transport dials only the user-enabled addresses):
         // no dev loopback and no host/port lane, so an unusable allowlist
         // fails closed instead of switching paths.
-        if directOnly || ticketMethod == .direct {
+        if ticketMethod == .direct {
             return supportedRoutes.filter { $0.kind == .iroh }
         }
         if ticketMethod == .tailscale {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -723,13 +723,9 @@ import Testing
         )
     }
 
-    /// Switching an Iroh-identified pairing to Tailscale Only still replaces
-    /// the live session (its route decisions were made under the old method),
-    /// but the replacement dial rides the Iroh lane pinned to the pairing's
-    /// numeric Tailscale addresses: transport admission stays the single auth
-    /// authority for every session purpose, and the raw TCP lane is reserved
-    /// for legacy pairings without an Iroh identity.
-    @Test func changingToTailscaleReplacesLiveIrohWithPinnedIrohDial() async throws {
+    /// Switching an Iroh-identified pairing to Tailscale Only replaces the
+    /// live session and dials the actual authorized Tailscale route.
+    @Test func changingToTailscaleReplacesLiveIrohWithTailscaleDial() async throws {
         let clock = TestClock()
         let router = LivenessHostRouter()
         // The factory boxes the live Iroh transport it hands out, so the test
@@ -738,7 +734,7 @@ import Testing
         let factory = KindRecordingTransportFactory(
             router: router,
             box: liveTransportBox,
-            failingKinds: [.tailscale]
+            failingKinds: []
         )
         let tailscale = try tailscale()
         let iroh = try iroh()
@@ -799,14 +795,85 @@ import Testing
         let applied = try await pollUntil {
             let originalTransportClosed =
                 await originalTransport?.isClosedForTesting() == true
-            return factory.attemptedKinds().filter { $0 == .iroh }.count == 2
+            return factory.attemptedKinds().filter { $0 == .iroh }.count == 1
                 && store.connectionState == .connected
                 && originalTransportClosed
         }
         #expect(applied)
+        #expect(store.activeRoute?.kind == .tailscale)
+        #expect(factory.attemptedKinds().filter { $0 == .tailscale }.count == 1)
+    }
+
+    /// A selected Tailscale route is strict. If its dial fails, the old Iroh
+    /// session stays closed and no Iroh retry is allowed to mask the failure.
+    @Test func failingTailscaleAfterMethodChangeDoesNotFallbackToIroh() async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        let liveTransportBox = TransportBox()
+        let factory = KindRecordingTransportFactory(
+            router: router,
+            box: liveTransportBox,
+            failingKinds: [.tailscale]
+        )
+        let tailscale = try tailscale()
+        let iroh = try iroh()
+        let (pairedStore, directory) = try makePairedMacStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await pairedStore.upsert(
+            macDeviceID: "test-mac",
+            displayName: "Test Mac",
+            routes: [tailscale, iroh],
+            instanceTag: "default",
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: clock.now
+        )
+        try await pairedStore.authorizeUserTailscaleRoutes(
+            macDeviceID: "test-mac",
+            instanceTag: "default",
+            stackUserID: "user-1",
+            teamID: nil,
+            routes: [tailscale]
+        )
+        let methodStore = MobileConnectionMethodStore(
+            defaults: UserDefaults(
+                suiteName: "connection-method-strict-failure-\(UUID().uuidString)"
+            )!
+        )
+        let store = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { clock.now },
+                supportedRouteKinds: [.iroh, .tailscale]
+            ),
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            connectionMethodStore: methodStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "connection-method-strict-failure-hint-\(UUID().uuidString)"
+            )!,
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+        await store.loadPairedMacs()
+
+        #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
         #expect(store.activeRoute?.kind == .iroh)
-        // Tailscale Only never dials the raw TCP lane for a pairing with an
-        // Iroh identity, even when that dial would be authorized.
-        #expect(!factory.attemptedKinds().contains(.tailscale))
+        let originalTransport = await liveTransportBox.get()
+
+        methodStore.method = .tailscale
+
+        let failed = try await pollUntil {
+            let originalTransportClosed =
+                await originalTransport?.isClosedForTesting() == true
+            return store.connectionState == .disconnected
+                && store.macConnectionStatus == .unavailable
+                && originalTransportClosed
+        }
+        #expect(failed)
+        #expect(store.activeRoute == nil)
+        #expect(factory.attemptedKinds() == [.iroh, .tailscale])
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -895,4 +895,114 @@ import Testing
         #expect(store.connectionError != nil)
         #expect(factory.attemptedKinds() == [.iroh, .tailscale])
     }
+
+    /// A strict Tailscale foreground selection must not be hidden by reconnect
+    /// promoting a different saved computer over Iroh after the selected Mac
+    /// fails.
+    @Test func failingSelectedTailscaleDoesNotPromoteAnotherSavedIrohMac()
+        async throws {
+        let clock = TestClock()
+        let router = LivenessHostRouter()
+        let liveTransportBox = TransportBox()
+        let factory = KindRecordingTransportFactory(
+            router: router,
+            box: liveTransportBox,
+            failingKinds: [.tailscale]
+        )
+        let tailscale = try tailscale()
+        let iroh = try iroh()
+        let otherIroh = try CmxAttachRoute(
+            id: "iroh-other",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(
+                    endpointID: String(repeating: "b", count: 64)
+                ),
+                pathHints: []
+            ),
+            priority: -10_000
+        )
+        let (pairedStore, directory) = try makePairedMacStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        try await pairedStore.upsert(
+            macDeviceID: "selected-mac",
+            displayName: "Selected Mac",
+            routes: [tailscale, iroh],
+            instanceTag: "default",
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: clock.now
+        )
+        try await pairedStore.authorizeUserTailscaleRoutes(
+            macDeviceID: "selected-mac",
+            instanceTag: "default",
+            stackUserID: "user-1",
+            teamID: nil,
+            routes: [tailscale]
+        )
+        try await pairedStore.upsert(
+            macDeviceID: "other-mac",
+            displayName: "Other Mac",
+            routes: [otherIroh],
+            instanceTag: "default",
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: clock.now
+        )
+        await router.setHostIdentity(
+            deviceID: "selected-mac",
+            instanceTag: "default",
+            displayName: "Selected Mac"
+        )
+        await router.setHostIdentity(
+            deviceID: "other-mac",
+            instanceTag: "default",
+            displayName: "Other Mac"
+        )
+        let methodStore = MobileConnectionMethodStore(
+            defaults: UserDefaults(
+                suiteName: "connection-method-strict-other-mac-\(UUID().uuidString)"
+            )!
+        )
+        let store = MobileShellComposite(
+            runtime: LivenessTestRuntime(
+                transportFactory: factory,
+                now: { clock.now },
+                supportedRouteKinds: [.iroh, .tailscale]
+            ),
+            isSignedIn: true,
+            pairedMacStore: pairedStore,
+            connectionMethodStore: methodStore,
+            identityProvider: StaticIdentityProvider(userID: "user-1"),
+            reachability: AlwaysOnlineReachability(),
+            pairingHintDefaults: UserDefaults(
+                suiteName: "connection-method-strict-other-mac-hint-\(UUID().uuidString)"
+            )!,
+            hiddenMacStore: InMemoryPairedMacHiddenStore()
+        )
+        await store.loadPairedMacs()
+
+        await store.setConnectionMethod(
+            .tailscale,
+            macDeviceID: "selected-mac",
+            instanceTag: "default"
+        )
+
+        let failed = try await pollUntil {
+            store.connectionState == .disconnected
+                && store.macConnectionStatus == .unavailable
+                && store.connectionError != nil
+        }
+        #expect(failed)
+        #expect(
+            store.connectionMethod(
+                forMacDeviceID: "selected-mac",
+                instanceTag: "default"
+            ) == .tailscale
+        )
+        #expect(store.foregroundMacDeviceID == nil)
+        #expect(factory.attemptedKinds() == [.tailscale])
+    }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -797,7 +797,11 @@ import Testing
         // live session before the method change replaces it.
         let originalTransport = await liveTransportBox.get()
 
-        methodStore.method = .tailscale
+        await store.setConnectionMethod(
+            .tailscale,
+            macDeviceID: "test-mac",
+            instanceTag: "default"
+        )
 
         // The reconnected route only proves the store's logical state; the
         // replaced live Iroh transport must also finish closing so no
@@ -873,7 +877,11 @@ import Testing
         #expect(store.activeRoute?.kind == .iroh)
         let originalTransport = await liveTransportBox.get()
 
-        methodStore.method = .tailscale
+        await store.setConnectionMethod(
+            .tailscale,
+            macDeviceID: "test-mac",
+            instanceTag: "default"
+        )
 
         let failed = try await pollUntil {
             let originalTransportClosed =

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -619,12 +619,22 @@ import Testing
             stackUserID: base.stackUserID,
             legacyTailscaleRoutes: [stale]
         )
+        let irohBacked = MobilePairedMac(
+            macDeviceID: base.macDeviceID,
+            displayName: base.displayName,
+            routes: [current, try iroh()],
+            createdAt: base.createdAt,
+            lastSeenAt: base.lastSeenAt,
+            isActive: base.isActive,
+            stackUserID: base.stackUserID
+        )
 
         #expect(MobileShellComposite.hasUsableTailscaleAuthorization(in: [authorized]))
         #expect(!MobileShellComposite.hasUsableTailscaleAuthorization(in: [base]))
         #expect(!MobileShellComposite.hasUsableTailscaleAuthorization(
             in: [staleAuthorization]
         ))
+        #expect(!MobileShellComposite.hasUsableTailscaleAuthorization(in: [irohBacked]))
     }
 
     @Test func usableTailscaleAuthorizationFindsLastMacInLargeSnapshot() throws {
@@ -874,6 +884,7 @@ import Testing
         }
         #expect(failed)
         #expect(store.activeRoute == nil)
+        #expect(store.connectionError != nil)
         #expect(factory.attemptedKinds() == [.iroh, .tailscale])
     }
 }


### PR DESCRIPTION
## Summary

- Make an explicit per-computer Tailscale selection dial only an authorized Tailscale route.
- Mark the selected connection unavailable when Tailscale fails, with no Iroh retry or fallback to another saved Mac.
- Always reconnect the selected foreground pairing when its picker method changes.
- Keep Automatic and Direct route policies unchanged.

## Verification

- Focused Swift tests: 4 strict route and recovery tests passed.
- Secondary connection tests: 2 Tailscale route tests passed.
- Tagged macOS build `tstrct` succeeded and is installed.
- Tagged iOS archive and local signing succeeded. Install is queued for Aziz’s iPhone because it became unreachable.
- Broader reconnect suite reports five pre-existing failures outside this change set.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Tailscale Only connections now use explicitly authorized Tailscale routes without Iroh fallback.
  * Reconnect no longer switches to another saved Mac after Tailscale failures.
  * Direct connections continue using dedicated Iroh routes.
  * Tailscale authorization requires an exact match to locally stored grant endpoints.
  * Connection failures now provide clearer operational error feedback.
* **Tests**
  * Added coverage for strict Tailscale routing and reconnect behavior.
* **Documentation**
  * Updated connection behavior documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
