### PR TITLE
fix(iOS): restore responsive terminal typing

### DIFF
--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -821,9 +821,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     private func clearSettledTerminalSendStatus(forTerminalID terminalID: String) {
-        guard terminalSendStatusesByTerminalID[terminalID] != .sending else { return }
-        terminalSendStatusesByTerminalID[terminalID] = nil
-        terminalSendOperationIDsByTerminalID[terminalID] = nil
+        // This method runs for every non-submit keystroke. Avoid mutating the
+        // observed status dictionary when there is no settled status to clear:
+        // an otherwise invisible `nil` assignment still invalidates every
+        // SwiftUI observer of the terminal status and makes the main actor do
+        // a full shell update per character.
+        guard let status = terminalSendStatusesByTerminalID[terminalID],
+              status != .sending else { return }
+        terminalSendStatusesByTerminalID.removeValue(forKey: terminalID)
+        terminalSendOperationIDsByTerminalID.removeValue(forKey: terminalID)
     }
 
     private func finishRawTerminalSend(
@@ -1586,10 +1592,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// down when its own token is still current, so it never deletes the new
     /// stream's continuation.
     private var terminalLiveFontTokensBySurfaceID: [String: UUID]
-    private var rawTerminalInputBuffer: MobileTerminalInputSendBuffer
-    private var terminalInputRPCPipeline: MobileTerminalInputRPCPipeline
-    private var rawTerminalInputDrainWaiters: [CheckedContinuation<Void, Never>]
-    private var isRawTerminalInputDrainLoopRunning: Bool
+    // Transport bookkeeping is deliberately outside the observed surface:
+    // these values change for every terminal keystroke but no view reads them.
+    // Letting @Observable instrument them adds registrar bookkeeping to every
+    // enqueue and can invalidate the shell on the input hot path.
+    @ObservationIgnored private var rawTerminalInputBuffer: MobileTerminalInputSendBuffer
+    @ObservationIgnored private var terminalInputRPCPipeline: MobileTerminalInputRPCPipeline
+    @ObservationIgnored private var rawTerminalInputDrainWaiters: [CheckedContinuation<Void, Never>]
+    @ObservationIgnored private var isRawTerminalInputDrainLoopRunning: Bool
     #if DEBUG
     var latencyProbeAutoNavigationTask: Task<Void, Never>?
     var latencyProbeTask: Task<Void, Never>?

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -669,7 +669,19 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
                             RenderGridApplyContract(
                                 columns: $0.columns,
                                 rows: $0.rows,
-                                isDelta: !$0.full
+                                isDelta: !$0.full,
+                                // Primary screen deltas use the ordered local
+                                // mirror fast path. Its generation fence is
+                                // sufficient and avoids a libghostty size
+                                // query for every echoed keystroke. Full and
+                                // alternate-screen frames retain the exact
+                                // dimension check used by replay safety.
+                                requiresSurfaceDimensionCheck: !(
+                                    store.usesScreenAnchoredRenderGrid
+                                        && !$0.full
+                                        && $0.anchor == .screen
+                                        && $0.activeScreen == .primary
+                                )
                             )
                         }
                         let applied = await surfaceView.processOutputAndWait(

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -3270,20 +3270,46 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             // resize/reflow since the previous applied frame, must not paint:
             // fail the apply so the caller resets its queue and replays.
             if let renderGridContract {
-                let measuredGrid = ghostty_surface_size(surface)
-                let gridGeneration = workQueue.noteObservedGrid(
-                    columns: Int(measuredGrid.columns),
-                    rows: Int(measuredGrid.rows)
-                )
-                let dimsMatch = Int(measuredGrid.columns) == renderGridContract.columns
-                    && Int(measuredGrid.rows) == renderGridContract.rows
+                // Screen-anchored primary deltas are chained to the exact
+                // locally observed grid. Querying libghostty's size for each
+                // keystroke adds a cross-thread surface read directly in the
+                // input-to-paint path, while the serial queue's generation is
+                // already updated by every local resize/reflow operation.
+                let measuredGrid: ghostty_surface_size_s?
+                let gridGeneration: UInt64
+                let dimsMatch: Bool
+                if renderGridContract.requiresSurfaceDimensionCheck {
+                    let measured = ghostty_surface_size(surface)
+                    measuredGrid = measured
+                    gridGeneration = workQueue.noteObservedGrid(
+                        columns: Int(measured.columns),
+                        rows: Int(measured.rows)
+                    )
+                    dimsMatch = Int(measured.columns) == renderGridContract.columns
+                        && Int(measured.rows) == renderGridContract.rows
+                } else {
+                    measuredGrid = nil
+                    gridGeneration = workQueue.observedGridGeneration
+                    // The producer's dimensions are stable for this direct
+                    // delta path. Compare them with the last locally observed
+                    // grid so stale daemon frames still fail closed; the
+                    // generation fence also rejects a delta that followed a
+                    // local reflow.
+                    dimsMatch = workQueue.observedGridMatches(
+                        columns: renderGridContract.columns,
+                        rows: renderGridContract.rows
+                    )
+                }
                 let deltaBaseIntact = !renderGridContract.isDelta
                     || workQueue.gridGenerationAtLastRenderGridApply == gridGeneration
                 if !dimsMatch || !deltaBaseIntact {
                     let appliedGeneration = workQueue.gridGenerationAtLastRenderGridApply
                         .map(String.init) ?? "nil"
+                    let localGrid = measuredGrid.map {
+                        "\($0.columns)x\($0.rows)"
+                    } ?? workQueue.observedGridDescription
                     MobileDebugLog.anchormux(
-                        "render_grid.apply_fence local=\(measuredGrid.columns)x\(measuredGrid.rows) " +
+                        "render_grid.apply_fence local=\(localGrid) " +
                             "frame=\(renderGridContract.columns)x\(renderGridContract.rows) " +
                             "delta=\(renderGridContract.isDelta) gen=\(gridGeneration) " +
                             "applied=\(appliedGeneration)"

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceWorkQueue.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceWorkQueue.swift
@@ -39,6 +39,25 @@ final class GhosttySurfaceWorkQueue: @unchecked Sendable {
         return observedGridGeneration
     }
 
+    /// Check the last grid recorded by a geometry or exact render-grid pass.
+    /// Must be called from ``queue``. This keeps the direct primary-screen
+    /// delta path fenced against stale producer dimensions without another
+    /// libghostty surface read.
+    func observedGridMatches(columns: Int, rows: Int) -> Bool {
+        observedGridColumns > 0
+            && observedGridRows > 0
+            && observedGridColumns == columns
+            && observedGridRows == rows
+    }
+
+    /// Human-readable form of the cached grid for fence diagnostics. Must be
+    /// called from ``queue``.
+    var observedGridDescription: String {
+        observedGridColumns > 0 && observedGridRows > 0
+            ? "\(observedGridColumns)x\(observedGridRows)"
+            : "unknown"
+    }
+
     init(generation: UInt64) {
         // carve-out justification: serial event-delivery queue for low-level libghostty C calls; not used as a lock.
         queue = DispatchQueue(

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/RenderGridApplyContract.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/RenderGridApplyContract.swift
@@ -17,10 +17,21 @@ public struct RenderGridApplyContract: Equatable, Sendable {
     /// Deltas additionally require that no resize changed the grid since the
     /// previous applied render-grid frame.
     public let isDelta: Bool
+    /// Whether applying this frame must query libghostty for the current grid
+    /// dimensions. The direct primary-screen delta path already has an
+    /// ordered, generation-tracked local grid and can avoid this query on
+    /// every keystroke; full frames and replay paths keep the check enabled.
+    public let requiresSurfaceDimensionCheck: Bool
 
-    public init(columns: Int, rows: Int, isDelta: Bool) {
+    public init(
+        columns: Int,
+        rows: Int,
+        isDelta: Bool,
+        requiresSurfaceDimensionCheck: Bool = true
+    ) {
         self.columns = columns
         self.rows = rows
         self.isDelta = isDelta
+        self.requiresSurfaceDimensionCheck = requiresSurfaceDimensionCheck
     }
 }


### PR DESCRIPTION
## Problem
On iOS, ordinary terminal typing became slow because every streamed character delta queried libghostty for surface dimensions and raw input transport mutations invalidated the observed shell state.

## Fix
- Use the serial work queue's cached grid and generation fence for ordered primary-screen deltas, avoiding a libghostty size read on each echoed character.
- Keep exact dimension checks for full frames, alternate-screen frames, and replay safety.
- Exclude raw input transport bookkeeping from `@Observable` tracking.
- Avoid status-dictionary mutations when there is no settled send status.

## Validation
- TerminalRawInputOrderingTests: 11 passed
- MobileTerminalRenderGrid: 82 passed
- Tagged iOS simulator build succeeded
- Physical iPhone `ios-typing` build installed and verified signed in + paired on Aziz (iPhone 17 Pro Max)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12001"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791170171&installation_model_id=21920&pr_number=12001&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12001&signature=3be649e9cea6eb3077e7ec69b237f6b83e29f9ec3f5c781a7e764124f45ec7ff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes slow terminal typing on iOS by eliminating per-keystroke libghostty surface-size queries and SwiftUI observation invalidation. Primary-screen deltas now use the serial work queue's cached grid and generation fence, raw input transport bookkeeping is excluded from `@Observable`, and status-dictionary mutations are skipped when there is no settled send status. Full frames, alternate-screen frames, and replay paths keep exact dimension checks.

<sup>Written for commit f8631554eb801b659c8ace479662c743aa55660b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved terminal rendering efficiency by reducing unnecessary surface-size checks during primary-screen updates.
  * Reduced per-keystroke state-tracking overhead for smoother input handling.

* **Reliability**
  * Enhanced render-grid validation and fallback reporting to improve consistency when applying terminal updates.
  * Preserved dimension checks for full-frame and alternate-screen rendering to maintain existing safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->