### PR TITLE
Fix Freestyle attach bundle readiness handling

### DIFF
--- a/web/services/vms/drivers/cmuxTuiDaemon.ts
+++ b/web/services/vms/drivers/cmuxTuiDaemon.ts
@@ -705,7 +705,10 @@ export function cmuxTuiAttachBundleCommand(options: {
     ? `case "$D" in *${shellQuote(needle)}*) ;; *) ${mint};; esac`
     : mint;
   return [
-    ...(options.readyGate ? [`{ ${options.readyGate}; } || exit ${CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT}`] : []),
+    // Run the readiness probe in a subshell. The Freestyle gate uses `exit` for
+    // its success and failure branches; without a subshell those exits terminate
+    // the entire attach bundle before the probe, device, and invitation sections.
+    ...(options.readyGate ? [`( ${options.readyGate}; ) || exit ${CMUX_TUI_ATTACH_BUNDLE_NOT_READY_EXIT}`] : []),
     `echo ${BUNDLE_MARKERS.probe}`,
     `${run} remote-probe --json; echo`,
     `echo ${BUNDLE_MARKERS.devices}`,

--- a/web/tests/vm-cmux-tui.test.ts
+++ b/web/tests/vm-cmux-tui.test.ts
@@ -1,5 +1,5 @@
-import { spawn } from "node:child_process";
-import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { spawn, spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { describe, expect, test } from "bun:test";
@@ -802,14 +802,73 @@ describe("cmux-tui attach bundle", () => {
     ["__CMUX_PROBE__", probe, "__CMUX_DEVICES__", devices, "__CMUX_INVITE__", invite, "__CMUX_END__", ""].join("\n");
   const invitation = `cmux://enroll/${Buffer.from(JSON.stringify({ id: "inv-abc", expires_at_unix: 1900000000 })).toString("base64url")}`;
 
-  test("one exec carries the readiness gate, the probe, the devices, and a conditional mint", () => {
-    const command = cmuxTuiAttachBundleCommand({ readyGate: "test -f /ready", deviceFingerprint: "fp-1" });
-    expect(command).toContain("{ test -f /ready; } || exit 3");
-    expect(command).toContain("remote-probe --json");
-    expect(command).toContain("remote enroll devices --session cloud --json");
-    expect(command).toContain(`case "$D" in *'"fingerprint":"fp-1"'*) ;; *) env HOME=/root /root/.cmux/bin/cmux-tui remote enroll create --session cloud --ttl 300 --json;; esac`);
-    expect(cmuxTuiAttachBundleCommand({})).not.toContain("exit 3");
-    expect(cmuxTuiAttachBundleCommand({})).not.toContain("case");
+  const runBundle = (readyGate: string, deviceFingerprint?: string) => {
+    const root = mkdtempSync(join(tmpdir(), "cmux-tui-attach-bundle-"));
+    const binary = join(root, "cmux-tui");
+    const callsPath = join(root, "calls");
+    writeFileSync(binary, [
+      "#!/bin/sh",
+      "printf '%s\\n' \"$*\" >> \"$CMUX_TEST_CALLS\"",
+      "case \"$*\" in",
+      `  'remote-probe --json') printf '%s\\n' '{"build_identity":"abc123","remote_protocol":12,"version":"0.13.0"}' ;;`,
+      `  'remote enroll devices --session cloud --json') printf '%s\\n' '[{"fingerprint":"fp-1","revoked_at_unix":null}]' ;;`,
+      `  'remote enroll create --session cloud --ttl 300 --json') printf '%s\\n' '${JSON.stringify({ uri: invitation })}' ;;`,
+      "  *) exit 64 ;;",
+      "esac",
+      "",
+    ].join("\n"));
+    chmodSync(binary, 0o755);
+    try {
+      const result = spawnSync("/bin/sh", ["-c", cmuxTuiAttachBundleCommand({ readyGate, deviceFingerprint, binary })], {
+        encoding: "utf8",
+        env: { ...process.env, CMUX_TEST_CALLS: callsPath },
+        timeout: 5_000,
+      });
+      expect(result.error).toBeUndefined();
+      return {
+        status: result.status,
+        stdout: result.stdout,
+        calls: existsSync(callsPath) ? readFileSync(callsPath, "utf8").trim().split("\n") : [],
+      };
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  };
+
+  test("a successful readiness exit continues with the complete attach bundle", () => {
+    const result = runBundle("exit 0", "fp-new");
+    expect(result.status).toBe(0);
+    expect(result.calls).toEqual([
+      "remote-probe --json",
+      "remote enroll devices --session cloud --json",
+      "remote enroll create --session cloud --ttl 300 --json",
+    ]);
+    const bundle = parseCmuxTuiAttachBundle(result.stdout, "freestyle", "vm-1", "fp-new");
+    expect(bundle.daemonBuild).toEqual({ commit: "abc123", remoteProtocol: 12, version: "0.13.0" });
+    expect(bundle.enrolled).toBe(false);
+    expect(bundle.invitation?.invitationId).toBe("inv-abc");
+  });
+
+  test("a failed readiness exit returns the repair signal without calling the daemon", () => {
+    const result = runBundle("exit 1");
+    expect(result.status).toBe(3);
+    expect(result.calls).toEqual([]);
+    expect(result.stdout).toBe("");
+  });
+
+  test("an enrolled device passes the readiness exit without minting an invitation", () => {
+    const result = runBundle("exit 0", "fp-1");
+    expect(result.status).toBe(0);
+    expect(result.calls).toEqual([
+      "remote-probe --json",
+      "remote enroll devices --session cloud --json",
+    ]);
+    const bundle = parseCmuxTuiAttachBundle(result.stdout, "freestyle", "vm-1", "fp-1");
+    expect(bundle.enrolled).toBe(true);
+    expect(bundle.invitation).toBeNull();
+  });
+
+  test("rejects a malformed device fingerprint", () => {
     expect(() => cmuxTuiAttachBundleCommand({ deviceFingerprint: "bad fp; rm -rf /" })).toThrow("unexpected shape");
   });
 


### PR DESCRIPTION
## Problem

Freestyle attach retries can return `502` with `cmux-tui attach bundle ... failed (exit 1)` before the daemon repair runs. The readiness helper uses `exit` for its result, and the attach bundle placed it in the parent shell.

## Change

Run the readiness helper in a subshell. Its success or failure now controls the bundle without terminating the bundle itself. A readiness failure still returns the existing retry signal (`exit 3`).

The regression tests execute the generated shell command with a fake daemon. They verify that a successful readiness result runs probe, device, and invitation steps; a failed result returns `3` without daemon calls; and an enrolled device does not mint an invitation.

## Validation

- Test-only commit fails on the three new runtime tests.
- Focused VM tests: 196 passed, 57 existing skips.
- `bun run typecheck`
- `bun run lint -- services/vms/drivers/cmuxTuiDaemon.ts tests/vm-cmux-tui.test.ts`
- `bun run lint:complexity`
- Live staging and production create/attach/destroy smoke passed on `f67edc96`.
- Live staging and production slug rename/clear/destroy smoke passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11983"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791157367&installation_model_id=21920&pr_number=11983&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11983&signature=10a1c73c29f0925ec933e7bfebccff866cd0db35d18cd4ae8507ac516ba74585"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Freestyle attach bundle so a failed readiness check no longer terminates the bundle shell, which caused premature `502` errors on retry. The readiness gate now runs in a subshell; a failed check still returns `exit 3` as the retry signal.

**Bug Fixes**
- Regression tests execute the generated shell command with a fake daemon to verify a successful readiness result runs the probe, device, and invitation steps.
- The tests also confirm a failed result returns `3` without daemon calls and an enrolled device does not mint an invitation.

<sup>Written for commit 2bb8dd594eef9cc2bc979c33feed78a35311e226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11983?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed attach-bundle readiness handling so a successful readiness check now continues through device probing and invitation steps.
  - Ensured failed readiness checks stop the bundle process with the appropriate not-ready result, without prematurely interrupting successful flows.

- **Tests**
  - Expanded coverage for readiness outcomes, enrolled-device handling, command execution order, bundle contents, and temporary-resource cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->