### PR TITLE
Refine iOS onboarding connection choices

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -674,6 +674,7 @@ struct CMUXMobileRootView: View {
         MobileSettingsView(
             connectedHostName: store.connectedHostName,
             startPairingScanner: pairingScannerAction,
+            startTailscalePairing: showPairingScanner,
             // Swaps the root sheet's content from Settings to Computers in
             // place; the presentation state machine allows this transition.
             showComputers: showComputers,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -32,6 +32,11 @@ struct MobileSettingsView: View {
     @Environment(\.mobileDiagnosticLog) private var diagnosticLog
     let connectedHostName: String
     let startPairingScanner: (() -> Void)?
+    /// Re-evaluates the scanner entrypoint after the replay picker changes the
+    /// connection method. Unlike ``startPairingScanner``, this callback is
+    /// intentionally not capability-gated at construction time, because the
+    /// selected method can make pairing available while the replay is open.
+    var startTailscalePairing: (() -> Void)? = nil
     /// Opens the Computers screen (the host dismisses or swaps this sheet
     /// first). `nil` hides the Connection section's All Computers row.
     var showComputers: (() -> Void)? = nil
@@ -555,7 +560,7 @@ struct MobileSettingsView: View {
                     onRetryConnection: retryAutomaticConnection,
                     onStartTailscalePairing: {
                         showingOnboarding = false
-                        startPairingScanner?()
+                        (startTailscalePairing ?? startPairingScanner)?()
                     },
                     onSetKeepAwake: { [store] enabled in
                         await OnboardingKeepAwakeOfferSource.set(enabled, on: store)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionPreview.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionPreview.swift
@@ -43,7 +43,10 @@ struct OnboardingConnectionPreview: View {
 
     private func deviceIcon(systemImage: String, tint: Color) -> some View {
         Circle()
-            .fill(tint.gradient)
+            // Keep the device nodes quiet while the connection state carries
+            // the meaning. The previous gradients made the card feel louder
+            // than the surrounding onboarding copy.
+            .fill(tint)
             .frame(width: density.previewDeviceSize, height: density.previewDeviceSize)
             .overlay {
                 Image(systemName: systemImage)
@@ -60,9 +63,7 @@ struct OnboardingConnectionPreview: View {
                     .fill(.thinMaterial)
                     .frame(width: density.previewAccountSize, height: density.previewAccountSize)
 
-                Image(systemName: phase == .ready
-                    ? "person.crop.circle.badge.checkmark"
-                    : "person.crop.circle")
+                Image(systemName: phase == .ready ? "checkmark" : "link")
                     .font(density.previewAccountFont.weight(.semibold))
                     .foregroundStyle(phase == .ready ? Color.green : Color.accentColor)
             }
@@ -93,16 +94,13 @@ struct OnboardingConnectionPreview: View {
             .foregroundStyle(.secondary)
             .accessibilityIdentifier("MobileOnboardingConnectionIdle")
         case .searching:
-            HStack(spacing: 8) {
-                ProgressView()
-                    .controlSize(.small)
-                Text(L10n.string(
+            ProgressView()
+                .controlSize(.small)
+                .tint(.secondary)
+                .accessibilityLabel(L10n.string(
                     "mobile.onboarding.connect.searching",
                     defaultValue: "Looking for your Mac…"
                 ))
-            }
-            .font(.subheadline.weight(.semibold))
-            .foregroundStyle(.secondary)
             .accessibilityIdentifier("MobileOnboardingConnectionSearching")
         case .fallback:
             Label(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionPreview.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionPreview.swift
@@ -63,7 +63,9 @@ struct OnboardingConnectionPreview: View {
                     .fill(.thinMaterial)
                     .frame(width: density.previewAccountSize, height: density.previewAccountSize)
 
-                Image(systemName: phase == .ready ? "checkmark" : "link")
+                Image(systemName: phase == .ready
+                    ? "person.crop.circle.badge.checkmark"
+                    : "person.crop.circle")
                     .font(density.previewAccountFont.weight(.semibold))
                     .foregroundStyle(phase == .ready ? Color.green : Color.accentColor)
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionView.swift
@@ -27,7 +27,8 @@ struct OnboardingConnectionView: View {
             OnboardingSceneContent(
                 title: title,
                 message: message,
-                visual: visual
+                visual: visual,
+                bodyLineReservation: 3
             )
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingConnectionView.swift
@@ -32,14 +32,15 @@ struct OnboardingConnectionView: View {
         }
     }
 
-    /// The method choice stays visible while there is still a decision to act
-    /// on; once connected it disappears (Settings keeps the control).
+    /// Keep the connection choice available for the whole connect page. A
+    /// successful automatic connection is not a commitment to Iroh; people
+    /// may still switch to Tailscale before leaving onboarding.
     private var showsMethodPicker: Bool {
-        phase == .idle || phase == .fallback
+        true
     }
 
-    /// The Keep Mac Awake ask takes the decision slot the picker vacated:
-    /// it exists only once the Mac is connected and its state is known.
+    /// The Keep Mac Awake ask appears once the Mac is connected and its state
+    /// is known, below the always-available method picker.
     private var visibleKeepAwakeOffer: OnboardingKeepAwakeOffer? {
         phase == .ready ? keepAwakeOffer : nil
     }
@@ -53,16 +54,25 @@ struct OnboardingConnectionView: View {
 
     @ViewBuilder
     private func connectionVisual(density: OnboardingConnectionVisualDensity) -> some View {
-        if verticalSizeClass == .compact, showsMethodPicker {
-            HStack(alignment: .center, spacing: density.sectionSpacing) {
-                OnboardingConnectionPreview(phase: phase, density: density)
+        if verticalSizeClass == .compact {
+            VStack(spacing: density.sectionSpacing) {
+                HStack(alignment: .center, spacing: density.sectionSpacing) {
+                    OnboardingConnectionPreview(phase: phase, density: density)
+                        .frame(maxWidth: .infinity)
+                    OnboardingConnectionMethodPicker(
+                        method: connectionMethod,
+                        density: density,
+                        onSelect: onSelectConnectionMethod
+                    )
                     .frame(maxWidth: .infinity)
-                OnboardingConnectionMethodPicker(
-                    method: connectionMethod,
-                    density: density,
-                    onSelect: onSelectConnectionMethod
-                )
-                .frame(maxWidth: .infinity)
+                }
+                if let visibleKeepAwakeOffer {
+                    OnboardingKeepAwakeCard(
+                        offer: visibleKeepAwakeOffer,
+                        density: density,
+                        onSet: onSetKeepAwake
+                    )
+                }
             }
             .fixedSize(horizontal: false, vertical: true)
         } else {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
@@ -272,7 +272,9 @@ struct OnboardingFlowView: View {
         var properties = eventProperties
         properties["connection_method"] = .string(method.rawValue)
         analytics.capture("ios_onboarding_connection_method_selected", properties)
-        onSelectConnectionMethod(method)
+        withAnimation(.smooth(duration: 0.25)) {
+            onSelectConnectionMethod(method)
+        }
     }
 
     private func startTailscalePairing() {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingFlowView.swift
@@ -272,8 +272,16 @@ struct OnboardingFlowView: View {
         var properties = eventProperties
         properties["connection_method"] = .string(method.rawValue)
         analytics.capture("ios_onboarding_connection_method_selected", properties)
+        let shouldStartTailscalePairing =
+            method == .tailscale && connectionPhase == .ready
         withAnimation(.smooth(duration: 0.25)) {
             onSelectConnectionMethod(method)
+        }
+        // A ready Iroh connection must not turn a Tailscale selection into an
+        // accidental onboarding completion. Pair the newly selected route now,
+        // while leaving the existing ready state untouched for other changes.
+        if shouldStartTailscalePairing {
+            startTailscalePairing()
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneContent.swift
@@ -8,6 +8,19 @@ struct OnboardingSceneContent<Visual: View>: View {
     let title: String
     let message: String
     let visual: Visual
+    let bodyLineReservation: Int
+
+    init(
+        title: String,
+        message: String,
+        visual: Visual,
+        bodyLineReservation: Int = 2
+    ) {
+        self.title = title
+        self.message = message
+        self.visual = visual
+        self.bodyLineReservation = bodyLineReservation
+    }
 
     @Environment(\.horizontalSizeClass) private var horizontalSizeClass
     @Environment(\.verticalSizeClass) private var verticalSizeClass
@@ -17,8 +30,13 @@ struct OnboardingSceneContent<Visual: View>: View {
         Group {
             if usesWideLayout {
                 HStack(alignment: .center, spacing: wideSpacing) {
-                    OnboardingSceneCopy(title: title, message: message, alignment: .leading)
-                        .frame(maxWidth: wideCopyMaxWidth)
+                    OnboardingSceneCopy(
+                        title: title,
+                        message: message,
+                        alignment: .leading,
+                        bodyLineReservation: bodyLineReservation
+                    )
+                    .frame(maxWidth: wideCopyMaxWidth)
                         .layoutPriority(1)
                     visual
                         .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
@@ -29,8 +47,13 @@ struct OnboardingSceneContent<Visual: View>: View {
                 .frame(maxWidth: 980, maxHeight: .infinity, alignment: .top)
             } else {
                 VStack(spacing: 18) {
-                    OnboardingSceneCopy(title: title, message: message, alignment: .center)
-                        .frame(maxWidth: 560)
+                    OnboardingSceneCopy(
+                        title: title,
+                        message: message,
+                        alignment: .center,
+                        bodyLineReservation: bodyLineReservation
+                    )
+                    .frame(maxWidth: 560)
                         .layoutPriority(1)
                     visual
                         .dynamicTypeSize(...DynamicTypeSize.xxxLarge)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneCopy.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneCopy.swift
@@ -5,6 +5,7 @@ struct OnboardingSceneCopy: View {
     let title: String
     let message: String
     let alignment: TextAlignment
+    let bodyLineReservation: Int
 
     var body: some View {
         VStack(alignment: alignment == .leading ? .leading : .center, spacing: 12) {
@@ -25,7 +26,7 @@ struct OnboardingSceneCopy: View {
                 message,
                 role: .body,
                 alignment: alignment,
-                maximumNumberOfLines: 3,
+                maximumNumberOfLines: bodyLineReservation,
                 reservesMaximumLines: true
             )
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneCopy.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneCopy.swift
@@ -16,14 +16,16 @@ struct OnboardingSceneCopy: View {
                 reservesMaximumLines: true
             )
 
-            // The body reserves its full two-line cap so pages with one-line
-            // and two-line copy hand the visual an identical remaining height
-            // (the device frames then render the same size on every page).
+            // The connect choices have different body copy. Tailscale can
+            // require a third line at phone width, so reserve that line for
+            // every choice and keep the label's line limit in sync. This
+            // makes switching methods preserve the visual's vertical anchor
+            // instead of remeasuring the page around the longer copy.
             OnboardingBalancedText(
                 message,
                 role: .body,
                 alignment: alignment,
-                maximumNumberOfLines: 2,
+                maximumNumberOfLines: 3,
                 reservesMaximumLines: true
             )
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneCopy.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingSceneCopy.swift
@@ -11,7 +11,9 @@ struct OnboardingSceneCopy: View {
             OnboardingBalancedText(
                 title,
                 role: .title,
-                alignment: alignment
+                alignment: alignment,
+                maximumNumberOfLines: 2,
+                reservesMaximumLines: true
             )
 
             // The body reserves its full two-line cap so pages with one-line

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/PairingView.swift
@@ -449,7 +449,10 @@ struct PairingView: View {
     }
 
     private func cancelDirectScanner() {
-        cancel()
+        // The camera is a nested sheet over PairingView. Cancelling it should
+        // return to the pairing form so the user can enter a code manually or
+        // try the scanner again, without losing the Tailscale setup context.
+        isShowingScanner = false
     }
 }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -304,7 +304,8 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(app.staticTexts[
             "Use the same cmux account on both devices. Your Mac connects automatically."
         ].exists)
-        XCTAssertTrue(app.staticTexts["Looking for your Mac…"].exists)
+        let connectionSearching = element("MobileOnboardingConnectionSearching")
+        XCTAssertTrue(connectionSearching.waitForExistence(timeout: 4))
         XCTAssertFalse(element("MobileOnboardingSignInBridge").exists)
         XCTAssertFalse(app.buttons["signin.apple"].exists)
         XCTAssertFalse(app.buttons["Scan Mac QR"].exists)
@@ -392,9 +393,12 @@ final class cmuxUITests: XCTestCase {
         capture("onboarding-05-scanner-fallback")
 
         scannerCancel.tap()
-        XCTAssertTrue(connectScene.waitForExistence(timeout: 4))
+        XCTAssertTrue(app.descendants(matching: .any)["MobilePairingView"].waitForExistence(timeout: 4))
+        XCTAssertFalse(connectScene.exists)
         XCTAssertTrue(scannerPreview.waitForNonExistence(timeout: 2))
         capture("onboarding-06-scanner-cancelled")
+        app.buttons["MobilePairingCancelButton"].tap()
+        XCTAssertTrue(connectScene.waitForExistence(timeout: 4))
         tap(automaticMethod, in: app)
         XCTAssertTrue(app.staticTexts["Your Mac connects automatically"].waitForExistence(timeout: 4))
 
@@ -658,6 +662,7 @@ final class cmuxUITests: XCTestCase {
         XCTAssertTrue(scannerCancel.waitForExistence(timeout: 4))
         scannerCancel.tap()
         XCTAssertTrue(scannerPreview.waitForNonExistence(timeout: 4))
+        app.buttons["MobilePairingCancelButton"].tap()
 
         let tailscaleDescription = app.descendants(matching: .any)[
             "MobileDisconnectedEmptyDescription"

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -394,7 +394,7 @@ final class cmuxUITests: XCTestCase {
 
         scannerCancel.tap()
         XCTAssertTrue(app.descendants(matching: .any)["MobilePairingView"].waitForExistence(timeout: 4))
-        XCTAssertFalse(connectScene.exists)
+        XCTAssertFalse(scanPairingCodeButton.isHittable)
         XCTAssertTrue(scannerPreview.waitForNonExistence(timeout: 2))
         capture("onboarding-06-scanner-cancelled")
         app.buttons["MobilePairingCancelButton"].tap()


### PR DESCRIPTION
## Summary
- keep Iroh discovery passive with a compact spinner and leave connection modes interactive
- keep Tailscale selectable after a successful Iroh connection and animate mode changes
- preserve the Tailscale pairing sheet when its scanner is cancelled
- stabilize onboarding copy height and simplify the connection visual

## Verification
- cloud macOS and iOS builds completed with tag obux
- isolated simulator preview exercised through onboarding connection flow
- focused UI test queued in hosted E2E below

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791139003&installation_model_id=21920&pr_number=11963&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11963&signature=c62196ee0827824cdc927454f41ccfa2e77dfd0b3885f07879bcd012e3c3ee8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * The connection method picker is now available throughout the connection flow.
  * Compact layouts now include the Keep Mac Awake option.
* **UI Improvements**
  * Selecting a connection method transitions smoothly.
  * Onboarding icons now use solid fills.
  * Connection searching uses a compact, accessible progress indicator.
  * Onboarding text maintains consistent spacing across connection choices.
* **Bug Fixes**
  * Cancelling the scanner now returns directly to the pairing screen.
  * Selecting Tailscale from a ready connection now starts pairing correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refines the iOS onboarding connection flow so users can change connection method at any time without losing pairing context.

- The method picker stays visible for the whole connect page instead of disappearing after a successful automatic connection.
- Selecting a connection method animates smoothly; choosing Tailscale while Iroh is connected starts pairing immediately, and the Settings replay picker keeps Tailscale pairing reachable after a method switch.
- Cancelling the Tailscale scanner returns to the pairing form instead of dismissing the sheet.
- Compact layouts show the Keep Mac Awake card below the method picker.
- Connection icons use solid fills with link or checkmark imagery instead of gradients and person icons.
- The searching state uses a compact accessibility-labeled spinner instead of a labeled row.
- The connect step reserves two title lines and three body lines so switching methods keeps the visual anchored.
- Updated UI tests cover the scanner cancel flow and the new searching accessibility element.

<sup>Written for commit 6cab9c7465be061accd811dc7af77758dfea3bf7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding and pairing presentation UX only; no auth, transport, or data-layer changes beyond when pairing is invoked from settings replay.
> 
> **Overview**
> Refines the iOS onboarding **connect** step so users can change connection method at any time—including after auto-connect succeeds—without losing Tailscale pairing context.
> 
> The method picker stays on screen for the whole connect page (with smooth animation on change). Choosing **Tailscale** while Iroh is already **ready** immediately starts Tailscale pairing instead of treating the session as finished. Settings’ onboarding replay wires a separate `startTailscalePairing` callback so pairing can open after the user switches method in the picker, even when the scanner action was nil at sheet construction.
> 
> **Pairing:** cancelling the nested QR scanner dismisses only the camera sheet and returns to `PairingView`, not the whole flow.
> 
> **UI polish:** connection preview uses solid device fills and a compact, accessibility-labeled spinner for “searching”; connect copy reserves three body lines (via `bodyLineReservation`) so switching methods doesn’t jump the layout; compact landscape stacks preview, picker, and Keep Mac Awake vertically.
> 
> UI tests were updated for the new searching accessibility element and the scanner-cancel → pairing sheet behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6cab9c7465be061accd811dc7af77758dfea3bf7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->