### PR TITLE
Fix iOS TestFlight archive type inference

### DIFF
--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileIrohRuntimeComposition.swift
@@ -1791,7 +1791,7 @@ public final class MobileIrohRuntimeComposition:
                       trustRoot: relayPolicyTrustRoot,
                       now: now()
                   ) else {
-                return []
+                return Set<String>()
             }
             return Set(cachedPolicy.relays.map(\.url))
         }
@@ -1818,7 +1818,7 @@ public final class MobileIrohRuntimeComposition:
                 && $0.endpointID == endpointID
                 && $0.identityGeneration == identity.generation
         } ?? false
-        let cachedManagedRelayURLs = await cachedManagedRelayURLsTask
+        let cachedManagedRelayURLs = await cachedManagedRelayURLsTask.value
         let cachedRelay: CmxIrohRelayTokenResponse?
         if let cachedBinding, bindingMatches {
             lastKnownBindingID = cachedBinding.bindingID


### PR DESCRIPTION
## Fix

The iOS TestFlight archive failed because the fallback `return []` in the relay-cache `Task` inferred `[Any]`, while the success path returned `Set<String>`. Return `Set<String>()` explicitly so both branches have the intended type.

## Verification

- `git diff --check`
- Hosted iOS TestFlight archive verification pending
- Previous failure: [workflow run 33939121745](https://github.com/manaflow-ai/cmux/actions/runs/33939121745)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/11998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791169259&installation_model_id=21920&pr_number=11998&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F11998&signature=7fa2c3fa5401c890a25c112ba7a38839a846782d45c558e93bdf9e3de920b86a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS TestFlight archive failure where the relay-cache task's empty fallback inferred `[Any]` instead of `Set<String>`, and resolves the task via `.value` directly so both branches share the intended type without affecting relay-cache behavior.

<sup>Written for commit 24e5fe41b6531825405e85b31bb453706ab82c12. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/11998?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved internal handling of cached relay configuration and fallback processing.
  * Preserved existing app behavior, with no changes to exported functionality or the user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->