### PR TITLE
Fix stale load generation race after scope validation

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -3651,8 +3651,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // requesting user still being current (mirroring the `.ok` path):
             // a stale 401 from a signed-out session that lands after a
             // different user signed in must not blank the new user's tree.
-            if loadGeneration == registryDevicesLoadGeneration,
-               await isScopeCurrent(scope) {
+            if await isScopeCurrent(scope),
+               loadGeneration == registryDevicesLoadGeneration {
                 registryDevices = []
             }
             recordAppEvent(
@@ -3675,12 +3675,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // are still in the same signed-in account/team scope, so a slow load can
         // never repopulate another scope's devices after sign-out, account switch,
         // or same-account team switch.
-        guard loadGeneration == registryDevicesLoadGeneration,
-              await isScopeCurrent(scope) else { return }
+        guard await isScopeCurrent(scope),
+              loadGeneration == registryDevicesLoadGeneration else { return }
         let connectedID = connectedMacDeviceID
         let hiddenIDs = await hiddenMacDeviceIDs(scope: scope)
-        guard loadGeneration == registryDevicesLoadGeneration,
-              await isScopeCurrent(scope) else { return }
+        guard await isScopeCurrent(scope),
+              loadGeneration == registryDevicesLoadGeneration else { return }
         let compatible = compatibleRegistryDevices(loaded)
         registryDevices = compatible
             .compactMap { device in
@@ -3991,8 +3991,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             loaded = try await pairedMacStore.loadAll(stackUserID: scope.userID, teamID: scope.teamID)
         } catch {
             mobileShellLog.error("paired mac store loadAll failed: \(String(describing: error), privacy: .public)")
-            if loadGeneration == pairedMacLoadGeneration,
-               await isScopeCurrent(scope) {
+            if await isScopeCurrent(scope),
+               loadGeneration == pairedMacLoadGeneration {
                 pairedMacLoadState = .failed
                 hiddenComputers = []
                 hasHiddenComputers = false
@@ -4012,8 +4012,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // The await above suspended the main actor; a sign-out, user switch, or
         // same-account team switch may have run meanwhile. Discard unless the
         // captured account/team scope is still current.
-        guard loadGeneration == pairedMacLoadGeneration,
-              await isScopeCurrent(scope) else {
+        guard await isScopeCurrent(scope),
+              loadGeneration == pairedMacLoadGeneration else {
             return
         }
         migrateLegacyWorkspaceComputerPriority(loadedMacs: loaded)
@@ -4027,8 +4027,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             from: loaded,
             hiddenIDs: hiddenIDs
         )
-        guard loadGeneration == pairedMacLoadGeneration,
-              await isScopeCurrent(scope) else {
+        guard await isScopeCurrent(scope),
+              loadGeneration == pairedMacLoadGeneration else {
             return
         }
         installStoredPairedMacCache(loaded, scope: scope)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/SequencedDeviceRegistry.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/SequencedDeviceRegistry.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobileShell
 import CmuxMobileShellModel
 
 /// Fixture-only registry that lets stale-load tests control response order.


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11880.

Reorder generation checks after awaited scope validation in registry and paired-Mac loaders so a newer refresh cannot be missed during actor suspension. Also import CmuxMobileShell in the sequenced registry test fixture so the focused tests compile.

Focused remote tests pass: stale team load and same-scope registry load.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11995"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791167032&installation_model_id=21920&pr_number=11995&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11995&signature=edee921a6098cc2846a560493a86c33688ffc92896766ab608c46f9476bb4698"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a stale load race where a registry or paired-Mac load that completes after a newer refresh started could still write its results to the UI. Generation checks now run after `await isScopeCurrent(scope)`, so a refresh that bumps the generation during the actor suspension is respected. Also imports `CmuxMobileShell` in the `SequencedDeviceRegistry` test fixture so the focused tests compile.

<sup>Written for commit 4f869e15a94a717ca50c2e59f0e7db7fb36cc1e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Reordered internal staleness checks without changing observable behavior.
* **Tests**
  * Updated test setup to reference the mobile shell module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->