### PR TITLE
Fix Freestyle tunnel enrollment timestamp fence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,6 +559,7 @@ jobs:
       - name: Database behavior tests
         env:
           CMUX_DB_TEST: "1"
+          CMUX_DB_TEST_DATABASE_URL: postgres://cmux:cmux@localhost:5432/cmux_test
           DATABASE_URL: postgres://cmux:cmux@localhost:5432/cmux_test
           DIRECT_DATABASE_URL: postgres://cmux:cmux@localhost:5432/cmux_test
         run: bun run test:db:behavior

--- a/web/README.md
+++ b/web/README.md
@@ -58,13 +58,17 @@ Useful commands:
 ```bash
 bun db:up       # start this worktree's Postgres
 bun db:migrate  # apply Drizzle migrations
-bun db:test     # start an isolated test DB on CMUX_PORT+11000 and run DB behavior tests
+bun db:test     # start an isolated test DB on CMUX_PORT+30000 and run DB behavior tests
 # Slow shared runners can raise the bounded per-test limit without changing
 # concurrency: CMUX_DB_TEST_TIMEOUT_MS=60000 bun db:test
 bun db:status   # print container, volume, port, and redacted DATABASE_URL
 bun db:reset    # delete and recreate this worktree's DB volume
 bun db:down     # stop this worktree's DB
 ```
+
+`bun db:test` sets `CMUX_DB_TEST_DATABASE_URL` to its isolated database. Direct
+`test:db:behavior` runs must set that variable explicitly; the runner maps both
+application database URLs to it and fails closed when it is absent.
 
 The local default URL shape is:
 

--- a/web/scripts/db-local.sh
+++ b/web/scripts/db-local.sh
@@ -132,6 +132,7 @@ case "$command" in
     export CMUX_DB_PORT="$((cmux_port + ${CMUX_TEST_DB_PORT_OFFSET:-30000}))"
     export DATABASE_URL="postgres://${db_user}:${db_password}@localhost:${CMUX_DB_PORT}/${CMUX_DB_NAME}"
     export DIRECT_DATABASE_URL="$DATABASE_URL"
+    export CMUX_DB_TEST_DATABASE_URL="$DATABASE_URL"
     bunx drizzle-kit migrate --config "$ROOT_DIR/drizzle.config.ts"
     bunx drizzle-kit migrate --config "$ROOT_DIR/drizzle.config.ts"
     bash "$ROOT_DIR/scripts/run-db-behavior-tests.sh"

--- a/web/scripts/run-db-behavior-tests.sh
+++ b/web/scripts/run-db-behavior-tests.sh
@@ -4,12 +4,14 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
-if [[ -z "${DIRECT_DATABASE_URL:-${DATABASE_URL:-}}" ]]; then
-  echo "DATABASE_URL or DIRECT_DATABASE_URL is required for DB behavior tests" >&2
+if [[ -z "${CMUX_DB_TEST_DATABASE_URL:-}" ]]; then
+  echo "CMUX_DB_TEST_DATABASE_URL is required for DB behavior tests" >&2
   exit 2
 fi
 
 export CMUX_DB_TEST=1
+export DATABASE_URL="$CMUX_DB_TEST_DATABASE_URL"
+export DIRECT_DATABASE_URL="$CMUX_DB_TEST_DATABASE_URL"
 
 db_test_timeout_ms="${CMUX_DB_TEST_TIMEOUT_MS:-30000}"
 if [[ ! "$db_test_timeout_ms" =~ ^[1-9][0-9]*$ ]]; then

--- a/web/services/vms/repository.ts
+++ b/web/services/vms/repository.ts
@@ -993,7 +993,10 @@ const tunnelEnrollmentRepositoryMethods: Pick<
           ],
           // A crashed request leaves an expired lease. Only that lease may be
           // replaced; a live owner remains authoritative on every instance.
-          setWhere: sql`${cloudVmTunnelEnrollmentLocks.expiresAt} <= ${now}`,
+          // Raw SQL fragments bypass Drizzle's timestamp column mapper. Pass
+          // the wire representation explicitly or postgres.js receives a
+          // Date object with no type serializer and rejects the query.
+          setWhere: sql`${cloudVmTunnelEnrollmentLocks.expiresAt} <= ${now.toISOString()}::timestamptz`,
           set: {
             ownerToken: input.ownerToken,
             expiresAt: input.expiresAt,

--- a/web/tests/vm-tunnel-enrollment-db.test.ts
+++ b/web/tests/vm-tunnel-enrollment-db.test.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import * as Effect from "effect/Effect";
 import postgres, { type Sql } from "postgres";
@@ -11,9 +12,13 @@ let sql: Sql | null = null;
 
 beforeAll(() => {
   if (!runDbTests) return;
-  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  const databaseURL = process.env.CMUX_DB_TEST_DATABASE_URL;
   if (!databaseURL) {
-    throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+    throw new Error("CMUX_DB_TEST_DATABASE_URL is required when CMUX_DB_TEST=1");
+  }
+  const configuredURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (configuredURL !== databaseURL) {
+    throw new Error("Cloud DB configuration must use CMUX_DB_TEST_DATABASE_URL in DB tests");
   }
   sql = postgres(databaseURL, { max: 1 });
 });
@@ -26,23 +31,32 @@ afterAll(async () => {
 describe("tunnel enrollment repository", () => {
   dbTest("acquires a lease with a timestamp conflict fence", async () => {
     if (!sql) throw new Error("test database not initialized");
-    await sql`truncate cloud_vm_tunnel_enrollment_locks`;
 
-    const expiresAt = new Date(Date.now() + 60_000);
+    const testID = randomUUID();
+    const userId = `test-tunnel-lock-user-${testID}`;
+    const deviceFingerprint = `test-tunnel-lock-device-${testID}`;
+    const expiresAt = new Date("9999-12-31T23:59:59.000Z");
     const acquire = (ownerToken: string) =>
       Effect.runPromise(
         Effect.gen(function* () {
           const repo = yield* VmRepository;
           return yield* repo.acquireTunnelEnrollmentLock!({
-            userId: "user-db-tunnel-lock",
-            deviceFingerprint: "device-db-tunnel-lock",
+            userId,
+            deviceFingerprint,
             ownerToken,
             expiresAt,
           });
         }).pipe(Effect.provide(VmRepositoryLive)),
       );
 
-    await expect(acquire("owner-db-tunnel-lock-1")).resolves.toBe(true);
-    await expect(acquire("owner-db-tunnel-lock-2")).resolves.toBe(false);
+    try {
+      await expect(acquire("owner-db-tunnel-lock-1")).resolves.toBe(true);
+      await expect(acquire("owner-db-tunnel-lock-2")).resolves.toBe(false);
+    } finally {
+      await sql`
+        delete from cloud_vm_tunnel_enrollment_locks
+        where user_id = ${userId} and device_fingerprint = ${deviceFingerprint}
+      `;
+    }
   });
 });

--- a/web/tests/vm-tunnel-enrollment-db.test.ts
+++ b/web/tests/vm-tunnel-enrollment-db.test.ts
@@ -1,0 +1,48 @@
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import * as Effect from "effect/Effect";
+import postgres, { type Sql } from "postgres";
+import { closeCloudDbForTests } from "../db/client";
+import { VmRepository, VmRepositoryLive } from "../services/vms/repository";
+
+const runDbTests = process.env.CMUX_DB_TEST === "1";
+const dbTest = runDbTests ? test : test.skip;
+
+let sql: Sql | null = null;
+
+beforeAll(() => {
+  if (!runDbTests) return;
+  const databaseURL = process.env.DIRECT_DATABASE_URL ?? process.env.DATABASE_URL;
+  if (!databaseURL) {
+    throw new Error("DATABASE_URL is required when CMUX_DB_TEST=1");
+  }
+  sql = postgres(databaseURL, { max: 1 });
+});
+
+afterAll(async () => {
+  await closeCloudDbForTests();
+  await sql?.end();
+});
+
+describe("tunnel enrollment repository", () => {
+  dbTest("acquires a lease with a timestamp conflict fence", async () => {
+    if (!sql) throw new Error("test database not initialized");
+    await sql`truncate cloud_vm_tunnel_enrollment_locks`;
+
+    const expiresAt = new Date(Date.now() + 60_000);
+    const acquire = (ownerToken: string) =>
+      Effect.runPromise(
+        Effect.gen(function* () {
+          const repo = yield* VmRepository;
+          return yield* repo.acquireTunnelEnrollmentLock!({
+            userId: "user-db-tunnel-lock",
+            deviceFingerprint: "device-db-tunnel-lock",
+            ownerToken,
+            expiresAt,
+          });
+        }).pipe(Effect.provide(VmRepositoryLive)),
+      );
+
+    await expect(acquire("owner-db-tunnel-lock-1")).resolves.toBe(true);
+    await expect(acquire("owner-db-tunnel-lock-2")).resolves.toBe(false);
+  });
+});


### PR DESCRIPTION
Fixes first-time Freestyle tunnel enrollment on the postgres.js development backend.

The conflict predicate is a raw SQL fragment, so Drizzle does not apply the timestamp column mapper there. It now sends an ISO timestamp with an explicit timestamptz cast. The lease compare-and-swap behavior is unchanged.

Regression sequence:
- commit 1 adds the database test and fails with postgres.js rejecting a Date parameter
- commit 2 serializes the raw predicate timestamp

Verified:
- focused database test passes against the tagged Postgres stack
- web typecheck passes
- live Freestyle VM create succeeds
- daemon workspace and exact tab rename advance the journal and persist in the next snapshot

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11970"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791145798&installation_model_id=21920&pr_number=11970&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11970&signature=d12f3e2b9c757d1856b642f4d5c847a44e35d14f7c0f3199314d41c8ca2a7988"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes first-time Freestyle tunnel enrollment on the postgres.js development backend. The raw SQL conflict predicate bypassed Drizzle's timestamp mapper, so postgres.js rejected the `Date` parameter; the predicate now sends an ISO timestamp with an explicit `timestamptz` cast, and lease compare-and-swap behavior is unchanged.

**Tests**
- Adds a database test for the lease fence, skipped unless `CMUX_DB_TEST=1` is set.
- DB behavior runs now require `CMUX_DB_TEST_DATABASE_URL`; the runner maps both application database URLs to it and CI sets it.

<sup>Written for commit e8e202c94c5053006e5c4db03d67f2b2496c5c3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11970?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed tunnel enrollment lock handling when comparing expiration timestamps, improving reliability for conflicting lock requests.

- **Tests**
  - Added database-backed coverage verifying that the first lock acquisition succeeds and subsequent conflicting requests are rejected.
  - Improved database behavior test setup to use a dedicated, consistently configured test database connection.

- **Documentation**
  - Updated database testing guidance, including the required test database configuration and revised local test port settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->