### PR TITLE
Keep Iroh enabled for the terminal client ABI

### DIFF
--- a/cmux-tui/crates/cmux-terminal-client/Cargo.toml
+++ b/cmux-tui/crates/cmux-terminal-client/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 base64.workspace = true
 bytes.workspace = true
-cmux-remote.workspace = true
+cmux-remote = { workspace = true, features = ["iroh-transport"] }
 cmux-remote-protocol.workspace = true
 cmux-tui-core.workspace = true
 getrandom.workspace = true


### PR DESCRIPTION
## Problem

The Iroh default feature is now disabled for the normal cmux-tui dependency graph. The separate `cmux-terminal-client` C ABI is still an Iroh-only client, but its manifest inherited that new default and no longer enabled `cmux-remote`'s `iroh-transport` feature. Workspace macOS clippy then failed with unresolved Iroh types.

## Change

Enable `cmux-remote/iroh-transport` explicitly for `cmux-terminal-client`. This keeps Iroh out of normal `cmux-tui` builds while preserving the existing C ABI client's transport.

## Validation

The release-path macOS arm64 build succeeded before this fix. Hosted verification will run clippy and the focused TUI test for this exact commit.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11989"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791163860&installation_model_id=21920&pr_number=11989&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11989&signature=f3ea9008b24f6384ea02e0c69443cdb5e5e84b8357758f31c2865c41f149c8bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables the `iroh-transport` feature for `cmux-terminal-client` so the C ABI client retains Iroh support after the default feature change.

- The client previously inherited the disabled-by-default Iroh setting, breaking macOS clippy with unresolved Iroh types.
- Normal `cmux-tui` builds stay without Iroh; only the C ABI client enables the transport.

<sup>Written for commit e135d5441ca6dcc13a29014d1823ab45b1c4cd52. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated remote connection transport support to improve connectivity compatibility.
  - This change does not alter the user interface or introduce new user-facing functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->