### PR TITLE
fix(web): keep locale navigation content and metadata in sync

### DIFF
--- a/web/app/[locale]/components/language-switcher.tsx
+++ b/web/app/[locale]/components/language-switcher.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { useEffect, useRef } from "react";
 import { useLocale } from "next-intl";
 import { useRouter, usePathname } from "../../../i18n/navigation";
 import { locales, localeNames, type Locale } from "../../../i18n/routing";
@@ -8,12 +9,25 @@ export function LanguageSwitcher() {
   const locale = useLocale() as Locale;
   const router = useRouter();
   const pathname = usePathname();
+  const pendingLocale = useRef<Locale | null>(null);
+
+  useEffect(() => {
+    if (pendingLocale.current !== locale) return;
+
+    // Locale changes can pass through the instant-navigation cache (and the
+    // default-locale redirect from /en to /). Refresh after next-intl has
+    // committed the new locale so server-rendered content and metadata come
+    // from the same locale as the URL.
+    pendingLocale.current = null;
+    router.refresh();
+  }, [locale, router]);
 
   function onChange(e: React.ChangeEvent<HTMLSelectElement>) {
     const newLocale = e.target.value as Locale;
     const qs = typeof window !== "undefined"
       ? window.location.search + window.location.hash
       : "";
+    pendingLocale.current = newLocale;
     router.replace(pathname + qs, { locale: newLocale });
   }
 

--- a/web/e2e/instant/marketing-navigation.instant.ts
+++ b/web/e2e/instant/marketing-navigation.instant.ts
@@ -10,3 +10,31 @@ test("blog navigation commits meaningful UI immediately", async ({ page }) => {
     await expect(page.getByRole("heading", { name: "Blog" })).toBeVisible();
   });
 });
+
+test("locale navigation refreshes content and metadata after the URL changes", async ({ page }) => {
+  await page.goto("/ko");
+  const language = page.locator('select[aria-label="Language"]').first();
+
+  await language.selectOption("en");
+  await page.waitForURL((url) => url.pathname === "/");
+  await expect(language).toHaveValue("en");
+  await expect(page).toHaveTitle("cmux - The terminal built for multitasking");
+  await expect(page.getByRole("heading", { name: "Features" })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "기능" })).toHaveCount(0);
+
+  await language.selectOption("ko");
+  await page.waitForURL((url) => url.pathname === "/ko");
+  await expect(language).toHaveValue("ko");
+  await expect(page).toHaveTitle("cmux — 멀티태스킹을 위해 만든 터미널");
+  await expect(page.getByRole("heading", { name: "기능" })).toBeVisible();
+
+  await language.selectOption("ja");
+  await page.waitForURL((url) => url.pathname === "/ja");
+  await expect(language).toHaveValue("ja");
+  await expect(page).toHaveTitle("cmux - マルチタスクのために作られたターミナル");
+  await expect(page.getByRole("heading", { name: "機能" })).toBeVisible();
+
+  await page.reload();
+  await expect(page).toHaveTitle("cmux - マルチタスクのために作られたターミナル");
+  await expect(page.getByRole("heading", { name: "機能" })).toBeVisible();
+});


### PR DESCRIPTION
## Problem

Changing the cmux.com language from Korean to English updated the URL and select control, but the instant-navigation shell could keep Korean server-rendered content and metadata after the `/en` to `/` canonical redirect.

## Fix

Refresh the server component tree after next-intl commits the requested locale. This keeps the URL, selected language, document metadata, and rendered content on one locale state through client navigation and reloads.

## Validation

- `bun run typecheck`
- `bun test tests/content-locale-link.test.tsx tests/app-route-layout-invariants.test.ts`
- `bun run lint -- app/[locale]/components/language-switcher.tsx e2e/instant/marketing-navigation.instant.ts`
- Playwright regression covers Korean → English, English → Japanese, and Japanese hard reload.
- Production reproduction confirmed the pre-fix stale Korean title/content behavior.

Closes #11979

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791154159&installation_model_id=21920&pr_number=11982&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11982&signature=9ac7f3881da0755e00863c43f4c4506e1b512354611add3f33a4cc98b0c9e91d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes locale switching on cmux.com so server-rendered content and metadata stay in sync with the URL. Changing language previously updated the URL and select control, but instant navigation could keep the old locale's content and title after the `/en` to `/` redirect.

- Refreshes the server component tree after `next-intl` commits the requested locale.
- Adds a Playwright regression covering Korean → English, English → Japanese, and Japanese hard reload.

Closes #11979.

<sup>Written for commit 12e7f5a888c0e8c060736c57062015d54e7b1f5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language switching so localized page content, headings, and metadata update correctly after selecting a new language.
  - Ensured language changes work consistently when switching between supported locales, including the default locale.
  - Preserved the selected locale and its translated content after reloading the page.

- **Tests**
  - Added coverage for locale navigation, translated page titles, headings, URL updates, and reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->