### PR TITLE
feat(auth): loopback sign-in for Linux TUI flows

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/auth.rs
+++ b/cmux-tui/crates/cmux-tui/src/auth.rs
@@ -1,0 +1,371 @@
+//! Account sign-in for the standalone TUI (headless/Linux flows).
+//!
+//! Mirrors the macOS `HostBrowserSignInFlow` contract end to end:
+//! `handler/native-sign-in` (mints the server-side handoff nonce) -> Stack
+//! sign-in -> `handler/after-sign-in` (extracts Stack tokens, validates the
+//! return-to) -> loopback callback carrying `cmux_auth_state`,
+//! `stack_refresh`, and `stack_access`.
+//!
+//! Tokens persist to the platform state directory with 0600 permissions.
+//! This module is dependency-light on purpose: the web handler performs the
+//! Stack work, so the TUI only needs a loopback listener and a JSON store.
+
+use std::fs;
+use std::io::{Read as _, Write as _};
+use std::net::{TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::PathBuf;
+use std::process::Command;
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
+
+use base64::Engine as _;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD as BASE64URL;
+use serde_json::Value;
+
+use crate::cli::AuthAction;
+
+const AUTH_WEB_ORIGIN: &str = "https://cmux.com";
+const CALLBACK_PATH: &str = "/auth-callback";
+const STATE_PARAM: &str = "cmux_auth_state";
+const LOGIN_TIMEOUT: Duration = Duration::from_secs(305);
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+struct StoredTokens {
+    refresh_token: String,
+    access_token: String,
+    stored_at_epoch: u64,
+}
+
+fn store_path() -> PathBuf {
+    let root = std::env::var("XDG_STATE_HOME")
+        .ok()
+        .filter(|value| !value.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| {
+            let home = std::env::var("HOME").unwrap_or_else(|_| ".".to_string());
+            PathBuf::from(home).join(".local/state")
+        });
+    root.join("cmux").join("auth.json")
+}
+
+fn load_tokens() -> Option<StoredTokens> {
+    let raw = fs::read_to_string(store_path()).ok()?;
+    serde_json::from_str(&raw).ok()
+}
+
+fn save_tokens(refresh_token: &str, access_token: &str) -> Result<(), String> {
+    let path = store_path();
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|error| format!("create state dir: {error}"))?;
+        let _ = fs::set_permissions(parent, fs::Permissions::from_mode(0o700));
+    }
+    let stored_at_epoch = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|value| value.as_secs())
+        .unwrap_or_default();
+    let tokens = StoredTokens {
+        refresh_token: refresh_token.to_string(),
+        access_token: access_token.to_string(),
+        stored_at_epoch,
+    };
+    let body =
+        serde_json::to_string_pretty(&tokens).map_err(|error| format!("encode tokens: {error}"))?;
+    fs::write(&path, body).map_err(|error| format!("write tokens: {error}"))?;
+    fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+        .map_err(|error| format!("chmod tokens: {error}"))?;
+    Ok(())
+}
+
+fn percent_encode_component(value: &str) -> String {
+    let mut encoded = String::with_capacity(value.len());
+    for byte in value.as_bytes() {
+        let unreserved = byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'.' | b'_' | b'~');
+        if unreserved {
+            encoded.push(*byte as char);
+        } else {
+            encoded.push_str(&format!("%{byte:02X}"));
+        }
+    }
+    encoded
+}
+
+fn random_state() -> String {
+    let mut bytes = [0u8; 32];
+    getrandom::fill(&mut bytes).expect("getrandom failure");
+    let mut hex = String::with_capacity(bytes.len() * 2);
+    for byte in bytes {
+        hex.push_str(&format!("{byte:02x}"));
+    }
+    hex
+}
+
+/// The exact URL chain the macOS app builds in
+/// `AuthEnvironment.signInURL(callbackState:)`.
+fn sign_in_url(callback_state: &str, listener_port: u16) -> String {
+    let native_callback = format!(
+        "http://127.0.0.1:{listener_port}{CALLBACK_PATH}?{STATE_PARAM}={callback_state}"
+    );
+    let after_sign_in = format!(
+        "{AUTH_WEB_ORIGIN}/handler/after-sign-in?native_app_return_to={}",
+        percent_encode_component(&native_callback)
+    );
+    format!(
+        "{AUTH_WEB_ORIGIN}/handler/native-sign-in?after_auth_return_to={}",
+        percent_encode_component(&after_sign_in)
+    )
+}
+
+fn try_open_browser(url: &str) -> bool {
+    let program: &str = if cfg!(target_os = "macos") { "open" } else { "xdg-open" };
+    Command::new(program).arg(url).spawn().is_ok()
+}
+
+fn parse_query(query: &str) -> Vec<(String, String)> {
+    query
+        .split('&')
+        .filter(|pair| !pair.is_empty())
+        .map(|pair| match pair.split_once('=') {
+            Some((name, value)) => (name.to_string(), decode_component(value)),
+            None => (decode_component(pair), String::new()),
+        })
+        .collect()
+}
+
+fn decode_component(value: &str) -> String {
+    let bytes = value.as_bytes();
+    let mut decoded = Vec::with_capacity(bytes.len());
+    let mut index = 0;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'%' if index + 2 < bytes.len() => {
+                let hex = &value[index + 1..index + 3];
+                match u8::from_str_radix(hex, 16) {
+                    Ok(byte) => {
+                        decoded.push(byte);
+                        index += 3;
+                    }
+                    Err(_) => {
+                        decoded.push(bytes[index]);
+                        index += 1;
+                    }
+                }
+            }
+            b'+' => {
+                decoded.push(b' ');
+                index += 1;
+            }
+            byte => {
+                decoded.push(byte);
+                index += 1;
+            }
+        }
+    }
+    String::from_utf8_lossy(&decoded).into_owned()
+}
+
+fn read_request(stream: &mut TcpStream) -> Option<String> {
+    let mut buffer = Vec::new();
+    let mut chunk = [0u8; 4096];
+    loop {
+        match stream.read(&mut chunk) {
+            Ok(0) => break,
+            Ok(read) => {
+                buffer.extend_from_slice(&chunk[..read]);
+                if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+                    break;
+                }
+                if buffer.len() > 64 * 1024 {
+                    break;
+                }
+            }
+            Err(_) => break,
+        }
+    }
+    let head = String::from_utf8_lossy(&buffer);
+    head.lines().next().map(str::to_string)
+}
+
+fn respond_success(stream: &mut TcpStream) {
+    let body = "<!doctype html><title>cmux</title><p>Signed in. You can close this window.</p>";
+    let response = format!(
+        "HTTP/1.1 200 OK\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(response.as_bytes());
+    let _ = stream.flush();
+}
+
+/// Decode the Stack access JWT payload and return (sub, exp_epoch).
+fn decode_access_token(access_token: &str) -> Option<(String, Option<u64>)> {
+    let mut parts = access_token.split('.');
+    let _header = parts.next()?;
+    let payload = parts.next()?;
+    let decoded = BASE64URL.decode(payload.trim_end_matches('=').as_bytes()).ok()?;
+    let value: Value = serde_json::from_slice(&decoded).ok()?;
+    let sub = value.get("sub").and_then(Value::as_str)?.to_string();
+    let exp = value.get("exp").and_then(Value::as_u64);
+    Some((sub, exp))
+}
+
+fn print_status() -> i32 {
+    match load_tokens() {
+        None => {
+            println!("Not signed in.");
+            println!("Run: cmux auth login");
+            0
+        }
+        Some(tokens) => {
+            println!("Signed in.");
+            if let Some((sub, exp)) = decode_access_token(&tokens.access_token) {
+                println!("  user_id:  {sub}");
+                if let Some(exp) = exp {
+                    let now = SystemTime::now()
+                        .duration_since(UNIX_EPOCH)
+                        .map(|value| value.as_secs())
+                        .unwrap_or_default();
+                    if exp <= now {
+                        println!("  note:     access token expired; refresh lands in a follow-up");
+                    }
+                }
+            }
+            0
+        }
+    }
+}
+
+fn run_login() -> i32 {
+    if load_tokens().is_some() {
+        println!("Already signed in. Use `cmux auth logout` to sign out first.");
+        return 0;
+    }
+    let listener = match TcpListener::bind(("127.0.0.1", 0)) {
+        Ok(listener) => listener,
+        Err(error) => {
+            eprintln!("cmux: bind loopback listener: {error}");
+            return 1;
+        }
+    };
+    let port = match listener.local_addr() {
+        Ok(address) => address.port(),
+        Err(error) => {
+            eprintln!("cmux: read listener port: {error}");
+            return 1;
+        }
+    };
+    let state = random_state();
+    let url = sign_in_url(&state, port);
+    println!("Opening sign-in on the cmux web app.");
+    println!("Sign-in URL: {url}");
+    let opened = try_open_browser(&url);
+    if !opened {
+        println!("Open this URL to sign in:");
+        println!("{url}");
+    }
+    println!("Waiting for the sign-in callback on 127.0.0.1:{port} (5m timeout)...");
+    let deadline = Instant::now() + LOGIN_TIMEOUT;
+    listener
+        .set_nonblocking(true)
+        .expect("listener nonblocking mode");
+    while Instant::now() < deadline {
+        let (mut stream, _) = match listener.accept() {
+            Ok(connection) => connection,
+            Err(error) if error.kind() == std::io::ErrorKind::WouldBlock => {
+                std::thread::sleep(Duration::from_millis(100));
+                continue;
+            }
+            Err(error) => {
+                eprintln!("cmux: accept: {error}");
+                return 1;
+            }
+        };
+        stream
+            .set_read_timeout(Some(Duration::from_secs(15)))
+            .expect("read timeout");
+        let request_line = match read_request(&mut stream) {
+            Some(line) => line,
+            None => continue,
+        };
+        let target = request_line.split_whitespace().nth(1).unwrap_or("").to_string();
+        if !target.starts_with(CALLBACK_PATH) {
+            respond_success(&mut stream);
+            continue;
+        }
+        let query = target.split_once('?').map(|(_, value)| value).unwrap_or("");
+        let params = parse_query(query);
+        let state_ok = params
+            .iter()
+            .any(|(name, value)| name == STATE_PARAM && *value == state);
+        if !state_ok {
+            let body = "<!doctype html><title>cmux</title><p>Sign-in state mismatch. Restart `cmux auth login`.</p>";
+            let response = format!(
+                "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes());
+            continue;
+        }
+        let refresh = params
+            .iter()
+            .find(|(name, _)| name == "stack_refresh")
+            .map(|(_, value)| value.clone());
+        let access = params
+            .iter()
+            .find(|(name, _)| name == "stack_access")
+            .map(|(_, value)| value.clone());
+        // `stack_access` is the Stack cookie payload: ["<refresh>", "<access>"].
+        let access_token = access.as_deref().and_then(|value| {
+            serde_json::from_str::<Vec<String>>(value)
+                .ok()
+                .and_then(|parts| parts.get(1).cloned())
+        });
+        let (refresh_token, access_token) = match (refresh, access_token) {
+            (Some(refresh), Some(access)) => (refresh, access),
+            _ => {
+                let body = "<!doctype html><title>cmux</title><p>Sign-in callback missing tokens.</p>";
+                let response = format!(
+                    "HTTP/1.1 400 Bad Request\r\nContent-Type: text/html; charset=utf-8\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                    body.len(),
+                    body
+                );
+                let _ = stream.write_all(response.as_bytes());
+                continue;
+            }
+        };
+        if let Err(error) = save_tokens(&refresh_token, &access_token) {
+            eprintln!("cmux: {error}");
+            return 1;
+        }
+        respond_success(&mut stream);
+        println!("Signed in.");
+        return 0;
+    }
+    println!("Timed out waiting for sign-in. Run `cmux auth status` once you've finished in the browser.");
+    1
+}
+
+fn run_logout() -> i32 {
+    if load_tokens().is_none() {
+        println!("Already signed out.");
+        return 0;
+    }
+    match fs::remove_file(store_path()) {
+        Ok(()) => {
+            println!("Signed out.");
+            0
+        }
+        Err(error) => {
+            eprintln!("cmux: clear tokens: {error}");
+            1
+        }
+    }
+}
+
+pub(crate) fn run(action: AuthAction) -> i32 {
+    match action {
+        AuthAction::Status => print_status(),
+        AuthAction::Login => run_login(),
+        AuthAction::Logout => run_logout(),
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/cli.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli.rs
@@ -6,6 +6,8 @@
 
 mod command;
 mod lifecycle;
+
+pub(crate) use command::AuthAction;
 mod raw;
 mod wire;
 
@@ -28,6 +30,7 @@ const PUBLIC_SCOPES: &[&str] = &[
     "browser",
     "notification",
     "agent",
+    "auth",
     "sidebar",
     "pairing",
     "projection",
@@ -158,6 +161,7 @@ pub fn run(args: &[String], startup_usage: &str) -> i32 {
         Ok(ParsedCommand::Command { global, plan }) => match plan {
             CommandPlan::Server(server) => lifecycle::run(global, server),
             CommandPlan::AgentHooks(plan) => command::run_agent_hooks(global, plan),
+            CommandPlan::Auth(plan) => crate::auth::run(plan.action),
             CommandPlan::Protocol(request) => wire::run(global, request),
             CommandPlan::SessionResetState(plan) => command::run_session_reset_state(global, plan),
             CommandPlan::Plugin(plugin) => command::run_plugin(global, plugin),

--- a/cmux-tui/crates/cmux-tui/src/cli/command.rs
+++ b/cmux-tui/crates/cmux-tui/src/cli/command.rs
@@ -24,6 +24,7 @@ pub(super) enum CommandPlan {
     Plugin(PluginPlan),
     ProviderAuthority(ProviderAuthorityPlan),
     RawCommand(super::raw::RawCommandPlan),
+    Auth(AuthPlan),
 }
 
 #[derive(Clone, Debug)]
@@ -171,10 +172,38 @@ pub(super) fn parse(args: &[String]) -> Result<CommandPlan, UsageError> {
         "projection" => parse_projection(&tokens.words[1..], &mut selectors, &mut tokens.flags)?,
         "provider" => parse_provider(&tokens.words[1..], &mut selectors, &mut tokens.flags)?,
         "raw" => parse_raw(&tokens.words[1..], &mut tokens.flags)?,
+        "auth" => parse_auth(&tokens.words[1..])?,
         value => return Err(super::unknown_scope(value)),
     };
     tokens.flags.reject_remaining()?;
     Ok(plan)
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum AuthAction {
+    Status,
+    Login,
+    Logout,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(super) struct AuthPlan {
+    pub action: AuthAction,
+}
+
+fn parse_auth(words: &[String]) -> Result<CommandPlan, UsageError> {
+    let action = match strs(words).as_slice() {
+        ["status"] => AuthAction::Status,
+        ["login"] => AuthAction::Login,
+        ["logout"] => AuthAction::Logout,
+        [action] => {
+            return Err(UsageError::new(format!(
+                "unknown auth action: {action}; use status|login|logout"
+            )));
+        }
+        _ => return Err(UsageError::new("usage: cmux auth <status|login|logout>")),
+    };
+    Ok(CommandPlan::Auth(AuthPlan { action }))
 }
 
 fn parse_server(words: &[String], flags: &mut Flags) -> Result<CommandPlan, UsageError> {

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -10,6 +10,7 @@
 mod agent_browser_provider;
 mod agent_hook_install;
 mod app;
+mod auth;
 mod browser_input;
 mod cli;
 mod client_log;

--- a/web/app/handler/after-sign-in/handler.ts
+++ b/web/app/handler/after-sign-in/handler.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import {
   DEFAULT_NATIVE_CALLBACK_SCHEME,
+  isAllowedLoopbackReturnTo,
   isAllowedNativeReturnTo,
 } from "../../lib/native-callback";
 import {
@@ -468,7 +469,11 @@ export function makeAfterSignInHandler(dependencies: AfterSignInHandlerDependenc
       );
       if (
         trustedPurchaseReturnTo === nativeReturnTo ||
-        isAllowedNativeReturnTo(nativeReturnTo, request)
+        isAllowedNativeReturnTo(nativeReturnTo, request) ||
+        // Loopback CLI/TUI callbacks mirror native scheme callbacks: the
+        // verified handoff nonce (checked below) decides auto-redirect vs
+        // the manual return page.
+        isAllowedLoopbackReturnTo(nativeReturnTo)
       ) {
         const href = buildNativeHref(nativeReturnTo, refreshToken, accessCookie);
         if (href) {

--- a/web/app/lib/native-callback.ts
+++ b/web/app/lib/native-callback.ts
@@ -40,7 +40,27 @@ export function isAllowedNativeReturnTo(
   }
 }
 
-export function isAllowedNativeScheme(
+export 
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "::1", "localhost"]);
+/**
+ * Loopback HTTP/HTTPS callbacks for CLI/TUI sign-in flows. Unlike native
+ * scheme callbacks these point at a listener on the signing user own
+ * machine, so they are only honored together with a verified handoff nonce
+ * (enforced at the after-sign-in call site). The path is pinned to the
+ * native callback host segment to keep the accepted target shape identical.
+ */
+export function isAllowedLoopbackReturnTo(href: string): boolean {
+  try {
+    const url = new URL(href);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return false;
+    if (!LOOPBACK_HOSTS.has(url.hostname.toLowerCase())) return false;
+    return url.pathname === "/" + NATIVE_CALLBACK_HOST;
+  } catch {
+    return false;
+  }
+}
+
+function isAllowedNativeScheme(
   scheme: string,
   request: NextRequest,
 ): boolean {

--- a/web/tests/after-sign-in-route.test.ts
+++ b/web/tests/after-sign-in-route.test.ts
@@ -425,6 +425,44 @@ describe("after sign-in native handoff", () => {
       }
     }
   });
+  test("redirects verified loopback CLI handoffs to the loopback listener", async () => {
+    handoffCookie = "handoff-nonce";
+    const nativeReturnTo =
+      "http://127.0.0.1:45991/auth-callback?cmux_auth_state=state-123";
+    const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+    expect(response.status).toBe(307);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    const location = response.headers.get("location");
+    expect(location).toBeTruthy();
+    const callbackURL = new URL(location!);
+    expect(callbackURL.protocol).toBe("http:");
+    expect(callbackURL.hostname).toBe("127.0.0.1");
+    expect(callbackURL.port).toBe("45991");
+    expect(callbackURL.pathname).toBe("/auth-callback");
+    expect(callbackURL.searchParams.get("cmux_auth_state")).toBe("state-123");
+    expect(callbackURL.searchParams.get("stack_refresh")).toBe("refresh-token");
+    expect(callbackURL.searchParams.get("stack_access")).toBe(
+      JSON.stringify(["refresh-token", "access-token"])
+    );
+  });
+  test("keeps the manual return page for loopback targets without a verified handoff nonce", async () => {
+    handoffCookie = "different-nonce";
+    const nativeReturnTo =
+      "http://127.0.0.1:45991/auth-callback?cmux_auth_state=state-123";
+    const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+    expect(response.status).toBe(200);
+    const html = await response.text();
+    expect(html).toContain("Return to cmux");
+    expect(returnHref(html)).toContain("http://127.0.0.1:45991/auth-callback");
+    expect(response.headers.get("location")).toBeNull();
+  });
+  test("rejects non-loopback http return-tos even with a verified handoff", async () => {
+    handoffCookie = "handoff-nonce";
+    const nativeReturnTo =
+      "http://attacker.example/auth-callback?cmux_auth_state=state-123";
+    const response = await GET(signInRequest(nativeReturnTo, "handoff-nonce"));
+    expect(response.headers.get("location")).toBe("https://cmux.test/");
+  });
 });
 
 describe("sign out and sign back in", () => {


### PR DESCRIPTION
## What

Adds the first Linux-native piece of the cmux account system: **loopback sign-in for the standalone TUI** (`cmux auth status|login|logout`), plus the web-side allowlist change it needs.

## Why

The account system (`CmuxAuthRuntime` over StackAuth) is shared iOS + macOS only. The Linux cmux Browser and TUI ship no auth surface at all — no CLI verbs, no scheme handler, no Account pane — so a headless cmux instance cannot join an account. This change gives the standalone TUI the same sign-in contract the macOS app uses, with no new backend.

## How it works

`cmux auth login`:

1. Binds a loopback listener on `127.0.0.1:<ephemeral>`.
2. Builds the exact URL chain `AuthEnvironment.signInURL(callbackState:)` builds:
   `handler/native-sign-in?after_auth_return_to=…` → `handler/after-sign-in?native_app_return_to=http://127.0.0.1:<port>/auth-callback?cmux_auth_state=<state>`.
3. Opens the URL in the user's browser (xdg-open / open), printing it as a fallback for headless hosts.
4. Waits (5 min) for the completing browser to hit the loopback callback, verifies `cmux_auth_state`, parses `stack_refresh` and the `stack_access` cookie payload (`["<refresh>","<access>"]`), and stores tokens in the platform state dir with `0600` permissions.

`auth status` decodes the access JWT (`sub`, `exp`); `auth logout` clears the store.

## Web-side change

`handler/after-sign-in` currently redirects only to native schemes (`cmux`, `cmux-nightly`, `cmux-dev*`). This extends the return-to allowlist with loopback HTTP(S) callbacks:

- shape-validated: `http:`/`https:`, host `127.0.0.1`/`::1`/`localhost`, path exactly `/auth-callback`
- passed through the **same trust model as native schemes**: a verified handoff nonce (issued by `handler/native-sign-in`, carried by the completing browser's cookie) auto-redirects; a mismatched nonce falls back to the manual return page; non-loopback `http` targets stay rejected even with a valid nonce

The tokens in the redirect always land on the signing user's own machine (loopback only), and the nonce binding reuses the existing handoff-cookie contract without changing it.

## Tests

- `web/tests/after-sign-in-route.test.ts`: three new cases — verified loopback redirect carries `cmux_auth_state`/`stack_refresh`/`stack_access`; mismatched nonce keeps the manual return page; non-loopback `http` rejected even with a valid nonce. (23 pass, eslint + tsgo clean.)
- `cmux-tui`: `cargo fmt`/`check`/`build --release` green; the login loop verified end-to-end against the real URL chain with a loopback callback (mock tokens: state verification, 0600 store, JWT decode in `status`, idempotent `logout`).

## Notes

- The browser app itself can adopt the same contract later (its `cmux://`-scheme handling would reuse this); this slice deliberately touches only the TUI.
- No backend changes: the Stack work stays in the web handler.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11987"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791160849&installation_model_id=21920&pr_number=11987&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11987&signature=0f3ae583b40a53aa4a2b39dfa54971d3cd1afc75dc1c6a943313cab1b4e00e5f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds account sign-in for the standalone Linux TUI. `cmux auth login` runs the loopback contract the macOS app uses — opens the browser, verifies the state on the callback, and stores tokens in the platform state dir with 0600 permissions — while `status` decodes the access JWT and `logout` clears the store. This is the first auth surface for Linux cmux, which previously had none.

**Web-side change**
- `handler/after-sign-in` now accepts loopback HTTP(S) return targets shaped `127.0.0.1`/`::1`/`localhost` with path `/auth-callback`, under the same handoff-nonce trust model as native schemes.
- Non-loopback HTTP targets stay rejected even with a valid nonce; a mismatched nonce falls back to the manual return page.

<sup>Written for commit 242b2f247e243241861a30db33c8cb5248ed5305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11987?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added account authentication commands to the standalone TUI: sign in, view authentication status, and sign out.
  - Sign-in opens a browser and securely completes authentication through a local callback.
  - Authentication status displays the signed-in state, user identifier, and token expiration information.
  - Sign-out removes locally stored authentication credentials.

- **Security**
  - Local authentication callbacks are restricted to approved loopback addresses and paths.
  - Invalid or unverified callback destinations are rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->