### PR TITLE
fix(portal): repaint the divider overlay only when it could have changed

### DIFF
--- a/Sources/Debug/RemoteTmux/TerminalWindowPortal+DebugDiagnostics.swift
+++ b/Sources/Debug/RemoteTmux/TerminalWindowPortal+DebugDiagnostics.swift
@@ -20,6 +20,10 @@ enum RemoteTmuxSizingDiagnostics {
     /// geometry this must stay bounded no matter which interactive flags
     /// are held, or the chain is a per-runloop-turn busy loop.
     static var externalGeometrySyncPassCount = 0
+    /// Divider-overlay invalidations. Each one costs a recursive walk of the
+    /// whole window view tree in `SplitDividerOverlayView.draw`, so with
+    /// static geometry this must not advance.
+    static var dividerOverlayRepaintCount = 0
 }
 
 extension WindowTerminalPortal {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1241,6 +1241,16 @@ final class WindowTerminalPortal: NSObject {
     /// already fingerprints exactly the geometry a sync pass reads and
     /// deliberately excludes the window's origin, so dragging a window by its
     /// titlebar does not repaint every tick.
+    /// Keeps the overlay above the hosted views, repainting only if that
+    /// re-placement actually moved something.
+    ///
+    /// Placement only, and deliberately cheap: this runs twice per
+    /// `synchronizeHostedView` (once through `ensureInstalled`, once at the
+    /// end), and `synchronizeAllHostedViews` runs that per entry. Anything
+    /// O(entries) in here is O(entries squared) for the batch, and a session
+    /// of mirrored tmux windows carries dozens of surfaces. The geometry
+    /// comparison lives in `refreshDividerOverlayIfGeometryChanged`, which the
+    /// batch calls once at its boundary.
     private func ensureDividerOverlayOnTop() {
         var placementChanged = false
 
@@ -1258,11 +1268,28 @@ final class WindowTerminalPortal: NSObject {
             placementChanged = true
         }
 
-        let signature = externalGeometrySignature()
-        let geometryChanged = lastDividerOverlaySignature != signature
-        lastDividerOverlaySignature = signature
+        guard placementChanged else { return }
+        markDividerOverlayNeedingDisplay()
+    }
 
-        guard placementChanged || geometryChanged else { return }
+    /// Repaints the overlay when the geometry it draws from has moved.
+    ///
+    /// `SplitDividerOverlayView.draw` walks the whole window view tree from
+    /// `contentView` before it consults `dirtyRect`, so an invalidation that
+    /// changes nothing still costs a full traversal. `shouldRenderOverlay`
+    /// paints a segment only where a portal-hosted surface crosses the divider
+    /// centerline, and those rects come from the hosted views this signature
+    /// fingerprints, so nothing the overlay can draw moves without moving the
+    /// signature. The signature excludes the window's origin, so a titlebar
+    /// drag stays free.
+    private func refreshDividerOverlayIfGeometryChanged() {
+        let signature = externalGeometrySignature()
+        guard lastDividerOverlaySignature != signature else { return }
+        lastDividerOverlaySignature = signature
+        markDividerOverlayNeedingDisplay()
+    }
+
+    private func markDividerOverlayNeedingDisplay() {
 #if DEBUG
         RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount += 1
 #endif
@@ -1273,6 +1300,11 @@ final class WindowTerminalPortal: NSObject {
     /// `lastHierarchySyncSignature`, which the layout-sync path owns and
     /// updates on its own schedule.
     private var lastDividerOverlaySignature: ExternalGeometrySignature?
+
+    /// Set while `synchronizeAllHostedViews` is walking its entries, so the
+    /// per-entry syncs skip the geometry comparison and the batch pays for it
+    /// once.
+    private var isBatchSynchronizingHostedViews = false
 
     @discardableResult
     private func ensureInstalled(syncLayout: Bool = true) -> Bool {
@@ -1933,6 +1965,13 @@ final class WindowTerminalPortal: NSObject {
         }
         pruneDeadEntries()
         let hostedIds = Array(entriesByHostedId.keys)
+        // One geometry comparison for the whole batch. Per entry it would be
+        // O(entries) work inside an O(entries) loop.
+        isBatchSynchronizingHostedViews = true
+        defer {
+            isBatchSynchronizingHostedViews = false
+            refreshDividerOverlayIfGeometryChanged()
+        }
         for hostedId in hostedIds {
             if hostedId == hostedIdToSkip { continue }
             // An already-hidden entry for a hidden tab is a no-op here by
@@ -2361,6 +2400,9 @@ final class WindowTerminalPortal: NSObject {
 #endif
 
         ensureDividerOverlayOnTop()
+        if !isBatchSynchronizingHostedViews {
+            refreshDividerOverlayIfGeometryChanged()
+        }
     }
 
     private func pruneDeadEntries() {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1234,6 +1234,9 @@ final class WindowTerminalPortal: NSObject {
         if !Self.rectApproximatelyEqual(dividerOverlayView.frame, hostView.bounds) {
             dividerOverlayView.frame = hostView.bounds
         }
+#if DEBUG
+        RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount += 1
+#endif
         dividerOverlayView.needsDisplay = true
     }
 

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1223,22 +1223,56 @@ final class WindowTerminalPortal: NSObject {
         )
     }
 
+    /// Re-places the divider overlay, and repaints it only when what it draws
+    /// could have moved.
+    ///
+    /// The repaint is not cheap: `SplitDividerOverlayView.draw` walks the whole
+    /// window view tree from `contentView` looking for split views before it
+    /// consults `dirtyRect`, so a one-pixel dirty region costs a full-hierarchy
+    /// traversal. This runs from `synchronizeHostedView`, once per hosted view
+    /// per geometry tick, and it used to invalidate unconditionally — the same
+    /// shape as the window-move echo storm, work scheduled off a pass that had
+    /// nothing to do. In a 20-second sample of an idle app that walk was the
+    /// heaviest cmux frame on the main thread.
+    ///
+    /// Dividers move when the panes around them resize, which reaches the
+    /// portal as a changed hosted frame, and splits appearing or disappearing
+    /// change the entry set. Both are in `ExternalGeometrySignature`, which
+    /// already fingerprints exactly the geometry a sync pass reads and
+    /// deliberately excludes the window's origin, so dragging a window by its
+    /// titlebar does not repaint every tick.
     private func ensureDividerOverlayOnTop() {
+        var placementChanged = false
+
         if dividerOverlayView.superview !== hostView {
             dividerOverlayView.frame = hostView.bounds
             hostView.addSubview(dividerOverlayView, positioned: .above, relativeTo: nil)
+            placementChanged = true
         } else if hostView.subviews.last !== dividerOverlayView {
             hostView.addSubview(dividerOverlayView, positioned: .above, relativeTo: nil)
+            placementChanged = true
         }
 
         if !Self.rectApproximatelyEqual(dividerOverlayView.frame, hostView.bounds) {
             dividerOverlayView.frame = hostView.bounds
+            placementChanged = true
         }
+
+        let signature = externalGeometrySignature()
+        let geometryChanged = lastDividerOverlaySignature != signature
+        lastDividerOverlaySignature = signature
+
+        guard placementChanged || geometryChanged else { return }
 #if DEBUG
         RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount += 1
 #endif
         dividerOverlayView.needsDisplay = true
     }
+
+    /// Geometry the divider overlay was last painted for. Separate from
+    /// `lastHierarchySyncSignature`, which the layout-sync path owns and
+    /// updates on its own schedule.
+    private var lastDividerOverlaySignature: ExternalGeometrySignature?
 
     @discardableResult
     private func ensureInstalled(syncLayout: Bool = true) -> Bool {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -589,6 +589,34 @@ private final class SplitDividerOverlayView: NSView {
         }
     }
 
+    /// Everything `draw` reads to decide which divider pixels it paints.
+    ///
+    /// Deliberately sourced from the same helper the draw path uses, so the
+    /// repaint gate cannot drift from the drawing. Gating on the portal's
+    /// hosted-frame signature instead was wrong for exactly that reason: that
+    /// signature records frames, while this filters on visibility as well, so
+    /// hiding a surface without moving it compared equal and left stale
+    /// divider pixels. A hidden entry keeps its frame by design, which makes
+    /// that the ordinary case rather than a corner one.
+    struct RenderInputs: Equatable {
+        let bounds: NSRect
+        let occludingHostedFrames: [NSRect]
+    }
+
+    func renderInputs() -> RenderInputs {
+        RenderInputs(
+            bounds: bounds,
+            occludingHostedFrames: hostedFramesLikelyToOccludeDividers()
+        )
+    }
+
+    /// `overlayDividerColor` resolves each split view's `dividerColor` against
+    /// the current appearance, which no geometry comparison can see.
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        needsDisplay = true
+    }
+
     private func shouldRenderOverlay(for segment: DividerSegment, hostedFrames: [NSRect]) -> Bool {
         // Draw only when a hosted surface actually intrudes across the divider centerline.
         // This preserves tiny-pane visibility fixes without darkening regular dividers.
@@ -1272,20 +1300,22 @@ final class WindowTerminalPortal: NSObject {
         markDividerOverlayNeedingDisplay()
     }
 
-    /// Repaints the overlay when the geometry it draws from has moved.
+    /// Repaints the overlay when what it would paint has changed.
     ///
     /// `SplitDividerOverlayView.draw` walks the whole window view tree from
     /// `contentView` before it consults `dirtyRect`, so an invalidation that
-    /// changes nothing still costs a full traversal. `shouldRenderOverlay`
-    /// paints a segment only where a portal-hosted surface crosses the divider
-    /// centerline, and those rects come from the hosted views this signature
-    /// fingerprints, so nothing the overlay can draw moves without moving the
-    /// signature. The signature excludes the window's origin, so a titlebar
-    /// drag stays free.
+    /// changes nothing still costs a full traversal. The comparison asks the
+    /// overlay for its own render inputs rather than reusing the portal's
+    /// geometry signature, because the two are not the same set: the overlay
+    /// paints a segment only where a hosted surface crosses the divider
+    /// centerline, and it drops hidden and windowless surfaces when deciding
+    /// that. Dragging a divider resizes the surfaces beside it, and both
+    /// bounds and those frames are window-relative, so moving the window by
+    /// its titlebar still costs nothing.
     private func refreshDividerOverlayIfGeometryChanged() {
-        let signature = externalGeometrySignature()
-        guard lastDividerOverlaySignature != signature else { return }
-        lastDividerOverlaySignature = signature
+        let inputs = dividerOverlayView.renderInputs()
+        guard lastDividerOverlayRenderInputs != inputs else { return }
+        lastDividerOverlayRenderInputs = inputs
         markDividerOverlayNeedingDisplay()
     }
 
@@ -1296,10 +1326,11 @@ final class WindowTerminalPortal: NSObject {
         dividerOverlayView.needsDisplay = true
     }
 
-    /// Geometry the divider overlay was last painted for. Separate from
-    /// `lastHierarchySyncSignature`, which the layout-sync path owns and
-    /// updates on its own schedule.
-    private var lastDividerOverlaySignature: ExternalGeometrySignature?
+    /// Render inputs the divider overlay was last painted for. Deliberately
+    /// not `ExternalGeometrySignature`: that one answers a different question
+    /// for the layout-sync path, and its contents are tuned for terminating
+    /// the sync echo chain.
+    private var lastDividerOverlayRenderInputs: SplitDividerOverlayView.RenderInputs?
 
     /// Set while `synchronizeAllHostedViews` is walking its entries, so the
     /// per-entry syncs skip the geometry comparison and the batch pays for it

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1922,6 +1922,7 @@
 		8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
 		5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */; };
+		5B0C00010000000000000101 /* PortalDividerOverlayRepaintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000102 /* PortalDividerOverlayRepaintTests.swift */; };
 		B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */; };
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
 		D0C658660000000000000002 /* PortalSplitDividerRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000001 /* PortalSplitDividerRegion.swift */; };
@@ -5145,6 +5146,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 		8672F0058672F0058672F005 /* PiFeedV2CallResultBox.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiFeedV2CallResultBox.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
 		5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerCursorOcclusionTests.swift; sourceTree = "<group>"; };
+		5B0C00010000000000000102 /* PortalDividerOverlayRepaintTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerOverlayRepaintTests.swift; sourceTree = "<group>"; };
 		4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalHitTestingPerformanceTests.swift; sourceTree = "<group>"; };
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
 		D0C658660000000000000001 /* PortalSplitDividerRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerRegion.swift; sourceTree = "<group>"; };
@@ -9498,6 +9500,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				9F007352E96022D7EFBE73C9 /* WorkspaceTodoSidebarModelTests.swift */,
 				5B0C00010000000000000004 /* SidebarResizerOcclusionResolverTests.swift */,
 				5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */,
+				5B0C00010000000000000102 /* PortalDividerOverlayRepaintTests.swift */,
 				C0DE1A080000000000000002 /* SavedLayoutDefinitionTests.swift */,
 				C0DE1A070000000000000002 /* SavedLayoutStoreTests.swift */,
 				5830CA11BAC0000000000001 /* SocketCallbackAwaiterMainThreadTests.swift */,
@@ -13200,6 +13203,7 @@ B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileRef
 				8672F0068672F0068672F006 /* PiFeedV2CallResultBox.swift in Sources */,
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 				5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */,
+				5B0C00010000000000000101 /* PortalDividerOverlayRepaintTests.swift in Sources */,
 					B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,
 					F11294000000000000000001 /* PortRetirementPublicationRegressionTests.swift in Sources */,

--- a/cmuxTests/PortalDividerOverlayRepaintTests.swift
+++ b/cmuxTests/PortalDividerOverlayRepaintTests.swift
@@ -1,0 +1,103 @@
+@preconcurrency import XCTest
+import AppKit
+import CmuxTerminal
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+extension TerminalWindowPortalLifecycleTests {
+
+    /// A hosted-view sync that changed nothing must not invalidate the divider
+    /// overlay. `SplitDividerOverlayView.draw` recursively walks the whole
+    /// window view tree from `contentView` before it consults `dirtyRect`, so
+    /// every invalidation costs a full-hierarchy traversal no matter how small
+    /// the dirty region. `synchronizeHostedView` runs per hosted view per
+    /// geometry tick, and it ended by invalidating unconditionally: in a
+    /// 20s idle sample that walk was the single heaviest cmux frame on the
+    /// main thread. Same shape as the window-move echo storm the sizing
+    /// counters guard — work scheduled off a pass that had nothing to do.
+    @MainActor
+    func testRedundantHostedViewSyncDoesNotRepaintDividerOverlay() throws {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340)
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let portal = makeTrackedPortal(window: window)
+        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
+        contentView.addSubview(anchor)
+
+        let surface = makeTrackedTerminalSurface()
+        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        drainMainQueue()
+        realizeWindowLayout(window)
+
+        // Baseline after installation and first layout have settled, so the
+        // delta covers only the redundant passes below.
+        let before = RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount
+        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
+        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
+        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
+
+        XCTAssertEqual(
+            RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount - before,
+            0,
+            "Syncing an unmoved hosted view must not invalidate the divider overlay"
+        )
+    }
+
+    /// The other half of the gate: a hosted view that actually moved still
+    /// repaints. Dividers move when the panes around them resize, which
+    /// reaches the portal as a changed hosted frame, so gating invalidation
+    /// on the geometry signature must not cost a real repaint. Without this
+    /// the first test passes trivially by never invalidating at all, and the
+    /// overlay would keep painting divider lines at stale positions.
+    @MainActor
+    func testMovedHostedViewRepaintsDividerOverlay() throws {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340)
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        realizeWindowLayout(window)
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let portal = makeTrackedPortal(window: window)
+        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
+        contentView.addSubview(anchor)
+
+        let surface = makeTrackedTerminalSurface()
+        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
+        portal.synchronizeHostedViewForAnchor(anchor)
+        drainMainQueue()
+        realizeWindowLayout(window)
+
+        let before = RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount
+        anchor.setFrameSize(NSSize(width: 200, height: 140))
+        contentView.layoutSubtreeIfNeeded()
+        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
+
+        XCTAssertGreaterThan(
+            RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount - before,
+            0,
+            "Resizing a hosted view must still invalidate the divider overlay"
+        )
+    }
+}

--- a/cmuxTests/PortalDividerOverlayRepaintTests.swift
+++ b/cmuxTests/PortalDividerOverlayRepaintTests.swift
@@ -18,38 +18,18 @@ extension TerminalWindowPortalLifecycleTests {
     /// geometry tick, and it ended by invalidating unconditionally: in a
     /// 20s idle sample that walk was the single heaviest cmux frame on the
     /// main thread. Same shape as the window-move echo storm the sizing
-    /// counters guard — work scheduled off a pass that had nothing to do.
+    /// counters guard, work scheduled off a pass that had nothing to do.
     @MainActor
     func testRedundantHostedViewSyncDoesNotRepaintDividerOverlay() throws {
-        let window = makeTestWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340)
-        )
-        defer {
-            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
-            window.orderOut(nil)
-        }
-        realizeWindowLayout(window)
-        guard let contentView = window.contentView else {
-            XCTFail("Expected content view")
-            return
-        }
+        let fixture = try makeDividerOverlayFixture()
+        defer { fixture.tearDown() }
 
-        let portal = makeTrackedPortal(window: window)
-        let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
-        contentView.addSubview(anchor)
+        settleDividerOverlay(portal: fixture.portal, anchor: fixture.anchor)
 
-        let surface = makeTrackedTerminalSurface()
-        portal.bind(hostedView: surface.hostedView, to: anchor, visibleInUI: true)
-        portal.synchronizeHostedViewForAnchor(anchor)
-        drainMainQueue()
-        realizeWindowLayout(window)
-
-        // Baseline after installation and first layout have settled, so the
-        // delta covers only the redundant passes below.
         let before = RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount
-        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
-        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
-        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
+        fixture.portal.synchronizeHostedViewForAnchor(fixture.anchor, syncLayout: false)
+        fixture.portal.synchronizeHostedViewForAnchor(fixture.anchor, syncLayout: false)
+        fixture.portal.synchronizeHostedViewForAnchor(fixture.anchor, syncLayout: false)
 
         XCTAssertEqual(
             RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount - before,
@@ -66,18 +46,42 @@ extension TerminalWindowPortalLifecycleTests {
     /// overlay would keep painting divider lines at stale positions.
     @MainActor
     func testMovedHostedViewRepaintsDividerOverlay() throws {
+        let fixture = try makeDividerOverlayFixture()
+        defer { fixture.tearDown() }
+
+        settleDividerOverlay(portal: fixture.portal, anchor: fixture.anchor)
+
+        let before = RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount
+        fixture.anchor.setFrameSize(NSSize(width: 200, height: 140))
+        fixture.contentView.layoutSubtreeIfNeeded()
+        fixture.portal.synchronizeHostedViewForAnchor(fixture.anchor, syncLayout: false)
+
+        XCTAssertGreaterThan(
+            RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount - before,
+            0,
+            "Resizing a hosted view must still invalidate the divider overlay"
+        )
+    }
+
+    // MARK: - Fixture
+
+    struct DividerOverlayFixture {
+        let portal: WindowTerminalPortal
+        let anchor: NSView
+        let contentView: NSView
+        let tearDown: () -> Void
+    }
+
+    @MainActor
+    func makeDividerOverlayFixture(
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) throws -> DividerOverlayFixture {
         let window = makeTestWindow(
             contentRect: NSRect(x: 0, y: 0, width: 520, height: 340)
         )
-        defer {
-            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
-            window.orderOut(nil)
-        }
         realizeWindowLayout(window)
-        guard let contentView = window.contentView else {
-            XCTFail("Expected content view")
-            return
-        }
+        let contentView = try XCTUnwrap(window.contentView, "Expected content view", file: file, line: line)
 
         let portal = makeTrackedPortal(window: window)
         let anchor = NSView(frame: NSRect(x: 8, y: 8, width: 240, height: 160))
@@ -89,15 +93,37 @@ extension TerminalWindowPortalLifecycleTests {
         drainMainQueue()
         realizeWindowLayout(window)
 
-        let before = RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount
-        anchor.setFrameSize(NSSize(width: 200, height: 140))
-        contentView.layoutSubtreeIfNeeded()
-        portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
-
-        XCTAssertGreaterThan(
-            RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount - before,
-            0,
-            "Resizing a hosted view must still invalidate the divider overlay"
+        return DividerOverlayFixture(
+            portal: portal,
+            anchor: anchor,
+            contentView: contentView,
+            tearDown: {
+                NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+                window.orderOut(nil)
+            }
         )
+    }
+
+    /// Deadline-bounded poll for a quiet portal.
+    ///
+    /// `realizeWindowLayout` ends in a fixed 50ms run-loop spin, which a loaded
+    /// CI worker can outrun: layout that settles after it would repaint inside
+    /// the window a test is measuring and fail it for the wrong reason. Sync
+    /// until a sync stops producing repaints, which is the real predicate the
+    /// assertions below depend on, rather than trusting a duration.
+    @MainActor
+    func settleDividerOverlay(
+        portal: WindowTerminalPortal,
+        anchor: NSView,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        for _ in 0..<50 {
+            let before = RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount
+            portal.synchronizeHostedViewForAnchor(anchor, syncLayout: false)
+            drainMainQueue()
+            if RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount == before { return }
+        }
+        XCTFail("Divider overlay never stopped repainting on an idle portal", file: file, line: line)
     }
 }

--- a/cmuxTests/PortalDividerOverlayRepaintTests.swift
+++ b/cmuxTests/PortalDividerOverlayRepaintTests.swift
@@ -63,12 +63,50 @@ extension TerminalWindowPortalLifecycleTests {
         )
     }
 
+    /// Hiding a hosted surface changes what the overlay paints even though
+    /// every frame stayed put, because `hostedFramesLikelyToOccludeDividers`
+    /// drops hidden and windowless surfaces and the overlay paints a segment
+    /// only where one of those rects crosses the divider centerline. A hidden
+    /// entry keeps its frame by design, so a frames-only comparison comes back
+    /// equal here and leaves divider pixels that should be gone.
+    @MainActor
+    func testHidingHostedViewWithoutMovingItRepaintsDividerOverlay() throws {
+        let fixture = try makeDividerOverlayFixture()
+        defer { fixture.tearDown() }
+
+        settleDividerOverlay(portal: fixture.portal, anchor: fixture.anchor)
+        let frameBeforeHide = fixture.hostedView.frame
+
+        let before = RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount
+        _ = fixture.portal.updateEntryVisibility(
+            forHostedId: ObjectIdentifier(fixture.hostedView),
+            visibleInUI: false
+        )
+        fixture.portal.synchronizeHostedViewForAnchor(fixture.anchor, syncLayout: false)
+
+        XCTAssertTrue(
+            fixture.hostedView.isHidden,
+            "Expected the hosted view to be hidden for this test to mean anything"
+        )
+        XCTAssertEqual(
+            fixture.hostedView.frame,
+            frameBeforeHide,
+            "Hiding must not move the frame, or this test would pass for the wrong reason"
+        )
+        XCTAssertGreaterThan(
+            RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount - before,
+            0,
+            "Hiding a hosted view must invalidate the divider overlay even with an unchanged frame"
+        )
+    }
+
     // MARK: - Fixture
 
     struct DividerOverlayFixture {
         let portal: WindowTerminalPortal
         let anchor: NSView
         let contentView: NSView
+        let hostedView: GhosttySurfaceScrollView
         let tearDown: () -> Void
     }
 
@@ -97,6 +135,7 @@ extension TerminalWindowPortalLifecycleTests {
             portal: portal,
             anchor: anchor,
             contentView: contentView,
+            hostedView: surface.hostedView,
             tearDown: {
                 NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
                 window.orderOut(nil)


### PR DESCRIPTION
**Status:** updated onto `main` (`78f4c82504`) as merge commit `9b03b5df44`. One conflict, in `Sources/TerminalWindowPortal.swift`, resolved by keeping both sides: `main` added a `deferDividerOverlay` parameter so batch syncs skip the overlay per entry, and this PR's gate now sits inside that branch. No upstream line was dropped (`git diff main` is additions only).

**Reviewer's guide**
- Read `ensureDividerOverlayOnTop`, `refreshDividerOverlayIfGeometryChanged`, `markDividerOverlayNeedingDisplay` and `SplitDividerOverlayView.RenderInputs` in `Sources/TerminalWindowPortal.swift`. The gate compares the overlay's own render inputs, so it cannot drift from what `draw` paints.
- Tests: `cmuxTests/PortalDividerOverlayRepaintTests.swift`. Red-then-green: the first commit adds the two failing tests, the second the fix.
- Skip: `Sources/Debug/RemoteTmux/TerminalWindowPortal+DebugDiagnostics.swift` (the counter).

---

## Summary

The divider overlay repainted on every portal sync, including syncs that changed nothing, and each repaint walks the whole window view tree.

`ensureDividerOverlayOnTop()` ended with an unconditional `dividerOverlayView.needsDisplay = true`. The two guards above it are careful, touching the view only when the overlay's superview, z-order, or frame is actually wrong. Then it repainted anyway.

`SplitDividerOverlayView.draw` walks the entire window view tree from `contentView` looking for `NSSplitView`s, and only consults `dirtyRect` after that walk, so a one-pixel dirty region still costs a full traversal. `synchronizeHostedView` calls it once per hosted view per geometry tick.

This gates the invalidation on whether what the overlay draws could have moved.

## Measurement

20-second `sample` of cmux 0.64.22 sitting idle, no window interaction:

| Frame | Samples |
|---|---|
| `SplitDividerOverlayView.collectDividerSegments` | 34 |
| `SplitDividerOverlayView.draw` (self) | 4 |

Main thread took 11527 samples, 10748 of them parked in `mach_msg2_trap`. Of the 779 that were real work, the divider walk was 34. That is 4.4%, and the heaviest single cmux frame on the main thread in an app doing nothing.

34 vs 4 also says the walk is 89% of the repaint, so the fix has to avoid the walk, not the fill.

The gate is cheaper than what it prevents: in a second sample under load, `externalGeometrySignature()` cost 2 samples against `collectDividerSegments`'s 14.

The regression test measures the same thing directly. Three syncs of a hosted view that has not moved:

| | Repaints |
|---|---|
| before | 6 |
| after | 0 |

Six, not three, because each `synchronizeHostedViewForAnchor` reaches `ensureDividerOverlayOnTop` twice.

## What the gate compares

`shouldRenderOverlay` paints a segment only where a portal-hosted surface crosses that divider's centerline, and those rects come from `hostedFramesLikelyToOccludeDividers()`. So the gate asks the overlay for its own render inputs: its bounds, plus exactly the frames that helper returns. One source for both, so the comparison cannot drift from the drawing.

Dragging a divider resizes the surfaces on either side, which changes those frames. Adding, closing, hiding or revealing a split changes which frames the helper returns at all. Bounds and hosted frames are window-relative, so moving the window by its titlebar still costs nothing, which is the property the window-move echo storm taught this file to protect.

An earlier revision of this PR compared `ExternalGeometrySignature` instead, and CodeRabbit was right to flag it. That type records hosted frames, while the helper above also filters out hidden and windowless surfaces, and a hidden entry keeps its frame on purpose. Hiding a surface therefore compared equal and left stale divider pixels. Widening `ExternalGeometrySignature` would have fixed the comparison at the cost of making every hide and reveal escalate to a full layout pass in `synchronizeLayoutHierarchy`, so the overlay got its own inputs instead.

Appearance is the one input no geometry comparison can see, since `overlayDividerColor` resolves each split view's `dividerColor` against the current appearance. `viewDidChangeEffectiveAppearance` repaints for that.

## Tests

Red-then-green per the repo policy. The first commit adds the first two against today's unconditional invalidation, so CI shows the idle test failing before the fix lands.

- `testRedundantHostedViewSyncDoesNotRepaintDividerOverlay`: three syncs of an unmoved hosted view must not invalidate.
- `testMovedHostedViewRepaintsDividerOverlay`: the other direction. A gate like this can fail by never invalidating at all, which would leave divider lines painted at stale positions after a split resize.
- `testHidingHostedViewWithoutMovingItRepaintsDividerOverlay`: hides a surface through `updateEntryVisibility` and asserts the frame did not move, so it fails if the repaint ever comes from something other than the visibility change.

They settle with a deadline-bounded poll rather than a fixed wait: sync until a sync stops producing repaints, bounded at 50 attempts. `realizeWindowLayout` ends in a 50ms run-loop spin, and layout settling after that on a loaded worker would repaint inside the measured window and fail a test for the wrong reason.

The counter they assert on, `RemoteTmuxSizingDiagnostics.dividerOverlayRepaintCount`, sits with the existing sizing counters because it guards the same class of bug.

## Related

Fourth idle-work fix in this area, all found in the same profiles:

- #10856: portal ownership scanned every pane's tabs to answer an identity question
- #10351: spinner titles woke the app on every frame
- #10349: focus-history entries resolved more than once per menu snapshot
- #10353: closed-item history grew unbounded

---

https://claude.ai/code/session_01Bj791kgph6Xk9CJf9c41Db

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented unnecessary divider overlay repaints when hosted-view placement and geometry remain unchanged, reducing redundant rendering work.
  - Ensured divider overlays repaint when geometry or visibility changes, keeping visual dividers accurately aligned.
  - Updated overlays when the app’s appearance changes.

- **Tests**
  - Added coverage confirming redundant synchronization does not trigger repaints.
  - Added coverage verifying resizing or hiding a hosted view triggers the expected repaint.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
