### PR TITLE
Fix safe-area propagation for bare iOS terminal surfaces

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -146,14 +146,14 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         // state write, so it is safe in `updateUIView`.
         context.coordinator.setTerminalPresentationActive(terminalPresentationIsActive)
         context.coordinator.attemptPendingOutputConsumerRecoveryPresentation()
-        guard let surfaceView = (uiView as? GhosttySurfaceHostView)?.surfaceView else { return }
+        let hostView = uiView as? GhosttySurfaceHostView
+        guard let surfaceView = hostView?.surfaceView ?? (uiView as? GhosttySurfaceView) else { return }
         surfaceView.autoFocusOnWindowAttach = autoFocusOnWindowAttach
         surfaceView.terminalTheme = terminalTheme
         surfaceView.terminalConfigTheme = terminalConfigTheme
         surfaceView.setTopContentInset(topContentInset)
-        if let hostView = uiView as? GhosttySurfaceHostView {
-            hostView.setCapturedBottomSafeAreaInset(bottomSafeAreaInset)
-        }
+        surfaceView.setCapturedBottomSafeAreaInset(bottomSafeAreaInset)
+        hostView?.setCapturedBottomSafeAreaInset(bottomSafeAreaInset)
         context.coordinator.onArtifactFilesRequested = onArtifactFilesRequested
         context.coordinator.onArtifactPathTapped = onArtifactPathTapped
         context.coordinator.onVisibleArtifactCountChanged = onVisibleArtifactCountChanged


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/11962. Propagates the captured bottom safe-area inset to bare GhosttySurfaceView instances as well as hosted surfaces, covering the alternate representable path.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791170623&installation_model_id=21920&pr_number=12002&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12002&signature=1932bda45ae387773ae254de5a6c9ec9cc8924764c97deaec5017664e6ff59da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates the bottom safe-area inset to bare `GhosttySurfaceView` instances as well as hosted surfaces. Previously, only `GhosttySurfaceHostView` received the captured inset, leaving bare surfaces without the correct safe-area padding.

<sup>Written for commit 196e01fddf855f63708889989c43c2b3b48263ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved surface view handling when updating the iOS interface.
  - Bottom safe-area spacing is now correctly applied to the surface view, improving layout around device edges.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->