### PR TITLE
Remove unused optional TUI transport dependencies

### DIFF
--- a/cmux-tui/Cargo.lock
+++ b/cmux-tui/Cargo.lock
@@ -712,7 +712,6 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "snow",
- "socket2 0.5.10",
  "subtle",
  "tempfile",
  "tokio",
@@ -4901,16 +4900,6 @@ dependencies = [
  "rustc_version",
  "sha2 0.10.9",
  "subtle",
-]
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/cmux-tui/crates/cmux-remote/Cargo.toml
+++ b/cmux-tui/crates/cmux-remote/Cargo.toml
@@ -12,7 +12,7 @@ workspace = true
 
 [features]
 default = ["wireguard-transport"]
-iroh-transport = ["dep:iroh", "dep:socket2"]
+iroh-transport = ["dep:iroh"]
 # Dial `ws://` routes through an in-process WireGuard tunnel (cmux-wg) when
 # the target sits inside the tunnel's routes.
 wireguard-transport = ["dep:cmux-wg"]
@@ -40,7 +40,6 @@ libc.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
-socket2 = { workspace = true, optional = true }
 snow.workspace = true
 subtle.workspace = true
 tokio.workspace = true

--- a/cmux-tui/crates/cmux-terminal-client/Cargo.toml
+++ b/cmux-tui/crates/cmux-terminal-client/Cargo.toml
@@ -16,7 +16,7 @@ workspace = true
 [dependencies]
 base64.workspace = true
 bytes.workspace = true
-cmux-remote = { workspace = true, features = ["iroh-transport"] }
+cmux-remote = { workspace = true, default-features = false, features = ["iroh-transport"] }
 cmux-remote-protocol.workspace = true
 cmux-tui-core.workspace = true
 getrandom.workspace = true


### PR DESCRIPTION
## Problem

`cmux-terminal-client` is an Iroh-only C ABI, but it inherited `cmux-remote`'s new WireGuard default. This adds an unused transport to that client. Separately, `cmux-remote` listed `socket2` as an optional direct dependency for the Iroh feature, but no cmux source uses it.

## Change

- Keep the terminal client on `cmux-remote` with only the explicit `iroh-transport` feature.
- Remove the unused optional `socket2` edge and its lockfile entry.

The normal cmux-tui build stays unchanged. The optional terminal client keeps its Iroh behavior.

## Validation

Hosted TUI verification will run Cargo checks with `--locked`, clippy, tests, and the release artifact build.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791171808&installation_model_id=21920&pr_number=12005&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12005&signature=1e00f7614e2958bf8c81e5e8650628859291dd3db5b5e3ca251d94c728a38493"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes unused optional transport dependencies from the TUI build so the terminal client no longer pulls in WireGuard by default.

- `cmux-terminal-client` now uses `cmux-remote` with `default-features = false` and only the `iroh-transport` feature, instead of inheriting the WireGuard default.
- Removes the unused optional `socket2` dependency from `cmux-remote` and its lockfile entry.
- `cmux-remote` keeps WireGuard as its default, so the normal cmux-tui build is unaffected.

<sup>Written for commit 79f9b2d59df4f20a5be8cda2f4934b81b70fc81a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated remote connectivity components to use a leaner set of optional capabilities.
  * Reduced unnecessary dependency inclusion for terminal client builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->