### PR TITLE
iOS: align grouped notification metadata with ordinary rows

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/NotificationFeedRow.swift
@@ -15,9 +15,12 @@ struct NotificationFeedRow: View, Equatable {
     }
 
     var body: some View {
-        HStack(spacing: 0) {
+        // Group controls own a bottom-trailing slot, not a full-height
+        // column that narrows the ordinary row's headline and provenance.
+        VStack(alignment: .trailing, spacing: 0) {
             NotificationFeedOpenRow(model: model, actions: actions, context: context)
                 .equatable()
+                .frame(maxWidth: .infinity)
 
             if let disclosure {
                 NotificationFeedDisclosureButton(
@@ -44,7 +47,7 @@ private struct NotificationFeedDisclosureButton: View {
             }
             .font(.caption.weight(.semibold))
             .foregroundStyle(.secondary)
-            .frame(minWidth: 44, minHeight: 44)
+            .frame(minWidth: 44, minHeight: 44, alignment: .trailing)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -335,6 +338,7 @@ private struct NotificationFeedProvenance: View {
                         isReachable: computerIsReachable,
                         allowsWrapping: true
                     )
+                    .frame(maxWidth: .infinity, alignment: .trailing)
                 }
             }
         } else if let sourceName {
@@ -372,6 +376,7 @@ private struct NotificationFeedComputer: View {
             .font(.caption)
             .foregroundStyle(isReachable ? Color.secondary.opacity(0.7) : Color.orange)
             .lineLimit(allowsWrapping ? 2 : 1)
+            .multilineTextAlignment(.trailing)
     }
 }
 

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -1,6 +1,7 @@
 import CMUXMobileCore
 import Network
 import UIKit
+import Vision
 import XCTest
 
 final class cmuxUITests: XCTestCase {
@@ -4073,6 +4074,76 @@ final class cmuxUITests: XCTestCase {
         assertShareSheetAfterTap(appLog, at: CGVector(dx: 0.5, dy: 0.5), name: "app-log label")
         assertShareSheetAfterTap(networkLog, at: CGVector(dx: 0.1, dy: 0.5), name: "network-log icon")
         assertShareSheetAfterTap(networkLog, at: CGVector(dx: 0.5, dy: 0.5), name: "network-log label")
+    }
+
+    @MainActor
+    func testNotificationHistoryKeepsOrdinaryRowTrailingAlignment() throws {
+        // Measure rendered glyphs, not List's full-width accessibility hit
+        // targets. Both variants mount the same production row and fixture.
+        for contentSize in ["UICTContentSizeCategoryL", "UICTContentSizeCategoryXXXL"] {
+            var ordinaryTimestamp: CGRect?
+            for grouped in [false, true] {
+                let app = launchApp(mockData: false, environment: [
+                    "CMUX_UITEST_NOTIFICATION_FEED_PREVIEW": "1",
+                    "CMUX_UITEST_NOTIFICATION_FEED_GROUP_PREVIEW": grouped ? "1" : "0",
+                ], launchArguments: ["-UIPreferredContentSizeCategoryName", contentSize])
+                defer { app.terminate() }
+
+                let parent = app.buttons["MobileNotificationFeedRow-studio-legacy-codex-approval"]
+                XCTAssertTrue(parent.waitForExistence(timeout: 10))
+                let screenshot = app.screenshot()
+                let attachment = XCTAttachment(screenshot: screenshot)
+                attachment.name = "Notification alignment, \(contentSize), grouped=\(grouped)"
+                attachment.lifetime = .keepAlways
+                add(attachment)
+
+                let request = VNRecognizeTextRequest()
+                request.recognitionLevel = .accurate
+                request.recognitionLanguages = ["en-US"]
+                let image = try XCTUnwrap(screenshot.image.cgImage)
+                try VNImageRequestHandler(cgImage: image).perform([request])
+                let observations = request.results ?? []
+
+                func renderedFrame(matching pattern: String) throws -> CGRect {
+                    for observation in observations {
+                        guard let text = observation.topCandidates(1).first,
+                              let range = text.string.range(of: pattern, options: .regularExpression),
+                              let bounds = try text.boundingBox(for: range)?.boundingBox else { continue }
+                        let frame = CGRect(
+                            x: app.frame.minX + bounds.minX * app.frame.width,
+                            y: app.frame.minY + (1 - bounds.maxY) * app.frame.height,
+                            width: bounds.width * app.frame.width,
+                            height: bounds.height * app.frame.height
+                        )
+                        if parent.frame.contains(CGPoint(x: frame.midX, y: frame.midY)) { return frame }
+                    }
+                    XCTFail("Missing rendered text matching \(pattern): \(observations.compactMap { $0.topCandidates(1).first?.string })")
+                    return .zero
+                }
+
+                let timestamp = try renderedFrame(matching: #"\d+\s+\w+\s+ago"#)
+                let computer = try renderedFrame(matching: "Studio")
+                XCTAssertEqual(computer.maxX, timestamp.maxX, accuracy: 3,
+                               "Computer metadata must stay trailing even when it wraps below the source")
+                if grouped {
+                    XCTAssertEqual(timestamp.maxX, try XCTUnwrap(ordinaryTimestamp).maxX, accuracy: 3,
+                                   "Grouping must not take width away from the ordinary row's timestamp")
+                    let toggle = app.buttons["MobileNotificationFeedGroupToggle-codex-approval"]
+                    XCTAssertTrue(toggle.exists)
+                    XCTAssertGreaterThanOrEqual(toggle.frame.minY, parent.frame.maxY - 1,
+                                                "The disclosure belongs below the full-width row content")
+                    XCTAssertGreaterThanOrEqual(toggle.frame.width, 44)
+                    XCTAssertGreaterThanOrEqual(toggle.frame.height, 44)
+                    toggle.tap()
+                    XCTAssertTrue(app.buttons["MobileNotificationFeedRow-studio-legacy-group-title-only"]
+                        .waitForExistence(timeout: 5))
+                    XCTAssertTrue((parent.value as? String)?.hasPrefix("Unread") == true,
+                                  "Expanding history must not open or mark the latest notification read")
+                } else {
+                    ordinaryTimestamp = timestamp
+                }
+            }
+        }
     }
 
     @MainActor

--- a/ios/cmuxUITests/cmuxUITests.swift
+++ b/ios/cmuxUITests/cmuxUITests.swift
@@ -4121,7 +4121,7 @@ final class cmuxUITests: XCTestCase {
                     return .zero
                 }
 
-                let timestamp = try renderedFrame(matching: #"\d+\s+\w+\s+ago"#)
+                let timestamp = try renderedFrame(matching: #"\d+\s+\w+\.?\s+ago"#)
                 let computer = try renderedFrame(matching: "Studio")
                 XCTAssertEqual(computer.maxX, timestamp.maxX, accuracy: 3,
                                "Computer metadata must stay trailing even when it wraps below the source")


### PR DESCRIPTION
## Summary

Grouped timestamps and computer names now reach the ordinary row's trailing edge. Count and disclosure sit below the full-width content, keeping their 44-point hit target. Wrapped computer labels remain trailing-aligned. Native nested rows and smooth expansion are unchanged.

Principled fix: remove the full-height accessory column instead of offsetting labels. Tradeoff: grouped rows gain one compact control line.

## Testing

- Corrected negative baseline failed on the original production row: grouped timestamp right edge 341.20pt versus ordinary 384.26pt (3pt tolerance). [Failure evidence](https://github.com/manaflow-ai/cmux/actions/runs/33947066849/job/101255171495).
- Feature head 2332883 passed the real-app screenshot test at default and XXXL text sizes: 1 test, 0 failures, 43.465 seconds. It checks glyph alignment, disclosure placement, expansion, and unread preservation. [Passing evidence](https://github.com/manaflow-ai/cmux/actions/runs/33947065616/job/101255155088).
- Updated cleanly with main at 226e1ad. Notification implementation is unchanged. [Final integration run](https://github.com/manaflow-ai/cmux/actions/runs/33948756974) tests current head 55f0131.
- Mac and iPhone ngroup builds compiled; both installed. The phone went offline before the signed launch could complete. Its readiness is not claimed.
- The manual workflow also reports pre-existing package-conventions lint failures in untouched files; it is not a required PR check. Required checks are enforced normally.
- The initial timestamp regex missed the period in “min.”; those initial runs are not valid regression evidence. The corrected baseline and passing run above replace them.

## Demo Video

This is a static layout correction; no new animation was introduced or recording captured in this follow-up. [Normal and XXXL screenshot attachments](https://github.com/manaflow-ai/cmux/actions/runs/33947065616/artifacts/9963771347) show the rendered ordinary and grouped rows.

## Review

Existing automatic review feedback has no actionable code findings or unresolved threads. No additional reviewer was invoked, per the repository's explicit opt-in policy.

## Checklist

- [x] Added a behavior-level regression test that fails on the original layout.
- [x] Focused iPhone Simulator test passed remotely at normal and XXXL text sizes.
- [x] Localization audited: no new user-facing strings; existing localized disclosure labels and number formatting retained.
- [x] Consulted [Apple HIG: Lists and tables](https://developer.apple.com/design/human-interface-guidelines/lists-and-tables). Clear row backgrounds are preserved; no new HIG deviation.
- [x] Existing review threads checked; no unresolved findings.
- [ ] Final integration test after updating main completed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/12010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1791176553&installation_model_id=21920&pr_number=12010&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F12010&signature=eab7de971c0573e5282b1b263dfdca021cec349b20646be58077804af83322b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns grouped notification metadata (timestamps, computer names) with ordinary rows by moving the disclosure below the full-width content, so grouped rows no longer lose title width. Grouped rows now show the disclosure on a separate compact line while keeping the 44-point hit target and unchanged nested rows.

- Adds a Vision-based UI test that checks rendered glyph positions at default and XXXL text sizes and tolerates abbreviated date punctuation.

<sup>Written for commit 55f0131e86580c35f12e7567e3b071988a2a8c6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/12010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved notification feed row alignment, including timestamps, computer details, disclosure controls, and grouped notification layouts.
  - Ensured expanded notification rows use the available width and grouped history controls remain positioned consistently.
  - Preserved unread status when expanding grouped notification history.

- **Tests**
  - Added coverage for notification alignment and grouped-feed behavior at larger accessibility text sizes, including grouped and ungrouped notifications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->