### PR TITLE
Harden Cloud VM base snapshot ladder

### DIFF
--- a/.github/workflows/ci-status-fallback.yml
+++ b/.github/workflows/ci-status-fallback.yml
@@ -15,6 +15,7 @@ on:
       - tests/test_ci_change_areas.py
       - .github/workflows/ci.yml
     types: [opened, edited, reopened, synchronize, ready_for_review]
+  workflow_dispatch: {}
 
 permissions: {}
 

--- a/.github/workflows/cloud-vm-image-contract.yml
+++ b/.github/workflows/cloud-vm-image-contract.yml
@@ -1,0 +1,65 @@
+name: Cloud VM image contract
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - web/package.json
+      - web/bun.lock
+      - web/scripts/devbox-image-common.ts
+      - web/scripts/derive-devbox-sizes.ts
+      - web/scripts/promote-devbox-image.ts
+      - web/scripts/validate-devbox-ladder.ts
+      - web/services/vms/images/manifest.json
+      - web/services/vms/images/sizes.ts
+      - web/services/vms/images/devbox/**
+      - web/tests/vm-image-*.test.ts
+      - .github/workflows/cloud-vm-image-contract.yml
+  push:
+    branches: [main]
+    paths:
+      - web/package.json
+      - web/bun.lock
+      - web/scripts/devbox-image-common.ts
+      - web/scripts/derive-devbox-sizes.ts
+      - web/scripts/promote-devbox-image.ts
+      - web/scripts/validate-devbox-ladder.ts
+      - web/services/vms/images/manifest.json
+      - web/services/vms/images/sizes.ts
+      - web/services/vms/images/devbox/**
+      - web/tests/vm-image-*.test.ts
+      - .github/workflows/cloud-vm-image-contract.yml
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloud-vm-image-contract-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  contract:
+    runs-on: ubuntu-24.04
+    defaults:
+      run:
+        working-directory: web
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+        with:
+          bun-version: "1.3.14"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Validate the checked-in image ladder
+        run: bun run devbox:manifest:check
+
+      - name: Test image contracts
+        run: bun test tests/vm-image-manifest.test.ts tests/vm-image-sizes.test.ts tests/vm-devbox-image.test.ts

--- a/web/package.json
+++ b/web/package.json
@@ -23,6 +23,7 @@
     "devbox:bake:freestyle": "bun scripts/build-devbox-freestyle.ts",
     "devbox:verify": "bun scripts/verify-devbox-image.ts",
     "devbox:promote": "bun scripts/promote-devbox-image.ts",
+    "devbox:manifest:check": "bun scripts/validate-devbox-ladder.ts",
     "devbox:probe:busybox": "bun scripts/probe-busybox-cmux-tui.ts",
     "db:check": "bunx drizzle-kit check --config drizzle.config.ts",
     "db:down": "bash scripts/db-local.sh down",

--- a/web/scripts/derive-devbox-sizes.ts
+++ b/web/scripts/derive-devbox-sizes.ts
@@ -10,7 +10,7 @@
  *
  * Usage:
  *   FREESTYLE_API_KEY=... bun scripts/derive-devbox-sizes.ts <master-snapshot-id> <slug-prefix>
- *       [--sizes sm,md,lg,xl,2xl] [--out <json>] [--replace-slug]
+ *       [--sizes sm,md,lg,lgx,xl,2xl] [--out <json>] [--replace-slug]
  *
  * Prints one line per size and a final JSON `{ sizes: { <name>: { imageId, slug, size } } }`
  * (also written to --out). Every derived VM is booted once more from its own
@@ -52,6 +52,12 @@ const requested = (argValue("--sizes") ?? VM_IMAGE_SIZE_NAMES.join(",")).split("
 for (const name of requested) {
   if (!isVmImageSizeName(name)) throw new Error(`--sizes: unknown size ${name}; expected ${VM_IMAGE_SIZE_NAMES.join(", ")}`);
 }
+if (new Set(requested).size !== requested.length) {
+  throw new Error("--sizes: each machine size may appear only once");
+}
+if (!/^[a-z0-9](?:[a-z0-9-]{0,57}[a-z0-9])?$/.test(slugPrefix) || slugPrefix.includes("--")) {
+  throw new Error(`slug prefix ${slugPrefix} must be 1–59 chars of [a-z0-9-] with no leading, trailing, or repeated hyphens`);
+}
 const sizes = requested as VmImageSizeName[];
 const replaceSlug = hasFlag("--replace-slug");
 
@@ -67,8 +73,13 @@ async function sh(vm: Exec, command: string, timeoutMs = 120_000): Promise<{ cod
 /** What the guest sees; disk is the root filesystem after the grow. */
 async function measure(vm: Exec): Promise<{ cpu: number; memoryMb: number; rootMb: number; units: string }> {
   const r = await sh(vm, "echo cpu=$(nproc); echo mem=$(awk '/MemTotal/ {print int($2/1024)}' /proc/meminfo); echo root=$(df -BM --output=size / | tail -1 | tr -dc 0-9); echo units=$(systemctl is-active cmux-tui-daemon cmux-desktop 2>/dev/null | tr '\\n' ',')");
+  if (r.code !== 0) throw new Error(`could not measure VM: ${r.out.slice(-300)}`);
   const get = (key: string) => r.out.match(new RegExp(`${key}=([^\\n]*)`))?.[1] ?? "";
-  return { cpu: Number(get("cpu")), memoryMb: Number(get("mem")), rootMb: Number(get("root")), units: get("units") };
+  const measured = { cpu: Number(get("cpu")), memoryMb: Number(get("mem")), rootMb: Number(get("root")), units: get("units") };
+  if (![measured.cpu, measured.memoryMb, measured.rootMb].every((value) => Number.isFinite(value) && value > 0)) {
+    throw new Error(`VM measurement was incomplete: ${JSON.stringify(measured)}`);
+  }
+  return measured;
 }
 
 /** Guest memory is a little under the allocation (kernel reservations); the root fs a little under the disk. */
@@ -101,8 +112,12 @@ const result: Record<string, { imageId: string; slug: string | null; size: VmIma
 
 // The master's own shape, so a size it already has is recorded without a copy.
 const probe = await fs.vms.create({ snapshotId: master, displayName: `${slugPrefix} size-probe`, firewall: FIREWALL });
-const masterShape = await measure(probe.vm);
-await probe.vm.delete();
+let masterShape: Awaited<ReturnType<typeof measure>>;
+try {
+  masterShape = await measure(probe.vm);
+} finally {
+  await probe.vm.delete().catch(() => {});
+}
 console.log(`master ${master}: ${masterShape.cpu} vCPU, ${masterShape.memoryMb} MiB, root ${masterShape.rootMb} MiB`);
 
 // The master's own slug: a derived md keeps the bare prefix only when that

--- a/web/scripts/devbox-image-common.ts
+++ b/web/scripts/devbox-image-common.ts
@@ -18,7 +18,7 @@ import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
-import { vmImageSizeRank, type VmImageSizeName } from "../services/vms/images/sizes";
+import { VM_IMAGE_SIZES, VM_IMAGE_SIZE_NAMES, vmImageSizeRank, type VmImageSizeName } from "../services/vms/images/sizes";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 export const webRoot = path.resolve(__dirname, "..");
@@ -468,6 +468,7 @@ export function promoteImageManifestEntry(
     options.sizes && options.sizes.length > 0
       ? [...options.sizes].sort((a, b) => vmImageSizeRank(a.size.name) - vmImageSizeRank(b.size.name))
       : [{ imageId: entry.imageId }];
+  const promotesLocalDevBase = kinds.includes("base") && variants.some((variant) => variant.size?.name === "sm");
   for (const kind of kinds) {
     for (const variant of variants) {
       const clash = manifest.images.find((candidate) =>
@@ -487,6 +488,7 @@ export function promoteImageManifestEntry(
   const demoted = manifest.images.map((candidate) => {
     if (candidate.provider !== entry.provider) return candidate;
     const next: DevboxManifestEntry = { ...candidate };
+    if (promotesLocalDevBase && next.provider === entry.provider && next.defaultForLocalDev) next.defaultForLocalDev = false;
     // A sized promotion demotes the provider's size-less defaults too: the
     // ladder replaces the single-shape image, not just one row of it.
     const sameSize = promotedSizes.has(sizeKey(next)) || (sizeKey(next) === "" && promotedSizes.size > 0);
@@ -505,6 +507,9 @@ export function promoteImageManifestEntry(
         kind,
         defaultForKind: true,
         ...(variant.size ? { size: variant.size } : {}),
+        ...(promotesLocalDevBase && kind === "base" && variant.size?.name === "sm"
+          ? { defaultForLocalDev: true }
+          : {}),
         ...(notes ? { notes } : {}),
       });
     }
@@ -560,6 +565,75 @@ export function imageManifestProblems(manifest: DevboxImageManifest): string[] {
   for (const [key, entries] of defaults) {
     if (entries.length > 1) {
       problems.push(`${key}: ${entries.length} entries flagged defaultForKind (${entries.map((e) => e.version).join(", ")})`);
+    }
+  }
+  return problems;
+}
+
+/**
+ * Checks the production Freestyle defaults as a complete machine-size
+ * ladder. Historical, size-less entries remain valid for rollback, but active
+ * defaults must cover every size with the exact shape that the resolver uses.
+ */
+export function devboxImageLadderProblems(
+  manifest: DevboxImageManifest,
+  provider: DevboxProvider = "freestyle",
+): string[] {
+  const problems: string[] = [];
+  for (const kind of ["base", "desktop"] as const) {
+    const defaults = manifest.images.filter(
+      (entry) => entry.provider === provider && (entry.kind ?? "base") === kind && entry.defaultForKind,
+    );
+    if (defaults.length === 0) {
+      problems.push(`${provider}/${kind}: no default image ladder`);
+      continue;
+    }
+    const byName = new Map<string, DevboxManifestEntry>();
+    for (const entry of defaults) {
+      const sizeName = entry.size?.name;
+      if (!sizeName) {
+        problems.push(`${entry.version}: ${provider}/${kind} default is size-less`);
+        continue;
+      }
+      if (byName.has(sizeName)) {
+        problems.push(`${provider}/${kind}/${sizeName}: duplicate default images`);
+        continue;
+      }
+      byName.set(sizeName, entry);
+      const expected = VM_IMAGE_SIZES.find((size) => size.name === sizeName);
+      if (!expected) continue;
+      if (
+        entry.size?.cpu !== expected.cpu ||
+        entry.size.memoryMb !== expected.memoryMb ||
+        entry.size.storageMb !== expected.storageMb
+      ) {
+        problems.push(
+          `${entry.version}: ${provider}/${kind}/${sizeName} shape is ` +
+            `${entry.size?.cpu} vCPU/${entry.size?.memoryMb} MiB/${entry.size?.storageMb} MiB; ` +
+            `expected ${expected.cpu} vCPU/${expected.memoryMb} MiB/${expected.storageMb} MiB`,
+        );
+      }
+    }
+    for (const name of VM_IMAGE_SIZE_NAMES) {
+      if (!byName.has(name)) problems.push(`${provider}/${kind}: missing default size ${name}`);
+    }
+    const ids = new Map<string, string>();
+    for (const [name, entry] of byName) {
+      const previous = ids.get(entry.imageId);
+      if (previous) {
+        problems.push(`${provider}/${kind}: image ${entry.imageId} is used for sizes ${previous} and ${name}`);
+      } else {
+        ids.set(entry.imageId, name);
+      }
+    }
+  }
+  const localDefaults = manifest.images.filter((entry) => entry.provider === provider && entry.defaultForLocalDev);
+  if (localDefaults.length !== 1) {
+    problems.push(`${provider}: expected exactly one defaultForLocalDev entry, found ${localDefaults.length}`);
+  } else {
+    const local = localDefaults[0];
+    if ((local.kind ?? "base") !== "base" || local.size?.name !== "sm" || !local.defaultForKind) {
+      problems.push(`${local.version}: defaultForLocalDev must be the base sm default`);
     }
   }
   return problems;

--- a/web/scripts/promote-devbox-image.ts
+++ b/web/scripts/promote-devbox-image.ts
@@ -15,7 +15,7 @@
  *   --bake-result <json>  adopt a bake script's --out file (its manifest entry
  *               and image id) instead of baking; still verified.
  *   --sizes     ladder sizes to derive from the verified bake (default
- *               sm,md,lg,xl,2xl; "none" records a single size-less entry):
+ *               sm,md,lg,lgx,xl,2xl; "none" records a single size-less entry):
  *               derive-devbox-sizes.ts boots the bake, resizes, snapshots and
  *               re-boots each one; the manifest gets one entry per kind and
  *               size, each the default for that kind+size. The bake must be
@@ -23,8 +23,8 @@
  *               freestyle/ubuntu-sm).
  *   --kinds     machine kinds the image serves; each gets a manifest entry
  *               flagged defaultForKind (default: desktop,base for a desktop
- *               bake, base for --no-desktop). A desktop image is a superset
- *               of a base one, so one snapshot can serve both.
+ *               bake, base for --no-desktop). Desktop and base defaults are
+ *               promoted separately; a base promotion must use --no-desktop.
  *   --pointer-slug  After promotion, move this account-local
  *               snapshot slug onto the new id (default cmux-devbox; "none"
  *               disables). A human/dashboard convenience: production boots
@@ -93,6 +93,9 @@ const sizesArg = argValue("--sizes") ?? VM_IMAGE_SIZE_NAMES.join(",");
 const sizeNames = sizesArg === "none" ? [] : sizesArg.split(",").map((name) => name.trim()).filter(Boolean);
 for (const name of sizeNames) {
   if (!isVmImageSizeName(name)) throw new Error(`--sizes: unknown size ${name}; expected ${VM_IMAGE_SIZE_NAMES.join(", ")} or none`);
+}
+if (new Set(sizeNames).size !== sizeNames.length) {
+  throw new Error("--sizes: each machine size may appear only once");
 }
 const dryRun = hasFlag("--dry-run");
 const existingImage = argValue("--image");

--- a/web/scripts/validate-devbox-ladder.ts
+++ b/web/scripts/validate-devbox-ladder.ts
@@ -1,0 +1,17 @@
+#!/usr/bin/env bun
+/** Validate the checked-in Freestyle image manifest and its complete ladder. */
+import {
+  devboxImageLadderProblems,
+  imageManifestProblems,
+  readImageManifest,
+} from "./devbox-image-common";
+
+const manifest = readImageManifest();
+const problems = [...imageManifestProblems(manifest), ...devboxImageLadderProblems(manifest)];
+if (problems.length > 0) {
+  console.error(`devbox image manifest is invalid:\n  ${problems.join("\n  ")}`);
+  process.exit(1);
+}
+
+const defaults = manifest.images.filter((entry) => entry.provider === "freestyle" && entry.defaultForKind);
+console.log(`devbox image manifest ok: ${defaults.length} validated Freestyle defaults across base and desktop ladders`);

--- a/web/services/vms/images/devbox/README.md
+++ b/web/services/vms/images/devbox/README.md
@@ -85,9 +85,9 @@ on 6901. The contract (`web/services/vms/images/desktop.ts`;
   `ARG CMUX_IMAGE_GHOSTTY_DEB_SHA256` before dpkg runs); the apt list is
   `ARG CMUX_IMAGE_DESKTOP_PACKAGES`. `devbox-image-common.ts` reads all three.
 
-A desktop image is a superset of a base one, so one Freestyle snapshot is
-registered under both kinds (`desktop` and `base`). `--no-desktop` bakes a
-shell-only snapshot.
+Desktop and base defaults use separate snapshots. `--no-desktop --kinds base`
+builds the shell-only base ladder; the verifier reads `/etc/cmux/image-stamp`
+and rejects a desktop snapshot passed as a base image.
 
 The Freestyle base slug is only the input to the cmux bake. The ids recorded in
 `manifest.json` are cmux-derived snapshots, created by baking cmux-tui and its
@@ -168,6 +168,10 @@ picks the smallest size whose memory covers the plan's `memoryMb`
 (`defaultMemoryMbForPlan`; today's default of 8 GiB lands on `md`), so
 the driver never resizes at create and nothing has to grow at boot. Snapshot
 slugs are `cmux-devbox-<size>` (`cmux-devbox` for `md`).
+
+Run `bun run devbox:manifest:check` before a promotion. It requires one
+validated default for every size in both ladders and checks the recorded CPU,
+memory, and disk values against `sizes.ts`.
 
 ### BusyBox probe
 

--- a/web/services/vms/images/manifest.json
+++ b/web/services/vms/images/manifest.json
@@ -6,7 +6,6 @@
       "version": "freestyle-cmux-devbox-beta1",
       "imageId": "sh-fb3dcf7b47894114889b10186626af5b",
       "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
-      "defaultForLocalDev": false,
       "cmuxdRemoteCommit": "none-cmux-tui",
       "builtAt": "2026-08-28T10:35:57.736Z",
       "builderScriptVersion": "6e40d373a9e25289770d1bfbfc515becafbd905f3b448741df4cc4ea2f2c6cd1",
@@ -25,7 +24,6 @@
       "version": "freestyle-cmux-devbox-20260902a",
       "imageId": "sh-08be343bf2b54b4bb0e5226b97eaa6c4",
       "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
-      "defaultForLocalDev": false,
       "kind": "base",
       "cmuxdRemoteCommit": "none-cmux-tui",
       "builtAt": "2026-09-02T06:29:06.423Z",
@@ -45,7 +43,6 @@
       "version": "freestyle-cmux-devbox-20260902b",
       "imageId": "sh-749d7644e9b04ca38c0718b56a9b767b",
       "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
-      "defaultForLocalDev": false,
       "kind": "base",
       "cmuxdRemoteCommit": "none-cmux-tui",
       "builtAt": "2026-09-02T07:33:59.078Z",
@@ -65,7 +62,6 @@
       "version": "freestyle-cmux-devbox-20260902b-edge",
       "imageId": "sh-585b6809ec0f408080aa7e9963e0eac9",
       "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
-      "defaultForLocalDev": false,
       "kind": "base",
       "cmuxdRemoteCommit": "none-cmux-tui",
       "builtAt": "2026-09-02T08:42:55.891Z",
@@ -86,7 +82,6 @@
       "version": "freestyle-cmux-devbox-20260902c",
       "imageId": "sh-940ec3bc46224c019e5e8d9a97053293",
       "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
-      "defaultForLocalDev": false,
       "kind": "base",
       "cmuxdRemoteCommit": "none-cmux-tui",
       "builtAt": "2026-09-02T08:33:56.761Z",
@@ -107,7 +102,6 @@
       "version": "freestyle-cmux-devbox-20260902h",
       "imageId": "sh-1d66b9cad53a4811b5f63a4cae0b3faf",
       "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
-      "defaultForLocalDev": false,
       "kind": "desktop",
       "cmuxdRemoteCommit": "none-cmux-tui",
       "repoCommit": "a894e69ba5be298d82041469e306207eda581798",
@@ -129,7 +123,6 @@
       "version": "freestyle-cmux-devbox-20260902h-base",
       "imageId": "sh-1d66b9cad53a4811b5f63a4cae0b3faf",
       "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
-      "defaultForLocalDev": false,
       "kind": "base",
       "cmuxdRemoteCommit": "none-cmux-tui",
       "repoCommit": "a894e69ba5be298d82041469e306207eda581798",
@@ -727,8 +720,7 @@
       "notes": "cmux devbox epoch 2026-09-01-r3 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon f277fe6f46, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-02 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract).",
       "cmuxTuiCommit": "f277fe6f467225f82294298964ca8cb95d2f4dae",
       "cmuxTuiSha256": "cab5af6915128889f1ee512cbae9bc9f63914bcc724efbe3d9bfba12326370b7",
-      "defaultForKind": false,
-      "defaultForLocalDev": false
+      "defaultForKind": false
     },
     {
       "provider": "freestyle",
@@ -2546,7 +2538,6 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0b9a8bfea4, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-eccf06e798fe4cd98bc0009ad709a3db, md=sh-0fb8713a752d4e5c99a05784eabc5c20, lg=sh-bc926cd8eb63412abf08645f4e4366a5, lgx=sh-bf4a83b45171495f86b81ecffa125ec0, xl=sh-87ffa11c724d4906ba5b53786f87caca, 2xl=sh-3039d8d90c424750ac05f609ad0aad53.",
       "cmuxTuiCommit": "0b9a8bfea493a05c041724ce99ca995455a5dcf0",
       "cmuxTuiSha256": "180a6d7cb6bed652083b832506690a19556fcc855d89e192635aa7bbd7040a13",
-      "defaultForLocalDev": false,
       "defaultForKind": false,
       "size": {
         "name": "sm",
@@ -2905,7 +2896,6 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon 0b9a8bfea4, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-d133043a79c24e98b14f33dc5eb591a3, md=sh-0405402edc6d471fb758142bea5a9b3f, lg=sh-d688562213fa40bd9681a591ea6ac0f6, lgx=sh-8bc500fc9a734387b090cd3cfe2e2166, xl=sh-ee55cacc20994aceb476ae735372fa31, 2xl=sh-11ae8b20c08f4af38c1514cbc2753569.",
       "cmuxTuiCommit": "0b9a8bfea493a05c041724ce99ca995455a5dcf0",
       "cmuxTuiSha256": "180a6d7cb6bed652083b832506690a19556fcc855d89e192635aa7bbd7040a13",
-      "defaultForLocalDev": false,
       "defaultForKind": false,
       "size": {
         "name": "sm",
@@ -3264,8 +3254,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForLocalDev": true,
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "sm",
         "cpu": 2,
@@ -3295,7 +3284,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "md",
         "cpu": 4,
@@ -3325,7 +3314,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lg",
         "cpu": 8,
@@ -3355,7 +3344,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "lgx",
         "cpu": 12,
@@ -3384,7 +3373,7 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
-      "defaultForKind": true,
+      "defaultForKind": false,
       "size": {
         "name": "xl",
         "cpu": 16,
@@ -3414,6 +3403,186 @@
       "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner, and the desktop layer (openbox/TigerVNC 5901, noVNC 6901, Ghostty, Chrome, Thunar) run by the cmux-desktop systemd unit as ubuntu; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon ca51db2c8f, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract, desktop on 5901/6901). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-0003615f317e430b9476e311b283fa12, md=sh-68828c99790541b7bc5d03d20e0564e1, lg=sh-11c8a7c5b83c47e7867ba0157b0fdb36, lgx=sh-f8fe1e9a5b184e139015806f208beb32, xl=sh-f78366e5a8884c6e81095f6a88ee14ae, 2xl=sh-2cf1a9cf5f194bb38328f026bc27e1ff.",
       "cmuxTuiCommit": "ca51db2c8fc2ebe7fb21ef5099c28ad878945c93",
       "cmuxTuiSha256": "3b6f987e7727cd04307088f73f5bd5d6135672eea1b93fb0ee846d3a0e60bde6",
+      "defaultForKind": false,
+      "size": {
+        "name": "2xl",
+        "cpu": 32,
+        "memoryMb": 65536,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-2xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-terminfo5-base-sm",
+      "imageId": "sh-c7fc7b1bfc2147fca8aefb56eb2e0056",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "557705c760118e2bf390f854e86d04d491bb1a1a",
+      "builtAt": "2026-09-04T23:49:07.277Z",
+      "builderScriptVersion": "579c4d30beddd6c16342dfa7a62539054faa6f9d007a44a4379f77809cee3cdd",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
+      "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
+      "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
+      "defaultForKind": true,
+      "size": {
+        "name": "sm",
+        "cpu": 2,
+        "memoryMb": 4096,
+        "storageMb": 16384,
+        "freestyleBase": "freestyle/ubuntu-sm"
+      },
+      "defaultForLocalDev": true
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-terminfo5-base-md",
+      "imageId": "sh-3a917ad675fb4e458a3e55b02c612f27",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "557705c760118e2bf390f854e86d04d491bb1a1a",
+      "builtAt": "2026-09-04T23:49:07.277Z",
+      "builderScriptVersion": "579c4d30beddd6c16342dfa7a62539054faa6f9d007a44a4379f77809cee3cdd",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
+      "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
+      "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
+      "defaultForKind": true,
+      "size": {
+        "name": "md",
+        "cpu": 4,
+        "memoryMb": 8192,
+        "storageMb": 32768,
+        "freestyleBase": "freestyle/ubuntu"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-terminfo5-base-lg",
+      "imageId": "sh-c6509e514cb94e0e992428ed4c700d88",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "557705c760118e2bf390f854e86d04d491bb1a1a",
+      "builtAt": "2026-09-04T23:49:07.277Z",
+      "builderScriptVersion": "579c4d30beddd6c16342dfa7a62539054faa6f9d007a44a4379f77809cee3cdd",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
+      "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
+      "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
+      "defaultForKind": true,
+      "size": {
+        "name": "lg",
+        "cpu": 8,
+        "memoryMb": 16384,
+        "storageMb": 65536,
+        "freestyleBase": "freestyle/ubuntu-lg"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-terminfo5-base-lgx",
+      "imageId": "sh-17fa02b5bbf549489b8da67a6ad429d8",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "557705c760118e2bf390f854e86d04d491bb1a1a",
+      "builtAt": "2026-09-04T23:49:07.277Z",
+      "builderScriptVersion": "579c4d30beddd6c16342dfa7a62539054faa6f9d007a44a4379f77809cee3cdd",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
+      "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
+      "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
+      "defaultForKind": true,
+      "size": {
+        "name": "lgx",
+        "cpu": 12,
+        "memoryMb": 24576,
+        "storageMb": 98304
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-terminfo5-base-xl",
+      "imageId": "sh-82c12d64d147464db20cc8256da77696",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "557705c760118e2bf390f854e86d04d491bb1a1a",
+      "builtAt": "2026-09-04T23:49:07.277Z",
+      "builderScriptVersion": "579c4d30beddd6c16342dfa7a62539054faa6f9d007a44a4379f77809cee3cdd",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
+      "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
+      "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
+      "defaultForKind": true,
+      "size": {
+        "name": "xl",
+        "cpu": 16,
+        "memoryMb": 32768,
+        "storageMb": 131072,
+        "freestyleBase": "freestyle/ubuntu-xl"
+      }
+    },
+    {
+      "provider": "freestyle",
+      "version": "freestyle-cmux-devbox-terminfo5-base-2xl",
+      "imageId": "sh-440f39219c7f4858977d0b2e9804838d",
+      "envVar": "FREESTYLE_SANDBOX_SNAPSHOT",
+      "kind": "base",
+      "cmuxdRemoteCommit": "none-cmux-tui",
+      "repoCommit": "557705c760118e2bf390f854e86d04d491bb1a1a",
+      "builtAt": "2026-09-04T23:49:07.277Z",
+      "builderScriptVersion": "579c4d30beddd6c16342dfa7a62539054faa6f9d007a44a4379f77809cee3cdd",
+      "agentToolResolvedVersions": {
+        "@anthropic-ai/claude-code": "2.1.252",
+        "@openai/codex": "0.151.0",
+        "opencode-ai": "1.18.25",
+        "@earendil-works/pi-coding-agent": "0.84.4",
+        "agent-browser": "0.35.2"
+      },
+      "validationStatus": "passed",
+      "notes": "cmux devbox epoch 2026-09-02-r4 Devbox on the Freestyle public platform (api.freestyle.sh) from freestyle/ubuntu-sm: the base's Node/Bun/Python/uv/Docker plus pinned agents, devtools, Chrome + cua-driver, ble.sh devshell, cmux login banner; ubuntu (uid 1000, NOPASSWD sudo) is the work user; baked cmux-tui daemon dbc4b56210, identity bound to the instance id, no create-time bootstrap. Validated 2026-09-04 with verify-devbox-image.ts by promote-devbox-image.ts (toolchain, agent pins, daemon contract). Sizes derived and re-booted by derive-devbox-sizes.ts: sm=sh-c7fc7b1bfc2147fca8aefb56eb2e0056, md=sh-3a917ad675fb4e458a3e55b02c612f27, lg=sh-c6509e514cb94e0e992428ed4c700d88, lgx=sh-17fa02b5bbf549489b8da67a6ad429d8, xl=sh-82c12d64d147464db20cc8256da77696, 2xl=sh-440f39219c7f4858977d0b2e9804838d.",
+      "cmuxTuiCommit": "dbc4b56210592341acd1f51c420cd7b743152424",
+      "cmuxTuiSha256": "861a3892e76e78eb4a5560dbfca48315f2c49a27b724f80b986a9ebb0de2374f",
       "defaultForKind": true,
       "size": {
         "name": "2xl",

--- a/web/tests/vm-image-manifest.test.ts
+++ b/web/tests/vm-image-manifest.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  devboxImageLadderProblems,
   imageManifestProblems,
   promoteImageManifestEntry,
   readImageManifest,
@@ -41,6 +42,36 @@ describe("checked-in image manifest", () => {
           .toEqual({ version: entry.version, validationStatus: "passed" });
       }
     }
+  });
+
+  test("has a complete, shape-correct base and desktop ladder", () => {
+    expect(devboxImageLadderProblems(readImageManifest())).toEqual([]);
+  });
+});
+
+describe("devboxImageLadderProblems", () => {
+  test("rejects a missing size and a wrong shape", () => {
+    const manifest = readImageManifest();
+    const base = manifest.images.filter((entry) => {
+      const isBaseDefault =
+        entry.provider === "freestyle" &&
+        (entry.kind ?? "base") === "base" &&
+        entry.defaultForKind;
+      return !isBaseDefault || !["sm", "md"].includes(entry.size?.name ?? "");
+    });
+    const sm = manifest.images.find(
+      (entry) => entry.provider === "freestyle" && (entry.kind ?? "base") === "base" && entry.size?.name === "sm" && entry.defaultForKind,
+    )!;
+    const bad = {
+      ...manifest,
+      images: [
+        ...base,
+        { ...sm, size: { ...sm.size!, memoryMb: sm.size!.memoryMb + 1 }, version: `${sm.version}-bad`, imageId: `${sm.imageId}-bad`, defaultForKind: true },
+      ],
+    };
+    const problems = devboxImageLadderProblems(bad);
+    expect(problems.some((problem) => problem.includes("missing default size md"))).toBe(true);
+    expect(problems.some((problem) => problem.includes("shape is"))).toBe(true);
   });
 });
 

--- a/web/tests/vm-image-sizes.test.ts
+++ b/web/tests/vm-image-sizes.test.ts
@@ -78,7 +78,7 @@ describe("promoteImageManifestEntry with sizes", () => {
     schemaVersion: 1,
     images: [
       // A pre-ladder, size-less default: the sized promotion replaces it.
-      entry({ version: "freestyle-old", imageId: "sh-old", kind: "base", defaultForKind: true }),
+      entry({ version: "freestyle-old", imageId: "sh-old", kind: "base", defaultForKind: true, defaultForLocalDev: true }),
       // An old desktop default: not this promotion's kind, untouched.
       entry({ version: "freestyle-old-desktop", imageId: "sh-old-d", kind: "desktop", defaultForKind: true }),
     ],
@@ -87,7 +87,7 @@ describe("promoteImageManifestEntry with sizes", () => {
   test("writes one entry per kind and size, ladder order, and demotes the size-less default", () => {
     const next = promoteImageManifestEntry(base, entry(), { kinds: ["base"], sizes, validationNotes: "ok" });
     expect(imageManifestProblems(next)).toEqual([]);
-    expect(next.images[0]).toMatchObject({ version: "freestyle-old", defaultForKind: false });
+    expect(next.images[0]).toMatchObject({ version: "freestyle-old", defaultForKind: false, defaultForLocalDev: false });
     expect(next.images[1]).toMatchObject({ version: "freestyle-old-desktop", defaultForKind: true });
     expect(next.images.slice(2).map((e) => [e.version, e.imageId, e.kind, e.size?.name, e.defaultForKind])).toEqual([
       ["freestyle-cmux-devbox-test-sm", "sh-sm", "base", "sm", true],
@@ -95,6 +95,7 @@ describe("promoteImageManifestEntry with sizes", () => {
       ["freestyle-cmux-devbox-test-xl", "sh-xl", "base", "xl", true],
     ]);
     expect(next.images[2].size).toEqual({ name: "sm", cpu: 2, memoryMb: 4096, storageMb: 16384, freestyleBase: "freestyle/ubuntu-sm" });
+    expect(next.images[2].defaultForLocalDev).toBe(true);
     expect(next.images[2].notes).toBe("epoch test ok");
   });
 


### PR DESCRIPTION
## Problem
The checked-in `base` defaults pointed at snapshots stamped with the desktop layer. The image promotion path also allowed incomplete or incorrectly shaped size ladders to become defaults.

## Change
- Build and promote a fresh shell-only Freestyle base ladder for `sm`, `md`, `lg`, `lgx`, `xl`, and `2xl`.
- Move local development to the new base `sm` snapshot.
- Add a manifest contract checker for complete, unique, shape-correct validated ladders.
- Make size derivation reject duplicate sizes, invalid slug prefixes, incomplete measurements, and leaked probe VMs.
- Add CI coverage for the manifest and image template contracts.
- Document separate base and desktop promotion rules.

## Live validation
- Fresh no-desktop bake passed `verify-devbox-image.ts --expect-kind base`.
- All six promoted base snapshot IDs passed the full verifier.
- Every derived size was rebooted and shape-checked during promotion.
- `bun run devbox:manifest:check` passed.
- Focused image tests passed: 39 tests, 0 failures.
- `bun run typecheck` passed.
- `bun run lint:complexity` passed.
- Targeted ESLint passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11984"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791158465&installation_model_id=21920&pr_number=11984&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11984&signature=e16602abedac764dd8f16863a68f643fec476d4c0dc899d3f4ff7ddbe37b929c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the checked-in base defaults, which pointed at snapshots stamped with the desktop layer, with a fresh shell-only base ladder for `sm`, `md`, `lg`, `lgx`, `xl`, and `2xl`, and moves local development to the new base `sm` snapshot. Also lets the CI status fallback workflow be triggered manually so a stale check can be re-run without a new commit.

**Validation and guards**
- Adds a manifest contract checker requiring one complete, unique, shape-correct validated default per size in both the base and desktop ladders.
- Size derivation now rejects duplicate sizes, invalid slug prefixes, and incomplete measurements, and cleans up probe VMs on failure.
- Adds CI coverage for the manifest, size, and image contract tests.
- Promotes base and desktop defaults separately; base promotion must use `--no-desktop`.

<sup>Written for commit aeffed1559666938c8ee7d50915eba7f4dfc61b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11984?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a new Devbox image ladder covering base and desktop configurations across multiple VM sizes, including the new `lgx` size.
  - Added a dedicated shell-only base image ladder with a separate local-development default.
- **Bug Fixes**
  - Improved image promotion and validation to detect duplicate sizes, invalid image metadata, missing defaults, and mismatched resource shapes.
- **Tests**
  - Added automated checks to verify Devbox image manifests and default ladders remain valid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->